### PR TITLE
Revert "LPD-33654 As used"

### DIFF
--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/exportimport/test/AssetPublisherExportImportTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/exportimport/test/AssetPublisherExportImportTest.java
@@ -776,11 +776,6 @@ public class AssetPublisherExportImportTest
 			TemplateConstants.LANG_TYPE_FTL, RandomTestUtil.randomString(),
 			_portal.getSiteDefaultLocale(group));
 
-		Assert.assertNotNull(
-			_ddmTemplateLocalService.getTemplate(
-				importedGroup.getGroupId(), classNameId,
-				ddmTemplate.getTemplateKey()));
-
 		PortletPreferences portletPreferences = getImportedPortletPreferences(
 			HashMapBuilder.put(
 				"displayStyle",
@@ -789,6 +784,11 @@ public class AssetPublisherExportImportTest
 						ddmTemplate.getTemplateKey()
 				}
 			).build());
+
+		Assert.assertNotNull(
+			_ddmTemplateLocalService.getTemplate(
+				importedGroup.getGroupId(), classNameId,
+				ddmTemplate.getTemplateKey()));
 
 		Assert.assertEquals(
 			PortletDisplayTemplate.DISPLAY_STYLE_PREFIX +


### PR DESCRIPTION
This reverts commit f34e47fe1be1b4a8cd68f2dbf8526e246369e973.

I'm reverting this commit because it's causing a test failure due to a missing template at that point.

Please see: https://testray.liferay.com/web/testray#/project/34754/routines/50445634/build/67473749/case-result/67474739

This template is created on that site during the export/import process triggered by the getImportedPortletPreferences call on the previous line.

Thanks!