### PR TITLE
LPD-34471 This is a workaround for the broken logic added in b4085258…

### DIFF
--- a/modules/apps/portal-instances/portal-instances-service/src/main/java/com/liferay/portal/instances/service/impl/PortalInstancesLocalServiceImpl.java
+++ b/modules/apps/portal-instances/portal-instances-service/src/main/java/com/liferay/portal/instances/service/impl/PortalInstancesLocalServiceImpl.java
@@ -55,6 +55,7 @@ import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.servlet.filters.threadlocal.ThreadLocalFilterThreadLocal;
 import com.liferay.portal.util.PortalInstances;
 import com.liferay.portlet.RenderRequestFactory;
 import com.liferay.portlet.RenderResponseFactory;
@@ -62,6 +63,7 @@ import com.liferay.site.initializer.SiteInitializer;
 import com.liferay.site.initializer.SiteInitializerRegistry;
 
 import java.util.List;
+import java.util.Objects;
 
 import javax.portlet.PortletConfig;
 import javax.portlet.PortletMode;
@@ -120,7 +122,7 @@ public class PortalInstancesLocalServiceImpl
 		ServiceContext currentThreadServiceContext =
 			ServiceContextThreadLocal.getServiceContext();
 
-		try (SafeCloseable safeCloseable =
+		try (SafeCloseable safeCloseable1 =
 				CompanyThreadLocal.setInitializingPortalInstance(true)) {
 
 			Role role = _roleLocalService.fetchRole(
@@ -152,6 +154,23 @@ public class PortalInstancesLocalServiceImpl
 				group.getGroupId(), true, new ServiceContext());
 
 			siteInitializer.initialize(group.getGroupId());
+
+			if (Objects.equals(
+					_BLANK_SITE_INITIALIZER_KEY, siteInitializerKey)) {
+
+				SiteInitializer welcomeSiteInitializer =
+					_siteInitializerRegistry.getSiteInitializer(
+						_WELCOME_SITE_INITIALIZER_KEY);
+
+				if (welcomeSiteInitializer != null) {
+					try (SafeCloseable safeCloseable2 =
+							ThreadLocalFilterThreadLocal.setFilterInvoked(
+								false)) {
+
+						welcomeSiteInitializer.initialize(group.getGroupId());
+					}
+				}
+			}
 		}
 		finally {
 			PermissionThreadLocal.setPermissionChecker(
@@ -299,6 +318,12 @@ public class PortalInstancesLocalServiceImpl
 
 		return serviceContext;
 	}
+
+	private static final String _BLANK_SITE_INITIALIZER_KEY =
+		"blank-site-initializer";
+
+	private static final String _WELCOME_SITE_INITIALIZER_KEY =
+		"com.liferay.site.initializer.welcome";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		PortalInstancesLocalServiceImpl.class);

--- a/portal-impl/src/com/liferay/portal/servlet/filters/threadlocal/ThreadLocalFilterThreadLocal.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/threadlocal/ThreadLocalFilterThreadLocal.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.servlet.filters.threadlocal;
 
 import com.liferay.petra.lang.CentralizedThreadLocal;
+import com.liferay.petra.lang.SafeCloseable;
 
 /**
  * @author Tina Tian
@@ -20,7 +21,11 @@ public class ThreadLocalFilterThreadLocal {
 		_filterInvoked.set(true);
 	}
 
-	private static final ThreadLocal<Boolean> _filterInvoked =
+	public static SafeCloseable setFilterInvoked(boolean filterInvoked) {
+		return _filterInvoked.setWithSafeCloseable(filterInvoked);
+	}
+
+	private static final CentralizedThreadLocal<Boolean> _filterInvoked =
 		new CentralizedThreadLocal<>(
 			ThreadLocalFilterThreadLocal.class + "._filterInvoked",
 			() -> Boolean.FALSE);


### PR DESCRIPTION
…b87c5228c77e8980e9dc44548413bf12 .That commit basically made BlankSiteInitializer requires WelcomeSiteInitializer run after it to work properly. However the WelcomeSiteInitializer has previously ran during the company creation, this change blindly deletes the layouts belong to WelcomeSiteInitializer, only hoping WelcomeSiteInitializer will rerun to fix the wrongfully deleted data. This was working because the previous bug fixed by LPD-30222. We were running the SiteInitializer 3 times for each group, which was very wasteful. After the duplicated SiteInitializer runs is fixed, now no one is fixing the deleted WelcomeSiteInitializer layouts for BlankSiteInitializer, therefore we have this issue. This work around is merely readd back the duplicated call to WelcomeSiteInitializer for BlankSiteInitializer. The real fix should be avoid doing blindly layout removal, either create the data correct from beginning or just fix the broken data without touching others.

@vicnate5 please follow up with SiteInitializer team for proper fix, thanks!
