### PR TITLE
Lpd 25633 optimization final

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -2897,7 +2897,7 @@ server.detector.server.id=wildfly</echo>
 					<equals arg1="${database.type}" arg2="mysql" />
 				</or>
 				<then>
-					<property name="database.url.upgrade" value="${database.url}&amp;rewriteBatchedStatements=true" />
+					<property name="database.url.upgrade" value="${database.url}&amp;rewriteBatchedStatements=true&amp;cachePrepStmts=true&amp;prepStmtCacheSize=1000&amp;prepStmtCacheSqlLimit=2048" />
 				</then>
 				<elseif>
 					<equals arg1="${database.type}" arg2="postgresql" />
@@ -12504,7 +12504,7 @@ portal.proxy.path=/${portal.proxy.path}</echo>
 						<replace
 							file="portal-impl/src/portal-ext.properties"
 							token="${database.url}"
-							value="${database.url}&amp;rewriteBatchedStatements=true"
+							value="${database.url}&amp;rewriteBatchedStatements=true&amp;cachePrepStmts=true&amp;prepStmtCacheSize=1000&amp;prepStmtCacheSqlLimit=2048"
 						/>
 					</then>
 					<elseif>

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/search/spi/model/index/contributor/AssetCategoryDocumentContributor.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/search/spi/model/index/contributor/AssetCategoryDocumentContributor.java
@@ -22,6 +22,8 @@ import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentContributor;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -48,6 +50,13 @@ public class AssetCategoryDocumentContributor
 	@Override
 	public void contribute(
 		Document document, BaseModel<AssetCategory> baseModel) {
+
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if ((serviceContext != null) && serviceContext.isStrictAdd()) {
+			return;
+		}
 
 		String className = document.get(Field.ENTRY_CLASS_NAME);
 		long classPK = GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK));

--- a/modules/apps/asset/asset-tags-service/src/main/java/com/liferay/asset/tags/internal/search/spi/model/index/contributor/AssetTagDocumentContributor.java
+++ b/modules/apps/asset/asset-tags-service/src/main/java/com/liferay/asset/tags/internal/search/spi/model/index/contributor/AssetTagDocumentContributor.java
@@ -16,6 +16,8 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentContributor;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -37,6 +39,13 @@ public class AssetTagDocumentContributor
 
 	@Override
 	public void contribute(Document document, BaseModel<AssetTag> baseModel) {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if ((serviceContext != null) && serviceContext.isStrictAdd()) {
+			return;
+		}
+
 		String className = document.get(Field.ENTRY_CLASS_NAME);
 
 		long classNameId = portal.getClassNameId(className);

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
@@ -43,8 +43,11 @@ import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.Serializable;
 
@@ -99,6 +102,27 @@ public class BatchEngineImportTaskExecutorImpl
 			batchEngineImportTask.getCompanyId(),
 			CTCollectionThreadLocal.getCTCollectionId());
 
+		File tempContentFile;
+
+		try (InputStream inputStream =
+				_batchEngineImportTaskLocalService.openContentInputStream(
+					batchEngineImportTask.getBatchEngineImportTaskId())) {
+
+			tempContentFile = FileUtil.createTempFile(inputStream);
+		}
+		catch (Throwable throwable) {
+			_log.error(
+				"Unable to save batch engine import task content as temp file" +
+					batchEngineImportTask,
+				throwable);
+
+			_updateBatchEngineImportTask(
+				BatchEngineTaskExecuteStatus.FAILED, batchEngineImportTask,
+				throwable.toString());
+
+			return;
+		}
+
 		try (SafeCloseable safeCloseable2 = SearchContext.openBatchMode()) {
 			batchEngineImportTask.setExecuteStatus(
 				BatchEngineTaskExecuteStatus.STARTED.toString());
@@ -109,10 +133,12 @@ public class BatchEngineImportTaskExecutorImpl
 					BatchEngineTaskContentType.valueOf(
 						batchEngineImportTask.getContentType()));
 
-			batchEngineImportTask.setTotalItemsCount(
-				batchEngineTaskProgress.getTotalItemsCount(
-					_batchEngineImportTaskLocalService.openContentInputStream(
-						batchEngineImportTask.getBatchEngineImportTaskId())));
+			try (InputStream inputStream = new FileInputStream(
+					tempContentFile)) {
+
+				batchEngineImportTask.setTotalItemsCount(
+					batchEngineTaskProgress.getTotalItemsCount(inputStream));
+			}
 
 			_batchEngineImportTaskLocalService.updateBatchEngineImportTask(
 				batchEngineImportTask);
@@ -120,7 +146,8 @@ public class BatchEngineImportTaskExecutorImpl
 			BatchEngineTaskExecutorUtil.execute(
 				checkPermissions,
 				() -> _importItems(
-					batchEngineImportTask, batchEngineTaskItemDelegate),
+					batchEngineImportTask, tempContentFile,
+					batchEngineTaskItemDelegate),
 				_userLocalService.getUser(batchEngineImportTask.getUserId()));
 
 			_updateBatchEngineImportTask(
@@ -138,6 +165,7 @@ public class BatchEngineImportTaskExecutorImpl
 				throwable.toString());
 		}
 		finally {
+			tempContentFile.delete();
 
 			// LPS-167011 Because of call to _updateBatchEngineImportTask when
 			// catching a Throwable
@@ -291,19 +319,17 @@ public class BatchEngineImportTaskExecutorImpl
 	}
 
 	private void _importItems(
-			BatchEngineImportTask batchEngineImportTask,
+			BatchEngineImportTask batchEngineImportTask, File contentFile,
 			BatchEngineTaskItemDelegate<?> batchEngineTaskItemDelegate)
 		throws Throwable {
 
 		Map<String, Serializable> parameters = _getParameters(
 			batchEngineImportTask);
 
-		try (BatchEngineImportTaskItemReader batchEngineImportTaskItemReader =
+		try (InputStream inputStream = new FileInputStream(contentFile);
+			BatchEngineImportTaskItemReader batchEngineImportTaskItemReader =
 				_getBatchEngineImportTaskItemReader(
-					batchEngineImportTask,
-					_batchEngineImportTaskLocalService.openContentInputStream(
-						batchEngineImportTask.getBatchEngineImportTaskId()),
-					parameters)) {
+					batchEngineImportTask, inputStream, parameters)) {
 
 			BatchEngineTaskItemDelegateExecutor
 				batchEngineTaskItemDelegateExecutor =

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
@@ -39,6 +39,7 @@ import com.liferay.portal.configuration.module.configuration.ConfigurationProvid
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -94,11 +95,11 @@ public class BatchEngineImportTaskExecutorImpl
 			startTime = System.currentTimeMillis();
 		}
 
-		SafeCloseable safeCloseable = CompanyThreadLocal.setWithSafeCloseable(
+		SafeCloseable safeCloseable1 = CompanyThreadLocal.setWithSafeCloseable(
 			batchEngineImportTask.getCompanyId(),
 			CTCollectionThreadLocal.getCTCollectionId());
 
-		try {
+		try (SafeCloseable safeCloseable2 = SearchContext.openBatchMode()) {
 			batchEngineImportTask.setExecuteStatus(
 				BatchEngineTaskExecuteStatus.STARTED.toString());
 			batchEngineImportTask.setStartTime(new Date());
@@ -141,7 +142,7 @@ public class BatchEngineImportTaskExecutorImpl
 			// LPS-167011 Because of call to _updateBatchEngineImportTask when
 			// catching a Throwable
 
-			safeCloseable.close();
+			safeCloseable1.close();
 		}
 
 		if (_log.isInfoEnabled()) {

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointRelevantObjectEntryModelListener.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointRelevantObjectEntryModelListener.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -126,8 +127,9 @@ public class APIEndpointRelevantObjectEntryModelListener
 		try {
 			Map<String, Serializable> values = objectEntry.getValues();
 
-			long apiApplicationId = (long)values.get(
-				"r_apiApplicationToAPIEndpoints_c_apiApplicationId");
+			long apiApplicationId = GetterUtil.getLong(
+				values.get(
+					"r_apiApplicationToAPIEndpoints_c_apiApplicationId"));
 
 			if (!_validationHelper.isValidObjectEntry(
 					"L_API_APPLICATION", apiApplicationId)) {
@@ -138,8 +140,8 @@ public class APIEndpointRelevantObjectEntryModelListener
 					"an-api-endpoint-must-be-related-to-an-api-application");
 			}
 
-			long responseAPISchemaId = (long)values.get(
-				"r_responseAPISchemaToAPIEndpoints_c_apiSchemaId");
+			long responseAPISchemaId = GetterUtil.getLong(
+				values.get("r_responseAPISchemaToAPIEndpoints_c_apiSchemaId"));
 
 			APIApplication.Endpoint.Scope scope =
 				APIApplication.Endpoint.Scope.parse(
@@ -150,8 +152,8 @@ public class APIEndpointRelevantObjectEntryModelListener
 					apiApplicationId, responseAPISchemaId, scope);
 			}
 
-			long requestAPISchemaId = (long)values.get(
-				"r_requestAPISchemaToAPIEndpoints_c_apiSchemaId");
+			long requestAPISchemaId = GetterUtil.getLong(
+				values.get("r_requestAPISchemaToAPIEndpoints_c_apiSchemaId"));
 
 			if (requestAPISchemaId != 0) {
 				_validateAPISchema(apiApplicationId, requestAPISchemaId, scope);

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIPropertyRelevantObjectEntryModelListener.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIPropertyRelevantObjectEntryModelListener.java
@@ -22,6 +22,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -118,8 +119,8 @@ public class APIPropertyRelevantObjectEntryModelListener
 		try {
 			Map<String, Serializable> values = objectEntry.getValues();
 
-			long apiSchemaId = (long)values.get(
-				"r_apiSchemaToAPIProperties_c_apiSchemaId");
+			long apiSchemaId = GetterUtil.getLong(
+				values.get("r_apiSchemaToAPIProperties_c_apiSchemaId"));
 
 			if (!_validationHelper.isValidObjectEntry(
 					"L_API_SCHEMA", apiSchemaId)) {
@@ -181,8 +182,8 @@ public class APIPropertyRelevantObjectEntryModelListener
 				}
 			}
 
-			long parentAPIPropertyId = (long)values.get(
-				"r_apiPropertyToAPIProperties_c_apiPropertyId");
+			long parentAPIPropertyId = GetterUtil.getLong(
+				values.get("r_apiPropertyToAPIProperties_c_apiPropertyId"));
 
 			if (parentAPIPropertyId != 0) {
 				if (!_validationHelper.isValidObjectEntry(

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APISchemaRelevantObjectEntryModelListener.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APISchemaRelevantObjectEntryModelListener.java
@@ -15,6 +15,7 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.io.Serializable;
@@ -58,8 +59,10 @@ public class APISchemaRelevantObjectEntryModelListener
 
 			if (!_validationHelper.isValidObjectEntry(
 					"L_API_APPLICATION",
-					(long)values.get(
-						"r_apiApplicationToAPISchemas_c_apiApplicationId"))) {
+					GetterUtil.getLong(
+						values.get(
+							"r_apiApplicationToAPISchemas_c_" +
+								"apiApplicationId")))) {
 
 				throw new ObjectEntryValuesException.InvalidObjectField(
 					null, "An API schema must be related to an API application",

--- a/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/dto/v1_0/util/ObjectFieldUtil.java
+++ b/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/dto/v1_0/util/ObjectFieldUtil.java
@@ -32,8 +32,7 @@ public class ObjectFieldUtil {
 			"defaultValue",
 			com.liferay.object.field.setting.util.ObjectFieldSettingUtil.
 				getDefaultValueAsString(
-					null, objectField.getObjectFieldId(),
-					objectFieldSettingLocalService, null)
+					null, objectField, objectFieldSettingLocalService, null)
 		).put(
 			"externalReferenceCode", objectField.getExternalReferenceCode()
 		).put(

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/converter/ObjectFieldDTOConverter.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/converter/ObjectFieldDTOConverter.java
@@ -78,7 +78,7 @@ public class ObjectFieldDTOConverter
 					() ->
 						com.liferay.object.field.setting.util.
 							ObjectFieldSettingUtil.getDefaultValueAsString(
-								null, objectField.getObjectFieldId(),
+								null, objectField,
 								_objectFieldSettingLocalService, null));
 				setExternalReferenceCode(objectField::getExternalReferenceCode);
 				setId(objectField::getObjectFieldId);

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/field/setting/util/ObjectFieldSettingUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/field/setting/util/ObjectFieldSettingUtil.java
@@ -31,22 +31,24 @@ import java.util.Objects;
 public class ObjectFieldSettingUtil {
 
 	public static String getDefaultValueAsString(
-		DDMExpressionFactory ddmExpressionFactory, long objectFieldId,
+		DDMExpressionFactory ddmExpressionFactory, ObjectField objectField,
 		ObjectFieldSettingLocalService objectFieldSettingLocalService,
 		Map<String, Object> values) {
 
-		ObjectFieldSetting defaultValueObjectFieldSetting =
-			objectFieldSettingLocalService.fetchObjectFieldSetting(
-				objectFieldId, ObjectFieldSettingConstants.NAME_DEFAULT_VALUE);
+		List<ObjectFieldSetting> objectFieldSettings =
+			objectField.getObjectFieldSettings();
+
+		ObjectFieldSetting defaultValueObjectFieldSetting = _findByName(
+			objectFieldSettings,
+			ObjectFieldSettingConstants.NAME_DEFAULT_VALUE);
 
 		if (defaultValueObjectFieldSetting == null) {
 			return null;
 		}
 
-		ObjectFieldSetting defaultValueTypeObjectFieldSetting =
-			objectFieldSettingLocalService.fetchObjectFieldSetting(
-				objectFieldId,
-				ObjectFieldSettingConstants.NAME_DEFAULT_VALUE_TYPE);
+		ObjectFieldSetting defaultValueTypeObjectFieldSetting = _findByName(
+			objectFieldSettings,
+			ObjectFieldSettingConstants.NAME_DEFAULT_VALUE_TYPE);
 
 		if ((defaultValueTypeObjectFieldSetting == null) ||
 			StringUtil.equals(
@@ -123,6 +125,18 @@ public class ObjectFieldSettingUtil {
 			getValue(
 				ObjectFieldSettingConstants.NAME_UNIQUE_VALUES,
 				objectFieldSetting));
+	}
+
+	private static ObjectFieldSetting _findByName(
+		List<ObjectFieldSetting> objectFieldSettings, String name) {
+
+		for (ObjectFieldSetting objectFieldSetting : objectFieldSettings) {
+			if (Objects.equals(objectFieldSetting.getName(), name)) {
+				return objectFieldSetting;
+			}
+		}
+
+		return null;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/field/util/ObjectFieldUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/field/util/ObjectFieldUtil.java
@@ -252,7 +252,7 @@ public class ObjectFieldUtil {
 				existingValues.put(
 					objectField.getName(),
 					ObjectFieldSettingUtil.getDefaultValueAsString(
-						null, objectField.getObjectFieldId(),
+						null, objectField,
 						ObjectFieldSettingLocalServiceUtil.getService(), null));
 			}
 

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalService.java
@@ -494,4 +494,9 @@ public interface ObjectEntryLocalService
 			ServiceContext serviceContext)
 		throws PortalException;
 
+	public ObjectEntry updateStatus(
+			long userId, ObjectEntry objectEntry, int status,
+			ServiceContext serviceContext)
+		throws PortalException;
+
 }

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceUtil.java
@@ -652,6 +652,15 @@ public class ObjectEntryLocalServiceUtil {
 			userId, objectEntryId, status, serviceContext);
 	}
 
+	public static ObjectEntry updateStatus(
+			long userId, ObjectEntry objectEntry, int status,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().updateStatus(
+			userId, objectEntry, status, serviceContext);
+	}
+
 	public static ObjectEntryLocalService getService() {
 		return _serviceSnapshot.get();
 	}

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceWrapper.java
@@ -750,6 +750,17 @@ public class ObjectEntryLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.object.model.ObjectEntry updateStatus(
+			long userId, com.liferay.object.model.ObjectEntry objectEntry,
+			int status,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _objectEntryLocalService.updateStatus(
+			userId, objectEntry, status, serviceContext);
+	}
+
+	@Override
 	public BasePersistence<?> getBasePersistence() {
 		return _objectEntryLocalService.getBasePersistence();
 	}

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/field/setting/util/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/field/setting/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 2.0.0

--- a/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/field/converter/ObjectFieldInfoFieldConverter.java
+++ b/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/field/converter/ObjectFieldInfoFieldConverter.java
@@ -205,7 +205,7 @@ public class ObjectFieldInfoFieldConverter {
 					listTypeEntry -> new OptionInfoFieldType(
 						Objects.equals(
 							ObjectFieldSettingUtil.getDefaultValueAsString(
-								null, objectField.getObjectFieldId(),
+								null, objectField,
 								_objectFieldSettingLocalService, null),
 							listTypeEntry.getKey()),
 						new FunctionInfoLocalizedValue<>(
@@ -383,8 +383,7 @@ public class ObjectFieldInfoFieldConverter {
 		ObjectField objectField) {
 
 		String defaultValue = ObjectFieldSettingUtil.getDefaultValueAsString(
-			null, objectField.getObjectFieldId(),
-			_objectFieldSettingLocalService, null);
+			null, objectField, _objectFieldSettingLocalService, null);
 
 		if (!objectField.isState()) {
 			return _getOptionInfoFieldTypes(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -160,7 +160,7 @@ public class DefaultObjectEntryManagerImpl
 			_addOrUpdateNestedObjectEntries(
 				dtoConverterContext, objectDefinition, objectEntry,
 				_getObjectRelationships(objectDefinition, objectEntry),
-				serviceBuilderObjectEntry.getPrimaryKey(), scopeKey));
+				serviceBuilderObjectEntry, scopeKey));
 	}
 
 	@Override
@@ -787,8 +787,7 @@ public class DefaultObjectEntryManagerImpl
 			_addOrUpdateNestedObjectEntries(
 				dtoConverterContext, objectDefinition, objectEntry,
 				_getObjectRelationships(objectDefinition, objectEntry),
-				serviceBuilderObjectEntry.getPrimaryKey(),
-				objectEntry.getScopeKey()));
+				serviceBuilderObjectEntry, objectEntry.getScopeKey()));
 	}
 
 	@Override
@@ -821,7 +820,7 @@ public class DefaultObjectEntryManagerImpl
 			_addOrUpdateNestedObjectEntries(
 				dtoConverterContext, objectDefinition, objectEntry,
 				_getObjectRelationships(objectDefinition, objectEntry),
-				serviceBuilderObjectEntry.getPrimaryKey(), scopeKey));
+				serviceBuilderObjectEntry, scopeKey));
 	}
 
 	private Map<String, String> _addAction(
@@ -853,10 +852,17 @@ public class DefaultObjectEntryManagerImpl
 				DTOConverterContext dtoConverterContext,
 				ObjectDefinition objectDefinition, ObjectEntry objectEntry,
 				Map<String, ObjectRelationship> objectRelationships,
-				long primaryKey, String scopeKey)
+				com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry,
+				String scopeKey)
 		throws Exception {
 
+		if (objectRelationships.isEmpty()) {
+			return serviceBuilderObjectEntry;
+		}
+
 		Map<String, Object> properties = objectEntry.getProperties();
+
+		long primaryKey = serviceBuilderObjectEntry.getPrimaryKey();
 
 		for (Map.Entry<String, ObjectRelationship> entry :
 				objectRelationships.entrySet()) {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/action/util/ObjectEntryVariablesUtil.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/action/util/ObjectEntryVariablesUtil.java
@@ -163,7 +163,7 @@ public class ObjectEntryVariablesUtil {
 
 			String defaultValue =
 				ObjectFieldSettingUtil.getDefaultValueAsString(
-					null, objectField.getObjectFieldId(),
+					null, objectField,
 					ObjectFieldSettingLocalServiceUtil.getService(), null);
 
 			if (Validator.isNotNull(defaultValue) &&

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/PicklistObjectFieldBusinessType.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/PicklistObjectFieldBusinessType.java
@@ -104,8 +104,8 @@ public class PicklistObjectFieldBusinessType
 				localizedValue.addString(
 					objectFieldRenderingContext.getLocale(),
 					ObjectFieldSettingUtil.getDefaultValueAsString(
-						null, objectField.getObjectFieldId(),
-						_objectFieldSettingLocalService, null));
+						null, objectField, _objectFieldSettingLocalService,
+						null));
 
 				return localizedValue;
 			}
@@ -278,8 +278,7 @@ public class PicklistObjectFieldBusinessType
 		}
 
 		String listEntryKey = ObjectFieldSettingUtil.getDefaultValueAsString(
-			null, objectField.getObjectFieldId(),
-			_objectFieldSettingLocalService, null);
+			null, objectField, _objectFieldSettingLocalService, null);
 
 		if (MapUtil.isNotEmpty(objectFieldRenderingContext.getProperties())) {
 			ListEntry listEntry =

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -271,8 +271,7 @@ public class ObjectEntryModelDocumentContributor
 		document.addKeyword(
 			"objectDefinitionName", objectDefinition.getShortName());
 
-		Map<String, Serializable> values = _objectEntryLocalService.getValues(
-			objectEntry.getObjectEntryId());
+		Map<String, Serializable> values = objectEntry.getValues();
 
 		List<ObjectField> objectFields =
 			_objectFieldLocalService.getObjectFields(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/workflow/ObjectEntryWorkflowHandler.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/workflow/ObjectEntryWorkflowHandler.java
@@ -98,6 +98,22 @@ public class ObjectEntryWorkflowHandler
 			userId, classPK, status, serviceContext);
 	}
 
+	@Override
+	public ObjectEntry updateStatus(
+			ObjectEntry objectEntry, int status,
+			Map<String, Serializable> workflowContext)
+		throws PortalException {
+
+		long userId = GetterUtil.getLong(
+			(String)workflowContext.get(WorkflowConstants.CONTEXT_USER_ID));
+
+		ServiceContext serviceContext = (ServiceContext)workflowContext.get(
+			"serviceContext");
+
+		return _objectEntryLocalService.updateStatus(
+			userId, objectEntry, status, serviceContext);
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		ObjectEntryWorkflowHandler.class);
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectEntryImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectEntryImpl.java
@@ -17,7 +17,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
-import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.io.Serializable;
 
@@ -76,13 +76,16 @@ public class ObjectEntryImpl extends ObjectEntryBaseImpl {
 					objectDefinition.getTitleObjectFieldId());
 
 			if (objectField != null) {
+				String title = ObjectEntryValuesUtil.getValueString(
+					objectField, getValues());
+
+				if (Validator.isNotNull(title)) {
+					return title;
+				}
+
 				return ObjectEntryValuesUtil.getValueString(
 					objectField,
-					HashMapBuilder.create(
-						getValues()
-					).putAll(
-						ObjectEntryLocalServiceUtil.getSystemValues(this)
-					).build());
+					ObjectEntryLocalServiceUtil.getSystemValues(this));
 			}
 		}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -2082,7 +2082,7 @@ public class ObjectEntryLocalServiceImpl
 			}
 
 			String value = ObjectFieldSettingUtil.getDefaultValueAsString(
-				_ddmExpressionFactory, objectField.getObjectFieldId(),
+				_ddmExpressionFactory, objectField,
 				_objectFieldSettingLocalService, (Map)values);
 
 			if (value != null) {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -99,6 +99,7 @@ import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.lang.CentralizedThreadLocal;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
@@ -148,6 +149,7 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.StrictObjectReindexThreadLocal;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
@@ -3907,8 +3909,11 @@ public class ObjectEntryLocalServiceImpl
 		Indexer<ObjectEntry> indexer = IndexerRegistryUtil.getIndexer(
 			objectDefinition.getClassName());
 
-		indexer.reindex(
-			objectDefinition.getClassName(), objectEntry.getObjectEntryId());
+		try (SafeCloseable safeCloseable =
+				StrictObjectReindexThreadLocal.setStrictObjectReindex(true)) {
+
+			indexer.reindex(objectEntry);
+		}
 	}
 
 	private void _setColumn(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -4190,9 +4190,11 @@ public class ObjectEntryLocalServiceImpl
 			String.valueOf(objectEntry.getObjectEntryId()), null, null, null, 0,
 			0, priority, serviceContext);
 
-		_assetLinkLocalService.updateLinks(
-			userId, assetEntry.getEntryId(), assetLinkEntryIds,
-			AssetLinkConstants.TYPE_RELATED);
+		if (assetLinkEntryIds != null) {
+			_assetLinkLocalService.updateLinks(
+				userId, assetEntry.getEntryId(), assetLinkEntryIds,
+				AssetLinkConstants.TYPE_RELATED);
+		}
 	}
 
 	private void _updateTable(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -340,12 +340,14 @@ public class ObjectEntryLocalServiceImpl
 			ObjectEntryThreadLocal.setSkipObjectValidationRules(false);
 		}
 
-		updateAsset(
-			serviceContext.getUserId(), objectEntry,
-			serviceContext.getAssetCategoryIds(),
-			serviceContext.getAssetTagNames(),
-			serviceContext.getAssetLinkEntryIds(),
-			serviceContext.getAssetPriority());
+		if (workflowAction != WorkflowConstants.ACTION_PUBLISH) {
+			_updateAsset(
+				serviceContext.getUserId(), objectEntry,
+				serviceContext.getAssetCategoryIds(),
+				serviceContext.getAssetTagNames(),
+				serviceContext.getAssetLinkEntryIds(),
+				serviceContext.getAssetPriority(), serviceContext);
+		}
 
 		_startWorkflowInstance(userId, objectEntry, serviceContext);
 
@@ -1486,39 +1488,9 @@ public class ObjectEntryLocalServiceImpl
 			String[] assetTagNames, long[] assetLinkEntryIds, Double priority)
 		throws PortalException {
 
-		ObjectDefinition objectDefinition =
-			_objectDefinitionPersistence.findByPrimaryKey(
-				objectEntry.getObjectDefinitionId());
-
-		if (!objectDefinition.isEnableCategorization()) {
-			assetCategoryIds = null;
-			assetTagNames = null;
-		}
-
-		String title = StringPool.BLANK;
-
-		try {
-			title = objectEntry.getTitleValue();
-		}
-		catch (PortalException portalException) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(portalException);
-			}
-		}
-
-		AssetEntry assetEntry = _assetEntryLocalService.updateEntry(
-			userId, objectEntry.getNonzeroGroupId(),
-			objectEntry.getCreateDate(), objectEntry.getModifiedDate(),
-			objectDefinition.getClassName(), objectEntry.getObjectEntryId(),
-			objectEntry.getUuid(), 0, assetCategoryIds, assetTagNames, true,
-			objectEntry.isApproved(), null, null, null, null,
-			ContentTypes.TEXT_PLAIN, title,
-			String.valueOf(objectEntry.getObjectEntryId()), null, null, null, 0,
-			0, priority);
-
-		_assetLinkLocalService.updateLinks(
-			userId, assetEntry.getEntryId(), assetLinkEntryIds,
-			AssetLinkConstants.TYPE_RELATED);
+		_updateAsset(
+			userId, objectEntry, assetCategoryIds, assetTagNames,
+			assetLinkEntryIds, priority, null);
 	}
 
 	@Override
@@ -1588,12 +1560,12 @@ public class ObjectEntryLocalServiceImpl
 			ObjectEntryThreadLocal.setSkipObjectValidationRules(false);
 		}
 
-		updateAsset(
+		_updateAsset(
 			serviceContext.getUserId(), objectEntry,
 			serviceContext.getAssetCategoryIds(),
 			serviceContext.getAssetTagNames(),
 			serviceContext.getAssetLinkEntryIds(),
-			serviceContext.getAssetPriority());
+			serviceContext.getAssetPriority(), serviceContext);
 
 		_startWorkflowInstance(userId, objectEntry, serviceContext);
 
@@ -1646,13 +1618,23 @@ public class ObjectEntryLocalServiceImpl
 			objectEntry = objectEntryPersistence.update(objectEntry);
 		}
 
-		ObjectDefinition objectDefinition =
-			_objectDefinitionPersistence.fetchByPrimaryKey(
-				objectEntry.getObjectDefinitionId());
+		if (serviceContext.isStrictAdd()) {
+			_updateAsset(
+				serviceContext.getUserId(), objectEntry,
+				serviceContext.getAssetCategoryIds(),
+				serviceContext.getAssetTagNames(),
+				serviceContext.getAssetLinkEntryIds(),
+				serviceContext.getAssetPriority(), serviceContext);
+		}
+		else {
+			ObjectDefinition objectDefinition =
+				_objectDefinitionPersistence.fetchByPrimaryKey(
+					objectEntry.getObjectDefinitionId());
 
-		_assetEntryLocalService.updateEntry(
-			objectDefinition.getClassName(), objectEntry.getObjectEntryId(),
-			null, null, true, objectEntry.isApproved());
+			_assetEntryLocalService.updateEntry(
+				objectDefinition.getClassName(), objectEntry.getObjectEntryId(),
+				null, null, true, objectEntry.isApproved());
+		}
 
 		_reindex(objectEntry);
 
@@ -4170,6 +4152,47 @@ public class ObjectEntryLocalServiceImpl
 		return StringUtil.replace(
 			value, value.charAt(NumberUtil.getDecimalSeparatorIndex(value)),
 			'.');
+	}
+
+	private void _updateAsset(
+			long userId, ObjectEntry objectEntry, long[] assetCategoryIds,
+			String[] assetTagNames, long[] assetLinkEntryIds, Double priority,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionPersistence.findByPrimaryKey(
+				objectEntry.getObjectDefinitionId());
+
+		if (!objectDefinition.isEnableCategorization()) {
+			assetCategoryIds = null;
+			assetTagNames = null;
+		}
+
+		String title = StringPool.BLANK;
+
+		try {
+			title = objectEntry.getTitleValue();
+		}
+		catch (PortalException portalException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(portalException);
+			}
+		}
+
+		AssetEntry assetEntry = _assetEntryLocalService.updateEntry(
+			userId, objectEntry.getNonzeroGroupId(),
+			objectEntry.getCreateDate(), objectEntry.getModifiedDate(),
+			objectDefinition.getClassName(), objectEntry.getObjectEntryId(),
+			objectEntry.getUuid(), 0, assetCategoryIds, assetTagNames, true,
+			objectEntry.isApproved(), null, null, null, null,
+			ContentTypes.TEXT_PLAIN, title,
+			String.valueOf(objectEntry.getObjectEntryId()), null, null, null, 0,
+			0, priority, serviceContext);
+
+		_assetLinkLocalService.updateLinks(
+			userId, assetEntry.getEntryId(), assetLinkEntryIds,
+			AssetLinkConstants.TYPE_RELATED);
 	}
 
 	private void _updateTable(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -1619,12 +1619,21 @@ public class ObjectEntryLocalServiceImpl
 		}
 
 		if (serviceContext.isStrictAdd()) {
-			_updateAsset(
-				serviceContext.getUserId(), objectEntry,
-				serviceContext.getAssetCategoryIds(),
-				serviceContext.getAssetTagNames(),
-				serviceContext.getAssetLinkEntryIds(),
-				serviceContext.getAssetPriority(), serviceContext);
+			boolean indexingEnabled = serviceContext.isIndexingEnabled();
+
+			serviceContext.setIndexingEnabled(false);
+
+			try {
+				_updateAsset(
+					serviceContext.getUserId(), objectEntry,
+					serviceContext.getAssetCategoryIds(),
+					serviceContext.getAssetTagNames(),
+					serviceContext.getAssetLinkEntryIds(),
+					serviceContext.getAssetPriority(), serviceContext);
+			}
+			finally {
+				serviceContext.setIndexingEnabled(indexingEnabled);
+			}
 		}
 		else {
 			ObjectDefinition objectDefinition =

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -1590,8 +1590,16 @@ public class ObjectEntryLocalServiceImpl
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		ObjectEntry objectEntry = objectEntryPersistence.findByPrimaryKey(
-			objectEntryId);
+		return updateStatus(
+			userId, objectEntryPersistence.findByPrimaryKey(objectEntryId),
+			status, serviceContext);
+	}
+
+	@Override
+	public ObjectEntry updateStatus(
+			long userId, ObjectEntry objectEntry, int status,
+			ServiceContext serviceContext)
+		throws PortalException {
 
 		if (objectEntry.getStatus() == status) {
 			return objectEntry;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -311,6 +311,7 @@ public class ObjectEntryLocalServiceImpl
 		ServiceContext resourcePermissionServiceContext = new ServiceContext();
 
 		resourcePermissionServiceContext.setIndexingEnabled(false);
+		resourcePermissionServiceContext.setStrictAdd(true);
 
 		_resourcePermissionLocalService.addResourcePermissions(
 			objectEntry.getCompanyId(), objectEntry.getGroupId(),

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -283,9 +283,7 @@ public class ObjectEntryLocalServiceImpl
 
 		User user = _userLocalService.getUser(userId);
 
-		_fillDefaultValue(
-			_objectFieldLocalService.getObjectFields(objectDefinitionId),
-			values);
+		_fillDefaultValue(objectDefinitionId, values);
 
 		_contributeValues(groupId, objectDefinition, userId, values);
 
@@ -2082,12 +2080,20 @@ public class ObjectEntryLocalServiceImpl
 	}
 
 	private void _fillDefaultValue(
-		List<ObjectField> objectFields, Map<String, Serializable> values) {
+		long objectDefinitionId, Map<String, Serializable> values) {
 
-		for (ObjectField objectField : objectFields) {
+		for (ObjectField objectField :
+				_objectFieldPersistence.findByObjectDefinitionId(
+					objectDefinitionId)) {
+
 			if (values.get(objectField.getName()) != null) {
 				continue;
 			}
+
+			objectField.setObjectFieldSettings(
+				_objectFieldSettingLocalService.
+					getObjectFieldObjectFieldSettings(
+						objectField.getObjectFieldId()));
 
 			String value = ObjectFieldSettingUtil.getDefaultValueAsString(
 				_ddmExpressionFactory, objectField,

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -293,14 +293,19 @@ public class ObjectEntryLocalServiceImpl
 			null, user.isGuestUser(), groupId, objectDefinition, objectEntryId,
 			serviceContext, userId, values);
 
+		Map<String, Serializable> insertedValues = new HashMap<>();
+
 		_insertIntoLocalizationTable(
-			objectDefinition, objectEntryId, values, workflowAction);
-		_insertIntoTable(
+			objectDefinition, objectEntryId, values, workflowAction,
+			insertedValues);
+
+		boolean dynamicObjectDefinitionStaicValues = _insertIntoTable(
 			_getDynamicObjectDefinitionTable(objectDefinitionId), objectEntryId,
-			values, workflowAction);
-		_insertIntoTable(
+			values, workflowAction, insertedValues);
+
+		boolean extensionDynamicObjectDefinitionStaicValues = _insertIntoTable(
 			_getExtensionDynamicObjectDefinitionTable(objectDefinitionId),
-			objectEntryId, values, workflowAction);
+			objectEntryId, values, workflowAction, insertedValues);
 
 		ObjectEntry objectEntry = objectEntryPersistence.create(objectEntryId);
 
@@ -317,6 +322,21 @@ public class ObjectEntryLocalServiceImpl
 		objectEntry.setStatus(WorkflowConstants.STATUS_DRAFT);
 		objectEntry.setStatusByUserId(user.getUserId());
 		objectEntry.setStatusDate(serviceContext.getModifiedDate(null));
+
+		if (dynamicObjectDefinitionStaicValues &&
+			extensionDynamicObjectDefinitionStaicValues) {
+
+			_addLocalizedObjectFieldValues(
+				DynamicObjectDefinitionLocalizationTableFactory.create(
+					_objectDefinitionPersistence.findByPrimaryKey(
+						objectEntry.getObjectDefinitionId()),
+					_objectFieldLocalService),
+				objectEntry.getObjectEntryId(), insertedValues);
+			_addObjectRelationshipERCFieldValue(
+				objectEntry.getObjectDefinitionId(), insertedValues);
+
+			objectEntry.setValues(insertedValues);
+		}
 
 		ServiceContext resourcePermissionServiceContext = new ServiceContext();
 
@@ -1413,7 +1433,7 @@ public class ObjectEntryLocalServiceImpl
 		else {
 			_insertIntoTable(
 				dynamicObjectDefinitionTable, primaryKey, values,
-				WorkflowConstants.ACTION_PUBLISH);
+				WorkflowConstants.ACTION_PUBLISH, new HashMap<>());
 		}
 	}
 
@@ -1523,7 +1543,8 @@ public class ObjectEntryLocalServiceImpl
 
 		_deleteFromLocalizationTable(objectDefinition, objectEntryId);
 		_insertIntoLocalizationTable(
-			objectDefinition, objectEntryId, values, workflowAction);
+			objectDefinition, objectEntryId, values, workflowAction,
+			new HashMap<>());
 		_updateTable(
 			_getDynamicObjectDefinitionTable(
 				objectEntry.getObjectDefinitionId()),
@@ -3463,7 +3484,8 @@ public class ObjectEntryLocalServiceImpl
 
 	private void _insertIntoLocalizationTable(
 			ObjectDefinition objectDefinition, long objectEntryId,
-			Map<String, Serializable> values, int workflowAction)
+			Map<String, Serializable> values, int workflowAction,
+			Map<String, Serializable> insertedValues)
 		throws PortalException {
 
 		DynamicObjectDefinitionLocalizationTable
@@ -3489,6 +3511,8 @@ public class ObjectEntryLocalServiceImpl
 			return;
 		}
 
+		List<String> columnNames = new ArrayList<>();
+
 		StringBundler sb = new StringBundler();
 
 		sb.append("insert into ");
@@ -3497,6 +3521,10 @@ public class ObjectEntryLocalServiceImpl
 		sb.append(
 			dynamicObjectDefinitionLocalizationTable.getForeignKeyColumnName());
 		sb.append(", languageId");
+
+		columnNames.add(
+			dynamicObjectDefinitionLocalizationTable.getForeignKeyColumnName());
+		columnNames.add("languageId");
 
 		int count = 2;
 
@@ -3511,6 +3539,8 @@ public class ObjectEntryLocalServiceImpl
 
 			sb.append(", ");
 			sb.append(objectField.getDBColumnName());
+
+			columnNames.add(objectField.getDBColumnName());
 
 			count++;
 		}
@@ -3541,9 +3571,11 @@ public class ObjectEntryLocalServiceImpl
 				int index = 1;
 
 				_setColumn(
-					preparedStatement, index++, Types.BIGINT, objectEntryId);
+					preparedStatement, index++, Types.BIGINT, objectEntryId,
+					columnNames, insertedValues);
 				_setColumn(
-					preparedStatement, index++, Types.VARCHAR, languageId);
+					preparedStatement, index++, Types.VARCHAR, languageId,
+					columnNames, insertedValues);
 
 				for (ObjectField objectField : objectFields) {
 					Column<?, ?> column =
@@ -3555,7 +3587,8 @@ public class ObjectEntryLocalServiceImpl
 						_getLocalizedValue(
 							languageId,
 							(Map<String, String>)values.get(
-								objectField.getI18nObjectFieldName())));
+								objectField.getI18nObjectFieldName())),
+						columnNames, insertedValues);
 				}
 
 				preparedStatement.addBatch();
@@ -3571,10 +3604,10 @@ public class ObjectEntryLocalServiceImpl
 		}
 	}
 
-	private void _insertIntoTable(
+	private boolean _insertIntoTable(
 			DynamicObjectDefinitionTable dynamicObjectDefinitionTable,
 			long objectEntryId, Map<String, Serializable> values,
-			int workflowAction)
+			int workflowAction, Map<String, Serializable> insertedValues)
 		throws PortalException {
 
 		StringBundler sb = new StringBundler();
@@ -3590,10 +3623,24 @@ public class ObjectEntryLocalServiceImpl
 
 		int count = 1;
 
+		List<String> columnNames = new ArrayList<>();
+
+		columnNames.add(primaryKeyColumn.getName());
+
 		List<ObjectField> objectFields =
 			dynamicObjectDefinitionTable.getObjectFields();
 
+		boolean staticValues = true;
+
 		for (ObjectField objectField : objectFields) {
+			if (objectField.compareBusinessType(
+					ObjectFieldConstants.BUSINESS_TYPE_AGGREGATION) ||
+				objectField.compareBusinessType(
+					ObjectFieldConstants.BUSINESS_TYPE_FORMULA)) {
+
+				staticValues = false;
+			}
+
 			if (!objectField.hasInsertValues() || objectField.isLocalized()) {
 				continue;
 			}
@@ -3609,6 +3656,9 @@ public class ObjectEntryLocalServiceImpl
 				sb.append(objectField.getDBColumnName());
 				sb.append(", ");
 				sb.append(objectField.getSortableDBColumnName());
+
+				columnNames.add(objectField.getDBColumnName());
+				columnNames.add(objectField.getSortableDBColumnName());
 
 				count += 2;
 
@@ -3645,6 +3695,8 @@ public class ObjectEntryLocalServiceImpl
 			sb.append(", ");
 			sb.append(objectField.getDBColumnName());
 
+			columnNames.add(objectField.getDBColumnName());
+
 			count++;
 		}
 
@@ -3670,7 +3722,9 @@ public class ObjectEntryLocalServiceImpl
 
 			int index = 1;
 
-			_setColumn(preparedStatement, index++, Types.BIGINT, objectEntryId);
+			_setColumn(
+				preparedStatement, index++, Types.BIGINT, objectEntryId,
+				columnNames, insertedValues);
 
 			for (ObjectField objectField : objectFields) {
 				if (!objectField.hasInsertValues() ||
@@ -3701,14 +3755,16 @@ public class ObjectEntryLocalServiceImpl
 							values.get(objectField.getName())));
 
 					_setColumn(
-						preparedStatement, index++, column.getSQLType(), value);
+						preparedStatement, index++, column.getSQLType(), value,
+						columnNames, insertedValues);
 
 					column = dynamicObjectDefinitionTable.getColumn(
 						objectField.getSortableDBColumnName());
 
 					_setColumn(
 						preparedStatement, index++, column.getSQLType(),
-						_getAutoIncrementSortableValue(prefix, suffix, value));
+						_getAutoIncrementSortableValue(prefix, suffix, value),
+						columnNames, insertedValues);
 
 					continue;
 				}
@@ -3719,7 +3775,7 @@ public class ObjectEntryLocalServiceImpl
 
 				_setColumn(
 					dynamicObjectDefinitionTable, index++, objectField,
-					preparedStatement, values);
+					preparedStatement, values, columnNames, insertedValues);
 			}
 
 			preparedStatement.executeUpdate();
@@ -3730,6 +3786,8 @@ public class ObjectEntryLocalServiceImpl
 		catch (Exception exception) {
 			throw new SystemException(exception);
 		}
+
+		return staticValues;
 	}
 
 	private List<Object[]> _list(
@@ -3760,6 +3818,19 @@ public class ObjectEntryLocalServiceImpl
 		}
 
 		return results;
+	}
+
+	private void _putInsertedValue(
+		Map<String, Serializable> insertedValues, String key,
+		Serializable serializable) {
+
+		if (!key.isEmpty() &&
+			(key.charAt(key.length() - 1) == CharPool.UNDERLINE)) {
+
+			key = key.substring(0, key.length() - 1);
+		}
+
+		insertedValues.put(key, serializable);
 	}
 
 	private void _putObjectFilterParser(
@@ -3932,7 +4003,8 @@ public class ObjectEntryLocalServiceImpl
 			DynamicObjectDefinitionTable dynamicObjectDefinitionTable,
 			int index, ObjectField objectField,
 			PreparedStatement preparedStatement,
-			Map<String, Serializable> values)
+			Map<String, Serializable> values, List<String> columnNames,
+			Map<String, Serializable> insertedValues)
 		throws Exception {
 
 		Column<?, ?> column = dynamicObjectDefinitionTable.getColumn(
@@ -3945,7 +4017,8 @@ public class ObjectEntryLocalServiceImpl
 
 			_setColumn(
 				preparedStatement, index, column.getSQLType(),
-				_encryptor.encrypt(_getKey(), (String)value));
+				_encryptor.encrypt(_getKey(), (String)value), columnNames,
+				insertedValues);
 		}
 		else if (objectField.compareBusinessType(
 					ObjectFieldConstants.BUSINESS_TYPE_MULTISELECT_PICKLIST)) {
@@ -3963,10 +4036,13 @@ public class ObjectEntryLocalServiceImpl
 			}
 
 			_setColumn(
-				preparedStatement, index, column.getSQLType(), valueString);
+				preparedStatement, index, column.getSQLType(), valueString,
+				columnNames, insertedValues);
 		}
 		else {
-			_setColumn(preparedStatement, index, column.getSQLType(), value);
+			_setColumn(
+				preparedStatement, index, column.getSQLType(), value,
+				columnNames, insertedValues);
 		}
 	}
 
@@ -3975,11 +4051,17 @@ public class ObjectEntryLocalServiceImpl
 	 */
 	private void _setColumn(
 			PreparedStatement preparedStatement, int index, int sqlType,
-			Object value)
+			Object value, List<String> columnNames,
+			Map<String, Serializable> insertedValues)
 		throws Exception {
 
 		if (sqlType == Types.BIGINT) {
-			preparedStatement.setLong(index, GetterUtil.getLong(value));
+			Long longValue = GetterUtil.getLong(value);
+
+			preparedStatement.setLong(index, longValue);
+
+			_putInsertedValue(
+				insertedValues, columnNames.get(index - 1), longValue);
 		}
 		else if (sqlType == Types.BLOB) {
 			if (PostgreSQLJDBCUtil.isPGStatement(preparedStatement)) {
@@ -3989,9 +4071,17 @@ public class ObjectEntryLocalServiceImpl
 			else {
 				preparedStatement.setBytes(index, (byte[])value);
 			}
+
+			_putInsertedValue(
+				insertedValues, columnNames.get(index - 1), (byte[])value);
 		}
 		else if (sqlType == Types.BOOLEAN) {
-			preparedStatement.setBoolean(index, GetterUtil.getBoolean(value));
+			Boolean booleanValue = GetterUtil.getBoolean(value);
+
+			preparedStatement.setBoolean(index, booleanValue);
+
+			_putInsertedValue(
+				insertedValues, columnNames.get(index - 1), booleanValue);
 		}
 		else if (sqlType == Types.CLOB) {
 			String valueString = String.valueOf(value);
@@ -4005,21 +4095,28 @@ public class ObjectEntryLocalServiceImpl
 				preparedStatement.setClob(
 					index, new StringReader(valueString), valueString.length());
 			}
+
+			_putInsertedValue(
+				insertedValues, columnNames.get(index - 1), valueString);
 		}
 		else if ((sqlType == Types.DATE) || (sqlType == Types.TIMESTAMP)) {
 			String valueString = GetterUtil.getString(value);
 
+			Timestamp timestampValue = null;
+
 			if (value instanceof Date) {
 				Date date = (Date)value;
 
-				preparedStatement.setTimestamp(
-					index, new Timestamp(date.getTime()));
+				timestampValue = new Timestamp(date.getTime());
+
+				preparedStatement.setTimestamp(index, timestampValue);
 			}
 			else if (value instanceof LocalDateTime) {
 				LocalDateTime localDateTime = (LocalDateTime)value;
 
-				preparedStatement.setTimestamp(
-					index, Timestamp.valueOf(localDateTime));
+				timestampValue = Timestamp.valueOf(localDateTime);
+
+				preparedStatement.setTimestamp(index, timestampValue);
 			}
 			else if (valueString.isEmpty()) {
 				preparedStatement.setTimestamp(index, null);
@@ -4028,30 +4125,52 @@ public class ObjectEntryLocalServiceImpl
 				Date date = DateUtil.parseDate(
 					"yyyy-MM-dd", valueString, LocaleUtil.getSiteDefault());
 
-				preparedStatement.setTimestamp(
-					index, new Timestamp(date.getTime()));
+				timestampValue = new Timestamp(date.getTime());
+
+				preparedStatement.setTimestamp(index, timestampValue);
 			}
+
+			_putInsertedValue(
+				insertedValues, columnNames.get(index - 1), timestampValue);
 		}
 		else if (sqlType == Types.DECIMAL) {
 			if (Validator.isNull(String.valueOf(value))) {
 				value = BigDecimal.ZERO;
 			}
 
-			preparedStatement.setBigDecimal(
-				index,
-				new BigDecimal(_toPeriodSeparator(String.valueOf(value))));
+			BigDecimal bigDecimal = new BigDecimal(
+				_toPeriodSeparator(String.valueOf(value)));
+
+			preparedStatement.setBigDecimal(index, bigDecimal);
+
+			_putInsertedValue(
+				insertedValues, columnNames.get(index - 1),
+				BigDecimalUtil.stripTrailingZeros(bigDecimal));
 		}
 		else if (sqlType == Types.DOUBLE) {
-			preparedStatement.setDouble(
-				index,
-				GetterUtil.getDouble(
-					_toPeriodSeparator(String.valueOf(value))));
+			Double doubleValue = GetterUtil.getDouble(
+				_toPeriodSeparator(String.valueOf(value)));
+
+			preparedStatement.setDouble(index, doubleValue);
+
+			_putInsertedValue(
+				insertedValues, columnNames.get(index - 1), doubleValue);
 		}
 		else if (sqlType == Types.INTEGER) {
-			preparedStatement.setInt(index, GetterUtil.getInteger(value));
+			Integer integerValue = GetterUtil.getInteger(value);
+
+			preparedStatement.setInt(index, integerValue);
+
+			_putInsertedValue(
+				insertedValues, columnNames.get(index - 1), integerValue);
 		}
 		else if (sqlType == Types.VARCHAR) {
-			preparedStatement.setString(index, String.valueOf(value));
+			String stringValue = String.valueOf(value);
+
+			preparedStatement.setString(index, stringValue);
+
+			_putInsertedValue(
+				insertedValues, columnNames.get(index - 1), stringValue);
 		}
 		else {
 			throw new IllegalArgumentException(
@@ -4236,6 +4355,8 @@ public class ObjectEntryLocalServiceImpl
 		sb.append(dynamicObjectDefinitionTable.getName());
 		sb.append(" set ");
 
+		List<String> columnNames = new ArrayList<>();
+
 		int count = 0;
 		ObjectEntry objectEntry = fetchObjectEntry(objectEntryId);
 
@@ -4285,6 +4406,8 @@ public class ObjectEntryLocalServiceImpl
 			sb.append(objectField.getDBColumnName());
 			sb.append(" = ?");
 
+			columnNames.add(objectField.getDBColumnName());
+
 			count++;
 		}
 
@@ -4305,6 +4428,8 @@ public class ObjectEntryLocalServiceImpl
 
 		sb.append(primaryKeyColumn.getName());
 
+		columnNames.add(primaryKeyColumn.getName());
+
 		sb.append(" = ?");
 
 		String sql = sb.toString();
@@ -4315,6 +4440,8 @@ public class ObjectEntryLocalServiceImpl
 
 		Connection connection = _currentConnection.getConnection(
 			objectEntryPersistence.getDataSource());
+
+		Map<String, Serializable> insertedValues = new HashMap<>();
 
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				sql)) {
@@ -4331,10 +4458,12 @@ public class ObjectEntryLocalServiceImpl
 
 				_setColumn(
 					dynamicObjectDefinitionTable, index++, objectField,
-					preparedStatement, values);
+					preparedStatement, values, columnNames, insertedValues);
 			}
 
-			_setColumn(preparedStatement, index++, Types.BIGINT, objectEntryId);
+			_setColumn(
+				preparedStatement, index++, Types.BIGINT, objectEntryId,
+				columnNames, insertedValues);
 
 			preparedStatement.executeUpdate();
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -164,6 +164,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
+import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.BigDecimalUtil;
@@ -258,6 +259,15 @@ public class ObjectEntryLocalServiceImpl
 			long userId, long groupId, long objectDefinitionId,
 			Map<String, Serializable> values, ServiceContext serviceContext)
 		throws PortalException {
+
+		serviceContext.setStrictAdd(true);
+
+		TransactionCommitCallbackUtil.registerCallback(
+			() -> {
+				serviceContext.setStrictAdd(false);
+
+				return null;
+			});
 
 		ObjectDefinition objectDefinition =
 			_objectDefinitionPersistence.findByPrimaryKey(objectDefinitionId);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -331,15 +331,15 @@ public class ObjectEntryLocalServiceImpl
 			String.valueOf(objectEntry.getPrimaryKey()), false,
 			resourcePermissionServiceContext);
 
-		try {
-			if (workflowAction == WorkflowConstants.ACTION_SAVE_DRAFT) {
+		if (workflowAction == WorkflowConstants.ACTION_SAVE_DRAFT) {
+			try {
 				ObjectEntryThreadLocal.setSkipObjectValidationRules(true);
-			}
 
-			objectEntry = objectEntryPersistence.update(objectEntry);
-		}
-		finally {
-			ObjectEntryThreadLocal.setSkipObjectValidationRules(false);
+				objectEntry = objectEntryPersistence.update(objectEntry);
+			}
+			finally {
+				ObjectEntryThreadLocal.setSkipObjectValidationRules(false);
+			}
 		}
 
 		if (workflowAction != WorkflowConstants.ACTION_PUBLISH) {
@@ -351,7 +351,7 @@ public class ObjectEntryLocalServiceImpl
 				serviceContext.getAssetPriority(), serviceContext);
 		}
 
-		_startWorkflowInstance(userId, objectEntry, serviceContext);
+		_startWorkflowInstance(userId, objectEntry, serviceContext, false);
 
 		boolean clearObjectEntryIdsMap =
 			ObjectActionThreadLocal.isClearObjectEntryIdsMap();
@@ -1569,7 +1569,7 @@ public class ObjectEntryLocalServiceImpl
 			serviceContext.getAssetLinkEntryIds(),
 			serviceContext.getAssetPriority(), serviceContext);
 
-		_startWorkflowInstance(userId, objectEntry, serviceContext);
+		_startWorkflowInstance(userId, objectEntry, serviceContext, true);
 
 		_deleteFileEntries(
 			objectEntry.getValues(), objectEntry.getObjectDefinitionId(),
@@ -4140,7 +4140,8 @@ public class ObjectEntryLocalServiceImpl
 	}
 
 	private void _startWorkflowInstance(
-			long userId, ObjectEntry objectEntry, ServiceContext serviceContext)
+			long userId, ObjectEntry objectEntry, ServiceContext serviceContext,
+			boolean skipModelListener)
 		throws PortalException {
 
 		ObjectDefinition objectDefinition =
@@ -4150,7 +4151,7 @@ public class ObjectEntryLocalServiceImpl
 		boolean workflowEnabled = WorkflowThreadLocal.isEnabled();
 
 		try {
-			_skipModelListeners.set(true);
+			_skipModelListeners.set(skipModelListener);
 
 			WorkflowThreadLocal.setEnabled(true);
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -158,6 +158,7 @@ import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -307,10 +308,15 @@ public class ObjectEntryLocalServiceImpl
 		objectEntry.setStatusByUserId(user.getUserId());
 		objectEntry.setStatusDate(serviceContext.getModifiedDate(null));
 
-		_resourceLocalService.addResources(
+		ServiceContext resourcePermissionServiceContext = new ServiceContext();
+
+		resourcePermissionServiceContext.setIndexingEnabled(false);
+
+		_resourcePermissionLocalService.addResourcePermissions(
 			objectEntry.getCompanyId(), objectEntry.getGroupId(),
 			objectEntry.getUserId(), objectDefinition.getClassName(),
-			objectEntry.getPrimaryKey(), false, false, false);
+			String.valueOf(objectEntry.getPrimaryKey()), false,
+			resourcePermissionServiceContext);
 
 		try {
 			if (workflowAction == WorkflowConstants.ACTION_SAVE_DRAFT) {
@@ -5062,6 +5068,9 @@ public class ObjectEntryLocalServiceImpl
 
 	@Reference
 	private ResourceLocalService _resourceLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
 
 	@Reference
 	private RoleLocalService _roleLocalService;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -340,9 +340,7 @@ public class ObjectEntryLocalServiceImpl
 			finally {
 				ObjectEntryThreadLocal.setSkipObjectValidationRules(false);
 			}
-		}
 
-		if (workflowAction != WorkflowConstants.ACTION_PUBLISH) {
 			_updateAsset(
 				serviceContext.getUserId(), objectEntry,
 				serviceContext.getAssetCategoryIds(),

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -332,8 +332,6 @@ public class ObjectEntryLocalServiceImpl
 
 		_startWorkflowInstance(userId, objectEntry, serviceContext);
 
-		_reindex(objectEntry);
-
 		boolean clearObjectEntryIdsMap =
 			ObjectActionThreadLocal.isClearObjectEntryIdsMap();
 
@@ -1585,8 +1583,6 @@ public class ObjectEntryLocalServiceImpl
 		_deleteFileEntries(
 			objectEntry.getValues(), objectEntry.getObjectDefinitionId(),
 			transientValues);
-
-		_reindex(objectEntry);
 
 		_executeObjectActions(
 			objectEntry.getCompanyId(),

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldSettingLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldSettingLocalServiceImpl.java
@@ -10,9 +10,9 @@ import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectFieldSetting;
 import com.liferay.object.model.impl.ObjectFieldSettingImpl;
-import com.liferay.object.service.ObjectFilterLocalService;
 import com.liferay.object.service.base.ObjectFieldSettingLocalServiceBaseImpl;
 import com.liferay.object.service.persistence.ObjectFieldPersistence;
+import com.liferay.object.service.persistence.ObjectFilterPersistence;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
@@ -69,7 +69,7 @@ public class ObjectFieldSettingLocalServiceImpl
 		if (objectField.compareBusinessType(
 				ObjectFieldConstants.BUSINESS_TYPE_AGGREGATION)) {
 
-			_objectFilterLocalService.deleteObjectFieldObjectFilter(
+			_objectFilterPersistence.removeByObjectFieldId(
 				objectField.getObjectFieldId());
 		}
 	}
@@ -105,8 +105,7 @@ public class ObjectFieldSettingLocalServiceImpl
 
 		objectFieldSetting.setName(ObjectFieldSettingConstants.NAME_FILTERS);
 		objectFieldSetting.setObjectFilters(
-			_objectFilterLocalService.getObjectFieldObjectFilter(
-				objectFieldId));
+			_objectFilterPersistence.findByObjectFieldId(objectFieldId));
 
 		objectFieldSettings = new ArrayList<>(objectFieldSettings);
 
@@ -133,7 +132,7 @@ public class ObjectFieldSettingLocalServiceImpl
 	private ObjectFieldPersistence _objectFieldPersistence;
 
 	@Reference
-	private ObjectFilterLocalService _objectFilterLocalService;
+	private ObjectFilterPersistence _objectFilterPersistence;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/display/context/ObjectEntryDisplayContextImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/display/context/ObjectEntryDisplayContextImpl.java
@@ -1341,7 +1341,7 @@ public class ObjectEntryDisplayContextImpl
 				existingValues.put(
 					objectField1.getName(),
 					ObjectFieldSettingUtil.getDefaultValueAsString(
-						null, objectField.getObjectFieldId(),
+						null, objectField,
 						ObjectFieldSettingLocalServiceUtil.getService(), null));
 			}
 		}

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/BufferedIndexerInvocationHandler.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/BufferedIndexerInvocationHandler.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.ClassedModel;
 import com.liferay.portal.kernel.search.Bufferable;
 import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.StrictObjectReindexThreadLocal;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
 import com.liferay.portal.kernel.util.MethodKey;
 import com.liferay.portal.search.configuration.IndexerRegistryConfiguration;
@@ -87,7 +88,16 @@ public class BufferedIndexerInvocationHandler implements InvocationHandler {
 		}
 
 		if (args[0] instanceof ClassedModel) {
-			if (Objects.equals(method.getName(), "reindex")) {
+			if (StrictObjectReindexThreadLocal.isStrictObjectReindex()) {
+				MethodKey methodKey = new MethodKey(
+					Indexer.class, method.getName(), Object.class);
+
+				IndexerRequest indexerRequest = new IndexerRequest(
+					methodKey.getMethod(), (ClassedModel)args[0], _indexer);
+
+				_bufferRequest(indexerRequest, indexerRequestBuffer);
+			}
+			else if (Objects.equals(method.getName(), "reindex")) {
 				MethodKey methodKey = new MethodKey(
 					Indexer.class, method.getName(), String.class, Long.TYPE);
 

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/BufferedIndexerInvocationHandler.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/BufferedIndexerInvocationHandler.java
@@ -86,25 +86,25 @@ public class BufferedIndexerInvocationHandler implements InvocationHandler {
 			return method.invoke(_indexer, args);
 		}
 
-		if ((args[0] instanceof ClassedModel) &&
-			Objects.equals(method.getName(), "reindex")) {
+		if (args[0] instanceof ClassedModel) {
+			if (Objects.equals(method.getName(), "reindex")) {
+				MethodKey methodKey = new MethodKey(
+					Indexer.class, method.getName(), String.class, Long.TYPE);
 
-			MethodKey methodKey = new MethodKey(
-				Indexer.class, method.getName(), String.class, Long.TYPE);
+				ClassedModel classedModel = (ClassedModel)args[0];
 
-			ClassedModel classedModel = (ClassedModel)args[0];
+				Long classPK = (Long)classedModel.getPrimaryKeyObj();
 
-			Long classPK = (Long)classedModel.getPrimaryKeyObj();
+				bufferRequest(
+					methodKey, classedModel.getModelClassName(), classPK,
+					indexerRequestBuffer);
+			}
+			else {
+				MethodKey methodKey = new MethodKey(
+					Indexer.class, method.getName(), Object.class);
 
-			bufferRequest(
-				methodKey, classedModel.getModelClassName(), classPK,
-				indexerRequestBuffer);
-		}
-		else if (args[0] instanceof ClassedModel) {
-			MethodKey methodKey = new MethodKey(
-				Indexer.class, method.getName(), Object.class);
-
-			bufferRequest(methodKey, args[0], indexerRequestBuffer);
+				bufferRequest(methodKey, args[0], indexerRequestBuffer);
+			}
 		}
 		else if (args.length == 2) {
 			String className = (String)args[0];

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/util/IndexerRequestBufferExecutorUtil.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/util/IndexerRequestBufferExecutorUtil.java
@@ -10,6 +10,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.search.IndexWriterHelper;
+import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.search.internal.buffer.BufferOverflowThreadLocal;
 import com.liferay.portal.search.internal.buffer.IndexerRequest;
@@ -76,7 +77,9 @@ public class IndexerRequestBufferExecutorUtil {
 			indexerRequestBuffer.remove(indexerRequest);
 		}
 
-		if (!BufferOverflowThreadLocal.isOverflowMode()) {
+		if (!BufferOverflowThreadLocal.isOverflowMode() &&
+			!SearchContext.isBatchMode()) {
+
 			IndexWriterHelper indexWriterHelper =
 				_indexWriterHelperSnapshot.get();
 

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/util/IndexerRequestBufferExecutorUtil.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/util/IndexerRequestBufferExecutorUtil.java
@@ -5,19 +5,24 @@
 
 package com.liferay.portal.search.internal.buffer.util;
 
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.concurrent.SystemExecutorServiceUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.search.IndexWriterHelper;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.search.internal.buffer.BufferOverflowThreadLocal;
 import com.liferay.portal.search.internal.buffer.IndexerRequest;
 import com.liferay.portal.search.internal.buffer.IndexerRequestBuffer;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.concurrent.ExecutorService;
 
 /**
  * @author Michael C. Han
@@ -30,6 +35,44 @@ public class IndexerRequestBufferExecutorUtil {
 
 	public static void execute(
 		IndexerRequestBuffer indexerRequestBuffer, int numRequests) {
+
+		if (SearchContext.isBatchMode()) {
+			ServiceContext serviceContext =
+				ServiceContextThreadLocal.getServiceContext();
+
+			if (serviceContext != null) {
+				serviceContext = (ServiceContext)serviceContext.clone();
+			}
+
+			ServiceContext finalServiceContext = serviceContext;
+
+			ExecutorService executorService =
+				SystemExecutorServiceUtil.getExecutorService();
+
+			SearchContext.registerBatchModeSyncFuture(
+				executorService.submit(
+					() -> {
+						ServiceContextThreadLocal.pushServiceContext(
+							finalServiceContext);
+
+						try (SafeCloseable safeCloseable =
+								SearchContext.openBatchMode(false)) {
+
+							_execute(indexerRequestBuffer, numRequests, false);
+						}
+						finally {
+							ServiceContextThreadLocal.popServiceContext();
+						}
+					}));
+		}
+		else {
+			_execute(indexerRequestBuffer, numRequests, true);
+		}
+	}
+
+	private static void _execute(
+		IndexerRequestBuffer indexerRequestBuffer, int numRequests,
+		boolean commit) {
 
 		Collection<IndexerRequest> completedIndexerRequests = new ArrayList<>();
 
@@ -77,9 +120,7 @@ public class IndexerRequestBufferExecutorUtil {
 			indexerRequestBuffer.remove(indexerRequest);
 		}
 
-		if (!BufferOverflowThreadLocal.isOverflowMode() &&
-			!SearchContext.isBatchMode()) {
-
+		if (!BufferOverflowThreadLocal.isOverflowMode() && commit) {
 			IndexWriterHelper indexWriterHelper =
 				_indexWriterHelperSnapshot.get();
 

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/index/UpdateDocumentIndexWriterImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/index/UpdateDocumentIndexWriterImpl.java
@@ -52,9 +52,6 @@ public class UpdateDocumentIndexWriterImpl
 
 		IndexWriter indexWriter = searchEngine.getIndexWriter();
 
-		searchPermissionDocumentContributor.addPermissionFields(
-			companyId, document);
-
 		SearchContext searchContext = new SearchContext();
 
 		searchContext.setCompanyId(companyId);

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/spi/model/index/contributor/GroupedModelDocumentContributor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/spi/model/index/contributor/GroupedModelDocumentContributor.java
@@ -6,9 +6,6 @@
 package com.liferay.portal.search.internal.spi.model.index.contributor;
 
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupedModel;
@@ -58,48 +55,25 @@ public class GroupedModelDocumentContributor
 	protected GroupLocalService groupLocalService;
 
 	private String _getGroupExternalReferenceCode(long siteGroupId) {
-		String groupExternalReferenceCode = StringPool.BLANK;
+		Group group = groupLocalService.fetchGroup(siteGroupId);
 
-		try {
-			Group group = groupLocalService.getGroup(siteGroupId);
-
-			groupExternalReferenceCode = group.getExternalReferenceCode();
-		}
-		catch (PortalException portalException) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(
-					"Unable to get group " + siteGroupId +
-						" while indexing document",
-					portalException);
-			}
+		if (group == null) {
+			return StringPool.BLANK;
 		}
 
-		return groupExternalReferenceCode;
+		return group.getExternalReferenceCode();
 	}
 
 	private String _getScopeGroupExternalReferenceCode(
 		GroupedModel groupedModel) {
 
-		String scopeGroupExternalReferenceCode = StringPool.BLANK;
+		Group group = groupLocalService.fetchGroup(groupedModel.getGroupId());
 
-		try {
-			Group group = groupLocalService.getGroup(groupedModel.getGroupId());
-
-			scopeGroupExternalReferenceCode = group.getExternalReferenceCode();
-		}
-		catch (PortalException portalException) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(
-					"Unable to get group " + groupedModel.getGroupId() +
-						" while indexing document",
-					portalException);
-			}
+		if (group == null) {
+			return StringPool.BLANK;
 		}
 
-		return scopeGroupExternalReferenceCode;
+		return group.getExternalReferenceCode();
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		GroupedModelDocumentContributor.class);
 
 }

--- a/modules/apps/sharing/sharing-search/src/main/java/com/liferay/sharing/search/internal/permission/SharingEntrySearchPermissionDocumentContributor.java
+++ b/modules/apps/sharing/sharing-search/src/main/java/com/liferay/sharing/search/internal/permission/SharingEntrySearchPermissionDocumentContributor.java
@@ -6,6 +6,8 @@
 package com.liferay.sharing.search.internal.permission;
 
 import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.search.spi.model.permission.contributor.SearchPermissionFieldContributor;
 import com.liferay.sharing.model.SharingEntry;
@@ -36,6 +38,13 @@ public class SharingEntrySearchPermissionDocumentContributor
 
 	@Override
 	public void contribute(Document document, String className, long classPK) {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if ((serviceContext != null) && serviceContext.isStrictAdd()) {
+			return;
+		}
+
 		List<SharingEntry> sharingEntries =
 			_sharingEntryLocalService.getSharingEntries(
 				_portal.getClassNameId(className), classPK);

--- a/modules/util/portal-tools-db-upgrade-client/properties/portal-upgrade-database.properties
+++ b/modules/util/portal-tools-db-upgrade-client/properties/portal-upgrade-database.properties
@@ -12,7 +12,7 @@
 ##
 
     #jdbc.default.driverClassName=org.mariadb.jdbc.Driver
-    #jdbc.default.url=jdbc:mariadb://localhost/lportal?useUnicode=true&characterEncoding=UTF-8&rewriteBatchedStatements=true&useFastDateParsing=false
+    #jdbc.default.url=jdbc:mariadb://localhost/lportal?useUnicode=true&characterEncoding=UTF-8&rewriteBatchedStatements=true&useFastDateParsing=false&cachePrepStmts=true&prepStmtCacheSize=1000&prepStmtCacheSqlLimit=2048
     #jdbc.default.username=
     #jdbc.default.password=
 
@@ -21,7 +21,7 @@
 ##
 
     #jdbc.default.driverClassName=com.mysql.cj.jdbc.Driver
-    #jdbc.default.url=jdbc:mysql://localhost/lportal?characterEncoding=UTF-8&dontTrackOpenResources=true&holdResultsOpenOverStatementClose=true&rewriteBatchedStatements=true&serverTimezone=GMT&useFastDateParsing=false&useUnicode=true
+    #jdbc.default.url=jdbc:mysql://localhost/lportal?characterEncoding=UTF-8&dontTrackOpenResources=true&holdResultsOpenOverStatementClose=true&rewriteBatchedStatements=true&serverTimezone=GMT&useFastDateParsing=false&useUnicode=true&cachePrepStmts=true&prepStmtCacheSize=1000&prepStmtCacheSqlLimit=2048
     #jdbc.default.username=
     #jdbc.default.password=
 

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -7,11 +7,14 @@ package com.liferay.portal.service.impl;
 
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.query.DSLQuery;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.bean.BeanPropertiesUtil;
 import com.liferay.portal.kernel.bean.BeanReference;
+import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
+import com.liferay.portal.kernel.dao.orm.FinderPath;
 import com.liferay.portal.kernel.dao.orm.QueryPos;
 import com.liferay.portal.kernel.dao.orm.SQLQuery;
 import com.liferay.portal.kernel.dao.orm.Session;
@@ -61,8 +64,11 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.model.impl.ResourceImpl;
 import com.liferay.portal.security.permission.PermissionCacheUtil;
 import com.liferay.portal.service.base.ResourcePermissionLocalServiceBaseImpl;
+import com.liferay.portal.service.persistence.impl.ResourcePermissionPersistenceImpl;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.util.dao.orm.CustomSQLUtil;
+
+import java.lang.reflect.Field;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -516,6 +522,23 @@ public class ResourcePermissionLocalServiceImpl
 			resourcePermissionPersistence.closeSession(session);
 
 			resourcePermissionPersistence.clearCache();
+		}
+	}
+
+	@Override
+	public void afterPropertiesSet() {
+		super.afterPropertiesSet();
+
+		try {
+			Field field = ReflectionUtil.getDeclaredField(
+				ResourcePermissionPersistenceImpl.class,
+				"_finderPathWithoutPaginationFindByC_N_S_P");
+
+			_finderPathWithoutPaginationFindByC_N_S_P = (FinderPath)field.get(
+				resourcePermissionPersistence);
+		}
+		catch (Exception exception) {
+			_log.error(exception);
 		}
 	}
 
@@ -1927,12 +1950,23 @@ public class ResourcePermissionLocalServiceImpl
 			Role role = _roleLocalService.getRole(
 				companyId, RoleConstants.OWNER);
 
-			if (_updateResourcePermission(
-					companyId, name, ResourceConstants.SCOPE_INDIVIDUAL,
-					primKey, userId, role.getRoleId(), Boolean.FALSE,
-					actionIds.toArray(new String[0]),
-					ResourcePermissionConstants.OPERATOR_SET, true,
-					resourcePermissionsMap)) {
+			List<ResourcePermission> addedResourcePermissions = null;
+
+			if (serviceContext.isStrictAdd()) {
+				addedResourcePermissions = new ArrayList<>();
+			}
+
+			ResourcePermission resourcePermission = _updateResourcePermission(
+				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
+				userId, role.getRoleId(), Boolean.FALSE,
+				actionIds.toArray(new String[0]),
+				ResourcePermissionConstants.OPERATOR_SET, true,
+				resourcePermissionsMap);
+
+			if (resourcePermission != null) {
+				if (addedResourcePermissions != null) {
+					addedResourcePermissions.add(resourcePermission);
+				}
 
 				modified = true;
 			}
@@ -1957,12 +1991,17 @@ public class ResourcePermissionLocalServiceImpl
 
 				Role groupRole = _roleLocalService.getDefaultGroupRole(groupId);
 
-				if (_updateResourcePermission(
-						companyId, name, ResourceConstants.SCOPE_INDIVIDUAL,
-						primKey, 0, groupRole.getRoleId(), Boolean.FALSE,
-						actions.toArray(new String[0]),
-						ResourcePermissionConstants.OPERATOR_SET, true,
-						resourcePermissionsMap)) {
+				resourcePermission = _updateResourcePermission(
+					companyId, name, ResourceConstants.SCOPE_INDIVIDUAL,
+					primKey, 0, groupRole.getRoleId(), Boolean.FALSE,
+					actions.toArray(new String[0]),
+					ResourcePermissionConstants.OPERATOR_SET, true,
+					resourcePermissionsMap);
+
+				if (resourcePermission != null) {
+					if (addedResourcePermissions != null) {
+						addedResourcePermissions.add(resourcePermission);
+					}
 
 					modified = true;
 				}
@@ -1992,15 +2031,26 @@ public class ResourcePermissionLocalServiceImpl
 				Role guestRole = _roleLocalService.getRole(
 					companyId, RoleConstants.GUEST);
 
-				if (_updateResourcePermission(
-						companyId, name, ResourceConstants.SCOPE_INDIVIDUAL,
-						primKey, 0, guestRole.getRoleId(), Boolean.TRUE,
-						actions.toArray(new String[0]),
-						ResourcePermissionConstants.OPERATOR_SET, true,
-						resourcePermissionsMap)) {
+				resourcePermission = _updateResourcePermission(
+					companyId, name, ResourceConstants.SCOPE_INDIVIDUAL,
+					primKey, 0, guestRole.getRoleId(), Boolean.TRUE,
+					actions.toArray(new String[0]),
+					ResourcePermissionConstants.OPERATOR_SET, true,
+					resourcePermissionsMap);
+
+				if (resourcePermission != null) {
+					if (addedResourcePermissions != null) {
+						addedResourcePermissions.add(resourcePermission);
+					}
 
 					modified = true;
 				}
+			}
+
+			if (addedResourcePermissions != null) {
+				_populateFinderCacheForC_N_S_P(
+					companyId, name, ResourceConstants.SCOPE_INDIVIDUAL,
+					primKey, addedResourcePermissions);
 			}
 		}
 		finally {
@@ -2068,23 +2118,25 @@ public class ResourcePermissionLocalServiceImpl
 		boolean modified = false;
 
 		try {
-			boolean guestPermissionModified = _updateResourcePermission(
-				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, name, 0,
-				guestRole.getRoleId(), Boolean.TRUE,
-				guestActionIds.toArray(new String[0]),
-				ResourcePermissionConstants.OPERATOR_SET, true,
-				resourcePermissionsMap);
-			boolean ownerPermissionModified = _updateResourcePermission(
-				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, name, 0,
-				ownerRole.getRoleId(), Boolean.FALSE,
-				ownerActionIds.toArray(new String[0]),
-				ResourcePermissionConstants.OPERATOR_SET, true,
-				resourcePermissionsMap);
+			ResourcePermission guestResourcePermission =
+				_updateResourcePermission(
+					companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, name,
+					0, guestRole.getRoleId(), Boolean.TRUE,
+					guestActionIds.toArray(new String[0]),
+					ResourcePermissionConstants.OPERATOR_SET, true,
+					resourcePermissionsMap);
+			ResourcePermission ownerResourcePermission =
+				_updateResourcePermission(
+					companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, name,
+					0, ownerRole.getRoleId(), Boolean.FALSE,
+					ownerActionIds.toArray(new String[0]),
+					ResourcePermissionConstants.OPERATOR_SET, true,
+					resourcePermissionsMap);
 
-			boolean siteMemberPermissionModified = false;
+			ResourcePermission siteMemberResourcePermission = null;
 
 			if (groupActionIds != null) {
-				siteMemberPermissionModified = _updateResourcePermission(
+				siteMemberResourcePermission = _updateResourcePermission(
 					companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, name,
 					0, siteMemberRole.getRoleId(), Boolean.FALSE,
 					groupActionIds.toArray(new String[0]),
@@ -2092,8 +2144,9 @@ public class ResourcePermissionLocalServiceImpl
 					resourcePermissionsMap);
 			}
 
-			if (guestPermissionModified || ownerPermissionModified ||
-				siteMemberPermissionModified) {
+			if ((guestResourcePermission != null) ||
+				(ownerResourcePermission != null) ||
+				(siteMemberResourcePermission != null)) {
 
 				modified = true;
 			}
@@ -2193,7 +2246,19 @@ public class ResourcePermissionLocalServiceImpl
 		return false;
 	}
 
-	private boolean _updateResourcePermission(
+	private void _populateFinderCacheForC_N_S_P(
+		long companyId, String name, int scope, String primKey,
+		List<ResourcePermission> resourcePermissions) {
+
+		if (_finderPathWithoutPaginationFindByC_N_S_P != null) {
+			FinderCacheUtil.putResult(
+				_finderPathWithoutPaginationFindByC_N_S_P,
+				new Object[] {companyId, name, scope, primKey},
+				resourcePermissions);
+		}
+	}
+
+	private ResourcePermission _updateResourcePermission(
 			long companyId, String name, int scope, String primKey,
 			long ownerId, long roleId, Boolean guestRole, String[] actionIds,
 			int operator, boolean fetch,
@@ -2215,11 +2280,11 @@ public class ResourcePermissionLocalServiceImpl
 				 (operator == ResourcePermissionConstants.OPERATOR_SET)) &&
 				(actionIds.length == 0)) {
 
-				return false;
+				return null;
 			}
 
 			if (operator == ResourcePermissionConstants.OPERATOR_REMOVE) {
-				return false;
+				return null;
 			}
 
 			long resourcePermissionId = counterLocalService.increment(
@@ -2288,7 +2353,8 @@ public class ResourcePermissionLocalServiceImpl
 			resourcePermission.setActionIds(actionIdsLong);
 			resourcePermission.setViewActionId((actionIdsLong % 2) == 1);
 
-			resourcePermissionPersistence.update(resourcePermission);
+			resourcePermission = resourcePermissionPersistence.update(
+				resourcePermission);
 
 			if (ArrayUtil.contains(actionIds, ActionKeys.MANAGE_SUBGROUPS)) {
 				PermissionCacheUtil.clearPrimaryKeyRoleCache();
@@ -2296,10 +2362,10 @@ public class ResourcePermissionLocalServiceImpl
 
 			IndexWriterHelperUtil.updatePermissionFields(name, primKey);
 
-			return true;
+			return resourcePermission;
 		}
 
-		return false;
+		return null;
 	}
 
 	private static final String _FIND_MISSING_RESOURCE_PERMISSIONS =
@@ -2316,6 +2382,8 @@ public class ResourcePermissionLocalServiceImpl
 		_individualPortletResourcePermissionProviderSnapshot = new Snapshot<>(
 			ResourcePermissionLocalServiceImpl.class,
 			IndividualPortletResourcePermissionProvider.class);
+
+	private FinderPath _finderPathWithoutPaginationFindByC_N_S_P;
 
 	@BeanReference(type = ResourceActionLocalService.class)
 	private ResourceActionLocalService _resourceActionLocalService;

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -346,13 +346,21 @@ public class ResourcePermissionLocalServiceImpl
 			return;
 		}
 
-		List<ResourcePermission> resourcePermissions =
-			resourcePermissionPersistence.findByC_N_S_P(
-				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey);
+		if (serviceContext.isStrictAdd()) {
+			_addResourcePermissions(
+				companyId, groupId, userId, name, primKey,
+				Collections.emptyList(), portletActions, serviceContext);
+		}
+		else {
+			List<ResourcePermission> resourcePermissions =
+				resourcePermissionPersistence.findByC_N_S_P(
+					companyId, name, ResourceConstants.SCOPE_INDIVIDUAL,
+					primKey);
 
-		_addResourcePermissions(
-			companyId, groupId, userId, name, primKey, resourcePermissions,
-			portletActions, serviceContext);
+			_addResourcePermissions(
+				companyId, groupId, userId, name, primKey, resourcePermissions,
+				portletActions, serviceContext);
+		}
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -40,9 +40,9 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
-import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.persistence.GroupPersistence;
 import com.liferay.portal.kernel.social.SocialActivityManagerUtil;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.transaction.Propagation;
@@ -694,7 +694,7 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 		// Tags
 
 		if ((tagNames != null) && ((entry != null) || (tagNames.length > 0))) {
-			Group siteGroup = _groupLocalService.getGroup(
+			Group siteGroup = _groupPersistence.findByPrimaryKey(
 				PortalUtil.getSiteGroupId(groupId));
 
 			List<AssetTag> tags = _assetTagLocalService.checkTags(
@@ -745,7 +745,7 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 		if (entry == null) {
 			entry = assetEntryPersistence.create(entryId);
 
-			Group group = _groupLocalService.getGroup(groupId);
+			Group group = _groupPersistence.findByPrimaryKey(groupId);
 
 			entry.setCompanyId(group.getCompanyId());
 
@@ -1324,8 +1324,8 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 	@BeanReference(type = ClassNameLocalService.class)
 	private ClassNameLocalService _classNameLocalService;
 
-	@BeanReference(type = GroupLocalService.class)
-	private GroupLocalService _groupLocalService;
+	@BeanReference(type = GroupPersistence.class)
+	private GroupPersistence _groupPersistence;
 
 	@BeanReference(type = SocialActivityCounterLocalService.class)
 	private SocialActivityCounterLocalService

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -666,8 +666,17 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 		validate(
 			groupId, className, classPK, classTypeId, categoryIds, tagNames);
 
-		AssetEntry entry = assetEntryPersistence.fetchByC_C(
-			classNameId, classPK);
+		AssetEntry entry = null;
+
+		boolean strictAdd = false;
+
+		if (serviceContext != null) {
+			strictAdd = serviceContext.isStrictAdd();
+		}
+
+		if (!strictAdd) {
+			entry = assetEntryPersistence.fetchByC_C(classNameId, classPK);
+		}
 
 		long entryId = 0;
 

--- a/portal-impl/src/com/liferay/portlet/social/service/impl/SocialActivityCounterLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/service/impl/SocialActivityCounterLocalServiceImpl.java
@@ -6,7 +6,7 @@
 package com.liferay.portlet.social.service.impl;
 
 import com.liferay.asset.kernel.model.AssetEntry;
-import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.asset.kernel.service.persistence.AssetEntryPersistence;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.cache.PortalCache;
@@ -354,8 +354,8 @@ public class SocialActivityCounterLocalServiceImpl
 		String className = PortalUtil.getClassName(classNameId);
 
 		if (!className.equals(User.class.getName())) {
-			AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
-				className, classPK);
+			AssetEntry assetEntry = _assetEntryPersistence.fetchByC_C(
+				classNameId, classPK);
 
 			deleteActivityCounters(assetEntry);
 		}
@@ -379,15 +379,16 @@ public class SocialActivityCounterLocalServiceImpl
 	public void deleteActivityCounters(String className, long classPK)
 		throws PortalException {
 
+		long classNameId = _classNameLocalService.getClassNameId(className);
+
 		if (!className.equals(User.class.getName())) {
-			AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
-				className, classPK);
+			AssetEntry assetEntry = _assetEntryPersistence.fetchByC_C(
+				classNameId, classPK);
 
 			deleteActivityCounters(assetEntry);
 		}
 		else {
-			socialActivityCounterPersistence.removeByC_C(
-				_classNameLocalService.getClassNameId(className), classPK);
+			socialActivityCounterPersistence.removeByC_C(classNameId, classPK);
 
 			_socialActivityLimitPersistence.removeByUserId(classPK);
 		}
@@ -430,16 +431,17 @@ public class SocialActivityCounterLocalServiceImpl
 	public void disableActivityCounters(String className, long classPK)
 		throws PortalException {
 
-		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
-			className, classPK);
+		long classNameId = _classNameLocalService.getClassNameId(className);
+
+		AssetEntry assetEntry = _assetEntryPersistence.fetchByC_C(
+			classNameId, classPK);
 
 		if (assetEntry == null) {
 			return;
 		}
 
 		List<SocialActivityCounter> activityCounters =
-			socialActivityCounterPersistence.findByC_C(
-				assetEntry.getClassNameId(), classPK);
+			socialActivityCounterPersistence.findByC_C(classNameId, classPK);
 
 		adjustUserContribution(assetEntry, false);
 
@@ -489,16 +491,17 @@ public class SocialActivityCounterLocalServiceImpl
 	public void enableActivityCounters(String className, long classPK)
 		throws PortalException {
 
-		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
-			className, classPK);
+		long classNameId = _classNameLocalService.getClassNameId(className);
+
+		AssetEntry assetEntry = _assetEntryPersistence.fetchByC_C(
+			classNameId, classPK);
 
 		if (assetEntry == null) {
 			return;
 		}
 
 		List<SocialActivityCounter> activityCounters =
-			socialActivityCounterPersistence.findByC_C(
-				assetEntry.getClassNameId(), classPK);
+			socialActivityCounterPersistence.findByC_C(classNameId, classPK);
 
 		adjustUserContribution(assetEntry, true);
 
@@ -1165,8 +1168,8 @@ public class SocialActivityCounterLocalServiceImpl
 				SocialActivityCounterConstants.NAME_ASSET_ACTIVITIES,
 				SocialActivityCounterConstants.TYPE_ASSET);
 
-	@BeanReference(type = AssetEntryLocalService.class)
-	private AssetEntryLocalService _assetEntryLocalService;
+	@BeanReference(type = AssetEntryPersistence.class)
+	private AssetEntryPersistence _assetEntryPersistence;
 
 	@BeanReference(type = ClassNameLocalService.class)
 	private ClassNameLocalService _classNameLocalService;

--- a/portal-impl/src/com/liferay/portlet/social/service/impl/SocialActivityCounterLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/service/impl/SocialActivityCounterLocalServiceImpl.java
@@ -412,15 +412,19 @@ public class SocialActivityCounterLocalServiceImpl
 	public void disableActivityCounters(long classNameId, long classPK)
 		throws PortalException {
 
+		List<SocialActivityCounter> activityCounters =
+			socialActivityCounterPersistence.findByC_C(classNameId, classPK);
+
+		if (activityCounters.isEmpty()) {
+			return;
+		}
+
 		AssetEntry assetEntry = _assetEntryPersistence.fetchByC_C(
 			classNameId, classPK);
 
 		if (assetEntry == null) {
 			return;
 		}
-
-		List<SocialActivityCounter> activityCounters =
-			socialActivityCounterPersistence.findByC_C(classNameId, classPK);
 
 		adjustUserContribution(assetEntry, false);
 
@@ -471,15 +475,19 @@ public class SocialActivityCounterLocalServiceImpl
 	public void enableActivityCounters(long classNameId, long classPK)
 		throws PortalException {
 
+		List<SocialActivityCounter> activityCounters =
+			socialActivityCounterPersistence.findByC_C(classNameId, classPK);
+
+		if (activityCounters.isEmpty()) {
+			return;
+		}
+
 		AssetEntry assetEntry = _assetEntryPersistence.fetchByC_C(
 			classNameId, classPK);
 
 		if (assetEntry == null) {
 			return;
 		}
-
-		List<SocialActivityCounter> activityCounters =
-			socialActivityCounterPersistence.findByC_C(classNameId, classPK);
 
 		adjustUserContribution(assetEntry, true);
 

--- a/portal-impl/src/com/liferay/portlet/social/service/impl/SocialActivityCounterLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/service/impl/SocialActivityCounterLocalServiceImpl.java
@@ -412,27 +412,6 @@ public class SocialActivityCounterLocalServiceImpl
 	public void disableActivityCounters(long classNameId, long classPK)
 		throws PortalException {
 
-		disableActivityCounters(PortalUtil.getClassName(classNameId), classPK);
-	}
-
-	/**
-	 * Disables all the counters of an asset identified by the class name and
-	 * class primary key.
-	 *
-	 * <p>
-	 * This method is used by the recycle bin to disable all counters of assets
-	 * put into the recycle bin. It adjusts the owner's contribution score.
-	 * </p>
-	 *
-	 * @param className the asset's class name
-	 * @param classPK the primary key of the asset
-	 */
-	@Override
-	public void disableActivityCounters(String className, long classPK)
-		throws PortalException {
-
-		long classNameId = _classNameLocalService.getClassNameId(className);
-
 		AssetEntry assetEntry = _assetEntryPersistence.fetchByC_C(
 			classNameId, classPK);
 
@@ -457,6 +436,26 @@ public class SocialActivityCounterLocalServiceImpl
 	}
 
 	/**
+	 * Disables all the counters of an asset identified by the class name and
+	 * class primary key.
+	 *
+	 * <p>
+	 * This method is used by the recycle bin to disable all counters of assets
+	 * put into the recycle bin. It adjusts the owner's contribution score.
+	 * </p>
+	 *
+	 * @param className the asset's class name
+	 * @param classPK the primary key of the asset
+	 */
+	@Override
+	public void disableActivityCounters(String className, long classPK)
+		throws PortalException {
+
+		disableActivityCounters(
+			_classNameLocalService.getClassNameId(className), classPK);
+	}
+
+	/**
 	 * Enables all activity counters of an asset identified by the class name ID
 	 * and class primary key.
 	 *
@@ -471,27 +470,6 @@ public class SocialActivityCounterLocalServiceImpl
 	@Override
 	public void enableActivityCounters(long classNameId, long classPK)
 		throws PortalException {
-
-		enableActivityCounters(PortalUtil.getClassName(classNameId), classPK);
-	}
-
-	/**
-	 * Enables all the counters of an asset identified by the class name and
-	 * class primary key.
-	 *
-	 * <p>
-	 * This method is used by the recycle bin to enable all counters of assets
-	 * restored from the recycle bin. It adjusts the owner's contribution score.
-	 * </p>
-	 *
-	 * @param className the asset's class name
-	 * @param classPK the primary key of the asset
-	 */
-	@Override
-	public void enableActivityCounters(String className, long classPK)
-		throws PortalException {
-
-		long classNameId = _classNameLocalService.getClassNameId(className);
 
 		AssetEntry assetEntry = _assetEntryPersistence.fetchByC_C(
 			classNameId, classPK);
@@ -514,6 +492,26 @@ public class SocialActivityCounterLocalServiceImpl
 		}
 
 		clearFinderCache();
+	}
+
+	/**
+	 * Enables all the counters of an asset identified by the class name and
+	 * class primary key.
+	 *
+	 * <p>
+	 * This method is used by the recycle bin to enable all counters of assets
+	 * restored from the recycle bin. It adjusts the owner's contribution score.
+	 * </p>
+	 *
+	 * @param className the asset's class name
+	 * @param classPK the primary key of the asset
+	 */
+	@Override
+	public void enableActivityCounters(String className, long classPK)
+		throws PortalException {
+
+		enableActivityCounters(
+			_classNameLocalService.getClassNameId(className), classPK);
 	}
 
 	/**

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -1007,7 +1007,7 @@
     # Env: LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_USERNAME
     #
     #jdbc.default.driverClassName=org.mariadb.jdbc.Driver
-    #jdbc.default.url=jdbc:mariadb://localhost/lportal?useUnicode=true&characterEncoding=UTF-8&rewriteBatchedStatements=true&useFastDateParsing=false
+    #jdbc.default.url=jdbc:mariadb://localhost/lportal?useUnicode=true&characterEncoding=UTF-8&rewriteBatchedStatements=true&useFastDateParsing=false&&cachePrepStmts=true&prepStmtCacheSize=1000&prepStmtCacheSqlLimit=2048
     #jdbc.default.username=
     #jdbc.default.password=
 
@@ -1020,7 +1020,7 @@
     # Env: LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_USERNAME
     #
     #jdbc.default.driverClassName=com.mysql.cj.jdbc.Driver
-    #jdbc.default.url=jdbc:mysql://localhost/lportal?characterEncoding=UTF-8&dontTrackOpenResources=true&holdResultsOpenOverStatementClose=true&rewriteBatchedStatements=true&serverTimezone=GMT&useFastDateParsing=false&useLocalSessionState=true&useLocalTransactionState=true&useUnicode=true
+    #jdbc.default.url=jdbc:mysql://localhost/lportal?characterEncoding=UTF-8&dontTrackOpenResources=true&holdResultsOpenOverStatementClose=true&rewriteBatchedStatements=true&serverTimezone=GMT&useFastDateParsing=false&useLocalSessionState=true&useLocalTransactionState=true&useUnicode=true&cachePrepStmts=true&prepStmtCacheSize=1000&prepStmtCacheSqlLimit=2048
     #jdbc.default.username=
     #jdbc.default.password=
 

--- a/portal-impl/test/portal-test.properties
+++ b/portal-impl/test/portal-test.properties
@@ -3,7 +3,7 @@ include-and-override=portal-test-ext.properties
 model.tree.rebuild.query.results.batch.size=3
 
 #jdbc.default.driverClassName=com.mysql.cj.jdbc.Driver
-#jdbc.default.url=jdbc:mysql://localhost/lportal?characterEncoding=UTF-8&dontTrackOpenResources=true&holdResultsOpenOverStatementClose=true&rewriteBatchedStatements=true&serverTimezone=GMT&useFastDateParsing=false&useUnicode=true
+#jdbc.default.url=jdbc:mysql://localhost/lportal?characterEncoding=UTF-8&dontTrackOpenResources=true&holdResultsOpenOverStatementClose=true&rewriteBatchedStatements=true&serverTimezone=GMT&useFastDateParsing=false&useUnicode=true&cachePrepStmts=true&prepStmtCacheSize=1000&prepStmtCacheSqlLimit=2048
 #jdbc.default.username=
 #jdbc.default.password=
 

--- a/portal-kernel/src/com/liferay/portal/kernel/search/SearchContext.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/SearchContext.java
@@ -5,6 +5,9 @@
 
 package com.liferay.portal.kernel.search;
 
+import com.liferay.petra.lang.CentralizedThreadLocal;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.search.facet.Facet;
@@ -29,6 +32,32 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author Julio Camarero
  */
 public class SearchContext implements Serializable {
+
+	public static boolean isBatchMode() {
+		Boolean batchMode = _batchModeThreadLocal.get();
+
+		if (batchMode == Boolean.TRUE) {
+			return true;
+		}
+
+		return false;
+	}
+
+	public static SafeCloseable openBatchMode() {
+		SafeCloseable safeCloseable =
+			_batchModeThreadLocal.setWithSafeCloseable(Boolean.TRUE);
+
+		return () -> {
+			safeCloseable.close();
+
+			try {
+				IndexWriterHelperUtil.commit();
+			}
+			catch (SearchException searchException) {
+				ReflectionUtil.throwException(searchException);
+			}
+		};
+	}
 
 	public void addFacet(Facet facet) {
 		if (facet == null) {
@@ -211,6 +240,10 @@ public class SearchContext implements Serializable {
 	}
 
 	public boolean isCommitImmediately() {
+		if (isBatchMode()) {
+			return false;
+		}
+
 		return _commitImmediately;
 	}
 
@@ -413,6 +446,10 @@ public class SearchContext implements Serializable {
 			_attributes.remove("searchPermissionContext");
 		}
 	}
+
+	private static final CentralizedThreadLocal<Boolean> _batchModeThreadLocal =
+		new CentralizedThreadLocal<>(
+			SearchContext.class.getName() + "._batchModeThreadLocal");
 
 	private boolean _andSearch;
 	private long[] _assetCategoryIds;

--- a/portal-kernel/src/com/liferay/portal/kernel/search/SearchContext.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/SearchContext.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.util.Validator;
 
 import java.io.Serializable;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -26,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
 
 /**
  * @author Brian Wing Shun Chan
@@ -34,29 +36,72 @@ import java.util.concurrent.ConcurrentHashMap;
 public class SearchContext implements Serializable {
 
 	public static boolean isBatchMode() {
-		Boolean batchMode = _batchModeThreadLocal.get();
+		List<Future<?>> batchModeSyncFutures =
+			_batchModeSyncFuturesThreadLocal.get();
 
-		if (batchMode == Boolean.TRUE) {
-			return true;
+		if (batchModeSyncFutures == null) {
+			return false;
 		}
 
-		return false;
+		return true;
 	}
 
 	public static SafeCloseable openBatchMode() {
+		return openBatchMode(true);
+	}
+
+	public static SafeCloseable openBatchMode(boolean commit) {
 		SafeCloseable safeCloseable =
-			_batchModeThreadLocal.setWithSafeCloseable(Boolean.TRUE);
+			_batchModeSyncFuturesThreadLocal.setWithSafeCloseable(
+				new ArrayList<>());
 
 		return () -> {
-			safeCloseable.close();
+			Exception exception1 = null;
 
 			try {
-				IndexWriterHelperUtil.commit();
+				for (Future<?> future :
+						_batchModeSyncFuturesThreadLocal.get()) {
+
+					try {
+						future.get();
+					}
+					catch (Exception exception2) {
+						if (exception1 != null) {
+							exception2.addSuppressed(exception1);
+						}
+
+						exception1 = exception2;
+					}
+				}
 			}
-			catch (SearchException searchException) {
-				ReflectionUtil.throwException(searchException);
+			finally {
+				safeCloseable.close();
+
+				try {
+					if (commit) {
+						IndexWriterHelperUtil.commit();
+					}
+				}
+				catch (SearchException searchException) {
+					if (exception1 != null) {
+						searchException.addSuppressed(exception1);
+					}
+
+					ReflectionUtil.throwException(searchException);
+				}
 			}
 		};
+	}
+
+	public static void registerBatchModeSyncFuture(Future<?> future) {
+		List<Future<?>> batchModeSyncFutures =
+			_batchModeSyncFuturesThreadLocal.get();
+
+		if (batchModeSyncFutures == null) {
+			throw new IllegalStateException("Not in batch mode");
+		}
+
+		batchModeSyncFutures.add(future);
 	}
 
 	public void addFacet(Facet facet) {
@@ -447,9 +492,10 @@ public class SearchContext implements Serializable {
 		}
 	}
 
-	private static final CentralizedThreadLocal<Boolean> _batchModeThreadLocal =
-		new CentralizedThreadLocal<>(
-			SearchContext.class.getName() + "._batchModeThreadLocal");
+	private static final CentralizedThreadLocal<List<Future<?>>>
+		_batchModeSyncFuturesThreadLocal = new CentralizedThreadLocal<>(
+			SearchContext.class.getName() +
+				"._batchModeSyncFuturesThreadLocal");
 
 	private boolean _andSearch;
 	private long[] _assetCategoryIds;

--- a/portal-kernel/src/com/liferay/portal/kernel/search/StrictObjectReindexThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/StrictObjectReindexThreadLocal.java
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.search;
+
+import com.liferay.petra.lang.CentralizedThreadLocal;
+import com.liferay.petra.lang.SafeCloseable;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class StrictObjectReindexThreadLocal {
+
+	public static boolean isStrictObjectReindex() {
+		return _strictObjectReindexThreadLocal.get();
+	}
+
+	public static SafeCloseable setStrictObjectReindex(
+		boolean strictObjectReindex) {
+
+		return _strictObjectReindexThreadLocal.setWithSafeCloseable(
+			strictObjectReindex);
+	}
+
+	private static final CentralizedThreadLocal<Boolean>
+		_strictObjectReindexThreadLocal = new CentralizedThreadLocal<>(
+			StrictObjectReindexThreadLocal.class +
+				"._strictObjectReindexThreadLocal",
+			() -> Boolean.FALSE);
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
@@ -1,1 +1,1 @@
-version 20.8.0
+version 20.9.0

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ServiceContext.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ServiceContext.java
@@ -127,6 +127,7 @@ public class ServiceContext implements Cloneable, Serializable {
 		serviceContext.setRequest(getRequest());
 		serviceContext.setScopeGroupId(getScopeGroupId());
 		serviceContext.setSignedIn(isSignedIn());
+		serviceContext.setStrictAdd(isStrictAdd());
 
 		if (_userDisplayURL != null) {
 			serviceContext.setUserDisplayURL(_userDisplayURL);
@@ -906,6 +907,10 @@ public class ServiceContext implements Cloneable, Serializable {
 		return _signedIn;
 	}
 
+	public boolean isStrictAdd() {
+		return _strictAdd;
+	}
+
 	/**
 	 * Merges all of the specified service context's non-<code>null</code>
 	 * attributes, attributes greater than <code>0</code>, and fields (except
@@ -1463,6 +1468,10 @@ public class ServiceContext implements Cloneable, Serializable {
 		_signedIn = signedIn;
 	}
 
+	public void setStrictAdd(boolean strictAdd) {
+		_strictAdd = strictAdd;
+	}
+
 	public void setTimeZone(TimeZone timeZone) {
 		_timeZone = timeZone;
 	}
@@ -1567,6 +1576,7 @@ public class ServiceContext implements Cloneable, Serializable {
 	private String _remoteHost;
 	private long _scopeGroupId;
 	private boolean _signedIn;
+	private boolean _strictAdd;
 	private TimeZone _timeZone;
 	private String _userDisplayURL;
 	private long _userId;

--- a/test.properties
+++ b/test.properties
@@ -340,7 +340,7 @@
     database.mariadb.service.cmd.stop=mariadb stop
     database.mariadb.service.executable=service
     database.mariadb.username=root
-    database.mariadb.url=jdbc:mariadb://${database.mariadb.host}/${database.mariadb.schema}?characterEncoding=UTF-8&rewriteBatchedStatements=true&useFastDateParsing=false&useUnicode=true
+    database.mariadb.url=jdbc:mariadb://${database.mariadb.host}/${database.mariadb.schema}?characterEncoding=UTF-8&rewriteBatchedStatements=true&useFastDateParsing=false&useUnicode=true&cachePrepStmts=true&prepStmtCacheSize=1000&prepStmtCacheSqlLimit=2048
     database.mariadb.version=10.2.20
     database.mariadb.version.cmd=--version
 
@@ -360,7 +360,7 @@
     database.mysql.service.cmd.stop=mysqld stop
     database.mysql.service.executable=service
     database.mysql.username=root
-    database.mysql.url=jdbc:mysql://${database.mysql.host}/${database.mysql.schema}?characterEncoding=UTF-8&dontTrackOpenResources=true&holdResultsOpenOverStatementClose=true&permitMysqlScheme&rewriteBatchedStatements=true&serverTimezone=GMT&useFastDateParsing=false&useUnicode=true
+    database.mysql.url=jdbc:mysql://${database.mysql.host}/${database.mysql.schema}?characterEncoding=UTF-8&dontTrackOpenResources=true&holdResultsOpenOverStatementClose=true&permitMysqlScheme&rewriteBatchedStatements=true&serverTimezone=GMT&useFastDateParsing=false&useUnicode=true&cachePrepStmts=true&prepStmtCacheSize=1000&prepStmtCacheSqlLimit=2048
     database.mysql.version=5.7
     database.mysql.version.cmd=--version
 


### PR DESCRIPTION
This is a complete redo for https://liferay.atlassian.net/browse/LPD-25633

I optimized off 92.53% of the total execution time, which means it is 13.39 times faster. @victorhcunha will post detailed test results later.

This pull completely removes the linear relationship between import entry count and DB select/update query count. No matter how many entries you are importing, we only fire out a near constant number of select/update queries. Of course the insert query count still has a linear bond with entry count, after all the whole thing is about inserting the data into DB.

The tx model is untouched, we are not merging multi-tx into one.

Search index model is refactored to have batch support. Each individual index request is still fired out right after the tx commit to push the work to ES asap. Therefore we still have the same number of index requests to ES through the entire import process. But none of those requests is asking for ES index refresh. At the end of the import process, after all index requests are processed, we fire out one last refresh request to make the changes visible from search.

It is important to keep the per entry tx model, not just because of the previous deadlock issue with HSQL, but also to make sure we actually can handle large batch import. With single tx model, all changes are buffered not only at Hibernate session/JDBC driver level, but also all search index requests are buffered too. For large batch import, we will run out of heap space for that. Also due to the buffering, ES server is not getting anything to work on until the end of the tx, then all work goes to it all at once, and portal has to sync wait ES to finish in order to continue. It is very wasteful working style. Portal is the main work executor, but it heavily uses both DB and ES. To make the work load balanced across the entire system, portal should dispatch work to db and ES as evenly and smoothly as possible. In real production env, portal/db/es are going to be 3 individual hardwares, they can truly work in parallel, let's why this multi tx model can help overall throughput.


@marco-leo I waited that ObjectEntry.getValues() change from object team for a few days, nothing happened. I ended up making the change myself to optimize just enough for the test case, see https://github.com/brianchandotcom/liferay-portal/commit/b5b0a9d45ab2ab9b7ac4299da7aada23ac51fbc5 there are still 2 loose ends that can be improved, but at least they are not needed for the current test case. Object team should continue the improvement as separate tasks.
Two pending items:
1) If the ObjectEntry's ObjectFields are localized, the prepopulation of the localization values are still querying db. This can be avoid by intercepting all localization insertions for prepopulation.
2) If the ObjectEntry's ObjectFields are not statical values, means they are "Aggregation" or "Formula" typed, then the values are not statically available from inputs. Those Aggregation/Formula logic need to be applied to the input values in order to have the collect values for prepopulation.

CC @vicnate5 @wesleygong @4lejandrito @BryanEngler @gustavolimav