### PR TITLE
LPD-34573 Migrate Site Initializer framework and template tests under site-management test suite

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -9851,7 +9851,6 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         **/friendly-url-test/**/*Test.java,\
         **/headless/headless-delivery/**/*Language*Test.java,\
         **/headless/headless-delivery/**/*NavigationMenu*Test.java,\
-        **/portal-search-test/**/IndexerClausesChangeTrackingTest.java,\
         **/redirect-test/**/*Test.java,\
         **/site/site-admin-test/**/*Test.java,\
         **/site/site-memberships-test/**/*Test.java,\
@@ -9882,35 +9881,62 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][site-management]=\
         (testray.main.component.name == "Breadcrumb Widget") OR \
+        (testray.main.component.name == "Click to Chat") OR \
         (testray.main.component.name == "Friendly URL Service") OR \
+        (testray.main.component.name == "Liferay Learn Site Initializer") OR \
+        (testray.main.component.name == "Liferay Online") OR \
+        (testray.main.component.name == "Liferaybotics") OR \
+        (testray.main.component.name == "Masterclass") OR \
         (testray.main.component.name == "Navigation Menus") OR \
+        (testray.main.component.name == "Site Initializer Extender") OR \
+        (testray.main.component.name == "Site Initializer Liferay Marketplace") OR \
+        (testray.main.component.name == "Site Initializer Raylife AP") OR \
+        (testray.main.component.name == "Site Initializer Raylife D2C") OR \
+        (testray.main.component.name == "Site Initializer Testray") OR \
         (testray.main.component.name == "Sitemap Protocol") OR \
         (testray.main.component.name == "Sites Administration") OR \
         (testray.main.component.name == "Sites Directory Widget") OR \
+        (testray.main.component.name == "Team Extranet") OR \
         (testray.main.component.name == "URL Redirections")
 
     test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8][site-management]=\
-        (testray.main.component.name == "Upgrades Site Management")
+        (testray.main.component.name == "Upgrades Site Management") OR \
+        (testray.main.component.name == "Upgrades Solutions")
 
     test.batch.run.property.query[functional-upgrade-tomcat90-db2111-jdk8][site-management]=\
         (database.types ~ db2) AND \
-        (testray.main.component.name == "Upgrades Site Management")
+        (\
+            (testray.main.component.name == "Upgrades Site Management") OR \
+            (testray.main.component.name == "Upgrades Solutions")
+        )
 
     test.batch.run.property.query[functional-upgrade-tomcat90-mariadb102-jdk8][site-management]=\
         (database.types ~ mariadb) AND \
-        (testray.main.component.name == "Upgrades Site Management")
+        (\
+            (testray.main.component.name == "Upgrades Site Management") OR \
+            (testray.main.component.name == "Upgrades Solutions")
+        )
 
     test.batch.run.property.query[functional-upgrade-tomcat90-oracle193-jdk8][site-management]=\
         (database.types ~ oracle) AND \
-        (testray.main.component.name == "Upgrades Site Management")
+        (\
+            (testray.main.component.name == "Upgrades Site Management") OR \
+            (testray.main.component.name == "Upgrades Solutions")
+        )
 
     test.batch.run.property.query[functional-upgrade-tomcat90-postgresql*-jdk8][site-management]=\
         (database.types ~ postgresql) AND \
-        (testray.main.component.name == "Upgrades Site Management")
+        (\
+            (testray.main.component.name == "Upgrades Site Management") OR \
+            (testray.main.component.name == "Upgrades Solutions")
+        )
 
     test.batch.run.property.query[functional-upgrade-tomcat90-sqlserver2017-jdk8][site-management]=\
         (database.types ~ sqlserver) AND \
-        (testray.main.component.name == "Upgrades Site Management")
+        (\
+            (testray.main.component.name == "Upgrades Site Management") OR \
+            (testray.main.component.name == "Upgrades Solutions")
+        )
 
     #
     # Site Template
@@ -11917,31 +11943,31 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
 
     testray.team.site-management.component.names=\
         Breadcrumb Widget,\
-        Friendly URL Service,\
-        Navigation Menus,\
-        Sitemap Protocol,\
-        Sites Administration,\
-        Sites Directory Widget,\
-        Upgrades Site Management,\
-        URL Redirections
-
-    testray.team.solutions.component.names=\
         Click to Chat,\
-        Digital Signature,\
+        Friendly URL Service,\
         Liferay Learn Site Initializer,\
         Liferay Online,\
         Liferaybotics,\
-        Marketplace,\
         Masterclass,\
+        Navigation Menus,\
         OSB Site Initializer EVP,\
-        Patching Tool,\
         Site Initializer Extender,\
         Site Initializer Liferay Marketplace,\
         Site Initializer Raylife AP,\
         Site Initializer Raylife D2C,\
         Site Initializer Testray,\
+        Sitemap Protocol,\
+        Sites Administration,\
+        Sites Directory Widget,\
         Team Extranet,\
-        Upgrades Solutions
+        Upgrades Site Management,\
+        Upgrades Solutions,\
+        URL Redirections
+
+    testray.team.solutions.component.names=\
+        Digital Signature,\
+        Marketplace,\
+        Patching Tool
 
 ##
 ## Utilities


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-34573

Minor change to move Site Initializer tests under site-management test suite. These were previously a part of the solutions test suite.