### PR TITLE
LPD-34312

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/action/executor/FunctionObjectActionExecutorImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/action/executor/FunctionObjectActionExecutorImpl.java
@@ -17,6 +17,7 @@ import com.liferay.portal.catapult.PortalCatapult;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
@@ -47,13 +48,19 @@ public class FunctionObjectActionExecutorImpl
 			JSONObject payloadJSONObject, long userId)
 		throws Exception {
 
-		_portalCatapult.launch(
-			_companyId, Http.Method.POST,
-			_functionObjectActionExecutorImplConfiguration.
-				oAuth2ApplicationExternalReferenceCode(),
-			payloadJSONObject,
-			_functionObjectActionExecutorImplConfiguration.resourcePath(),
-			userId);
+		TransactionCommitCallbackUtil.registerCallback(
+			() -> {
+				_portalCatapult.launch(
+					_companyId, Http.Method.POST,
+					_functionObjectActionExecutorImplConfiguration.
+						oAuth2ApplicationExternalReferenceCode(),
+					payloadJSONObject,
+					_functionObjectActionExecutorImplConfiguration.
+						resourcePath(),
+					userId);
+
+				return null;
+			});
 	}
 
 	@Override

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectClientExtensions.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectClientExtensions.testcase
@@ -250,4 +250,57 @@ definition {
 		}
 	}
 
+	@description = "LPD-34312 - Verify that an object action using a client extension can update unmodifiable system object definition field"
+	@priority = 5
+	test CanTriggerActionWithUnmodifiableSystemObjectDefinition {
+		task ("Given Liferay Sample Etc Spring Boot is deployed into the current virtual instance") {
+			var clientExtensionSamples = "liferay-sample-etc-spring-boot";
+
+			for (var clientExtension : list ${clientExtensionSamples}) {
+				AntCommands.runCommand("build-test-liferay-sample-workspace.xml", "deploy-workspace-client-extension -Dvirtual.instance.id=${companyWebId} -Dworkspace.client.extension.name=${clientExtension}");
+			}
+
+			AntCommands.runCommand("build-test-liferay-sample-workspace.xml", "start-liferay-sample-etc-spring-boot -Dvirtual.instance.id=${companyWebId}");
+		}
+
+		task ("and Given the User unmodifiable system object definition") {
+			ObjectAdmin.openObjectAdmin();
+
+			ObjectPortlet.selectSystemObject(label = "User");
+		}
+
+		task ("and Given an object action using a client extension") {
+			ObjectAdmin.goToActionsTab();
+
+			ObjectAdmin.addObjectActionViaUI(
+				actionLabel = "Custom Action",
+				actionName = "customAction",
+				active = "true",
+				thenAction = "object-action-executor[function#liferay-sample-etc-spring-boot-object-action-2]",
+				whenAction = "On After Add");
+		}
+
+		task ("When a new user is added") {
+			User.openUsersAdmin();
+
+			User.addCP(
+				userEmailAddress = "userea@liferay.com",
+				userFirstName = "userfn",
+				userLastName = "userln",
+				userScreenName = "usersn");
+
+			Alert.viewSuccessMessage();
+		}
+
+		task ("Then the user screen name is updated") {
+			User.openUsersAdmin();
+
+			User.viewCP(
+				userEmailAddress = "userea@liferay.com",
+				userFirstName = "userfn",
+				userLastName = "userln",
+				userScreenName = "userfn");
+		}
+	}
+
 }

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-spring-boot/build.gradle
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-spring-boot/build.gradle
@@ -21,6 +21,7 @@ apply plugin: "org.springframework.boot"
 
 dependencies {
 	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot", version: "latest.release"
+	implementation group: "com.liferay", name: "com.liferay.petra.string", version: "latest.release"
 	implementation group: "com.liferay", name: "org.apache.commons.logging", version: "1.2.LIFERAY-PATCHED-2"
 	implementation group: "net.datafaker", name: "datafaker", version: "1.9.0"
 	implementation group: "org.json", name: "json", version: "20231013"

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-spring-boot/client-extension.yaml
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-spring-boot/client-extension.yaml
@@ -10,6 +10,7 @@ liferay-sample-etc-spring-boot-oauth-application-user-agent:
     .serviceScheme: http
     name: Liferay Sample Etc Spring Boot OAuth Application User Agent
     scopes:
+        - Liferay.Headless.Admin.User.everything
         - Liferay.Headless.Admin.Workflow.everything
     type: oAuthApplicationUserAgent
 liferay-sample-etc-spring-boot-object-action-1:

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-spring-boot/src/main/java/com/liferay/sample/ObjectAction2RestController.java
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-spring-boot/src/main/java/com/liferay/sample/ObjectAction2RestController.java
@@ -5,10 +5,13 @@
 
 package com.liferay.sample;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import com.liferay.petra.string.StringBundler;
 
+import org.json.JSONObject;
+
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.function.client.WebClient;
 
 /**
  * @author Raymond Augé
@@ -30,12 +34,39 @@ public class ObjectAction2RestController extends BaseRestController {
 	public ResponseEntity<String> post(
 		@AuthenticationPrincipal Jwt jwt, @RequestBody String json) {
 
-		log(jwt, _log, json);
+		JSONObject jsonObject = new JSONObject(json);
 
-		return new ResponseEntity<>(json, HttpStatus.OK);
+		JSONObject modelDTOAccountJSONObject = jsonObject.getJSONObject(
+			"modelDTOAccount");
+
+		if (modelDTOAccountJSONObject == null) {
+			return new ResponseEntity<>(json, HttpStatus.OK);
+		}
+
+		return new ResponseEntity<>(
+			WebClient.create(
+				StringBundler.concat(
+					lxcDXPServerProtocol, "://", lxcDXPMainDomain,
+					"/o/headless-admin-user/v1.0/user-accounts/",
+					modelDTOAccountJSONObject.getLong("id"))
+			).patch(
+			).accept(
+				MediaType.APPLICATION_JSON
+			).contentType(
+				MediaType.APPLICATION_JSON
+			).bodyValue(
+				new JSONObject(
+				).put(
+					"alternateName",
+					modelDTOAccountJSONObject.getString("givenName")
+				).toString()
+			).header(
+				HttpHeaders.AUTHORIZATION, "Bearer " + jwt.getTokenValue()
+			).retrieve(
+			).bodyToMono(
+				String.class
+			).block(),
+			HttpStatus.OK);
 	}
-
-	private static final Log _log = LogFactory.getLog(
-		ObjectAction2RestController.class);
 
 }

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-spring-boot/src/main/resources/application-default.properties
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-spring-boot/src/main/resources/application-default.properties
@@ -1,4 +1,12 @@
 #
+# LXC
+#
+
+com.liferay.lxc.dxp.domains=localhost:8080
+com.liferay.lxc.dxp.mainDomain=localhost:8080
+com.liferay.lxc.dxp.server.protocol=http
+
+#
 # OAuth
 #
 


### PR DESCRIPTION
Hi Brian, 
This is a resend of https://github.com/brianchandotcom/liferay-portal/pull/153460.

I only reviewed the TransactionCommitCallback change, not the test logic.

Here TransactionCommitCallback is needed as invocation comes from model listener and may modify the same model entity.

The best way to fix this kind of issue is to restructure/redesign to avoid modifying same model, but here it is an extension point which means we do not have control of the invoked logic, thus the last resort is TransactionCommitCallback.

The team should apply the same approach to other impls of ObjectActionExecutorImpl to make the behavior consistent, they will send following pulls.