### PR TITLE
LPD-33577 Jobs are not rescheduled in the cluster, when the master node is stopped and a new master is selected

### DIFF
--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/messaging/DispatchConfigurator.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/messaging/DispatchConfigurator.java
@@ -193,7 +193,7 @@ public class DispatchConfigurator {
 
 		@Override
 		protected void doMasterTokenReleased() throws Exception {
-			_deleteScheduledJobs();
+			_addScheduledJobs();
 		}
 
 	}

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/messaging/DispatchConfigurator.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/messaging/DispatchConfigurator.java
@@ -11,7 +11,9 @@ import com.liferay.dispatch.executor.DispatchTaskClusterMode;
 import com.liferay.dispatch.internal.helper.DispatchTriggerHelper;
 import com.liferay.dispatch.model.DispatchTrigger;
 import com.liferay.dispatch.service.DispatchTriggerLocalService;
+import com.liferay.portal.kernel.cluster.BaseClusterMasterTokenTransitionListener;
 import com.liferay.portal.kernel.cluster.ClusterMasterExecutor;
+import com.liferay.portal.kernel.cluster.ClusterMasterTokenTransitionListener;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.Destination;
@@ -42,6 +44,14 @@ public class DispatchConfigurator {
 			new DestinationConfiguration(
 				DestinationConfiguration.DESTINATION_TYPE_PARALLEL,
 				DispatchConstants.EXECUTOR_DESTINATION_NAME);
+
+		if (_clusterMasterExecutor.isEnabled()) {
+			_dispatchClusterMasterTokenTransitionListener =
+				new DispatchClusterMasterTokenTransitionListener();
+
+			_clusterMasterExecutor.addClusterMasterTokenTransitionListener(
+				_dispatchClusterMasterTokenTransitionListener);
+		}
 
 		destinationConfiguration.setMaximumQueueSize(_MAXIMUM_QUEUE_SIZE);
 
@@ -78,6 +88,22 @@ public class DispatchConfigurator {
 		_serviceRegistration = bundleContext.registerService(
 			Destination.class, destination, properties);
 
+		_addScheduledJobs();
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_deleteScheduledJobs();
+
+		_serviceRegistration.unregister();
+
+		if (_clusterMasterExecutor.isEnabled()) {
+			_clusterMasterExecutor.removeClusterMasterTokenTransitionListener(
+				_dispatchClusterMasterTokenTransitionListener);
+		}
+	}
+
+	private void _addScheduledJobs() {
 		for (DispatchTrigger dispatchTrigger :
 				_dispatchTriggerLocalService.getDispatchTriggers(true)) {
 
@@ -102,8 +128,7 @@ public class DispatchConfigurator {
 		}
 	}
 
-	@Deactivate
-	protected void deactivate() {
+	private void _deleteScheduledJobs() {
 		for (DispatchTrigger dispatchTrigger :
 				_dispatchTriggerLocalService.getDispatchTriggers(true)) {
 
@@ -118,8 +143,6 @@ public class DispatchConfigurator {
 			_dispatchTriggerHelper.deleteSchedulerJob(
 				dispatchTrigger, dispatchTaskClusterMode.getStorageType());
 		}
-
-		_serviceRegistration.unregister();
 	}
 
 	private boolean _isSchedulable(
@@ -149,6 +172,9 @@ public class DispatchConfigurator {
 	@Reference
 	private DestinationFactory _destinationFactory;
 
+	private ClusterMasterTokenTransitionListener
+		_dispatchClusterMasterTokenTransitionListener;
+
 	@Reference
 	private DispatchTriggerHelper _dispatchTriggerHelper;
 
@@ -156,5 +182,20 @@ public class DispatchConfigurator {
 	private DispatchTriggerLocalService _dispatchTriggerLocalService;
 
 	private ServiceRegistration<Destination> _serviceRegistration;
+
+	private class DispatchClusterMasterTokenTransitionListener
+		extends BaseClusterMasterTokenTransitionListener {
+
+		@Override
+		protected void doMasterTokenAcquired() throws Exception {
+			_addScheduledJobs();
+		}
+
+		@Override
+		protected void doMasterTokenReleased() throws Exception {
+			_deleteScheduledJobs();
+		}
+
+	}
 
 }

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/messaging/DispatchConfigurator.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/messaging/DispatchConfigurator.java
@@ -21,8 +21,6 @@ import com.liferay.portal.kernel.messaging.DestinationConfiguration;
 import com.liferay.portal.kernel.messaging.DestinationFactory;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 
-import java.util.Dictionary;
-import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
 
 import org.osgi.framework.BundleContext;
@@ -54,8 +52,7 @@ public class DispatchConfigurator {
 				DispatchConstants.EXECUTOR_DESTINATION_NAME);
 
 		destinationConfiguration.setMaximumQueueSize(_MAXIMUM_QUEUE_SIZE);
-
-		RejectedExecutionHandler rejectedExecutionHandler =
+		destinationConfiguration.setRejectedExecutionHandler(
 			new ThreadPoolExecutor.CallerRunsPolicy() {
 
 				@Override
@@ -72,21 +69,16 @@ public class DispatchConfigurator {
 					super.rejectedExecution(runnable, threadPoolExecutor);
 				}
 
-			};
-
-		destinationConfiguration.setRejectedExecutionHandler(
-			rejectedExecutionHandler);
+			});
 
 		Destination destination = _destinationFactory.createDestination(
 			destinationConfiguration);
 
-		Dictionary<String, Object> properties =
+		_serviceRegistration = bundleContext.registerService(
+			Destination.class, destination,
 			HashMapDictionaryBuilder.<String, Object>put(
 				"destination.name", destination.getName()
-			).build();
-
-		_serviceRegistration = bundleContext.registerService(
-			Destination.class, destination, properties);
+			).build());
 
 		_addScheduledJobs();
 	}

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/messaging/DispatchConfigurator.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/messaging/DispatchConfigurator.java
@@ -40,11 +40,6 @@ public class DispatchConfigurator {
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
-		DestinationConfiguration destinationConfiguration =
-			new DestinationConfiguration(
-				DestinationConfiguration.DESTINATION_TYPE_PARALLEL,
-				DispatchConstants.EXECUTOR_DESTINATION_NAME);
-
 		if (_clusterMasterExecutor.isEnabled()) {
 			_dispatchClusterMasterTokenTransitionListener =
 				new DispatchClusterMasterTokenTransitionListener();
@@ -52,6 +47,11 @@ public class DispatchConfigurator {
 			_clusterMasterExecutor.addClusterMasterTokenTransitionListener(
 				_dispatchClusterMasterTokenTransitionListener);
 		}
+
+		DestinationConfiguration destinationConfiguration =
+			new DestinationConfiguration(
+				DestinationConfiguration.DESTINATION_TYPE_PARALLEL,
+				DispatchConstants.EXECUTOR_DESTINATION_NAME);
 
 		destinationConfiguration.setMaximumQueueSize(_MAXIMUM_QUEUE_SIZE);
 

--- a/modules/apps/dispatch/dispatch-service/src/test/java/com/liferay/dispatch/internal/messaging/DispatchConfiguratorTest.java
+++ b/modules/apps/dispatch/dispatch-service/src/test/java/com/liferay/dispatch/internal/messaging/DispatchConfiguratorTest.java
@@ -507,16 +507,16 @@ public class DispatchConfiguratorTest {
 
 		Mockito.verify(
 			_dispatchTriggerHelper
-		).deleteSchedulerJob(
+		).addSchedulerJob(
 			Mockito.same(_allNodesDispatchTrigger),
-			Mockito.eq(StorageType.MEMORY)
+			Mockito.eq(StorageType.MEMORY), Mockito.any()
 		);
 
 		Mockito.verify(
 			_dispatchTriggerHelper, Mockito.never()
-		).deleteSchedulerJob(
+		).addSchedulerJob(
 			Mockito.same(_notApplicableDispatchTrigger),
-			Mockito.eq(StorageType.MEMORY)
+			Mockito.eq(StorageType.MEMORY), Mockito.any()
 		);
 
 		_dispatchConfigurator.deactivate();

--- a/modules/apps/dispatch/dispatch-service/src/test/java/com/liferay/dispatch/internal/messaging/DispatchConfiguratorTest.java
+++ b/modules/apps/dispatch/dispatch-service/src/test/java/com/liferay/dispatch/internal/messaging/DispatchConfiguratorTest.java
@@ -90,7 +90,9 @@ public class DispatchConfiguratorTest {
 	}
 
 	@Test
-	public void testNoClusterNoListener() throws Exception {
+	public void testOnActivationNoClusterMasterTokenTransitionListenerAddedWhenClusterDisabled()
+		throws Exception {
+
 		Mockito.when(
 			_clusterMasterExecutor.isEnabled()
 		).thenReturn(
@@ -381,7 +383,9 @@ public class DispatchConfiguratorTest {
 	}
 
 	@Test
-	public void testOnMasterTokenAcquired() throws Exception {
+	public void testOnMasterTokenAcquiredSchedulesAllTypesOfJobs()
+		throws Exception {
+
 		Mockito.when(
 			_clusterMasterExecutor.isEnabled()
 		).thenReturn(
@@ -462,7 +466,9 @@ public class DispatchConfiguratorTest {
 	}
 
 	@Test
-	public void testOnMasterTokenReleased() throws Exception {
+	public void testOnMasterTokenReleasedSchedulesOnlyAllNodesJobs()
+		throws Exception {
+
 		Mockito.when(
 			_clusterMasterExecutor.isEnabled()
 		).thenReturn(

--- a/modules/apps/dispatch/dispatch-service/src/test/java/com/liferay/dispatch/internal/messaging/DispatchConfiguratorTest.java
+++ b/modules/apps/dispatch/dispatch-service/src/test/java/com/liferay/dispatch/internal/messaging/DispatchConfiguratorTest.java
@@ -10,6 +10,7 @@ import com.liferay.dispatch.internal.helper.DispatchTriggerHelper;
 import com.liferay.dispatch.model.DispatchTrigger;
 import com.liferay.dispatch.service.DispatchTriggerLocalService;
 import com.liferay.portal.kernel.cluster.ClusterMasterExecutor;
+import com.liferay.portal.kernel.cluster.ClusterMasterTokenTransitionListener;
 import com.liferay.portal.kernel.messaging.Destination;
 import com.liferay.portal.kernel.messaging.DestinationFactory;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
@@ -23,6 +24,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -84,6 +86,39 @@ public class DispatchConfiguratorTest {
 			_singleNodePersistedDispatchTrigger.getDispatchTaskClusterMode()
 		).thenReturn(
 			DispatchTaskClusterMode.SINGLE_NODE_PERSISTED.getMode()
+		);
+	}
+
+	@Test
+	public void testNoClusterNoListener() throws Exception {
+		Mockito.when(
+			_clusterMasterExecutor.isEnabled()
+		).thenReturn(
+			false
+		);
+
+		Mockito.when(
+			_clusterMasterExecutor.isMaster()
+		).thenReturn(
+			false
+		);
+
+		_dispatchConfigurator.activate(_bundleContext);
+
+		Mockito.reset(_dispatchTriggerHelper);
+
+		Mockito.verify(
+			_clusterMasterExecutor, Mockito.never()
+		).addClusterMasterTokenTransitionListener(
+			Mockito.any()
+		);
+
+		_dispatchConfigurator.deactivate();
+
+		Mockito.verify(
+			_clusterMasterExecutor, Mockito.never()
+		).removeClusterMasterTokenTransitionListener(
+			Mockito.any()
 		);
 	}
 
@@ -342,6 +377,154 @@ public class DispatchConfiguratorTest {
 		).deleteSchedulerJob(
 			Mockito.same(_singleNodePersistedDispatchTrigger),
 			Mockito.eq(StorageType.PERSISTED)
+		);
+	}
+
+	@Test
+	public void testOnMasterTokenAcquired() throws Exception {
+		Mockito.when(
+			_clusterMasterExecutor.isEnabled()
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_clusterMasterExecutor.isMaster()
+		).thenReturn(
+			false
+		);
+
+		ArgumentCaptor<ClusterMasterTokenTransitionListener> argumentCaptor =
+			ArgumentCaptor.forClass(ClusterMasterTokenTransitionListener.class);
+
+		_dispatchConfigurator.activate(_bundleContext);
+
+		Mockito.reset(_dispatchTriggerHelper);
+
+		Mockito.verify(
+			_clusterMasterExecutor
+		).addClusterMasterTokenTransitionListener(
+			argumentCaptor.capture()
+		);
+
+		Mockito.when(
+			_clusterMasterExecutor.isMaster()
+		).thenReturn(
+			true
+		);
+
+		ClusterMasterTokenTransitionListener
+			clusterMasterTokenTransitionListener = argumentCaptor.getValue();
+
+		clusterMasterTokenTransitionListener.masterTokenAcquired();
+
+		Mockito.verify(
+			_dispatchTriggerLocalService, Mockito.times(2)
+		).getDispatchTriggers(
+			Mockito.eq(true)
+		);
+
+		Mockito.verify(
+			_dispatchTriggerHelper
+		).addSchedulerJob(
+			Mockito.same(_allNodesDispatchTrigger),
+			Mockito.eq(StorageType.MEMORY), Mockito.any()
+		);
+
+		Mockito.verify(
+			_dispatchTriggerHelper, Mockito.never()
+		).addSchedulerJob(
+			Mockito.same(_notApplicableDispatchTrigger),
+			Mockito.eq(StorageType.MEMORY), Mockito.any()
+		);
+
+		Mockito.verify(
+			_dispatchTriggerHelper
+		).addSchedulerJob(
+			Mockito.same(_singleNodeMemoryClusteredDispatchTrigger),
+			Mockito.eq(StorageType.MEMORY_CLUSTERED), Mockito.any()
+		);
+
+		Mockito.verify(
+			_dispatchTriggerHelper
+		).addSchedulerJob(
+			Mockito.same(_singleNodePersistedDispatchTrigger),
+			Mockito.eq(StorageType.PERSISTED), Mockito.any()
+		);
+
+		_dispatchConfigurator.deactivate();
+
+		Mockito.verify(
+			_clusterMasterExecutor
+		).removeClusterMasterTokenTransitionListener(
+			Mockito.same(clusterMasterTokenTransitionListener)
+		);
+	}
+
+	@Test
+	public void testOnMasterTokenReleased() throws Exception {
+		Mockito.when(
+			_clusterMasterExecutor.isEnabled()
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_clusterMasterExecutor.isMaster()
+		).thenReturn(
+			true
+		);
+
+		ArgumentCaptor<ClusterMasterTokenTransitionListener> argumentCaptor =
+			ArgumentCaptor.forClass(ClusterMasterTokenTransitionListener.class);
+
+		_dispatchConfigurator.activate(_bundleContext);
+
+		Mockito.reset(_dispatchTriggerHelper);
+
+		Mockito.verify(
+			_clusterMasterExecutor
+		).addClusterMasterTokenTransitionListener(
+			argumentCaptor.capture()
+		);
+
+		Mockito.when(
+			_clusterMasterExecutor.isMaster()
+		).thenReturn(
+			false
+		);
+
+		ClusterMasterTokenTransitionListener
+			clusterMasterTokenTransitionListener = argumentCaptor.getValue();
+
+		clusterMasterTokenTransitionListener.masterTokenReleased();
+
+		Mockito.verify(
+			_dispatchTriggerLocalService, Mockito.times(2)
+		).getDispatchTriggers(
+			Mockito.eq(true)
+		);
+
+		Mockito.verify(
+			_dispatchTriggerHelper
+		).deleteSchedulerJob(
+			Mockito.same(_allNodesDispatchTrigger),
+			Mockito.eq(StorageType.MEMORY)
+		);
+
+		Mockito.verify(
+			_dispatchTriggerHelper, Mockito.never()
+		).deleteSchedulerJob(
+			Mockito.same(_notApplicableDispatchTrigger),
+			Mockito.eq(StorageType.MEMORY)
+		);
+
+		_dispatchConfigurator.deactivate();
+
+		Mockito.verify(
+			_clusterMasterExecutor
+		).removeClusterMasterTokenTransitionListener(
+			Mockito.same(clusterMasterTokenTransitionListener)
 		);
 	}
 

--- a/modules/apps/dispatch/dispatch-service/src/test/java/com/liferay/dispatch/internal/messaging/DispatchConfiguratorTest.java
+++ b/modules/apps/dispatch/dispatch-service/src/test/java/com/liferay/dispatch/internal/messaging/DispatchConfiguratorTest.java
@@ -525,6 +525,20 @@ public class DispatchConfiguratorTest {
 			Mockito.eq(StorageType.MEMORY), Mockito.any()
 		);
 
+		Mockito.verify(
+			_dispatchTriggerHelper, Mockito.never()
+		).addSchedulerJob(
+			Mockito.same(_singleNodeMemoryClusteredDispatchTrigger),
+			Mockito.eq(StorageType.MEMORY_CLUSTERED), Mockito.any()
+		);
+
+		Mockito.verify(
+			_dispatchTriggerHelper, Mockito.never()
+		).addSchedulerJob(
+			Mockito.same(_singleNodePersistedDispatchTrigger),
+			Mockito.eq(StorageType.PERSISTED), Mockito.any()
+		);
+
 		_dispatchConfigurator.deactivate();
 
 		Mockito.verify(

--- a/modules/apps/dispatch/dispatch-service/src/test/java/com/liferay/dispatch/internal/messaging/DispatchConfiguratorTest.java
+++ b/modules/apps/dispatch/dispatch-service/src/test/java/com/liferay/dispatch/internal/messaging/DispatchConfiguratorTest.java
@@ -90,7 +90,7 @@ public class DispatchConfiguratorTest {
 	}
 
 	@Test
-	public void testOnActivationNoClusterMasterTokenTransitionListenerAddedWhenClusterDisabled()
+	public void testActivateNoClusterMasterTokenTransitionListenerAddedWhenClusterDisabled()
 		throws Exception {
 
 		Mockito.when(
@@ -125,7 +125,7 @@ public class DispatchConfiguratorTest {
 	}
 
 	@Test
-	public void testOnActivationSchedulesAllTypesOfJobsOnMasterNode()
+	public void testActivateSchedulesAllTypesOfJobsOnMasterNode()
 		throws Exception {
 
 		Mockito.when(
@@ -188,7 +188,7 @@ public class DispatchConfiguratorTest {
 	}
 
 	@Test
-	public void testOnActivationSchedulesOnlyAllNodesJobs() throws Exception {
+	public void testActivateSchedulesOnlyAllNodesJobs() throws Exception {
 		Mockito.when(
 			_clusterMasterExecutor.isMaster()
 		).thenReturn(
@@ -249,7 +249,7 @@ public class DispatchConfiguratorTest {
 	}
 
 	@Test
-	public void testOnDeactivationUnschedulesAllTypeOfJobsOnMasterNode() {
+	public void testDeactivateUnschedulesAllTypeOfJobsOnMasterNode() {
 		Mockito.when(
 			_clusterMasterExecutor.isMaster()
 		).thenReturn(
@@ -316,7 +316,7 @@ public class DispatchConfiguratorTest {
 	}
 
 	@Test
-	public void testOnDeactivationUnschedulesOnlyAllNodesJobs() {
+	public void testDeactivateUnschedulesOnlyAllNodesJobs() {
 		Mockito.when(
 			_clusterMasterExecutor.isMaster()
 		).thenReturn(
@@ -383,7 +383,7 @@ public class DispatchConfiguratorTest {
 	}
 
 	@Test
-	public void testOnMasterTokenAcquiredSchedulesAllTypesOfJobs()
+	public void testMasterTokenAcquiredSchedulesAllTypesOfJobs()
 		throws Exception {
 
 		Mockito.when(
@@ -466,7 +466,7 @@ public class DispatchConfiguratorTest {
 	}
 
 	@Test
-	public void testOnMasterTokenReleasedSchedulesOnlyAllNodesJobs()
+	public void testMasterTokenReleasedSchedulesOnlyAllNodesJobs()
 		throws Exception {
 
 		Mockito.when(


### PR DESCRIPTION
See: https://github.com/brianchandotcom/liferay-portal/pull/153741

Ticket: https://liferay.atlassian.net/browse/LPD-33577

---
These are the methods we are testing:

- activate
- deactivate
- masterTokenAcquired
- masterTokenReleased

We have updated the names to make it match with the pattern:

`test[methodName][extraInfo]`

---

cc/ @vendeltoreki
