### PR TITLE
LRDOCS-13893 Wordsmithing Breaking Changes Amendments

### DIFF
--- a/readme/BREAKING_CHANGES_AMENDMENTS.markdown
+++ b/readme/BREAKING_CHANGES_AMENDMENTS.markdown
@@ -575,16 +575,15 @@ LPS-197267 Move PermissionConverter to portal-security-permission-api and Remove
 
 ## What portal-kernel/src/com/liferay/portal/kernel/security/permission/PermissionConverterUtil.java
 
-Remove class PermissionConverterUtil.
+The PermissionConverterUtil class is removed.
 
 ## Why
 
-Move PermissionConverter to portal-security-permission-api.
+The PermissionConverter APIs are now in portal-security-permission-api.
 
 ## Alternative
 
- Use OSGi service reference PermissionConverter
-
+Use an OSGi service to reference PermissionConverter.
 ```
 
 ----

--- a/readme/BREAKING_CHANGES_AMENDMENTS.markdown
+++ b/readme/BREAKING_CHANGES_AMENDMENTS.markdown
@@ -597,11 +597,11 @@ LPS-197267 Remove unused PermissionConverter overloaded methods
 
 # breaking
 
-## What portal-kernel/src/com/liferay/portal/kernel/security/permission/PermissionConverterUtil.java
+## What modules/apps/portal-security/portal-security-permission-api/src/main/java/com/liferay/portal/security/permission/converter/PermissionConverter.java
 
-Remove class PermissionConverterUtil.
+The convertPermissions(long) and convertPermissions(long, PermissionConversionFilter) methods are removed from PermissionConverter.
 
 ## Why
 
-Move PermissionConverter to portal-security-permission-api.
+These methods are no longer used after refactoring the PermissionConverter APIs.
 ```


### PR DESCRIPTION
See: https://liferay.atlassian.net/browse/LRDOCS-13893

Here are edits for the newest entries. I noticed that for some reason one of the entries incorrectly copied the previous commit's change, so I looked up the commit and rewrote it to reflect the actual breaking change.

Note that I was not able to get a response from the team in the last week to confirm an explanation for this commit, so if it's a problem that I didn't have their input for this, I could instead just remove the entry altogether. But I was at least able to put the obvious explanation (for "Why"), even if it's not that informative.

Please let me know if there is anything else I can do for this. Thanks.