### PR TITLE
LPD-35896 Rather than upgrading bnd-invoker's bnd lib version, workar…

### DIFF
--- a/common.bnd
+++ b/common.bnd
@@ -13,6 +13,9 @@ Liferay-Portal-Release-Info: ${release.info.release.info}
 Liferay-Portal-Server-Info: ${release.info.server.info}
 Liferay-Portal-Version: ${release.info.version}
 Liferay-Portal-Version-Display-Name: ${release.info.version.display.name}
+Require-Capability:\
+	osgi.ee;\
+		filter:="(&(osgi.ee=JavaSE)(version=${ant.build.javac.target}))"
 -donotcopy: (\.touch)
 -fixupmessages.deprecated=annotations are deprecated
 -sources: false


### PR DESCRIPTION
…ound its java version limit. We really should move all ant based project to gradle, then bnd-invoker can just be removed.