### PR TITLE
LPD-35541 DM: replace the deprecated google library js api

### DIFF
--- a/modules/apps/document-library-google-docs/document-library-google-docs/src/main/resources/com/liferay/document/library/google/docs/internal/display/context/dependencies/google_file_picker.ftl
+++ b/modules/apps/document-library-google-docs/document-library-google-docs/src/main/resources/com/liferay/document/library/google/docs/internal/display/context/dependencies/google_file_picker.ftl
@@ -63,22 +63,27 @@ GoogleFilePicker.prototype = {
 	_onAuthAPILoad: function() {
 		var instance = this;
 
-		window.gapi.auth.authorize(
-			{
-				'client_id': GoogleFilePicker.CLIENT_ID,
-				'immediate': false,
-				'scope': GoogleFilePicker.SCOPE
-			},
-			function(authResult) {
-				if (authResult && !authResult.error) {
-					instance._oauthToken = authResult.access_token;
-
-					instance._authAPILoaded = true;
-
-					instance._createPicker();
+		var tokenClient = google.accounts.oauth2.initTokenClient({
+			client_id: GoogleFilePicker.CLIENT_ID,
+			'immediate': false,
+			scope: GoogleFilePicker.SCOPE[0],
+			callback: (authResult) => {
+				if (authResult && authResult.error !== undefined) {
+					throw (authResult);
 				}
+
+				instance._oauthToken = authResult.access_token;
+
+				instance._authAPILoaded = true;
+
+				instance._createPicker();
+			},
+			error_callback: function(error) {
+				console.error(error);
 			}
-		);
+		});
+
+		tokenClient.requestAccessToken();
 	},
 
 	_onPickerAPILoad: function() {
@@ -131,6 +136,15 @@ if (!window.gapi && !document.getElementById('googleAPILoader')) {
 }
 else if (window.gapi) {
 	Liferay.fire('googleAPILoaded');
+}
+
+if (!google) {
+	var scriptNodeGis = document.createElement('script');
+
+	scriptNodeGis.id = 'gisAPILoader';
+	scriptNodeGis.src = 'https://accounts.google.com/gsi/client';
+
+	document.body.appendChild(scriptNodeGis);
 }
 
 var FilePicker = GoogleFilePicker;

--- a/modules/apps/document-library-google-docs/document-library-google-docs/src/main/resources/com/liferay/document/library/google/docs/internal/display/context/dependencies/google_file_picker.ftl
+++ b/modules/apps/document-library-google-docs/document-library-google-docs/src/main/resources/com/liferay/document/library/google/docs/internal/display/context/dependencies/google_file_picker.ftl
@@ -64,9 +64,6 @@ GoogleFilePicker.prototype = {
 		var instance = this;
 
 		var tokenClient = google.accounts.oauth2.initTokenClient({
-			client_id: GoogleFilePicker.CLIENT_ID,
-			immediate: false,
-			scope: GoogleFilePicker.SCOPE,
 			callback: (authResult) => {
 				if (authResult && authResult.error !== undefined) {
 					throw (authResult);
@@ -78,11 +75,14 @@ GoogleFilePicker.prototype = {
 
 				instance._createPicker();
 			},
+			client_id: GoogleFilePicker.CLIENT_ID,
 			error_callback: function(error) {
 				if (process.env.NODE_ENV === 'development') {
 					console.error(error);
 				}
-			}
+			},
+			immediate: false,
+			scope: GoogleFilePicker.SCOPE
 		});
 
 		tokenClient.requestAccessToken();

--- a/modules/apps/document-library-google-docs/document-library-google-docs/src/main/resources/com/liferay/document/library/google/docs/internal/display/context/dependencies/google_file_picker.ftl
+++ b/modules/apps/document-library-google-docs/document-library-google-docs/src/main/resources/com/liferay/document/library/google/docs/internal/display/context/dependencies/google_file_picker.ftl
@@ -1,9 +1,9 @@
 function GoogleFilePicker(callback) {
-	if (window.gapi) {
+	if (window.google) {
 		callback();
 	}
 	else {
-		Liferay.once('googleAPILoaded', callback);
+		Liferay.once('gisAPILoaded', callback);
 	}
 }
 
@@ -122,8 +122,8 @@ GoogleFilePicker.SCOPE = [
 	'https://www.googleapis.com/auth/drive.readonly'
 ];
 
-window.onGoogleAPILoad = function() {
-	Liferay.fire('googleAPILoaded');
+window.onGisAPILoad = function() {
+	Liferay.fire('gisAPILoaded');
 };
 
 if (!window.gapi && !document.getElementById('googleAPILoader')) {
@@ -134,14 +134,12 @@ if (!window.gapi && !document.getElementById('googleAPILoader')) {
 
 	document.body.appendChild(scriptNode);
 }
-else if (window.gapi) {
-	Liferay.fire('googleAPILoaded');
-}
 
-if (!google) {
+if (!window.google) {
 	var scriptNodeGis = document.createElement('script');
 
 	scriptNodeGis.id = 'gisAPILoader';
+	scriptNodeGis.onload = onGisAPILoad;
 	scriptNodeGis.src = 'https://accounts.google.com/gsi/client';
 
 	document.body.appendChild(scriptNodeGis);

--- a/modules/apps/document-library-google-docs/document-library-google-docs/src/main/resources/com/liferay/document/library/google/docs/internal/display/context/dependencies/google_file_picker.ftl
+++ b/modules/apps/document-library-google-docs/document-library-google-docs/src/main/resources/com/liferay/document/library/google/docs/internal/display/context/dependencies/google_file_picker.ftl
@@ -65,8 +65,8 @@ GoogleFilePicker.prototype = {
 
 		var tokenClient = google.accounts.oauth2.initTokenClient({
 			client_id: GoogleFilePicker.CLIENT_ID,
-			'immediate': false,
-			scope: GoogleFilePicker.SCOPE[0],
+			immediate: false,
+			scope: GoogleFilePicker.SCOPE,
 			callback: (authResult) => {
 				if (authResult && authResult.error !== undefined) {
 					throw (authResult);
@@ -79,7 +79,9 @@ GoogleFilePicker.prototype = {
 				instance._createPicker();
 			},
 			error_callback: function(error) {
-				console.error(error);
+				if (process.env.NODE_ENV === 'development') {
+					console.error(error);
+				}
 			}
 		});
 
@@ -118,9 +120,7 @@ GoogleFilePicker.API_KEY = '${htmlUtil.escapeJS(googleAppsAPIKey)}';
 
 GoogleFilePicker.CLIENT_ID = '${htmlUtil.escapeJS(googleClientId)}';
 
-GoogleFilePicker.SCOPE = [
-	'https://www.googleapis.com/auth/drive.readonly'
-];
+GoogleFilePicker.SCOPE = 'https://www.googleapis.com/auth/drive.readonly';
 
 window.onGisAPILoad = function() {
 	Liferay.fire('gisAPILoaded');


### PR DESCRIPTION
Follow up of https://github.com/brianchandotcom/liferay-portal/pull/154120
See https://github.com/brianchandotcom/liferay-portal/pull/154120#issuecomment-2346713293 

> @ambrinchaudhary not sorted
> 
> 		var tokenClient = google.accounts.oauth2.initTokenClient({
> 			client_id: GoogleFilePicker.CLIENT_ID,
> 			immediate: false,
> 			scope: GoogleFilePicker.SCOPE,
> 			callback: (authResult) => {
> plesae resend. Thx.

# What is this trying to solve?
[Link to issue](https://liferay.atlassian.net/browse/LPD-35045)

New OAuth Client IDs cannot use the deprecated google library js api

# How am I solving this
Using the new Google API

# How can be tested
This new API works with old API keys and new ones generated with OAuth 2.0.

For testing with old API Keys: get the credentials from 1Password
For testing with new API Keys: follow the steps described in https://liferay.atlassian.net/browse/LPD-35045. Pending request to IT to get this credentials in our 1Password vault.
Current functional tests are ignored due to google security issues while automating the authentication.