### PR TITLE
Lpd 36475

### DIFF
--- a/modules/core/petra/petra-reflect/bnd.bnd
+++ b/modules/core/petra/petra-reflect/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Petra Reflect
 Bundle-SymbolicName: com.liferay.petra.reflect
-Bundle-Version: 7.0.1
+Bundle-Version: 7.1.0
 Export-Package: com.liferay.petra.reflect

--- a/modules/core/petra/petra-reflect/src/main/java/com/liferay/petra/reflect/ReflectionUtil.java
+++ b/modules/core/petra/petra-reflect/src/main/java/com/liferay/petra/reflect/ReflectionUtil.java
@@ -5,6 +5,7 @@
 
 package com.liferay.petra.reflect;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
@@ -48,6 +49,10 @@ public class ReflectionUtil {
 		method.setAccessible(true);
 
 		return method;
+	}
+
+	public static MethodHandles.Lookup getImplLookup() {
+		return _implLookup;
 	}
 
 	public static Class<?>[] getInterfaces(Object object) {
@@ -103,6 +108,22 @@ public class ReflectionUtil {
 		throws E {
 
 		throw (E)throwable;
+	}
+
+	private static final MethodHandles.Lookup _implLookup;
+
+	static {
+		try {
+			Field field = MethodHandles.Lookup.class.getDeclaredField(
+				"IMPL_LOOKUP");
+
+			field.setAccessible(true);
+
+			_implLookup = (MethodHandles.Lookup)field.get(null);
+		}
+		catch (Exception exception) {
+			throw new ExceptionInInitializerError(exception);
+		}
 	}
 
 }

--- a/modules/core/petra/petra-reflect/src/main/resources/com/liferay/petra/reflect/packageinfo
+++ b/modules/core/petra/petra-reflect/src/main/resources/com/liferay/petra/reflect/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0

--- a/modules/core/petra/petra-reflect/src/test/java/com/liferay/petra/reflect/ReflectionUtilTest.java
+++ b/modules/core/petra/petra-reflect/src/test/java/com/liferay/petra/reflect/ReflectionUtilTest.java
@@ -5,8 +5,10 @@
 
 package com.liferay.petra.reflect;
 
+import com.liferay.portal.kernel.test.SwappableSecurityManager;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
+import com.liferay.portal.kernel.test.rule.NewEnv;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.lang.reflect.Field;
@@ -16,7 +18,10 @@ import java.lang.reflect.Modifier;
 import java.net.URL;
 import java.net.URLClassLoader;
 
+import java.security.Permission;
+
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Assert;
@@ -34,6 +39,37 @@ public class ReflectionUtilTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			CodeCoverageAssertor.INSTANCE, LiferayUnitTestRule.INSTANCE);
+
+	@NewEnv(type = NewEnv.Type.JVM)
+	@Test
+	public void testClassInitializationFailure() throws Exception {
+		SecurityException securityException = new SecurityException();
+
+		try (SwappableSecurityManager swappableSecurityManager =
+				new SwappableSecurityManager() {
+
+					@Override
+					public void checkPermission(Permission permission) {
+						if (Objects.equals(
+								permission.getName(),
+								"accessDeclaredMembers")) {
+
+							throw securityException;
+						}
+					}
+
+				}) {
+
+			swappableSecurityManager.install();
+
+			Class.forName(ReflectionUtil.class.getName());
+
+			Assert.fail();
+		}
+		catch (ExceptionInInitializerError eiie) {
+			Assert.assertSame(securityException, eiie.getCause());
+		}
+	}
 
 	@Test
 	public void testConstructor() {
@@ -86,6 +122,11 @@ public class ReflectionUtilTest {
 
 		Assert.assertTrue(method.isAccessible());
 		Assert.assertSame(TestClass._privateStaticObject, method.invoke(null));
+	}
+
+	@Test
+	public void testGetImplLookup() {
+		Assert.assertNotNull(ReflectionUtil.getImplLookup());
 	}
 
 	@Test

--- a/portal-impl/src/com/liferay/portal/language/LanguageResources.java
+++ b/portal-impl/src/com/liferay/portal/language/LanguageResources.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.language;
 
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.module.service.Snapshot;
@@ -15,6 +16,10 @@ import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.AggregateResourceBundle;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -238,7 +243,13 @@ public class LanguageResources {
 				_locale);
 
 			if (overrideResourceBundle != null) {
-				return overrideResourceBundle.getObject(key);
+				try {
+					return _handleGetObjectMethodHandle.invokeExact(
+						overrideResourceBundle, key);
+				}
+				catch (Throwable throwable) {
+					ReflectionUtil.throwException(throwable);
+				}
 			}
 
 			return null;
@@ -250,7 +261,13 @@ public class LanguageResources {
 				_locale);
 
 			if (overrideResourceBundle != null) {
-				return overrideResourceBundle.keySet();
+				try {
+					return (Set<String>)_handleKeySetMethodHandle.invokeExact(
+						overrideResourceBundle);
+				}
+				catch (Throwable throwable) {
+					ReflectionUtil.throwException(throwable);
+				}
 			}
 
 			return Collections.emptySet();
@@ -258,6 +275,27 @@ public class LanguageResources {
 
 		private DynamicOverrideResourceBundle(Locale locale) {
 			_locale = locale;
+		}
+
+		private static final MethodHandle _handleGetObjectMethodHandle;
+		private static final MethodHandle _handleKeySetMethodHandle;
+
+		static {
+			try {
+				MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+				_handleGetObjectMethodHandle = lookup.findVirtual(
+					ResourceBundle.class, "handleGetObject",
+					MethodType.methodType(Object.class, String.class));
+
+				_handleKeySetMethodHandle = lookup.findVirtual(
+					ResourceBundle.class, "handleKeySet",
+					MethodType.methodType(Set.class));
+			}
+			catch (ReflectiveOperationException reflectiveOperationException) {
+				throw new ExceptionInInitializerError(
+					reflectiveOperationException);
+			}
 		}
 
 		private final Locale _locale;


### PR DESCRIPTION
@tinatian @vicnate5 please backport for LXC, thanks!

@victorhcunha please run a check for login case, thanks!

@tinatian @kevhlee ResourceBundle wrapper without using the parent field is a very tricky thing to do. It can be done like what I did in this pull, but not by the way to simply delegate ResourceBundle.handleGetObject() to inner ResourceBundle.getObject() and ResourceBundle.handleKeySet() to inner ResourceBundle.keySet(). 