### PR TITLE
LPD-35723 A temp logging support, revert in the end. Due to JAXRS con…

### DIFF
--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
@@ -64,6 +64,9 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -120,13 +123,25 @@ public class ObjectDefinitionResourceImpl
 			startTime = System.currentTimeMillis();
 		}
 
-		_objectDefinitionService.deleteObjectDefinition(objectDefinitionId);
+		try {
+			TransactionInvokerUtil.invoke(
+				_transactionConfig,
+				() -> {
+					_objectDefinitionService.deleteObjectDefinition(
+						objectDefinitionId);
+
+					return null;
+				});
+		}
+		catch (Throwable throwable) {
+			throw new Exception(throwable);
+		}
 
 		if (_log.isInfoEnabled()) {
 			_log.info(
 				StringBundler.concat(
-					"Deleted object definition ", objectDefinitionId,
-					" in ", System.currentTimeMillis() - startTime, "ms"));
+					"Deleted object definition ", objectDefinitionId, " in ",
+					System.currentTimeMillis() - startTime, "ms"));
 		}
 	}
 
@@ -1442,6 +1457,9 @@ public class ObjectDefinitionResourceImpl
 
 	private static final EntityModel _entityModel =
 		new ObjectDefinitionEntityModel();
+	private static final TransactionConfig _transactionConfig =
+		TransactionConfig.Factory.create(
+			Propagation.REQUIRES_NEW, new Class<?>[] {Exception.class});
 
 	@Reference
 	private Language _language;


### PR DESCRIPTION
…trols transaction scope, at this level after Resource call, the tx is not committed yet, therefore the timing was not including search indexing. Wrap up a new tx to ensure we time for search. Since this Resource works at top level under JAXRS, the new TX itself won't cause any other side affect, but we still need to revert it in the of the optimization.

@victorhcunha this is an important follow up for https://github.com/brianchandotcom/liferay-portal/pull/154194 , make sure you include this commit for the baseline, otherwise we are not counting search indexing time.

CC @vicnate5 