### PR TITLE
LPD-30952 Remove incorrectly upgraded import since only some of the constants got moved to CommerceOrderPaymentConstants not all of them

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/imports.txt
+++ b/modules/util/source-formatter/src/main/resources/dependencies/imports.txt
@@ -55,7 +55,6 @@ com.liferay.commerce.account.service.CommerceAccountGroupRelLocalServiceUtil=com
 com.liferay.commerce.account.service.CommerceAccountGroupRelService=com.liferay.account.service.AccountGroupRelService
 com.liferay.commerce.account.service.CommerceAccountGroupRelServiceUtil=com.liferay.account.service.AccountGroupRelServiceUtil
 com.liferay.commerce.constants.CommerceDestinationNames=com.liferay.portal.kernel.messaging.DestinationNames
-com.liferay.commerce.constants.CommerceOrderConstants=com.liferay.commerce.constants.CommerceOrderPaymentConstants
 com.liferay.commerce.model.CommerceCountry=com.liferay.portal.kernel.model.Country
 com.liferay.commerce.model.CommerceRegion=com.liferay.portal.kernel.model.Region
 com.liferay.commerce.product.content.util.CPContentHelper=com.liferay.commerce.product.content.helper.CPContentHelper


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-30952

cc: @drewbrokke @nicolas-sss
Manually forwarded from https://github.com/liferay-devtools/liferay-portal/pull/225/
Passed review and SF locally, ci:test:hotel on CI, SF failure was unrelated

Not sure if we want to add testing to this still since we normally dont add testing for new imports.txt cases, adding testing to this fix seems to add as much value as adding testing to the rest of the cases