### PR TITLE
LPD-34573 Remove Site Initializer tests from site-management

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -6106,8 +6106,6 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
     # Liferay Site Initializer
     #
 
-    dist.type[liferay-site-initializer]=release
-
     test.batch.dist.app.servers[liferay-site-initializer]=tomcat
 
     test.batch.names[liferay-site-initializer]=\

--- a/test.properties
+++ b/test.properties
@@ -9717,75 +9717,49 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         (testray.main.component.name == "Breadcrumb Widget") OR \
         (testray.main.component.name == "Click to Chat") OR \
         (testray.main.component.name == "Friendly URL Service") OR \
-        (testray.main.component.name == "Liferay Learn Site Initializer") OR \
-        (testray.main.component.name == "Liferay Online") OR \
-        (testray.main.component.name == "Liferaybotics") OR \
-        (testray.main.component.name == "Masterclass") OR \
         (testray.main.component.name == "Navigation Menus") OR \
-        (testray.main.component.name == "Site Initializer Extender") OR \
-        (testray.main.component.name == "Site Initializer Liferay Marketplace") OR \
-        (testray.main.component.name == "Site Initializer Raylife AP") OR \
-        (testray.main.component.name == "Site Initializer Raylife D2C") OR \
-        (testray.main.component.name == "Site Initializer Testray") OR \
         (testray.main.component.name == "Sitemap Protocol") OR \
         (testray.main.component.name == "Sites Administration") OR \
         (testray.main.component.name == "Sites Directory Widget") OR \
-        (testray.main.component.name == "Team Extranet") OR \
         (testray.main.component.name == "URL Redirections")
 
     test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8][site-management]=\
-        (testray.main.component.name == "Upgrades Site Management") OR \
-        (testray.main.component.name == "Upgrades Solutions")
+        (testray.main.component.name == "Upgrades Site Management")
 
     test.batch.run.property.query[functional-upgrade-tomcat90-db2111-jdk8][site-management]=\
         (\
             (database.types == null) OR \
             (database.types ~ db2)\
         ) AND \
-        (\
-            (testray.main.component.name == "Upgrades Site Management") OR \
-            (testray.main.component.name == "Upgrades Solutions")\
-        )
+        (testray.main.component.name == "Upgrades Site Management")
 
     test.batch.run.property.query[functional-upgrade-tomcat90-mariadb102-jdk8][site-management]=\
         (\
             (database.types == null) OR \
             (database.types ~ mariadb)\
         ) AND \
-        (\
-            (testray.main.component.name == "Upgrades Site Management") OR \
-            (testray.main.component.name == "Upgrades Solutions")\
-        )
+        (testray.main.component.name == "Upgrades Site Management")
 
     test.batch.run.property.query[functional-upgrade-tomcat90-oracle193-jdk8][site-management]=\
         (\
             (database.types == null) OR \
             (database.types ~ oracle)\
         ) AND \
-        (\
-            (testray.main.component.name == "Upgrades Site Management") OR \
-            (testray.main.component.name == "Upgrades Solutions")\
-        )
+        (testray.main.component.name == "Upgrades Site Management")
 
     test.batch.run.property.query[functional-upgrade-tomcat90-postgresql*-jdk8][site-management]=\
         (\
             (database.types == null) OR \
             (database.types ~ postgresql)\
         ) AND \
-        (\
-            (testray.main.component.name == "Upgrades Site Management") OR \
-            (testray.main.component.name == "Upgrades Solutions")\
-        )
+        (testray.main.component.name == "Upgrades Site Management")
 
     test.batch.run.property.query[functional-upgrade-tomcat90-sqlserver2017-jdk8][site-management]=\
         (\
             (database.types == null) OR \
             (database.types ~ sqlserver)\
         ) AND \
-        (\
-            (testray.main.component.name == "Upgrades Site Management") OR \
-            (testray.main.component.name == "Upgrades Solutions")\
-        )
+        (testray.main.component.name == "Upgrades Site Management")
 
     #
     # Site Template


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-34573

Minor change to move Site Initializer tests under site-management test suite. These were previously a part of the solutions test suite.