### PR TITLE
LPD-36899 Define portal.suite.search.engine property for Collections tests

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/segmentation/collections/Collections.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/segmentation/collections/Collections.testcase
@@ -4,6 +4,7 @@ definition {
 	property ci.retries.disabled = "true";
 	property custom.properties = "jsonws.web.service.paths.excludes=";
 	property portal.release = "true";
+	property portal.suite.search.engine = "elasticsearch7,opensearch2,solr";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Collections";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/segmentation/collections/CollectionsWithStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/segmentation/collections/CollectionsWithStaging.testcase
@@ -3,6 +3,7 @@ definition {
 
 	property ci.retries.disabled = "true";
 	property portal.release = "true";
+	property portal.suite.search.engine = "elasticsearch7,opensearch2,solr";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Collections";
 

--- a/test.properties
+++ b/test.properties
@@ -8977,8 +8977,7 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][search]=\
         (portal.suite.search.engine ~ elasticsearch7) AND \
-        (testray.main.component.name != "Upgrades Search") AND \
-        (testray.main.component.name == "Collections")
+        (testray.main.component.name != "Upgrades Search")
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk11_open][search]=\
         (portal.suite.search.engine ~ openjdk11)


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-36899

Minor fix for the search suite to properly run functional tests.