### PR TITLE
LPD-34375 | LPD-35442 Handle undo/redo for repeatable fields | Fixing Image field onChange and Blur event order

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/Layout.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/Layout.es.js
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import React, {useContext, useEffect} from 'react';
+import React, {useContext} from 'react';
 
 import {getFormId, getFormNode} from '../../../utils/formId.es';
-import {EVENT_TYPES} from '../../actions/eventTypes.es';
 import {useConfig} from '../../hooks/useConfig.es';
 import {useEvaluate} from '../../hooks/useEvaluate.es';
 import {useForm, useFormState} from '../../hooks/useForm.es';
@@ -30,41 +29,6 @@ export function Layout({components, editable, itemPath, rows, viewMode}) {
 	const variants = useContext(VariantsContext);
 
 	const Components = components ?? mergeVariants(editable, variants);
-
-	useEffect(() => {
-		dispatch({type: EVENT_TYPES.HISTORY.RESET});
-	}, [defaultLanguageId, dispatch]);
-
-	useEffect(() => {
-		const goToHandler = ({step}) => {
-			dispatch({step, type: EVENT_TYPES.HISTORY.GOTO});
-		};
-		const handleStoreState = () => {
-			dispatch({type: EVENT_TYPES.HISTORY.ADD});
-		};
-		const undoHandler = () => {
-			dispatch({type: EVENT_TYPES.HISTORY.PREV});
-		};
-		const redoHandler = () => {
-			dispatch({type: EVENT_TYPES.HISTORY.NEXT});
-		};
-
-		Liferay.on('journal:goto', goToHandler);
-		Liferay.on('journal:undo', undoHandler);
-		Liferay.on('journal:redo', redoHandler);
-		Liferay.on('journal:storeState', handleStoreState);
-
-		return () => {
-			Liferay.detach('journal:goto', goToHandler);
-			Liferay.detach('journal:undo', undoHandler);
-			Liferay.detach('journal:redo', redoHandler);
-			Liferay.detach('journal:storeState', handleStoreState);
-		};
-	}, [dispatch]);
-
-	useEffect(() => {
-		dispatch({type: EVENT_TYPES.HISTORY.RESET});
-	}, [dispatch]);
 
 	return (
 		<Components.Rows

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/WebContentVariant.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/WebContentVariant.es.js
@@ -203,6 +203,8 @@ function Placeholder({field, index, nestedFieldIndex}) {
 				type: EVENT_TYPES.FORM_VIEW.REPEATABLE_FIELD.CHANGE_ORDER,
 			});
 
+			Liferay.fire('journal:storeState', {fieldName: 'Repeatable Moved'});
+
 			item.index = targetIndex;
 		},
 	});

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/WebContentVariant.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/WebContentVariant.es.js
@@ -5,7 +5,7 @@
 
 import ClayLayout from '@clayui/layout';
 import classnames from 'classnames';
-import React, {forwardRef, useRef} from 'react';
+import React, {forwardRef, useEffect, useRef} from 'react';
 import {useDrop} from 'react-dnd';
 
 import {EVENT_TYPES} from '../../../custom/form/eventTypes';
@@ -34,7 +34,7 @@ export const Column = forwardRef(
 		},
 		ref
 	) => {
-		const {portletId} = useFormState();
+		const {defaultLanguageId, portletId} = useFormState();
 
 		const addr = {
 			'data-ddm-field-column': index,
@@ -45,6 +45,43 @@ export const Column = forwardRef(
 		const firstField = column.fields[0];
 		const isFieldSetOrGroup = firstField?.type === 'fieldset';
 		const isFieldSet = firstField?.ddmStructureId && isFieldSetOrGroup;
+
+		const defaultLanguageIdRef = useRef(defaultLanguageId);
+		const dispatch = useForm();
+
+		useEffect(() => {
+			if (defaultLanguageIdRef.current !== defaultLanguageId) {
+				defaultLanguageIdRef.current = defaultLanguageId;
+				dispatch({type: EVENT_TYPES.HISTORY.RESET});
+			}
+		}, [defaultLanguageId, dispatch]);
+
+		useEffect(() => {
+			const goToHandler = ({step}) => {
+				dispatch({step, type: EVENT_TYPES.HISTORY.GOTO});
+			};
+			const handleStoreState = () => {
+				dispatch({type: EVENT_TYPES.HISTORY.ADD});
+			};
+			const undoHandler = () => {
+				dispatch({type: EVENT_TYPES.HISTORY.PREV});
+			};
+			const redoHandler = () => {
+				dispatch({type: EVENT_TYPES.HISTORY.NEXT});
+			};
+
+			Liferay.on('journal:goto', goToHandler);
+			Liferay.on('journal:undo', undoHandler);
+			Liferay.on('journal:redo', redoHandler);
+			Liferay.on('journal:storeState', handleStoreState);
+
+			return () => {
+				Liferay.detach('journal:goto', goToHandler);
+				Liferay.detach('journal:undo', undoHandler);
+				Liferay.detach('journal:redo', redoHandler);
+				Liferay.detach('journal:storeState', handleStoreState);
+			};
+		}, [dispatch]);
 
 		return (
 			<ClayLayout.Col

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/thunks/fieldChange.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/thunks/fieldChange.es.js
@@ -94,7 +94,8 @@ export default function fieldChange({
 			if (
 				fieldInstance.type === 'numeric' ||
 				fieldInstance.type === 'text' ||
-				fieldInstance.type === 'rich_text'
+				fieldInstance.type === 'rich_text' ||
+				fieldInstance.type === 'image'
 			) {
 				dispatch({type: EVENT_TYPES.HISTORY.EDITED});
 			}
@@ -184,7 +185,8 @@ export default function fieldChange({
 			if (
 				fieldInstance.type !== 'numeric' &&
 				fieldInstance.type !== 'text' &&
-				fieldInstance.type !== 'rich_text'
+				fieldInstance.type !== 'rich_text' &&
+				fieldInstance.type !== 'image'
 			) {
 				setTimeout(
 					() =>

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/eventTypes.ts
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/eventTypes.ts
@@ -18,6 +18,15 @@ const FORM_VIEW = {
 	},
 };
 
+const HISTORY = {
+	ADD: 'add_step',
+	BLUR: 'handle_blur',
+	EDITED: 'mark_edited',
+	NEXT: 'next_step',
+	PREV: 'prev_step',
+	RESET: 'reset_history',
+};
+
 const OBJECT = {
 	FIELDS_CHANGE: 'object_fields_change',
 	RELATIONSHIPS_CHANGE: 'object_relationships_change',
@@ -45,6 +54,7 @@ const RULES = {
 export const EVENT_TYPES = {
 	FORM_BUILDER,
 	FORM_VIEW,
+	HISTORY,
 	OBJECT,
 	PAGE,
 	PAGINATION,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -613,12 +613,16 @@ export default function FieldBase({
 								}
 							)}
 							disabled={readOnly || disabledRepeatableButton}
-							onClick={() =>
+							onClick={() => {
 								dispatch({
 									payload: name,
 									type: CORE_EVENT_TYPES.FIELD.REMOVED,
-								})
-							}
+								});
+
+								Liferay.fire('journal:storeState', {
+									fieldName: 'Repeatable Removed',
+								});
+							}}
 							small
 							title={Liferay.Language.get('remove')}
 							type="button"
@@ -641,12 +645,16 @@ export default function FieldBase({
 							}
 						)}
 						disabled={readOnly || disabledRepeatableButton}
-						onClick={() =>
+						onClick={() => {
 							dispatch({
 								payload: name,
 								type: CORE_EVENT_TYPES.FIELD.REPEATED,
-							})
-						}
+							});
+
+							Liferay.fire('journal:storeState', {
+								fieldName: 'Repeatable Added',
+							});
+						}}
 						small
 						title={Liferay.Language.get('duplicate')}
 						type="button"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
@@ -119,7 +119,9 @@ const ImagePicker = ({
 		}
 
 		openSelectionModal({
-			onClose: () => onBlur(event),
+			onClose: () => {
+				setTimeout(() => onBlur(event), 100);
+			},
 			onSelect: handleFieldChanged,
 			selectEventName: `${portletNamespace}selectDocumentLibrary`,
 			title: sub(
@@ -256,6 +258,7 @@ const ImagePicker = ({
 								disabled={readOnly}
 								lang={editingLanguageId}
 								name={`${name}-description`}
+								onBlur={onBlur}
 								onChange={({event, target: {value}}) =>
 									dispatchValue(
 										{value: {description: value, event}},


### PR DESCRIPTION
Forwarding manually from: https://github.com/liferay-forms/liferay-portal/pull/2612

Tickets:
[LPD-35442](https://liferay.atlassian.net/browse/LPD-35442) - Image field creates several steps in the history
[LPD-34375](https://liferay.atlassian.net/browse/LPD-34375) - Handle undo/redo for repeatable fields

Changes:
[LPD-35442](https://liferay.atlassian.net/browse/LPD-35442) - Image field creates several steps in the history
The onBlur event was handled sooner than the onChange event of the selectionModal. This caused an issue on our side creating a step in the historyReducer, as we only create that snapshot onBlur, when there was an edit registered before thru an onChange handler. I also had to make sure we only want to create a history step for the image field after the onBlur event.

[LPD-34375](https://liferay.atlassian.net/browse/LPD-34375) - Handle undo/redo for repeatable fields
I moved all our event Listeners related to the Undo/Redo feature from the Layout Component to the WebContentVariant Component. I also created a storeState event for every Repeatable field aciton, like add/remove/move.


Thanks,