### PR TITLE
LPD-36957 Make auto tagging work with asset libraries

### DIFF
--- a/modules/apps/asset/asset-auto-tagger-service/src/main/java/com/liferay/asset/auto/tagger/internal/messaging/AssetAutoTaggerMessageListener.java
+++ b/modules/apps/asset/asset-auto-tagger-service/src/main/java/com/liferay/asset/auto/tagger/internal/messaging/AssetAutoTaggerMessageListener.java
@@ -8,9 +8,11 @@ package com.liferay.asset.auto.tagger.internal.messaging;
 import com.liferay.asset.auto.tagger.AssetAutoTagger;
 import com.liferay.asset.auto.tagger.internal.constants.AssetAutoTaggerDestinationNames;
 import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageListener;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -26,9 +28,12 @@ public class AssetAutoTaggerMessageListener extends BaseMessageListener {
 
 	@Override
 	protected void doReceive(Message message) throws Exception {
-		AssetEntry assetEntry = (AssetEntry)message.getPayload();
+		try (SafeCloseable safeCloseable =
+				GroupThreadLocal.setWithSafeCloseable(
+					message.getLong("groupId"))) {
 
-		_assetAutoTagger.tag(assetEntry);
+			_assetAutoTagger.tag((AssetEntry)message.get("assetEntry"));
+		}
 	}
 
 	@Reference

--- a/modules/apps/asset/asset-auto-tagger-service/src/main/java/com/liferay/asset/auto/tagger/internal/messaging/AssetAutoTaggerMessageListener.java
+++ b/modules/apps/asset/asset-auto-tagger-service/src/main/java/com/liferay/asset/auto/tagger/internal/messaging/AssetAutoTaggerMessageListener.java
@@ -29,7 +29,7 @@ public class AssetAutoTaggerMessageListener extends BaseMessageListener {
 	@Override
 	protected void doReceive(Message message) throws Exception {
 		try (SafeCloseable safeCloseable =
-				GroupThreadLocal.setWithSafeCloseable(
+				GroupThreadLocal.setGroupIdWithSafeCloseable(
 					message.getLong("groupId"))) {
 
 			_assetAutoTagger.tag((AssetEntry)message.get("assetEntry"));

--- a/modules/apps/asset/asset-auto-tagger-service/src/main/java/com/liferay/asset/auto/tagger/internal/model/listener/AssetEntryModelListener.java
+++ b/modules/apps/asset/asset-auto-tagger-service/src/main/java/com/liferay/asset/auto/tagger/internal/model/listener/AssetEntryModelListener.java
@@ -28,6 +28,8 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 
@@ -91,7 +93,12 @@ public class AssetEntryModelListener extends BaseModelListener<AssetEntry> {
 
 					Message message = new Message();
 
-					message.setPayload(assetEntry);
+					message.setValues(
+						HashMapBuilder.<String, Object>put(
+							"assetEntry", assetEntry
+						).put(
+							"groupId", _getGroupId(assetEntry)
+						).build());
 
 					_messageBus.sendMessage(
 						AssetAutoTaggerDestinationNames.ASSET_AUTO_TAGGER,
@@ -130,6 +137,23 @@ public class AssetEntryModelListener extends BaseModelListener<AssetEntry> {
 		return _assetAutoTaggerConfigurationFactory.
 			getGroupAssetAutoTaggerConfiguration(
 				_groupLocalService.getGroup(assetEntry.getGroupId()));
+	}
+
+	private long _getGroupId(AssetEntry assetEntry) {
+		Long groupId = GroupThreadLocal.getGroupId();
+
+		if ((groupId != null) && (groupId != 0)) {
+			return groupId;
+		}
+
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext != null) {
+			return serviceContext.getScopeGroupId();
+		}
+
+		return assetEntry.getGroupId();
 	}
 
 	private boolean _isUpdateAutoTags() {

--- a/portal-kernel/src/com/liferay/portal/kernel/util/GroupThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/GroupThreadLocal.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.kernel.util;
 
 import com.liferay.petra.lang.CentralizedThreadLocal;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupConstants;
@@ -46,13 +47,17 @@ public class GroupThreadLocal {
 		}
 	}
 
+	public static SafeCloseable setWithSafeCloseable(long groupId) {
+		return _groupId.setWithSafeCloseable(groupId);
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		GroupThreadLocal.class);
 
 	private static final ThreadLocal<Boolean> _deleteInProcess =
 		new CentralizedThreadLocal<>(
 			GroupThreadLocal.class + "._deleteInProcess", () -> Boolean.FALSE);
-	private static final ThreadLocal<Long> _groupId =
+	private static final CentralizedThreadLocal<Long> _groupId =
 		new CentralizedThreadLocal<>(
 			GroupThreadLocal.class + "._groupId",
 			() -> GroupConstants.DEFAULT_LIVE_GROUP_ID);

--- a/portal-kernel/src/com/liferay/portal/kernel/util/GroupThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/GroupThreadLocal.java
@@ -47,7 +47,7 @@ public class GroupThreadLocal {
 		}
 	}
 
-	public static SafeCloseable setWithSafeCloseable(long groupId) {
+	public static SafeCloseable setGroupIdWithSafeCloseable(long groupId) {
 		return _groupId.setWithSafeCloseable(groupId);
 	}
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-36957

In order to prevent content from being accessible from disconnected sites, additional restrictions were enforced. This required group/service context thread locals to be fully initialized, logic that was only triggered in depots.

# How am I fixing it?

By initializing the group thread local when auto tagging assets.

# Why doesn't this include any test?

The existing `DepotAutoTagging.testcase` covers this issue.

# Additional notes

This is a followup to https://github.com/brianchandotcom/liferay-portal/pull/154440. Only the last SF commit is new.