### PR TITLE
Lpd 35723 optimization 11

### DIFF
--- a/modules/apps/asset/asset-display-page-api/bnd.bnd
+++ b/modules/apps/asset/asset-display-page-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Asset Display Page API
 Bundle-SymbolicName: com.liferay.asset.display.page.api
-Bundle-Version: 16.1.6
+Bundle-Version: 16.2.0
 Export-Package:\
 	com.liferay.asset.display.page.configuration,\
 	com.liferay.asset.display.page.constants,\

--- a/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/service/persistence/AssetDisplayPageEntryPersistence.java
+++ b/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/service/persistence/AssetDisplayPageEntryPersistence.java
@@ -674,6 +674,161 @@ public interface AssetDisplayPageEntryPersistence
 	public int countByLayoutPageTemplateEntryId(long layoutPageTemplateEntryId);
 
 	/**
+	 * Returns all the asset display page entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @return the matching asset display page entries
+	 */
+	public java.util.List<AssetDisplayPageEntry> findByG_CN(
+		long groupId, long classNameId);
+
+	/**
+	 * Returns a range of all the asset display page entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetDisplayPageEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of asset display page entries
+	 * @param end the upper bound of the range of asset display page entries (not inclusive)
+	 * @return the range of matching asset display page entries
+	 */
+	public java.util.List<AssetDisplayPageEntry> findByG_CN(
+		long groupId, long classNameId, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the asset display page entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetDisplayPageEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of asset display page entries
+	 * @param end the upper bound of the range of asset display page entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching asset display page entries
+	 */
+	public java.util.List<AssetDisplayPageEntry> findByG_CN(
+		long groupId, long classNameId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<AssetDisplayPageEntry>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the asset display page entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetDisplayPageEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of asset display page entries
+	 * @param end the upper bound of the range of asset display page entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching asset display page entries
+	 */
+	public java.util.List<AssetDisplayPageEntry> findByG_CN(
+		long groupId, long classNameId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<AssetDisplayPageEntry>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first asset display page entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset display page entry
+	 * @throws NoSuchDisplayPageEntryException if a matching asset display page entry could not be found
+	 */
+	public AssetDisplayPageEntry findByG_CN_First(
+			long groupId, long classNameId,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<AssetDisplayPageEntry> orderByComparator)
+		throws NoSuchDisplayPageEntryException;
+
+	/**
+	 * Returns the first asset display page entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset display page entry, or <code>null</code> if a matching asset display page entry could not be found
+	 */
+	public AssetDisplayPageEntry fetchByG_CN_First(
+		long groupId, long classNameId,
+		com.liferay.portal.kernel.util.OrderByComparator<AssetDisplayPageEntry>
+			orderByComparator);
+
+	/**
+	 * Returns the last asset display page entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset display page entry
+	 * @throws NoSuchDisplayPageEntryException if a matching asset display page entry could not be found
+	 */
+	public AssetDisplayPageEntry findByG_CN_Last(
+			long groupId, long classNameId,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<AssetDisplayPageEntry> orderByComparator)
+		throws NoSuchDisplayPageEntryException;
+
+	/**
+	 * Returns the last asset display page entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset display page entry, or <code>null</code> if a matching asset display page entry could not be found
+	 */
+	public AssetDisplayPageEntry fetchByG_CN_Last(
+		long groupId, long classNameId,
+		com.liferay.portal.kernel.util.OrderByComparator<AssetDisplayPageEntry>
+			orderByComparator);
+
+	/**
+	 * Returns the asset display page entries before and after the current asset display page entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param assetDisplayPageEntryId the primary key of the current asset display page entry
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next asset display page entry
+	 * @throws NoSuchDisplayPageEntryException if a asset display page entry with the primary key could not be found
+	 */
+	public AssetDisplayPageEntry[] findByG_CN_PrevAndNext(
+			long assetDisplayPageEntryId, long groupId, long classNameId,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<AssetDisplayPageEntry> orderByComparator)
+		throws NoSuchDisplayPageEntryException;
+
+	/**
+	 * Removes all the asset display page entries where groupId = &#63; and classNameId = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 */
+	public void removeByG_CN(long groupId, long classNameId);
+
+	/**
+	 * Returns the number of asset display page entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @return the number of matching asset display page entries
+	 */
+	public int countByG_CN(long groupId, long classNameId);
+
+	/**
 	 * Returns the asset display page entry where groupId = &#63; and classNameId = &#63; and classPK = &#63; or throws a <code>NoSuchDisplayPageEntryException</code> if it could not be found.
 	 *
 	 * @param groupId the group ID

--- a/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/service/persistence/AssetDisplayPageEntryUtil.java
+++ b/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/service/persistence/AssetDisplayPageEntryUtil.java
@@ -904,6 +904,196 @@ public class AssetDisplayPageEntryUtil {
 	}
 
 	/**
+	 * Returns all the asset display page entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @return the matching asset display page entries
+	 */
+	public static List<AssetDisplayPageEntry> findByG_CN(
+		long groupId, long classNameId) {
+
+		return getPersistence().findByG_CN(groupId, classNameId);
+	}
+
+	/**
+	 * Returns a range of all the asset display page entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetDisplayPageEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of asset display page entries
+	 * @param end the upper bound of the range of asset display page entries (not inclusive)
+	 * @return the range of matching asset display page entries
+	 */
+	public static List<AssetDisplayPageEntry> findByG_CN(
+		long groupId, long classNameId, int start, int end) {
+
+		return getPersistence().findByG_CN(groupId, classNameId, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the asset display page entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetDisplayPageEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of asset display page entries
+	 * @param end the upper bound of the range of asset display page entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching asset display page entries
+	 */
+	public static List<AssetDisplayPageEntry> findByG_CN(
+		long groupId, long classNameId, int start, int end,
+		OrderByComparator<AssetDisplayPageEntry> orderByComparator) {
+
+		return getPersistence().findByG_CN(
+			groupId, classNameId, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the asset display page entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetDisplayPageEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of asset display page entries
+	 * @param end the upper bound of the range of asset display page entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching asset display page entries
+	 */
+	public static List<AssetDisplayPageEntry> findByG_CN(
+		long groupId, long classNameId, int start, int end,
+		OrderByComparator<AssetDisplayPageEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByG_CN(
+			groupId, classNameId, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first asset display page entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset display page entry
+	 * @throws NoSuchDisplayPageEntryException if a matching asset display page entry could not be found
+	 */
+	public static AssetDisplayPageEntry findByG_CN_First(
+			long groupId, long classNameId,
+			OrderByComparator<AssetDisplayPageEntry> orderByComparator)
+		throws com.liferay.asset.display.page.exception.
+			NoSuchDisplayPageEntryException {
+
+		return getPersistence().findByG_CN_First(
+			groupId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Returns the first asset display page entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset display page entry, or <code>null</code> if a matching asset display page entry could not be found
+	 */
+	public static AssetDisplayPageEntry fetchByG_CN_First(
+		long groupId, long classNameId,
+		OrderByComparator<AssetDisplayPageEntry> orderByComparator) {
+
+		return getPersistence().fetchByG_CN_First(
+			groupId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Returns the last asset display page entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset display page entry
+	 * @throws NoSuchDisplayPageEntryException if a matching asset display page entry could not be found
+	 */
+	public static AssetDisplayPageEntry findByG_CN_Last(
+			long groupId, long classNameId,
+			OrderByComparator<AssetDisplayPageEntry> orderByComparator)
+		throws com.liferay.asset.display.page.exception.
+			NoSuchDisplayPageEntryException {
+
+		return getPersistence().findByG_CN_Last(
+			groupId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Returns the last asset display page entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset display page entry, or <code>null</code> if a matching asset display page entry could not be found
+	 */
+	public static AssetDisplayPageEntry fetchByG_CN_Last(
+		long groupId, long classNameId,
+		OrderByComparator<AssetDisplayPageEntry> orderByComparator) {
+
+		return getPersistence().fetchByG_CN_Last(
+			groupId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Returns the asset display page entries before and after the current asset display page entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param assetDisplayPageEntryId the primary key of the current asset display page entry
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next asset display page entry
+	 * @throws NoSuchDisplayPageEntryException if a asset display page entry with the primary key could not be found
+	 */
+	public static AssetDisplayPageEntry[] findByG_CN_PrevAndNext(
+			long assetDisplayPageEntryId, long groupId, long classNameId,
+			OrderByComparator<AssetDisplayPageEntry> orderByComparator)
+		throws com.liferay.asset.display.page.exception.
+			NoSuchDisplayPageEntryException {
+
+		return getPersistence().findByG_CN_PrevAndNext(
+			assetDisplayPageEntryId, groupId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Removes all the asset display page entries where groupId = &#63; and classNameId = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 */
+	public static void removeByG_CN(long groupId, long classNameId) {
+		getPersistence().removeByG_CN(groupId, classNameId);
+	}
+
+	/**
+	 * Returns the number of asset display page entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @return the number of matching asset display page entries
+	 */
+	public static int countByG_CN(long groupId, long classNameId) {
+		return getPersistence().countByG_CN(groupId, classNameId);
+	}
+
+	/**
 	 * Returns the asset display page entry where groupId = &#63; and classNameId = &#63; and classPK = &#63; or throws a <code>NoSuchDisplayPageEntryException</code> if it could not be found.
 	 *
 	 * @param groupId the group ID

--- a/modules/apps/asset/asset-display-page-api/src/main/resources/com/liferay/asset/display/page/service/persistence/packageinfo
+++ b/modules/apps/asset/asset-display-page-api/src/main/resources/com/liferay/asset/display/page/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 3.3.0

--- a/modules/apps/asset/asset-display-page-service/service.xml
+++ b/modules/apps/asset/asset-display-page-service/service.xml
@@ -37,6 +37,10 @@
 		<finder name="LayoutPageTemplateEntryId" return-type="Collection">
 			<finder-column name="layoutPageTemplateEntryId" />
 		</finder>
+		<finder name="G_CN" return-type="Collection">
+			<finder-column name="groupId" />
+			<finder-column name="classNameId" />
+		</finder>
 		<finder name="G_C_C" return-type="AssetDisplayPageEntry" unique="true">
 			<finder-column name="groupId" />
 			<finder-column name="classNameId" />

--- a/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/internal/model/listener/AssetEntryModelListener.java
+++ b/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/internal/model/listener/AssetEntryModelListener.java
@@ -5,10 +5,10 @@
 
 package com.liferay.asset.display.page.internal.model.listener;
 
-import com.liferay.asset.display.page.model.AssetDisplayPageEntry;
 import com.liferay.asset.display.page.service.AssetDisplayPageEntryLocalService;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
 
@@ -25,14 +25,13 @@ public class AssetEntryModelListener extends BaseModelListener<AssetEntry> {
 	public void onBeforeRemove(AssetEntry assetEntry)
 		throws ModelListenerException {
 
-		AssetDisplayPageEntry assetDisplayPageEntry =
-			_assetDisplayPageEntryLocalService.fetchAssetDisplayPageEntry(
+		try {
+			_assetDisplayPageEntryLocalService.deleteAssetDisplayPageEntry(
 				assetEntry.getGroupId(), assetEntry.getClassNameId(),
 				assetEntry.getClassPK());
-
-		if (assetDisplayPageEntry != null) {
-			_assetDisplayPageEntryLocalService.deleteAssetDisplayPageEntry(
-				assetDisplayPageEntry);
+		}
+		catch (PortalException portalException) {
+			throw new ModelListenerException(portalException);
 		}
 	}
 

--- a/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/service/impl/AssetDisplayPageEntryLocalServiceImpl.java
+++ b/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/service/impl/AssetDisplayPageEntryLocalServiceImpl.java
@@ -22,6 +22,7 @@ import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalServ
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.sql.dsl.query.DSLQuery;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -34,11 +35,14 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
+import com.liferay.portal.kernel.util.BulkDeleteCacheThreadLocal;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.Portal;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -118,8 +122,39 @@ public class AssetDisplayPageEntryLocalServiceImpl
 			long groupId, long classNameId, long classPK)
 		throws PortalException {
 
-		assetDisplayPageEntryPersistence.removeByG_C_C(
-			groupId, classNameId, classPK);
+		Map<Long, List<AssetDisplayPageEntry>>
+			partitionAssetDisplayPageEntries =
+				BulkDeleteCacheThreadLocal.getBulkDeleteCache(
+					StringBundler.concat(
+						AssetDisplayPageEntryLocalServiceImpl.class.getName(),
+						".fetchAssetDisplayPageEntry#", groupId, classNameId),
+					() -> MapUtil.toPartitionMap(
+						assetDisplayPageEntryPersistence.findByG_CN(
+							groupId, classNameId),
+						AssetDisplayPageEntry::getClassPK));
+
+		if (partitionAssetDisplayPageEntries == null) {
+			AssetDisplayPageEntry assetDisplayPageEntry =
+				assetDisplayPageEntryPersistence.fetchByG_C_C(
+					groupId, classNameId, classPK);
+
+			if (assetDisplayPageEntry != null) {
+				assetDisplayPageEntryPersistence.remove(assetDisplayPageEntry);
+			}
+		}
+		else {
+			List<AssetDisplayPageEntry> assetDisplayPageEntries =
+				partitionAssetDisplayPageEntries.remove(classPK);
+
+			if (assetDisplayPageEntries != null) {
+				for (AssetDisplayPageEntry assetDisplayPageEntry :
+						assetDisplayPageEntries) {
+
+					assetDisplayPageEntryPersistence.remove(
+						assetDisplayPageEntry);
+				}
+			}
+		}
 	}
 
 	@Override

--- a/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/service/persistence/impl/AssetDisplayPageEntryPersistenceImpl.java
+++ b/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/service/persistence/impl/AssetDisplayPageEntryPersistenceImpl.java
@@ -2566,6 +2566,562 @@ public class AssetDisplayPageEntryPersistenceImpl
 		_FINDER_COLUMN_LAYOUTPAGETEMPLATEENTRYID_LAYOUTPAGETEMPLATEENTRYID_2 =
 			"assetDisplayPageEntry.layoutPageTemplateEntryId = ?";
 
+	private FinderPath _finderPathWithPaginationFindByG_CN;
+	private FinderPath _finderPathWithoutPaginationFindByG_CN;
+	private FinderPath _finderPathCountByG_CN;
+
+	/**
+	 * Returns all the asset display page entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @return the matching asset display page entries
+	 */
+	@Override
+	public List<AssetDisplayPageEntry> findByG_CN(
+		long groupId, long classNameId) {
+
+		return findByG_CN(
+			groupId, classNameId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the asset display page entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetDisplayPageEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of asset display page entries
+	 * @param end the upper bound of the range of asset display page entries (not inclusive)
+	 * @return the range of matching asset display page entries
+	 */
+	@Override
+	public List<AssetDisplayPageEntry> findByG_CN(
+		long groupId, long classNameId, int start, int end) {
+
+		return findByG_CN(groupId, classNameId, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the asset display page entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetDisplayPageEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of asset display page entries
+	 * @param end the upper bound of the range of asset display page entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching asset display page entries
+	 */
+	@Override
+	public List<AssetDisplayPageEntry> findByG_CN(
+		long groupId, long classNameId, int start, int end,
+		OrderByComparator<AssetDisplayPageEntry> orderByComparator) {
+
+		return findByG_CN(
+			groupId, classNameId, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the asset display page entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetDisplayPageEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of asset display page entries
+	 * @param end the upper bound of the range of asset display page entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching asset display page entries
+	 */
+	@Override
+	public List<AssetDisplayPageEntry> findByG_CN(
+		long groupId, long classNameId, int start, int end,
+		OrderByComparator<AssetDisplayPageEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		try (SafeCloseable safeCloseable =
+				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
+					AssetDisplayPageEntry.class)) {
+
+			FinderPath finderPath = null;
+			Object[] finderArgs = null;
+
+			if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+				(orderByComparator == null)) {
+
+				if (useFinderCache) {
+					finderPath = _finderPathWithoutPaginationFindByG_CN;
+					finderArgs = new Object[] {groupId, classNameId};
+				}
+			}
+			else if (useFinderCache) {
+				finderPath = _finderPathWithPaginationFindByG_CN;
+				finderArgs = new Object[] {
+					groupId, classNameId, start, end, orderByComparator
+				};
+			}
+
+			List<AssetDisplayPageEntry> list = null;
+
+			if (useFinderCache) {
+				list = (List<AssetDisplayPageEntry>)finderCache.getResult(
+					finderPath, finderArgs, this);
+
+				if ((list != null) && !list.isEmpty()) {
+					for (AssetDisplayPageEntry assetDisplayPageEntry : list) {
+						if ((groupId != assetDisplayPageEntry.getGroupId()) ||
+							(classNameId !=
+								assetDisplayPageEntry.getClassNameId())) {
+
+							list = null;
+
+							break;
+						}
+					}
+				}
+			}
+
+			if (list == null) {
+				StringBundler sb = null;
+
+				if (orderByComparator != null) {
+					sb = new StringBundler(
+						4 + (orderByComparator.getOrderByFields().length * 2));
+				}
+				else {
+					sb = new StringBundler(4);
+				}
+
+				sb.append(_SQL_SELECT_ASSETDISPLAYPAGEENTRY_WHERE);
+
+				sb.append(_FINDER_COLUMN_G_CN_GROUPID_2);
+
+				sb.append(_FINDER_COLUMN_G_CN_CLASSNAMEID_2);
+
+				if (orderByComparator != null) {
+					appendOrderByComparator(
+						sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+				}
+				else {
+					sb.append(AssetDisplayPageEntryModelImpl.ORDER_BY_JPQL);
+				}
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(groupId);
+
+					queryPos.add(classNameId);
+
+					list = (List<AssetDisplayPageEntry>)QueryUtil.list(
+						query, getDialect(), start, end);
+
+					cacheResult(list);
+
+					if (useFinderCache) {
+						finderCache.putResult(finderPath, finderArgs, list);
+					}
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return list;
+		}
+	}
+
+	/**
+	 * Returns the first asset display page entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset display page entry
+	 * @throws NoSuchDisplayPageEntryException if a matching asset display page entry could not be found
+	 */
+	@Override
+	public AssetDisplayPageEntry findByG_CN_First(
+			long groupId, long classNameId,
+			OrderByComparator<AssetDisplayPageEntry> orderByComparator)
+		throws NoSuchDisplayPageEntryException {
+
+		AssetDisplayPageEntry assetDisplayPageEntry = fetchByG_CN_First(
+			groupId, classNameId, orderByComparator);
+
+		if (assetDisplayPageEntry != null) {
+			return assetDisplayPageEntry;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", classNameId=");
+		sb.append(classNameId);
+
+		sb.append("}");
+
+		throw new NoSuchDisplayPageEntryException(sb.toString());
+	}
+
+	/**
+	 * Returns the first asset display page entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset display page entry, or <code>null</code> if a matching asset display page entry could not be found
+	 */
+	@Override
+	public AssetDisplayPageEntry fetchByG_CN_First(
+		long groupId, long classNameId,
+		OrderByComparator<AssetDisplayPageEntry> orderByComparator) {
+
+		List<AssetDisplayPageEntry> list = findByG_CN(
+			groupId, classNameId, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last asset display page entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset display page entry
+	 * @throws NoSuchDisplayPageEntryException if a matching asset display page entry could not be found
+	 */
+	@Override
+	public AssetDisplayPageEntry findByG_CN_Last(
+			long groupId, long classNameId,
+			OrderByComparator<AssetDisplayPageEntry> orderByComparator)
+		throws NoSuchDisplayPageEntryException {
+
+		AssetDisplayPageEntry assetDisplayPageEntry = fetchByG_CN_Last(
+			groupId, classNameId, orderByComparator);
+
+		if (assetDisplayPageEntry != null) {
+			return assetDisplayPageEntry;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", classNameId=");
+		sb.append(classNameId);
+
+		sb.append("}");
+
+		throw new NoSuchDisplayPageEntryException(sb.toString());
+	}
+
+	/**
+	 * Returns the last asset display page entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset display page entry, or <code>null</code> if a matching asset display page entry could not be found
+	 */
+	@Override
+	public AssetDisplayPageEntry fetchByG_CN_Last(
+		long groupId, long classNameId,
+		OrderByComparator<AssetDisplayPageEntry> orderByComparator) {
+
+		int count = countByG_CN(groupId, classNameId);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<AssetDisplayPageEntry> list = findByG_CN(
+			groupId, classNameId, count - 1, count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the asset display page entries before and after the current asset display page entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param assetDisplayPageEntryId the primary key of the current asset display page entry
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next asset display page entry
+	 * @throws NoSuchDisplayPageEntryException if a asset display page entry with the primary key could not be found
+	 */
+	@Override
+	public AssetDisplayPageEntry[] findByG_CN_PrevAndNext(
+			long assetDisplayPageEntryId, long groupId, long classNameId,
+			OrderByComparator<AssetDisplayPageEntry> orderByComparator)
+		throws NoSuchDisplayPageEntryException {
+
+		AssetDisplayPageEntry assetDisplayPageEntry = findByPrimaryKey(
+			assetDisplayPageEntryId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			AssetDisplayPageEntry[] array = new AssetDisplayPageEntryImpl[3];
+
+			array[0] = getByG_CN_PrevAndNext(
+				session, assetDisplayPageEntry, groupId, classNameId,
+				orderByComparator, true);
+
+			array[1] = assetDisplayPageEntry;
+
+			array[2] = getByG_CN_PrevAndNext(
+				session, assetDisplayPageEntry, groupId, classNameId,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected AssetDisplayPageEntry getByG_CN_PrevAndNext(
+		Session session, AssetDisplayPageEntry assetDisplayPageEntry,
+		long groupId, long classNameId,
+		OrderByComparator<AssetDisplayPageEntry> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				5 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(4);
+		}
+
+		sb.append(_SQL_SELECT_ASSETDISPLAYPAGEENTRY_WHERE);
+
+		sb.append(_FINDER_COLUMN_G_CN_GROUPID_2);
+
+		sb.append(_FINDER_COLUMN_G_CN_CLASSNAMEID_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(AssetDisplayPageEntryModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(groupId);
+
+		queryPos.add(classNameId);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						assetDisplayPageEntry)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<AssetDisplayPageEntry> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the asset display page entries where groupId = &#63; and classNameId = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 */
+	@Override
+	public void removeByG_CN(long groupId, long classNameId) {
+		for (AssetDisplayPageEntry assetDisplayPageEntry :
+				findByG_CN(
+					groupId, classNameId, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+					null)) {
+
+			remove(assetDisplayPageEntry);
+		}
+	}
+
+	/**
+	 * Returns the number of asset display page entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @return the number of matching asset display page entries
+	 */
+	@Override
+	public int countByG_CN(long groupId, long classNameId) {
+		try (SafeCloseable safeCloseable =
+				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
+					AssetDisplayPageEntry.class)) {
+
+			FinderPath finderPath = _finderPathCountByG_CN;
+
+			Object[] finderArgs = new Object[] {groupId, classNameId};
+
+			Long count = (Long)finderCache.getResult(
+				finderPath, finderArgs, this);
+
+			if (count == null) {
+				StringBundler sb = new StringBundler(3);
+
+				sb.append(_SQL_COUNT_ASSETDISPLAYPAGEENTRY_WHERE);
+
+				sb.append(_FINDER_COLUMN_G_CN_GROUPID_2);
+
+				sb.append(_FINDER_COLUMN_G_CN_CLASSNAMEID_2);
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(groupId);
+
+					queryPos.add(classNameId);
+
+					count = (Long)query.uniqueResult();
+
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return count.intValue();
+		}
+	}
+
+	private static final String _FINDER_COLUMN_G_CN_GROUPID_2 =
+		"assetDisplayPageEntry.groupId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_CN_CLASSNAMEID_2 =
+		"assetDisplayPageEntry.classNameId = ?";
+
 	private FinderPath _finderPathFetchByG_C_C;
 	private FinderPath _finderPathCountByG_C_C;
 
@@ -3826,6 +4382,25 @@ public class AssetDisplayPageEntryPersistenceImpl
 			"countByLayoutPageTemplateEntryId",
 			new String[] {Long.class.getName()},
 			new String[] {"layoutPageTemplateEntryId"}, false);
+
+		_finderPathWithPaginationFindByG_CN = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_CN",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "classNameId"}, true);
+
+		_finderPathWithoutPaginationFindByG_CN = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_CN",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"groupId", "classNameId"}, true);
+
+		_finderPathCountByG_CN = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_CN",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"groupId", "classNameId"}, false);
 
 		_finderPathFetchByG_C_C = new FinderPath(
 			FINDER_CLASS_NAME_ENTITY, "fetchByG_C_C",

--- a/modules/apps/asset/asset-display-page-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/asset/asset-display-page-service/src/main/resources/META-INF/sql/indexes.sql
@@ -1,3 +1,4 @@
-create unique index IX_73E15F86 on AssetDisplayPageEntry (groupId, ctCollectionId, classNameId, classPK);
+create unique index IX_F3AB130A on AssetDisplayPageEntry (groupId, classNameId, ctCollectionId, classPK);
+create unique index IX_9920AB1F on AssetDisplayPageEntry (groupId, uuid_[$COLUMN_LENGTH:75$], ctCollectionId);
 create index IX_BFB8A913 on AssetDisplayPageEntry (layoutPageTemplateEntryId);
-create unique index IX_EF42C6CB on AssetDisplayPageEntry (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId);
+create index IX_DEA3F2DD on AssetDisplayPageEntry (uuid_[$COLUMN_LENGTH:75$]);

--- a/modules/apps/asset/asset-display-page-test/src/testIntegration/java/com/liferay/asset/display/page/service/persistence/test/AssetDisplayPageEntryPersistenceTest.java
+++ b/modules/apps/asset/asset-display-page-test/src/testIntegration/java/com/liferay/asset/display/page/service/persistence/test/AssetDisplayPageEntryPersistenceTest.java
@@ -248,6 +248,14 @@ public class AssetDisplayPageEntryPersistenceTest {
 	}
 
 	@Test
+	public void testCountByG_CN() throws Exception {
+		_persistence.countByG_CN(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextLong());
+
+		_persistence.countByG_CN(0L, 0L);
+	}
+
+	@Test
 	public void testCountByG_C_C() throws Exception {
 		_persistence.countByG_C_C(
 			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(),

--- a/modules/apps/asset/asset-entry-rel-api/src/main/java/com/liferay/asset/entry/rel/service/AssetEntryAssetCategoryRelLocalService.java
+++ b/modules/apps/asset/asset-entry-rel-api/src/main/java/com/liferay/asset/entry/rel/service/AssetEntryAssetCategoryRelLocalService.java
@@ -6,6 +6,7 @@
 package com.liferay.asset.entry.rel.service;
 
 import com.liferay.asset.entry.rel.model.AssetEntryAssetCategoryRel;
+import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.sql.dsl.query.DSLQuery;
 import com.liferay.portal.kernel.change.tracking.CTAware;
@@ -130,6 +131,9 @@ public interface AssetEntryAssetCategoryRelLocalService
 
 	public void deleteAssetEntryAssetCategoryRelByAssetCategoryId(
 		long assetCategoryId);
+
+	public void deleteAssetEntryAssetCategoryRelByAssetEntry(
+		AssetEntry assetEntry);
 
 	public void deleteAssetEntryAssetCategoryRelByAssetEntryId(
 		long assetEntryId);

--- a/modules/apps/asset/asset-entry-rel-api/src/main/java/com/liferay/asset/entry/rel/service/AssetEntryAssetCategoryRelLocalServiceUtil.java
+++ b/modules/apps/asset/asset-entry-rel-api/src/main/java/com/liferay/asset/entry/rel/service/AssetEntryAssetCategoryRelLocalServiceUtil.java
@@ -141,6 +141,12 @@ public class AssetEntryAssetCategoryRelLocalServiceUtil {
 			assetCategoryId);
 	}
 
+	public static void deleteAssetEntryAssetCategoryRelByAssetEntry(
+		com.liferay.asset.kernel.model.AssetEntry assetEntry) {
+
+		getService().deleteAssetEntryAssetCategoryRelByAssetEntry(assetEntry);
+	}
+
 	public static void deleteAssetEntryAssetCategoryRelByAssetEntryId(
 		long assetEntryId) {
 

--- a/modules/apps/asset/asset-entry-rel-api/src/main/java/com/liferay/asset/entry/rel/service/AssetEntryAssetCategoryRelLocalServiceWrapper.java
+++ b/modules/apps/asset/asset-entry-rel-api/src/main/java/com/liferay/asset/entry/rel/service/AssetEntryAssetCategoryRelLocalServiceWrapper.java
@@ -150,6 +150,14 @@ public class AssetEntryAssetCategoryRelLocalServiceWrapper
 	}
 
 	@Override
+	public void deleteAssetEntryAssetCategoryRelByAssetEntry(
+		com.liferay.asset.kernel.model.AssetEntry assetEntry) {
+
+		_assetEntryAssetCategoryRelLocalService.
+			deleteAssetEntryAssetCategoryRelByAssetEntry(assetEntry);
+	}
+
+	@Override
 	public void deleteAssetEntryAssetCategoryRelByAssetEntryId(
 		long assetEntryId) {
 

--- a/modules/apps/asset/asset-entry-rel-api/src/main/resources/com/liferay/asset/entry/rel/service/packageinfo
+++ b/modules/apps/asset/asset-entry-rel-api/src/main/resources/com/liferay/asset/entry/rel/service/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/asset/asset-entry-rel-service/src/main/java/com/liferay/asset/entry/rel/service/impl/AssetEntryAssetCategoryRelLocalServiceImpl.java
+++ b/modules/apps/asset/asset-entry-rel-service/src/main/java/com/liferay/asset/entry/rel/service/impl/AssetEntryAssetCategoryRelLocalServiceImpl.java
@@ -20,10 +20,13 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.SearchException;
+import com.liferay.portal.kernel.util.BulkDeleteCacheThreadLocal;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 
 import java.util.List;
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -101,8 +104,32 @@ public class AssetEntryAssetCategoryRelLocalServiceImpl
 	public void deleteAssetEntryAssetCategoryRelByAssetEntryId(
 		long assetEntryId) {
 
-		assetEntryAssetCategoryRelPersistence.removeByAssetEntryId(
-			assetEntryId);
+		Map<Long, List<AssetEntryAssetCategoryRel>>
+			partitionAssetEntryAssetCategoryRels =
+				BulkDeleteCacheThreadLocal.getBulkDeleteCache(
+					AssetEntryAssetCategoryRelLocalServiceImpl.class.getName() +
+						".deleteAssetEntryAssetCategoryRelByAssetEntryId",
+					() -> MapUtil.toPartitionMap(
+						assetEntryAssetCategoryRelPersistence.findAll(),
+						AssetEntryAssetCategoryRel::getAssetEntryId));
+
+		if (partitionAssetEntryAssetCategoryRels == null) {
+			assetEntryAssetCategoryRelPersistence.removeByAssetEntryId(
+				assetEntryId);
+		}
+		else {
+			List<AssetEntryAssetCategoryRel> assetEntryAssetCategoryRels =
+				partitionAssetEntryAssetCategoryRels.remove(assetEntryId);
+
+			if (assetEntryAssetCategoryRels != null) {
+				for (AssetEntryAssetCategoryRel assetEntryAssetCategoryRel :
+						assetEntryAssetCategoryRels) {
+
+					assetEntryAssetCategoryRelPersistence.remove(
+						assetEntryAssetCategoryRel);
+				}
+			}
+		}
 
 		_reindex(assetEntryId);
 	}

--- a/modules/apps/asset/asset-entry-rel-service/src/main/java/com/liferay/asset/entry/rel/service/impl/AssetEntryAssetCategoryRelLocalServiceImpl.java
+++ b/modules/apps/asset/asset-entry-rel-service/src/main/java/com/liferay/asset/entry/rel/service/impl/AssetEntryAssetCategoryRelLocalServiceImpl.java
@@ -80,7 +80,7 @@ public class AssetEntryAssetCategoryRelLocalServiceImpl
 				assetEntryAssetCategoryRel);
 		}
 
-		_reindex(assetEntryId);
+		_reindex(_assetEntryLocalService.fetchEntry(assetEntryId));
 	}
 
 	@Override
@@ -96,30 +96,33 @@ public class AssetEntryAssetCategoryRelLocalServiceImpl
 				assetEntryAssetCategoryRelPersistence.remove(
 					assetEntryAssetCategoryRel);
 
-				_reindex(assetEntryAssetCategoryRel.getAssetEntryId());
+				_reindex(
+					_assetEntryLocalService.fetchEntry(
+						assetEntryAssetCategoryRel.getAssetEntryId()));
 			});
 	}
 
 	@Override
-	public void deleteAssetEntryAssetCategoryRelByAssetEntryId(
-		long assetEntryId) {
+	public void deleteAssetEntryAssetCategoryRelByAssetEntry(
+		AssetEntry assetEntry) {
 
 		Map<Long, List<AssetEntryAssetCategoryRel>>
 			partitionAssetEntryAssetCategoryRels =
 				BulkDeleteCacheThreadLocal.getBulkDeleteCache(
 					AssetEntryAssetCategoryRelLocalServiceImpl.class.getName() +
-						".deleteAssetEntryAssetCategoryRelByAssetEntryId",
+						".deleteAssetEntryAssetCategoryRelByAssetEntry",
 					() -> MapUtil.toPartitionMap(
 						assetEntryAssetCategoryRelPersistence.findAll(),
 						AssetEntryAssetCategoryRel::getAssetEntryId));
 
 		if (partitionAssetEntryAssetCategoryRels == null) {
 			assetEntryAssetCategoryRelPersistence.removeByAssetEntryId(
-				assetEntryId);
+				assetEntry.getEntryId());
 		}
 		else {
 			List<AssetEntryAssetCategoryRel> assetEntryAssetCategoryRels =
-				partitionAssetEntryAssetCategoryRels.remove(assetEntryId);
+				partitionAssetEntryAssetCategoryRels.remove(
+					assetEntry.getEntryId());
 
 			if (assetEntryAssetCategoryRels != null) {
 				for (AssetEntryAssetCategoryRel assetEntryAssetCategoryRel :
@@ -131,7 +134,19 @@ public class AssetEntryAssetCategoryRelLocalServiceImpl
 			}
 		}
 
-		_reindex(assetEntryId);
+		_reindex(assetEntry);
+	}
+
+	@Override
+	public void deleteAssetEntryAssetCategoryRelByAssetEntryId(
+		long assetEntryId) {
+
+		AssetEntry assetEntry = _assetEntryLocalService.fetchAssetEntry(
+			assetEntryId);
+
+		if (assetEntry != null) {
+			deleteAssetEntryAssetCategoryRelByAssetEntry(assetEntry);
+		}
 	}
 
 	@Override
@@ -252,14 +267,7 @@ public class AssetEntryAssetCategoryRelLocalServiceImpl
 			AssetEntryAssetCategoryRel::getAssetEntryId);
 	}
 
-	private void _reindex(long assetEntryId) {
-		if (assetEntryId <= 0) {
-			return;
-		}
-
-		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
-			assetEntryId);
-
+	private void _reindex(AssetEntry assetEntry) {
 		if (assetEntry == null) {
 			return;
 		}

--- a/modules/apps/asset/asset-entry-rel-test/src/testIntegration/java/com/liferay/asset/entry/rel/test/AssetEntryAssetCategoryRelLocalServiceTest.java
+++ b/modules/apps/asset/asset-entry-rel-test/src/testIntegration/java/com/liferay/asset/entry/rel/test/AssetEntryAssetCategoryRelLocalServiceTest.java
@@ -155,15 +155,21 @@ public class AssetEntryAssetCategoryRelLocalServiceTest {
 	}
 
 	@Test
-	public void testDeleteAssetEntryAssetCategoryRelByAssetEntryId() {
-		long assetEntryId1 = RandomTestUtil.randomLong();
+	public void testDeleteAssetEntryAssetCategoryRelByAssetEntryId()
+		throws Exception {
+
+		_group = GroupTestUtil.addGroup();
+
+		_assetEntry1 = AssetTestUtil.addAssetEntry(_group.getGroupId());
+		_assetEntry2 = AssetTestUtil.addAssetEntry(_group.getGroupId());
+
 		long assetCategoryId = RandomTestUtil.randomLong();
 
-		_addAssetEntryAssetCategoryRel(assetEntryId1, assetCategoryId);
+		_addAssetEntryAssetCategoryRel(
+			_assetEntry1.getEntryId(), assetCategoryId);
 
-		long assetEntryId2 = RandomTestUtil.randomLong();
-
-		_addAssetEntryAssetCategoryRel(assetEntryId2, assetCategoryId);
+		_addAssetEntryAssetCategoryRel(
+			_assetEntry2.getEntryId(), assetCategoryId);
 
 		Assert.assertEquals(
 			_initialAssetEntryAssetCategoryRelsCount + 2,
@@ -171,7 +177,8 @@ public class AssetEntryAssetCategoryRelLocalServiceTest {
 				getAssetEntryAssetCategoryRelsCount());
 
 		_assetEntryAssetCategoryRelLocalService.
-			deleteAssetEntryAssetCategoryRelByAssetEntryId(assetEntryId1);
+			deleteAssetEntryAssetCategoryRelByAssetEntryId(
+				_assetEntry1.getEntryId());
 
 		Assert.assertEquals(
 			_initialAssetEntryAssetCategoryRelsCount + 1,
@@ -187,7 +194,8 @@ public class AssetEntryAssetCategoryRelLocalServiceTest {
 			assetEntryAssetCategoryRels.get(0);
 
 		Assert.assertEquals(
-			assetEntryId2, assetEntryAssetCategoryRel.getAssetEntryId());
+			_assetEntry2.getEntryId(),
+			assetEntryAssetCategoryRel.getAssetEntryId());
 		Assert.assertEquals(
 			assetCategoryId, assetEntryAssetCategoryRel.getAssetCategoryId());
 		Assert.assertEquals(0, assetEntryAssetCategoryRel.getPriority());
@@ -378,6 +386,12 @@ public class AssetEntryAssetCategoryRelLocalServiceTest {
 
 		return assetEntryAssetCategoryRel;
 	}
+
+	@DeleteAfterTestRun
+	private AssetEntry _assetEntry1;
+
+	@DeleteAfterTestRun
+	private AssetEntry _assetEntry2;
 
 	@Inject
 	private AssetEntryAssetCategoryRelLocalService

--- a/modules/apps/asset/asset-link-service/src/main/java/com/liferay/asset/link/service/impl/AssetLinkLocalServiceImpl.java
+++ b/modules/apps/asset/asset-link-service/src/main/java/com/liferay/asset/link/service/impl/AssetLinkLocalServiceImpl.java
@@ -17,6 +17,7 @@ import com.liferay.asset.link.service.base.AssetLinkLocalServiceBaseImpl;
 import com.liferay.exportimport.kernel.lar.StagedModelType;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.query.DSLQuery;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -28,12 +29,17 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.SystemEventLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.BulkDeleteCacheThreadLocal;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.model.adapter.util.ModelAdapterUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -180,12 +186,85 @@ public class AssetLinkLocalServiceImpl extends AssetLinkLocalServiceBaseImpl {
 	 */
 	@Override
 	public void deleteLinks(long entryId) {
-		for (AssetLink link : assetLinkPersistence.findByEntryId1(entryId)) {
-			deleteLink(link);
+		Map<Long, List<AssetLink>> leftPartitionAssetLinks =
+			BulkDeleteCacheThreadLocal.getBulkDeleteCache(
+				StringBundler.concat(
+					AssetLinkLocalServiceImpl.class.getName(),
+					".deleteLinks#left#", entryId),
+				() -> MapUtil.toPartitionMap(
+					assetLinkPersistence.findAll(), AssetLink::getEntryId1));
+
+		if (leftPartitionAssetLinks == null) {
+			for (AssetLink link :
+					assetLinkPersistence.findByEntryId1(entryId)) {
+
+				deleteLink(link);
+			}
+
+			for (AssetLink link :
+					assetLinkPersistence.findByEntryId2(entryId)) {
+
+				deleteLink(link);
+			}
+
+			return;
 		}
 
-		for (AssetLink link : assetLinkPersistence.findByEntryId2(entryId)) {
-			deleteLink(link);
+		Set<AssetLink> deletedAssetLinks = new HashSet<>();
+
+		List<AssetLink> leftAssetLinks = leftPartitionAssetLinks.remove(
+			entryId);
+
+		if (leftAssetLinks != null) {
+			for (AssetLink leftAssetLink : leftAssetLinks) {
+				assetLinkPersistence.remove(leftAssetLink);
+
+				deletedAssetLinks.add(leftAssetLink);
+			}
+		}
+
+		Map<Long, List<AssetLink>> rightPartitionAssetLinks =
+			BulkDeleteCacheThreadLocal.getBulkDeleteCache(
+				StringBundler.concat(
+					AssetLinkLocalServiceImpl.class.getName(),
+					".deleteLinks#right#", entryId),
+				() -> MapUtil.toPartitionMap(
+					assetLinkPersistence.findAll(), AssetLink::getEntryId2));
+
+		List<AssetLink> rightAssetLinks = rightPartitionAssetLinks.remove(
+			entryId);
+
+		if (rightAssetLinks != null) {
+			for (AssetLink rightAssetLink : rightAssetLinks) {
+				if (deletedAssetLinks.add(rightAssetLink)) {
+					assetLinkPersistence.remove(rightAssetLink);
+				}
+			}
+		}
+
+		for (AssetLink deletedAssetLink : deletedAssetLinks) {
+			leftPartitionAssetLinks.computeIfPresent(
+				deletedAssetLink.getEntryId1(),
+				(key, assetLinks) -> {
+					assetLinks.remove(deletedAssetLink);
+
+					if (assetLinks.isEmpty()) {
+						return null;
+					}
+
+					return assetLinks;
+				});
+			rightPartitionAssetLinks.computeIfPresent(
+				deletedAssetLink.getEntryId2(),
+				(key, assetLinks) -> {
+					assetLinks.remove(deletedAssetLink);
+
+					if (assetLinks.isEmpty()) {
+						return null;
+					}
+
+					return assetLinks;
+				});
 		}
 	}
 

--- a/modules/apps/asset/asset-list-api/bnd.bnd
+++ b/modules/apps/asset/asset-list-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Asset List API
 Bundle-SymbolicName: com.liferay.asset.list.api
-Bundle-Version: 18.0.1
+Bundle-Version: 18.1.0
 Export-Package:\
 	com.liferay.asset.list.asset.entry.provider,\
 	com.liferay.asset.list.constants,\

--- a/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/AssetListEntryAssetEntryRelLocalService.java
+++ b/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/AssetListEntryAssetEntryRelLocalService.java
@@ -142,6 +142,10 @@ public interface AssetListEntryAssetEntryRelLocalService
 			long assetListEntryId, long segmentsEntryId, int position)
 		throws PortalException;
 
+	public void deleteAssetListEntryAssetEntryRelByAssetEntryId(
+			long assetEntryId)
+		throws PortalException;
+
 	public void deleteAssetListEntryAssetEntryRelByAssetListEntryId(
 		long assetListEntryId);
 

--- a/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/AssetListEntryAssetEntryRelLocalServiceUtil.java
+++ b/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/AssetListEntryAssetEntryRelLocalServiceUtil.java
@@ -143,6 +143,14 @@ public class AssetListEntryAssetEntryRelLocalServiceUtil {
 			assetListEntryId, segmentsEntryId, position);
 	}
 
+	public static void deleteAssetListEntryAssetEntryRelByAssetEntryId(
+			long assetEntryId)
+		throws PortalException {
+
+		getService().deleteAssetListEntryAssetEntryRelByAssetEntryId(
+			assetEntryId);
+	}
+
 	public static void deleteAssetListEntryAssetEntryRelByAssetListEntryId(
 		long assetListEntryId) {
 

--- a/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/AssetListEntryAssetEntryRelLocalServiceWrapper.java
+++ b/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/AssetListEntryAssetEntryRelLocalServiceWrapper.java
@@ -154,6 +154,15 @@ public class AssetListEntryAssetEntryRelLocalServiceWrapper
 	}
 
 	@Override
+	public void deleteAssetListEntryAssetEntryRelByAssetEntryId(
+			long assetEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_assetListEntryAssetEntryRelLocalService.
+			deleteAssetListEntryAssetEntryRelByAssetEntryId(assetEntryId);
+	}
+
+	@Override
 	public void deleteAssetListEntryAssetEntryRelByAssetListEntryId(
 		long assetListEntryId) {
 

--- a/modules/apps/asset/asset-list-api/src/main/resources/com/liferay/asset/list/service/packageinfo
+++ b/modules/apps/asset/asset-list-api/src/main/resources/com/liferay/asset/list/service/packageinfo
@@ -1,1 +1,1 @@
-version 6.2.0
+version 6.3.0

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/model/listener/AssetEntryModelListener.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/model/listener/AssetEntryModelListener.java
@@ -6,7 +6,6 @@
 package com.liferay.asset.list.internal.model.listener;
 
 import com.liferay.asset.kernel.model.AssetEntry;
-import com.liferay.asset.list.model.AssetListEntryAssetEntryRel;
 import com.liferay.asset.list.service.AssetListEntryAssetEntryRelLocalService;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -28,23 +27,17 @@ public class AssetEntryModelListener extends BaseModelListener<AssetEntry> {
 	public void onAfterRemove(AssetEntry assetEntry)
 		throws ModelListenerException {
 
-		for (AssetListEntryAssetEntryRel assetListEntryAssetEntryRel :
-				_assetListEntryAssetEntryRelLocalService.
-					getAssetListEntryAssetEntryRelByAssetEntryId(
-						assetEntry.getEntryId())) {
-
-			try {
-				_assetListEntryAssetEntryRelLocalService.
-					deleteAssetListEntryAssetEntryRel(
-						assetListEntryAssetEntryRel);
+		try {
+			_assetListEntryAssetEntryRelLocalService.
+				deleteAssetListEntryAssetEntryRelByAssetEntryId(
+					assetEntry.getEntryId());
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
 			}
-			catch (PortalException portalException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(portalException);
-				}
 
-				throw new ModelListenerException(portalException);
-			}
+			throw new ModelListenerException(portalException);
 		}
 	}
 

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/impl/AssetListEntryAssetEntryRelLocalServiceImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/impl/AssetListEntryAssetEntryRelLocalServiceImpl.java
@@ -16,9 +16,12 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.util.BulkDeleteCacheThreadLocal;
+import com.liferay.portal.kernel.util.MapUtil;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -134,6 +137,46 @@ public class AssetListEntryAssetEntryRelLocalServiceImpl
 		return deleteAssetListEntryAssetEntryRel(
 			assetListEntryAssetEntryRelPersistence.findByA_S_P(
 				assetListEntryId, segmentsEntryId, position));
+	}
+
+	@Override
+	public void deleteAssetListEntryAssetEntryRelByAssetEntryId(
+			long assetEntryId)
+		throws PortalException {
+
+		String ownerName =
+			AssetListEntryAssetEntryRelLocalServiceImpl.class.getName() +
+				".deleteAssetListEntryAssetEntryRelByAssetEntryId";
+
+		Map<Long, List<AssetListEntryAssetEntryRel>>
+			partitionAssetListEntryAssetEntryRels =
+				BulkDeleteCacheThreadLocal.getBulkDeleteCache(
+					ownerName,
+					() -> MapUtil.toPartitionMap(
+						assetListEntryAssetEntryRelPersistence.findAll(),
+						AssetListEntryAssetEntryRel::getAssetEntryId));
+
+		if (partitionAssetListEntryAssetEntryRels == null) {
+			for (AssetListEntryAssetEntryRel assetListEntryAssetEntryRel :
+					assetListEntryAssetEntryRelPersistence.findByAssetEntryId(
+						assetEntryId)) {
+
+				deleteAssetListEntryAssetEntryRel(assetListEntryAssetEntryRel);
+			}
+		}
+		else {
+			List<AssetListEntryAssetEntryRel> assetListEntryAssetEntryRels =
+				partitionAssetListEntryAssetEntryRels.remove(assetEntryId);
+
+			if (assetListEntryAssetEntryRels != null) {
+				for (AssetListEntryAssetEntryRel assetListEntryAssetEntryRel :
+						assetListEntryAssetEntryRels) {
+
+					deleteAssetListEntryAssetEntryRel(
+						assetListEntryAssetEntryRel);
+				}
+			}
+		}
 	}
 
 	@Override

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/service/AssetEntryLocalServiceWrapper.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/service/AssetEntryLocalServiceWrapper.java
@@ -43,23 +43,23 @@ public class AssetEntryLocalServiceWrapper
 	}
 
 	@Override
-	public void deleteEntry(AssetEntry entry) throws PortalException {
+	public AssetEntry deleteEntry(AssetEntry entry) throws PortalException {
 		_assetEntryAssetCategoryRelLocalService.
 			deleteAssetEntryAssetCategoryRelByAssetEntryId(entry.getEntryId());
 
-		super.deleteEntry(entry);
+		return super.deleteEntry(entry);
 	}
 
 	@Override
-	public void deleteEntry(long entryId) throws PortalException {
+	public AssetEntry deleteEntry(long entryId) throws PortalException {
 		_assetEntryAssetCategoryRelLocalService.
 			deleteAssetEntryAssetCategoryRelByAssetEntryId(entryId);
 
-		super.deleteEntry(entryId);
+		return super.deleteEntry(entryId);
 	}
 
 	@Override
-	public void deleteEntry(String className, long classPK)
+	public AssetEntry deleteEntry(String className, long classPK)
 		throws PortalException {
 
 		AssetEntry entry = super.fetchEntry(className, classPK);
@@ -70,7 +70,7 @@ public class AssetEntryLocalServiceWrapper
 					entry.getEntryId());
 		}
 
-		super.deleteEntry(className, classPK);
+		return super.deleteEntry(className, classPK);
 	}
 
 	@Override

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/service/AssetEntryLocalServiceWrapper.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/service/AssetEntryLocalServiceWrapper.java
@@ -62,7 +62,7 @@ public class AssetEntryLocalServiceWrapper
 	public AssetEntry deleteEntry(String className, long classPK)
 		throws PortalException {
 
-		AssetEntry entry = super.fetchEntry(className, classPK);
+		AssetEntry entry = super.deleteEntry(className, classPK);
 
 		if (entry != null) {
 			_assetEntryAssetCategoryRelLocalService.
@@ -70,7 +70,7 @@ public class AssetEntryLocalServiceWrapper
 					entry.getEntryId());
 		}
 
-		return super.deleteEntry(className, classPK);
+		return entry;
 	}
 
 	@Override

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/service/AssetEntryLocalServiceWrapper.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/service/AssetEntryLocalServiceWrapper.java
@@ -27,7 +27,7 @@ public class AssetEntryLocalServiceWrapper
 	@Override
 	public AssetEntry deleteAssetEntry(AssetEntry entry) {
 		_assetEntryAssetCategoryRelLocalService.
-			deleteAssetEntryAssetCategoryRelByAssetEntryId(entry.getEntryId());
+			deleteAssetEntryAssetCategoryRelByAssetEntry(entry);
 
 		return super.deleteAssetEntry(entry);
 	}
@@ -66,8 +66,7 @@ public class AssetEntryLocalServiceWrapper
 
 		if (entry != null) {
 			_assetEntryAssetCategoryRelLocalService.
-				deleteAssetEntryAssetCategoryRelByAssetEntryId(
-					entry.getEntryId());
+				deleteAssetEntryAssetCategoryRelByAssetEntry(entry);
 		}
 
 		return entry;

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/service/persistence/LayoutClassedModelUsagePersistence.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/service/persistence/LayoutClassedModelUsagePersistence.java
@@ -526,6 +526,161 @@ public interface LayoutClassedModelUsagePersistence
 	public int countByPlid(long plid);
 
 	/**
+	 * Returns all the layout classed model usages where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @return the matching layout classed model usages
+	 */
+	public java.util.List<LayoutClassedModelUsage> findByC_CN(
+		long companyId, long classNameId);
+
+	/**
+	 * Returns a range of all the layout classed model usages where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutClassedModelUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of layout classed model usages
+	 * @param end the upper bound of the range of layout classed model usages (not inclusive)
+	 * @return the range of matching layout classed model usages
+	 */
+	public java.util.List<LayoutClassedModelUsage> findByC_CN(
+		long companyId, long classNameId, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the layout classed model usages where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutClassedModelUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of layout classed model usages
+	 * @param end the upper bound of the range of layout classed model usages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout classed model usages
+	 */
+	public java.util.List<LayoutClassedModelUsage> findByC_CN(
+		long companyId, long classNameId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<LayoutClassedModelUsage> orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the layout classed model usages where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutClassedModelUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of layout classed model usages
+	 * @param end the upper bound of the range of layout classed model usages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching layout classed model usages
+	 */
+	public java.util.List<LayoutClassedModelUsage> findByC_CN(
+		long companyId, long classNameId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<LayoutClassedModelUsage> orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first layout classed model usage in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching layout classed model usage
+	 * @throws NoSuchLayoutClassedModelUsageException if a matching layout classed model usage could not be found
+	 */
+	public LayoutClassedModelUsage findByC_CN_First(
+			long companyId, long classNameId,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<LayoutClassedModelUsage> orderByComparator)
+		throws NoSuchLayoutClassedModelUsageException;
+
+	/**
+	 * Returns the first layout classed model usage in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching layout classed model usage, or <code>null</code> if a matching layout classed model usage could not be found
+	 */
+	public LayoutClassedModelUsage fetchByC_CN_First(
+		long companyId, long classNameId,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<LayoutClassedModelUsage> orderByComparator);
+
+	/**
+	 * Returns the last layout classed model usage in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching layout classed model usage
+	 * @throws NoSuchLayoutClassedModelUsageException if a matching layout classed model usage could not be found
+	 */
+	public LayoutClassedModelUsage findByC_CN_Last(
+			long companyId, long classNameId,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<LayoutClassedModelUsage> orderByComparator)
+		throws NoSuchLayoutClassedModelUsageException;
+
+	/**
+	 * Returns the last layout classed model usage in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching layout classed model usage, or <code>null</code> if a matching layout classed model usage could not be found
+	 */
+	public LayoutClassedModelUsage fetchByC_CN_Last(
+		long companyId, long classNameId,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<LayoutClassedModelUsage> orderByComparator);
+
+	/**
+	 * Returns the layout classed model usages before and after the current layout classed model usage in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param layoutClassedModelUsageId the primary key of the current layout classed model usage
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next layout classed model usage
+	 * @throws NoSuchLayoutClassedModelUsageException if a layout classed model usage with the primary key could not be found
+	 */
+	public LayoutClassedModelUsage[] findByC_CN_PrevAndNext(
+			long layoutClassedModelUsageId, long companyId, long classNameId,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<LayoutClassedModelUsage> orderByComparator)
+		throws NoSuchLayoutClassedModelUsageException;
+
+	/**
+	 * Removes all the layout classed model usages where companyId = &#63; and classNameId = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 */
+	public void removeByC_CN(long companyId, long classNameId);
+
+	/**
+	 * Returns the number of layout classed model usages where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @return the number of matching layout classed model usages
+	 */
+	public int countByC_CN(long companyId, long classNameId);
+
+	/**
 	 * Returns all the layout classed model usages where classNameId = &#63; and classPK = &#63;.
 	 *
 	 * @param classNameId the class name ID

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/service/persistence/LayoutClassedModelUsageUtil.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/service/persistence/LayoutClassedModelUsageUtil.java
@@ -716,6 +716,197 @@ public class LayoutClassedModelUsageUtil {
 	}
 
 	/**
+	 * Returns all the layout classed model usages where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @return the matching layout classed model usages
+	 */
+	public static List<LayoutClassedModelUsage> findByC_CN(
+		long companyId, long classNameId) {
+
+		return getPersistence().findByC_CN(companyId, classNameId);
+	}
+
+	/**
+	 * Returns a range of all the layout classed model usages where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutClassedModelUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of layout classed model usages
+	 * @param end the upper bound of the range of layout classed model usages (not inclusive)
+	 * @return the range of matching layout classed model usages
+	 */
+	public static List<LayoutClassedModelUsage> findByC_CN(
+		long companyId, long classNameId, int start, int end) {
+
+		return getPersistence().findByC_CN(companyId, classNameId, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout classed model usages where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutClassedModelUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of layout classed model usages
+	 * @param end the upper bound of the range of layout classed model usages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout classed model usages
+	 */
+	public static List<LayoutClassedModelUsage> findByC_CN(
+		long companyId, long classNameId, int start, int end,
+		OrderByComparator<LayoutClassedModelUsage> orderByComparator) {
+
+		return getPersistence().findByC_CN(
+			companyId, classNameId, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout classed model usages where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutClassedModelUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of layout classed model usages
+	 * @param end the upper bound of the range of layout classed model usages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching layout classed model usages
+	 */
+	public static List<LayoutClassedModelUsage> findByC_CN(
+		long companyId, long classNameId, int start, int end,
+		OrderByComparator<LayoutClassedModelUsage> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByC_CN(
+			companyId, classNameId, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first layout classed model usage in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching layout classed model usage
+	 * @throws NoSuchLayoutClassedModelUsageException if a matching layout classed model usage could not be found
+	 */
+	public static LayoutClassedModelUsage findByC_CN_First(
+			long companyId, long classNameId,
+			OrderByComparator<LayoutClassedModelUsage> orderByComparator)
+		throws com.liferay.layout.exception.
+			NoSuchLayoutClassedModelUsageException {
+
+		return getPersistence().findByC_CN_First(
+			companyId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Returns the first layout classed model usage in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching layout classed model usage, or <code>null</code> if a matching layout classed model usage could not be found
+	 */
+	public static LayoutClassedModelUsage fetchByC_CN_First(
+		long companyId, long classNameId,
+		OrderByComparator<LayoutClassedModelUsage> orderByComparator) {
+
+		return getPersistence().fetchByC_CN_First(
+			companyId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Returns the last layout classed model usage in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching layout classed model usage
+	 * @throws NoSuchLayoutClassedModelUsageException if a matching layout classed model usage could not be found
+	 */
+	public static LayoutClassedModelUsage findByC_CN_Last(
+			long companyId, long classNameId,
+			OrderByComparator<LayoutClassedModelUsage> orderByComparator)
+		throws com.liferay.layout.exception.
+			NoSuchLayoutClassedModelUsageException {
+
+		return getPersistence().findByC_CN_Last(
+			companyId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Returns the last layout classed model usage in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching layout classed model usage, or <code>null</code> if a matching layout classed model usage could not be found
+	 */
+	public static LayoutClassedModelUsage fetchByC_CN_Last(
+		long companyId, long classNameId,
+		OrderByComparator<LayoutClassedModelUsage> orderByComparator) {
+
+		return getPersistence().fetchByC_CN_Last(
+			companyId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Returns the layout classed model usages before and after the current layout classed model usage in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param layoutClassedModelUsageId the primary key of the current layout classed model usage
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next layout classed model usage
+	 * @throws NoSuchLayoutClassedModelUsageException if a layout classed model usage with the primary key could not be found
+	 */
+	public static LayoutClassedModelUsage[] findByC_CN_PrevAndNext(
+			long layoutClassedModelUsageId, long companyId, long classNameId,
+			OrderByComparator<LayoutClassedModelUsage> orderByComparator)
+		throws com.liferay.layout.exception.
+			NoSuchLayoutClassedModelUsageException {
+
+		return getPersistence().findByC_CN_PrevAndNext(
+			layoutClassedModelUsageId, companyId, classNameId,
+			orderByComparator);
+	}
+
+	/**
+	 * Removes all the layout classed model usages where companyId = &#63; and classNameId = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 */
+	public static void removeByC_CN(long companyId, long classNameId) {
+		getPersistence().removeByC_CN(companyId, classNameId);
+	}
+
+	/**
+	 * Returns the number of layout classed model usages where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @return the number of matching layout classed model usages
+	 */
+	public static int countByC_CN(long companyId, long classNameId) {
+		return getPersistence().countByC_CN(companyId, classNameId);
+	}
+
+	/**
 	 * Returns all the layout classed model usages where classNameId = &#63; and classPK = &#63;.
 	 *
 	 * @param classNameId the class name ID

--- a/modules/apps/layout/layout-api/src/main/resources/com/liferay/layout/service/persistence/packageinfo
+++ b/modules/apps/layout/layout-api/src/main/resources/com/liferay/layout/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.1.0

--- a/modules/apps/layout/layout-service/service.xml
+++ b/modules/apps/layout/layout-service/service.xml
@@ -35,6 +35,10 @@
 		<finder name="Plid" return-type="Collection" where="containerKey IS NOT NULL">
 			<finder-column name="plid" />
 		</finder>
+		<finder name="C_CN" return-type="Collection" where="containerKey IS NOT NULL">
+			<finder-column name="companyId" />
+			<finder-column name="classNameId" />
+		</finder>
 		<finder name="CN_CPK" return-type="Collection" where="containerKey IS NOT NULL">
 			<finder-column name="classNameId" />
 			<finder-column name="classPK" />

--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/service/impl/LayoutClassedModelUsageLocalServiceImpl.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/service/impl/LayoutClassedModelUsageLocalServiceImpl.java
@@ -15,12 +15,16 @@ import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.BulkDeleteCacheThreadLocal;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 
 import java.util.List;
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -75,7 +79,34 @@ public class LayoutClassedModelUsageLocalServiceImpl
 
 	@Override
 	public void deleteLayoutClassedModelUsages(long classNameId, long classPK) {
-		layoutClassedModelUsagePersistence.removeByCN_CPK(classNameId, classPK);
+		Map<Long, List<LayoutClassedModelUsage>>
+			partitionLayoutClassedModelUsages =
+				BulkDeleteCacheThreadLocal.getBulkDeleteCache(
+					LayoutClassedModelUsageLocalServiceImpl.class.getName() +
+						".deleteLayoutClassedModelUsages#" + classNameId,
+					() -> MapUtil.toPartitionMap(
+						layoutClassedModelUsagePersistence.findByC_CN(
+							CompanyThreadLocal.getCompanyId(), classNameId),
+						LayoutClassedModelUsage::getClassPK));
+
+		if (partitionLayoutClassedModelUsages == null) {
+			layoutClassedModelUsagePersistence.removeByCN_CPK(
+				classNameId, classPK);
+
+			return;
+		}
+
+		List<LayoutClassedModelUsage> layoutClassedModelUsages =
+			partitionLayoutClassedModelUsages.remove(classPK);
+
+		if (layoutClassedModelUsages != null) {
+			for (LayoutClassedModelUsage layoutClassedModelUsage :
+					layoutClassedModelUsages) {
+
+				layoutClassedModelUsagePersistence.remove(
+					layoutClassedModelUsage);
+			}
+		}
 	}
 
 	@Override

--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/service/persistence/impl/LayoutClassedModelUsagePersistenceImpl.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/service/persistence/impl/LayoutClassedModelUsagePersistenceImpl.java
@@ -2034,6 +2034,566 @@ public class LayoutClassedModelUsagePersistenceImpl
 	private static final String _FINDER_COLUMN_PLID_PLID_2 =
 		"layoutClassedModelUsage.plid = ? AND layoutClassedModelUsage.containerKey IS NOT NULL";
 
+	private FinderPath _finderPathWithPaginationFindByC_CN;
+	private FinderPath _finderPathWithoutPaginationFindByC_CN;
+	private FinderPath _finderPathCountByC_CN;
+
+	/**
+	 * Returns all the layout classed model usages where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @return the matching layout classed model usages
+	 */
+	@Override
+	public List<LayoutClassedModelUsage> findByC_CN(
+		long companyId, long classNameId) {
+
+		return findByC_CN(
+			companyId, classNameId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the layout classed model usages where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutClassedModelUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of layout classed model usages
+	 * @param end the upper bound of the range of layout classed model usages (not inclusive)
+	 * @return the range of matching layout classed model usages
+	 */
+	@Override
+	public List<LayoutClassedModelUsage> findByC_CN(
+		long companyId, long classNameId, int start, int end) {
+
+		return findByC_CN(companyId, classNameId, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout classed model usages where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutClassedModelUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of layout classed model usages
+	 * @param end the upper bound of the range of layout classed model usages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching layout classed model usages
+	 */
+	@Override
+	public List<LayoutClassedModelUsage> findByC_CN(
+		long companyId, long classNameId, int start, int end,
+		OrderByComparator<LayoutClassedModelUsage> orderByComparator) {
+
+		return findByC_CN(
+			companyId, classNameId, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the layout classed model usages where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>LayoutClassedModelUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of layout classed model usages
+	 * @param end the upper bound of the range of layout classed model usages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching layout classed model usages
+	 */
+	@Override
+	public List<LayoutClassedModelUsage> findByC_CN(
+		long companyId, long classNameId, int start, int end,
+		OrderByComparator<LayoutClassedModelUsage> orderByComparator,
+		boolean useFinderCache) {
+
+		try (SafeCloseable safeCloseable =
+				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
+					LayoutClassedModelUsage.class)) {
+
+			FinderPath finderPath = null;
+			Object[] finderArgs = null;
+
+			if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+				(orderByComparator == null)) {
+
+				if (useFinderCache) {
+					finderPath = _finderPathWithoutPaginationFindByC_CN;
+					finderArgs = new Object[] {companyId, classNameId};
+				}
+			}
+			else if (useFinderCache) {
+				finderPath = _finderPathWithPaginationFindByC_CN;
+				finderArgs = new Object[] {
+					companyId, classNameId, start, end, orderByComparator
+				};
+			}
+
+			List<LayoutClassedModelUsage> list = null;
+
+			if (useFinderCache) {
+				list = (List<LayoutClassedModelUsage>)finderCache.getResult(
+					finderPath, finderArgs, this);
+
+				if ((list != null) && !list.isEmpty()) {
+					for (LayoutClassedModelUsage layoutClassedModelUsage :
+							list) {
+
+						if ((companyId !=
+								layoutClassedModelUsage.getCompanyId()) ||
+							(classNameId !=
+								layoutClassedModelUsage.getClassNameId())) {
+
+							list = null;
+
+							break;
+						}
+					}
+				}
+			}
+
+			if (list == null) {
+				StringBundler sb = null;
+
+				if (orderByComparator != null) {
+					sb = new StringBundler(
+						4 + (orderByComparator.getOrderByFields().length * 2));
+				}
+				else {
+					sb = new StringBundler(4);
+				}
+
+				sb.append(_SQL_SELECT_LAYOUTCLASSEDMODELUSAGE_WHERE);
+
+				sb.append(_FINDER_COLUMN_C_CN_COMPANYID_2);
+
+				sb.append(_FINDER_COLUMN_C_CN_CLASSNAMEID_2);
+
+				if (orderByComparator != null) {
+					appendOrderByComparator(
+						sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+				}
+				else {
+					sb.append(LayoutClassedModelUsageModelImpl.ORDER_BY_JPQL);
+				}
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(companyId);
+
+					queryPos.add(classNameId);
+
+					list = (List<LayoutClassedModelUsage>)QueryUtil.list(
+						query, getDialect(), start, end);
+
+					cacheResult(list);
+
+					if (useFinderCache) {
+						finderCache.putResult(finderPath, finderArgs, list);
+					}
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return list;
+		}
+	}
+
+	/**
+	 * Returns the first layout classed model usage in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching layout classed model usage
+	 * @throws NoSuchLayoutClassedModelUsageException if a matching layout classed model usage could not be found
+	 */
+	@Override
+	public LayoutClassedModelUsage findByC_CN_First(
+			long companyId, long classNameId,
+			OrderByComparator<LayoutClassedModelUsage> orderByComparator)
+		throws NoSuchLayoutClassedModelUsageException {
+
+		LayoutClassedModelUsage layoutClassedModelUsage = fetchByC_CN_First(
+			companyId, classNameId, orderByComparator);
+
+		if (layoutClassedModelUsage != null) {
+			return layoutClassedModelUsage;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("companyId=");
+		sb.append(companyId);
+
+		sb.append(", classNameId=");
+		sb.append(classNameId);
+
+		sb.append("}");
+
+		throw new NoSuchLayoutClassedModelUsageException(sb.toString());
+	}
+
+	/**
+	 * Returns the first layout classed model usage in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching layout classed model usage, or <code>null</code> if a matching layout classed model usage could not be found
+	 */
+	@Override
+	public LayoutClassedModelUsage fetchByC_CN_First(
+		long companyId, long classNameId,
+		OrderByComparator<LayoutClassedModelUsage> orderByComparator) {
+
+		List<LayoutClassedModelUsage> list = findByC_CN(
+			companyId, classNameId, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last layout classed model usage in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching layout classed model usage
+	 * @throws NoSuchLayoutClassedModelUsageException if a matching layout classed model usage could not be found
+	 */
+	@Override
+	public LayoutClassedModelUsage findByC_CN_Last(
+			long companyId, long classNameId,
+			OrderByComparator<LayoutClassedModelUsage> orderByComparator)
+		throws NoSuchLayoutClassedModelUsageException {
+
+		LayoutClassedModelUsage layoutClassedModelUsage = fetchByC_CN_Last(
+			companyId, classNameId, orderByComparator);
+
+		if (layoutClassedModelUsage != null) {
+			return layoutClassedModelUsage;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("companyId=");
+		sb.append(companyId);
+
+		sb.append(", classNameId=");
+		sb.append(classNameId);
+
+		sb.append("}");
+
+		throw new NoSuchLayoutClassedModelUsageException(sb.toString());
+	}
+
+	/**
+	 * Returns the last layout classed model usage in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching layout classed model usage, or <code>null</code> if a matching layout classed model usage could not be found
+	 */
+	@Override
+	public LayoutClassedModelUsage fetchByC_CN_Last(
+		long companyId, long classNameId,
+		OrderByComparator<LayoutClassedModelUsage> orderByComparator) {
+
+		int count = countByC_CN(companyId, classNameId);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<LayoutClassedModelUsage> list = findByC_CN(
+			companyId, classNameId, count - 1, count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the layout classed model usages before and after the current layout classed model usage in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param layoutClassedModelUsageId the primary key of the current layout classed model usage
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next layout classed model usage
+	 * @throws NoSuchLayoutClassedModelUsageException if a layout classed model usage with the primary key could not be found
+	 */
+	@Override
+	public LayoutClassedModelUsage[] findByC_CN_PrevAndNext(
+			long layoutClassedModelUsageId, long companyId, long classNameId,
+			OrderByComparator<LayoutClassedModelUsage> orderByComparator)
+		throws NoSuchLayoutClassedModelUsageException {
+
+		LayoutClassedModelUsage layoutClassedModelUsage = findByPrimaryKey(
+			layoutClassedModelUsageId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			LayoutClassedModelUsage[] array =
+				new LayoutClassedModelUsageImpl[3];
+
+			array[0] = getByC_CN_PrevAndNext(
+				session, layoutClassedModelUsage, companyId, classNameId,
+				orderByComparator, true);
+
+			array[1] = layoutClassedModelUsage;
+
+			array[2] = getByC_CN_PrevAndNext(
+				session, layoutClassedModelUsage, companyId, classNameId,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected LayoutClassedModelUsage getByC_CN_PrevAndNext(
+		Session session, LayoutClassedModelUsage layoutClassedModelUsage,
+		long companyId, long classNameId,
+		OrderByComparator<LayoutClassedModelUsage> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				5 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(4);
+		}
+
+		sb.append(_SQL_SELECT_LAYOUTCLASSEDMODELUSAGE_WHERE);
+
+		sb.append(_FINDER_COLUMN_C_CN_COMPANYID_2);
+
+		sb.append(_FINDER_COLUMN_C_CN_CLASSNAMEID_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(LayoutClassedModelUsageModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(companyId);
+
+		queryPos.add(classNameId);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						layoutClassedModelUsage)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<LayoutClassedModelUsage> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the layout classed model usages where companyId = &#63; and classNameId = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 */
+	@Override
+	public void removeByC_CN(long companyId, long classNameId) {
+		for (LayoutClassedModelUsage layoutClassedModelUsage :
+				findByC_CN(
+					companyId, classNameId, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null)) {
+
+			remove(layoutClassedModelUsage);
+		}
+	}
+
+	/**
+	 * Returns the number of layout classed model usages where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @return the number of matching layout classed model usages
+	 */
+	@Override
+	public int countByC_CN(long companyId, long classNameId) {
+		try (SafeCloseable safeCloseable =
+				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
+					LayoutClassedModelUsage.class)) {
+
+			FinderPath finderPath = _finderPathCountByC_CN;
+
+			Object[] finderArgs = new Object[] {companyId, classNameId};
+
+			Long count = (Long)finderCache.getResult(
+				finderPath, finderArgs, this);
+
+			if (count == null) {
+				StringBundler sb = new StringBundler(3);
+
+				sb.append(_SQL_COUNT_LAYOUTCLASSEDMODELUSAGE_WHERE);
+
+				sb.append(_FINDER_COLUMN_C_CN_COMPANYID_2);
+
+				sb.append(_FINDER_COLUMN_C_CN_CLASSNAMEID_2);
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(companyId);
+
+					queryPos.add(classNameId);
+
+					count = (Long)query.uniqueResult();
+
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return count.intValue();
+		}
+	}
+
+	private static final String _FINDER_COLUMN_C_CN_COMPANYID_2 =
+		"layoutClassedModelUsage.companyId = ? AND ";
+
+	private static final String _FINDER_COLUMN_C_CN_CLASSNAMEID_2 =
+		"layoutClassedModelUsage.classNameId = ? AND layoutClassedModelUsage.containerKey IS NOT NULL";
+
 	private FinderPath _finderPathWithPaginationFindByCN_CPK;
 	private FinderPath _finderPathWithoutPaginationFindByCN_CPK;
 	private FinderPath _finderPathCountByCN_CPK;
@@ -7294,6 +7854,25 @@ public class LayoutClassedModelUsagePersistenceImpl
 		_finderPathCountByPlid = new FinderPath(
 			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByPlid",
 			new String[] {Long.class.getName()}, new String[] {"plid"}, false);
+
+		_finderPathWithPaginationFindByC_CN = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_CN",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId"}, true);
+
+		_finderPathWithoutPaginationFindByC_CN = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_CN",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "classNameId"}, true);
+
+		_finderPathCountByC_CN = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_CN",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "classNameId"}, false);
 
 		_finderPathWithPaginationFindByCN_CPK = new FinderPath(
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCN_CPK",

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/persistence/test/LayoutClassedModelUsagePersistenceTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/persistence/test/LayoutClassedModelUsagePersistenceTest.java
@@ -251,6 +251,14 @@ public class LayoutClassedModelUsagePersistenceTest {
 	}
 
 	@Test
+	public void testCountByC_CN() throws Exception {
+		_persistence.countByC_CN(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextLong());
+
+		_persistence.countByC_CN(0L, 0L);
+	}
+
+	@Test
 	public void testCountByCN_CPK() throws Exception {
 		_persistence.countByCN_CPK(
 			RandomTestUtil.nextLong(), RandomTestUtil.nextLong());

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
@@ -60,6 +60,7 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
@@ -123,7 +124,7 @@ public class ObjectDefinitionResourceImpl
 			startTime = System.currentTimeMillis();
 		}
 
-		try {
+		try (SafeCloseable safeCloseable = SearchContext.openBatchMode()) {
 			TransactionInvokerUtil.invoke(
 				_transactionConfig,
 				() -> {

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
@@ -54,6 +54,7 @@ import com.liferay.object.service.ObjectValidationRuleLocalService;
 import com.liferay.object.service.ObjectViewLocalService;
 import com.liferay.object.service.ObjectViewService;
 import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
@@ -69,6 +70,7 @@ import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.BulkDeleteCacheThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -124,7 +126,10 @@ public class ObjectDefinitionResourceImpl
 			startTime = System.currentTimeMillis();
 		}
 
-		try (SafeCloseable safeCloseable = SearchContext.openBatchMode()) {
+		try (SafeCloseable safeCloseable1 = SearchContext.openBatchMode();
+			SafeCloseable safeCloseable2 =
+				BulkDeleteCacheThreadLocal.openBulkDeleteMode()) {
+
 			TransactionInvokerUtil.invoke(
 				_transactionConfig,
 				() -> {

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionThreadLocal.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionThreadLocal.java
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.definition.util;
+
+import com.liferay.object.entry.util.ObjectEntryThreadLocal;
+import com.liferay.petra.lang.CentralizedThreadLocal;
+import com.liferay.petra.lang.SafeCloseable;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class ObjectDefinitionThreadLocal {
+
+	public static boolean isDeleteObjectDefinitionId(long objectDefinitionId) {
+		Long deleteObjectDefinitionId =
+			_deleteObjectDefinitionIdThreadLocal.get();
+
+		if ((deleteObjectDefinitionId != null) &&
+			(deleteObjectDefinitionId == objectDefinitionId)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	public static SafeCloseable setDeleteObjectDefinitionId(long id) {
+		return _deleteObjectDefinitionIdThreadLocal.setWithSafeCloseable(id);
+	}
+
+	private static final CentralizedThreadLocal<Long>
+		_deleteObjectDefinitionIdThreadLocal = new CentralizedThreadLocal<>(
+			ObjectEntryThreadLocal.class +
+				"._deleteObjectDefinitionIdThreadLocal");
+
+}

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/tree/TreeFactory.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/tree/TreeFactory.java
@@ -5,6 +5,8 @@
 
 package com.liferay.object.tree;
 
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.exception.PortalException;
 
 /**
@@ -12,7 +14,10 @@ import com.liferay.portal.kernel.exception.PortalException;
  */
 public interface TreeFactory {
 
-	public Tree createObjectDefinitionTree(long objectDefinitionId)
+	public Tree createObjectDefinitionTree(
+			long objectDefinitionId,
+			UnsafeFunction<Long, ObjectDefinition, PortalException>
+				objectDefinitionLookupUnsafeFunction)
 		throws PortalException;
 
 	public Tree createObjectEntryTree(long objectEntryId)

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/definition/util/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/definition/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/tree/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/tree/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 3.0.0

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -4892,8 +4892,8 @@ public class DefaultObjectEntryManagerImplTest
 		throws Exception {
 
 		Tree tree = TreeTestUtil.createObjectEntryTree(
-			externalReferenceCodeSuffix, _objectEntryLocalService,
-			objectFieldLocalService,
+			externalReferenceCodeSuffix, objectDefinitionLocalService,
+			_objectEntryLocalService, objectFieldLocalService,
 			_rootObjectDefinition.getObjectDefinitionId(),
 			_objectRelationshipLocalService, _treeFactory);
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -435,7 +435,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		throws PortalException {
 
 		Tree tree = _treeFactory.createObjectDefinitionTree(
-			rootObjectDefinitionId);
+			rootObjectDefinitionId,
+			_objectDefinitionLocalService::getObjectDefinition);
 
 		Iterator<Node> iterator = tree.iterator();
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/util/ObjectDefinitionResourcePermissionUtil.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/util/ObjectDefinitionResourcePermissionUtil.java
@@ -146,7 +146,8 @@ public class ObjectDefinitionResourcePermissionUtil {
 		int weight = _INITIAL_WEIGHT;
 
 		Tree tree = treeFactory.createObjectDefinitionTree(
-			rootNodeObjectDefinition.getObjectDefinitionId());
+			rootNodeObjectDefinition.getObjectDefinitionId(),
+			objectDefinitionPersistence::findByPrimaryKey);
 
 		Iterator<Node> iterator = tree.iterator();
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/tree/TreeFactoryImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/tree/TreeFactoryImpl.java
@@ -8,10 +8,8 @@ package com.liferay.object.internal.tree;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectRelationship;
-import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
-import com.liferay.object.service.impl.ObjectRelationshipLocalServiceImpl;
 import com.liferay.object.tree.Edge;
 import com.liferay.object.tree.Node;
 import com.liferay.object.tree.Tree;
@@ -20,7 +18,6 @@ import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.util.ListUtil;
 
 import java.util.ArrayList;
@@ -38,15 +35,14 @@ import org.osgi.service.component.annotations.Reference;
 public class TreeFactoryImpl implements TreeFactory {
 
 	@Override
-	public Tree createObjectDefinitionTree(long objectDefinitionId)
+	public Tree createObjectDefinitionTree(
+			long objectDefinitionId,
+			UnsafeFunction<Long, ObjectDefinition, PortalException>
+				objectDefinitionLookupUnsafeFunction)
 		throws PortalException {
 
-		ObjectDefinitionLocalService objectDefinitionLocalService =
-			_objectDefinitionLocalServiceSnapshot.get();
-
 		ObjectDefinition rootObjectDefinition =
-			objectDefinitionLocalService.getObjectDefinition(
-				objectDefinitionId);
+			objectDefinitionLookupUnsafeFunction.apply(objectDefinitionId);
 
 		return _create(
 			objectDefinitionId,
@@ -55,7 +51,7 @@ public class TreeFactoryImpl implements TreeFactory {
 					node.getPrimaryKey(), true),
 				objectRelationship -> {
 					ObjectDefinition objectDefinition2 =
-						objectDefinitionLocalService.getObjectDefinition(
+						objectDefinitionLookupUnsafeFunction.apply(
 							objectRelationship.getObjectDefinitionId2());
 
 					if (rootObjectDefinition.isApproved() !=
@@ -131,11 +127,6 @@ public class TreeFactoryImpl implements TreeFactory {
 
 		return new Tree(rootNode);
 	}
-
-	private static final Snapshot<ObjectDefinitionLocalService>
-		_objectDefinitionLocalServiceSnapshot = new Snapshot<>(
-			ObjectRelationshipLocalServiceImpl.class,
-			ObjectDefinitionLocalService.class, null, true);
 
 	@Reference
 	private ObjectEntryLocalService _objectEntryLocalService;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectEntryImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectEntryImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.object.model.impl;
 
+import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.entry.util.ObjectEntryValuesUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
@@ -23,6 +24,7 @@ import java.io.Serializable;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author Marco Leo
@@ -81,6 +83,17 @@ public class ObjectEntryImpl extends ObjectEntryBaseImpl {
 
 				if (Validator.isNotNull(title)) {
 					return title;
+				}
+
+				if (!Objects.equals(
+						objectField.getBusinessType(),
+						ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT) &&
+					!Objects.equals(
+						objectField.getBusinessType(),
+						ObjectFieldConstants.BUSINESS_TYPE_RICH_TEXT) &&
+					Objects.equals(objectField.getName(), "id")) {
+
+					return String.valueOf(getObjectEntryId());
 				}
 
 				return ObjectEntryValuesUtil.getValueString(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -123,6 +123,7 @@ import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
 import com.liferay.portal.kernel.service.persistence.ResourcePermissionPersistence;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.util.BulkDeleteCacheThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -142,12 +143,14 @@ import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.osgi.framework.BundleContext;
@@ -622,6 +625,15 @@ public class ObjectDefinitionLocalServiceImpl
 		}
 
 		objectDefinitionPersistence.remove(objectDefinition);
+
+		Set<String> names = BulkDeleteCacheThreadLocal.getBulkDeleteCache(
+			ResourcePermissionLocalService.class.getName(), HashSet::new);
+
+		if (names != null) {
+			for (String name : names) {
+				_resourcePermissionLocalService.deleteResourcePermissions(name);
+			}
+		}
 
 		return objectDefinition;
 	}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -948,7 +948,8 @@ public class ObjectDefinitionLocalServiceImpl
 					"are ineligible for publication");
 		}
 
-		Tree tree = _treeFactory.createObjectDefinitionTree(objectDefinitionId);
+		Tree tree = _treeFactory.createObjectDefinitionTree(
+			objectDefinitionId, objectDefinitionPersistence::findByPrimaryKey);
 
 		Iterator<Node> iterator = tree.iterator();
 
@@ -1109,7 +1110,8 @@ public class ObjectDefinitionLocalServiceImpl
 				objectDefinitionId);
 
 		Tree tree = _treeFactory.createObjectDefinitionTree(
-			objectDefinition.getObjectDefinitionId());
+			objectDefinition.getObjectDefinitionId(),
+			objectDefinitionPersistence::findByPrimaryKey);
 
 		Iterator<Node> iterator = tree.iterator(
 			objectDefinition.getObjectDefinitionId());

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -92,8 +92,10 @@ import com.liferay.portal.kernel.cluster.ClusterExecutorUtil;
 import com.liferay.portal.kernel.cluster.ClusterRequest;
 import com.liferay.portal.kernel.dao.jdbc.CurrentConnection;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.DefaultActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
+import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.dependency.manager.DependencyManagerSyncUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
@@ -503,13 +505,45 @@ public class ObjectDefinitionLocalServiceImpl
 		if (!objectDefinition.isUnmodifiableSystemObject()) {
 			_deleteObjectDefinitionPLOEntries(objectDefinition);
 
-			List<ObjectEntry> objectEntries =
-				_objectEntryPersistence.findByObjectDefinitionId(
-					objectDefinition.getObjectDefinitionId());
+			ActionableDynamicQuery actionableDynamicQuery =
+				new DefaultActionableDynamicQuery() {
 
-			for (ObjectEntry objectEntry : objectEntries) {
-				_objectEntryLocalService.deleteObjectEntry(objectEntry);
-			}
+					@Override
+					protected void intervalCompleted(
+							long startPrimaryKey, long endPrimaryKey)
+						throws PortalException {
+
+						Session session = _objectEntryPersistence.openSession();
+
+						session.flush();
+
+						session.clear();
+					}
+
+				};
+
+			actionableDynamicQuery.setBaseLocalService(
+				_objectEntryLocalService);
+			actionableDynamicQuery.setClassLoader(getClassLoader());
+			actionableDynamicQuery.setModelClass(ObjectEntry.class);
+
+			actionableDynamicQuery.setPrimaryKeyPropertyName("objectEntryId");
+
+			actionableDynamicQuery.setAddCriteriaMethod(
+				dynamicQuery -> {
+					Property nameProperty = PropertyFactoryUtil.forName(
+						"objectDefinitionId");
+
+					dynamicQuery.add(
+						nameProperty.eq(
+							objectDefinition.getObjectDefinitionId()));
+				});
+
+			actionableDynamicQuery.setPerformActionMethod(
+				(ObjectEntry objectEntry) ->
+					_objectEntryLocalService.deleteObjectEntry(objectEntry));
+
+			actionableDynamicQuery.performActions();
 		}
 
 		for (ObjectRelationship objectRelationship :

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -120,6 +120,7 @@ import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
+import com.liferay.portal.kernel.service.persistence.ResourcePermissionPersistence;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -513,11 +514,19 @@ public class ObjectDefinitionLocalServiceImpl
 							long startPrimaryKey, long endPrimaryKey)
 						throws PortalException {
 
-						Session session = _objectEntryPersistence.openSession();
+						Session portletSession =
+							_objectEntryPersistence.openSession();
 
-						session.flush();
+						portletSession.flush();
 
-						session.clear();
+						portletSession.clear();
+
+						Session portalSession =
+							_resourcePermissionPersistence.openSession();
+
+						portalSession.flush();
+
+						portalSession.clear();
 					}
 
 				};
@@ -2594,6 +2603,9 @@ public class ObjectDefinitionLocalServiceImpl
 
 	@Reference
 	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private ResourcePermissionPersistence _resourcePermissionPersistence;
 
 	private final Map
 		<ObjectDefinitionDeployer, Map<Long, List<ServiceRegistration<?>>>>

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -15,6 +15,7 @@ import com.liferay.layout.service.LayoutClassedModelUsageLocalService;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.definition.util.ObjectDefinitionThreadLocal;
 import com.liferay.object.definition.util.ObjectDefinitionUtil;
 import com.liferay.object.deployer.InactiveObjectDefinitionDeployer;
 import com.liferay.object.deployer.ObjectDefinitionDeployer;
@@ -93,6 +94,7 @@ import com.liferay.portal.kernel.cluster.ClusterRequest;
 import com.liferay.portal.kernel.dao.jdbc.CurrentConnection;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DefaultActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.Session;
@@ -142,6 +144,8 @@ import com.liferay.portal.search.spi.model.query.contributor.ModelPreFilterContr
 import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
+import java.sql.PreparedStatement;
+
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -152,6 +156,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
@@ -551,11 +556,42 @@ public class ObjectDefinitionLocalServiceImpl
 							objectDefinition.getObjectDefinitionId()));
 				});
 
-			actionableDynamicQuery.setPerformActionMethod(
-				(ObjectEntry objectEntry) ->
-					_objectEntryLocalService.deleteObjectEntry(objectEntry));
+			AtomicBoolean deletedMarker = new AtomicBoolean();
 
-			actionableDynamicQuery.performActions();
+			actionableDynamicQuery.setPerformActionMethod(
+				(ObjectEntry objectEntry) -> {
+					deletedMarker.set(true);
+
+					_objectEntryLocalService.deleteObjectEntry(objectEntry);
+				});
+
+			try (SafeCloseable safeCloseable =
+					ObjectDefinitionThreadLocal.setDeleteObjectDefinitionId(
+						objectDefinition.getObjectDefinitionId())) {
+
+				actionableDynamicQuery.performActions();
+
+				if (deletedMarker.get()) {
+					_resourcePermissionLocalService.deleteResourcePermissions(
+						objectDefinition.getCompanyId(),
+						objectDefinition.getClassName(),
+						ResourceConstants.SCOPE_INDIVIDUAL);
+
+					_assetEntryLocalService.deleteEntries(
+						objectDefinition.getCompanyId(),
+						objectDefinition.getClassName());
+
+					_deleteFromTable(objectDefinition.getDBTableName());
+
+					_deleteFromTable(
+						objectDefinition.getExtensionDBTableName());
+
+					if (objectDefinition.isEnableLocalization()) {
+						_deleteFromTable(
+							objectDefinition.getLocalizationDBTableName());
+					}
+				}
+			}
 		}
 
 		for (ObjectRelationship objectRelationship :
@@ -1713,6 +1749,27 @@ public class ObjectDefinitionLocalServiceImpl
 				dynamicObjectDefinitionTable.getTableName(), false,
 				objectField.getDBColumnName());
 		}
+	}
+
+	private void _deleteFromTable(String dbTableName) throws PortalException {
+		Session session = objectDefinitionPersistence.openSession();
+
+		try {
+			session.apply(
+				connection -> {
+					try (PreparedStatement preparedStatement =
+							connection.prepareStatement(
+								"delete from " + dbTableName)) {
+
+						preparedStatement.executeUpdate();
+					}
+				});
+		}
+		finally {
+			objectDefinitionPersistence.closeSession(session);
+		}
+
+		FinderCacheUtil.clearDSLQueryCache(dbTableName);
 	}
 
 	private void _deleteObjectDefinitionPLOEntries(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -204,6 +204,7 @@ import com.liferay.portal.search.sort.Sorts;
 import com.liferay.portal.service.PersistedModelLocalServiceRegistryUtil;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
+import com.liferay.portlet.asset.util.DeletedAssetObjectThreadLocal;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -549,8 +550,15 @@ public class ObjectEntryLocalServiceImpl
 			objectEntry.getCompanyId(), objectDefinition.getClassName(),
 			ResourceConstants.SCOPE_INDIVIDUAL, objectEntry.getObjectEntryId());
 
-		_assetEntryLocalService.deleteEntry(
-			objectDefinition.getClassName(), objectEntry.getObjectEntryId());
+		try (SafeCloseable safeCloseable =
+				DeletedAssetObjectThreadLocal.setWithSafeCloseable(
+					objectDefinition.getClassName(),
+					objectEntry.getObjectEntryId())) {
+
+			_assetEntryLocalService.deleteEntry(
+				objectDefinition.getClassName(),
+				objectEntry.getObjectEntryId());
+		}
 
 		_workflowInstanceLinkLocalService.deleteWorkflowInstanceLinks(
 			objectEntry.getCompanyId(), objectEntry.getNonzeroGroupId(),

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -124,6 +124,7 @@ import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.jdbc.CurrentConnection;
 import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
+import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.encryptor.Encryptor;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
@@ -2086,10 +2087,26 @@ public class ObjectEntryLocalServiceImpl
 			long primaryKey)
 		throws PortalException {
 
-		runSQL(
-			StringBundler.concat(
-				"delete from ", dbTableName, " where ",
-				pkObjectFieldDBColumnName, " = ", primaryKey));
+		Session session = objectEntryPersistence.openSession();
+
+		try {
+			session.apply(
+				connection -> {
+					try (PreparedStatement preparedStatement =
+							connection.prepareStatement(
+								StringBundler.concat(
+									"delete from ", dbTableName, " where ",
+									pkObjectFieldDBColumnName, " = ?"))) {
+
+						preparedStatement.setLong(1, primaryKey);
+
+						preparedStatement.executeUpdate();
+					}
+				});
+		}
+		finally {
+			objectEntryPersistence.closeSession(session);
+		}
 
 		FinderCacheUtil.clearDSLQueryCache(dbTableName);
 	}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -34,6 +34,7 @@ import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.constants.ObjectFieldValidationConstants;
 import com.liferay.object.constants.ObjectFilterConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.definition.util.ObjectDefinitionThreadLocal;
 import com.liferay.object.entry.ObjectEntryContext;
 import com.liferay.object.entry.contributor.ObjectEntryValuesContributor;
 import com.liferay.object.entry.util.ObjectEntryThreadLocal;
@@ -205,7 +206,6 @@ import com.liferay.portal.search.sort.Sorts;
 import com.liferay.portal.service.PersistedModelLocalServiceRegistryUtil;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
-import com.liferay.portlet.asset.util.DeletedAssetObjectThreadLocal;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -547,20 +547,6 @@ public class ObjectEntryLocalServiceImpl
 			_objectDefinitionPersistence.findByPrimaryKey(
 				objectEntry.getObjectDefinitionId());
 
-		_resourceLocalService.deleteResource(
-			objectEntry.getCompanyId(), objectDefinition.getClassName(),
-			ResourceConstants.SCOPE_INDIVIDUAL, objectEntry.getObjectEntryId());
-
-		try (SafeCloseable safeCloseable =
-				DeletedAssetObjectThreadLocal.setWithSafeCloseable(
-					objectDefinition.getClassName(),
-					objectEntry.getObjectEntryId())) {
-
-			_assetEntryLocalService.deleteEntry(
-				objectDefinition.getClassName(),
-				objectEntry.getObjectEntryId());
-		}
-
 		_workflowInstanceLinkLocalService.deleteWorkflowInstanceLinks(
 			objectEntry.getCompanyId(), objectEntry.getNonzeroGroupId(),
 			objectDefinition.getClassName(), objectEntry.getObjectEntryId());
@@ -569,20 +555,33 @@ public class ObjectEntryLocalServiceImpl
 			Collections.emptyMap(), objectDefinition.getObjectDefinitionId(),
 			objectEntry::getValues);
 
-		_deleteFromTable(
-			objectDefinition.getDBTableName(),
-			objectDefinition.getPKObjectFieldDBColumnName(),
-			objectEntry.getObjectEntryId());
-		_deleteFromTable(
-			objectDefinition.getExtensionDBTableName(),
-			objectDefinition.getPKObjectFieldDBColumnName(),
-			objectEntry.getObjectEntryId());
+		if (!ObjectDefinitionThreadLocal.isDeleteObjectDefinitionId(
+				objectDefinition.getObjectDefinitionId())) {
 
-		if (objectDefinition.isEnableLocalization()) {
+			_resourceLocalService.deleteResource(
+				objectEntry.getCompanyId(), objectDefinition.getClassName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				objectEntry.getObjectEntryId());
+
+			_assetEntryLocalService.deleteEntry(
+				objectDefinition.getClassName(),
+				objectEntry.getObjectEntryId());
+
 			_deleteFromTable(
-				objectDefinition.getLocalizationDBTableName(),
+				objectDefinition.getDBTableName(),
 				objectDefinition.getPKObjectFieldDBColumnName(),
 				objectEntry.getObjectEntryId());
+			_deleteFromTable(
+				objectDefinition.getExtensionDBTableName(),
+				objectDefinition.getPKObjectFieldDBColumnName(),
+				objectEntry.getObjectEntryId());
+
+			if (objectDefinition.isEnableLocalization()) {
+				_deleteFromTable(
+					objectDefinition.getLocalizationDBTableName(),
+					objectDefinition.getPKObjectFieldDBColumnName(),
+					objectEntry.getObjectEntryId());
+			}
 		}
 
 		deleteRelatedObjectEntries(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -239,6 +239,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import javax.crypto.spec.SecretKeySpec;
 
@@ -536,8 +537,6 @@ public class ObjectEntryLocalServiceImpl
 	public ObjectEntry deleteObjectEntry(ObjectEntry objectEntry)
 		throws PortalException {
 
-		Map<String, Serializable> values = objectEntry.getValues();
-
 		ObjectActionThreadLocal.clearObjectEntryIdsMap();
 
 		objectEntry = objectEntryPersistence.remove(objectEntry);
@@ -556,6 +555,10 @@ public class ObjectEntryLocalServiceImpl
 		_workflowInstanceLinkLocalService.deleteWorkflowInstanceLinks(
 			objectEntry.getCompanyId(), objectEntry.getNonzeroGroupId(),
 			objectDefinition.getClassName(), objectEntry.getObjectEntryId());
+
+		_deleteFileEntries(
+			Collections.emptyMap(), objectDefinition.getObjectDefinitionId(),
+			objectEntry::getValues);
 
 		_deleteFromTable(
 			objectDefinition.getDBTableName(),
@@ -576,10 +579,6 @@ public class ObjectEntryLocalServiceImpl
 		deleteRelatedObjectEntries(
 			objectEntry.getGroupId(), objectDefinition.getObjectDefinitionId(),
 			objectEntry.getPrimaryKey());
-
-		_deleteFileEntries(
-			Collections.emptyMap(), objectDefinition.getObjectDefinitionId(),
-			values);
 
 		if (!objectDefinition.isActive() ||
 			!objectDefinition.isEnableIndexSearch()) {
@@ -1989,21 +1988,35 @@ public class ObjectEntryLocalServiceImpl
 		Map<String, Serializable> newValues, long objectDefinitionId,
 		Map<String, Serializable> oldValues) {
 
+		_deleteFileEntries(newValues, objectDefinitionId, () -> oldValues);
+	}
+
+	private void _deleteFileEntries(
+		Map<String, Serializable> newValues, long objectDefinitionId,
+		Supplier<Map<String, Serializable>> oldValuesSupplier) {
+
 		List<ObjectField> objectFields =
 			_objectFieldPersistence.findByObjectDefinitionId(
 				objectDefinitionId);
 
+		Map<String, Serializable> oldValues = null;
+
 		for (ObjectField objectField : objectFields) {
-			if (objectField.isSystem()) {
+			if (objectField.isSystem() ||
+				!Objects.equals(
+					objectField.getBusinessType(),
+					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
+
 				continue;
+			}
+
+			if (oldValues == null) {
+				oldValues = oldValuesSupplier.get();
 			}
 
 			String objectFieldName = objectField.getName();
 
-			if (!Objects.equals(
-					objectField.getBusinessType(),
-					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT) ||
-				Objects.equals(
+			if (Objects.equals(
 					GetterUtil.getLong(newValues.get(objectFieldName)),
 					GetterUtil.getLong(oldValues.get(objectFieldName)))) {
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -4278,7 +4278,8 @@ public class ObjectEntryLocalServiceImpl
 		TreeFactory treeFactory = _treeFactorySnapshot.get();
 
 		Tree objectDefinitionTree = treeFactory.createObjectDefinitionTree(
-			objectDefinition.getRootObjectDefinitionId());
+			objectDefinition.getRootObjectDefinitionId(),
+			_objectDefinitionPersistence::findByPrimaryKey);
 
 		Node objectDefinitionNode = objectDefinitionTree.getNode(
 			objectDefinition.getObjectDefinitionId());

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java
@@ -624,7 +624,8 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 		throws PortalException {
 
 		Tree tree = _treeFactory.createObjectDefinitionTree(
-			objectDefinition.getRootObjectDefinitionId());
+			objectDefinition.getRootObjectDefinitionId(),
+			_objectDefinitionPersistence::findByPrimaryKey);
 
 		Node node = tree.getNode(objectDefinition.getObjectDefinitionId());
 

--- a/modules/apps/object/object-test-util/src/main/java/com/liferay/object/test/util/TreeTestUtil.java
+++ b/modules/apps/object/object-test-util/src/main/java/com/liferay/object/test/util/TreeTestUtil.java
@@ -104,11 +104,13 @@ public class TreeTestUtil {
 					ObjectDefinitionTestUtil.addCustomObjectDefinition("AB"))));
 
 		return treeFactory.createObjectDefinitionTree(
-			objectDefinitionA.getObjectDefinitionId());
+			objectDefinitionA.getObjectDefinitionId(),
+			objectDefinitionLocalService::getObjectDefinition);
 	}
 
 	public static Tree createObjectEntryTree(
 			String externalReferenceCodeSuffix,
+			ObjectDefinitionLocalService objectDefinitionLocalService,
 			ObjectEntryLocalService objectEntryLocalService,
 			ObjectFieldLocalService objectFieldLocalService,
 			long rootObjectDefinitionId,
@@ -117,7 +119,8 @@ public class TreeTestUtil {
 		throws PortalException {
 
 		Tree objectDefinitionTree = treeFactory.createObjectDefinitionTree(
-			rootObjectDefinitionId);
+			rootObjectDefinitionId,
+			objectDefinitionLocalService::getObjectDefinition);
 
 		Iterator<Node> iterator = objectDefinitionTree.iterator();
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -1901,7 +1901,8 @@ public class ObjectDefinitionLocalServiceTest {
 				"AB", new String[0]
 			).build(),
 			_treeFactory.createObjectDefinitionTree(
-				objectDefinition.getRootObjectDefinitionId()),
+				objectDefinition.getRootObjectDefinitionId(),
+				_objectDefinitionLocalService::getObjectDefinition),
 			_objectDefinitionLocalService);
 
 		// Unbind object definition leaf node
@@ -1913,7 +1914,8 @@ public class ObjectDefinitionLocalServiceTest {
 				"A", new String[0]
 			).build(),
 			_treeFactory.createObjectDefinitionTree(
-				objectDefinition.getRootObjectDefinitionId()),
+				objectDefinition.getRootObjectDefinitionId(),
+				_objectDefinitionLocalService::getObjectDefinition),
 			_objectDefinitionLocalService);
 
 		// Unbind object definition root node
@@ -2680,7 +2682,9 @@ public class ObjectDefinitionLocalServiceTest {
 
 		TreeTestUtil.assertObjectDefinitionTree(
 			expectedMap,
-			_treeFactory.createObjectDefinitionTree(rootObjectDefinitionId),
+			_treeFactory.createObjectDefinitionTree(
+				rootObjectDefinitionId,
+				_objectDefinitionLocalService::getObjectDefinition),
 			_objectDefinitionLocalService);
 	}
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -1920,8 +1920,8 @@ public class ObjectEntryLocalServiceTest {
 			rootObjectDefinitionNode.getPrimaryKey());
 
 		Tree objectEntryTree1 = TreeTestUtil.createObjectEntryTree(
-			"1", _objectEntryLocalService, _objectFieldLocalService,
-			rootObjectDefinitionNode.getPrimaryKey(),
+			"1", _objectDefinitionLocalService, _objectEntryLocalService,
+			_objectFieldLocalService, rootObjectDefinitionNode.getPrimaryKey(),
 			_objectRelationshipLocalService, _treeFactory);
 
 		TreeTestUtil.assertObjectEntryTree(
@@ -1939,8 +1939,8 @@ public class ObjectEntryLocalServiceTest {
 			objectEntryTree1, _objectEntryLocalService);
 
 		Tree objectEntryTree2 = TreeTestUtil.createObjectEntryTree(
-			"2", _objectEntryLocalService, _objectFieldLocalService,
-			rootObjectDefinitionNode.getPrimaryKey(),
+			"2", _objectDefinitionLocalService, _objectEntryLocalService,
+			_objectFieldLocalService, rootObjectDefinitionNode.getPrimaryKey(),
 			_objectRelationshipLocalService, _treeFactory);
 
 		TreeTestUtil.assertObjectEntryTree(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryServiceTest.java
@@ -425,8 +425,8 @@ public class ObjectEntryServiceTest {
 		Node objectDefinitionRootNode = _tree.getRootNode();
 
 		Tree objectEntryTree = TreeTestUtil.createObjectEntryTree(
-			"1", _objectEntryLocalService, _objectFieldLocalService,
-			objectDefinitionRootNode.getPrimaryKey(),
+			"1", _objectDefinitionLocalService, _objectEntryLocalService,
+			_objectFieldLocalService, objectDefinitionRootNode.getPrimaryKey(),
 			_objectRelationshipLocalService, _treeFactory);
 
 		_setUser(_user);
@@ -480,8 +480,8 @@ public class ObjectEntryServiceTest {
 		// Root individual permissions must be inherited
 
 		objectEntryTree = TreeTestUtil.createObjectEntryTree(
-			"1", _objectEntryLocalService, _objectFieldLocalService,
-			objectDefinitionRootNode.getPrimaryKey(),
+			"1", _objectDefinitionLocalService, _objectEntryLocalService,
+			_objectFieldLocalService, objectDefinitionRootNode.getPrimaryKey(),
 			_objectRelationshipLocalService, _treeFactory);
 
 		Node objectEntryRootNode = objectEntryTree.getRootNode();
@@ -506,7 +506,8 @@ public class ObjectEntryServiceTest {
 		_setUser(_adminUser);
 
 		objectEntryTree = TreeTestUtil.createObjectEntryTree(
-			"1", _objectEntryLocalService, _objectFieldLocalService,
+			"1", _objectDefinitionLocalService, _objectEntryLocalService,
+			_objectFieldLocalService,
 			_rootObjectDefinition.getRootObjectDefinitionId(),
 			_objectRelationshipLocalService, _treeFactory);
 
@@ -620,8 +621,8 @@ public class ObjectEntryServiceTest {
 		Node objectDefinitionRootNode = _tree.getRootNode();
 
 		Tree objectEntryTree = TreeTestUtil.createObjectEntryTree(
-			"1", _objectEntryLocalService, _objectFieldLocalService,
-			objectDefinitionRootNode.getPrimaryKey(),
+			"1", _objectDefinitionLocalService, _objectEntryLocalService,
+			_objectFieldLocalService, objectDefinitionRootNode.getPrimaryKey(),
 			_objectRelationshipLocalService, _treeFactory);
 
 		_setUser(_user);

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
@@ -461,14 +461,16 @@ public class ObjectRelationshipLocalServiceTest {
 						"A", new String[0]
 					).build(),
 					_treeFactory.createObjectDefinitionTree(
-						objectDefinition1.getObjectDefinitionId()),
+						objectDefinition1.getObjectDefinitionId(),
+						_objectDefinitionLocalService::getObjectDefinition),
 					_objectDefinitionLocalService);
 				TreeTestUtil.assertObjectDefinitionTree(
 					LinkedHashMapBuilder.put(
 						"AA", new String[0]
 					).build(),
 					_treeFactory.createObjectDefinitionTree(
-						objectDefinition2.getObjectDefinitionId()),
+						objectDefinition2.getObjectDefinitionId(),
+						_objectDefinitionLocalService::getObjectDefinition),
 					_objectDefinitionLocalService);
 			});
 	}
@@ -486,7 +488,8 @@ public class ObjectRelationshipLocalServiceTest {
 						"AA", new String[0]
 					).build(),
 					_treeFactory.createObjectDefinitionTree(
-						objectDefinition1.getObjectDefinitionId()),
+						objectDefinition1.getObjectDefinitionId(),
+						_objectDefinitionLocalService::getObjectDefinition),
 					_objectDefinitionLocalService));
 	}
 
@@ -512,7 +515,8 @@ public class ObjectRelationshipLocalServiceTest {
 						"AA", new String[0]
 					).build(),
 					_treeFactory.createObjectDefinitionTree(
-						objectDefinition1.getObjectDefinitionId()),
+						objectDefinition1.getObjectDefinitionId(),
+						_objectDefinitionLocalService::getObjectDefinition),
 					_objectDefinitionLocalService));
 	}
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/entries/display/context/test/ObjectEntryDisplayContextTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/entries/display/context/test/ObjectEntryDisplayContextTest.java
@@ -72,9 +72,9 @@ public class ObjectEntryDisplayContextTest {
 				TestPropsValues.getUserId(), nodeA.getPrimaryKey());
 
 		TreeTestUtil.createObjectEntryTree(
-			"1", _objectEntryLocalService, _objectFieldLocalService,
-			nodeA.getPrimaryKey(), _objectRelationshipLocalService,
-			_treeFactory);
+			"1", _objectDefinitionLocalService, _objectEntryLocalService,
+			_objectFieldLocalService, nodeA.getPrimaryKey(),
+			_objectRelationshipLocalService, _treeFactory);
 
 		ObjectDefinition objectDefinitionAA =
 			_objectDefinitionLocalService.getObjectDefinition(

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/portlet/action/GetObjectRelationshipEdgeCandidatesMVCResourceCommand.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/portlet/action/GetObjectRelationshipEdgeCandidatesMVCResourceCommand.java
@@ -86,7 +86,8 @@ public class GetObjectRelationshipEdgeCandidatesMVCResourceCommand
 			}
 
 			Tree tree = _treeFactory.createObjectDefinitionTree(
-				objectDefinition1.getRootObjectDefinitionId());
+				objectDefinition1.getRootObjectDefinitionId(),
+				_objectDefinitionLocalService::getObjectDefinition);
 
 			int depth = ParamUtil.getInteger(resourceRequest, "depth");
 

--- a/modules/apps/object/source-formatter-suppressions.xml
+++ b/modules/apps/object/source-formatter-suppressions.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 
 <suppressions>
+	<checkstyle>
+		<suppress checks="PersistenceCallCheck" files="object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl\.java" />
+	</checkstyle>
 	<source-check>
 		<suppress checks="JavaAPISignatureCheck" files="object-api/src/main/java/com/liferay/object/scope/ObjectScopeProvider\.java" />
 	</source-check>

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/ElasticsearchIndexWriter.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/ElasticsearchIndexWriter.java
@@ -345,7 +345,9 @@ public class ElasticsearchIndexWriter extends BaseIndexWriter {
 		BulkDocumentResponse bulkDocumentResponse =
 			_searchEngineAdapter.execute(bulkDocumentRequest);
 
-		if (bulkDocumentResponse.hasErrors()) {
+		if ((bulkDocumentResponse != null) &&
+			bulkDocumentResponse.hasErrors()) {
+
 			if (_elasticsearchConfigurationWrapper.logExceptionsOnly()) {
 				_log.error("Update failed");
 			}

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterImpl.java
@@ -5,8 +5,13 @@
 
 package com.liferay.portal.search.elasticsearch7.internal.search.engine.adapter;
 
+import com.liferay.petra.lang.CentralizedThreadLocal;
 import com.liferay.portal.kernel.search.Query;
+import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.query.QueryTranslator;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
 import com.liferay.portal.search.engine.adapter.ccr.CCRRequest;
 import com.liferay.portal.search.engine.adapter.ccr.CCRRequestExecutor;
@@ -14,6 +19,8 @@ import com.liferay.portal.search.engine.adapter.ccr.CCRResponse;
 import com.liferay.portal.search.engine.adapter.cluster.ClusterRequest;
 import com.liferay.portal.search.engine.adapter.cluster.ClusterRequestExecutor;
 import com.liferay.portal.search.engine.adapter.cluster.ClusterResponse;
+import com.liferay.portal.search.engine.adapter.document.BulkDocumentRequest;
+import com.liferay.portal.search.engine.adapter.document.BulkableDocumentRequest;
 import com.liferay.portal.search.engine.adapter.document.DocumentRequest;
 import com.liferay.portal.search.engine.adapter.document.DocumentRequestExecutor;
 import com.liferay.portal.search.engine.adapter.document.DocumentResponse;
@@ -26,6 +33,8 @@ import com.liferay.portal.search.engine.adapter.search.SearchResponse;
 import com.liferay.portal.search.engine.adapter.snapshot.SnapshotRequest;
 import com.liferay.portal.search.engine.adapter.snapshot.SnapshotRequestExecutor;
 import com.liferay.portal.search.engine.adapter.snapshot.SnapshotResponse;
+
+import java.util.List;
 
 import org.elasticsearch.index.query.QueryBuilder;
 
@@ -67,6 +76,84 @@ public class ElasticsearchSearchEngineAdapterImpl
 	@Override
 	public <S extends DocumentResponse> S execute(
 		DocumentRequest<S> documentRequest) {
+
+		if (SearchContext.isBatchMode() &&
+			(documentRequest instanceof BulkableDocumentRequest ||
+			 documentRequest instanceof BulkDocumentRequest)) {
+
+			BulkDocumentRequest bulkDocumentRequest =
+				_bulkDocumentRequestThreadLocal.get();
+
+			if (bulkDocumentRequest == null) {
+				bulkDocumentRequest = new BulkDocumentRequest();
+
+				_bulkDocumentRequestThreadLocal.set(bulkDocumentRequest);
+
+				BulkDocumentRequest finalBulkDocumentRequest =
+					bulkDocumentRequest;
+
+				SearchContext.registerBatchModeSyncCallable(
+					() -> {
+						List<BulkableDocumentRequest<?>>
+							bulkableDocumentRequests =
+								finalBulkDocumentRequest.
+									getBulkableDocumentRequests();
+
+						if (bulkableDocumentRequests.isEmpty()) {
+							return null;
+						}
+
+						try {
+							finalBulkDocumentRequest.accept(
+								_documentRequestExecutor);
+						}
+						catch (RuntimeException runtimeException) {
+							throw _getRuntimeException(runtimeException);
+						}
+						finally {
+							_bulkDocumentRequestThreadLocal.remove();
+						}
+
+						return null;
+					});
+			}
+
+			if (documentRequest instanceof BulkDocumentRequest) {
+				BulkDocumentRequest incomingBulkDocumentRequest =
+					(BulkDocumentRequest)documentRequest;
+
+				for (BulkableDocumentRequest<?> bulkableDocumentRequest :
+						incomingBulkDocumentRequest.
+							getBulkableDocumentRequests()) {
+
+					bulkDocumentRequest.addBulkableDocumentRequest(
+						bulkableDocumentRequest);
+				}
+			}
+			else {
+				bulkDocumentRequest.addBulkableDocumentRequest(
+					(BulkableDocumentRequest)documentRequest);
+			}
+
+			List<BulkableDocumentRequest<?>> bulkableDocumentRequests =
+				bulkDocumentRequest.getBulkableDocumentRequests();
+
+			if (bulkableDocumentRequests.size() >= _HIBERNATE_JDBC_BATCH_SIZE) {
+				try {
+					S documentResponse = documentRequest.accept(
+						_documentRequestExecutor);
+
+					bulkableDocumentRequests.clear();
+
+					return documentResponse;
+				}
+				catch (RuntimeException runtimeException) {
+					throw _getRuntimeException(runtimeException);
+				}
+			}
+
+			return null;
+		}
 
 		try {
 			return documentRequest.accept(_documentRequestExecutor);
@@ -152,6 +239,14 @@ public class ElasticsearchSearchEngineAdapterImpl
 
 		return runtimeException1;
 	}
+
+	private static final int _HIBERNATE_JDBC_BATCH_SIZE = GetterUtil.getInteger(
+		PropsUtil.get(PropsKeys.HIBERNATE_JDBC_BATCH_SIZE));
+
+	private static final ThreadLocal<BulkDocumentRequest>
+		_bulkDocumentRequestThreadLocal = new CentralizedThreadLocal<>(
+			ElasticsearchSearchEngineAdapterImpl.class.getName() +
+				"._bulkDocumentRequestThreadLocal");
 
 	@Reference(target = "(search.engine.impl=Elasticsearch)")
 	private CCRRequestExecutor _ccrRequestExecutor;

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/document/BulkDocumentRequestExecutorImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/document/BulkDocumentRequestExecutorImpl.java
@@ -128,23 +128,38 @@ public class BulkDocumentRequestExecutorImpl
 			bulkableDocumentRequest.accept(
 				request -> {
 					if (request instanceof DeleteDocumentRequest) {
+						DeleteDocumentRequest deleteDocumentRequest =
+							(DeleteDocumentRequest)request;
+
+						deleteDocumentRequest.setRefresh(false);
+
 						DeleteRequest deleteRequest =
 							_elasticsearchBulkableDocumentRequestTranslator.
-								translate((DeleteDocumentRequest)request);
+								translate(deleteDocumentRequest);
 
 						bulkRequest.add(deleteRequest);
 					}
 					else if (request instanceof IndexDocumentRequest) {
+						IndexDocumentRequest indexDocumentRequest =
+							(IndexDocumentRequest)request;
+
+						indexDocumentRequest.setRefresh(false);
+
 						IndexRequest indexRequest =
 							_elasticsearchBulkableDocumentRequestTranslator.
-								translate((IndexDocumentRequest)request);
+								translate(indexDocumentRequest);
 
 						bulkRequest.add(indexRequest);
 					}
 					else if (request instanceof UpdateDocumentRequest) {
+						UpdateDocumentRequest updateDocumentRequest =
+							(UpdateDocumentRequest)request;
+
+						updateDocumentRequest.setRefresh(false);
+
 						UpdateRequest updateRequest =
 							_elasticsearchBulkableDocumentRequestTranslator.
-								translate((UpdateDocumentRequest)request);
+								translate(updateDocumentRequest);
 
 						bulkRequest.add(updateRequest);
 					}

--- a/modules/apps/portal-search/portal-search-api/bnd.bnd
+++ b/modules/apps/portal-search/portal-search-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Search API
 Bundle-SymbolicName: com.liferay.portal.search.api
-Bundle-Version: 16.2.1
+Bundle-Version: 17.0.0
 Export-Package:\
 	com.liferay.portal.search.aggregation,\
 	com.liferay.portal.search.aggregation.bucket,\

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/configuration/IndexerRegistryConfiguration.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/configuration/IndexerRegistryConfiguration.java
@@ -29,10 +29,4 @@ public interface IndexerRegistryConfiguration {
 	@Meta.AD(deflt = "10000", name = "max-buffer-size", required = false)
 	public int maxBufferSize();
 
-	@Meta.AD(
-		deflt = "0.90", max = "0.99", min = "0.1",
-		name = "minimum-buffer-availability-percentage", required = false
-	)
-	public float minimumBufferAvailabilityPercentage();
-
 }

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/configuration/IndexerRegistryConfiguration.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/configuration/IndexerRegistryConfiguration.java
@@ -26,7 +26,7 @@ public interface IndexerRegistryConfiguration {
 	@Meta.AD(deflt = "true", name = "buffered", required = false)
 	public boolean buffered();
 
-	@Meta.AD(deflt = "10000", name = "max-buffer-size", required = false)
+	@Meta.AD(deflt = "100000", name = "max-buffer-size", required = false)
 	public int maxBufferSize();
 
 }

--- a/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/configuration/packageinfo
+++ b/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/configuration/packageinfo
@@ -1,1 +1,1 @@
-version 5.3.0
+version 6.0.0

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/IndexerRequestBuffer.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/IndexerRequestBuffer.java
@@ -82,6 +82,19 @@ public class IndexerRequestBuffer {
 		return _indexerRequests.size();
 	}
 
+	public IndexerRequestBuffer transferCopy() {
+		IndexerRequestBuffer indexerRequestBuffer = new IndexerRequestBuffer();
+
+		LinkedHashMap<IndexerRequest, IndexerRequest> indexerRequests =
+			indexerRequestBuffer._indexerRequests;
+
+		indexerRequests.putAll(_indexerRequests);
+
+		_indexerRequests.clear();
+
+		return indexerRequestBuffer;
+	}
+
 	private static final ThreadLocal<List<IndexerRequestBuffer>>
 		_indexerRequestBuffersThreadLocal = new CentralizedThreadLocal<>(
 			IndexerRequestBuffer.class + "._indexerRequestBuffersThreadLocal",

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/IndexerRequestBufferOverflowHandler.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/IndexerRequestBufferOverflowHandler.java
@@ -5,18 +5,11 @@
 
 package com.liferay.portal.search.internal.buffer;
 
-import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.search.configuration.IndexerRegistryConfiguration;
 import com.liferay.portal.search.internal.buffer.util.IndexerRequestBufferExecutorUtil;
 
-import java.util.Map;
-
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Modified;
 
 /**
  * @author Michael C. Han
@@ -41,56 +34,18 @@ public class IndexerRequestBufferOverflowHandler {
 			return;
 		}
 
-		int numRequests = Math.round(
-			currentBufferSize -
-				Math.abs(maxBufferSize * _minimumBufferAvailabilityPercentage));
+		try {
+			BufferOverflowThreadLocal.setOverflowMode(true);
 
-		if (numRequests > 0) {
-			try {
-				BufferOverflowThreadLocal.setOverflowMode(true);
-
-				IndexerRequestBufferExecutorUtil.execute(
-					indexerRequestBuffer, numRequests);
-			}
-			finally {
-				BufferOverflowThreadLocal.setOverflowMode(false);
-			}
+			IndexerRequestBufferExecutorUtil.execute(
+				indexerRequestBuffer, currentBufferSize);
+		}
+		finally {
+			BufferOverflowThreadLocal.setOverflowMode(false);
 		}
 	}
-
-	@Activate
-	@Modified
-	protected void activate(Map<String, Object> properties) {
-		IndexerRegistryConfiguration indexerRegistryConfiguration =
-			ConfigurableUtil.createConfigurable(
-				IndexerRegistryConfiguration.class, properties);
-
-		float minimumBufferAvailabilityPercentage =
-			indexerRegistryConfiguration.minimumBufferAvailabilityPercentage();
-
-		if ((minimumBufferAvailabilityPercentage > 1) ||
-			(minimumBufferAvailabilityPercentage < 0.1)) {
-
-			if (_log.isWarnEnabled()) {
-				_log.warn(
-					StringBundler.concat(
-						"Invalid minimum buffer availability percentage: ",
-						minimumBufferAvailabilityPercentage,
-						", using default value",
-						_DEFAULT_MINIMUM_BUFFER_AVAILABILITY_PERCENTAGE));
-			}
-		}
-
-		_minimumBufferAvailabilityPercentage =
-			minimumBufferAvailabilityPercentage;
-	}
-
-	private static final float _DEFAULT_MINIMUM_BUFFER_AVAILABILITY_PERCENTAGE =
-		0.90F;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		IndexerRequestBufferOverflowHandler.class);
-
-	private volatile float _minimumBufferAvailabilityPercentage;
 
 }

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/util/IndexerRequestBufferExecutorUtil.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/util/IndexerRequestBufferExecutorUtil.java
@@ -61,6 +61,9 @@ public class IndexerRequestBufferExecutorUtil {
 		ExecutorService executorService =
 			SystemExecutorServiceUtil.getExecutorService();
 
+		IndexerRequestBuffer transferCopyIndexerRequestBuffer =
+			indexerRequestBuffer.transferCopy();
+
 		SearchContext.registerBatchModeSyncFuture(
 			executorService.submit(
 				() -> {
@@ -70,7 +73,9 @@ public class IndexerRequestBufferExecutorUtil {
 					try (SafeCloseable safeCloseable =
 							SearchContext.openBatchMode(false)) {
 
-						_execute(indexerRequestBuffer, numRequests, false);
+						_execute(
+							transferCopyIndexerRequestBuffer,
+							transferCopyIndexerRequestBuffer.size(), false);
 					}
 					finally {
 						ServiceContextThreadLocal.popServiceContext();

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/util/IndexerRequestBufferExecutorUtil.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/util/IndexerRequestBufferExecutorUtil.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.util.BulkDeleteCacheThreadLocal;
 import com.liferay.portal.search.internal.buffer.BufferOverflowThreadLocal;
 import com.liferay.portal.search.internal.buffer.IndexerRequest;
 import com.liferay.portal.search.internal.buffer.IndexerRequestBuffer;
@@ -38,6 +39,12 @@ public class IndexerRequestBufferExecutorUtil {
 
 		if (!SearchContext.isBatchMode()) {
 			_execute(indexerRequestBuffer, numRequests, true);
+
+			return;
+		}
+
+		if (BulkDeleteCacheThreadLocal.isBulkDeleteMode()) {
+			_execute(indexerRequestBuffer, numRequests, false);
 
 			return;
 		}

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/util/IndexerRequestBufferExecutorUtil.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/util/IndexerRequestBufferExecutorUtil.java
@@ -24,6 +24,9 @@ import com.liferay.portal.search.internal.buffer.IndexerRequestBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author Michael C. Han
@@ -64,23 +67,38 @@ public class IndexerRequestBufferExecutorUtil {
 		IndexerRequestBuffer transferCopyIndexerRequestBuffer =
 			indexerRequestBuffer.transferCopy();
 
-		SearchContext.registerBatchModeSyncFuture(
-			executorService.submit(
-				() -> {
-					ServiceContextThreadLocal.pushServiceContext(
-						finalServiceContext);
+		AtomicReference<Future<?>> futureReference = new AtomicReference<>();
 
-					try (SafeCloseable safeCloseable =
-							SearchContext.openBatchMode(false)) {
+		FutureTask<?> futureTask = new FutureTask<Void>(
+			() -> {
+				ServiceContextThreadLocal.pushServiceContext(
+					finalServiceContext);
 
-						_execute(
-							transferCopyIndexerRequestBuffer,
-							transferCopyIndexerRequestBuffer.size(), false);
-					}
-					finally {
-						ServiceContextThreadLocal.popServiceContext();
-					}
-				}));
+				try (SafeCloseable safeCloseable = SearchContext.openBatchMode(
+						false)) {
+
+					_execute(
+						transferCopyIndexerRequestBuffer,
+						transferCopyIndexerRequestBuffer.size(), false);
+				}
+				catch (Exception exception) {
+					_log.error(exception);
+				}
+				finally {
+					ServiceContextThreadLocal.popServiceContext();
+
+					SearchContext.unregisterBatchModeSyncFuture(
+						futureReference.get());
+				}
+
+				return null;
+			});
+
+		futureReference.set(futureTask);
+
+		SearchContext.registerBatchModeSyncFuture(futureTask);
+
+		executorService.execute(futureTask);
 	}
 
 	private static void _execute(

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerWriterImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/indexer/IndexerWriterImpl.java
@@ -37,6 +37,7 @@ import com.liferay.portal.search.indexer.BaseModelRetriever;
 import com.liferay.portal.search.indexer.IndexerDocumentBuilder;
 import com.liferay.portal.search.indexer.IndexerWriter;
 import com.liferay.portal.search.internal.index.contributor.helper.ModelIndexerWriterDocumentHelperImpl;
+import com.liferay.portal.search.model.uid.UIDFactory;
 import com.liferay.portal.search.permission.SearchPermissionIndexWriter;
 import com.liferay.portal.search.spi.model.index.contributor.ModelIndexerWriterContributor;
 import com.liferay.portal.search.spi.model.index.contributor.helper.IndexerWriterMode;
@@ -61,7 +62,8 @@ public class IndexerWriterImpl<T extends BaseModel<?>>
 		SearchPermissionIndexWriter searchPermissionIndexWriter,
 		UpdateDocumentIndexWriter updateDocumentIndexWriter,
 		IndexStatusManager indexStatusManager,
-		IndexWriterHelper indexWriterHelper, Props props) {
+		IndexWriterHelper indexWriterHelper, Props props,
+		UIDFactory uidFactory) {
 
 		_modelSearchSettings = modelSearchSettings;
 		_baseModelRetriever = baseModelRetriever;
@@ -74,6 +76,7 @@ public class IndexerWriterImpl<T extends BaseModel<?>>
 		_indexStatusManager = indexStatusManager;
 		_indexWriterHelper = indexWriterHelper;
 		_props = props;
+		_uidFactory = uidFactory;
 	}
 
 	@Override
@@ -96,11 +99,9 @@ public class IndexerWriterImpl<T extends BaseModel<?>>
 			return;
 		}
 
-		long companyId = _modelIndexerWriterContributor.getCompanyId(baseModel);
-
-		String uid = _indexerDocumentBuilder.getDocumentUID(baseModel);
-
-		delete(companyId, uid);
+		delete(
+			_modelIndexerWriterContributor.getCompanyId(baseModel),
+			_uidFactory.getUID(baseModel));
 
 		_modelIndexerWriterContributor.modelDeleted(baseModel);
 	}
@@ -330,6 +331,7 @@ public class IndexerWriterImpl<T extends BaseModel<?>>
 	private final ModelSearchSettings _modelSearchSettings;
 	private final Props _props;
 	private final SearchPermissionIndexWriter _searchPermissionIndexWriter;
+	private final UIDFactory _uidFactory;
 	private final UpdateDocumentIndexWriter _updateDocumentIndexWriter;
 
 }

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/osgi/util/tracker/ModelSearchConfiguratorServiceTrackerCustomizer.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/osgi/util/tracker/ModelSearchConfiguratorServiceTrackerCustomizer.java
@@ -49,6 +49,7 @@ import com.liferay.portal.search.internal.indexer.ModelSearchSettingsImpl;
 import com.liferay.portal.search.internal.indexer.helper.AddSearchKeywordsQueryContributorHelper;
 import com.liferay.portal.search.internal.indexer.helper.PreFilterContributorHelper;
 import com.liferay.portal.search.internal.searcher.helper.IndexSearcherHelper;
+import com.liferay.portal.search.model.uid.UIDFactory;
 import com.liferay.portal.search.permission.SearchPermissionDocumentContributor;
 import com.liferay.portal.search.permission.SearchPermissionIndexWriter;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
@@ -247,6 +248,9 @@ public class ModelSearchConfiguratorServiceTrackerCustomizer
 		searchResultPermissionFilterFactory;
 
 	@Reference
+	protected UIDFactory uidFactory;
+
+	@Reference
 	protected UpdateDocumentIndexWriter updateDocumentIndexWriter;
 
 	private Indexer<?> _buildIndexer(
@@ -322,7 +326,7 @@ public class ModelSearchConfiguratorServiceTrackerCustomizer
 			modelSearchConfigurator.getModelIndexerWriterContributor(),
 			indexerDocumentBuilder, searchPermissionIndexWriter,
 			updateDocumentIndexWriter, indexStatusManager, indexWriterHelper,
-			props);
+			props, uidFactory);
 
 		serviceRegistrationHolder.setIndexerWriterServiceRegistration(
 			_bundleContext.registerService(

--- a/modules/apps/saved-content/saved-content-api/bnd.bnd
+++ b/modules/apps/saved-content/saved-content-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Saved Content API
 Bundle-SymbolicName: com.liferay.saved.content.api
-Bundle-Version: 3.0.1
+Bundle-Version: 3.1.0
 Export-Package:\
 	com.liferay.saved.content.exception,\
 	com.liferay.saved.content.model,\

--- a/modules/apps/saved-content/saved-content-api/src/main/java/com/liferay/saved/content/service/persistence/SavedContentEntryPersistence.java
+++ b/modules/apps/saved-content/saved-content-api/src/main/java/com/liferay/saved/content/service/persistence/SavedContentEntryPersistence.java
@@ -958,6 +958,231 @@ public interface SavedContentEntryPersistence
 	public int filterCountByG_U(long groupId, long userId);
 
 	/**
+	 * Returns all the saved content entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @return the matching saved content entries
+	 */
+	public java.util.List<SavedContentEntry> findByG_CN(
+		long groupId, long classNameId);
+
+	/**
+	 * Returns a range of all the saved content entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SavedContentEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of saved content entries
+	 * @param end the upper bound of the range of saved content entries (not inclusive)
+	 * @return the range of matching saved content entries
+	 */
+	public java.util.List<SavedContentEntry> findByG_CN(
+		long groupId, long classNameId, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the saved content entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SavedContentEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of saved content entries
+	 * @param end the upper bound of the range of saved content entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching saved content entries
+	 */
+	public java.util.List<SavedContentEntry> findByG_CN(
+		long groupId, long classNameId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<SavedContentEntry>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the saved content entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SavedContentEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of saved content entries
+	 * @param end the upper bound of the range of saved content entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching saved content entries
+	 */
+	public java.util.List<SavedContentEntry> findByG_CN(
+		long groupId, long classNameId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<SavedContentEntry>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first saved content entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching saved content entry
+	 * @throws NoSuchSavedContentEntryException if a matching saved content entry could not be found
+	 */
+	public SavedContentEntry findByG_CN_First(
+			long groupId, long classNameId,
+			com.liferay.portal.kernel.util.OrderByComparator<SavedContentEntry>
+				orderByComparator)
+		throws NoSuchSavedContentEntryException;
+
+	/**
+	 * Returns the first saved content entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching saved content entry, or <code>null</code> if a matching saved content entry could not be found
+	 */
+	public SavedContentEntry fetchByG_CN_First(
+		long groupId, long classNameId,
+		com.liferay.portal.kernel.util.OrderByComparator<SavedContentEntry>
+			orderByComparator);
+
+	/**
+	 * Returns the last saved content entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching saved content entry
+	 * @throws NoSuchSavedContentEntryException if a matching saved content entry could not be found
+	 */
+	public SavedContentEntry findByG_CN_Last(
+			long groupId, long classNameId,
+			com.liferay.portal.kernel.util.OrderByComparator<SavedContentEntry>
+				orderByComparator)
+		throws NoSuchSavedContentEntryException;
+
+	/**
+	 * Returns the last saved content entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching saved content entry, or <code>null</code> if a matching saved content entry could not be found
+	 */
+	public SavedContentEntry fetchByG_CN_Last(
+		long groupId, long classNameId,
+		com.liferay.portal.kernel.util.OrderByComparator<SavedContentEntry>
+			orderByComparator);
+
+	/**
+	 * Returns the saved content entries before and after the current saved content entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param savedContentEntryId the primary key of the current saved content entry
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next saved content entry
+	 * @throws NoSuchSavedContentEntryException if a saved content entry with the primary key could not be found
+	 */
+	public SavedContentEntry[] findByG_CN_PrevAndNext(
+			long savedContentEntryId, long groupId, long classNameId,
+			com.liferay.portal.kernel.util.OrderByComparator<SavedContentEntry>
+				orderByComparator)
+		throws NoSuchSavedContentEntryException;
+
+	/**
+	 * Returns all the saved content entries that the user has permission to view where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @return the matching saved content entries that the user has permission to view
+	 */
+	public java.util.List<SavedContentEntry> filterFindByG_CN(
+		long groupId, long classNameId);
+
+	/**
+	 * Returns a range of all the saved content entries that the user has permission to view where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SavedContentEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of saved content entries
+	 * @param end the upper bound of the range of saved content entries (not inclusive)
+	 * @return the range of matching saved content entries that the user has permission to view
+	 */
+	public java.util.List<SavedContentEntry> filterFindByG_CN(
+		long groupId, long classNameId, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the saved content entries that the user has permissions to view where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SavedContentEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of saved content entries
+	 * @param end the upper bound of the range of saved content entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching saved content entries that the user has permission to view
+	 */
+	public java.util.List<SavedContentEntry> filterFindByG_CN(
+		long groupId, long classNameId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<SavedContentEntry>
+			orderByComparator);
+
+	/**
+	 * Returns the saved content entries before and after the current saved content entry in the ordered set of saved content entries that the user has permission to view where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param savedContentEntryId the primary key of the current saved content entry
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next saved content entry
+	 * @throws NoSuchSavedContentEntryException if a saved content entry with the primary key could not be found
+	 */
+	public SavedContentEntry[] filterFindByG_CN_PrevAndNext(
+			long savedContentEntryId, long groupId, long classNameId,
+			com.liferay.portal.kernel.util.OrderByComparator<SavedContentEntry>
+				orderByComparator)
+		throws NoSuchSavedContentEntryException;
+
+	/**
+	 * Removes all the saved content entries where groupId = &#63; and classNameId = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 */
+	public void removeByG_CN(long groupId, long classNameId);
+
+	/**
+	 * Returns the number of saved content entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @return the number of matching saved content entries
+	 */
+	public int countByG_CN(long groupId, long classNameId);
+
+	/**
+	 * Returns the number of saved content entries that the user has permission to view where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @return the number of matching saved content entries that the user has permission to view
+	 */
+	public int filterCountByG_CN(long groupId, long classNameId);
+
+	/**
 	 * Returns all the saved content entries where userId = &#63; and classNameId = &#63;.
 	 *
 	 * @param userId the user ID

--- a/modules/apps/saved-content/saved-content-api/src/main/java/com/liferay/saved/content/service/persistence/SavedContentEntryUtil.java
+++ b/modules/apps/saved-content/saved-content-api/src/main/java/com/liferay/saved/content/service/persistence/SavedContentEntryUtil.java
@@ -1223,6 +1223,282 @@ public class SavedContentEntryUtil {
 	}
 
 	/**
+	 * Returns all the saved content entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @return the matching saved content entries
+	 */
+	public static List<SavedContentEntry> findByG_CN(
+		long groupId, long classNameId) {
+
+		return getPersistence().findByG_CN(groupId, classNameId);
+	}
+
+	/**
+	 * Returns a range of all the saved content entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SavedContentEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of saved content entries
+	 * @param end the upper bound of the range of saved content entries (not inclusive)
+	 * @return the range of matching saved content entries
+	 */
+	public static List<SavedContentEntry> findByG_CN(
+		long groupId, long classNameId, int start, int end) {
+
+		return getPersistence().findByG_CN(groupId, classNameId, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the saved content entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SavedContentEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of saved content entries
+	 * @param end the upper bound of the range of saved content entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching saved content entries
+	 */
+	public static List<SavedContentEntry> findByG_CN(
+		long groupId, long classNameId, int start, int end,
+		OrderByComparator<SavedContentEntry> orderByComparator) {
+
+		return getPersistence().findByG_CN(
+			groupId, classNameId, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the saved content entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SavedContentEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of saved content entries
+	 * @param end the upper bound of the range of saved content entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching saved content entries
+	 */
+	public static List<SavedContentEntry> findByG_CN(
+		long groupId, long classNameId, int start, int end,
+		OrderByComparator<SavedContentEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByG_CN(
+			groupId, classNameId, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first saved content entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching saved content entry
+	 * @throws NoSuchSavedContentEntryException if a matching saved content entry could not be found
+	 */
+	public static SavedContentEntry findByG_CN_First(
+			long groupId, long classNameId,
+			OrderByComparator<SavedContentEntry> orderByComparator)
+		throws com.liferay.saved.content.exception.
+			NoSuchSavedContentEntryException {
+
+		return getPersistence().findByG_CN_First(
+			groupId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Returns the first saved content entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching saved content entry, or <code>null</code> if a matching saved content entry could not be found
+	 */
+	public static SavedContentEntry fetchByG_CN_First(
+		long groupId, long classNameId,
+		OrderByComparator<SavedContentEntry> orderByComparator) {
+
+		return getPersistence().fetchByG_CN_First(
+			groupId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Returns the last saved content entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching saved content entry
+	 * @throws NoSuchSavedContentEntryException if a matching saved content entry could not be found
+	 */
+	public static SavedContentEntry findByG_CN_Last(
+			long groupId, long classNameId,
+			OrderByComparator<SavedContentEntry> orderByComparator)
+		throws com.liferay.saved.content.exception.
+			NoSuchSavedContentEntryException {
+
+		return getPersistence().findByG_CN_Last(
+			groupId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Returns the last saved content entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching saved content entry, or <code>null</code> if a matching saved content entry could not be found
+	 */
+	public static SavedContentEntry fetchByG_CN_Last(
+		long groupId, long classNameId,
+		OrderByComparator<SavedContentEntry> orderByComparator) {
+
+		return getPersistence().fetchByG_CN_Last(
+			groupId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Returns the saved content entries before and after the current saved content entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param savedContentEntryId the primary key of the current saved content entry
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next saved content entry
+	 * @throws NoSuchSavedContentEntryException if a saved content entry with the primary key could not be found
+	 */
+	public static SavedContentEntry[] findByG_CN_PrevAndNext(
+			long savedContentEntryId, long groupId, long classNameId,
+			OrderByComparator<SavedContentEntry> orderByComparator)
+		throws com.liferay.saved.content.exception.
+			NoSuchSavedContentEntryException {
+
+		return getPersistence().findByG_CN_PrevAndNext(
+			savedContentEntryId, groupId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Returns all the saved content entries that the user has permission to view where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @return the matching saved content entries that the user has permission to view
+	 */
+	public static List<SavedContentEntry> filterFindByG_CN(
+		long groupId, long classNameId) {
+
+		return getPersistence().filterFindByG_CN(groupId, classNameId);
+	}
+
+	/**
+	 * Returns a range of all the saved content entries that the user has permission to view where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SavedContentEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of saved content entries
+	 * @param end the upper bound of the range of saved content entries (not inclusive)
+	 * @return the range of matching saved content entries that the user has permission to view
+	 */
+	public static List<SavedContentEntry> filterFindByG_CN(
+		long groupId, long classNameId, int start, int end) {
+
+		return getPersistence().filterFindByG_CN(
+			groupId, classNameId, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the saved content entries that the user has permissions to view where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SavedContentEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of saved content entries
+	 * @param end the upper bound of the range of saved content entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching saved content entries that the user has permission to view
+	 */
+	public static List<SavedContentEntry> filterFindByG_CN(
+		long groupId, long classNameId, int start, int end,
+		OrderByComparator<SavedContentEntry> orderByComparator) {
+
+		return getPersistence().filterFindByG_CN(
+			groupId, classNameId, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns the saved content entries before and after the current saved content entry in the ordered set of saved content entries that the user has permission to view where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param savedContentEntryId the primary key of the current saved content entry
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next saved content entry
+	 * @throws NoSuchSavedContentEntryException if a saved content entry with the primary key could not be found
+	 */
+	public static SavedContentEntry[] filterFindByG_CN_PrevAndNext(
+			long savedContentEntryId, long groupId, long classNameId,
+			OrderByComparator<SavedContentEntry> orderByComparator)
+		throws com.liferay.saved.content.exception.
+			NoSuchSavedContentEntryException {
+
+		return getPersistence().filterFindByG_CN_PrevAndNext(
+			savedContentEntryId, groupId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Removes all the saved content entries where groupId = &#63; and classNameId = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 */
+	public static void removeByG_CN(long groupId, long classNameId) {
+		getPersistence().removeByG_CN(groupId, classNameId);
+	}
+
+	/**
+	 * Returns the number of saved content entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @return the number of matching saved content entries
+	 */
+	public static int countByG_CN(long groupId, long classNameId) {
+		return getPersistence().countByG_CN(groupId, classNameId);
+	}
+
+	/**
+	 * Returns the number of saved content entries that the user has permission to view where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @return the number of matching saved content entries that the user has permission to view
+	 */
+	public static int filterCountByG_CN(long groupId, long classNameId) {
+		return getPersistence().filterCountByG_CN(groupId, classNameId);
+	}
+
+	/**
 	 * Returns all the saved content entries where userId = &#63; and classNameId = &#63;.
 	 *
 	 * @param userId the user ID

--- a/modules/apps/saved-content/saved-content-api/src/main/resources/com/liferay/saved/content/service/persistence/packageinfo
+++ b/modules/apps/saved-content/saved-content-api/src/main/resources/com/liferay/saved/content/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/saved-content/saved-content-service/service.xml
+++ b/modules/apps/saved-content/saved-content-service/service.xml
@@ -38,6 +38,10 @@
 			<finder-column name="groupId" />
 			<finder-column name="userId" />
 		</finder>
+		<finder name="G_CN" return-type="Collection">
+			<finder-column name="groupId" />
+			<finder-column name="classNameId" />
+		</finder>
 		<finder name="U_C" return-type="Collection">
 			<finder-column name="userId" />
 			<finder-column name="classNameId" />

--- a/modules/apps/saved-content/saved-content-service/src/main/java/com/liferay/saved/content/internal/model/listener/AssetEntryModelListener.java
+++ b/modules/apps/saved-content/saved-content-service/src/main/java/com/liferay/saved/content/internal/model/listener/AssetEntryModelListener.java
@@ -9,7 +9,6 @@ import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
-import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.saved.content.service.SavedContentEntryLocalService;
 
 import org.osgi.service.component.annotations.Component;
@@ -26,13 +25,9 @@ public class AssetEntryModelListener extends BaseModelListener<AssetEntry> {
 		throws ModelListenerException {
 
 		_savedContentEntryLocalService.deleteSavedContentEntries(
-			assetEntry.getGroupId(),
-			_classNameLocalService.getClassNameId(assetEntry.getClassName()),
+			assetEntry.getGroupId(), assetEntry.getClassNameId(),
 			assetEntry.getClassPK());
 	}
-
-	@Reference
-	private ClassNameLocalService _classNameLocalService;
 
 	@Reference
 	private SavedContentEntryLocalService _savedContentEntryLocalService;

--- a/modules/apps/saved-content/saved-content-service/src/main/java/com/liferay/saved/content/service/impl/SavedContentEntryLocalServiceImpl.java
+++ b/modules/apps/saved-content/saved-content-service/src/main/java/com/liferay/saved/content/service/impl/SavedContentEntryLocalServiceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.saved.content.service.impl;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
@@ -14,10 +15,15 @@ import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.BulkDeleteCacheThreadLocal;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.saved.content.exception.DuplicateSavedContentEntryException;
 import com.liferay.saved.content.exception.NoSuchSavedContentEntryException;
 import com.liferay.saved.content.model.SavedContentEntry;
 import com.liferay.saved.content.service.base.SavedContentEntryLocalServiceBaseImpl;
+
+import java.util.List;
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -92,8 +98,31 @@ public class SavedContentEntryLocalServiceImpl
 	public void deleteSavedContentEntries(
 		long groupId, long classNameId, long classPK) {
 
-		savedContentEntryPersistence.removeByG_C_C(
-			groupId, classNameId, classPK);
+		Map<Long, List<SavedContentEntry>> partitionSavedContentEntries =
+			BulkDeleteCacheThreadLocal.getBulkDeleteCache(
+				StringBundler.concat(
+					SavedContentEntryLocalServiceImpl.class.getName(),
+					".deleteSavedContentEntries#", groupId, classNameId),
+				() -> MapUtil.toPartitionMap(
+					savedContentEntryPersistence.findByG_CN(
+						groupId, classNameId),
+					SavedContentEntry::getClassPK));
+
+		if (partitionSavedContentEntries == null) {
+			savedContentEntryPersistence.removeByG_C_C(
+				groupId, classNameId, classPK);
+
+			return;
+		}
+
+		List<SavedContentEntry> savedContentEntries =
+			partitionSavedContentEntries.remove(classPK);
+
+		if (savedContentEntries != null) {
+			for (SavedContentEntry savedContentEntry : savedContentEntries) {
+				savedContentEntryPersistence.remove(savedContentEntry);
+			}
+		}
 	}
 
 	@Override

--- a/modules/apps/saved-content/saved-content-service/src/main/java/com/liferay/saved/content/service/persistence/impl/SavedContentEntryPersistenceImpl.java
+++ b/modules/apps/saved-content/saved-content-service/src/main/java/com/liferay/saved/content/service/persistence/impl/SavedContentEntryPersistenceImpl.java
@@ -3861,6 +3861,968 @@ public class SavedContentEntryPersistenceImpl
 	private static final String _FINDER_COLUMN_G_U_USERID_2 =
 		"savedContentEntry.userId = ?";
 
+	private FinderPath _finderPathWithPaginationFindByG_CN;
+	private FinderPath _finderPathWithoutPaginationFindByG_CN;
+	private FinderPath _finderPathCountByG_CN;
+
+	/**
+	 * Returns all the saved content entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @return the matching saved content entries
+	 */
+	@Override
+	public List<SavedContentEntry> findByG_CN(long groupId, long classNameId) {
+		return findByG_CN(
+			groupId, classNameId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the saved content entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SavedContentEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of saved content entries
+	 * @param end the upper bound of the range of saved content entries (not inclusive)
+	 * @return the range of matching saved content entries
+	 */
+	@Override
+	public List<SavedContentEntry> findByG_CN(
+		long groupId, long classNameId, int start, int end) {
+
+		return findByG_CN(groupId, classNameId, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the saved content entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SavedContentEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of saved content entries
+	 * @param end the upper bound of the range of saved content entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching saved content entries
+	 */
+	@Override
+	public List<SavedContentEntry> findByG_CN(
+		long groupId, long classNameId, int start, int end,
+		OrderByComparator<SavedContentEntry> orderByComparator) {
+
+		return findByG_CN(
+			groupId, classNameId, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the saved content entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SavedContentEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of saved content entries
+	 * @param end the upper bound of the range of saved content entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching saved content entries
+	 */
+	@Override
+	public List<SavedContentEntry> findByG_CN(
+		long groupId, long classNameId, int start, int end,
+		OrderByComparator<SavedContentEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		try (SafeCloseable safeCloseable =
+				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
+					SavedContentEntry.class)) {
+
+			FinderPath finderPath = null;
+			Object[] finderArgs = null;
+
+			if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+				(orderByComparator == null)) {
+
+				if (useFinderCache) {
+					finderPath = _finderPathWithoutPaginationFindByG_CN;
+					finderArgs = new Object[] {groupId, classNameId};
+				}
+			}
+			else if (useFinderCache) {
+				finderPath = _finderPathWithPaginationFindByG_CN;
+				finderArgs = new Object[] {
+					groupId, classNameId, start, end, orderByComparator
+				};
+			}
+
+			List<SavedContentEntry> list = null;
+
+			if (useFinderCache) {
+				list = (List<SavedContentEntry>)finderCache.getResult(
+					finderPath, finderArgs, this);
+
+				if ((list != null) && !list.isEmpty()) {
+					for (SavedContentEntry savedContentEntry : list) {
+						if ((groupId != savedContentEntry.getGroupId()) ||
+							(classNameId !=
+								savedContentEntry.getClassNameId())) {
+
+							list = null;
+
+							break;
+						}
+					}
+				}
+			}
+
+			if (list == null) {
+				StringBundler sb = null;
+
+				if (orderByComparator != null) {
+					sb = new StringBundler(
+						4 + (orderByComparator.getOrderByFields().length * 2));
+				}
+				else {
+					sb = new StringBundler(4);
+				}
+
+				sb.append(_SQL_SELECT_SAVEDCONTENTENTRY_WHERE);
+
+				sb.append(_FINDER_COLUMN_G_CN_GROUPID_2);
+
+				sb.append(_FINDER_COLUMN_G_CN_CLASSNAMEID_2);
+
+				if (orderByComparator != null) {
+					appendOrderByComparator(
+						sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+				}
+				else {
+					sb.append(SavedContentEntryModelImpl.ORDER_BY_JPQL);
+				}
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(groupId);
+
+					queryPos.add(classNameId);
+
+					list = (List<SavedContentEntry>)QueryUtil.list(
+						query, getDialect(), start, end);
+
+					cacheResult(list);
+
+					if (useFinderCache) {
+						finderCache.putResult(finderPath, finderArgs, list);
+					}
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return list;
+		}
+	}
+
+	/**
+	 * Returns the first saved content entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching saved content entry
+	 * @throws NoSuchSavedContentEntryException if a matching saved content entry could not be found
+	 */
+	@Override
+	public SavedContentEntry findByG_CN_First(
+			long groupId, long classNameId,
+			OrderByComparator<SavedContentEntry> orderByComparator)
+		throws NoSuchSavedContentEntryException {
+
+		SavedContentEntry savedContentEntry = fetchByG_CN_First(
+			groupId, classNameId, orderByComparator);
+
+		if (savedContentEntry != null) {
+			return savedContentEntry;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", classNameId=");
+		sb.append(classNameId);
+
+		sb.append("}");
+
+		throw new NoSuchSavedContentEntryException(sb.toString());
+	}
+
+	/**
+	 * Returns the first saved content entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching saved content entry, or <code>null</code> if a matching saved content entry could not be found
+	 */
+	@Override
+	public SavedContentEntry fetchByG_CN_First(
+		long groupId, long classNameId,
+		OrderByComparator<SavedContentEntry> orderByComparator) {
+
+		List<SavedContentEntry> list = findByG_CN(
+			groupId, classNameId, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last saved content entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching saved content entry
+	 * @throws NoSuchSavedContentEntryException if a matching saved content entry could not be found
+	 */
+	@Override
+	public SavedContentEntry findByG_CN_Last(
+			long groupId, long classNameId,
+			OrderByComparator<SavedContentEntry> orderByComparator)
+		throws NoSuchSavedContentEntryException {
+
+		SavedContentEntry savedContentEntry = fetchByG_CN_Last(
+			groupId, classNameId, orderByComparator);
+
+		if (savedContentEntry != null) {
+			return savedContentEntry;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", classNameId=");
+		sb.append(classNameId);
+
+		sb.append("}");
+
+		throw new NoSuchSavedContentEntryException(sb.toString());
+	}
+
+	/**
+	 * Returns the last saved content entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching saved content entry, or <code>null</code> if a matching saved content entry could not be found
+	 */
+	@Override
+	public SavedContentEntry fetchByG_CN_Last(
+		long groupId, long classNameId,
+		OrderByComparator<SavedContentEntry> orderByComparator) {
+
+		int count = countByG_CN(groupId, classNameId);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<SavedContentEntry> list = findByG_CN(
+			groupId, classNameId, count - 1, count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the saved content entries before and after the current saved content entry in the ordered set where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param savedContentEntryId the primary key of the current saved content entry
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next saved content entry
+	 * @throws NoSuchSavedContentEntryException if a saved content entry with the primary key could not be found
+	 */
+	@Override
+	public SavedContentEntry[] findByG_CN_PrevAndNext(
+			long savedContentEntryId, long groupId, long classNameId,
+			OrderByComparator<SavedContentEntry> orderByComparator)
+		throws NoSuchSavedContentEntryException {
+
+		SavedContentEntry savedContentEntry = findByPrimaryKey(
+			savedContentEntryId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SavedContentEntry[] array = new SavedContentEntryImpl[3];
+
+			array[0] = getByG_CN_PrevAndNext(
+				session, savedContentEntry, groupId, classNameId,
+				orderByComparator, true);
+
+			array[1] = savedContentEntry;
+
+			array[2] = getByG_CN_PrevAndNext(
+				session, savedContentEntry, groupId, classNameId,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected SavedContentEntry getByG_CN_PrevAndNext(
+		Session session, SavedContentEntry savedContentEntry, long groupId,
+		long classNameId,
+		OrderByComparator<SavedContentEntry> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				5 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(4);
+		}
+
+		sb.append(_SQL_SELECT_SAVEDCONTENTENTRY_WHERE);
+
+		sb.append(_FINDER_COLUMN_G_CN_GROUPID_2);
+
+		sb.append(_FINDER_COLUMN_G_CN_CLASSNAMEID_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(SavedContentEntryModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(groupId);
+
+		queryPos.add(classNameId);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						savedContentEntry)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<SavedContentEntry> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Returns all the saved content entries that the user has permission to view where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @return the matching saved content entries that the user has permission to view
+	 */
+	@Override
+	public List<SavedContentEntry> filterFindByG_CN(
+		long groupId, long classNameId) {
+
+		return filterFindByG_CN(
+			groupId, classNameId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the saved content entries that the user has permission to view where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SavedContentEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of saved content entries
+	 * @param end the upper bound of the range of saved content entries (not inclusive)
+	 * @return the range of matching saved content entries that the user has permission to view
+	 */
+	@Override
+	public List<SavedContentEntry> filterFindByG_CN(
+		long groupId, long classNameId, int start, int end) {
+
+		return filterFindByG_CN(groupId, classNameId, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the saved content entries that the user has permissions to view where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SavedContentEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of saved content entries
+	 * @param end the upper bound of the range of saved content entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching saved content entries that the user has permission to view
+	 */
+	@Override
+	public List<SavedContentEntry> filterFindByG_CN(
+		long groupId, long classNameId, int start, int end,
+		OrderByComparator<SavedContentEntry> orderByComparator) {
+
+		if (!InlineSQLHelperUtil.isEnabled(groupId)) {
+			return findByG_CN(
+				groupId, classNameId, start, end, orderByComparator);
+		}
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				4 + (orderByComparator.getOrderByFields().length * 2));
+		}
+		else {
+			sb = new StringBundler(5);
+		}
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sb.append(_FILTER_SQL_SELECT_SAVEDCONTENTENTRY_WHERE);
+		}
+		else {
+			sb.append(
+				_FILTER_SQL_SELECT_SAVEDCONTENTENTRY_NO_INLINE_DISTINCT_WHERE_1);
+		}
+
+		sb.append(_FINDER_COLUMN_G_CN_GROUPID_2);
+
+		sb.append(_FINDER_COLUMN_G_CN_CLASSNAMEID_2);
+
+		if (!getDB().isSupportsInlineDistinct()) {
+			sb.append(
+				_FILTER_SQL_SELECT_SAVEDCONTENTENTRY_NO_INLINE_DISTINCT_WHERE_2);
+		}
+
+		if (orderByComparator != null) {
+			if (getDB().isSupportsInlineDistinct()) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator, true);
+			}
+			else {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_TABLE, orderByComparator, true);
+			}
+		}
+		else {
+			if (getDB().isSupportsInlineDistinct()) {
+				sb.append(
+					SavedContentEntryModelImpl.ORDER_BY_SQL_INLINE_DISTINCT);
+			}
+			else {
+				sb.append(SavedContentEntryModelImpl.ORDER_BY_SQL);
+			}
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), SavedContentEntry.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN, groupId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+			if (getDB().isSupportsInlineDistinct()) {
+				sqlQuery.addEntity(
+					_FILTER_ENTITY_ALIAS, SavedContentEntryImpl.class);
+			}
+			else {
+				sqlQuery.addEntity(
+					_FILTER_ENTITY_TABLE, SavedContentEntryImpl.class);
+			}
+
+			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+			queryPos.add(groupId);
+
+			queryPos.add(classNameId);
+
+			return (List<SavedContentEntry>)QueryUtil.list(
+				sqlQuery, getDialect(), start, end);
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	/**
+	 * Returns the saved content entries before and after the current saved content entry in the ordered set of saved content entries that the user has permission to view where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param savedContentEntryId the primary key of the current saved content entry
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next saved content entry
+	 * @throws NoSuchSavedContentEntryException if a saved content entry with the primary key could not be found
+	 */
+	@Override
+	public SavedContentEntry[] filterFindByG_CN_PrevAndNext(
+			long savedContentEntryId, long groupId, long classNameId,
+			OrderByComparator<SavedContentEntry> orderByComparator)
+		throws NoSuchSavedContentEntryException {
+
+		if (!InlineSQLHelperUtil.isEnabled(groupId)) {
+			return findByG_CN_PrevAndNext(
+				savedContentEntryId, groupId, classNameId, orderByComparator);
+		}
+
+		SavedContentEntry savedContentEntry = findByPrimaryKey(
+			savedContentEntryId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SavedContentEntry[] array = new SavedContentEntryImpl[3];
+
+			array[0] = filterGetByG_CN_PrevAndNext(
+				session, savedContentEntry, groupId, classNameId,
+				orderByComparator, true);
+
+			array[1] = savedContentEntry;
+
+			array[2] = filterGetByG_CN_PrevAndNext(
+				session, savedContentEntry, groupId, classNameId,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected SavedContentEntry filterGetByG_CN_PrevAndNext(
+		Session session, SavedContentEntry savedContentEntry, long groupId,
+		long classNameId,
+		OrderByComparator<SavedContentEntry> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				6 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(5);
+		}
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sb.append(_FILTER_SQL_SELECT_SAVEDCONTENTENTRY_WHERE);
+		}
+		else {
+			sb.append(
+				_FILTER_SQL_SELECT_SAVEDCONTENTENTRY_NO_INLINE_DISTINCT_WHERE_1);
+		}
+
+		sb.append(_FINDER_COLUMN_G_CN_GROUPID_2);
+
+		sb.append(_FINDER_COLUMN_G_CN_CLASSNAMEID_2);
+
+		if (!getDB().isSupportsInlineDistinct()) {
+			sb.append(
+				_FILTER_SQL_SELECT_SAVEDCONTENTENTRY_NO_INLINE_DISTINCT_WHERE_2);
+		}
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				if (getDB().isSupportsInlineDistinct()) {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_ALIAS, orderByConditionFields[i],
+							true));
+				}
+				else {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_TABLE, orderByConditionFields[i],
+							true));
+				}
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				if (getDB().isSupportsInlineDistinct()) {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_ALIAS, orderByFields[i], true));
+				}
+				else {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_TABLE, orderByFields[i], true));
+				}
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			if (getDB().isSupportsInlineDistinct()) {
+				sb.append(
+					SavedContentEntryModelImpl.ORDER_BY_SQL_INLINE_DISTINCT);
+			}
+			else {
+				sb.append(SavedContentEntryModelImpl.ORDER_BY_SQL);
+			}
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), SavedContentEntry.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN, groupId);
+
+		SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+		sqlQuery.setFirstResult(0);
+		sqlQuery.setMaxResults(2);
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sqlQuery.addEntity(
+				_FILTER_ENTITY_ALIAS, SavedContentEntryImpl.class);
+		}
+		else {
+			sqlQuery.addEntity(
+				_FILTER_ENTITY_TABLE, SavedContentEntryImpl.class);
+		}
+
+		QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+		queryPos.add(groupId);
+
+		queryPos.add(classNameId);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						savedContentEntry)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<SavedContentEntry> list = sqlQuery.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the saved content entries where groupId = &#63; and classNameId = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 */
+	@Override
+	public void removeByG_CN(long groupId, long classNameId) {
+		for (SavedContentEntry savedContentEntry :
+				findByG_CN(
+					groupId, classNameId, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+					null)) {
+
+			remove(savedContentEntry);
+		}
+	}
+
+	/**
+	 * Returns the number of saved content entries where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @return the number of matching saved content entries
+	 */
+	@Override
+	public int countByG_CN(long groupId, long classNameId) {
+		try (SafeCloseable safeCloseable =
+				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
+					SavedContentEntry.class)) {
+
+			FinderPath finderPath = _finderPathCountByG_CN;
+
+			Object[] finderArgs = new Object[] {groupId, classNameId};
+
+			Long count = (Long)finderCache.getResult(
+				finderPath, finderArgs, this);
+
+			if (count == null) {
+				StringBundler sb = new StringBundler(3);
+
+				sb.append(_SQL_COUNT_SAVEDCONTENTENTRY_WHERE);
+
+				sb.append(_FINDER_COLUMN_G_CN_GROUPID_2);
+
+				sb.append(_FINDER_COLUMN_G_CN_CLASSNAMEID_2);
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(groupId);
+
+					queryPos.add(classNameId);
+
+					count = (Long)query.uniqueResult();
+
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return count.intValue();
+		}
+	}
+
+	/**
+	 * Returns the number of saved content entries that the user has permission to view where groupId = &#63; and classNameId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @return the number of matching saved content entries that the user has permission to view
+	 */
+	@Override
+	public int filterCountByG_CN(long groupId, long classNameId) {
+		if (!InlineSQLHelperUtil.isEnabled(groupId)) {
+			return countByG_CN(groupId, classNameId);
+		}
+
+		StringBundler sb = new StringBundler(3);
+
+		sb.append(_FILTER_SQL_COUNT_SAVEDCONTENTENTRY_WHERE);
+
+		sb.append(_FINDER_COLUMN_G_CN_GROUPID_2);
+
+		sb.append(_FINDER_COLUMN_G_CN_CLASSNAMEID_2);
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), SavedContentEntry.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN, groupId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+			sqlQuery.addScalar(
+				COUNT_COLUMN_NAME, com.liferay.portal.kernel.dao.orm.Type.LONG);
+
+			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+			queryPos.add(groupId);
+
+			queryPos.add(classNameId);
+
+			Long count = (Long)sqlQuery.uniqueResult();
+
+			return count.intValue();
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	private static final String _FINDER_COLUMN_G_CN_GROUPID_2 =
+		"savedContentEntry.groupId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_CN_CLASSNAMEID_2 =
+		"savedContentEntry.classNameId = ?";
+
 	private FinderPath _finderPathWithPaginationFindByU_C;
 	private FinderPath _finderPathWithoutPaginationFindByU_C;
 	private FinderPath _finderPathCountByU_C;
@@ -7957,6 +8919,25 @@ public class SavedContentEntryPersistenceImpl
 			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_U",
 			new String[] {Long.class.getName(), Long.class.getName()},
 			new String[] {"groupId", "userId"}, false);
+
+		_finderPathWithPaginationFindByG_CN = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_CN",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "classNameId"}, true);
+
+		_finderPathWithoutPaginationFindByG_CN = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_CN",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"groupId", "classNameId"}, true);
+
+		_finderPathCountByG_CN = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_CN",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"groupId", "classNameId"}, false);
 
 		_finderPathWithPaginationFindByU_C = new FinderPath(
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByU_C",

--- a/modules/apps/saved-content/saved-content-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/saved-content/saved-content-service/src/main/resources/META-INF/sql/indexes.sql
@@ -1,6 +1,8 @@
 create index IX_85EFE02D on SavedContentEntry (classNameId, classPK, companyId);
+create unique index IX_A4BA5449 on SavedContentEntry (classNameId, userId, classPK, ctCollectionId, companyId);
 create index IX_5F4B6779 on SavedContentEntry (groupId, classNameId, classPK);
-create unique index IX_CFA82491 on SavedContentEntry (groupId, userId, classNameId, classPK, ctCollectionId);
+create unique index IX_3C86B2DD on SavedContentEntry (groupId, classNameId, userId, classPK, ctCollectionId);
+create index IX_26BC5C5E on SavedContentEntry (groupId, userId);
 create unique index IX_8168C76E on SavedContentEntry (groupId, uuid_[$COLUMN_LENGTH:75$], ctCollectionId);
-create unique index IX_55E08A15 on SavedContentEntry (userId, classNameId, classPK, ctCollectionId, companyId);
+create index IX_39920D80 on SavedContentEntry (userId);
 create index IX_AAA0B3AE on SavedContentEntry (uuid_[$COLUMN_LENGTH:75$]);

--- a/modules/apps/saved-content/saved-content-test/src/testIntegration/java/com/liferay/saved/content/service/persistence/test/SavedContentEntryPersistenceTest.java
+++ b/modules/apps/saved-content/saved-content-test/src/testIntegration/java/com/liferay/saved/content/service/persistence/test/SavedContentEntryPersistenceTest.java
@@ -235,6 +235,14 @@ public class SavedContentEntryPersistenceTest {
 	}
 
 	@Test
+	public void testCountByG_CN() throws Exception {
+		_persistence.countByG_CN(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextLong());
+
+		_persistence.countByG_CN(0L, 0L);
+	}
+
+	@Test
 	public void testCountByU_C() throws Exception {
 		_persistence.countByU_C(
 			RandomTestUtil.nextLong(), RandomTestUtil.nextLong());

--- a/modules/apps/view-count/view-count-api/bnd.bnd
+++ b/modules/apps/view-count/view-count-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay View Count API
 Bundle-SymbolicName: com.liferay.view.count.api
-Bundle-Version: 4.0.1
+Bundle-Version: 4.1.0
 Export-Package:\
 	com.liferay.view.count.configuration,\
 	com.liferay.view.count.exception,\

--- a/modules/apps/view-count/view-count-api/src/main/java/com/liferay/view/count/service/persistence/ViewCountEntryPersistence.java
+++ b/modules/apps/view-count/view-count-api/src/main/java/com/liferay/view/count/service/persistence/ViewCountEntryPersistence.java
@@ -35,6 +35,161 @@ public interface ViewCountEntryPersistence
 	 */
 
 	/**
+	 * Returns all the view count entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @return the matching view count entries
+	 */
+	public java.util.List<ViewCountEntry> findByC_CN(
+		long companyId, long classNameId);
+
+	/**
+	 * Returns a range of all the view count entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ViewCountEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of view count entries
+	 * @param end the upper bound of the range of view count entries (not inclusive)
+	 * @return the range of matching view count entries
+	 */
+	public java.util.List<ViewCountEntry> findByC_CN(
+		long companyId, long classNameId, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the view count entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ViewCountEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of view count entries
+	 * @param end the upper bound of the range of view count entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching view count entries
+	 */
+	public java.util.List<ViewCountEntry> findByC_CN(
+		long companyId, long classNameId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<ViewCountEntry>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the view count entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ViewCountEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of view count entries
+	 * @param end the upper bound of the range of view count entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching view count entries
+	 */
+	public java.util.List<ViewCountEntry> findByC_CN(
+		long companyId, long classNameId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<ViewCountEntry>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first view count entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching view count entry
+	 * @throws NoSuchEntryException if a matching view count entry could not be found
+	 */
+	public ViewCountEntry findByC_CN_First(
+			long companyId, long classNameId,
+			com.liferay.portal.kernel.util.OrderByComparator<ViewCountEntry>
+				orderByComparator)
+		throws NoSuchEntryException;
+
+	/**
+	 * Returns the first view count entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching view count entry, or <code>null</code> if a matching view count entry could not be found
+	 */
+	public ViewCountEntry fetchByC_CN_First(
+		long companyId, long classNameId,
+		com.liferay.portal.kernel.util.OrderByComparator<ViewCountEntry>
+			orderByComparator);
+
+	/**
+	 * Returns the last view count entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching view count entry
+	 * @throws NoSuchEntryException if a matching view count entry could not be found
+	 */
+	public ViewCountEntry findByC_CN_Last(
+			long companyId, long classNameId,
+			com.liferay.portal.kernel.util.OrderByComparator<ViewCountEntry>
+				orderByComparator)
+		throws NoSuchEntryException;
+
+	/**
+	 * Returns the last view count entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching view count entry, or <code>null</code> if a matching view count entry could not be found
+	 */
+	public ViewCountEntry fetchByC_CN_Last(
+		long companyId, long classNameId,
+		com.liferay.portal.kernel.util.OrderByComparator<ViewCountEntry>
+			orderByComparator);
+
+	/**
+	 * Returns the view count entries before and after the current view count entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param viewCountEntryPK the primary key of the current view count entry
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next view count entry
+	 * @throws NoSuchEntryException if a view count entry with the primary key could not be found
+	 */
+	public ViewCountEntry[] findByC_CN_PrevAndNext(
+			ViewCountEntryPK viewCountEntryPK, long companyId, long classNameId,
+			com.liferay.portal.kernel.util.OrderByComparator<ViewCountEntry>
+				orderByComparator)
+		throws NoSuchEntryException;
+
+	/**
+	 * Removes all the view count entries where companyId = &#63; and classNameId = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 */
+	public void removeByC_CN(long companyId, long classNameId);
+
+	/**
+	 * Returns the number of view count entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @return the number of matching view count entries
+	 */
+	public int countByC_CN(long companyId, long classNameId);
+
+	/**
 	 * Caches the view count entry in the entity cache if it is enabled.
 	 *
 	 * @param viewCountEntry the view count entry

--- a/modules/apps/view-count/view-count-api/src/main/java/com/liferay/view/count/service/persistence/ViewCountEntryUtil.java
+++ b/modules/apps/view-count/view-count-api/src/main/java/com/liferay/view/count/service/persistence/ViewCountEntryUtil.java
@@ -111,6 +111,193 @@ public class ViewCountEntryUtil {
 	}
 
 	/**
+	 * Returns all the view count entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @return the matching view count entries
+	 */
+	public static List<ViewCountEntry> findByC_CN(
+		long companyId, long classNameId) {
+
+		return getPersistence().findByC_CN(companyId, classNameId);
+	}
+
+	/**
+	 * Returns a range of all the view count entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ViewCountEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of view count entries
+	 * @param end the upper bound of the range of view count entries (not inclusive)
+	 * @return the range of matching view count entries
+	 */
+	public static List<ViewCountEntry> findByC_CN(
+		long companyId, long classNameId, int start, int end) {
+
+		return getPersistence().findByC_CN(companyId, classNameId, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the view count entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ViewCountEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of view count entries
+	 * @param end the upper bound of the range of view count entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching view count entries
+	 */
+	public static List<ViewCountEntry> findByC_CN(
+		long companyId, long classNameId, int start, int end,
+		OrderByComparator<ViewCountEntry> orderByComparator) {
+
+		return getPersistence().findByC_CN(
+			companyId, classNameId, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the view count entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ViewCountEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of view count entries
+	 * @param end the upper bound of the range of view count entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching view count entries
+	 */
+	public static List<ViewCountEntry> findByC_CN(
+		long companyId, long classNameId, int start, int end,
+		OrderByComparator<ViewCountEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByC_CN(
+			companyId, classNameId, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first view count entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching view count entry
+	 * @throws NoSuchEntryException if a matching view count entry could not be found
+	 */
+	public static ViewCountEntry findByC_CN_First(
+			long companyId, long classNameId,
+			OrderByComparator<ViewCountEntry> orderByComparator)
+		throws com.liferay.view.count.exception.NoSuchEntryException {
+
+		return getPersistence().findByC_CN_First(
+			companyId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Returns the first view count entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching view count entry, or <code>null</code> if a matching view count entry could not be found
+	 */
+	public static ViewCountEntry fetchByC_CN_First(
+		long companyId, long classNameId,
+		OrderByComparator<ViewCountEntry> orderByComparator) {
+
+		return getPersistence().fetchByC_CN_First(
+			companyId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Returns the last view count entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching view count entry
+	 * @throws NoSuchEntryException if a matching view count entry could not be found
+	 */
+	public static ViewCountEntry findByC_CN_Last(
+			long companyId, long classNameId,
+			OrderByComparator<ViewCountEntry> orderByComparator)
+		throws com.liferay.view.count.exception.NoSuchEntryException {
+
+		return getPersistence().findByC_CN_Last(
+			companyId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Returns the last view count entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching view count entry, or <code>null</code> if a matching view count entry could not be found
+	 */
+	public static ViewCountEntry fetchByC_CN_Last(
+		long companyId, long classNameId,
+		OrderByComparator<ViewCountEntry> orderByComparator) {
+
+		return getPersistence().fetchByC_CN_Last(
+			companyId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Returns the view count entries before and after the current view count entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param viewCountEntryPK the primary key of the current view count entry
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next view count entry
+	 * @throws NoSuchEntryException if a view count entry with the primary key could not be found
+	 */
+	public static ViewCountEntry[] findByC_CN_PrevAndNext(
+			ViewCountEntryPK viewCountEntryPK, long companyId, long classNameId,
+			OrderByComparator<ViewCountEntry> orderByComparator)
+		throws com.liferay.view.count.exception.NoSuchEntryException {
+
+		return getPersistence().findByC_CN_PrevAndNext(
+			viewCountEntryPK, companyId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Removes all the view count entries where companyId = &#63; and classNameId = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 */
+	public static void removeByC_CN(long companyId, long classNameId) {
+		getPersistence().removeByC_CN(companyId, classNameId);
+	}
+
+	/**
+	 * Returns the number of view count entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @return the number of matching view count entries
+	 */
+	public static int countByC_CN(long companyId, long classNameId) {
+		return getPersistence().countByC_CN(companyId, classNameId);
+	}
+
+	/**
 	 * Caches the view count entry in the entity cache if it is enabled.
 	 *
 	 * @param viewCountEntry the view count entry

--- a/modules/apps/view-count/view-count-api/src/main/resources/com/liferay/view/count/service/persistence/packageinfo
+++ b/modules/apps/view-count/view-count-api/src/main/resources/com/liferay/view/count/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/view-count/view-count-service/service.xml
+++ b/modules/apps/view-count/view-count-service/service.xml
@@ -15,5 +15,12 @@
 		<!-- Other fields -->
 
 		<column name="viewCount" type="long" />
+
+		<!-- Finder methods -->
+
+		<finder name="C_CN" return-type="Collection">
+			<finder-column name="companyId" />
+			<finder-column name="classNameId" />
+		</finder>
 	</entity>
 </service-builder>

--- a/modules/apps/view-count/view-count-service/src/main/java/com/liferay/view/count/model/impl/ViewCountEntryModelImpl.java
+++ b/modules/apps/view-count/view-count-service/src/main/java/com/liferay/view/count/model/impl/ViewCountEntryModelImpl.java
@@ -10,6 +10,7 @@ import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.model.CacheModel;
 import com.liferay.portal.kernel.model.ModelWrapper;
 import com.liferay.portal.kernel.model.impl.BaseModelImpl;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -88,18 +89,16 @@ public class ViewCountEntryModelImpl
 	public static final String TX_MANAGER = "liferayTransactionManager";
 
 	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *		#getColumnBitmask(String)}
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long COMPANYID_COLUMN_BITMASK = 1L;
+	public static final long CLASSNAMEID_COLUMN_BITMASK = 1L;
 
 	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *		#getColumnBitmask(String)}
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long CLASSNAMEID_COLUMN_BITMASK = 2L;
+	public static final long COMPANYID_COLUMN_BITMASK = 2L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
@@ -278,6 +277,16 @@ public class ViewCountEntryModelImpl
 		_companyId = companyId;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public long getOriginalCompanyId() {
+		return GetterUtil.getLong(
+			this.<Long>getColumnOriginalValue("companyId"));
+	}
+
 	@Override
 	public String getClassName() {
 		if (getClassNameId() <= 0) {
@@ -310,6 +319,16 @@ public class ViewCountEntryModelImpl
 		}
 
 		_classNameId = classNameId;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public long getOriginalClassNameId() {
+		return GetterUtil.getLong(
+			this.<Long>getColumnOriginalValue("classNameId"));
 	}
 
 	@Override

--- a/modules/apps/view-count/view-count-service/src/main/java/com/liferay/view/count/service/impl/ViewCountEntryLocalServiceImpl.java
+++ b/modules/apps/view-count/view-count-service/src/main/java/com/liferay/view/count/service/impl/ViewCountEntryLocalServiceImpl.java
@@ -9,6 +9,7 @@ import com.liferay.osgi.service.tracker.collections.map.ServiceReferenceMapperFa
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.petra.sql.dsl.Table;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.change.tracking.CTAware;
@@ -23,6 +24,8 @@ import com.liferay.portal.kernel.spring.aop.Property;
 import com.liferay.portal.kernel.spring.aop.Retry;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
+import com.liferay.portal.kernel.util.BulkDeleteCacheThreadLocal;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.view.count.ViewCountManager;
 import com.liferay.view.count.configuration.ViewCountConfiguration;
@@ -34,6 +37,7 @@ import com.liferay.view.count.service.base.ViewCountEntryLocalServiceBaseImpl;
 import com.liferay.view.count.service.persistence.ViewCountEntryPK;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -60,14 +64,37 @@ public class ViewCountEntryLocalServiceImpl
 	public void deleteViewCount(
 		long companyId, long classNameId, long classPK) {
 
-		ViewCountEntryPK viewCountEntryPK = new ViewCountEntryPK(
-			companyId, classNameId, classPK);
+		Map<Long, List<ViewCountEntry>> partitionViewCountEntries =
+			BulkDeleteCacheThreadLocal.getBulkDeleteCache(
+				StringBundler.concat(
+					ViewCountEntryLocalServiceImpl.class.getName(),
+					".deleteViewCount#", companyId, classNameId),
+				() -> MapUtil.toPartitionMap(
+					viewCountEntryPersistence.findByC_CN(
+						companyId, classNameId),
+					ViewCountEntry::getClassPK));
 
-		ViewCountEntry viewCountEntry =
-			viewCountEntryPersistence.fetchByPrimaryKey(viewCountEntryPK);
+		if (partitionViewCountEntries == null) {
+			ViewCountEntryPK viewCountEntryPK = new ViewCountEntryPK(
+				companyId, classNameId, classPK);
 
-		if (viewCountEntry != null) {
-			viewCountEntryPersistence.remove(viewCountEntry);
+			ViewCountEntry viewCountEntry =
+				viewCountEntryPersistence.fetchByPrimaryKey(viewCountEntryPK);
+
+			if (viewCountEntry != null) {
+				viewCountEntryPersistence.remove(viewCountEntry);
+			}
+
+			return;
+		}
+
+		List<ViewCountEntry> viewCountEntries =
+			partitionViewCountEntries.remove(classPK);
+
+		if (viewCountEntries != null) {
+			for (ViewCountEntry viewCountEntry : viewCountEntries) {
+				viewCountEntryPersistence.remove(viewCountEntry);
+			}
 		}
 	}
 

--- a/modules/apps/view-count/view-count-service/src/main/java/com/liferay/view/count/service/persistence/impl/ViewCountEntryPersistenceImpl.java
+++ b/modules/apps/view-count/view-count-service/src/main/java/com/liferay/view/count/service/persistence/impl/ViewCountEntryPersistenceImpl.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.dao.orm.FinderPath;
 import com.liferay.portal.kernel.dao.orm.Query;
+import com.liferay.portal.kernel.dao.orm.QueryPos;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.dao.orm.SessionFactory;
@@ -22,6 +23,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.view.count.exception.NoSuchEntryException;
 import com.liferay.view.count.model.ViewCountEntry;
@@ -34,6 +36,8 @@ import com.liferay.view.count.service.persistence.ViewCountEntryUtil;
 import com.liferay.view.count.service.persistence.impl.constants.ViewCountPersistenceConstants;
 
 import java.io.Serializable;
+
+import java.lang.reflect.InvocationHandler;
 
 import java.util.List;
 import java.util.Map;
@@ -78,6 +82,545 @@ public class ViewCountEntryPersistenceImpl
 	private FinderPath _finderPathWithPaginationFindAll;
 	private FinderPath _finderPathWithoutPaginationFindAll;
 	private FinderPath _finderPathCountAll;
+	private FinderPath _finderPathWithPaginationFindByC_CN;
+	private FinderPath _finderPathWithoutPaginationFindByC_CN;
+	private FinderPath _finderPathCountByC_CN;
+
+	/**
+	 * Returns all the view count entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @return the matching view count entries
+	 */
+	@Override
+	public List<ViewCountEntry> findByC_CN(long companyId, long classNameId) {
+		return findByC_CN(
+			companyId, classNameId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the view count entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ViewCountEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of view count entries
+	 * @param end the upper bound of the range of view count entries (not inclusive)
+	 * @return the range of matching view count entries
+	 */
+	@Override
+	public List<ViewCountEntry> findByC_CN(
+		long companyId, long classNameId, int start, int end) {
+
+		return findByC_CN(companyId, classNameId, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the view count entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ViewCountEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of view count entries
+	 * @param end the upper bound of the range of view count entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching view count entries
+	 */
+	@Override
+	public List<ViewCountEntry> findByC_CN(
+		long companyId, long classNameId, int start, int end,
+		OrderByComparator<ViewCountEntry> orderByComparator) {
+
+		return findByC_CN(
+			companyId, classNameId, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the view count entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ViewCountEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of view count entries
+	 * @param end the upper bound of the range of view count entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching view count entries
+	 */
+	@Override
+	public List<ViewCountEntry> findByC_CN(
+		long companyId, long classNameId, int start, int end,
+		OrderByComparator<ViewCountEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			if (useFinderCache) {
+				finderPath = _finderPathWithoutPaginationFindByC_CN;
+				finderArgs = new Object[] {companyId, classNameId};
+			}
+		}
+		else if (useFinderCache) {
+			finderPath = _finderPathWithPaginationFindByC_CN;
+			finderArgs = new Object[] {
+				companyId, classNameId, start, end, orderByComparator
+			};
+		}
+
+		List<ViewCountEntry> list = null;
+
+		if (useFinderCache) {
+			list = (List<ViewCountEntry>)finderCache.getResult(
+				finderPath, finderArgs, this);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (ViewCountEntry viewCountEntry : list) {
+					if ((companyId != viewCountEntry.getCompanyId()) ||
+						(classNameId != viewCountEntry.getClassNameId())) {
+
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler sb = null;
+
+			if (orderByComparator != null) {
+				sb = new StringBundler(
+					4 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				sb = new StringBundler(4);
+			}
+
+			sb.append(_SQL_SELECT_VIEWCOUNTENTRY_WHERE);
+
+			sb.append(_FINDER_COLUMN_C_CN_COMPANYID_2);
+
+			sb.append(_FINDER_COLUMN_C_CN_CLASSNAMEID_2);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else {
+				sb.append(ViewCountEntryModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(companyId);
+
+				queryPos.add(classNameId);
+
+				list = (List<ViewCountEntry>)QueryUtil.list(
+					query, getDialect(), start, end);
+
+				cacheResult(list);
+
+				if (useFinderCache) {
+					finderCache.putResult(finderPath, finderArgs, list);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first view count entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching view count entry
+	 * @throws NoSuchEntryException if a matching view count entry could not be found
+	 */
+	@Override
+	public ViewCountEntry findByC_CN_First(
+			long companyId, long classNameId,
+			OrderByComparator<ViewCountEntry> orderByComparator)
+		throws NoSuchEntryException {
+
+		ViewCountEntry viewCountEntry = fetchByC_CN_First(
+			companyId, classNameId, orderByComparator);
+
+		if (viewCountEntry != null) {
+			return viewCountEntry;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("companyId=");
+		sb.append(companyId);
+
+		sb.append(", classNameId=");
+		sb.append(classNameId);
+
+		sb.append("}");
+
+		throw new NoSuchEntryException(sb.toString());
+	}
+
+	/**
+	 * Returns the first view count entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching view count entry, or <code>null</code> if a matching view count entry could not be found
+	 */
+	@Override
+	public ViewCountEntry fetchByC_CN_First(
+		long companyId, long classNameId,
+		OrderByComparator<ViewCountEntry> orderByComparator) {
+
+		List<ViewCountEntry> list = findByC_CN(
+			companyId, classNameId, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last view count entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching view count entry
+	 * @throws NoSuchEntryException if a matching view count entry could not be found
+	 */
+	@Override
+	public ViewCountEntry findByC_CN_Last(
+			long companyId, long classNameId,
+			OrderByComparator<ViewCountEntry> orderByComparator)
+		throws NoSuchEntryException {
+
+		ViewCountEntry viewCountEntry = fetchByC_CN_Last(
+			companyId, classNameId, orderByComparator);
+
+		if (viewCountEntry != null) {
+			return viewCountEntry;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("companyId=");
+		sb.append(companyId);
+
+		sb.append(", classNameId=");
+		sb.append(classNameId);
+
+		sb.append("}");
+
+		throw new NoSuchEntryException(sb.toString());
+	}
+
+	/**
+	 * Returns the last view count entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching view count entry, or <code>null</code> if a matching view count entry could not be found
+	 */
+	@Override
+	public ViewCountEntry fetchByC_CN_Last(
+		long companyId, long classNameId,
+		OrderByComparator<ViewCountEntry> orderByComparator) {
+
+		int count = countByC_CN(companyId, classNameId);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<ViewCountEntry> list = findByC_CN(
+			companyId, classNameId, count - 1, count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the view count entries before and after the current view count entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param viewCountEntryPK the primary key of the current view count entry
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next view count entry
+	 * @throws NoSuchEntryException if a view count entry with the primary key could not be found
+	 */
+	@Override
+	public ViewCountEntry[] findByC_CN_PrevAndNext(
+			ViewCountEntryPK viewCountEntryPK, long companyId, long classNameId,
+			OrderByComparator<ViewCountEntry> orderByComparator)
+		throws NoSuchEntryException {
+
+		ViewCountEntry viewCountEntry = findByPrimaryKey(viewCountEntryPK);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			ViewCountEntry[] array = new ViewCountEntryImpl[3];
+
+			array[0] = getByC_CN_PrevAndNext(
+				session, viewCountEntry, companyId, classNameId,
+				orderByComparator, true);
+
+			array[1] = viewCountEntry;
+
+			array[2] = getByC_CN_PrevAndNext(
+				session, viewCountEntry, companyId, classNameId,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected ViewCountEntry getByC_CN_PrevAndNext(
+		Session session, ViewCountEntry viewCountEntry, long companyId,
+		long classNameId, OrderByComparator<ViewCountEntry> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				5 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(4);
+		}
+
+		sb.append(_SQL_SELECT_VIEWCOUNTENTRY_WHERE);
+
+		sb.append(_FINDER_COLUMN_C_CN_COMPANYID_2);
+
+		sb.append(_FINDER_COLUMN_C_CN_CLASSNAMEID_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(ViewCountEntryModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(companyId);
+
+		queryPos.add(classNameId);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						viewCountEntry)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<ViewCountEntry> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the view count entries where companyId = &#63; and classNameId = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 */
+	@Override
+	public void removeByC_CN(long companyId, long classNameId) {
+		for (ViewCountEntry viewCountEntry :
+				findByC_CN(
+					companyId, classNameId, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null)) {
+
+			remove(viewCountEntry);
+		}
+	}
+
+	/**
+	 * Returns the number of view count entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @return the number of matching view count entries
+	 */
+	@Override
+	public int countByC_CN(long companyId, long classNameId) {
+		FinderPath finderPath = _finderPathCountByC_CN;
+
+		Object[] finderArgs = new Object[] {companyId, classNameId};
+
+		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
+
+		if (count == null) {
+			StringBundler sb = new StringBundler(3);
+
+			sb.append(_SQL_COUNT_VIEWCOUNTENTRY_WHERE);
+
+			sb.append(_FINDER_COLUMN_C_CN_COMPANYID_2);
+
+			sb.append(_FINDER_COLUMN_C_CN_CLASSNAMEID_2);
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(companyId);
+
+				queryPos.add(classNameId);
+
+				count = (Long)query.uniqueResult();
+
+				finderCache.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_C_CN_COMPANYID_2 =
+		"viewCountEntry.id.companyId = ? AND ";
+
+	private static final String _FINDER_COLUMN_C_CN_CLASSNAMEID_2 =
+		"viewCountEntry.id.classNameId = ?";
 
 	public ViewCountEntryPersistenceImpl() {
 		setModelClass(ViewCountEntry.class);
@@ -277,6 +820,26 @@ public class ViewCountEntryPersistenceImpl
 	public ViewCountEntry updateImpl(ViewCountEntry viewCountEntry) {
 		boolean isNew = viewCountEntry.isNew();
 
+		if (!(viewCountEntry instanceof ViewCountEntryModelImpl)) {
+			InvocationHandler invocationHandler = null;
+
+			if (ProxyUtil.isProxyClass(viewCountEntry.getClass())) {
+				invocationHandler = ProxyUtil.getInvocationHandler(
+					viewCountEntry);
+
+				throw new IllegalArgumentException(
+					"Implement ModelWrapper in viewCountEntry proxy " +
+						invocationHandler.getClass());
+			}
+
+			throw new IllegalArgumentException(
+				"Implement ModelWrapper in custom ViewCountEntry implementation " +
+					viewCountEntry.getClass());
+		}
+
+		ViewCountEntryModelImpl viewCountEntryModelImpl =
+			(ViewCountEntryModelImpl)viewCountEntry;
+
 		Session session = null;
 
 		try {
@@ -297,7 +860,7 @@ public class ViewCountEntryPersistenceImpl
 		}
 
 		entityCache.putResult(
-			ViewCountEntryImpl.class, viewCountEntry, false, true);
+			ViewCountEntryImpl.class, viewCountEntryModelImpl, false, true);
 
 		if (isNew) {
 			viewCountEntry.setNew(false);
@@ -583,6 +1146,25 @@ public class ViewCountEntryPersistenceImpl
 			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countAll",
 			new String[0], new String[0], false);
 
+		_finderPathWithPaginationFindByC_CN = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_CN",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId"}, true);
+
+		_finderPathWithoutPaginationFindByC_CN = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_CN",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "classNameId"}, true);
+
+		_finderPathCountByC_CN = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_CN",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "classNameId"}, false);
+
 		ViewCountEntryUtil.setPersistence(this);
 	}
 
@@ -628,13 +1210,22 @@ public class ViewCountEntryPersistenceImpl
 	private static final String _SQL_SELECT_VIEWCOUNTENTRY =
 		"SELECT viewCountEntry FROM ViewCountEntry viewCountEntry";
 
+	private static final String _SQL_SELECT_VIEWCOUNTENTRY_WHERE =
+		"SELECT viewCountEntry FROM ViewCountEntry viewCountEntry WHERE ";
+
 	private static final String _SQL_COUNT_VIEWCOUNTENTRY =
 		"SELECT COUNT(viewCountEntry) FROM ViewCountEntry viewCountEntry";
+
+	private static final String _SQL_COUNT_VIEWCOUNTENTRY_WHERE =
+		"SELECT COUNT(viewCountEntry) FROM ViewCountEntry viewCountEntry WHERE ";
 
 	private static final String _ORDER_BY_ENTITY_ALIAS = "viewCountEntry.";
 
 	private static final String _NO_SUCH_ENTITY_WITH_PRIMARY_KEY =
 		"No ViewCountEntry exists with the primary key ";
+
+	private static final String _NO_SUCH_ENTITY_WITH_KEY =
+		"No ViewCountEntry exists with the key {";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ViewCountEntryPersistenceImpl.class);

--- a/modules/apps/view-count/view-count-test/src/testIntegration/java/com/liferay/view/count/service/persistence/test/ViewCountEntryPersistenceTest.java
+++ b/modules/apps/view-count/view-count-test/src/testIntegration/java/com/liferay/view/count/service/persistence/test/ViewCountEntryPersistenceTest.java
@@ -137,6 +137,14 @@ public class ViewCountEntryPersistenceTest {
 	}
 
 	@Test
+	public void testCountByC_CN() throws Exception {
+		_persistence.countByC_CN(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextLong());
+
+		_persistence.countByC_CN(0L, 0L);
+	}
+
+	@Test
 	public void testFindByPrimaryKeyExisting() throws Exception {
 		ViewCountEntry newViewCountEntry = addViewCountEntry();
 

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ResourcePermissionPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/ResourcePermissionPersistenceTest.java
@@ -218,6 +218,16 @@ public class ResourcePermissionPersistenceTest {
 	}
 
 	@Test
+	public void testCountByC_N_S() throws Exception {
+		_persistence.countByC_N_S(
+			RandomTestUtil.nextLong(), "", RandomTestUtil.nextInt());
+
+		_persistence.countByC_N_S(0L, "null", 0);
+
+		_persistence.countByC_N_S(0L, (String)null, 0);
+	}
+
+	@Test
 	public void testCountByC_S_P() throws Exception {
 		_persistence.countByC_S_P(
 			RandomTestUtil.nextLong(), RandomTestUtil.nextInt(), "");

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetEntryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetEntryPersistenceTest.java
@@ -297,6 +297,14 @@ public class AssetEntryPersistenceTest {
 	}
 
 	@Test
+	public void testCountByC_CN() throws Exception {
+		_persistence.countByC_CN(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextLong());
+
+		_persistence.countByC_CN(0L, 0L);
+	}
+
+	@Test
 	public void testCountByC_C() throws Exception {
 		_persistence.countByC_C(
 			RandomTestUtil.nextLong(), RandomTestUtil.nextLong());

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialActivityPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/social/service/persistence/test/SocialActivityPersistenceTest.java
@@ -239,6 +239,14 @@ public class SocialActivityPersistenceTest {
 	}
 
 	@Test
+	public void testCountByC_CN() throws Exception {
+		_persistence.countByC_CN(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextLong());
+
+		_persistence.countByC_CN(0L, 0L);
+	}
+
+	@Test
 	public void testCountByC_C() throws Exception {
 		_persistence.countByC_C(
 			RandomTestUtil.nextLong(), RandomTestUtil.nextLong());

--- a/portal-impl/src/com/liferay/portal/service.xml
+++ b/portal-impl/src/com/liferay/portal/service.xml
@@ -2141,6 +2141,11 @@
 			<finder-column name="companyId" />
 			<finder-column comparator="LIKE" name="primKey" />
 		</finder>
+		<finder name="C_N_S" return-type="Collection">
+			<finder-column name="companyId" />
+			<finder-column name="name" />
+			<finder-column name="scope" />
+		</finder>
 		<finder name="C_S_P" return-type="Collection">
 			<finder-column name="companyId" />
 			<finder-column name="scope" />

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourceActionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourceActionLocalServiceImpl.java
@@ -29,13 +29,16 @@ import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.persistence.ResourcePermissionPersistence;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
+import com.liferay.portal.kernel.util.BulkDeleteCacheThreadLocal;
 import com.liferay.portal.security.permission.PermissionCacheUtil;
 import com.liferay.portal.service.base.ResourceActionLocalServiceBaseImpl;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -256,45 +259,56 @@ public class ResourceActionLocalServiceImpl
 	@Override
 	public ResourceAction deleteResourceAction(ResourceAction resourceAction) {
 		String name = resourceAction.getName();
-		long bitwiseValue = resourceAction.getBitwiseValue();
 
-		ActionableDynamicQuery.AddCriteriaMethod addCriteriaMethod =
-			dynamicQuery -> {
-				Property nameProperty = PropertyFactoryUtil.forName("name");
+		Set<String> names = BulkDeleteCacheThreadLocal.getBulkDeleteCache(
+			ResourcePermissionLocalService.class.getName(), HashSet::new);
 
-				dynamicQuery.add(nameProperty.eq(name));
-			};
+		if (names == null) {
+			long bitwiseValue = resourceAction.getBitwiseValue();
 
-		_companyLocalService.forEachCompanyId(
-			companyId -> {
-				ActionableDynamicQuery actionableDynamicQuery =
-					_resourcePermissionLocalService.getActionableDynamicQuery();
+			ActionableDynamicQuery.AddCriteriaMethod addCriteriaMethod =
+				dynamicQuery -> {
+					Property nameProperty = PropertyFactoryUtil.forName("name");
 
-				actionableDynamicQuery.setAddCriteriaMethod(addCriteriaMethod);
-				actionableDynamicQuery.setCompanyId(companyId);
-				actionableDynamicQuery.setPerformActionMethod(
-					(ResourcePermission resourcePermission) -> {
-						long actionIds = resourcePermission.getActionIds();
+					dynamicQuery.add(nameProperty.eq(name));
+				};
 
-						if ((actionIds & bitwiseValue) != 0) {
-							actionIds &= ~bitwiseValue;
+			_companyLocalService.forEachCompanyId(
+				companyId -> {
+					ActionableDynamicQuery actionableDynamicQuery =
+						_resourcePermissionLocalService.
+							getActionableDynamicQuery();
 
-							resourcePermission.setActionIds(actionIds);
-							resourcePermission.setViewActionId(
-								(actionIds % 2) == 1);
+					actionableDynamicQuery.setAddCriteriaMethod(
+						addCriteriaMethod);
+					actionableDynamicQuery.setCompanyId(companyId);
+					actionableDynamicQuery.setPerformActionMethod(
+						(ResourcePermission resourcePermission) -> {
+							long actionIds = resourcePermission.getActionIds();
 
-							_resourcePermissionPersistence.update(
-								resourcePermission);
-						}
-					});
+							if ((actionIds & bitwiseValue) != 0) {
+								actionIds &= ~bitwiseValue;
 
-				try {
-					actionableDynamicQuery.performActions();
-				}
-				catch (PortalException portalException) {
-					throw new SystemException(portalException);
-				}
-			});
+								resourcePermission.setActionIds(actionIds);
+								resourcePermission.setViewActionId(
+									(actionIds % 2) == 1);
+
+								_resourcePermissionPersistence.update(
+									resourcePermission);
+							}
+						});
+
+					try {
+						actionableDynamicQuery.performActions();
+					}
+					catch (PortalException portalException) {
+						throw new SystemException(portalException);
+					}
+				});
+		}
+		else {
+			names.add(name);
+		}
 
 		resourceActionPersistence.remove(resourceAction);
 

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -656,10 +656,21 @@ public class ResourcePermissionLocalServiceImpl
 				StringBundler.concat(
 					ResourcePermissionLocalServiceImpl.class.getName(),
 					".deleteResourcePermissions#", companyId, name, scope),
-				() -> MapUtil.toPartitionMap(
-					resourcePermissionPersistence.findByC_N_S(
-						companyId, name, scope),
-					ResourcePermission::getPrimKey));
+				() -> {
+					Session session =
+						resourcePermissionPersistence.openSession();
+
+					session.flush();
+
+					List<ResourcePermission> resourcePermissions =
+						resourcePermissionPersistence.findByC_N_S(
+							companyId, name, scope);
+
+					session.clear();
+
+					return MapUtil.toPartitionMap(
+						resourcePermissions, ResourcePermission::getPrimKey);
+				});
 
 		if (partitionResourcePermissions == null) {
 			for (ResourcePermission resourcePermission :

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -57,8 +57,10 @@ import com.liferay.portal.kernel.service.persistence.RolePersistence;
 import com.liferay.portal.kernel.spring.aop.Property;
 import com.liferay.portal.kernel.spring.aop.Retry;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.BulkDeleteCacheThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.model.impl.ResourceImpl;
@@ -643,13 +645,35 @@ public class ResourcePermissionLocalServiceImpl
 			long companyId, String name, int scope, String primKey)
 		throws PortalException {
 
-		List<ResourcePermission> resourcePermissions =
-			resourcePermissionPersistence.findByC_N_S_P(
-				companyId, name, scope, primKey);
+		Map<String, List<ResourcePermission>> partitionResourcePermissions =
+			BulkDeleteCacheThreadLocal.getBulkDeleteCache(
+				StringBundler.concat(
+					ResourcePermissionLocalServiceImpl.class.getName(),
+					".deleteResourcePermissions#", companyId, name, scope),
+				() -> MapUtil.toPartitionMap(
+					resourcePermissionPersistence.findByC_N_S(
+						companyId, name, scope),
+					ResourcePermission::getPrimKey));
 
-		for (ResourcePermission resourcePermission : resourcePermissions) {
-			deleteResourcePermission(
-				resourcePermission.getResourcePermissionId());
+		if (partitionResourcePermissions == null) {
+			for (ResourcePermission resourcePermission :
+					resourcePermissionPersistence.findByC_N_S_P(
+						companyId, name, scope, primKey)) {
+
+				deleteResourcePermission(
+					resourcePermission.getResourcePermissionId());
+			}
+
+			return;
+		}
+
+		List<ResourcePermission> resourcePermissions =
+			partitionResourcePermissions.remove(primKey);
+
+		if (resourcePermissions != null) {
+			for (ResourcePermission resourcePermission : resourcePermissions) {
+				resourcePermissionPersistence.remove(resourcePermission);
+			}
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -52,6 +52,7 @@ import com.liferay.portal.kernel.service.SQLStateAcceptor;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.permission.ModelPermissions;
 import com.liferay.portal.kernel.service.permission.ModelPermissionsFactory;
+import com.liferay.portal.kernel.service.persistence.LongPKRemoveFunction;
 import com.liferay.portal.kernel.service.persistence.ResourceActionPersistence;
 import com.liferay.portal.kernel.service.persistence.RolePersistence;
 import com.liferay.portal.kernel.spring.aop.Property;
@@ -64,6 +65,7 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.model.impl.ResourceImpl;
+import com.liferay.portal.model.impl.ResourcePermissionModelImpl;
 import com.liferay.portal.security.permission.PermissionCacheUtil;
 import com.liferay.portal.service.base.ResourcePermissionLocalServiceBaseImpl;
 import com.liferay.portal.service.persistence.impl.ResourcePermissionPersistenceImpl;
@@ -542,6 +544,10 @@ public class ResourcePermissionLocalServiceImpl
 		catch (Exception exception) {
 			_log.error(exception);
 		}
+
+		_resourcePermissionLongPKRemoveFunction = new LongPKRemoveFunction<>(
+			resourcePermissionPersistence,
+			ResourcePermissionModelImpl.TABLE_NAME, "resourcePermissionId");
 	}
 
 	@Override
@@ -672,7 +678,9 @@ public class ResourcePermissionLocalServiceImpl
 
 		if (resourcePermissions != null) {
 			for (ResourcePermission resourcePermission : resourcePermissions) {
-				resourcePermissionPersistence.remove(resourcePermission);
+				resourcePermissionPersistence.removeByFunction(
+					resourcePermission,
+					_resourcePermissionLongPKRemoveFunction);
 			}
 		}
 	}
@@ -2423,6 +2431,9 @@ public class ResourcePermissionLocalServiceImpl
 
 	@BeanReference(type = ResourceActionPersistence.class)
 	private ResourceActionPersistence _resourceActionPersistence;
+
+	private LongPKRemoveFunction<ResourcePermission>
+		_resourcePermissionLongPKRemoveFunction;
 
 	@BeanReference(type = RoleLocalService.class)
 	private RoleLocalService _roleLocalService;

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -52,16 +52,13 @@ import com.liferay.portal.kernel.service.SQLStateAcceptor;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.permission.ModelPermissions;
 import com.liferay.portal.kernel.service.permission.ModelPermissionsFactory;
-import com.liferay.portal.kernel.service.persistence.LongPKRemoveFunction;
 import com.liferay.portal.kernel.service.persistence.ResourceActionPersistence;
 import com.liferay.portal.kernel.service.persistence.RolePersistence;
 import com.liferay.portal.kernel.spring.aop.Property;
 import com.liferay.portal.kernel.spring.aop.Retry;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.BulkDeleteCacheThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
-import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.model.impl.ResourceImpl;
@@ -546,10 +543,6 @@ public class ResourcePermissionLocalServiceImpl
 		catch (Exception exception) {
 			_log.error(exception);
 		}
-
-		_resourcePermissionLongPKRemoveFunction = new LongPKRemoveFunction<>(
-			resourcePermissionPersistence,
-			ResourcePermissionModelImpl.TABLE_NAME, "resourcePermissionId");
 	}
 
 	@Override
@@ -684,48 +677,13 @@ public class ResourcePermissionLocalServiceImpl
 			long companyId, String name, int scope, String primKey)
 		throws PortalException {
 
-		Map<String, List<ResourcePermission>> partitionResourcePermissions =
-			BulkDeleteCacheThreadLocal.getBulkDeleteCache(
-				StringBundler.concat(
-					ResourcePermissionLocalServiceImpl.class.getName(),
-					".deleteResourcePermissions#", companyId, name, scope),
-				() -> {
-					Session session =
-						resourcePermissionPersistence.openSession();
-
-					session.flush();
-
-					List<ResourcePermission> resourcePermissions =
-						resourcePermissionPersistence.findByC_N_S(
-							companyId, name, scope);
-
-					session.clear();
-
-					return MapUtil.toPartitionMap(
-						resourcePermissions, ResourcePermission::getPrimKey);
-				});
-
-		if (partitionResourcePermissions == null) {
-			for (ResourcePermission resourcePermission :
-					resourcePermissionPersistence.findByC_N_S_P(
-						companyId, name, scope, primKey)) {
-
-				deleteResourcePermission(
-					resourcePermission.getResourcePermissionId());
-			}
-
-			return;
-		}
-
 		List<ResourcePermission> resourcePermissions =
-			partitionResourcePermissions.remove(primKey);
+			resourcePermissionPersistence.findByC_N_S_P(
+				companyId, name, scope, primKey);
 
-		if (resourcePermissions != null) {
-			for (ResourcePermission resourcePermission : resourcePermissions) {
-				resourcePermissionPersistence.removeByFunction(
-					resourcePermission,
-					_resourcePermissionLongPKRemoveFunction);
-			}
+		for (ResourcePermission resourcePermission : resourcePermissions) {
+			deleteResourcePermission(
+				resourcePermission.getResourcePermissionId());
 		}
 	}
 
@@ -2484,9 +2442,6 @@ public class ResourcePermissionLocalServiceImpl
 
 	@BeanReference(type = ResourceActionPersistence.class)
 	private ResourceActionPersistence _resourceActionPersistence;
-
-	private LongPKRemoveFunction<ResourcePermission>
-		_resourcePermissionLongPKRemoveFunction;
 
 	@BeanReference(type = RoleLocalService.class)
 	private RoleLocalService _roleLocalService;

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -697,6 +697,11 @@ public class ResourcePermissionLocalServiceImpl
 	}
 
 	@Override
+	public void deleteResourcePermissions(String name) {
+		resourcePermissionPersistence.removeByName(name);
+	}
+
+	@Override
 	public ResourcePermission fetchResourcePermission(
 		long companyId, String name, int scope, String primKey, long roleId) {
 

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -74,6 +74,8 @@ import com.liferay.util.dao.orm.CustomSQLUtil;
 
 import java.lang.reflect.Field;
 
+import java.sql.PreparedStatement;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -592,6 +594,37 @@ public class ResourcePermissionLocalServiceImpl
 				sourceResourcePermission.isViewActionId());
 
 			resourcePermissionPersistence.update(targetResourcePermission);
+		}
+	}
+
+	@Override
+	public void deleteResourcePermissions(
+			long companyId, String name, int scope)
+		throws PortalException {
+
+		Session session = resourcePermissionPersistence.openSession();
+
+		try {
+			session.apply(
+				connection -> {
+					try (PreparedStatement preparedStatement =
+							connection.prepareStatement(_DELETE_BY_C_N_S)) {
+
+						preparedStatement.setLong(1, companyId);
+						preparedStatement.setString(2, name);
+						preparedStatement.setInt(3, scope);
+
+						int results = preparedStatement.executeUpdate();
+
+						if (results > 0) {
+							resourcePermissionPersistence.clearCache();
+							PermissionCacheUtil.clearCache();
+						}
+					}
+				});
+		}
+		finally {
+			resourcePermissionPersistence.closeSession(session);
 		}
 	}
 
@@ -2424,6 +2457,10 @@ public class ResourcePermissionLocalServiceImpl
 
 		return null;
 	}
+
+	private static final String _DELETE_BY_C_N_S =
+		"delete from " + ResourcePermissionModelImpl.TABLE_NAME +
+			" where companyId = ? and name = ? and scope = ?";
 
 	private static final String _FIND_MISSING_RESOURCE_PERMISSIONS =
 		ResourcePermissionLocalServiceImpl.class.getName() +

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/ResourcePermissionPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/ResourcePermissionPersistenceImpl.java
@@ -2500,6 +2500,636 @@ public class ResourcePermissionPersistenceImpl
 	private static final String _FINDER_COLUMN_C_LIKEP_PRIMKEY_3 =
 		"(resourcePermission.primKey IS NULL OR resourcePermission.primKey LIKE '')";
 
+	private FinderPath _finderPathWithPaginationFindByC_N_S;
+	private FinderPath _finderPathWithoutPaginationFindByC_N_S;
+	private FinderPath _finderPathCountByC_N_S;
+
+	/**
+	 * Returns all the resource permissions where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @return the matching resource permissions
+	 */
+	@Override
+	public List<ResourcePermission> findByC_N_S(
+		long companyId, String name, int scope) {
+
+		return findByC_N_S(
+			companyId, name, scope, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the resource permissions where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ResourcePermissionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @param start the lower bound of the range of resource permissions
+	 * @param end the upper bound of the range of resource permissions (not inclusive)
+	 * @return the range of matching resource permissions
+	 */
+	@Override
+	public List<ResourcePermission> findByC_N_S(
+		long companyId, String name, int scope, int start, int end) {
+
+		return findByC_N_S(companyId, name, scope, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the resource permissions where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ResourcePermissionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @param start the lower bound of the range of resource permissions
+	 * @param end the upper bound of the range of resource permissions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching resource permissions
+	 */
+	@Override
+	public List<ResourcePermission> findByC_N_S(
+		long companyId, String name, int scope, int start, int end,
+		OrderByComparator<ResourcePermission> orderByComparator) {
+
+		return findByC_N_S(
+			companyId, name, scope, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the resource permissions where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ResourcePermissionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @param start the lower bound of the range of resource permissions
+	 * @param end the upper bound of the range of resource permissions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching resource permissions
+	 */
+	@Override
+	public List<ResourcePermission> findByC_N_S(
+		long companyId, String name, int scope, int start, int end,
+		OrderByComparator<ResourcePermission> orderByComparator,
+		boolean useFinderCache) {
+
+		try (SafeCloseable safeCloseable =
+				CTPersistenceHelperUtil.setCTCollectionIdWithSafeCloseable(
+					ResourcePermission.class)) {
+
+			name = Objects.toString(name, "");
+
+			FinderPath finderPath = null;
+			Object[] finderArgs = null;
+
+			if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+				(orderByComparator == null)) {
+
+				if (useFinderCache) {
+					finderPath = _finderPathWithoutPaginationFindByC_N_S;
+					finderArgs = new Object[] {companyId, name, scope};
+				}
+			}
+			else if (useFinderCache) {
+				finderPath = _finderPathWithPaginationFindByC_N_S;
+				finderArgs = new Object[] {
+					companyId, name, scope, start, end, orderByComparator
+				};
+			}
+
+			List<ResourcePermission> list = null;
+
+			if (useFinderCache) {
+				list = (List<ResourcePermission>)FinderCacheUtil.getResult(
+					finderPath, finderArgs, this);
+
+				if ((list != null) && !list.isEmpty()) {
+					for (ResourcePermission resourcePermission : list) {
+						if ((companyId != resourcePermission.getCompanyId()) ||
+							!name.equals(resourcePermission.getName()) ||
+							(scope != resourcePermission.getScope())) {
+
+							list = null;
+
+							break;
+						}
+					}
+				}
+			}
+
+			if (list == null) {
+				StringBundler sb = null;
+
+				if (orderByComparator != null) {
+					sb = new StringBundler(
+						5 + (orderByComparator.getOrderByFields().length * 2));
+				}
+				else {
+					sb = new StringBundler(5);
+				}
+
+				sb.append(_SQL_SELECT_RESOURCEPERMISSION_WHERE);
+
+				sb.append(_FINDER_COLUMN_C_N_S_COMPANYID_2);
+
+				boolean bindName = false;
+
+				if (name.isEmpty()) {
+					sb.append(_FINDER_COLUMN_C_N_S_NAME_3);
+				}
+				else {
+					bindName = true;
+
+					sb.append(_FINDER_COLUMN_C_N_S_NAME_2);
+				}
+
+				sb.append(_FINDER_COLUMN_C_N_S_SCOPE_2);
+
+				if (orderByComparator != null) {
+					appendOrderByComparator(
+						sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+				}
+				else {
+					sb.append(ResourcePermissionModelImpl.ORDER_BY_JPQL);
+				}
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(companyId);
+
+					if (bindName) {
+						queryPos.add(name);
+					}
+
+					queryPos.add(scope);
+
+					list = (List<ResourcePermission>)QueryUtil.list(
+						query, getDialect(), start, end);
+
+					cacheResult(list);
+
+					if (useFinderCache) {
+						FinderCacheUtil.putResult(finderPath, finderArgs, list);
+					}
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return list;
+		}
+	}
+
+	/**
+	 * Returns the first resource permission in the ordered set where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching resource permission
+	 * @throws NoSuchResourcePermissionException if a matching resource permission could not be found
+	 */
+	@Override
+	public ResourcePermission findByC_N_S_First(
+			long companyId, String name, int scope,
+			OrderByComparator<ResourcePermission> orderByComparator)
+		throws NoSuchResourcePermissionException {
+
+		ResourcePermission resourcePermission = fetchByC_N_S_First(
+			companyId, name, scope, orderByComparator);
+
+		if (resourcePermission != null) {
+			return resourcePermission;
+		}
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("companyId=");
+		sb.append(companyId);
+
+		sb.append(", name=");
+		sb.append(name);
+
+		sb.append(", scope=");
+		sb.append(scope);
+
+		sb.append("}");
+
+		throw new NoSuchResourcePermissionException(sb.toString());
+	}
+
+	/**
+	 * Returns the first resource permission in the ordered set where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching resource permission, or <code>null</code> if a matching resource permission could not be found
+	 */
+	@Override
+	public ResourcePermission fetchByC_N_S_First(
+		long companyId, String name, int scope,
+		OrderByComparator<ResourcePermission> orderByComparator) {
+
+		List<ResourcePermission> list = findByC_N_S(
+			companyId, name, scope, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last resource permission in the ordered set where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching resource permission
+	 * @throws NoSuchResourcePermissionException if a matching resource permission could not be found
+	 */
+	@Override
+	public ResourcePermission findByC_N_S_Last(
+			long companyId, String name, int scope,
+			OrderByComparator<ResourcePermission> orderByComparator)
+		throws NoSuchResourcePermissionException {
+
+		ResourcePermission resourcePermission = fetchByC_N_S_Last(
+			companyId, name, scope, orderByComparator);
+
+		if (resourcePermission != null) {
+			return resourcePermission;
+		}
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("companyId=");
+		sb.append(companyId);
+
+		sb.append(", name=");
+		sb.append(name);
+
+		sb.append(", scope=");
+		sb.append(scope);
+
+		sb.append("}");
+
+		throw new NoSuchResourcePermissionException(sb.toString());
+	}
+
+	/**
+	 * Returns the last resource permission in the ordered set where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching resource permission, or <code>null</code> if a matching resource permission could not be found
+	 */
+	@Override
+	public ResourcePermission fetchByC_N_S_Last(
+		long companyId, String name, int scope,
+		OrderByComparator<ResourcePermission> orderByComparator) {
+
+		int count = countByC_N_S(companyId, name, scope);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<ResourcePermission> list = findByC_N_S(
+			companyId, name, scope, count - 1, count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the resource permissions before and after the current resource permission in the ordered set where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * @param resourcePermissionId the primary key of the current resource permission
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next resource permission
+	 * @throws NoSuchResourcePermissionException if a resource permission with the primary key could not be found
+	 */
+	@Override
+	public ResourcePermission[] findByC_N_S_PrevAndNext(
+			long resourcePermissionId, long companyId, String name, int scope,
+			OrderByComparator<ResourcePermission> orderByComparator)
+		throws NoSuchResourcePermissionException {
+
+		name = Objects.toString(name, "");
+
+		ResourcePermission resourcePermission = findByPrimaryKey(
+			resourcePermissionId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			ResourcePermission[] array = new ResourcePermissionImpl[3];
+
+			array[0] = getByC_N_S_PrevAndNext(
+				session, resourcePermission, companyId, name, scope,
+				orderByComparator, true);
+
+			array[1] = resourcePermission;
+
+			array[2] = getByC_N_S_PrevAndNext(
+				session, resourcePermission, companyId, name, scope,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected ResourcePermission getByC_N_S_PrevAndNext(
+		Session session, ResourcePermission resourcePermission, long companyId,
+		String name, int scope,
+		OrderByComparator<ResourcePermission> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				6 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(5);
+		}
+
+		sb.append(_SQL_SELECT_RESOURCEPERMISSION_WHERE);
+
+		sb.append(_FINDER_COLUMN_C_N_S_COMPANYID_2);
+
+		boolean bindName = false;
+
+		if (name.isEmpty()) {
+			sb.append(_FINDER_COLUMN_C_N_S_NAME_3);
+		}
+		else {
+			bindName = true;
+
+			sb.append(_FINDER_COLUMN_C_N_S_NAME_2);
+		}
+
+		sb.append(_FINDER_COLUMN_C_N_S_SCOPE_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(ResourcePermissionModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(companyId);
+
+		if (bindName) {
+			queryPos.add(name);
+		}
+
+		queryPos.add(scope);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						resourcePermission)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<ResourcePermission> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the resource permissions where companyId = &#63; and name = &#63; and scope = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 */
+	@Override
+	public void removeByC_N_S(long companyId, String name, int scope) {
+		for (ResourcePermission resourcePermission :
+				findByC_N_S(
+					companyId, name, scope, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null)) {
+
+			remove(resourcePermission);
+		}
+	}
+
+	/**
+	 * Returns the number of resource permissions where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @return the number of matching resource permissions
+	 */
+	@Override
+	public int countByC_N_S(long companyId, String name, int scope) {
+		try (SafeCloseable safeCloseable =
+				CTPersistenceHelperUtil.setCTCollectionIdWithSafeCloseable(
+					ResourcePermission.class)) {
+
+			name = Objects.toString(name, "");
+
+			FinderPath finderPath = _finderPathCountByC_N_S;
+
+			Object[] finderArgs = new Object[] {companyId, name, scope};
+
+			Long count = (Long)FinderCacheUtil.getResult(
+				finderPath, finderArgs, this);
+
+			if (count == null) {
+				StringBundler sb = new StringBundler(4);
+
+				sb.append(_SQL_COUNT_RESOURCEPERMISSION_WHERE);
+
+				sb.append(_FINDER_COLUMN_C_N_S_COMPANYID_2);
+
+				boolean bindName = false;
+
+				if (name.isEmpty()) {
+					sb.append(_FINDER_COLUMN_C_N_S_NAME_3);
+				}
+				else {
+					bindName = true;
+
+					sb.append(_FINDER_COLUMN_C_N_S_NAME_2);
+				}
+
+				sb.append(_FINDER_COLUMN_C_N_S_SCOPE_2);
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(companyId);
+
+					if (bindName) {
+						queryPos.add(name);
+					}
+
+					queryPos.add(scope);
+
+					count = (Long)query.uniqueResult();
+
+					FinderCacheUtil.putResult(finderPath, finderArgs, count);
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return count.intValue();
+		}
+	}
+
+	private static final String _FINDER_COLUMN_C_N_S_COMPANYID_2 =
+		"resourcePermission.companyId = ? AND ";
+
+	private static final String _FINDER_COLUMN_C_N_S_NAME_2 =
+		"resourcePermission.name = ? AND ";
+
+	private static final String _FINDER_COLUMN_C_N_S_NAME_3 =
+		"(resourcePermission.name IS NULL OR resourcePermission.name = '') AND ";
+
+	private static final String _FINDER_COLUMN_C_N_S_SCOPE_2 =
+		"resourcePermission.scope = ?";
+
 	private FinderPath _finderPathWithPaginationFindByC_S_P;
 	private FinderPath _finderPathWithoutPaginationFindByC_S_P;
 	private FinderPath _finderPathCountByC_S_P;
@@ -9043,6 +9673,31 @@ public class ResourcePermissionPersistenceImpl
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_LikeP",
 			new String[] {Long.class.getName(), String.class.getName()},
 			new String[] {"companyId", "primKey"}, false);
+
+		_finderPathWithPaginationFindByC_N_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_N_S",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "name", "scope"}, true);
+
+		_finderPathWithoutPaginationFindByC_N_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_N_S",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {"companyId", "name", "scope"}, true);
+
+		_finderPathCountByC_N_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_N_S",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {"companyId", "name", "scope"}, false);
 
 		_finderPathWithPaginationFindByC_S_P = new FinderPath(
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_S_P",

--- a/portal-impl/src/com/liferay/portal/systemevent/SystemEventAdvice.java
+++ b/portal-impl/src/com/liferay/portal/systemevent/SystemEventAdvice.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.SystemEventLocalServiceUtil;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.systemevent.SystemEventHierarchyEntry;
 import com.liferay.portal.kernel.systemevent.SystemEventHierarchyEntryThreadLocal;
+import com.liferay.portal.kernel.util.BulkDeleteCacheThreadLocal;
 
 import java.io.Serializable;
 
@@ -44,6 +45,10 @@ public class SystemEventAdvice extends ChainableMethodAdvice {
 	public Object before(
 			AopMethodInvocation aopMethodInvocation, Object[] arguments)
 		throws Throwable {
+
+		if (BulkDeleteCacheThreadLocal.isBulkDeleteMode()) {
+			return null;
+		}
 
 		SystemEvent systemEvent = aopMethodInvocation.getAdviceMethodContext();
 
@@ -80,6 +85,10 @@ public class SystemEventAdvice extends ChainableMethodAdvice {
 			AopMethodInvocation aopMethodInvocation, Object[] arguments,
 			Object result)
 		throws Throwable {
+
+		if (BulkDeleteCacheThreadLocal.isBulkDeleteMode()) {
+			return;
+		}
 
 		SystemEvent systemEvent = aopMethodInvocation.getAdviceMethodContext();
 
@@ -145,6 +154,10 @@ public class SystemEventAdvice extends ChainableMethodAdvice {
 	@Override
 	protected void duringFinally(
 		AopMethodInvocation aopMethodInvocation, Object[] arguments) {
+
+		if (BulkDeleteCacheThreadLocal.isBulkDeleteMode()) {
+			return;
+		}
 
 		SystemEvent systemEvent = aopMethodInvocation.getAdviceMethodContext();
 

--- a/portal-impl/src/com/liferay/portal/systemevent/SystemEventAdvice.java
+++ b/portal-impl/src/com/liferay/portal/systemevent/SystemEventAdvice.java
@@ -30,7 +30,10 @@ import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author Zsolt Berentey
@@ -226,17 +229,25 @@ public class SystemEventAdvice extends ChainableMethodAdvice {
 			return stagedModel.getUuid();
 		}
 
+		Class<?> modelClass = classedModel.getClass();
+
+		String className = modelClass.getName();
+
+		if (_noUUIDClassNames.contains(className)) {
+			return StringPool.BLANK;
+		}
+
 		Method getUuidMethod = null;
 
 		try {
-			Class<?> modelClass = classedModel.getClass();
-
 			getUuidMethod = modelClass.getMethod("getUuid", new Class<?>[0]);
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {
 				_log.debug(exception);
 			}
+
+			_noUUIDClassNames.add(className);
 
 			return StringPool.BLANK;
 		}
@@ -319,5 +330,8 @@ public class SystemEventAdvice extends ChainableMethodAdvice {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		SystemEventAdvice.class);
+
+	private final Set<String> _noUUIDClassNames = Collections.newSetFromMap(
+		new ConcurrentHashMap<>());
 
 }

--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetEntryImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetEntryImpl.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.ClassNameLocalServiceUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.view.count.ViewCountManagerUtil;
+import com.liferay.portlet.asset.util.DeletedAssetObjectThreadLocal;
 
 import java.util.List;
 
@@ -29,6 +30,12 @@ public class AssetEntryImpl extends AssetEntryBaseImpl {
 
 	@Override
 	public AssetRenderer<?> getAssetRenderer() {
+		if (DeletedAssetObjectThreadLocal.isDeletedAssetObject(
+				getClassName(), getClassPK())) {
+
+			return null;
+		}
+
 		AssetRendererFactory<?> assetRendererFactory =
 			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(
 				getClassName());

--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetEntryImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetEntryImpl.java
@@ -31,7 +31,7 @@ public class AssetEntryImpl extends AssetEntryBaseImpl {
 	@Override
 	public AssetRenderer<?> getAssetRenderer() {
 		if (DeletedAssetObjectThreadLocal.isDeletedAssetObject(
-				getClassName(), getClassPK())) {
+				getClassNameId(), getClassPK())) {
 
 			return null;
 		}

--- a/portal-impl/src/com/liferay/portlet/asset/service.xml
+++ b/portal-impl/src/com/liferay/portlet/asset/service.xml
@@ -157,13 +157,13 @@
 			<finder-column name="groupId" />
 			<finder-column name="classUuid" />
 		</finder>
-		<finder name="C_C" return-type="AssetEntry" unique="true">
-			<finder-column name="classNameId" />
-			<finder-column name="classPK" />
-		</finder>
 		<finder name="C_CN" return-type="Collection">
 			<finder-column name="companyId" />
 			<finder-column name="classNameId" />
+		</finder>
+		<finder name="C_C" return-type="AssetEntry" unique="true">
+			<finder-column name="classNameId" />
+			<finder-column name="classPK" />
 		</finder>
 		<finder name="G_C_V" return-type="Collection">
 			<finder-column name="groupId" />

--- a/portal-impl/src/com/liferay/portlet/asset/service.xml
+++ b/portal-impl/src/com/liferay/portlet/asset/service.xml
@@ -161,6 +161,10 @@
 			<finder-column name="classNameId" />
 			<finder-column name="classPK" />
 		</finder>
+		<finder name="C_CN" return-type="Collection">
+			<finder-column name="companyId" />
+			<finder-column name="classNameId" />
+		</finder>
 		<finder name="G_C_V" return-type="Collection">
 			<finder-column name="groupId" />
 			<finder-column name="classNameId" />

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -25,6 +25,7 @@ import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.model.Group;
@@ -180,10 +181,20 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 			BulkDeleteCacheThreadLocal.getBulkDeleteCache(
 				AssetEntryLocalServiceImpl.class.getName() + ".deleteEntry#" +
 					classNameId,
-				() -> MapUtil.toPartitionMap(
-					assetEntryPersistence.findByC_CN(
-						CompanyThreadLocal.getCompanyId(), classNameId),
-					AssetEntry::getClassPK));
+				() -> {
+					Session session = assetEntryPersistence.openSession();
+
+					session.flush();
+
+					List<AssetEntry> assetEntries =
+						assetEntryPersistence.findByC_CN(
+							CompanyThreadLocal.getCompanyId(), classNameId);
+
+					session.clear();
+
+					return MapUtil.toPartitionMap(
+						assetEntries, AssetEntry::getClassPK);
+				});
 
 		if (partitionAssertEntries == null) {
 			AssetEntry entry = assetEntryPersistence.fetchByC_C(

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -19,6 +19,7 @@ import com.liferay.asset.kernel.validator.AssetEntryValidatorExclusionRule;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -57,6 +58,7 @@ import com.liferay.portal.kernel.view.count.ViewCountManagerUtil;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.asset.service.base.AssetEntryLocalServiceBaseImpl;
 import com.liferay.portlet.asset.service.permission.AssetCategoryPermission;
+import com.liferay.portlet.asset.util.DeletedAssetEntryThreadLocal;
 import com.liferay.social.kernel.model.SocialActivityConstants;
 import com.liferay.social.kernel.service.SocialActivityCounterLocalService;
 
@@ -103,7 +105,11 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 
 		// Social
 
-		SocialActivityManagerUtil.deleteActivities(entry);
+		try (SafeCloseable safeCloseable =
+				DeletedAssetEntryThreadLocal.setWithSafeCloseable(entry)) {
+
+			SocialActivityManagerUtil.deleteActivities(entry);
+		}
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -7,6 +7,7 @@ package com.liferay.portlet.asset.service.impl;
 
 import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
 import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetEntries_AssetTagsTable;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.model.AssetRenderer;
 import com.liferay.asset.kernel.model.AssetTag;
@@ -20,6 +21,7 @@ import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -37,6 +39,7 @@ import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
@@ -49,7 +52,9 @@ import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.BulkDeleteCacheThreadLocal;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.RenderLayoutContentThreadLocal;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -65,6 +70,7 @@ import com.liferay.social.kernel.service.SocialActivityCounterLocalService;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Provides the local service for accessing, deleting, updating, and validating
@@ -80,21 +86,49 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 	@SystemEvent(type = SystemEventConstants.TYPE_DELETE)
 	public void deleteEntry(AssetEntry entry) throws PortalException {
 
-		// Entry
-
-		List<AssetTag> tags = assetEntryPersistence.getAssetTags(
-			entry.getEntryId());
-
-		assetEntryPersistence.remove(entry);
-
 		// Tags
 
-		for (AssetTag tag : tags) {
-			if (entry.isVisible()) {
-				_assetTagLocalService.decrementAssetCount(
-					tag.getTagId(), entry.getClassNameId());
+		Map<Long, List<Object[]>> partitionAssetEntryAssetTagIds =
+			BulkDeleteCacheThreadLocal.getBulkDeleteCache(
+				AssetEntryLocalServiceImpl.class.getName() + ".deleteEntry",
+				() -> MapUtil.toPartitionMap(
+					dslQuery(
+						DSLQueryFactoryUtil.select(
+							AssetEntries_AssetTagsTable.INSTANCE.entryId,
+							AssetEntries_AssetTagsTable.INSTANCE.tagId
+						).from(
+							AssetEntries_AssetTagsTable.INSTANCE
+						).where(
+							AssetEntries_AssetTagsTable.INSTANCE.companyId.eq(
+								CompanyThreadLocal.getCompanyId())
+						)),
+					ids -> (Long)ids[0]));
+
+		if (partitionAssetEntryAssetTagIds == null) {
+			List<AssetTag> tags = assetEntryPersistence.getAssetTags(
+				entry.getEntryId());
+
+			for (AssetTag tag : tags) {
+				if (entry.isVisible()) {
+					_assetTagLocalService.decrementAssetCount(
+						tag.getTagId(), entry.getClassNameId());
+				}
 			}
 		}
+		else {
+			List<Object[]> assertEntryAssetTagIds =
+				partitionAssetEntryAssetTagIds.remove(entry.getEntryId());
+
+			if (assertEntryAssetTagIds != null) {
+				for (Object[] assetEntryAssetTag : assertEntryAssetTagIds) {
+					assetTagPersistence.remove((Long)assetEntryAssetTag[1]);
+				}
+			}
+		}
+
+		// Entry
+
+		assetEntryPersistence.remove(entry);
 
 		// View count
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -20,10 +20,15 @@ import com.liferay.asset.kernel.validator.AssetEntryValidatorExclusionRule;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.petra.lang.CentralizedThreadLocal;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanReference;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.DefaultActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -48,7 +53,6 @@ import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.persistence.GroupPersistence;
-import com.liferay.portal.kernel.service.persistence.LongPKRemoveFunction;
 import com.liferay.portal.kernel.social.SocialActivityManagerUtil;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.transaction.Propagation;
@@ -67,13 +71,17 @@ import com.liferay.portlet.asset.model.impl.AssetEntryModelImpl;
 import com.liferay.portlet.asset.service.base.AssetEntryLocalServiceBaseImpl;
 import com.liferay.portlet.asset.service.permission.AssetCategoryPermission;
 import com.liferay.portlet.asset.util.DeletedAssetEntryThreadLocal;
+import com.liferay.portlet.asset.util.DeletedAssetObjectThreadLocal;
 import com.liferay.social.kernel.model.SocialActivityConstants;
 import com.liferay.social.kernel.service.SocialActivityCounterLocalService;
+
+import java.sql.PreparedStatement;
 
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Provides the local service for accessing, deleting, updating, and validating
@@ -86,82 +94,105 @@ import java.util.Map;
 public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 
 	@Override
-	public void afterPropertiesSet() {
-		super.afterPropertiesSet();
+	public void deleteEntries(long companyId, String className)
+		throws PortalException {
 
-		_assetEntryLongPKRemoveFunction = new LongPKRemoveFunction<>(
-			assetEntryPersistence, AssetEntryModelImpl.TABLE_NAME, "entryId");
+		long classNameId = _classNameLocalService.getClassNameId(className);
+
+		ActionableDynamicQuery actionableDynamicQuery =
+			new DefaultActionableDynamicQuery() {
+
+				@Override
+				protected void actionsCompleted() throws PortalException {
+					Session session = assetEntryPersistence.openSession();
+
+					session.flush();
+
+					session.clear();
+				}
+
+				@Override
+				protected void intervalCompleted(
+						long startPrimaryKey, long endPrimaryKey)
+					throws PortalException {
+
+					Session session = assetEntryPersistence.openSession();
+
+					session.flush();
+
+					session.clear();
+				}
+
+			};
+
+		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setClassLoader(getClassLoader());
+		actionableDynamicQuery.setModelClass(AssetEntry.class);
+
+		actionableDynamicQuery.setPrimaryKeyPropertyName("entryId");
+
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property companyIdProperty = PropertyFactoryUtil.forName(
+					"companyId");
+
+				dynamicQuery.add(companyIdProperty.eq(companyId));
+
+				Property classNameIdProperty = PropertyFactoryUtil.forName(
+					"classNameId");
+
+				dynamicQuery.add(classNameIdProperty.eq(classNameId));
+			});
+
+		actionableDynamicQuery.setPerformActionMethod(
+			(AssetEntry assetEntry) -> {
+
+				// Must do aop service call to go through service wrappers
+
+				try (SafeCloseable safeCloseable =
+						DeletedAssetObjectThreadLocal.setWithSafeCloseable(
+							assetEntry.getClassName(),
+							assetEntry.getClassPK())) {
+
+					assetEntryLocalService.deleteEntry(assetEntry);
+				}
+			});
+
+		try (SafeCloseable safeCloseable1 =
+				_removeFunctionThreadLocal.setWithSafeCloseable(
+					Function.identity())) {
+
+			actionableDynamicQuery.performActions();
+		}
+
+		Session session = assetEntryPersistence.openSession();
+
+		try {
+			session.apply(
+				connection -> {
+					try (PreparedStatement preparedStatement =
+							connection.prepareStatement(_DELETE_BY_C_CN)) {
+
+						preparedStatement.setLong(1, companyId);
+						preparedStatement.setLong(2, classNameId);
+
+						int results = preparedStatement.executeUpdate();
+
+						if (results > 0) {
+							assetEntryPersistence.clearCache();
+						}
+					}
+				});
+		}
+		finally {
+			assetEntryPersistence.closeSession(session);
+		}
 	}
 
 	@Override
 	@SystemEvent(type = SystemEventConstants.TYPE_DELETE)
 	public AssetEntry deleteEntry(AssetEntry entry) throws PortalException {
-
-		// Tags
-
-		Map<Long, List<Object[]>> partitionAssetEntryAssetTagIds =
-			BulkDeleteCacheThreadLocal.getBulkDeleteCache(
-				AssetEntryLocalServiceImpl.class.getName() + ".deleteEntry",
-				() -> MapUtil.toPartitionMap(
-					dslQuery(
-						DSLQueryFactoryUtil.select(
-							AssetEntries_AssetTagsTable.INSTANCE.entryId,
-							AssetEntries_AssetTagsTable.INSTANCE.tagId
-						).from(
-							AssetEntries_AssetTagsTable.INSTANCE
-						).where(
-							AssetEntries_AssetTagsTable.INSTANCE.companyId.eq(
-								CompanyThreadLocal.getCompanyId())
-						)),
-					ids -> (Long)ids[0]));
-
-		if (partitionAssetEntryAssetTagIds == null) {
-			List<AssetTag> tags = assetEntryPersistence.getAssetTags(
-				entry.getEntryId());
-
-			for (AssetTag tag : tags) {
-				if (entry.isVisible()) {
-					_assetTagLocalService.decrementAssetCount(
-						tag.getTagId(), entry.getClassNameId());
-				}
-			}
-
-			// Entry
-
-			entry = assetEntryPersistence.remove(entry);
-		}
-		else {
-			List<Object[]> assertEntryAssetTagIds =
-				partitionAssetEntryAssetTagIds.remove(entry.getEntryId());
-
-			if (assertEntryAssetTagIds != null) {
-				for (Object[] assetEntryAssetTag : assertEntryAssetTagIds) {
-					assetTagPersistence.remove((Long)assetEntryAssetTag[1]);
-				}
-			}
-
-			// Entry
-
-			assetEntryPersistence.removeByFunction(
-				entry, _assetEntryLongPKRemoveFunction);
-		}
-
-		// View count
-
-		ViewCountManagerUtil.deleteViewCount(
-			entry.getCompanyId(),
-			_classNameLocalService.getClassNameId(AssetEntry.class),
-			entry.getEntryId());
-
-		// Social
-
-		try (SafeCloseable safeCloseable =
-				DeletedAssetEntryThreadLocal.setWithSafeCloseable(entry)) {
-
-			SocialActivityManagerUtil.deleteActivities(entry);
-		}
-
-		return entry;
+		return _deleteEntry(entry, _removeFunctionThreadLocal.get());
 	}
 
 	@Override
@@ -175,42 +206,11 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 	public AssetEntry deleteEntry(String className, long classPK)
 		throws PortalException {
 
-		long classNameId = _classNameLocalService.getClassNameId(className);
+		AssetEntry entry = assetEntryPersistence.fetchByC_C(
+			_classNameLocalService.getClassNameId(className), classPK);
 
-		Map<Long, List<AssetEntry>> partitionAssertEntries =
-			BulkDeleteCacheThreadLocal.getBulkDeleteCache(
-				AssetEntryLocalServiceImpl.class.getName() + ".deleteEntry#" +
-					classNameId,
-				() -> {
-					Session session = assetEntryPersistence.openSession();
-
-					session.flush();
-
-					List<AssetEntry> assetEntries =
-						assetEntryPersistence.findByC_CN(
-							CompanyThreadLocal.getCompanyId(), classNameId);
-
-					session.clear();
-
-					return MapUtil.toPartitionMap(
-						assetEntries, AssetEntry::getClassPK);
-				});
-
-		if (partitionAssertEntries == null) {
-			AssetEntry entry = assetEntryPersistence.fetchByC_C(
-				classNameId, classPK);
-
-			if (entry != null) {
-				return deleteEntry(entry);
-			}
-
-			return null;
-		}
-
-		List<AssetEntry> assetEntries = partitionAssertEntries.remove(classPK);
-
-		if (assetEntries != null) {
-			return deleteEntry(assetEntries.get(0));
+		if (entry != null) {
+			return deleteEntry(entry);
 		}
 
 		return null;
@@ -1323,6 +1323,81 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 		indexer.reindex(assetRenderer.getAssetObject());
 	}
 
+	private AssetEntry _deleteEntry(
+			AssetEntry entry, Function<AssetEntry, AssetEntry> removefunction)
+		throws PortalException {
+
+		// Tags
+
+		Map<Long, List<Object[]>> partitionAssetEntryAssetTagIds =
+			BulkDeleteCacheThreadLocal.getBulkDeleteCache(
+				AssetEntryLocalServiceImpl.class.getName() + ".deleteEntry",
+				() -> MapUtil.toPartitionMap(
+					dslQuery(
+						DSLQueryFactoryUtil.select(
+							AssetEntries_AssetTagsTable.INSTANCE.entryId,
+							AssetEntries_AssetTagsTable.INSTANCE.tagId
+						).from(
+							AssetEntries_AssetTagsTable.INSTANCE
+						).where(
+							AssetEntries_AssetTagsTable.INSTANCE.companyId.eq(
+								CompanyThreadLocal.getCompanyId())
+						)),
+					ids -> (Long)ids[0]));
+
+		if (partitionAssetEntryAssetTagIds == null) {
+			List<AssetTag> tags = assetEntryPersistence.getAssetTags(
+				entry.getEntryId());
+
+			for (AssetTag tag : tags) {
+				if (entry.isVisible()) {
+					_assetTagLocalService.decrementAssetCount(
+						tag.getTagId(), entry.getClassNameId());
+				}
+			}
+
+			// Entry
+
+			entry = assetEntryPersistence.remove(entry);
+		}
+		else {
+			List<Object[]> assertEntryAssetTagIds =
+				partitionAssetEntryAssetTagIds.remove(entry.getEntryId());
+
+			if (assertEntryAssetTagIds != null) {
+				for (Object[] assetEntryAssetTag : assertEntryAssetTagIds) {
+					assetTagPersistence.remove((Long)assetEntryAssetTag[1]);
+				}
+			}
+
+			// Entry
+
+			if (removefunction == null) {
+				assetEntryPersistence.remove(entry);
+			}
+			else {
+				assetEntryPersistence.removeByFunction(entry, removefunction);
+			}
+		}
+
+		// View count
+
+		ViewCountManagerUtil.deleteViewCount(
+			entry.getCompanyId(),
+			_classNameLocalService.getClassNameId(AssetEntry.class),
+			entry.getEntryId());
+
+		// Social
+
+		try (SafeCloseable safeCloseable =
+				DeletedAssetEntryThreadLocal.setWithSafeCloseable(entry)) {
+
+			SocialActivityManagerUtil.deleteActivities(entry);
+		}
+
+		return entry;
+	}
+
 	private List<AssetEntryValidator> _getAssetEntryValidators(
 		String className) {
 
@@ -1394,10 +1469,19 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 		}
 	}
 
+	private static final String _DELETE_BY_C_CN =
+		"delete from " + AssetEntryModelImpl.TABLE_NAME +
+			" where companyId = ? and classNameId = ?";
+
+	private static final CentralizedThreadLocal
+		<Function<AssetEntry, AssetEntry>> _removeFunctionThreadLocal =
+			new CentralizedThreadLocal<>(
+				AssetEntryLocalServiceImpl.class.getName() +
+					"._removeFunctionThreadLocal");
+
 	@BeanReference(type = AssetCategoryLocalService.class)
 	private AssetCategoryLocalService _assetCategoryLocalService;
 
-	private LongPKRemoveFunction<AssetEntry> _assetEntryLongPKRemoveFunction;
 	private final ServiceTrackerMap
 		<String, List<AssetEntryValidatorExclusionRule>>
 			_assetEntryValidatorExclusionRuleServiceTrackerMap =

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -47,6 +47,7 @@ import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.persistence.GroupPersistence;
+import com.liferay.portal.kernel.service.persistence.LongPKRemoveFunction;
 import com.liferay.portal.kernel.social.SocialActivityManagerUtil;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.transaction.Propagation;
@@ -61,6 +62,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.view.count.ViewCountManagerUtil;
 import com.liferay.portal.util.PropsValues;
+import com.liferay.portlet.asset.model.impl.AssetEntryModelImpl;
 import com.liferay.portlet.asset.service.base.AssetEntryLocalServiceBaseImpl;
 import com.liferay.portlet.asset.service.permission.AssetCategoryPermission;
 import com.liferay.portlet.asset.util.DeletedAssetEntryThreadLocal;
@@ -81,6 +83,14 @@ import java.util.Map;
  * @author Zsolt Berentey
  */
 public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
+
+	@Override
+	public void afterPropertiesSet() {
+		super.afterPropertiesSet();
+
+		_assetEntryLongPKRemoveFunction = new LongPKRemoveFunction<>(
+			assetEntryPersistence, AssetEntryModelImpl.TABLE_NAME, "entryId");
+	}
 
 	@Override
 	@SystemEvent(type = SystemEventConstants.TYPE_DELETE)
@@ -114,6 +124,10 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 						tag.getTagId(), entry.getClassNameId());
 				}
 			}
+
+			// Entry
+
+			assetEntryPersistence.remove(entry);
 		}
 		else {
 			List<Object[]> assertEntryAssetTagIds =
@@ -124,11 +138,12 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 					assetTagPersistence.remove((Long)assetEntryAssetTag[1]);
 				}
 			}
+
+			// Entry
+
+			assetEntryPersistence.removeByFunction(
+				entry, _assetEntryLongPKRemoveFunction);
 		}
-
-		// Entry
-
-		assetEntryPersistence.remove(entry);
 
 		// View count
 
@@ -1346,6 +1361,7 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 	@BeanReference(type = AssetCategoryLocalService.class)
 	private AssetCategoryLocalService _assetCategoryLocalService;
 
+	private LongPKRemoveFunction<AssetEntry> _assetEntryLongPKRemoveFunction;
 	private final ServiceTrackerMap
 		<String, List<AssetEntryValidatorExclusionRule>>
 			_assetEntryValidatorExclusionRuleServiceTrackerMap =

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -94,7 +94,7 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 
 	@Override
 	@SystemEvent(type = SystemEventConstants.TYPE_DELETE)
-	public void deleteEntry(AssetEntry entry) throws PortalException {
+	public AssetEntry deleteEntry(AssetEntry entry) throws PortalException {
 
 		// Tags
 
@@ -127,7 +127,7 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 
 			// Entry
 
-			assetEntryPersistence.remove(entry);
+			entry = assetEntryPersistence.remove(entry);
 		}
 		else {
 			List<Object[]> assertEntryAssetTagIds =
@@ -159,25 +159,29 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 
 			SocialActivityManagerUtil.deleteActivities(entry);
 		}
+
+		return entry;
 	}
 
 	@Override
-	public void deleteEntry(long entryId) throws PortalException {
+	public AssetEntry deleteEntry(long entryId) throws PortalException {
 		AssetEntry entry = assetEntryPersistence.findByPrimaryKey(entryId);
 
-		deleteEntry(entry);
+		return deleteEntry(entry);
 	}
 
 	@Override
-	public void deleteEntry(String className, long classPK)
+	public AssetEntry deleteEntry(String className, long classPK)
 		throws PortalException {
 
 		AssetEntry entry = assetEntryPersistence.fetchByC_C(
 			_classNameLocalService.getClassNameId(className), classPK);
 
 		if (entry != null) {
-			deleteEntry(entry);
+			return deleteEntry(entry);
 		}
+
+		return null;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -174,11 +174,32 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 	public AssetEntry deleteEntry(String className, long classPK)
 		throws PortalException {
 
-		AssetEntry entry = assetEntryPersistence.fetchByC_C(
-			_classNameLocalService.getClassNameId(className), classPK);
+		long classNameId = _classNameLocalService.getClassNameId(className);
 
-		if (entry != null) {
-			return deleteEntry(entry);
+		Map<Long, List<AssetEntry>> partitionAssertEntries =
+			BulkDeleteCacheThreadLocal.getBulkDeleteCache(
+				AssetEntryLocalServiceImpl.class.getName() + ".deleteEntry#" +
+					classNameId,
+				() -> MapUtil.toPartitionMap(
+					assetEntryPersistence.findByC_CN(
+						CompanyThreadLocal.getCompanyId(), classNameId),
+					AssetEntry::getClassPK));
+
+		if (partitionAssertEntries == null) {
+			AssetEntry entry = assetEntryPersistence.fetchByC_C(
+				classNameId, classPK);
+
+			if (entry != null) {
+				return deleteEntry(entry);
+			}
+
+			return null;
+		}
+
+		List<AssetEntry> assetEntries = partitionAssertEntries.remove(classPK);
+
+		if (assetEntries != null) {
+			return deleteEntry(assetEntries.get(0));
 		}
 
 		return null;

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -151,7 +151,7 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 
 				try (SafeCloseable safeCloseable =
 						DeletedAssetObjectThreadLocal.setWithSafeCloseable(
-							assetEntry.getClassName(),
+							assetEntry.getClassNameId(),
 							assetEntry.getClassPK())) {
 
 					assetEntryLocalService.deleteEntry(assetEntry);

--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetEntryPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetEntryPersistenceImpl.java
@@ -3530,6 +3530,556 @@ public class AssetEntryPersistenceImpl
 	private static final String _FINDER_COLUMN_G_CU_CLASSUUID_3 =
 		"(assetEntry.classUuid IS NULL OR assetEntry.classUuid = '')";
 
+	private FinderPath _finderPathWithPaginationFindByC_CN;
+	private FinderPath _finderPathWithoutPaginationFindByC_CN;
+	private FinderPath _finderPathCountByC_CN;
+
+	/**
+	 * Returns all the asset entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @return the matching asset entries
+	 */
+	@Override
+	public List<AssetEntry> findByC_CN(long companyId, long classNameId) {
+		return findByC_CN(
+			companyId, classNameId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the asset entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of asset entries
+	 * @param end the upper bound of the range of asset entries (not inclusive)
+	 * @return the range of matching asset entries
+	 */
+	@Override
+	public List<AssetEntry> findByC_CN(
+		long companyId, long classNameId, int start, int end) {
+
+		return findByC_CN(companyId, classNameId, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the asset entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of asset entries
+	 * @param end the upper bound of the range of asset entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching asset entries
+	 */
+	@Override
+	public List<AssetEntry> findByC_CN(
+		long companyId, long classNameId, int start, int end,
+		OrderByComparator<AssetEntry> orderByComparator) {
+
+		return findByC_CN(
+			companyId, classNameId, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the asset entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of asset entries
+	 * @param end the upper bound of the range of asset entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching asset entries
+	 */
+	@Override
+	public List<AssetEntry> findByC_CN(
+		long companyId, long classNameId, int start, int end,
+		OrderByComparator<AssetEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		try (SafeCloseable safeCloseable =
+				CTPersistenceHelperUtil.setCTCollectionIdWithSafeCloseable(
+					AssetEntry.class)) {
+
+			FinderPath finderPath = null;
+			Object[] finderArgs = null;
+
+			if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+				(orderByComparator == null)) {
+
+				if (useFinderCache) {
+					finderPath = _finderPathWithoutPaginationFindByC_CN;
+					finderArgs = new Object[] {companyId, classNameId};
+				}
+			}
+			else if (useFinderCache) {
+				finderPath = _finderPathWithPaginationFindByC_CN;
+				finderArgs = new Object[] {
+					companyId, classNameId, start, end, orderByComparator
+				};
+			}
+
+			List<AssetEntry> list = null;
+
+			if (useFinderCache) {
+				list = (List<AssetEntry>)FinderCacheUtil.getResult(
+					finderPath, finderArgs, this);
+
+				if ((list != null) && !list.isEmpty()) {
+					for (AssetEntry assetEntry : list) {
+						if ((companyId != assetEntry.getCompanyId()) ||
+							(classNameId != assetEntry.getClassNameId())) {
+
+							list = null;
+
+							break;
+						}
+					}
+				}
+			}
+
+			if (list == null) {
+				StringBundler sb = null;
+
+				if (orderByComparator != null) {
+					sb = new StringBundler(
+						4 + (orderByComparator.getOrderByFields().length * 2));
+				}
+				else {
+					sb = new StringBundler(4);
+				}
+
+				sb.append(_SQL_SELECT_ASSETENTRY_WHERE);
+
+				sb.append(_FINDER_COLUMN_C_CN_COMPANYID_2);
+
+				sb.append(_FINDER_COLUMN_C_CN_CLASSNAMEID_2);
+
+				if (orderByComparator != null) {
+					appendOrderByComparator(
+						sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+				}
+				else {
+					sb.append(AssetEntryModelImpl.ORDER_BY_JPQL);
+				}
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(companyId);
+
+					queryPos.add(classNameId);
+
+					list = (List<AssetEntry>)QueryUtil.list(
+						query, getDialect(), start, end);
+
+					cacheResult(list);
+
+					if (useFinderCache) {
+						FinderCacheUtil.putResult(finderPath, finderArgs, list);
+					}
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return list;
+		}
+	}
+
+	/**
+	 * Returns the first asset entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset entry
+	 * @throws NoSuchEntryException if a matching asset entry could not be found
+	 */
+	@Override
+	public AssetEntry findByC_CN_First(
+			long companyId, long classNameId,
+			OrderByComparator<AssetEntry> orderByComparator)
+		throws NoSuchEntryException {
+
+		AssetEntry assetEntry = fetchByC_CN_First(
+			companyId, classNameId, orderByComparator);
+
+		if (assetEntry != null) {
+			return assetEntry;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("companyId=");
+		sb.append(companyId);
+
+		sb.append(", classNameId=");
+		sb.append(classNameId);
+
+		sb.append("}");
+
+		throw new NoSuchEntryException(sb.toString());
+	}
+
+	/**
+	 * Returns the first asset entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset entry, or <code>null</code> if a matching asset entry could not be found
+	 */
+	@Override
+	public AssetEntry fetchByC_CN_First(
+		long companyId, long classNameId,
+		OrderByComparator<AssetEntry> orderByComparator) {
+
+		List<AssetEntry> list = findByC_CN(
+			companyId, classNameId, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last asset entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset entry
+	 * @throws NoSuchEntryException if a matching asset entry could not be found
+	 */
+	@Override
+	public AssetEntry findByC_CN_Last(
+			long companyId, long classNameId,
+			OrderByComparator<AssetEntry> orderByComparator)
+		throws NoSuchEntryException {
+
+		AssetEntry assetEntry = fetchByC_CN_Last(
+			companyId, classNameId, orderByComparator);
+
+		if (assetEntry != null) {
+			return assetEntry;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("companyId=");
+		sb.append(companyId);
+
+		sb.append(", classNameId=");
+		sb.append(classNameId);
+
+		sb.append("}");
+
+		throw new NoSuchEntryException(sb.toString());
+	}
+
+	/**
+	 * Returns the last asset entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset entry, or <code>null</code> if a matching asset entry could not be found
+	 */
+	@Override
+	public AssetEntry fetchByC_CN_Last(
+		long companyId, long classNameId,
+		OrderByComparator<AssetEntry> orderByComparator) {
+
+		int count = countByC_CN(companyId, classNameId);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<AssetEntry> list = findByC_CN(
+			companyId, classNameId, count - 1, count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the asset entries before and after the current asset entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param entryId the primary key of the current asset entry
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next asset entry
+	 * @throws NoSuchEntryException if a asset entry with the primary key could not be found
+	 */
+	@Override
+	public AssetEntry[] findByC_CN_PrevAndNext(
+			long entryId, long companyId, long classNameId,
+			OrderByComparator<AssetEntry> orderByComparator)
+		throws NoSuchEntryException {
+
+		AssetEntry assetEntry = findByPrimaryKey(entryId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			AssetEntry[] array = new AssetEntryImpl[3];
+
+			array[0] = getByC_CN_PrevAndNext(
+				session, assetEntry, companyId, classNameId, orderByComparator,
+				true);
+
+			array[1] = assetEntry;
+
+			array[2] = getByC_CN_PrevAndNext(
+				session, assetEntry, companyId, classNameId, orderByComparator,
+				false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected AssetEntry getByC_CN_PrevAndNext(
+		Session session, AssetEntry assetEntry, long companyId,
+		long classNameId, OrderByComparator<AssetEntry> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				5 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(4);
+		}
+
+		sb.append(_SQL_SELECT_ASSETENTRY_WHERE);
+
+		sb.append(_FINDER_COLUMN_C_CN_COMPANYID_2);
+
+		sb.append(_FINDER_COLUMN_C_CN_CLASSNAMEID_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(AssetEntryModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(companyId);
+
+		queryPos.add(classNameId);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(assetEntry)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<AssetEntry> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the asset entries where companyId = &#63; and classNameId = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 */
+	@Override
+	public void removeByC_CN(long companyId, long classNameId) {
+		for (AssetEntry assetEntry :
+				findByC_CN(
+					companyId, classNameId, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null)) {
+
+			remove(assetEntry);
+		}
+	}
+
+	/**
+	 * Returns the number of asset entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @return the number of matching asset entries
+	 */
+	@Override
+	public int countByC_CN(long companyId, long classNameId) {
+		try (SafeCloseable safeCloseable =
+				CTPersistenceHelperUtil.setCTCollectionIdWithSafeCloseable(
+					AssetEntry.class)) {
+
+			FinderPath finderPath = _finderPathCountByC_CN;
+
+			Object[] finderArgs = new Object[] {companyId, classNameId};
+
+			Long count = (Long)FinderCacheUtil.getResult(
+				finderPath, finderArgs, this);
+
+			if (count == null) {
+				StringBundler sb = new StringBundler(3);
+
+				sb.append(_SQL_COUNT_ASSETENTRY_WHERE);
+
+				sb.append(_FINDER_COLUMN_C_CN_COMPANYID_2);
+
+				sb.append(_FINDER_COLUMN_C_CN_CLASSNAMEID_2);
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(companyId);
+
+					queryPos.add(classNameId);
+
+					count = (Long)query.uniqueResult();
+
+					FinderCacheUtil.putResult(finderPath, finderArgs, count);
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return count.intValue();
+		}
+	}
+
+	private static final String _FINDER_COLUMN_C_CN_COMPANYID_2 =
+		"assetEntry.companyId = ? AND ";
+
+	private static final String _FINDER_COLUMN_C_CN_CLASSNAMEID_2 =
+		"assetEntry.classNameId = ?";
+
 	private FinderPath _finderPathFetchByC_C;
 	private FinderPath _finderPathCountByC_C;
 
@@ -6373,6 +6923,25 @@ public class AssetEntryPersistenceImpl
 			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_CU",
 			new String[] {Long.class.getName(), String.class.getName()},
 			new String[] {"groupId", "classUuid"}, false);
+
+		_finderPathWithPaginationFindByC_CN = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_CN",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId"}, true);
+
+		_finderPathWithoutPaginationFindByC_CN = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_CN",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "classNameId"}, true);
+
+		_finderPathCountByC_CN = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_CN",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "classNameId"}, false);
 
 		_finderPathFetchByC_C = new FinderPath(
 			FINDER_CLASS_NAME_ENTITY, "fetchByC_C",

--- a/portal-impl/src/com/liferay/portlet/asset/util/DeletedAssetEntryThreadLocal.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/DeletedAssetEntryThreadLocal.java
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portlet.asset.util;
+
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.petra.lang.CentralizedThreadLocal;
+import com.liferay.petra.lang.SafeCloseable;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class DeletedAssetEntryThreadLocal {
+
+	public static boolean isDeletedAssetEntry(long classNameId, long classPK) {
+		AssetEntry assetEntry = _assetEntryThreadLocal.get();
+
+		if (assetEntry == null) {
+			return false;
+		}
+
+		if ((assetEntry.getClassNameId() == classNameId) &&
+			(assetEntry.getClassPK() == classPK)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	public static SafeCloseable setWithSafeCloseable(AssetEntry assetEntry) {
+		return _assetEntryThreadLocal.setWithSafeCloseable(assetEntry);
+	}
+
+	private static final CentralizedThreadLocal<AssetEntry>
+		_assetEntryThreadLocal = new CentralizedThreadLocal<>(
+			DeletedAssetEntryThreadLocal.class + "._assetEntryThreadLocal");
+
+}

--- a/portal-impl/src/com/liferay/portlet/asset/util/DeletedAssetObjectThreadLocal.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/DeletedAssetObjectThreadLocal.java
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portlet.asset.util;
+
+import com.liferay.petra.lang.CentralizedThreadLocal;
+import com.liferay.petra.lang.SafeCloseable;
+
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class DeletedAssetObjectThreadLocal {
+
+	public static boolean isDeletedAssetObject(String className, long classPK) {
+		Map.Entry<String, Long> entry = _assetObjectThreadLocal.get();
+
+		if (entry == null) {
+			return false;
+		}
+
+		if (Objects.equals(entry.getKey(), className) &&
+			(entry.getValue() == classPK)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	public static SafeCloseable setWithSafeCloseable(
+		String className, long classPK) {
+
+		return _assetObjectThreadLocal.setWithSafeCloseable(
+			new AbstractMap.SimpleImmutableEntry<>(className, classPK));
+	}
+
+	private static final CentralizedThreadLocal<Map.Entry<String, Long>>
+		_assetObjectThreadLocal = new CentralizedThreadLocal<>(
+			DeletedAssetObjectThreadLocal.class + "._assetObjectThreadLocal");
+
+}

--- a/portal-impl/src/com/liferay/portlet/asset/util/DeletedAssetObjectThreadLocal.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/DeletedAssetObjectThreadLocal.java
@@ -17,14 +17,14 @@ import java.util.Objects;
  */
 public class DeletedAssetObjectThreadLocal {
 
-	public static boolean isDeletedAssetObject(String className, long classPK) {
-		Map.Entry<String, Long> entry = _assetObjectThreadLocal.get();
+	public static boolean isDeletedAssetObject(long classNameId, long classPK) {
+		Map.Entry<Long, Long> entry = _assetObjectThreadLocal.get();
 
 		if (entry == null) {
 			return false;
 		}
 
-		if (Objects.equals(entry.getKey(), className) &&
+		if (Objects.equals(entry.getKey(), classNameId) &&
 			(entry.getValue() == classPK)) {
 
 			return true;
@@ -34,13 +34,13 @@ public class DeletedAssetObjectThreadLocal {
 	}
 
 	public static SafeCloseable setWithSafeCloseable(
-		String className, long classPK) {
+		long classNameId, long classPK) {
 
 		return _assetObjectThreadLocal.setWithSafeCloseable(
-			new AbstractMap.SimpleImmutableEntry<>(className, classPK));
+			new AbstractMap.SimpleImmutableEntry<>(classNameId, classPK));
 	}
 
-	private static final CentralizedThreadLocal<Map.Entry<String, Long>>
+	private static final CentralizedThreadLocal<Map.Entry<Long, Long>>
 		_assetObjectThreadLocal = new CentralizedThreadLocal<>(
 			DeletedAssetObjectThreadLocal.class + "._assetObjectThreadLocal");
 

--- a/portal-impl/src/com/liferay/portlet/asset/util/packageinfo
+++ b/portal-impl/src/com/liferay/portlet/asset/util/packageinfo
@@ -1,1 +1,1 @@
-version 5.2.0
+version 5.3.0

--- a/portal-impl/src/com/liferay/portlet/social/service.xml
+++ b/portal-impl/src/com/liferay/portlet/social/service.xml
@@ -57,6 +57,10 @@
 		<finder name="ReceiverUserId" return-type="Collection">
 			<finder-column name="receiverUserId" />
 		</finder>
+		<finder name="C_CN" return-type="Collection">
+			<finder-column name="companyId" />
+			<finder-column name="classNameId" />
+		</finder>
 		<finder name="C_C" return-type="Collection">
 			<finder-column name="classNameId" />
 			<finder-column name="classPK" />

--- a/portal-impl/src/com/liferay/portlet/social/service/impl/SocialActivityLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/service/impl/SocialActivityLocalServiceImpl.java
@@ -28,6 +28,8 @@ import com.liferay.portal.kernel.service.persistence.UserPersistence;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.util.BulkDeleteCacheThreadLocal;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portlet.asset.util.DeletedAssetEntryThreadLocal;
 import com.liferay.portlet.social.service.base.SocialActivityLocalServiceBaseImpl;
 import com.liferay.portlet.social.util.SocialActivityHierarchyEntry;
 import com.liferay.portlet.social.util.SocialActivityHierarchyEntryThreadLocal;
@@ -1176,8 +1178,15 @@ public class SocialActivityLocalServiceImpl
 			}
 		}
 
-		_socialActivityCounterLocalService.deleteActivityCounters(
-			classNameId, classPK);
+		String className = PortalUtil.getClassName(classNameId);
+
+		if (!className.equals(User.class.getName()) &&
+			!DeletedAssetEntryThreadLocal.isDeletedAssetEntry(
+				classNameId, classPK)) {
+
+			_socialActivityCounterLocalService.deleteActivityCounters(
+				classNameId, classPK);
+		}
 	}
 
 	protected boolean isLogActivity(SocialActivity activity) {

--- a/portal-impl/src/com/liferay/portlet/social/service/impl/SocialActivityLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/service/impl/SocialActivityLocalServiceImpl.java
@@ -20,11 +20,14 @@ import com.liferay.portal.kernel.messaging.async.Async;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.persistence.UserPersistence;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.util.BulkDeleteCacheThreadLocal;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portlet.social.service.base.SocialActivityLocalServiceBaseImpl;
 import com.liferay.portlet.social.util.SocialActivityHierarchyEntry;
 import com.liferay.portlet.social.util.SocialActivityHierarchyEntryThreadLocal;
@@ -43,6 +46,7 @@ import com.liferay.social.kernel.service.persistence.SocialActivitySettingPersis
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 
 /**
@@ -1143,10 +1147,34 @@ public class SocialActivityLocalServiceImpl
 	protected void deleteActivities(long classNameId, long classPK)
 		throws PortalException {
 
-		_socialActivitySetLocalService.decrementActivityCount(
-			classNameId, classPK);
+		Map<Long, List<SocialActivity>> partitionSocialActivities =
+			BulkDeleteCacheThreadLocal.getBulkDeleteCache(
+				SocialActivityLocalServiceImpl.class.getName() +
+					".deleteActivities#" + classNameId,
+				() -> MapUtil.toPartitionMap(
+					socialActivityPersistence.findByC_CN(
+						CompanyThreadLocal.getCompanyId(), classNameId),
+					SocialActivity::getClassPK));
 
-		socialActivityPersistence.removeByC_C(classNameId, classPK);
+		if (partitionSocialActivities == null) {
+			_socialActivitySetLocalService.decrementActivityCount(
+				classNameId, classPK);
+
+			socialActivityPersistence.removeByC_C(classNameId, classPK);
+		}
+		else {
+			List<SocialActivity> socialActivities =
+				partitionSocialActivities.remove(classPK);
+
+			if (socialActivities != null) {
+				for (SocialActivity socialActivity : socialActivities) {
+					_socialActivitySetLocalService.decrementActivityCount(
+						classNameId, classPK);
+
+					socialActivityPersistence.remove(socialActivity);
+				}
+			}
+		}
 
 		_socialActivityCounterLocalService.deleteActivityCounters(
 			classNameId, classPK);

--- a/portal-impl/src/com/liferay/portlet/social/service/impl/SocialActivityLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/service/impl/SocialActivityLocalServiceImpl.java
@@ -49,6 +49,7 @@ import com.liferay.social.kernel.service.persistence.SocialActivitySettingPersis
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 
 /**
@@ -1178,11 +1179,10 @@ public class SocialActivityLocalServiceImpl
 			}
 		}
 
-		String className = PortalUtil.getClassName(classNameId);
-
-		if (!className.equals(User.class.getName()) &&
-			!DeletedAssetEntryThreadLocal.isDeletedAssetEntry(
-				classNameId, classPK)) {
+		if (!DeletedAssetEntryThreadLocal.isDeletedAssetEntry(
+				classNameId, classPK) &&
+			!Objects.equals(
+				User.class.getName(), PortalUtil.getClassName(classNameId))) {
 
 			_socialActivityCounterLocalService.deleteActivityCounters(
 				classNameId, classPK);

--- a/portal-impl/src/com/liferay/portlet/social/service/persistence/impl/SocialActivityPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/service/persistence/impl/SocialActivityPersistenceImpl.java
@@ -2872,6 +2872,557 @@ public class SocialActivityPersistenceImpl
 	private static final String _FINDER_COLUMN_RECEIVERUSERID_RECEIVERUSERID_2 =
 		"socialActivity.receiverUserId = ?";
 
+	private FinderPath _finderPathWithPaginationFindByC_CN;
+	private FinderPath _finderPathWithoutPaginationFindByC_CN;
+	private FinderPath _finderPathCountByC_CN;
+
+	/**
+	 * Returns all the social activities where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @return the matching social activities
+	 */
+	@Override
+	public List<SocialActivity> findByC_CN(long companyId, long classNameId) {
+		return findByC_CN(
+			companyId, classNameId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the social activities where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SocialActivityModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of social activities
+	 * @param end the upper bound of the range of social activities (not inclusive)
+	 * @return the range of matching social activities
+	 */
+	@Override
+	public List<SocialActivity> findByC_CN(
+		long companyId, long classNameId, int start, int end) {
+
+		return findByC_CN(companyId, classNameId, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the social activities where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SocialActivityModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of social activities
+	 * @param end the upper bound of the range of social activities (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching social activities
+	 */
+	@Override
+	public List<SocialActivity> findByC_CN(
+		long companyId, long classNameId, int start, int end,
+		OrderByComparator<SocialActivity> orderByComparator) {
+
+		return findByC_CN(
+			companyId, classNameId, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the social activities where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SocialActivityModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of social activities
+	 * @param end the upper bound of the range of social activities (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching social activities
+	 */
+	@Override
+	public List<SocialActivity> findByC_CN(
+		long companyId, long classNameId, int start, int end,
+		OrderByComparator<SocialActivity> orderByComparator,
+		boolean useFinderCache) {
+
+		try (SafeCloseable safeCloseable =
+				CTPersistenceHelperUtil.setCTCollectionIdWithSafeCloseable(
+					SocialActivity.class)) {
+
+			FinderPath finderPath = null;
+			Object[] finderArgs = null;
+
+			if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+				(orderByComparator == null)) {
+
+				if (useFinderCache) {
+					finderPath = _finderPathWithoutPaginationFindByC_CN;
+					finderArgs = new Object[] {companyId, classNameId};
+				}
+			}
+			else if (useFinderCache) {
+				finderPath = _finderPathWithPaginationFindByC_CN;
+				finderArgs = new Object[] {
+					companyId, classNameId, start, end, orderByComparator
+				};
+			}
+
+			List<SocialActivity> list = null;
+
+			if (useFinderCache) {
+				list = (List<SocialActivity>)FinderCacheUtil.getResult(
+					finderPath, finderArgs, this);
+
+				if ((list != null) && !list.isEmpty()) {
+					for (SocialActivity socialActivity : list) {
+						if ((companyId != socialActivity.getCompanyId()) ||
+							(classNameId != socialActivity.getClassNameId())) {
+
+							list = null;
+
+							break;
+						}
+					}
+				}
+			}
+
+			if (list == null) {
+				StringBundler sb = null;
+
+				if (orderByComparator != null) {
+					sb = new StringBundler(
+						4 + (orderByComparator.getOrderByFields().length * 2));
+				}
+				else {
+					sb = new StringBundler(4);
+				}
+
+				sb.append(_SQL_SELECT_SOCIALACTIVITY_WHERE);
+
+				sb.append(_FINDER_COLUMN_C_CN_COMPANYID_2);
+
+				sb.append(_FINDER_COLUMN_C_CN_CLASSNAMEID_2);
+
+				if (orderByComparator != null) {
+					appendOrderByComparator(
+						sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+				}
+				else {
+					sb.append(SocialActivityModelImpl.ORDER_BY_JPQL);
+				}
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(companyId);
+
+					queryPos.add(classNameId);
+
+					list = (List<SocialActivity>)QueryUtil.list(
+						query, getDialect(), start, end);
+
+					cacheResult(list);
+
+					if (useFinderCache) {
+						FinderCacheUtil.putResult(finderPath, finderArgs, list);
+					}
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return list;
+		}
+	}
+
+	/**
+	 * Returns the first social activity in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching social activity
+	 * @throws NoSuchActivityException if a matching social activity could not be found
+	 */
+	@Override
+	public SocialActivity findByC_CN_First(
+			long companyId, long classNameId,
+			OrderByComparator<SocialActivity> orderByComparator)
+		throws NoSuchActivityException {
+
+		SocialActivity socialActivity = fetchByC_CN_First(
+			companyId, classNameId, orderByComparator);
+
+		if (socialActivity != null) {
+			return socialActivity;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("companyId=");
+		sb.append(companyId);
+
+		sb.append(", classNameId=");
+		sb.append(classNameId);
+
+		sb.append("}");
+
+		throw new NoSuchActivityException(sb.toString());
+	}
+
+	/**
+	 * Returns the first social activity in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching social activity, or <code>null</code> if a matching social activity could not be found
+	 */
+	@Override
+	public SocialActivity fetchByC_CN_First(
+		long companyId, long classNameId,
+		OrderByComparator<SocialActivity> orderByComparator) {
+
+		List<SocialActivity> list = findByC_CN(
+			companyId, classNameId, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last social activity in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching social activity
+	 * @throws NoSuchActivityException if a matching social activity could not be found
+	 */
+	@Override
+	public SocialActivity findByC_CN_Last(
+			long companyId, long classNameId,
+			OrderByComparator<SocialActivity> orderByComparator)
+		throws NoSuchActivityException {
+
+		SocialActivity socialActivity = fetchByC_CN_Last(
+			companyId, classNameId, orderByComparator);
+
+		if (socialActivity != null) {
+			return socialActivity;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("companyId=");
+		sb.append(companyId);
+
+		sb.append(", classNameId=");
+		sb.append(classNameId);
+
+		sb.append("}");
+
+		throw new NoSuchActivityException(sb.toString());
+	}
+
+	/**
+	 * Returns the last social activity in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching social activity, or <code>null</code> if a matching social activity could not be found
+	 */
+	@Override
+	public SocialActivity fetchByC_CN_Last(
+		long companyId, long classNameId,
+		OrderByComparator<SocialActivity> orderByComparator) {
+
+		int count = countByC_CN(companyId, classNameId);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<SocialActivity> list = findByC_CN(
+			companyId, classNameId, count - 1, count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the social activities before and after the current social activity in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param activityId the primary key of the current social activity
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next social activity
+	 * @throws NoSuchActivityException if a social activity with the primary key could not be found
+	 */
+	@Override
+	public SocialActivity[] findByC_CN_PrevAndNext(
+			long activityId, long companyId, long classNameId,
+			OrderByComparator<SocialActivity> orderByComparator)
+		throws NoSuchActivityException {
+
+		SocialActivity socialActivity = findByPrimaryKey(activityId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SocialActivity[] array = new SocialActivityImpl[3];
+
+			array[0] = getByC_CN_PrevAndNext(
+				session, socialActivity, companyId, classNameId,
+				orderByComparator, true);
+
+			array[1] = socialActivity;
+
+			array[2] = getByC_CN_PrevAndNext(
+				session, socialActivity, companyId, classNameId,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected SocialActivity getByC_CN_PrevAndNext(
+		Session session, SocialActivity socialActivity, long companyId,
+		long classNameId, OrderByComparator<SocialActivity> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				5 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(4);
+		}
+
+		sb.append(_SQL_SELECT_SOCIALACTIVITY_WHERE);
+
+		sb.append(_FINDER_COLUMN_C_CN_COMPANYID_2);
+
+		sb.append(_FINDER_COLUMN_C_CN_CLASSNAMEID_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(SocialActivityModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(companyId);
+
+		queryPos.add(classNameId);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						socialActivity)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<SocialActivity> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the social activities where companyId = &#63; and classNameId = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 */
+	@Override
+	public void removeByC_CN(long companyId, long classNameId) {
+		for (SocialActivity socialActivity :
+				findByC_CN(
+					companyId, classNameId, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null)) {
+
+			remove(socialActivity);
+		}
+	}
+
+	/**
+	 * Returns the number of social activities where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @return the number of matching social activities
+	 */
+	@Override
+	public int countByC_CN(long companyId, long classNameId) {
+		try (SafeCloseable safeCloseable =
+				CTPersistenceHelperUtil.setCTCollectionIdWithSafeCloseable(
+					SocialActivity.class)) {
+
+			FinderPath finderPath = _finderPathCountByC_CN;
+
+			Object[] finderArgs = new Object[] {companyId, classNameId};
+
+			Long count = (Long)FinderCacheUtil.getResult(
+				finderPath, finderArgs, this);
+
+			if (count == null) {
+				StringBundler sb = new StringBundler(3);
+
+				sb.append(_SQL_COUNT_SOCIALACTIVITY_WHERE);
+
+				sb.append(_FINDER_COLUMN_C_CN_COMPANYID_2);
+
+				sb.append(_FINDER_COLUMN_C_CN_CLASSNAMEID_2);
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(companyId);
+
+					queryPos.add(classNameId);
+
+					count = (Long)query.uniqueResult();
+
+					FinderCacheUtil.putResult(finderPath, finderArgs, count);
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return count.intValue();
+		}
+	}
+
+	private static final String _FINDER_COLUMN_C_CN_COMPANYID_2 =
+		"socialActivity.companyId = ? AND ";
+
+	private static final String _FINDER_COLUMN_C_CN_CLASSNAMEID_2 =
+		"socialActivity.classNameId = ?";
+
 	private FinderPath _finderPathWithPaginationFindByC_C;
 	private FinderPath _finderPathWithoutPaginationFindByC_C;
 	private FinderPath _finderPathCountByC_C;
@@ -6632,6 +7183,25 @@ public class SocialActivityPersistenceImpl
 			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByReceiverUserId",
 			new String[] {Long.class.getName()},
 			new String[] {"receiverUserId"}, false);
+
+		_finderPathWithPaginationFindByC_CN = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_CN",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "classNameId"}, true);
+
+		_finderPathWithoutPaginationFindByC_CN = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_CN",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "classNameId"}, true);
+
+		_finderPathCountByC_CN = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_CN",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "classNameId"}, false);
 
 		_finderPathWithPaginationFindByC_C = new FinderPath(
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C",

--- a/portal-impl/src/portal-osgi-configuration.properties
+++ b/portal-impl/src/portal-osgi-configuration.properties
@@ -4579,10 +4579,6 @@
     #
     #configuration.override.com.liferay.portal.search.configuration.IndexerRegistryConfiguration_maxBufferSize=
     #
-    # Env: LIFERAY_CONFIGURATION_PERIOD_OVERRIDE_PERIOD_COM_PERIOD_LIFERAY_PERIOD_PORTAL_PERIOD_SEARCH_PERIOD_CONFIGURATION_PERIOD__UPPERCASEI_NDEXER_UPPERCASER_EGISTRY_UPPERCASEC_ONFIGURATION_UNDERLINE_MINIMUM_UPPERCASEB_UFFER_UPPERCASEA_VAILABILITY_UPPERCASEP_ERCENTAGE
-    #
-    #configuration.override.com.liferay.portal.search.configuration.IndexerRegistryConfiguration_minimumBufferAvailabilityPercentage=
-    #
     # Env: LIFERAY_CONFIGURATION_PERIOD_OVERRIDE_PERIOD_COM_PERIOD_LIFERAY_PERIOD_PORTAL_PERIOD_SEARCH_PERIOD_CONFIGURATION_PERIOD__UPPERCASEQ_UERY_UPPERCASEP_RE_UPPERCASEP_ROCESS_UPPERCASEC_ONFIGURATION_UNDERLINE_FIELD_UPPERCASEN_AME_UPPERCASEP_ATTERNS
     #
     #configuration.override.com.liferay.portal.search.configuration.QueryPreProcessConfiguration_fieldNamePatterns=

--- a/portal-kernel/src/com/liferay/announcements/kernel/service/persistence/packageinfo
+++ b/portal-kernel/src/com/liferay/announcements/kernel/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.1.0

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetEntryLocalService.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetEntryLocalService.java
@@ -146,11 +146,11 @@ public interface AssetEntryLocalService
 	public void deleteAssetTagAssetEntry(long tagId, long entryId);
 
 	@SystemEvent(type = SystemEventConstants.TYPE_DELETE)
-	public void deleteEntry(AssetEntry entry) throws PortalException;
+	public AssetEntry deleteEntry(AssetEntry entry) throws PortalException;
 
-	public void deleteEntry(long entryId) throws PortalException;
+	public AssetEntry deleteEntry(long entryId) throws PortalException;
 
-	public void deleteEntry(String className, long classPK)
+	public AssetEntry deleteEntry(String className, long classPK)
 		throws PortalException;
 
 	public void deleteGroupEntries(long groupId) throws PortalException;

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetEntryLocalService.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetEntryLocalService.java
@@ -145,6 +145,9 @@ public interface AssetEntryLocalService
 
 	public void deleteAssetTagAssetEntry(long tagId, long entryId);
 
+	public void deleteEntries(long companyId, String className)
+		throws PortalException;
+
 	@SystemEvent(type = SystemEventConstants.TYPE_DELETE)
 	public AssetEntry deleteEntry(AssetEntry entry) throws PortalException;
 

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetEntryLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetEntryLocalServiceUtil.java
@@ -145,18 +145,20 @@ public class AssetEntryLocalServiceUtil {
 		getService().deleteAssetTagAssetEntry(tagId, entryId);
 	}
 
-	public static void deleteEntry(AssetEntry entry) throws PortalException {
-		getService().deleteEntry(entry);
-	}
-
-	public static void deleteEntry(long entryId) throws PortalException {
-		getService().deleteEntry(entryId);
-	}
-
-	public static void deleteEntry(String className, long classPK)
+	public static AssetEntry deleteEntry(AssetEntry entry)
 		throws PortalException {
 
-		getService().deleteEntry(className, classPK);
+		return getService().deleteEntry(entry);
+	}
+
+	public static AssetEntry deleteEntry(long entryId) throws PortalException {
+		return getService().deleteEntry(entryId);
+	}
+
+	public static AssetEntry deleteEntry(String className, long classPK)
+		throws PortalException {
+
+		return getService().deleteEntry(className, classPK);
 	}
 
 	public static void deleteGroupEntries(long groupId) throws PortalException {

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetEntryLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetEntryLocalServiceUtil.java
@@ -145,6 +145,12 @@ public class AssetEntryLocalServiceUtil {
 		getService().deleteAssetTagAssetEntry(tagId, entryId);
 	}
 
+	public static void deleteEntries(long companyId, String className)
+		throws PortalException {
+
+		getService().deleteEntries(companyId, className);
+	}
+
 	public static AssetEntry deleteEntry(AssetEntry entry)
 		throws PortalException {
 

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetEntryLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetEntryLocalServiceWrapper.java
@@ -152,6 +152,13 @@ public class AssetEntryLocalServiceWrapper
 	}
 
 	@Override
+	public void deleteEntries(long companyId, String className)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_assetEntryLocalService.deleteEntries(companyId, className);
+	}
+
+	@Override
 	public AssetEntry deleteEntry(AssetEntry entry)
 		throws com.liferay.portal.kernel.exception.PortalException {
 

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetEntryLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetEntryLocalServiceWrapper.java
@@ -152,24 +152,24 @@ public class AssetEntryLocalServiceWrapper
 	}
 
 	@Override
-	public void deleteEntry(AssetEntry entry)
+	public AssetEntry deleteEntry(AssetEntry entry)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
-		_assetEntryLocalService.deleteEntry(entry);
+		return _assetEntryLocalService.deleteEntry(entry);
 	}
 
 	@Override
-	public void deleteEntry(long entryId)
+	public AssetEntry deleteEntry(long entryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
-		_assetEntryLocalService.deleteEntry(entryId);
+		return _assetEntryLocalService.deleteEntry(entryId);
 	}
 
 	@Override
-	public void deleteEntry(String className, long classPK)
+	public AssetEntry deleteEntry(String className, long classPK)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
-		_assetEntryLocalService.deleteEntry(className, classPK);
+		return _assetEntryLocalService.deleteEntry(className, classPK);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/asset/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 12.2.0
+version 13.0.0

--- a/portal-kernel/src/com/liferay/asset/kernel/service/persistence/AssetEntryPersistence.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/persistence/AssetEntryPersistence.java
@@ -944,6 +944,161 @@ public interface AssetEntryPersistence
 	public int countByG_CU(long groupId, String classUuid);
 
 	/**
+	 * Returns all the asset entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @return the matching asset entries
+	 */
+	public java.util.List<AssetEntry> findByC_CN(
+		long companyId, long classNameId);
+
+	/**
+	 * Returns a range of all the asset entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of asset entries
+	 * @param end the upper bound of the range of asset entries (not inclusive)
+	 * @return the range of matching asset entries
+	 */
+	public java.util.List<AssetEntry> findByC_CN(
+		long companyId, long classNameId, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the asset entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of asset entries
+	 * @param end the upper bound of the range of asset entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching asset entries
+	 */
+	public java.util.List<AssetEntry> findByC_CN(
+		long companyId, long classNameId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<AssetEntry>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the asset entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of asset entries
+	 * @param end the upper bound of the range of asset entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching asset entries
+	 */
+	public java.util.List<AssetEntry> findByC_CN(
+		long companyId, long classNameId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<AssetEntry>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first asset entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset entry
+	 * @throws NoSuchEntryException if a matching asset entry could not be found
+	 */
+	public AssetEntry findByC_CN_First(
+			long companyId, long classNameId,
+			com.liferay.portal.kernel.util.OrderByComparator<AssetEntry>
+				orderByComparator)
+		throws NoSuchEntryException;
+
+	/**
+	 * Returns the first asset entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset entry, or <code>null</code> if a matching asset entry could not be found
+	 */
+	public AssetEntry fetchByC_CN_First(
+		long companyId, long classNameId,
+		com.liferay.portal.kernel.util.OrderByComparator<AssetEntry>
+			orderByComparator);
+
+	/**
+	 * Returns the last asset entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset entry
+	 * @throws NoSuchEntryException if a matching asset entry could not be found
+	 */
+	public AssetEntry findByC_CN_Last(
+			long companyId, long classNameId,
+			com.liferay.portal.kernel.util.OrderByComparator<AssetEntry>
+				orderByComparator)
+		throws NoSuchEntryException;
+
+	/**
+	 * Returns the last asset entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset entry, or <code>null</code> if a matching asset entry could not be found
+	 */
+	public AssetEntry fetchByC_CN_Last(
+		long companyId, long classNameId,
+		com.liferay.portal.kernel.util.OrderByComparator<AssetEntry>
+			orderByComparator);
+
+	/**
+	 * Returns the asset entries before and after the current asset entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param entryId the primary key of the current asset entry
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next asset entry
+	 * @throws NoSuchEntryException if a asset entry with the primary key could not be found
+	 */
+	public AssetEntry[] findByC_CN_PrevAndNext(
+			long entryId, long companyId, long classNameId,
+			com.liferay.portal.kernel.util.OrderByComparator<AssetEntry>
+				orderByComparator)
+		throws NoSuchEntryException;
+
+	/**
+	 * Removes all the asset entries where companyId = &#63; and classNameId = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 */
+	public void removeByC_CN(long companyId, long classNameId);
+
+	/**
+	 * Returns the number of asset entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @return the number of matching asset entries
+	 */
+	public int countByC_CN(long companyId, long classNameId);
+
+	/**
 	 * Returns the asset entry where classNameId = &#63; and classPK = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
 	 *
 	 * @param classNameId the class name ID

--- a/portal-kernel/src/com/liferay/asset/kernel/service/persistence/AssetEntryUtil.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/persistence/AssetEntryUtil.java
@@ -1186,6 +1186,193 @@ public class AssetEntryUtil {
 	}
 
 	/**
+	 * Returns all the asset entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @return the matching asset entries
+	 */
+	public static List<AssetEntry> findByC_CN(
+		long companyId, long classNameId) {
+
+		return getPersistence().findByC_CN(companyId, classNameId);
+	}
+
+	/**
+	 * Returns a range of all the asset entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of asset entries
+	 * @param end the upper bound of the range of asset entries (not inclusive)
+	 * @return the range of matching asset entries
+	 */
+	public static List<AssetEntry> findByC_CN(
+		long companyId, long classNameId, int start, int end) {
+
+		return getPersistence().findByC_CN(companyId, classNameId, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the asset entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of asset entries
+	 * @param end the upper bound of the range of asset entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching asset entries
+	 */
+	public static List<AssetEntry> findByC_CN(
+		long companyId, long classNameId, int start, int end,
+		OrderByComparator<AssetEntry> orderByComparator) {
+
+		return getPersistence().findByC_CN(
+			companyId, classNameId, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the asset entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of asset entries
+	 * @param end the upper bound of the range of asset entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching asset entries
+	 */
+	public static List<AssetEntry> findByC_CN(
+		long companyId, long classNameId, int start, int end,
+		OrderByComparator<AssetEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByC_CN(
+			companyId, classNameId, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first asset entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset entry
+	 * @throws NoSuchEntryException if a matching asset entry could not be found
+	 */
+	public static AssetEntry findByC_CN_First(
+			long companyId, long classNameId,
+			OrderByComparator<AssetEntry> orderByComparator)
+		throws com.liferay.asset.kernel.exception.NoSuchEntryException {
+
+		return getPersistence().findByC_CN_First(
+			companyId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Returns the first asset entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset entry, or <code>null</code> if a matching asset entry could not be found
+	 */
+	public static AssetEntry fetchByC_CN_First(
+		long companyId, long classNameId,
+		OrderByComparator<AssetEntry> orderByComparator) {
+
+		return getPersistence().fetchByC_CN_First(
+			companyId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Returns the last asset entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset entry
+	 * @throws NoSuchEntryException if a matching asset entry could not be found
+	 */
+	public static AssetEntry findByC_CN_Last(
+			long companyId, long classNameId,
+			OrderByComparator<AssetEntry> orderByComparator)
+		throws com.liferay.asset.kernel.exception.NoSuchEntryException {
+
+		return getPersistence().findByC_CN_Last(
+			companyId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Returns the last asset entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset entry, or <code>null</code> if a matching asset entry could not be found
+	 */
+	public static AssetEntry fetchByC_CN_Last(
+		long companyId, long classNameId,
+		OrderByComparator<AssetEntry> orderByComparator) {
+
+		return getPersistence().fetchByC_CN_Last(
+			companyId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Returns the asset entries before and after the current asset entry in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param entryId the primary key of the current asset entry
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next asset entry
+	 * @throws NoSuchEntryException if a asset entry with the primary key could not be found
+	 */
+	public static AssetEntry[] findByC_CN_PrevAndNext(
+			long entryId, long companyId, long classNameId,
+			OrderByComparator<AssetEntry> orderByComparator)
+		throws com.liferay.asset.kernel.exception.NoSuchEntryException {
+
+		return getPersistence().findByC_CN_PrevAndNext(
+			entryId, companyId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Removes all the asset entries where companyId = &#63; and classNameId = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 */
+	public static void removeByC_CN(long companyId, long classNameId) {
+		getPersistence().removeByC_CN(companyId, classNameId);
+	}
+
+	/**
+	 * Returns the number of asset entries where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @return the number of matching asset entries
+	 */
+	public static int countByC_CN(long companyId, long classNameId) {
+		return getPersistence().countByC_CN(companyId, classNameId);
+	}
+
+	/**
 	 * Returns the asset entry where classNameId = &#63; and classPK = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
 	 *
 	 * @param classNameId the class name ID

--- a/portal-kernel/src/com/liferay/asset/kernel/service/persistence/packageinfo
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 15.0.0
+version 15.1.0

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/persistence/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 7.6.0
+version 7.7.0

--- a/portal-kernel/src/com/liferay/expando/kernel/service/persistence/packageinfo
+++ b/portal-kernel/src/com/liferay/expando/kernel/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 3.3.0
+version 3.4.0

--- a/portal-kernel/src/com/liferay/exportimport/kernel/service/persistence/packageinfo
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 2.5.0
+version 2.6.0

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/service/persistence/TableMapperImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/service/persistence/TableMapperImpl.java
@@ -399,11 +399,13 @@ public class TableMapperImpl<L extends BaseModel<L>, R extends BaseModel<R>>
 
 		int rowCount = 0;
 
-		try {
-			rowCount = deleteSqlUpdate.update(masterPrimaryKey);
-		}
-		catch (Exception exception) {
-			throw new SystemException(exception);
+		if (slavePrimaryKeys.length > 0) {
+			try {
+				rowCount = deleteSqlUpdate.update(masterPrimaryKey);
+			}
+			catch (Exception exception) {
+				throw new SystemException(exception);
+			}
 		}
 
 		if ((masterModelListeners.length > 0) ||

--- a/portal-kernel/src/com/liferay/portal/kernel/search/SearchContext.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/SearchContext.java
@@ -38,7 +38,7 @@ import java.util.concurrent.Future;
 public class SearchContext implements Serializable {
 
 	public static boolean isBatchMode() {
-		Map.Entry<List<Future<?>>, List<Callable<Void>>> entry =
+		Map.Entry<Set<Future<?>>, List<Callable<Void>>> entry =
 			_batchModeSyncFuturesAndCallablesThreadLocal.get();
 
 		if (entry == null) {
@@ -56,13 +56,14 @@ public class SearchContext implements Serializable {
 		SafeCloseable safeCloseable =
 			_batchModeSyncFuturesAndCallablesThreadLocal.setWithSafeCloseable(
 				new AbstractMap.SimpleImmutableEntry<>(
-					new ArrayList<>(), new ArrayList<>()));
+					Collections.newSetFromMap(new ConcurrentHashMap<>()),
+					new ArrayList<>()));
 
 		return () -> {
 			Exception exception1 = null;
 
 			try {
-				Map.Entry<List<Future<?>>, List<Callable<Void>>> entry =
+				Map.Entry<Set<Future<?>>, List<Callable<Void>>> entry =
 					_batchModeSyncFuturesAndCallablesThreadLocal.get();
 
 				for (Future<?> future : entry.getKey()) {
@@ -111,7 +112,7 @@ public class SearchContext implements Serializable {
 	}
 
 	public static void registerBatchModeSyncCallable(Callable<Void> callable) {
-		Map.Entry<List<Future<?>>, List<Callable<Void>>> entry =
+		Map.Entry<Set<Future<?>>, List<Callable<Void>>> entry =
 			_batchModeSyncFuturesAndCallablesThreadLocal.get();
 
 		if (entry == null) {
@@ -124,16 +125,27 @@ public class SearchContext implements Serializable {
 	}
 
 	public static void registerBatchModeSyncFuture(Future<?> future) {
-		Map.Entry<List<Future<?>>, List<Callable<Void>>> entry =
+		Map.Entry<Set<Future<?>>, List<Callable<Void>>> entry =
 			_batchModeSyncFuturesAndCallablesThreadLocal.get();
 
 		if (entry == null) {
 			throw new IllegalStateException("Not in batch mode");
 		}
 
-		List<Future<?>> batchModeSyncFutures = entry.getKey();
+		Set<Future<?>> batchModeSyncFutures = entry.getKey();
 
 		batchModeSyncFutures.add(future);
+	}
+
+	public static void unregisterBatchModeSyncFuture(Future<?> future) {
+		Map.Entry<Set<Future<?>>, List<Callable<Void>>> entry =
+			_batchModeSyncFuturesAndCallablesThreadLocal.get();
+
+		if (entry != null) {
+			Set<Future<?>> batchModeSyncFutures = entry.getKey();
+
+			batchModeSyncFutures.remove(future);
+		}
 	}
 
 	public void addFacet(Facet facet) {
@@ -525,7 +537,7 @@ public class SearchContext implements Serializable {
 	}
 
 	private static final CentralizedThreadLocal
-		<Map.Entry<List<Future<?>>, List<Callable<Void>>>>
+		<Map.Entry<Set<Future<?>>, List<Callable<Void>>>>
 			_batchModeSyncFuturesAndCallablesThreadLocal =
 				new CentralizedThreadLocal<>(
 					SearchContext.class.getName() +

--- a/portal-kernel/src/com/liferay/portal/kernel/search/SearchContext.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/SearchContext.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.util.Validator;
 
 import java.io.Serializable;
 
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -26,6 +27,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 
@@ -36,10 +38,10 @@ import java.util.concurrent.Future;
 public class SearchContext implements Serializable {
 
 	public static boolean isBatchMode() {
-		List<Future<?>> batchModeSyncFutures =
-			_batchModeSyncFuturesThreadLocal.get();
+		Map.Entry<List<Future<?>>, List<Callable<Void>>> entry =
+			_batchModeSyncFuturesAndCallablesThreadLocal.get();
 
-		if (batchModeSyncFutures == null) {
+		if (entry == null) {
 			return false;
 		}
 
@@ -52,18 +54,33 @@ public class SearchContext implements Serializable {
 
 	public static SafeCloseable openBatchMode(boolean commit) {
 		SafeCloseable safeCloseable =
-			_batchModeSyncFuturesThreadLocal.setWithSafeCloseable(
-				new ArrayList<>());
+			_batchModeSyncFuturesAndCallablesThreadLocal.setWithSafeCloseable(
+				new AbstractMap.SimpleImmutableEntry<>(
+					new ArrayList<>(), new ArrayList<>()));
 
 		return () -> {
 			Exception exception1 = null;
 
 			try {
-				for (Future<?> future :
-						_batchModeSyncFuturesThreadLocal.get()) {
+				Map.Entry<List<Future<?>>, List<Callable<Void>>> entry =
+					_batchModeSyncFuturesAndCallablesThreadLocal.get();
 
+				for (Future<?> future : entry.getKey()) {
 					try {
 						future.get();
+					}
+					catch (Exception exception2) {
+						if (exception1 != null) {
+							exception2.addSuppressed(exception1);
+						}
+
+						exception1 = exception2;
+					}
+				}
+
+				for (Callable<?> callable : entry.getValue()) {
+					try {
+						callable.call();
 					}
 					catch (Exception exception2) {
 						if (exception1 != null) {
@@ -93,13 +110,28 @@ public class SearchContext implements Serializable {
 		};
 	}
 
-	public static void registerBatchModeSyncFuture(Future<?> future) {
-		List<Future<?>> batchModeSyncFutures =
-			_batchModeSyncFuturesThreadLocal.get();
+	public static void registerBatchModeSyncCallable(Callable<Void> callable) {
+		Map.Entry<List<Future<?>>, List<Callable<Void>>> entry =
+			_batchModeSyncFuturesAndCallablesThreadLocal.get();
 
-		if (batchModeSyncFutures == null) {
+		if (entry == null) {
 			throw new IllegalStateException("Not in batch mode");
 		}
+
+		List<Callable<Void>> batchModeSyncCallables = entry.getValue();
+
+		batchModeSyncCallables.add(callable);
+	}
+
+	public static void registerBatchModeSyncFuture(Future<?> future) {
+		Map.Entry<List<Future<?>>, List<Callable<Void>>> entry =
+			_batchModeSyncFuturesAndCallablesThreadLocal.get();
+
+		if (entry == null) {
+			throw new IllegalStateException("Not in batch mode");
+		}
+
+		List<Future<?>> batchModeSyncFutures = entry.getKey();
 
 		batchModeSyncFutures.add(future);
 	}
@@ -492,10 +524,12 @@ public class SearchContext implements Serializable {
 		}
 	}
 
-	private static final CentralizedThreadLocal<List<Future<?>>>
-		_batchModeSyncFuturesThreadLocal = new CentralizedThreadLocal<>(
-			SearchContext.class.getName() +
-				"._batchModeSyncFuturesThreadLocal");
+	private static final CentralizedThreadLocal
+		<Map.Entry<List<Future<?>>, List<Callable<Void>>>>
+			_batchModeSyncFuturesAndCallablesThreadLocal =
+				new CentralizedThreadLocal<>(
+					SearchContext.class.getName() +
+						"._batchModeSyncFuturesThreadLocal");
 
 	private boolean _andSearch;
 	private long[] _assetCategoryIds;

--- a/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
@@ -1,1 +1,1 @@
-version 20.9.0
+version 20.10.0

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalService.java
@@ -322,6 +322,8 @@ public interface ResourcePermissionLocalService
 			long companyId, String name, int scope, String primKey)
 		throws PortalException;
 
+	public void deleteResourcePermissions(String name);
+
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public <T> T dslQuery(DSLQuery dslQuery);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalService.java
@@ -272,6 +272,10 @@ public interface ResourcePermissionLocalService
 	public ResourcePermission deleteResourcePermission(
 		ResourcePermission resourcePermission);
 
+	public void deleteResourcePermissions(
+			long companyId, String name, int scope)
+		throws PortalException;
+
 	/**
 	 * Deletes all resource permissions at the scope to resources of the type.
 	 * This method should not be confused with any of the

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalServiceUtil.java
@@ -335,6 +335,10 @@ public class ResourcePermissionLocalServiceUtil {
 		getService().deleteResourcePermissions(companyId, name, scope, primKey);
 	}
 
+	public static void deleteResourcePermissions(String name) {
+		getService().deleteResourcePermissions(name);
+	}
+
 	public static <T> T dslQuery(DSLQuery dslQuery) {
 		return getService().dslQuery(dslQuery);
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalServiceUtil.java
@@ -279,6 +279,13 @@ public class ResourcePermissionLocalServiceUtil {
 		return getService().deleteResourcePermission(resourcePermission);
 	}
 
+	public static void deleteResourcePermissions(
+			long companyId, String name, int scope)
+		throws PortalException {
+
+		getService().deleteResourcePermissions(companyId, name, scope);
+	}
+
 	/**
 	 * Deletes all resource permissions at the scope to resources of the type.
 	 * This method should not be confused with any of the

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalServiceWrapper.java
@@ -355,6 +355,11 @@ public class ResourcePermissionLocalServiceWrapper
 	}
 
 	@Override
+	public void deleteResourcePermissions(String name) {
+		_resourcePermissionLocalService.deleteResourcePermissions(name);
+	}
+
+	@Override
 	public <T> T dslQuery(com.liferay.petra.sql.dsl.query.DSLQuery dslQuery) {
 		return _resourcePermissionLocalService.dslQuery(dslQuery);
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ResourcePermissionLocalServiceWrapper.java
@@ -294,6 +294,15 @@ public class ResourcePermissionLocalServiceWrapper
 			resourcePermission);
 	}
 
+	@Override
+	public void deleteResourcePermissions(
+			long companyId, String name, int scope)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_resourcePermissionLocalService.deleteResourcePermissions(
+			companyId, name, scope);
+	}
+
 	/**
 	 * Deletes all resource permissions at the scope to resources of the type.
 	 * This method should not be confused with any of the

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/BasePersistence.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/BasePersistence.java
@@ -24,6 +24,7 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 import javax.sql.DataSource;
 
@@ -252,6 +253,8 @@ public interface BasePersistence<T extends BaseModel<T>> {
 	 * @return the model instance that was removed
 	 */
 	public T remove(T model);
+
+	public T removeByFunction(T model, Function<T, T> function);
 
 	/**
 	 * Sets the data source for this model.

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/LongPKRemoveFunction.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/LongPKRemoveFunction.java
@@ -1,0 +1,63 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.service.persistence;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
+import com.liferay.portal.kernel.dao.orm.Session;
+import com.liferay.portal.kernel.model.BaseModel;
+
+import java.sql.PreparedStatement;
+
+import java.util.function.Function;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class LongPKRemoveFunction<T extends BaseModel<T>>
+	implements Function<T, T> {
+
+	public LongPKRemoveFunction(
+		BasePersistence<T> basePersistence, String tableName,
+		String pkFieldName) {
+
+		_basePersistence = basePersistence;
+
+		_deleteSQL = StringBundler.concat(
+			"delete from ", tableName, " where ", pkFieldName,
+			" = ? and ctCollectionId = ?");
+	}
+
+	@Override
+	public T apply(T baseModel) {
+		Session session = _basePersistence.openSession();
+
+		try {
+			session.apply(
+				connection -> {
+					try (PreparedStatement preparedStatement =
+							connection.prepareStatement(_deleteSQL)) {
+
+						preparedStatement.setLong(
+							1, (long)baseModel.getPrimaryKeyObj());
+						preparedStatement.setLong(
+							2, CTCollectionThreadLocal.getCTCollectionId());
+
+						preparedStatement.executeUpdate();
+					}
+				});
+		}
+		finally {
+			_basePersistence.closeSession(session);
+		}
+
+		return baseModel;
+	}
+
+	private final BasePersistence<T> _basePersistence;
+	private final String _deleteSQL;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/ResourcePermissionPersistence.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/ResourcePermissionPersistence.java
@@ -691,6 +691,172 @@ public interface ResourcePermissionPersistence
 	public int countByC_LikeP(long companyId, String primKey);
 
 	/**
+	 * Returns all the resource permissions where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @return the matching resource permissions
+	 */
+	public java.util.List<ResourcePermission> findByC_N_S(
+		long companyId, String name, int scope);
+
+	/**
+	 * Returns a range of all the resource permissions where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ResourcePermissionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @param start the lower bound of the range of resource permissions
+	 * @param end the upper bound of the range of resource permissions (not inclusive)
+	 * @return the range of matching resource permissions
+	 */
+	public java.util.List<ResourcePermission> findByC_N_S(
+		long companyId, String name, int scope, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the resource permissions where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ResourcePermissionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @param start the lower bound of the range of resource permissions
+	 * @param end the upper bound of the range of resource permissions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching resource permissions
+	 */
+	public java.util.List<ResourcePermission> findByC_N_S(
+		long companyId, String name, int scope, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<ResourcePermission>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the resource permissions where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ResourcePermissionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @param start the lower bound of the range of resource permissions
+	 * @param end the upper bound of the range of resource permissions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching resource permissions
+	 */
+	public java.util.List<ResourcePermission> findByC_N_S(
+		long companyId, String name, int scope, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<ResourcePermission>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first resource permission in the ordered set where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching resource permission
+	 * @throws NoSuchResourcePermissionException if a matching resource permission could not be found
+	 */
+	public ResourcePermission findByC_N_S_First(
+			long companyId, String name, int scope,
+			com.liferay.portal.kernel.util.OrderByComparator<ResourcePermission>
+				orderByComparator)
+		throws NoSuchResourcePermissionException;
+
+	/**
+	 * Returns the first resource permission in the ordered set where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching resource permission, or <code>null</code> if a matching resource permission could not be found
+	 */
+	public ResourcePermission fetchByC_N_S_First(
+		long companyId, String name, int scope,
+		com.liferay.portal.kernel.util.OrderByComparator<ResourcePermission>
+			orderByComparator);
+
+	/**
+	 * Returns the last resource permission in the ordered set where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching resource permission
+	 * @throws NoSuchResourcePermissionException if a matching resource permission could not be found
+	 */
+	public ResourcePermission findByC_N_S_Last(
+			long companyId, String name, int scope,
+			com.liferay.portal.kernel.util.OrderByComparator<ResourcePermission>
+				orderByComparator)
+		throws NoSuchResourcePermissionException;
+
+	/**
+	 * Returns the last resource permission in the ordered set where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching resource permission, or <code>null</code> if a matching resource permission could not be found
+	 */
+	public ResourcePermission fetchByC_N_S_Last(
+		long companyId, String name, int scope,
+		com.liferay.portal.kernel.util.OrderByComparator<ResourcePermission>
+			orderByComparator);
+
+	/**
+	 * Returns the resource permissions before and after the current resource permission in the ordered set where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * @param resourcePermissionId the primary key of the current resource permission
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next resource permission
+	 * @throws NoSuchResourcePermissionException if a resource permission with the primary key could not be found
+	 */
+	public ResourcePermission[] findByC_N_S_PrevAndNext(
+			long resourcePermissionId, long companyId, String name, int scope,
+			com.liferay.portal.kernel.util.OrderByComparator<ResourcePermission>
+				orderByComparator)
+		throws NoSuchResourcePermissionException;
+
+	/**
+	 * Removes all the resource permissions where companyId = &#63; and name = &#63; and scope = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 */
+	public void removeByC_N_S(long companyId, String name, int scope);
+
+	/**
+	 * Returns the number of resource permissions where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @return the number of matching resource permissions
+	 */
+	public int countByC_N_S(long companyId, String name, int scope);
+
+	/**
 	 * Returns all the resource permissions where companyId = &#63; and scope = &#63; and primKey = &#63;.
 	 *
 	 * @param companyId the company ID

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/ResourcePermissionUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/ResourcePermissionUtil.java
@@ -895,6 +895,207 @@ public class ResourcePermissionUtil {
 	}
 
 	/**
+	 * Returns all the resource permissions where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @return the matching resource permissions
+	 */
+	public static List<ResourcePermission> findByC_N_S(
+		long companyId, String name, int scope) {
+
+		return getPersistence().findByC_N_S(companyId, name, scope);
+	}
+
+	/**
+	 * Returns a range of all the resource permissions where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ResourcePermissionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @param start the lower bound of the range of resource permissions
+	 * @param end the upper bound of the range of resource permissions (not inclusive)
+	 * @return the range of matching resource permissions
+	 */
+	public static List<ResourcePermission> findByC_N_S(
+		long companyId, String name, int scope, int start, int end) {
+
+		return getPersistence().findByC_N_S(companyId, name, scope, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the resource permissions where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ResourcePermissionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @param start the lower bound of the range of resource permissions
+	 * @param end the upper bound of the range of resource permissions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching resource permissions
+	 */
+	public static List<ResourcePermission> findByC_N_S(
+		long companyId, String name, int scope, int start, int end,
+		OrderByComparator<ResourcePermission> orderByComparator) {
+
+		return getPersistence().findByC_N_S(
+			companyId, name, scope, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the resource permissions where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ResourcePermissionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @param start the lower bound of the range of resource permissions
+	 * @param end the upper bound of the range of resource permissions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching resource permissions
+	 */
+	public static List<ResourcePermission> findByC_N_S(
+		long companyId, String name, int scope, int start, int end,
+		OrderByComparator<ResourcePermission> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByC_N_S(
+			companyId, name, scope, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first resource permission in the ordered set where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching resource permission
+	 * @throws NoSuchResourcePermissionException if a matching resource permission could not be found
+	 */
+	public static ResourcePermission findByC_N_S_First(
+			long companyId, String name, int scope,
+			OrderByComparator<ResourcePermission> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchResourcePermissionException {
+
+		return getPersistence().findByC_N_S_First(
+			companyId, name, scope, orderByComparator);
+	}
+
+	/**
+	 * Returns the first resource permission in the ordered set where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching resource permission, or <code>null</code> if a matching resource permission could not be found
+	 */
+	public static ResourcePermission fetchByC_N_S_First(
+		long companyId, String name, int scope,
+		OrderByComparator<ResourcePermission> orderByComparator) {
+
+		return getPersistence().fetchByC_N_S_First(
+			companyId, name, scope, orderByComparator);
+	}
+
+	/**
+	 * Returns the last resource permission in the ordered set where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching resource permission
+	 * @throws NoSuchResourcePermissionException if a matching resource permission could not be found
+	 */
+	public static ResourcePermission findByC_N_S_Last(
+			long companyId, String name, int scope,
+			OrderByComparator<ResourcePermission> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchResourcePermissionException {
+
+		return getPersistence().findByC_N_S_Last(
+			companyId, name, scope, orderByComparator);
+	}
+
+	/**
+	 * Returns the last resource permission in the ordered set where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching resource permission, or <code>null</code> if a matching resource permission could not be found
+	 */
+	public static ResourcePermission fetchByC_N_S_Last(
+		long companyId, String name, int scope,
+		OrderByComparator<ResourcePermission> orderByComparator) {
+
+		return getPersistence().fetchByC_N_S_Last(
+			companyId, name, scope, orderByComparator);
+	}
+
+	/**
+	 * Returns the resource permissions before and after the current resource permission in the ordered set where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * @param resourcePermissionId the primary key of the current resource permission
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next resource permission
+	 * @throws NoSuchResourcePermissionException if a resource permission with the primary key could not be found
+	 */
+	public static ResourcePermission[] findByC_N_S_PrevAndNext(
+			long resourcePermissionId, long companyId, String name, int scope,
+			OrderByComparator<ResourcePermission> orderByComparator)
+		throws com.liferay.portal.kernel.exception.
+			NoSuchResourcePermissionException {
+
+		return getPersistence().findByC_N_S_PrevAndNext(
+			resourcePermissionId, companyId, name, scope, orderByComparator);
+	}
+
+	/**
+	 * Removes all the resource permissions where companyId = &#63; and name = &#63; and scope = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 */
+	public static void removeByC_N_S(long companyId, String name, int scope) {
+		getPersistence().removeByC_N_S(companyId, name, scope);
+	}
+
+	/**
+	 * Returns the number of resource permissions where companyId = &#63; and name = &#63; and scope = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param name the name
+	 * @param scope the scope
+	 * @return the number of matching resource permissions
+	 */
+	public static int countByC_N_S(long companyId, String name, int scope) {
+		return getPersistence().countByC_N_S(companyId, name, scope);
+	}
+
+	/**
 	 * Returns all the resource permissions where companyId = &#63; and scope = &#63; and primKey = &#63;.
 	 *
 	 * @param companyId the company ID

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/change/tracking/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/change/tracking/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 1.5.0

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/BasePersistenceImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/BasePersistenceImpl.java
@@ -94,6 +94,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 
 import javax.sql.DataSource;
 
@@ -647,6 +648,11 @@ public class BasePersistenceImpl<T extends BaseModel<T>>
 
 	@Override
 	public T remove(T model) {
+		return removeByFunction(model, this::removeImpl);
+	}
+
+	@Override
+	public T removeByFunction(T model, Function<T, T> function) {
 		if (ReadOnlyTransactionThreadLocal.isReadOnly()) {
 			throw new IllegalStateException(
 				"Remove called with read only transaction");
@@ -664,7 +670,7 @@ public class BasePersistenceImpl<T extends BaseModel<T>>
 			modelListener.onBeforeRemove(model);
 		}
 
-		T removedModel = removeImpl(model);
+		T removedModel = function.apply(model);
 
 		if (removedModel != null) {
 			model = removedModel;

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.0
+version 4.2.0

--- a/portal-kernel/src/com/liferay/portal/kernel/util/BulkDeleteCacheThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/BulkDeleteCacheThreadLocal.java
@@ -31,6 +31,17 @@ public class BulkDeleteCacheThreadLocal {
 			ownerName, key -> supplier.get());
 	}
 
+	public static boolean isBulkDeleteMode() {
+		Map<String, Object> bulkDeleteCacheMap =
+			_bulkDeleteCacheThreadLocal.get();
+
+		if (bulkDeleteCacheMap == null) {
+			return false;
+		}
+
+		return true;
+	}
+
 	public static SafeCloseable openBulkDeleteMode() {
 		return _bulkDeleteCacheThreadLocal.setWithSafeCloseable(
 			new HashMap<>());

--- a/portal-kernel/src/com/liferay/portal/kernel/util/BulkDeleteCacheThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/BulkDeleteCacheThreadLocal.java
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.util;
+
+import com.liferay.petra.lang.CentralizedThreadLocal;
+import com.liferay.petra.lang.SafeCloseable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class BulkDeleteCacheThreadLocal {
+
+	public static <T> T getBulkDeleteCache(
+		String ownerName, Supplier<T> supplier) {
+
+		Map<String, Object> bulkDeleteCacheMap =
+			_bulkDeleteCacheThreadLocal.get();
+
+		if (bulkDeleteCacheMap == null) {
+			return null;
+		}
+
+		return (T)bulkDeleteCacheMap.computeIfAbsent(
+			ownerName, key -> supplier.get());
+	}
+
+	public static SafeCloseable openBulkDeleteMode() {
+		return _bulkDeleteCacheThreadLocal.setWithSafeCloseable(
+			new HashMap<>());
+	}
+
+	private static final CentralizedThreadLocal<Map<String, Object>>
+		_bulkDeleteCacheThreadLocal = new CentralizedThreadLocal<>(
+			BulkDeleteCacheThreadLocal.class + "._bulkDeleteCacheThreadLocal");
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/MapUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/MapUtil.java
@@ -12,14 +12,17 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 
 import java.lang.reflect.Constructor;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 
 /**
  * @author Brian Wing Shun Chan
@@ -367,6 +370,25 @@ public class MapUtil {
 		}
 
 		return (LinkedHashMap<String, T>)map;
+	}
+
+	public static <K, V> Map<K, List<V>> toPartitionMap(
+		List<V> list, Function<V, K> keyExtractor) {
+
+		if (list.isEmpty()) {
+			return Collections.emptyMap();
+		}
+
+		Map<K, List<V>> map = new HashMap<>();
+
+		for (V v : list) {
+			List<V> partitionList = map.computeIfAbsent(
+				keyExtractor.apply(v), key -> new ArrayList<>());
+
+			partitionList.add(v);
+		}
+
+		return map;
 	}
 
 	public static String toString(Map<?, ?> map) {

--- a/portal-kernel/src/com/liferay/ratings/kernel/service/persistence/packageinfo
+++ b/portal-kernel/src/com/liferay/ratings/kernel/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 4.3.0
+version 4.4.0

--- a/portal-kernel/src/com/liferay/social/kernel/service/persistence/SocialActivityPersistence.java
+++ b/portal-kernel/src/com/liferay/social/kernel/service/persistence/SocialActivityPersistence.java
@@ -796,6 +796,161 @@ public interface SocialActivityPersistence
 	public int countByReceiverUserId(long receiverUserId);
 
 	/**
+	 * Returns all the social activities where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @return the matching social activities
+	 */
+	public java.util.List<SocialActivity> findByC_CN(
+		long companyId, long classNameId);
+
+	/**
+	 * Returns a range of all the social activities where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SocialActivityModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of social activities
+	 * @param end the upper bound of the range of social activities (not inclusive)
+	 * @return the range of matching social activities
+	 */
+	public java.util.List<SocialActivity> findByC_CN(
+		long companyId, long classNameId, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the social activities where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SocialActivityModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of social activities
+	 * @param end the upper bound of the range of social activities (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching social activities
+	 */
+	public java.util.List<SocialActivity> findByC_CN(
+		long companyId, long classNameId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<SocialActivity>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the social activities where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SocialActivityModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of social activities
+	 * @param end the upper bound of the range of social activities (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching social activities
+	 */
+	public java.util.List<SocialActivity> findByC_CN(
+		long companyId, long classNameId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<SocialActivity>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first social activity in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching social activity
+	 * @throws NoSuchActivityException if a matching social activity could not be found
+	 */
+	public SocialActivity findByC_CN_First(
+			long companyId, long classNameId,
+			com.liferay.portal.kernel.util.OrderByComparator<SocialActivity>
+				orderByComparator)
+		throws NoSuchActivityException;
+
+	/**
+	 * Returns the first social activity in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching social activity, or <code>null</code> if a matching social activity could not be found
+	 */
+	public SocialActivity fetchByC_CN_First(
+		long companyId, long classNameId,
+		com.liferay.portal.kernel.util.OrderByComparator<SocialActivity>
+			orderByComparator);
+
+	/**
+	 * Returns the last social activity in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching social activity
+	 * @throws NoSuchActivityException if a matching social activity could not be found
+	 */
+	public SocialActivity findByC_CN_Last(
+			long companyId, long classNameId,
+			com.liferay.portal.kernel.util.OrderByComparator<SocialActivity>
+				orderByComparator)
+		throws NoSuchActivityException;
+
+	/**
+	 * Returns the last social activity in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching social activity, or <code>null</code> if a matching social activity could not be found
+	 */
+	public SocialActivity fetchByC_CN_Last(
+		long companyId, long classNameId,
+		com.liferay.portal.kernel.util.OrderByComparator<SocialActivity>
+			orderByComparator);
+
+	/**
+	 * Returns the social activities before and after the current social activity in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param activityId the primary key of the current social activity
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next social activity
+	 * @throws NoSuchActivityException if a social activity with the primary key could not be found
+	 */
+	public SocialActivity[] findByC_CN_PrevAndNext(
+			long activityId, long companyId, long classNameId,
+			com.liferay.portal.kernel.util.OrderByComparator<SocialActivity>
+				orderByComparator)
+		throws NoSuchActivityException;
+
+	/**
+	 * Removes all the social activities where companyId = &#63; and classNameId = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 */
+	public void removeByC_CN(long companyId, long classNameId);
+
+	/**
+	 * Returns the number of social activities where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @return the number of matching social activities
+	 */
+	public int countByC_CN(long companyId, long classNameId);
+
+	/**
 	 * Returns all the social activities where classNameId = &#63; and classPK = &#63;.
 	 *
 	 * @param classNameId the class name ID

--- a/portal-kernel/src/com/liferay/social/kernel/service/persistence/SocialActivityUtil.java
+++ b/portal-kernel/src/com/liferay/social/kernel/service/persistence/SocialActivityUtil.java
@@ -1021,6 +1021,193 @@ public class SocialActivityUtil {
 	}
 
 	/**
+	 * Returns all the social activities where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @return the matching social activities
+	 */
+	public static List<SocialActivity> findByC_CN(
+		long companyId, long classNameId) {
+
+		return getPersistence().findByC_CN(companyId, classNameId);
+	}
+
+	/**
+	 * Returns a range of all the social activities where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SocialActivityModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of social activities
+	 * @param end the upper bound of the range of social activities (not inclusive)
+	 * @return the range of matching social activities
+	 */
+	public static List<SocialActivity> findByC_CN(
+		long companyId, long classNameId, int start, int end) {
+
+		return getPersistence().findByC_CN(companyId, classNameId, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the social activities where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SocialActivityModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of social activities
+	 * @param end the upper bound of the range of social activities (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching social activities
+	 */
+	public static List<SocialActivity> findByC_CN(
+		long companyId, long classNameId, int start, int end,
+		OrderByComparator<SocialActivity> orderByComparator) {
+
+		return getPersistence().findByC_CN(
+			companyId, classNameId, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the social activities where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SocialActivityModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param start the lower bound of the range of social activities
+	 * @param end the upper bound of the range of social activities (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching social activities
+	 */
+	public static List<SocialActivity> findByC_CN(
+		long companyId, long classNameId, int start, int end,
+		OrderByComparator<SocialActivity> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByC_CN(
+			companyId, classNameId, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first social activity in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching social activity
+	 * @throws NoSuchActivityException if a matching social activity could not be found
+	 */
+	public static SocialActivity findByC_CN_First(
+			long companyId, long classNameId,
+			OrderByComparator<SocialActivity> orderByComparator)
+		throws com.liferay.social.kernel.exception.NoSuchActivityException {
+
+		return getPersistence().findByC_CN_First(
+			companyId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Returns the first social activity in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching social activity, or <code>null</code> if a matching social activity could not be found
+	 */
+	public static SocialActivity fetchByC_CN_First(
+		long companyId, long classNameId,
+		OrderByComparator<SocialActivity> orderByComparator) {
+
+		return getPersistence().fetchByC_CN_First(
+			companyId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Returns the last social activity in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching social activity
+	 * @throws NoSuchActivityException if a matching social activity could not be found
+	 */
+	public static SocialActivity findByC_CN_Last(
+			long companyId, long classNameId,
+			OrderByComparator<SocialActivity> orderByComparator)
+		throws com.liferay.social.kernel.exception.NoSuchActivityException {
+
+		return getPersistence().findByC_CN_Last(
+			companyId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Returns the last social activity in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching social activity, or <code>null</code> if a matching social activity could not be found
+	 */
+	public static SocialActivity fetchByC_CN_Last(
+		long companyId, long classNameId,
+		OrderByComparator<SocialActivity> orderByComparator) {
+
+		return getPersistence().fetchByC_CN_Last(
+			companyId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Returns the social activities before and after the current social activity in the ordered set where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param activityId the primary key of the current social activity
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next social activity
+	 * @throws NoSuchActivityException if a social activity with the primary key could not be found
+	 */
+	public static SocialActivity[] findByC_CN_PrevAndNext(
+			long activityId, long companyId, long classNameId,
+			OrderByComparator<SocialActivity> orderByComparator)
+		throws com.liferay.social.kernel.exception.NoSuchActivityException {
+
+		return getPersistence().findByC_CN_PrevAndNext(
+			activityId, companyId, classNameId, orderByComparator);
+	}
+
+	/**
+	 * Removes all the social activities where companyId = &#63; and classNameId = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 */
+	public static void removeByC_CN(long companyId, long classNameId) {
+		getPersistence().removeByC_CN(companyId, classNameId);
+	}
+
+	/**
+	 * Returns the number of social activities where companyId = &#63; and classNameId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param classNameId the class name ID
+	 * @return the number of matching social activities
+	 */
+	public static int countByC_CN(long companyId, long classNameId) {
+		return getPersistence().countByC_CN(companyId, classNameId);
+	}
+
+	/**
 	 * Returns all the social activities where classNameId = &#63; and classPK = &#63;.
 	 *
 	 * @param classNameId the class name ID

--- a/portal-kernel/src/com/liferay/social/kernel/service/persistence/packageinfo
+++ b/portal-kernel/src/com/liferay/social/kernel/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 4.3.0
+version 4.4.0

--- a/sql/indexes.sql
+++ b/sql/indexes.sql
@@ -360,6 +360,7 @@ create index IX_F542E9BC on SocialActivity (activitySetId);
 create unique index IX_7E6A9AAD on SocialActivity (classNameId, classPK, groupId, userId, type_, receiverUserId, ctCollectionId, createDate);
 create index IX_85370BF4 on SocialActivity (classNameId, classPK, mirrorActivityId);
 create index IX_D0E9029E on SocialActivity (classNameId, classPK, type_);
+create index IX_F885EA9C on SocialActivity (classNameId, companyId);
 create index IX_64B1BC66 on SocialActivity (companyId);
 create index IX_2A2468 on SocialActivity (groupId);
 create index IX_1271F25F on SocialActivity (mirrorActivityId);

--- a/sql/indexes.sql
+++ b/sql/indexes.sql
@@ -33,6 +33,7 @@ create index IX_112337B8 on AssetEntries_AssetTags (companyId);
 create index IX_B2A61B55 on AssetEntries_AssetTags (tagId);
 
 create unique index IX_7BF8337B on AssetEntry (classNameId, classPK, ctCollectionId);
+create index IX_23280E2 on AssetEntry (classNameId, companyId);
 create index IX_7306C60 on AssetEntry (companyId);
 create index IX_75D42FF9 on AssetEntry (expirationDate);
 create index IX_6418BB52 on AssetEntry (groupId, classNameId, publishDate, expirationDate);


### PR DESCRIPTION
This optimizes ObjectDefinition deletion performance down to linear.

Picture 1 shows the comparison for datasets that master baseline can finish within a waitable time (under 2 days).
![chart1](https://github.com/user-attachments/assets/6739c817-5d7f-4160-9a5c-58231970173e)

Comparing the largest dataset in this chart, which is 200K entries, the time dropped from 133595.332s (37.11hours) to 49.686s, **that is 99.96% off**, or in other term, **2688.79 times faster**. We did not run larger dataset for master baseline since it takes too much time.

Picture 2 shows PR only datapoints all the way to 2M dataset.
![chart2](https://github.com/user-attachments/assets/4cdcebd6-d99b-454b-829c-d58ed47a2fda)

With this PR, 2M enties deletion took 482.015sec = 8.03mins to finish.

By doing polynomial curve fitting, we get:

Tbaseline = 0.0014 * N^3 + 2.7513 * N^2 + 62.5485 * N − 158.0342

Tpr = 0.1884 * N + 3.9899

With this projection, if we were ever trying to run a 2M entries delete on master baseline, it would take:
Tb(2000) = 0.0014 * (2000)^3 + 2.7513 * (2000)^2 + 62.5485 * 2000 − 158.0342 = 22330138.9658s = 22330138.9658 / 60 / 60 / 24 = 258.45 days

Although it is mathematically pointless to compare a higher degree function with linear one, the ratio is always going to be infinite as the input is approaching infinite. But still to show the difference in real world, for a 2M entries deletion, this change makes it 22330138.9658/482.015 = 46326.65 times faster.

@victorhcunha 's detailed test results are at https://docs.google.com/spreadsheets/d/1igYs403Pp1cq3W_7Z_0p1vGZW-kIb1glvRmHk5HYLnE/edit?gid=0#gid=0


**For client db + client codebase test case, it took 36mins to finish**. This is worse than out 2M entries result for 2 reasons:

1) Client db has way more than 2M AssetEntry.
2) Client codebase is old that miss some other optimizations we have on master that noticeably improves non-db related AssetEntry removal performance.

I would suggest the client to upgrade to newer version of portal to gain the other performance improvements, rather than tracing down all missing pieces for hotfixes.

@gabrielwas @MarinhoFeliphe @JerryAdrianoo see the circular dependency issue fix at https://github.com/brianchandotcom/liferay-portal/commit/fc8ccd99bee5992cee6d183843e5d91fe614350e

CC @vicnate5 @wesleygong @marco-leo