### PR TITLE
LPD-32124 - Make sure format respects ignored files

### DIFF
--- a/modules/_node-scripts/package.json
+++ b/modules/_node-scripts/package.json
@@ -4,7 +4,7 @@
 		"node-scripts": "./bin.js"
 	},
 	"com.liferay": {
-		"sha256": "cac3daa828efb61bd37b788e564c73cb201b9f9d02a018e256813524f864a23e"
+		"sha256": "f4f028ede881f713241a1bca9a40598a67e5d696d81ab73924c772645da17719"
 	},
 	"dependencies": {
 		"@babel/preset-env": "7.24.7",


### PR DESCRIPTION
This is causing SF issues in CI, so we need to regen to fix failures

@brianchandotcom from now on, we need you to avoid making changes to `_node-scripts` directory unless you also run the "regen" command. We can fix this, but in the mean time, if you need to make changes in that directory just close the PR and have us do it so that we can regen the hash properly.

[This commit](https://github.com/liferay/liferay-portal/commit/2cc91827724ed6c580dd0afde5d760190716dda2) made the hash out of sync