### PR TITLE
LPD-37502 Update fetchByERC

### DIFF
--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceAddressLocalService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceAddressLocalService.java
@@ -97,11 +97,11 @@ public interface CommerceAddressLocalService extends BaseLocalService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceAddress fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId);
+	public CommerceAddress fetchCommerceAddress(long commerceAddressId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceAddress fetchCommerceAddress(long commerceAddressId);
+	public CommerceAddress fetchCommerceAddressByExternalReferenceCode(
+		String externalReferenceCode, long companyId);
 
 	@Indexable(type = IndexableType.REINDEX)
 	public CommerceAddress geolocateCommerceAddress(long commerceAddressId)

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceAddressLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceAddressLocalServiceUtil.java
@@ -117,15 +117,15 @@ public class CommerceAddressLocalServiceUtil {
 		getService().deleteRegionCommerceAddresses(regionId);
 	}
 
-	public static CommerceAddress fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CommerceAddress fetchCommerceAddress(long commerceAddressId) {
 		return getService().fetchCommerceAddress(commerceAddressId);
+	}
+
+	public static CommerceAddress fetchCommerceAddressByExternalReferenceCode(
+		String externalReferenceCode, long companyId) {
+
+		return getService().fetchCommerceAddressByExternalReferenceCode(
+			externalReferenceCode, companyId);
 	}
 
 	public static CommerceAddress geolocateCommerceAddress(

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceAddressLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceAddressLocalServiceWrapper.java
@@ -126,20 +126,21 @@ public class CommerceAddressLocalServiceWrapper
 	}
 
 	@Override
-	public com.liferay.commerce.model.CommerceAddress
-		fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId) {
-
-		return _commerceAddressLocalService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public com.liferay.commerce.model.CommerceAddress fetchCommerceAddress(
 		long commerceAddressId) {
 
 		return _commerceAddressLocalService.fetchCommerceAddress(
 			commerceAddressId);
+	}
+
+	@Override
+	public com.liferay.commerce.model.CommerceAddress
+		fetchCommerceAddressByExternalReferenceCode(
+			String externalReferenceCode, long companyId) {
+
+		return _commerceAddressLocalService.
+			fetchCommerceAddressByExternalReferenceCode(
+				externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceAddressService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceAddressService.java
@@ -78,12 +78,12 @@ public interface CommerceAddressService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceAddress fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
+	public CommerceAddress fetchCommerceAddress(long commerceAddressId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceAddress fetchCommerceAddress(long commerceAddressId)
+	public CommerceAddress fetchCommerceAddressByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceAddressServiceUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceAddressServiceUtil.java
@@ -83,18 +83,18 @@ public class CommerceAddressServiceUtil {
 		getService().deleteCommerceAddress(commerceAddressId);
 	}
 
-	public static CommerceAddress fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CommerceAddress fetchCommerceAddress(long commerceAddressId)
 		throws PortalException {
 
 		return getService().fetchCommerceAddress(commerceAddressId);
+	}
+
+	public static CommerceAddress fetchCommerceAddressByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		return getService().fetchCommerceAddressByExternalReferenceCode(
+			externalReferenceCode, companyId);
 	}
 
 	public static List<CommerceAddress> getBillingCommerceAddresses(

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceAddressServiceWrapper.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceAddressServiceWrapper.java
@@ -83,21 +83,22 @@ public class CommerceAddressServiceWrapper
 	}
 
 	@Override
-	public com.liferay.commerce.model.CommerceAddress
-			fetchByExternalReferenceCode(
-				String externalReferenceCode, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _commerceAddressService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public com.liferay.commerce.model.CommerceAddress fetchCommerceAddress(
 			long commerceAddressId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commerceAddressService.fetchCommerceAddress(commerceAddressId);
+	}
+
+	@Override
+	public com.liferay.commerce.model.CommerceAddress
+			fetchCommerceAddressByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _commerceAddressService.
+			fetchCommerceAddressByExternalReferenceCode(
+				externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderItemLocalService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderItemLocalService.java
@@ -245,10 +245,6 @@ public interface CommerceOrderItemLocalService
 		DynamicQuery dynamicQuery, Projection projection);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceOrderItem fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId);
-
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceOrderItem fetchCommerceOrderItem(long commerceOrderItemId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderItemLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderItemLocalServiceUtil.java
@@ -288,13 +288,6 @@ public class CommerceOrderItemLocalServiceUtil {
 		return getService().dynamicQueryCount(dynamicQuery, projection);
 	}
 
-	public static CommerceOrderItem fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CommerceOrderItem fetchCommerceOrderItem(
 		long commerceOrderItemId) {
 

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderItemLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderItemLocalServiceWrapper.java
@@ -323,15 +323,6 @@ public class CommerceOrderItemLocalServiceWrapper
 	}
 
 	@Override
-	public com.liferay.commerce.model.CommerceOrderItem
-		fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId) {
-
-		return _commerceOrderItemLocalService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public com.liferay.commerce.model.CommerceOrderItem fetchCommerceOrderItem(
 		long commerceOrderItemId) {
 

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderItemService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderItemService.java
@@ -82,12 +82,12 @@ public interface CommerceOrderItemService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceOrderItem fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
+	public CommerceOrderItem fetchCommerceOrderItem(long commerceOrderItemId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceOrderItem fetchCommerceOrderItem(long commerceOrderItemId)
+	public CommerceOrderItem fetchCommerceOrderItemByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderItemServiceUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderItemServiceUtil.java
@@ -93,19 +93,20 @@ public class CommerceOrderItemServiceUtil {
 			commerceOrderId, commerceOrderItemIds, externalReferenceCodes);
 	}
 
-	public static CommerceOrderItem fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CommerceOrderItem fetchCommerceOrderItem(
 			long commerceOrderItemId)
 		throws PortalException {
 
 		return getService().fetchCommerceOrderItem(commerceOrderItemId);
+	}
+
+	public static CommerceOrderItem
+			fetchCommerceOrderItemByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		return getService().fetchCommerceOrderItemByExternalReferenceCode(
+			externalReferenceCode, companyId);
 	}
 
 	public static List<CommerceOrderItem>

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderItemServiceWrapper.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderItemServiceWrapper.java
@@ -100,22 +100,23 @@ public class CommerceOrderItemServiceWrapper
 	}
 
 	@Override
-	public com.liferay.commerce.model.CommerceOrderItem
-			fetchByExternalReferenceCode(
-				String externalReferenceCode, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _commerceOrderItemService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public com.liferay.commerce.model.CommerceOrderItem fetchCommerceOrderItem(
 			long commerceOrderItemId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commerceOrderItemService.fetchCommerceOrderItem(
 			commerceOrderItemId);
+	}
+
+	@Override
+	public com.liferay.commerce.model.CommerceOrderItem
+			fetchCommerceOrderItemByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _commerceOrderItemService.
+			fetchCommerceOrderItemByExternalReferenceCode(
+				externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalService.java
@@ -304,10 +304,6 @@ public interface CommerceOrderLocalService
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceOrder fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId);
-
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceOrder fetchCommerceOrder(long commerceOrderId);
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceUtil.java
@@ -377,13 +377,6 @@ public class CommerceOrderLocalServiceUtil {
 			userId, commerceOrderId, workflowTaskId, transitionName, comment);
 	}
 
-	public static CommerceOrder fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CommerceOrder fetchCommerceOrder(long commerceOrderId) {
 		return getService().fetchCommerceOrder(commerceOrderId);
 	}

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceWrapper.java
@@ -411,15 +411,6 @@ public class CommerceOrderLocalServiceWrapper
 	}
 
 	@Override
-	public com.liferay.commerce.model.CommerceOrder
-		fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId) {
-
-		return _commerceOrderLocalService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public com.liferay.commerce.model.CommerceOrder fetchCommerceOrder(
 		long commerceOrderId) {
 

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderNoteLocalService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderNoteLocalService.java
@@ -212,10 +212,6 @@ public interface CommerceOrderNoteLocalService
 		DynamicQuery dynamicQuery, Projection projection);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceOrderNote fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId);
-
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceOrderNote fetchCommerceOrderNote(long commerceOrderNoteId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderNoteLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderNoteLocalServiceUtil.java
@@ -239,13 +239,6 @@ public class CommerceOrderNoteLocalServiceUtil {
 		return getService().dynamicQueryCount(dynamicQuery, projection);
 	}
 
-	public static CommerceOrderNote fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CommerceOrderNote fetchCommerceOrderNote(
 		long commerceOrderNoteId) {
 

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderNoteLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderNoteLocalServiceWrapper.java
@@ -268,15 +268,6 @@ public class CommerceOrderNoteLocalServiceWrapper
 	}
 
 	@Override
-	public com.liferay.commerce.model.CommerceOrderNote
-		fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId) {
-
-		return _commerceOrderNoteLocalService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public com.liferay.commerce.model.CommerceOrderNote fetchCommerceOrderNote(
 		long commerceOrderNoteId) {
 

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderNoteService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderNoteService.java
@@ -58,12 +58,12 @@ public interface CommerceOrderNoteService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceOrderNote fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
+	public CommerceOrderNote fetchCommerceOrderNote(long commerceOrderNoteId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceOrderNote fetchCommerceOrderNote(long commerceOrderNoteId)
+	public CommerceOrderNote fetchCommerceOrderNoteByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderNoteServiceUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderNoteServiceUtil.java
@@ -56,19 +56,20 @@ public class CommerceOrderNoteServiceUtil {
 		getService().deleteCommerceOrderNote(commerceOrderNoteId);
 	}
 
-	public static CommerceOrderNote fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CommerceOrderNote fetchCommerceOrderNote(
 			long commerceOrderNoteId)
 		throws PortalException {
 
 		return getService().fetchCommerceOrderNote(commerceOrderNoteId);
+	}
+
+	public static CommerceOrderNote
+			fetchCommerceOrderNoteByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		return getService().fetchCommerceOrderNoteByExternalReferenceCode(
+			externalReferenceCode, companyId);
 	}
 
 	public static CommerceOrderNote getCommerceOrderNote(

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderNoteServiceWrapper.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderNoteServiceWrapper.java
@@ -59,22 +59,23 @@ public class CommerceOrderNoteServiceWrapper
 	}
 
 	@Override
-	public com.liferay.commerce.model.CommerceOrderNote
-			fetchByExternalReferenceCode(
-				String externalReferenceCode, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _commerceOrderNoteService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public com.liferay.commerce.model.CommerceOrderNote fetchCommerceOrderNote(
 			long commerceOrderNoteId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commerceOrderNoteService.fetchCommerceOrderNote(
 			commerceOrderNoteId);
+	}
+
+	@Override
+	public com.liferay.commerce.model.CommerceOrderNote
+			fetchCommerceOrderNoteByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _commerceOrderNoteService.
+			fetchCommerceOrderNoteByExternalReferenceCode(
+				externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderService.java
@@ -110,11 +110,6 @@ public interface CommerceOrderService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceOrder fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException;
-
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceOrder fetchCommerceOrder(long commerceOrderId)
 		throws PortalException;
 
@@ -134,6 +129,11 @@ public interface CommerceOrderService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceOrder fetchCommerceOrder(String uuid, long groupId)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public CommerceOrder fetchCommerceOrderByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderServiceUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderServiceUtil.java
@@ -143,14 +143,6 @@ public class CommerceOrderServiceUtil {
 			commerceOrderId, workflowTaskId, transitionName, comment);
 	}
 
-	public static CommerceOrder fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CommerceOrder fetchCommerceOrder(long commerceOrderId)
 		throws PortalException {
 
@@ -181,6 +173,14 @@ public class CommerceOrderServiceUtil {
 		throws PortalException {
 
 		return getService().fetchCommerceOrder(uuid, groupId);
+	}
+
+	public static CommerceOrder fetchCommerceOrderByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		return getService().fetchCommerceOrderByExternalReferenceCode(
+			externalReferenceCode, companyId);
 	}
 
 	public static CommerceOrder getCommerceOrder(long commerceOrderId)

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderServiceWrapper.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderServiceWrapper.java
@@ -146,16 +146,6 @@ public class CommerceOrderServiceWrapper
 	}
 
 	@Override
-	public com.liferay.commerce.model.CommerceOrder
-			fetchByExternalReferenceCode(
-				String externalReferenceCode, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _commerceOrderService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public com.liferay.commerce.model.CommerceOrder fetchCommerceOrder(
 			long commerceOrderId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -191,6 +181,16 @@ public class CommerceOrderServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commerceOrderService.fetchCommerceOrder(uuid, groupId);
+	}
+
+	@Override
+	public com.liferay.commerce.model.CommerceOrder
+			fetchCommerceOrderByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
+			externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderTypeLocalService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderTypeLocalService.java
@@ -215,10 +215,6 @@ public interface CommerceOrderTypeLocalService
 		DynamicQuery dynamicQuery, Projection projection);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceOrderType fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId);
-
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceOrderType fetchCommerceOrderType(long commerceOrderTypeId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderTypeLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderTypeLocalServiceUtil.java
@@ -231,13 +231,6 @@ public class CommerceOrderTypeLocalServiceUtil {
 		return getService().dynamicQueryCount(dynamicQuery, projection);
 	}
 
-	public static CommerceOrderType fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CommerceOrderType fetchCommerceOrderType(
 		long commerceOrderTypeId) {
 

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderTypeLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderTypeLocalServiceWrapper.java
@@ -257,15 +257,6 @@ public class CommerceOrderTypeLocalServiceWrapper
 	}
 
 	@Override
-	public com.liferay.commerce.model.CommerceOrderType
-		fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId) {
-
-		return _commerceOrderTypeLocalService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public com.liferay.commerce.model.CommerceOrderType fetchCommerceOrderType(
 		long commerceOrderTypeId) {
 

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderTypeService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderTypeService.java
@@ -60,12 +60,12 @@ public interface CommerceOrderTypeService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceOrderType fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
+	public CommerceOrderType fetchCommerceOrderType(long commerceOrderTypeId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceOrderType fetchCommerceOrderType(long commerceOrderTypeId)
+	public CommerceOrderType fetchCommerceOrderTypeByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderTypeServiceUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderTypeServiceUtil.java
@@ -57,19 +57,20 @@ public class CommerceOrderTypeServiceUtil {
 		return getService().deleteCommerceOrderType(commerceOrderTypeId);
 	}
 
-	public static CommerceOrderType fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CommerceOrderType fetchCommerceOrderType(
 			long commerceOrderTypeId)
 		throws PortalException {
 
 		return getService().fetchCommerceOrderType(commerceOrderTypeId);
+	}
+
+	public static CommerceOrderType
+			fetchCommerceOrderTypeByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		return getService().fetchCommerceOrderTypeByExternalReferenceCode(
+			externalReferenceCode, companyId);
 	}
 
 	public static CommerceOrderType getCommerceOrderType(

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderTypeServiceWrapper.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderTypeServiceWrapper.java
@@ -59,22 +59,23 @@ public class CommerceOrderTypeServiceWrapper
 	}
 
 	@Override
-	public com.liferay.commerce.model.CommerceOrderType
-			fetchByExternalReferenceCode(
-				String externalReferenceCode, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _commerceOrderTypeService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public com.liferay.commerce.model.CommerceOrderType fetchCommerceOrderType(
 			long commerceOrderTypeId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commerceOrderTypeService.fetchCommerceOrderType(
 			commerceOrderTypeId);
+	}
+
+	@Override
+	public com.liferay.commerce.model.CommerceOrderType
+			fetchCommerceOrderTypeByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _commerceOrderTypeService.
+			fetchCommerceOrderTypeByExternalReferenceCode(
+				externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-api/src/main/resources/com/liferay/commerce/service/packageinfo
+++ b/modules/apps/commerce/commerce-api/src/main/resources/com/liferay/commerce/service/packageinfo
@@ -1,1 +1,1 @@
-version 40.1.0
+version 41.0.0

--- a/modules/apps/commerce/commerce-discount-api/bnd.bnd
+++ b/modules/apps/commerce/commerce-discount-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Commerce Discount API
 Bundle-SymbolicName: com.liferay.commerce.discount.api
-Bundle-Version: 22.0.1
+Bundle-Version: 23.0.0
 Export-Package:\
 	com.liferay.commerce.discount.application.strategy,\
 	com.liferay.commerce.discount.configuration,\

--- a/modules/apps/commerce/commerce-discount-api/src/main/java/com/liferay/commerce/discount/service/CommerceDiscountLocalService.java
+++ b/modules/apps/commerce/commerce-discount-api/src/main/java/com/liferay/commerce/discount/service/CommerceDiscountLocalService.java
@@ -366,19 +366,6 @@ public interface CommerceDiscountLocalService
 	public long dynamicQueryCount(
 		DynamicQuery dynamicQuery, Projection projection);
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 #fetchByExternalReferenceCode(String, long)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceDiscount fetchByExternalReferenceCode(
-		long companyId, String externalReferenceCode);
-
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceDiscount fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId);
-
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceDiscount fetchCommerceDiscount(long commerceDiscountId);
 

--- a/modules/apps/commerce/commerce-discount-api/src/main/java/com/liferay/commerce/discount/service/CommerceDiscountLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-discount-api/src/main/java/com/liferay/commerce/discount/service/CommerceDiscountLocalServiceUtil.java
@@ -477,25 +477,6 @@ public class CommerceDiscountLocalServiceUtil {
 		return getService().dynamicQueryCount(dynamicQuery, projection);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 #fetchByExternalReferenceCode(String, long)}
-	 */
-	@Deprecated
-	public static CommerceDiscount fetchByExternalReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		return getService().fetchByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	public static CommerceDiscount fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CommerceDiscount fetchCommerceDiscount(
 		long commerceDiscountId) {
 

--- a/modules/apps/commerce/commerce-discount-api/src/main/java/com/liferay/commerce/discount/service/CommerceDiscountLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-discount-api/src/main/java/com/liferay/commerce/discount/service/CommerceDiscountLocalServiceWrapper.java
@@ -525,29 +525,6 @@ public class CommerceDiscountLocalServiceWrapper
 			dynamicQuery, projection);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 #fetchByExternalReferenceCode(String, long)}
-	 */
-	@Deprecated
-	@Override
-	public com.liferay.commerce.discount.model.CommerceDiscount
-		fetchByExternalReferenceCode(
-			long companyId, String externalReferenceCode) {
-
-		return _commerceDiscountLocalService.fetchByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	@Override
-	public com.liferay.commerce.discount.model.CommerceDiscount
-		fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId) {
-
-		return _commerceDiscountLocalService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	@Override
 	public com.liferay.commerce.discount.model.CommerceDiscount
 		fetchCommerceDiscount(long commerceDiscountId) {

--- a/modules/apps/commerce/commerce-discount-api/src/main/java/com/liferay/commerce/discount/service/CommerceDiscountService.java
+++ b/modules/apps/commerce/commerce-discount-api/src/main/java/com/liferay/commerce/discount/service/CommerceDiscountService.java
@@ -136,23 +136,13 @@ public interface CommerceDiscountService extends BaseService {
 	public void deleteCommerceDiscount(long commerceDiscountId)
 		throws PortalException;
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 #fetchByExternalReferenceCode(String, long)}
-	 */
-	@Deprecated
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceDiscount fetchByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
-		throws PortalException;
-
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceDiscount fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException;
-
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceDiscount fetchCommerceDiscount(long commerceDiscountId)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public CommerceDiscount fetchCommerceDiscountByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/commerce/commerce-discount-api/src/main/java/com/liferay/commerce/discount/service/CommerceDiscountServiceUtil.java
+++ b/modules/apps/commerce/commerce-discount-api/src/main/java/com/liferay/commerce/discount/service/CommerceDiscountServiceUtil.java
@@ -194,32 +194,19 @@ public class CommerceDiscountServiceUtil {
 		getService().deleteCommerceDiscount(commerceDiscountId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 #fetchByExternalReferenceCode(String, long)}
-	 */
-	@Deprecated
-	public static CommerceDiscount fetchByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
-		throws PortalException {
-
-		return getService().fetchByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	public static CommerceDiscount fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CommerceDiscount fetchCommerceDiscount(
 			long commerceDiscountId)
 		throws PortalException {
 
 		return getService().fetchCommerceDiscount(commerceDiscountId);
+	}
+
+	public static CommerceDiscount fetchCommerceDiscountByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		return getService().fetchCommerceDiscountByExternalReferenceCode(
+			externalReferenceCode, companyId);
 	}
 
 	public static CommerceDiscount getCommerceDiscount(long commerceDiscountId)

--- a/modules/apps/commerce/commerce-discount-api/src/main/java/com/liferay/commerce/discount/service/CommerceDiscountServiceWrapper.java
+++ b/modules/apps/commerce/commerce-discount-api/src/main/java/com/liferay/commerce/discount/service/CommerceDiscountServiceWrapper.java
@@ -207,31 +207,6 @@ public class CommerceDiscountServiceWrapper
 		_commerceDiscountService.deleteCommerceDiscount(commerceDiscountId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 #fetchByExternalReferenceCode(String, long)}
-	 */
-	@Deprecated
-	@Override
-	public com.liferay.commerce.discount.model.CommerceDiscount
-			fetchByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _commerceDiscountService.fetchByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	@Override
-	public com.liferay.commerce.discount.model.CommerceDiscount
-			fetchByExternalReferenceCode(
-				String externalReferenceCode, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _commerceDiscountService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	@Override
 	public com.liferay.commerce.discount.model.CommerceDiscount
 			fetchCommerceDiscount(long commerceDiscountId)
@@ -239,6 +214,17 @@ public class CommerceDiscountServiceWrapper
 
 		return _commerceDiscountService.fetchCommerceDiscount(
 			commerceDiscountId);
+	}
+
+	@Override
+	public com.liferay.commerce.discount.model.CommerceDiscount
+			fetchCommerceDiscountByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _commerceDiscountService.
+			fetchCommerceDiscountByExternalReferenceCode(
+				externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-discount-api/src/main/resources/com/liferay/commerce/discount/service/packageinfo
+++ b/modules/apps/commerce/commerce-discount-api/src/main/resources/com/liferay/commerce/discount/service/packageinfo
@@ -1,1 +1,1 @@
-version 11.0.0
+version 12.0.0

--- a/modules/apps/commerce/commerce-discount-service/src/main/java/com/liferay/commerce/discount/service/http/CommerceDiscountServiceHttp.java
+++ b/modules/apps/commerce/commerce-discount-service/src/main/java/com/liferay/commerce/discount/service/http/CommerceDiscountServiceHttp.java
@@ -449,94 +449,6 @@ public class CommerceDiscountServiceHttp {
 	}
 
 	public static com.liferay.commerce.discount.model.CommerceDiscount
-			fetchByExternalReferenceCode(
-				HttpPrincipal httpPrincipal, long companyId,
-				String externalReferenceCode)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		try {
-			MethodKey methodKey = new MethodKey(
-				CommerceDiscountServiceUtil.class,
-				"fetchByExternalReferenceCode",
-				_fetchByExternalReferenceCodeParameterTypes7);
-
-			MethodHandler methodHandler = new MethodHandler(
-				methodKey, companyId, externalReferenceCode);
-
-			Object returnObj = null;
-
-			try {
-				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
-			}
-			catch (Exception exception) {
-				if (exception instanceof
-						com.liferay.portal.kernel.exception.PortalException) {
-
-					throw (com.liferay.portal.kernel.exception.PortalException)
-						exception;
-				}
-
-				throw new com.liferay.portal.kernel.exception.SystemException(
-					exception);
-			}
-
-			return (com.liferay.commerce.discount.model.CommerceDiscount)
-				returnObj;
-		}
-		catch (com.liferay.portal.kernel.exception.SystemException
-					systemException) {
-
-			_log.error(systemException, systemException);
-
-			throw systemException;
-		}
-	}
-
-	public static com.liferay.commerce.discount.model.CommerceDiscount
-			fetchByExternalReferenceCode(
-				HttpPrincipal httpPrincipal, String externalReferenceCode,
-				long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		try {
-			MethodKey methodKey = new MethodKey(
-				CommerceDiscountServiceUtil.class,
-				"fetchByExternalReferenceCode",
-				_fetchByExternalReferenceCodeParameterTypes8);
-
-			MethodHandler methodHandler = new MethodHandler(
-				methodKey, externalReferenceCode, companyId);
-
-			Object returnObj = null;
-
-			try {
-				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
-			}
-			catch (Exception exception) {
-				if (exception instanceof
-						com.liferay.portal.kernel.exception.PortalException) {
-
-					throw (com.liferay.portal.kernel.exception.PortalException)
-						exception;
-				}
-
-				throw new com.liferay.portal.kernel.exception.SystemException(
-					exception);
-			}
-
-			return (com.liferay.commerce.discount.model.CommerceDiscount)
-				returnObj;
-		}
-		catch (com.liferay.portal.kernel.exception.SystemException
-					systemException) {
-
-			_log.error(systemException, systemException);
-
-			throw systemException;
-		}
-	}
-
-	public static com.liferay.commerce.discount.model.CommerceDiscount
 			fetchCommerceDiscount(
 				HttpPrincipal httpPrincipal, long commerceDiscountId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -544,10 +456,54 @@ public class CommerceDiscountServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceDiscountServiceUtil.class, "fetchCommerceDiscount",
-				_fetchCommerceDiscountParameterTypes9);
+				_fetchCommerceDiscountParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commerceDiscountId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.commerce.discount.model.CommerceDiscount)
+				returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.commerce.discount.model.CommerceDiscount
+			fetchCommerceDiscountByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				CommerceDiscountServiceUtil.class,
+				"fetchCommerceDiscountByExternalReferenceCode",
+				_fetchCommerceDiscountByExternalReferenceCodeParameterTypes8);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, externalReferenceCode, companyId);
 
 			Object returnObj = null;
 
@@ -586,7 +542,7 @@ public class CommerceDiscountServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceDiscountServiceUtil.class, "getCommerceDiscount",
-				_getCommerceDiscountParameterTypes10);
+				_getCommerceDiscountParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commerceDiscountId);
@@ -630,7 +586,7 @@ public class CommerceDiscountServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceDiscountServiceUtil.class, "getCommerceDiscounts",
-				_getCommerceDiscountsParameterTypes11);
+				_getCommerceDiscountsParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, couponCode);
@@ -675,7 +631,7 @@ public class CommerceDiscountServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceDiscountServiceUtil.class, "getCommerceDiscounts",
-				_getCommerceDiscountsParameterTypes12);
+				_getCommerceDiscountsParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, level, active, status);
@@ -717,7 +673,7 @@ public class CommerceDiscountServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceDiscountServiceUtil.class, "getCommerceDiscountsCount",
-				_getCommerceDiscountsCountParameterTypes13);
+				_getCommerceDiscountsCountParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, couponCode);
@@ -759,7 +715,7 @@ public class CommerceDiscountServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				CommerceDiscountServiceUtil.class,
 				"getCommerceDiscountsCountByPricingClassId",
-				_getCommerceDiscountsCountByPricingClassIdParameterTypes14);
+				_getCommerceDiscountsCountByPricingClassIdParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commercePricingClassId, title);
@@ -804,7 +760,7 @@ public class CommerceDiscountServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				CommerceDiscountServiceUtil.class,
 				"searchByCommercePricingClassId",
-				_searchByCommercePricingClassIdParameterTypes15);
+				_searchByCommercePricingClassIdParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commercePricingClassId, title, start, end);
@@ -851,7 +807,7 @@ public class CommerceDiscountServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceDiscountServiceUtil.class, "searchCommerceDiscounts",
-				_searchCommerceDiscountsParameterTypes16);
+				_searchCommerceDiscountsParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, keywords, status, start, end, sort);
@@ -906,7 +862,7 @@ public class CommerceDiscountServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceDiscountServiceUtil.class, "updateCommerceDiscount",
-				_updateCommerceDiscountParameterTypes17);
+				_updateCommerceDiscountParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commerceDiscountId, title, target, useCouponCode,
@@ -967,7 +923,7 @@ public class CommerceDiscountServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceDiscountServiceUtil.class, "updateCommerceDiscount",
-				_updateCommerceDiscountParameterTypes18);
+				_updateCommerceDiscountParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commerceDiscountId, title, target, useCouponCode,
@@ -1029,7 +985,7 @@ public class CommerceDiscountServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceDiscountServiceUtil.class, "updateCommerceDiscount",
-				_updateCommerceDiscountParameterTypes19);
+				_updateCommerceDiscountParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commerceDiscountId, title, target, useCouponCode,
@@ -1080,7 +1036,7 @@ public class CommerceDiscountServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				CommerceDiscountServiceUtil.class,
 				"updateCommerceDiscountExternalReferenceCode",
-				_updateCommerceDiscountExternalReferenceCodeParameterTypes20);
+				_updateCommerceDiscountExternalReferenceCodeParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commerceDiscountId, externalReferenceCode);
@@ -1124,7 +1080,7 @@ public class CommerceDiscountServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				CommerceDiscountServiceUtil.class,
 				"updateCommerceDiscountExternalReferenceCode",
-				_updateCommerceDiscountExternalReferenceCodeParameterTypes21);
+				_updateCommerceDiscountExternalReferenceCodeParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, commerceDiscountId);
@@ -1232,37 +1188,32 @@ public class CommerceDiscountServiceHttp {
 		};
 	private static final Class<?>[] _deleteCommerceDiscountParameterTypes6 =
 		new Class[] {long.class};
-	private static final Class<?>[]
-		_fetchByExternalReferenceCodeParameterTypes7 = new Class[] {
-			long.class, String.class
-		};
-	private static final Class<?>[]
-		_fetchByExternalReferenceCodeParameterTypes8 = new Class[] {
-			String.class, long.class
-		};
-	private static final Class<?>[] _fetchCommerceDiscountParameterTypes9 =
+	private static final Class<?>[] _fetchCommerceDiscountParameterTypes7 =
 		new Class[] {long.class};
-	private static final Class<?>[] _getCommerceDiscountParameterTypes10 =
+	private static final Class<?>[]
+		_fetchCommerceDiscountByExternalReferenceCodeParameterTypes8 =
+			new Class[] {String.class, long.class};
+	private static final Class<?>[] _getCommerceDiscountParameterTypes9 =
 		new Class[] {long.class};
+	private static final Class<?>[] _getCommerceDiscountsParameterTypes10 =
+		new Class[] {long.class, String.class};
 	private static final Class<?>[] _getCommerceDiscountsParameterTypes11 =
-		new Class[] {long.class, String.class};
-	private static final Class<?>[] _getCommerceDiscountsParameterTypes12 =
 		new Class[] {long.class, String.class, boolean.class, int.class};
-	private static final Class<?>[] _getCommerceDiscountsCountParameterTypes13 =
+	private static final Class<?>[] _getCommerceDiscountsCountParameterTypes12 =
 		new Class[] {long.class, String.class};
 	private static final Class<?>[]
-		_getCommerceDiscountsCountByPricingClassIdParameterTypes14 =
+		_getCommerceDiscountsCountByPricingClassIdParameterTypes13 =
 			new Class[] {long.class, String.class};
 	private static final Class<?>[]
-		_searchByCommercePricingClassIdParameterTypes15 = new Class[] {
+		_searchByCommercePricingClassIdParameterTypes14 = new Class[] {
 			long.class, String.class, int.class, int.class
 		};
-	private static final Class<?>[] _searchCommerceDiscountsParameterTypes16 =
+	private static final Class<?>[] _searchCommerceDiscountsParameterTypes15 =
 		new Class[] {
 			long.class, String.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.search.Sort.class
 		};
-	private static final Class<?>[] _updateCommerceDiscountParameterTypes17 =
+	private static final Class<?>[] _updateCommerceDiscountParameterTypes16 =
 		new Class[] {
 			long.class, String.class, String.class, boolean.class, String.class,
 			boolean.class, java.math.BigDecimal.class,
@@ -1273,7 +1224,7 @@ public class CommerceDiscountServiceHttp {
 			int.class, int.class, boolean.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateCommerceDiscountParameterTypes18 =
+	private static final Class<?>[] _updateCommerceDiscountParameterTypes17 =
 		new Class[] {
 			long.class, String.class, String.class, boolean.class, String.class,
 			boolean.class, java.math.BigDecimal.class, String.class,
@@ -1284,7 +1235,7 @@ public class CommerceDiscountServiceHttp {
 			int.class, int.class, int.class, boolean.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateCommerceDiscountParameterTypes19 =
+	private static final Class<?>[] _updateCommerceDiscountParameterTypes18 =
 		new Class[] {
 			long.class, String.class, String.class, boolean.class, String.class,
 			boolean.class, java.math.BigDecimal.class, String.class,
@@ -1296,10 +1247,10 @@ public class CommerceDiscountServiceHttp {
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[]
-		_updateCommerceDiscountExternalReferenceCodeParameterTypes20 =
+		_updateCommerceDiscountExternalReferenceCodeParameterTypes19 =
 			new Class[] {long.class, String.class};
 	private static final Class<?>[]
-		_updateCommerceDiscountExternalReferenceCodeParameterTypes21 =
+		_updateCommerceDiscountExternalReferenceCodeParameterTypes20 =
 			new Class[] {String.class, long.class};
 
 }

--- a/modules/apps/commerce/commerce-discount-service/src/main/java/com/liferay/commerce/discount/service/impl/CommerceDiscountLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-discount-service/src/main/java/com/liferay/commerce/discount/service/impl/CommerceDiscountLocalServiceImpl.java
@@ -642,35 +642,6 @@ public class CommerceDiscountLocalServiceImpl
 		}
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 *             #fetchByExternalReferenceCode(String, long)}
-	 */
-	@Deprecated
-	@Override
-	public CommerceDiscount fetchByExternalReferenceCode(
-		long companyId, String externalReferenceCode) {
-
-		if (Validator.isBlank(externalReferenceCode)) {
-			return null;
-		}
-
-		return commerceDiscountPersistence.fetchByERC_C(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
-	public CommerceDiscount fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		if (Validator.isBlank(externalReferenceCode)) {
-			return null;
-		}
-
-		return commerceDiscountPersistence.fetchByERC_C(
-			externalReferenceCode, companyId);
-	}
-
 	@Override
 	public CommerceDiscount fetchDefaultCommerceDiscount(
 		long commerceChannelAccountEntryRelId, long cpDefinitionId,

--- a/modules/apps/commerce/commerce-discount-service/src/main/java/com/liferay/commerce/discount/service/impl/CommerceDiscountServiceImpl.java
+++ b/modules/apps/commerce/commerce-discount-service/src/main/java/com/liferay/commerce/discount/service/impl/CommerceDiscountServiceImpl.java
@@ -279,27 +279,13 @@ public class CommerceDiscountServiceImpl
 		commerceDiscountLocalService.deleteCommerceDiscount(commerceDiscountId);
 	}
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
-	 *             #fetchByExternalReferenceCode(String, long)}
-	 */
-	@Deprecated
 	@Override
-	public CommerceDiscount fetchByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
-		throws PortalException {
-
-		return fetchByExternalReferenceCode(externalReferenceCode, companyId);
-	}
-
-	@Override
-	public CommerceDiscount fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
+	public CommerceDiscount fetchCommerceDiscount(long commerceDiscountId)
 		throws PortalException {
 
 		CommerceDiscount commerceDiscount =
-			commerceDiscountLocalService.fetchByExternalReferenceCode(
-				externalReferenceCode, companyId);
+			commerceDiscountLocalService.fetchCommerceDiscount(
+				commerceDiscountId);
 
 		if (commerceDiscount != null) {
 			_commerceDiscountResourcePermission.check(
@@ -310,12 +296,14 @@ public class CommerceDiscountServiceImpl
 	}
 
 	@Override
-	public CommerceDiscount fetchCommerceDiscount(long commerceDiscountId)
+	public CommerceDiscount fetchCommerceDiscountByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		CommerceDiscount commerceDiscount =
-			commerceDiscountLocalService.fetchCommerceDiscount(
-				commerceDiscountId);
+			commerceDiscountLocalService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, companyId);
 
 		if (commerceDiscount != null) {
 			_commerceDiscountResourcePermission.check(

--- a/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/CommerceAccountsImporter.java
+++ b/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/CommerceAccountsImporter.java
@@ -239,7 +239,7 @@ public class CommerceAccountsImporter {
 
 					CommercePriceList commercePriceList =
 						_commercePriceListLocalService.
-							fetchByExternalReferenceCode(
+							fetchCommercePriceListByExternalReferenceCode(
 								externalReferenceCode,
 								serviceContext.getCompanyId());
 

--- a/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/CommerceInventoryWarehousesImporter.java
+++ b/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/CommerceInventoryWarehousesImporter.java
@@ -90,7 +90,7 @@ public class CommerceInventoryWarehousesImporter {
 
 		CommerceInventoryWarehouse commerceInventoryWarehouse =
 			_commerceInventoryWarehouseLocalService.
-				fetchCommerceInventoryWarehouseByReferenceCode(
+				fetchCommerceInventoryWarehouseByExternalReferenceCode(
 					externalReferenceCode, serviceContext.getCompanyId());
 
 		if (Validator.isNotNull(externalReferenceCode) &&

--- a/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/CommercePriceEntriesImporter.java
+++ b/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/CommercePriceEntriesImporter.java
@@ -153,8 +153,10 @@ public class CommercePriceEntriesImporter {
 			_friendlyURLNormalizer.normalize(name);
 
 		CommercePriceList commercePriceList =
-			_commercePriceListLocalService.fetchByExternalReferenceCode(
-				priceListExternalReferenceCode, serviceContext.getCompanyId());
+			_commercePriceListLocalService.
+				fetchCommercePriceListByExternalReferenceCode(
+					priceListExternalReferenceCode,
+					serviceContext.getCompanyId());
 
 		if (commercePriceList == null) {
 			throw new NoSuchPriceListException(
@@ -165,7 +167,7 @@ public class CommercePriceEntriesImporter {
 			"externalReferenceCode");
 
 		CPInstance cpInstance =
-			_cpInstanceLocalService.fetchByExternalReferenceCode(
+			_cpInstanceLocalService.fetchCPInstanceByExternalReferenceCode(
 				externalReferenceCode, serviceContext.getCompanyId());
 
 		if (cpInstance == null) {

--- a/modules/apps/commerce/commerce-inventory-api/bnd.bnd
+++ b/modules/apps/commerce/commerce-inventory-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Commerce Inventory API
 Bundle-SymbolicName: com.liferay.commerce.inventory.api
-Bundle-Version: 31.0.1
+Bundle-Version: 32.0.0
 Export-Package:\
 	com.liferay.commerce.inventory.configuration,\
 	com.liferay.commerce.inventory.constants,\

--- a/modules/apps/commerce/commerce-inventory-api/src/main/java/com/liferay/commerce/inventory/service/CommerceInventoryWarehouseLocalService.java
+++ b/modules/apps/commerce/commerce-inventory-api/src/main/java/com/liferay/commerce/inventory/service/CommerceInventoryWarehouseLocalService.java
@@ -221,11 +221,6 @@ public interface CommerceInventoryWarehouseLocalService
 		fetchCommerceInventoryWarehouseByExternalReferenceCode(
 			String externalReferenceCode, long companyId);
 
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceInventoryWarehouse
-		fetchCommerceInventoryWarehouseByReferenceCode(
-			String externalReferenceCode, long companyId);
-
 	/**
 	 * Returns the commerce inventory warehouse with the matching UUID and company.
 	 *

--- a/modules/apps/commerce/commerce-inventory-api/src/main/java/com/liferay/commerce/inventory/service/CommerceInventoryWarehouseLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-inventory-api/src/main/java/com/liferay/commerce/inventory/service/CommerceInventoryWarehouseLocalServiceUtil.java
@@ -242,14 +242,6 @@ public class CommerceInventoryWarehouseLocalServiceUtil {
 				externalReferenceCode, companyId);
 	}
 
-	public static CommerceInventoryWarehouse
-		fetchCommerceInventoryWarehouseByReferenceCode(
-			String externalReferenceCode, long companyId) {
-
-		return getService().fetchCommerceInventoryWarehouseByReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	/**
 	 * Returns the commerce inventory warehouse with the matching UUID and company.
 	 *

--- a/modules/apps/commerce/commerce-inventory-api/src/main/java/com/liferay/commerce/inventory/service/CommerceInventoryWarehouseLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-inventory-api/src/main/java/com/liferay/commerce/inventory/service/CommerceInventoryWarehouseLocalServiceWrapper.java
@@ -273,16 +273,6 @@ public class CommerceInventoryWarehouseLocalServiceWrapper
 				externalReferenceCode, companyId);
 	}
 
-	@Override
-	public com.liferay.commerce.inventory.model.CommerceInventoryWarehouse
-		fetchCommerceInventoryWarehouseByReferenceCode(
-			String externalReferenceCode, long companyId) {
-
-		return _commerceInventoryWarehouseLocalService.
-			fetchCommerceInventoryWarehouseByReferenceCode(
-				externalReferenceCode, companyId);
-	}
-
 	/**
 	 * Returns the commerce inventory warehouse with the matching UUID and company.
 	 *

--- a/modules/apps/commerce/commerce-inventory-api/src/main/java/com/liferay/commerce/inventory/service/CommerceInventoryWarehouseService.java
+++ b/modules/apps/commerce/commerce-inventory-api/src/main/java/com/liferay/commerce/inventory/service/CommerceInventoryWarehouseService.java
@@ -66,8 +66,9 @@ public interface CommerceInventoryWarehouseService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceInventoryWarehouse fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
+	public CommerceInventoryWarehouse
+			fetchCommerceInventoryWarehouseByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	public CommerceInventoryWarehouse geolocateCommerceInventoryWarehouse(

--- a/modules/apps/commerce/commerce-inventory-api/src/main/java/com/liferay/commerce/inventory/service/CommerceInventoryWarehouseServiceUtil.java
+++ b/modules/apps/commerce/commerce-inventory-api/src/main/java/com/liferay/commerce/inventory/service/CommerceInventoryWarehouseServiceUtil.java
@@ -63,12 +63,14 @@ public class CommerceInventoryWarehouseServiceUtil {
 			commerceInventoryWarehouseId);
 	}
 
-	public static CommerceInventoryWarehouse fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
+	public static CommerceInventoryWarehouse
+			fetchCommerceInventoryWarehouseByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
+		return getService().
+			fetchCommerceInventoryWarehouseByExternalReferenceCode(
+				externalReferenceCode, companyId);
 	}
 
 	public static CommerceInventoryWarehouse

--- a/modules/apps/commerce/commerce-inventory-api/src/main/java/com/liferay/commerce/inventory/service/CommerceInventoryWarehouseServiceWrapper.java
+++ b/modules/apps/commerce/commerce-inventory-api/src/main/java/com/liferay/commerce/inventory/service/CommerceInventoryWarehouseServiceWrapper.java
@@ -66,12 +66,13 @@ public class CommerceInventoryWarehouseServiceWrapper
 
 	@Override
 	public com.liferay.commerce.inventory.model.CommerceInventoryWarehouse
-			fetchByExternalReferenceCode(
+			fetchCommerceInventoryWarehouseByExternalReferenceCode(
 				String externalReferenceCode, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
-		return _commerceInventoryWarehouseService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
+		return _commerceInventoryWarehouseService.
+			fetchCommerceInventoryWarehouseByExternalReferenceCode(
+				externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-inventory-api/src/main/resources/com/liferay/commerce/inventory/service/packageinfo
+++ b/modules/apps/commerce/commerce-inventory-api/src/main/resources/com/liferay/commerce/inventory/service/packageinfo
@@ -1,1 +1,1 @@
-version 21.0.0
+version 22.0.0

--- a/modules/apps/commerce/commerce-inventory-service/src/main/java/com/liferay/commerce/inventory/service/http/CommerceInventoryWarehouseServiceHttp.java
+++ b/modules/apps/commerce/commerce-inventory-service/src/main/java/com/liferay/commerce/inventory/service/http/CommerceInventoryWarehouseServiceHttp.java
@@ -188,7 +188,7 @@ public class CommerceInventoryWarehouseServiceHttp {
 
 	public static
 		com.liferay.commerce.inventory.model.CommerceInventoryWarehouse
-				fetchByExternalReferenceCode(
+				fetchCommerceInventoryWarehouseByExternalReferenceCode(
 					HttpPrincipal httpPrincipal, String externalReferenceCode,
 					long companyId)
 			throws com.liferay.portal.kernel.exception.PortalException {
@@ -196,8 +196,8 @@ public class CommerceInventoryWarehouseServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceInventoryWarehouseServiceUtil.class,
-				"fetchByExternalReferenceCode",
-				_fetchByExternalReferenceCodeParameterTypes3);
+				"fetchCommerceInventoryWarehouseByExternalReferenceCode",
+				_fetchCommerceInventoryWarehouseByExternalReferenceCodeParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, companyId);
@@ -854,9 +854,8 @@ public class CommerceInventoryWarehouseServiceHttp {
 			long.class
 		};
 	private static final Class<?>[]
-		_fetchByExternalReferenceCodeParameterTypes3 = new Class[] {
-			String.class, long.class
-		};
+		_fetchCommerceInventoryWarehouseByExternalReferenceCodeParameterTypes3 =
+			new Class[] {String.class, long.class};
 	private static final Class<?>[]
 		_geolocateCommerceInventoryWarehouseParameterTypes4 = new Class[] {
 			long.class, double.class, double.class

--- a/modules/apps/commerce/commerce-inventory-service/src/main/java/com/liferay/commerce/inventory/service/impl/CommerceInventoryWarehouseLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-inventory-service/src/main/java/com/liferay/commerce/inventory/service/impl/CommerceInventoryWarehouseLocalServiceImpl.java
@@ -170,15 +170,6 @@ public class CommerceInventoryWarehouseLocalServiceImpl
 			deleteCommerceInventoryWarehouse(commerceInventoryWarehouse);
 	}
 
-	@Override
-	public CommerceInventoryWarehouse
-		fetchCommerceInventoryWarehouseByReferenceCode(
-			String externalReferenceCode, long companyId) {
-
-		return commerceInventoryWarehousePersistence.fetchByERC_C(
-			externalReferenceCode, companyId);
-	}
-
 	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public CommerceInventoryWarehouse geolocateCommerceInventoryWarehouse(

--- a/modules/apps/commerce/commerce-inventory-service/src/main/java/com/liferay/commerce/inventory/service/impl/CommerceInventoryWarehouseServiceImpl.java
+++ b/modules/apps/commerce/commerce-inventory-service/src/main/java/com/liferay/commerce/inventory/service/impl/CommerceInventoryWarehouseServiceImpl.java
@@ -95,13 +95,14 @@ public class CommerceInventoryWarehouseServiceImpl
 	}
 
 	@Override
-	public CommerceInventoryWarehouse fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
+	public CommerceInventoryWarehouse
+			fetchCommerceInventoryWarehouseByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		CommerceInventoryWarehouse commerceInventoryWarehouse =
 			commerceInventoryWarehouseLocalService.
-				fetchCommerceInventoryWarehouseByReferenceCode(
+				fetchCommerceInventoryWarehouseByExternalReferenceCode(
 					externalReferenceCode, companyId);
 
 		if (commerceInventoryWarehouse != null) {

--- a/modules/apps/commerce/commerce-order-rule-api/bnd.bnd
+++ b/modules/apps/commerce/commerce-order-rule-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Commerce Order Rule API
 Bundle-SymbolicName: com.liferay.commerce.order.rule.api
-Bundle-Version: 9.0.1
+Bundle-Version: 10.0.0
 Export-Package:\
 	com.liferay.commerce.order.rule.configuration,\
 	com.liferay.commerce.order.rule.constants,\

--- a/modules/apps/commerce/commerce-order-rule-api/src/main/java/com/liferay/commerce/order/rule/service/COREntryService.java
+++ b/modules/apps/commerce/commerce-order-rule-api/src/main/java/com/liferay/commerce/order/rule/service/COREntryService.java
@@ -56,12 +56,12 @@ public interface COREntryService extends BaseService {
 	public COREntry deleteCOREntry(long corEntryId) throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public COREntry fetchByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
-		throws PortalException;
+	public COREntry fetchCOREntry(long corEntryId) throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public COREntry fetchCOREntry(long corEntryId) throws PortalException;
+	public COREntry fetchCOREntryByExternalReferenceCode(
+			long companyId, String externalReferenceCode)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<COREntry> getCOREntries(

--- a/modules/apps/commerce/commerce-order-rule-api/src/main/java/com/liferay/commerce/order/rule/service/COREntryServiceUtil.java
+++ b/modules/apps/commerce/commerce-order-rule-api/src/main/java/com/liferay/commerce/order/rule/service/COREntryServiceUtil.java
@@ -55,18 +55,18 @@ public class COREntryServiceUtil {
 		return getService().deleteCOREntry(corEntryId);
 	}
 
-	public static COREntry fetchByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
-		throws PortalException {
-
-		return getService().fetchByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
 	public static COREntry fetchCOREntry(long corEntryId)
 		throws PortalException {
 
 		return getService().fetchCOREntry(corEntryId);
+	}
+
+	public static COREntry fetchCOREntryByExternalReferenceCode(
+			long companyId, String externalReferenceCode)
+		throws PortalException {
+
+		return getService().fetchCOREntryByExternalReferenceCode(
+			companyId, externalReferenceCode);
 	}
 
 	public static List<COREntry> getCOREntries(

--- a/modules/apps/commerce/commerce-order-rule-api/src/main/java/com/liferay/commerce/order/rule/service/COREntryServiceWrapper.java
+++ b/modules/apps/commerce/commerce-order-rule-api/src/main/java/com/liferay/commerce/order/rule/service/COREntryServiceWrapper.java
@@ -54,21 +54,21 @@ public class COREntryServiceWrapper
 	}
 
 	@Override
-	public com.liferay.commerce.order.rule.model.COREntry
-			fetchByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _corEntryService.fetchByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	@Override
 	public com.liferay.commerce.order.rule.model.COREntry fetchCOREntry(
 			long corEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _corEntryService.fetchCOREntry(corEntryId);
+	}
+
+	@Override
+	public com.liferay.commerce.order.rule.model.COREntry
+			fetchCOREntryByExternalReferenceCode(
+				long companyId, String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _corEntryService.fetchCOREntryByExternalReferenceCode(
+			companyId, externalReferenceCode);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-order-rule-api/src/main/resources/com/liferay/commerce/order/rule/service/packageinfo
+++ b/modules/apps/commerce/commerce-order-rule-api/src/main/resources/com/liferay/commerce/order/rule/service/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 5.0.0

--- a/modules/apps/commerce/commerce-order-rule-service/src/main/java/com/liferay/commerce/order/rule/service/http/COREntryServiceHttp.java
+++ b/modules/apps/commerce/commerce-order-rule-service/src/main/java/com/liferay/commerce/order/rule/service/http/COREntryServiceHttp.java
@@ -134,19 +134,17 @@ public class COREntryServiceHttp {
 		}
 	}
 
-	public static com.liferay.commerce.order.rule.model.COREntry
-			fetchByExternalReferenceCode(
-				HttpPrincipal httpPrincipal, long companyId,
-				String externalReferenceCode)
+	public static com.liferay.commerce.order.rule.model.COREntry fetchCOREntry(
+			HttpPrincipal httpPrincipal, long corEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				COREntryServiceUtil.class, "fetchByExternalReferenceCode",
-				_fetchByExternalReferenceCodeParameterTypes2);
+				COREntryServiceUtil.class, "fetchCOREntry",
+				_fetchCOREntryParameterTypes2);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, companyId, externalReferenceCode);
+				methodKey, corEntryId);
 
 			Object returnObj = null;
 
@@ -176,17 +174,20 @@ public class COREntryServiceHttp {
 		}
 	}
 
-	public static com.liferay.commerce.order.rule.model.COREntry fetchCOREntry(
-			HttpPrincipal httpPrincipal, long corEntryId)
+	public static com.liferay.commerce.order.rule.model.COREntry
+			fetchCOREntryByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, long companyId,
+				String externalReferenceCode)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				COREntryServiceUtil.class, "fetchCOREntry",
-				_fetchCOREntryParameterTypes3);
+				COREntryServiceUtil.class,
+				"fetchCOREntryByExternalReferenceCode",
+				_fetchCOREntryByExternalReferenceCodeParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, corEntryId);
+				methodKey, companyId, externalReferenceCode);
 
 			Object returnObj = null;
 
@@ -532,12 +533,12 @@ public class COREntryServiceHttp {
 	};
 	private static final Class<?>[] _deleteCOREntryParameterTypes1 =
 		new Class[] {long.class};
+	private static final Class<?>[] _fetchCOREntryParameterTypes2 =
+		new Class[] {long.class};
 	private static final Class<?>[]
-		_fetchByExternalReferenceCodeParameterTypes2 = new Class[] {
+		_fetchCOREntryByExternalReferenceCodeParameterTypes3 = new Class[] {
 			long.class, String.class
 		};
-	private static final Class<?>[] _fetchCOREntryParameterTypes3 =
-		new Class[] {long.class};
 	private static final Class<?>[] _getCOREntriesParameterTypes4 =
 		new Class[] {long.class, boolean.class, int.class, int.class};
 	private static final Class<?>[] _getCOREntriesParameterTypes5 =

--- a/modules/apps/commerce/commerce-order-rule-service/src/main/java/com/liferay/commerce/order/rule/service/impl/COREntryServiceImpl.java
+++ b/modules/apps/commerce/commerce-order-rule-service/src/main/java/com/liferay/commerce/order/rule/service/impl/COREntryServiceImpl.java
@@ -67,13 +67,8 @@ public class COREntryServiceImpl extends COREntryServiceBaseImpl {
 	}
 
 	@Override
-	public COREntry fetchByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
-		throws PortalException {
-
-		COREntry corEntry =
-			corEntryLocalService.fetchCOREntryByExternalReferenceCode(
-				externalReferenceCode, companyId);
+	public COREntry fetchCOREntry(long corEntryId) throws PortalException {
+		COREntry corEntry = corEntryLocalService.fetchCOREntry(corEntryId);
 
 		if (corEntry != null) {
 			_corEntryModelResourcePermission.check(
@@ -84,8 +79,13 @@ public class COREntryServiceImpl extends COREntryServiceBaseImpl {
 	}
 
 	@Override
-	public COREntry fetchCOREntry(long corEntryId) throws PortalException {
-		COREntry corEntry = corEntryLocalService.fetchCOREntry(corEntryId);
+	public COREntry fetchCOREntryByExternalReferenceCode(
+			long companyId, String externalReferenceCode)
+		throws PortalException {
+
+		COREntry corEntry =
+			corEntryLocalService.fetchCOREntryByExternalReferenceCode(
+				externalReferenceCode, companyId);
 
 		if (corEntry != null) {
 			_corEntryModelResourcePermission.check(

--- a/modules/apps/commerce/commerce-price-list-api/bnd.bnd
+++ b/modules/apps/commerce/commerce-price-list-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Commerce Price List API
 Bundle-SymbolicName: com.liferay.commerce.price.list.api
-Bundle-Version: 29.1.1
+Bundle-Version: 30.0.0
 Export-Package:\
 	com.liferay.commerce.price.list.configuration,\
 	com.liferay.commerce.price.list.constants,\

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceEntryLocalService.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceEntryLocalService.java
@@ -263,10 +263,6 @@ public interface CommercePriceEntryLocalService
 		DynamicQuery dynamicQuery, Projection projection);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommercePriceEntry fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId);
-
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommercePriceEntry fetchCommercePriceEntry(
 		long commercePriceEntryId);
 

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceEntryLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceEntryLocalServiceUtil.java
@@ -301,13 +301,6 @@ public class CommercePriceEntryLocalServiceUtil {
 		return getService().dynamicQueryCount(dynamicQuery, projection);
 	}
 
-	public static CommercePriceEntry fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CommercePriceEntry fetchCommercePriceEntry(
 		long commercePriceEntryId) {
 

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceEntryLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceEntryLocalServiceWrapper.java
@@ -337,14 +337,6 @@ public class CommercePriceEntryLocalServiceWrapper
 	}
 
 	@Override
-	public CommercePriceEntry fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return _commercePriceEntryLocalService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CommercePriceEntry fetchCommercePriceEntry(
 		long commercePriceEntryId) {
 

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceEntryService.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceEntryService.java
@@ -96,12 +96,12 @@ public interface CommercePriceEntryService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommercePriceEntry fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
+	public CommercePriceEntry fetchCommercePriceEntry(long commercePriceEntryId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommercePriceEntry fetchCommercePriceEntry(long commercePriceEntryId)
+	public CommercePriceEntry fetchCommercePriceEntryByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceEntryServiceUtil.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceEntryServiceUtil.java
@@ -118,19 +118,20 @@ public class CommercePriceEntryServiceUtil {
 		getService().deleteCommercePriceEntry(commercePriceEntryId);
 	}
 
-	public static CommercePriceEntry fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CommercePriceEntry fetchCommercePriceEntry(
 			long commercePriceEntryId)
 		throws PortalException {
 
 		return getService().fetchCommercePriceEntry(commercePriceEntryId);
+	}
+
+	public static CommercePriceEntry
+			fetchCommercePriceEntryByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		return getService().fetchCommercePriceEntryByExternalReferenceCode(
+			externalReferenceCode, companyId);
 	}
 
 	public static List<CommercePriceEntry> getCommercePriceEntries(

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceEntryServiceWrapper.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceEntryServiceWrapper.java
@@ -123,20 +123,21 @@ public class CommercePriceEntryServiceWrapper
 	}
 
 	@Override
-	public CommercePriceEntry fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _commercePriceEntryService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CommercePriceEntry fetchCommercePriceEntry(long commercePriceEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commercePriceEntryService.fetchCommercePriceEntry(
 			commercePriceEntryId);
+	}
+
+	@Override
+	public CommercePriceEntry fetchCommercePriceEntryByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _commercePriceEntryService.
+			fetchCommercePriceEntryByExternalReferenceCode(
+				externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceListLocalService.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceListLocalService.java
@@ -255,10 +255,6 @@ public interface CommercePriceListLocalService
 		DynamicQuery dynamicQuery, Projection projection);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommercePriceList fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId);
-
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommercePriceList fetchCatalogBaseCommercePriceList(long groupId)
 		throws PortalException;
 

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceListLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceListLocalServiceUtil.java
@@ -289,13 +289,6 @@ public class CommercePriceListLocalServiceUtil {
 		return getService().dynamicQueryCount(dynamicQuery, projection);
 	}
 
-	public static CommercePriceList fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CommercePriceList fetchCatalogBaseCommercePriceList(
 			long groupId)
 		throws PortalException {

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceListLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceListLocalServiceWrapper.java
@@ -321,14 +321,6 @@ public class CommercePriceListLocalServiceWrapper
 	}
 
 	@Override
-	public CommercePriceList fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return _commercePriceListLocalService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CommercePriceList fetchCatalogBaseCommercePriceList(long groupId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceListService.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceListService.java
@@ -76,11 +76,6 @@ public interface CommercePriceListService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommercePriceList fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException;
-
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommercePriceList fetchCatalogBaseCommercePriceListByType(
 			long groupId, String type)
 		throws PortalException;
@@ -96,6 +91,11 @@ public interface CommercePriceListService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommercePriceList fetchCommercePriceList(long commercePriceListId)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public CommercePriceList fetchCommercePriceListByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceListServiceUtil.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceListServiceUtil.java
@@ -81,14 +81,6 @@ public class CommercePriceListServiceUtil {
 		getService().deleteCommercePriceList(commercePriceListId);
 	}
 
-	public static CommercePriceList fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CommercePriceList fetchCatalogBaseCommercePriceListByType(
 			long groupId, String type)
 		throws PortalException {
@@ -114,6 +106,15 @@ public class CommercePriceListServiceUtil {
 		throws PortalException {
 
 		return getService().fetchCommercePriceList(commercePriceListId);
+	}
+
+	public static CommercePriceList
+			fetchCommercePriceListByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		return getService().fetchCommercePriceListByExternalReferenceCode(
+			externalReferenceCode, companyId);
 	}
 
 	public static CommercePriceList getCommercePriceList(

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceListServiceWrapper.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommercePriceListServiceWrapper.java
@@ -83,15 +83,6 @@ public class CommercePriceListServiceWrapper
 	}
 
 	@Override
-	public CommercePriceList fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _commercePriceListService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CommercePriceList fetchCatalogBaseCommercePriceListByType(
 			long groupId, String type)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -119,6 +110,16 @@ public class CommercePriceListServiceWrapper
 
 		return _commercePriceListService.fetchCommercePriceList(
 			commercePriceListId);
+	}
+
+	@Override
+	public CommercePriceList fetchCommercePriceListByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _commercePriceListService.
+			fetchCommercePriceListByExternalReferenceCode(
+				externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommerceTierPriceEntryLocalService.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommerceTierPriceEntryLocalService.java
@@ -329,10 +329,6 @@ public interface CommerceTierPriceEntryLocalService
 		DynamicQuery dynamicQuery, Projection projection);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceTierPriceEntry fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId);
-
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceTierPriceEntry fetchClosestCommerceTierPriceEntry(
 		long commercePriceEntryId, BigDecimal minQuantity);
 

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommerceTierPriceEntryLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommerceTierPriceEntryLocalServiceUtil.java
@@ -412,13 +412,6 @@ public class CommerceTierPriceEntryLocalServiceUtil {
 		return getService().dynamicQueryCount(dynamicQuery, projection);
 	}
 
-	public static CommerceTierPriceEntry fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CommerceTierPriceEntry fetchClosestCommerceTierPriceEntry(
 		long commercePriceEntryId, java.math.BigDecimal minQuantity) {
 

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommerceTierPriceEntryLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommerceTierPriceEntryLocalServiceWrapper.java
@@ -453,14 +453,6 @@ public class CommerceTierPriceEntryLocalServiceWrapper
 	}
 
 	@Override
-	public CommerceTierPriceEntry fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return _commerceTierPriceEntryLocalService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CommerceTierPriceEntry fetchClosestCommerceTierPriceEntry(
 		long commercePriceEntryId, java.math.BigDecimal minQuantity) {
 

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommerceTierPriceEntryService.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommerceTierPriceEntryService.java
@@ -99,13 +99,14 @@ public interface CommerceTierPriceEntryService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceTierPriceEntry fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
+	public CommerceTierPriceEntry fetchCommerceTierPriceEntry(
+			long commerceTierPriceEntryId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceTierPriceEntry fetchCommerceTierPriceEntry(
-			long commerceTierPriceEntryId)
+	public CommerceTierPriceEntry
+			fetchCommerceTierPriceEntryByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommerceTierPriceEntryServiceUtil.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommerceTierPriceEntryServiceUtil.java
@@ -128,20 +128,21 @@ public class CommerceTierPriceEntryServiceUtil {
 		getService().deleteCommerceTierPriceEntry(commerceTierPriceEntryId);
 	}
 
-	public static CommerceTierPriceEntry fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CommerceTierPriceEntry fetchCommerceTierPriceEntry(
 			long commerceTierPriceEntryId)
 		throws PortalException {
 
 		return getService().fetchCommerceTierPriceEntry(
 			commerceTierPriceEntryId);
+	}
+
+	public static CommerceTierPriceEntry
+			fetchCommerceTierPriceEntryByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		return getService().fetchCommerceTierPriceEntryByExternalReferenceCode(
+			externalReferenceCode, companyId);
 	}
 
 	public static List<CommerceTierPriceEntry> getCommerceTierPriceEntries(

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommerceTierPriceEntryServiceWrapper.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/CommerceTierPriceEntryServiceWrapper.java
@@ -133,21 +133,23 @@ public class CommerceTierPriceEntryServiceWrapper
 	}
 
 	@Override
-	public CommerceTierPriceEntry fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _commerceTierPriceEntryService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CommerceTierPriceEntry fetchCommerceTierPriceEntry(
 			long commerceTierPriceEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commerceTierPriceEntryService.fetchCommerceTierPriceEntry(
 			commerceTierPriceEntryId);
+	}
+
+	@Override
+	public CommerceTierPriceEntry
+			fetchCommerceTierPriceEntryByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _commerceTierPriceEntryService.
+			fetchCommerceTierPriceEntryByExternalReferenceCode(
+				externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-price-list-api/src/main/resources/com/liferay/commerce/price/list/service/packageinfo
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/resources/com/liferay/commerce/price/list/service/packageinfo
@@ -1,1 +1,1 @@
-version 18.0.0
+version 19.0.0

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/http/CommercePriceEntryServiceHttp.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/http/CommercePriceEntryServiceHttp.java
@@ -303,19 +303,17 @@ public class CommercePriceEntryServiceHttp {
 	}
 
 	public static com.liferay.commerce.price.list.model.CommercePriceEntry
-			fetchByExternalReferenceCode(
-				HttpPrincipal httpPrincipal, String externalReferenceCode,
-				long companyId)
+			fetchCommercePriceEntry(
+				HttpPrincipal httpPrincipal, long commercePriceEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				CommercePriceEntryServiceUtil.class,
-				"fetchByExternalReferenceCode",
-				_fetchByExternalReferenceCodeParameterTypes5);
+				CommercePriceEntryServiceUtil.class, "fetchCommercePriceEntry",
+				_fetchCommercePriceEntryParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, externalReferenceCode, companyId);
+				methodKey, commercePriceEntryId);
 
 			Object returnObj = null;
 
@@ -347,17 +345,19 @@ public class CommercePriceEntryServiceHttp {
 	}
 
 	public static com.liferay.commerce.price.list.model.CommercePriceEntry
-			fetchCommercePriceEntry(
-				HttpPrincipal httpPrincipal, long commercePriceEntryId)
+			fetchCommercePriceEntryByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				CommercePriceEntryServiceUtil.class, "fetchCommercePriceEntry",
-				_fetchCommercePriceEntryParameterTypes6);
+				CommercePriceEntryServiceUtil.class,
+				"fetchCommercePriceEntryByExternalReferenceCode",
+				_fetchCommercePriceEntryByExternalReferenceCodeParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, commercePriceEntryId);
+				methodKey, externalReferenceCode, companyId);
 
 			Object returnObj = null;
 
@@ -969,12 +969,11 @@ public class CommercePriceEntryServiceHttp {
 		};
 	private static final Class<?>[] _deleteCommercePriceEntryParameterTypes4 =
 		new Class[] {long.class};
-	private static final Class<?>[]
-		_fetchByExternalReferenceCodeParameterTypes5 = new Class[] {
-			String.class, long.class
-		};
-	private static final Class<?>[] _fetchCommercePriceEntryParameterTypes6 =
+	private static final Class<?>[] _fetchCommercePriceEntryParameterTypes5 =
 		new Class[] {long.class};
+	private static final Class<?>[]
+		_fetchCommercePriceEntryByExternalReferenceCodeParameterTypes6 =
+			new Class[] {String.class, long.class};
 	private static final Class<?>[] _getCommercePriceEntriesParameterTypes7 =
 		new Class[] {long.class, int.class, int.class};
 	private static final Class<?>[] _getCommercePriceEntriesParameterTypes8 =

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/http/CommercePriceListServiceHttp.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/http/CommercePriceListServiceHttp.java
@@ -193,50 +193,6 @@ public class CommercePriceListServiceHttp {
 	}
 
 	public static com.liferay.commerce.price.list.model.CommercePriceList
-			fetchByExternalReferenceCode(
-				HttpPrincipal httpPrincipal, String externalReferenceCode,
-				long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		try {
-			MethodKey methodKey = new MethodKey(
-				CommercePriceListServiceUtil.class,
-				"fetchByExternalReferenceCode",
-				_fetchByExternalReferenceCodeParameterTypes3);
-
-			MethodHandler methodHandler = new MethodHandler(
-				methodKey, externalReferenceCode, companyId);
-
-			Object returnObj = null;
-
-			try {
-				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
-			}
-			catch (Exception exception) {
-				if (exception instanceof
-						com.liferay.portal.kernel.exception.PortalException) {
-
-					throw (com.liferay.portal.kernel.exception.PortalException)
-						exception;
-				}
-
-				throw new com.liferay.portal.kernel.exception.SystemException(
-					exception);
-			}
-
-			return (com.liferay.commerce.price.list.model.CommercePriceList)
-				returnObj;
-		}
-		catch (com.liferay.portal.kernel.exception.SystemException
-					systemException) {
-
-			_log.error(systemException, systemException);
-
-			throw systemException;
-		}
-	}
-
-	public static com.liferay.commerce.price.list.model.CommercePriceList
 			fetchCatalogBaseCommercePriceListByType(
 				HttpPrincipal httpPrincipal, long groupId, String type)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -245,7 +201,7 @@ public class CommercePriceListServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				CommercePriceListServiceUtil.class,
 				"fetchCatalogBaseCommercePriceListByType",
-				_fetchCatalogBaseCommercePriceListByTypeParameterTypes4);
+				_fetchCatalogBaseCommercePriceListByTypeParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, type);
@@ -288,7 +244,7 @@ public class CommercePriceListServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				CommercePriceListServiceUtil.class,
 				"fetchCommerceCatalogBasePriceListByType",
-				_fetchCommerceCatalogBasePriceListByTypeParameterTypes5);
+				_fetchCommerceCatalogBasePriceListByTypeParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, type);
@@ -330,10 +286,54 @@ public class CommercePriceListServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommercePriceListServiceUtil.class, "fetchCommercePriceList",
-				_fetchCommercePriceListParameterTypes6);
+				_fetchCommercePriceListParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commercePriceListId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.commerce.price.list.model.CommercePriceList)
+				returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.commerce.price.list.model.CommercePriceList
+			fetchCommercePriceListByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				CommercePriceListServiceUtil.class,
+				"fetchCommercePriceListByExternalReferenceCode",
+				_fetchCommercePriceListByExternalReferenceCodeParameterTypes6);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, externalReferenceCode, companyId);
 
 			Object returnObj = null;
 
@@ -938,19 +938,18 @@ public class CommercePriceListServiceHttp {
 	private static final Class<?>[] _deleteCommercePriceListParameterTypes2 =
 		new Class[] {long.class};
 	private static final Class<?>[]
-		_fetchByExternalReferenceCodeParameterTypes3 = new Class[] {
-			String.class, long.class
-		};
-	private static final Class<?>[]
-		_fetchCatalogBaseCommercePriceListByTypeParameterTypes4 = new Class[] {
+		_fetchCatalogBaseCommercePriceListByTypeParameterTypes3 = new Class[] {
 			long.class, String.class
 		};
 	private static final Class<?>[]
-		_fetchCommerceCatalogBasePriceListByTypeParameterTypes5 = new Class[] {
+		_fetchCommerceCatalogBasePriceListByTypeParameterTypes4 = new Class[] {
 			long.class, String.class
 		};
-	private static final Class<?>[] _fetchCommercePriceListParameterTypes6 =
+	private static final Class<?>[] _fetchCommercePriceListParameterTypes5 =
 		new Class[] {long.class};
+	private static final Class<?>[]
+		_fetchCommercePriceListByExternalReferenceCodeParameterTypes6 =
+			new Class[] {String.class, long.class};
 	private static final Class<?>[] _getCommercePriceListParameterTypes7 =
 		new Class[] {long.class};
 	private static final Class<?>[] _getCommercePriceListsParameterTypes8 =

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/http/CommerceTierPriceEntryServiceHttp.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/http/CommerceTierPriceEntryServiceHttp.java
@@ -348,19 +348,18 @@ public class CommerceTierPriceEntryServiceHttp {
 	}
 
 	public static com.liferay.commerce.price.list.model.CommerceTierPriceEntry
-			fetchByExternalReferenceCode(
-				HttpPrincipal httpPrincipal, String externalReferenceCode,
-				long companyId)
+			fetchCommerceTierPriceEntry(
+				HttpPrincipal httpPrincipal, long commerceTierPriceEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceTierPriceEntryServiceUtil.class,
-				"fetchByExternalReferenceCode",
-				_fetchByExternalReferenceCodeParameterTypes6);
+				"fetchCommerceTierPriceEntry",
+				_fetchCommerceTierPriceEntryParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, externalReferenceCode, companyId);
+				methodKey, commerceTierPriceEntryId);
 
 			Object returnObj = null;
 
@@ -392,18 +391,19 @@ public class CommerceTierPriceEntryServiceHttp {
 	}
 
 	public static com.liferay.commerce.price.list.model.CommerceTierPriceEntry
-			fetchCommerceTierPriceEntry(
-				HttpPrincipal httpPrincipal, long commerceTierPriceEntryId)
+			fetchCommerceTierPriceEntryByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceTierPriceEntryServiceUtil.class,
-				"fetchCommerceTierPriceEntry",
-				_fetchCommerceTierPriceEntryParameterTypes7);
+				"fetchCommerceTierPriceEntryByExternalReferenceCode",
+				_fetchCommerceTierPriceEntryByExternalReferenceCodeParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, commerceTierPriceEntryId);
+				methodKey, externalReferenceCode, companyId);
 
 			Object returnObj = null;
 
@@ -942,11 +942,10 @@ public class CommerceTierPriceEntryServiceHttp {
 	private static final Class<?>[]
 		_deleteCommerceTierPriceEntryParameterTypes5 = new Class[] {long.class};
 	private static final Class<?>[]
-		_fetchByExternalReferenceCodeParameterTypes6 = new Class[] {
-			String.class, long.class
-		};
+		_fetchCommerceTierPriceEntryParameterTypes6 = new Class[] {long.class};
 	private static final Class<?>[]
-		_fetchCommerceTierPriceEntryParameterTypes7 = new Class[] {long.class};
+		_fetchCommerceTierPriceEntryByExternalReferenceCodeParameterTypes7 =
+			new Class[] {String.class, long.class};
 	private static final Class<?>[]
 		_getCommerceTierPriceEntriesParameterTypes8 = new Class[] {
 			long.class, int.class, int.class

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceEntryLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceEntryLocalServiceImpl.java
@@ -399,18 +399,6 @@ public class CommercePriceEntryLocalServiceImpl
 	}
 
 	@Override
-	public CommercePriceEntry fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		if (Validator.isBlank(externalReferenceCode)) {
-			return null;
-		}
-
-		return commercePriceEntryPersistence.fetchByERC_C(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CommercePriceEntry fetchCommercePriceEntry(
 		long commercePriceListId, String cpInstanceUuid, int status,
 		String unitOfMeasureKey) {

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceEntryServiceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceEntryServiceImpl.java
@@ -166,13 +166,12 @@ public class CommercePriceEntryServiceImpl
 	}
 
 	@Override
-	public CommercePriceEntry fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
+	public CommercePriceEntry fetchCommercePriceEntry(long commercePriceEntryId)
 		throws PortalException {
 
 		CommercePriceEntry commercePriceEntry =
-			commercePriceEntryLocalService.fetchByExternalReferenceCode(
-				externalReferenceCode, companyId);
+			commercePriceEntryLocalService.fetchCommercePriceEntry(
+				commercePriceEntryId);
 
 		if (commercePriceEntry != null) {
 			_commercePriceListModelResourcePermission.check(
@@ -184,12 +183,14 @@ public class CommercePriceEntryServiceImpl
 	}
 
 	@Override
-	public CommercePriceEntry fetchCommercePriceEntry(long commercePriceEntryId)
+	public CommercePriceEntry fetchCommercePriceEntryByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		CommercePriceEntry commercePriceEntry =
-			commercePriceEntryLocalService.fetchCommercePriceEntry(
-				commercePriceEntryId);
+			commercePriceEntryLocalService.
+				fetchCommercePriceEntryByExternalReferenceCode(
+					externalReferenceCode, companyId);
 
 		if (commercePriceEntry != null) {
 			_commercePriceListModelResourcePermission.check(

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListLocalServiceImpl.java
@@ -357,18 +357,6 @@ public class CommercePriceListLocalServiceImpl
 	}
 
 	@Override
-	public CommercePriceList fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		if (Validator.isBlank(externalReferenceCode)) {
-			return null;
-		}
-
-		return commercePriceListPersistence.fetchByERC_C(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CommercePriceList fetchCatalogBaseCommercePriceList(long groupId)
 		throws PortalException {
 

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListServiceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommercePriceListServiceImpl.java
@@ -146,23 +146,6 @@ public class CommercePriceListServiceImpl
 	}
 
 	@Override
-	public CommercePriceList fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		CommercePriceList commercePriceList =
-			commercePriceListLocalService.fetchByExternalReferenceCode(
-				externalReferenceCode, companyId);
-
-		if (commercePriceList != null) {
-			_commercePriceListModelResourcePermission.check(
-				getPermissionChecker(), commercePriceList, ActionKeys.VIEW);
-		}
-
-		return commercePriceList;
-	}
-
-	@Override
 	public CommercePriceList fetchCatalogBaseCommercePriceListByType(
 			long groupId, String type)
 		throws PortalException {
@@ -203,6 +186,24 @@ public class CommercePriceListServiceImpl
 		if (commercePriceList != null) {
 			_commercePriceListModelResourcePermission.check(
 				getPermissionChecker(), commercePriceListId, ActionKeys.VIEW);
+		}
+
+		return commercePriceList;
+	}
+
+	@Override
+	public CommercePriceList fetchCommercePriceListByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		CommercePriceList commercePriceList =
+			commercePriceListLocalService.
+				fetchCommercePriceListByExternalReferenceCode(
+					externalReferenceCode, companyId);
+
+		if (commercePriceList != null) {
+			_commercePriceListModelResourcePermission.check(
+				getPermissionChecker(), commercePriceList, ActionKeys.VIEW);
 		}
 
 		return commercePriceList;

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommerceTierPriceEntryLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommerceTierPriceEntryLocalServiceImpl.java
@@ -508,14 +508,6 @@ public class CommerceTierPriceEntryLocalServiceImpl
 	}
 
 	@Override
-	public CommerceTierPriceEntry fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return commerceTierPriceEntryPersistence.fetchByERC_C(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CommerceTierPriceEntry fetchClosestCommerceTierPriceEntry(
 		long commercePriceEntryId, BigDecimal minQuantity) {
 

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommerceTierPriceEntryServiceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/impl/CommerceTierPriceEntryServiceImpl.java
@@ -208,13 +208,13 @@ public class CommerceTierPriceEntryServiceImpl
 	}
 
 	@Override
-	public CommerceTierPriceEntry fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
+	public CommerceTierPriceEntry fetchCommerceTierPriceEntry(
+			long commerceTierPriceEntryId)
 		throws PortalException {
 
 		CommerceTierPriceEntry commerceTierPriceEntry =
-			commerceTierPriceEntryLocalService.fetchByExternalReferenceCode(
-				externalReferenceCode, companyId);
+			commerceTierPriceEntryLocalService.fetchCommerceTierPriceEntry(
+				commerceTierPriceEntryId);
 
 		if (commerceTierPriceEntry != null) {
 			CommercePriceEntry commercePriceEntry =
@@ -229,13 +229,15 @@ public class CommerceTierPriceEntryServiceImpl
 	}
 
 	@Override
-	public CommerceTierPriceEntry fetchCommerceTierPriceEntry(
-			long commerceTierPriceEntryId)
+	public CommerceTierPriceEntry
+			fetchCommerceTierPriceEntryByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		CommerceTierPriceEntry commerceTierPriceEntry =
-			commerceTierPriceEntryLocalService.fetchCommerceTierPriceEntry(
-				commerceTierPriceEntryId);
+			commerceTierPriceEntryLocalService.
+				fetchCommerceTierPriceEntryByExternalReferenceCode(
+					externalReferenceCode, companyId);
 
 		if (commerceTierPriceEntry != null) {
 			CommercePriceEntry commercePriceEntry =

--- a/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/test/CommercePriceEntryLocalServiceTest.java
+++ b/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/test/CommercePriceEntryLocalServiceTest.java
@@ -294,8 +294,9 @@ public class CommercePriceEntryLocalServiceTest {
 			promoPrice);
 
 		CommercePriceEntry commercePriceEntry =
-			_commercePriceEntryLocalService.fetchByExternalReferenceCode(
-				externalReferenceCode, _group.getCompanyId());
+			_commercePriceEntryLocalService.
+				fetchCommercePriceEntryByExternalReferenceCode(
+					externalReferenceCode, _group.getCompanyId());
 
 		_assertPriceEntryAttributes(
 			cpInstance, price, promoPrice, commercePriceEntry);

--- a/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/test/CommercePriceListLocalServiceTest.java
+++ b/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/test/CommercePriceListLocalServiceTest.java
@@ -336,8 +336,9 @@ public class CommercePriceListLocalServiceTest {
 			RandomTestUtil.randomDouble(), true, null, null);
 
 		CommercePriceList commercePriceList =
-			_commercePriceListLocalService.fetchByExternalReferenceCode(
-				externalReferenceCode, _group.getCompanyId());
+			_commercePriceListLocalService.
+				fetchCommercePriceListByExternalReferenceCode(
+					externalReferenceCode, _group.getCompanyId());
 
 		_assertPriceListAttributes(
 			updatedCurrency, updatedName, commercePriceList);

--- a/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/test/CommerceTierPriceEntryLocalServiceTest.java
+++ b/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/test/CommerceTierPriceEntryLocalServiceTest.java
@@ -248,8 +248,9 @@ public class CommerceTierPriceEntryLocalServiceTest {
 			promoPrice, externalReferenceCode, null);
 
 		CommerceTierPriceEntry commerceTierPriceEntry =
-			_commerceTierPriceEntryLocalService.fetchByExternalReferenceCode(
-				externalReferenceCode, _group.getCompanyId());
+			_commerceTierPriceEntryLocalService.
+				fetchCommerceTierPriceEntryByExternalReferenceCode(
+					externalReferenceCode, _group.getCompanyId());
 
 		_assertTierPriceEntryAttributes(
 			commercePriceEntry, minQuantity, price, promoPrice,
@@ -386,8 +387,9 @@ public class CommerceTierPriceEntryLocalServiceTest {
 			null, priceEntryExternalReferenceCode);
 
 		CommercePriceEntry actualCommercePriceEntry =
-			_commercePriceEntryLocalService.fetchByExternalReferenceCode(
-				priceEntryExternalReferenceCode, _group.getCompanyId());
+			_commercePriceEntryLocalService.
+				fetchCommercePriceEntryByExternalReferenceCode(
+					priceEntryExternalReferenceCode, _group.getCompanyId());
 
 		Assert.assertTrue(actualCommercePriceEntry.isHasTierPrice());
 

--- a/modules/apps/commerce/commerce-pricing-api/bnd.bnd
+++ b/modules/apps/commerce/commerce-pricing-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Commerce Pricing API
 Bundle-SymbolicName: com.liferay.commerce.pricing.api
-Bundle-Version: 16.0.1
+Bundle-Version: 17.0.0
 Export-Package:\
 	com.liferay.commerce.pricing.configuration,\
 	com.liferay.commerce.pricing.constants,\

--- a/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePriceModifierLocalService.java
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePriceModifierLocalService.java
@@ -264,10 +264,6 @@ public interface CommercePriceModifierLocalService
 		DynamicQuery dynamicQuery, Projection projection);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommercePriceModifier fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId);
-
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommercePriceModifier fetchCommercePriceModifier(
 		long commercePriceModifierId);
 

--- a/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePriceModifierLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePriceModifierLocalServiceUtil.java
@@ -311,13 +311,6 @@ public class CommercePriceModifierLocalServiceUtil {
 		return getService().dynamicQueryCount(dynamicQuery, projection);
 	}
 
-	public static CommercePriceModifier fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CommercePriceModifier fetchCommercePriceModifier(
 		long commercePriceModifierId) {
 

--- a/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePriceModifierLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePriceModifierLocalServiceWrapper.java
@@ -348,14 +348,6 @@ public class CommercePriceModifierLocalServiceWrapper
 	}
 
 	@Override
-	public CommercePriceModifier fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return _commercePriceModifierLocalService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CommercePriceModifier fetchCommercePriceModifier(
 		long commercePriceModifierId) {
 

--- a/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePriceModifierService.java
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePriceModifierService.java
@@ -78,13 +78,14 @@ public interface CommercePriceModifierService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommercePriceModifier fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
+	public CommercePriceModifier fetchCommercePriceModifier(
+			long commercePriceModifierId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommercePriceModifier fetchCommercePriceModifier(
-			long commercePriceModifierId)
+	public CommercePriceModifier
+			fetchCommercePriceModifierByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePriceModifierServiceUtil.java
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePriceModifierServiceUtil.java
@@ -82,19 +82,20 @@ public class CommercePriceModifierServiceUtil {
 			commercePriceModifierId);
 	}
 
-	public static CommercePriceModifier fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CommercePriceModifier fetchCommercePriceModifier(
 			long commercePriceModifierId)
 		throws PortalException {
 
 		return getService().fetchCommercePriceModifier(commercePriceModifierId);
+	}
+
+	public static CommercePriceModifier
+			fetchCommercePriceModifierByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		return getService().fetchCommercePriceModifierByExternalReferenceCode(
+			externalReferenceCode, companyId);
 	}
 
 	public static CommercePriceModifier getCommercePriceModifier(

--- a/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePriceModifierServiceWrapper.java
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePriceModifierServiceWrapper.java
@@ -84,21 +84,23 @@ public class CommercePriceModifierServiceWrapper
 	}
 
 	@Override
-	public CommercePriceModifier fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _commercePriceModifierService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CommercePriceModifier fetchCommercePriceModifier(
 			long commercePriceModifierId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commercePriceModifierService.fetchCommercePriceModifier(
 			commercePriceModifierId);
+	}
+
+	@Override
+	public CommercePriceModifier
+			fetchCommercePriceModifierByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _commercePriceModifierService.
+			fetchCommercePriceModifierByExternalReferenceCode(
+				externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePricingClassLocalService.java
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePricingClassLocalService.java
@@ -233,10 +233,6 @@ public interface CommercePricingClassLocalService
 		DynamicQuery dynamicQuery, Projection projection);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommercePricingClass fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId);
-
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommercePricingClass fetchCommercePricingClass(
 		long commercePricingClassId);
 

--- a/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePricingClassLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePricingClassLocalServiceUtil.java
@@ -247,13 +247,6 @@ public class CommercePricingClassLocalServiceUtil {
 		return getService().dynamicQueryCount(dynamicQuery, projection);
 	}
 
-	public static CommercePricingClass fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CommercePricingClass fetchCommercePricingClass(
 		long commercePricingClassId) {
 

--- a/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePricingClassLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePricingClassLocalServiceWrapper.java
@@ -279,14 +279,6 @@ public class CommercePricingClassLocalServiceWrapper
 	}
 
 	@Override
-	public CommercePricingClass fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return _commercePricingClassLocalService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CommercePricingClass fetchCommercePricingClass(
 		long commercePricingClassId) {
 

--- a/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePricingClassService.java
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePricingClassService.java
@@ -67,13 +67,14 @@ public interface CommercePricingClassService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommercePricingClass fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
+	public CommercePricingClass fetchCommercePricingClass(
+			long commercePricingClassId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommercePricingClass fetchCommercePricingClass(
-			long commercePricingClassId)
+	public CommercePricingClass
+			fetchCommercePricingClassByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePricingClassServiceUtil.java
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePricingClassServiceUtil.java
@@ -62,19 +62,20 @@ public class CommercePricingClassServiceUtil {
 		return getService().deleteCommercePricingClass(commercePricingClassId);
 	}
 
-	public static CommercePricingClass fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CommercePricingClass fetchCommercePricingClass(
 			long commercePricingClassId)
 		throws PortalException {
 
 		return getService().fetchCommercePricingClass(commercePricingClassId);
+	}
+
+	public static CommercePricingClass
+			fetchCommercePricingClassByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		return getService().fetchCommercePricingClassByExternalReferenceCode(
+			externalReferenceCode, companyId);
 	}
 
 	public static CommercePricingClass getCommercePricingClass(

--- a/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePricingClassServiceWrapper.java
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/java/com/liferay/commerce/pricing/service/CommercePricingClassServiceWrapper.java
@@ -64,21 +64,23 @@ public class CommercePricingClassServiceWrapper
 	}
 
 	@Override
-	public CommercePricingClass fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _commercePricingClassService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CommercePricingClass fetchCommercePricingClass(
 			long commercePricingClassId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commercePricingClassService.fetchCommercePricingClass(
 			commercePricingClassId);
+	}
+
+	@Override
+	public CommercePricingClass
+			fetchCommercePricingClassByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _commercePricingClassService.
+			fetchCommercePricingClassByExternalReferenceCode(
+				externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-pricing-api/src/main/resources/com/liferay/commerce/pricing/service/packageinfo
+++ b/modules/apps/commerce/commerce-pricing-api/src/main/resources/com/liferay/commerce/pricing/service/packageinfo
@@ -1,1 +1,1 @@
-version 7.0.0
+version 8.0.0

--- a/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/http/CommercePriceModifierServiceHttp.java
+++ b/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/http/CommercePriceModifierServiceHttp.java
@@ -199,19 +199,18 @@ public class CommercePriceModifierServiceHttp {
 	}
 
 	public static com.liferay.commerce.pricing.model.CommercePriceModifier
-			fetchByExternalReferenceCode(
-				HttpPrincipal httpPrincipal, String externalReferenceCode,
-				long companyId)
+			fetchCommercePriceModifier(
+				HttpPrincipal httpPrincipal, long commercePriceModifierId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommercePriceModifierServiceUtil.class,
-				"fetchByExternalReferenceCode",
-				_fetchByExternalReferenceCodeParameterTypes3);
+				"fetchCommercePriceModifier",
+				_fetchCommercePriceModifierParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, externalReferenceCode, companyId);
+				methodKey, commercePriceModifierId);
 
 			Object returnObj = null;
 
@@ -243,18 +242,19 @@ public class CommercePriceModifierServiceHttp {
 	}
 
 	public static com.liferay.commerce.pricing.model.CommercePriceModifier
-			fetchCommercePriceModifier(
-				HttpPrincipal httpPrincipal, long commercePriceModifierId)
+			fetchCommercePriceModifierByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommercePriceModifierServiceUtil.class,
-				"fetchCommercePriceModifier",
-				_fetchCommercePriceModifierParameterTypes4);
+				"fetchCommercePriceModifierByExternalReferenceCode",
+				_fetchCommercePriceModifierByExternalReferenceCodeParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, commercePriceModifierId);
+				methodKey, externalReferenceCode, companyId);
 
 			Object returnObj = null;
 
@@ -629,12 +629,11 @@ public class CommercePriceModifierServiceHttp {
 		};
 	private static final Class<?>[]
 		_deleteCommercePriceModifierParameterTypes2 = new Class[] {long.class};
-	private static final Class<?>[]
-		_fetchByExternalReferenceCodeParameterTypes3 = new Class[] {
-			String.class, long.class
-		};
-	private static final Class<?>[] _fetchCommercePriceModifierParameterTypes4 =
+	private static final Class<?>[] _fetchCommercePriceModifierParameterTypes3 =
 		new Class[] {long.class};
+	private static final Class<?>[]
+		_fetchCommercePriceModifierByExternalReferenceCodeParameterTypes4 =
+			new Class[] {String.class, long.class};
 	private static final Class<?>[] _getCommercePriceModifierParameterTypes5 =
 		new Class[] {long.class};
 	private static final Class<?>[] _getCommercePriceModifiersParameterTypes6 =

--- a/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/http/CommercePricingClassServiceHttp.java
+++ b/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/http/CommercePricingClassServiceHttp.java
@@ -180,19 +180,18 @@ public class CommercePricingClassServiceHttp {
 	}
 
 	public static com.liferay.commerce.pricing.model.CommercePricingClass
-			fetchByExternalReferenceCode(
-				HttpPrincipal httpPrincipal, String externalReferenceCode,
-				long companyId)
+			fetchCommercePricingClass(
+				HttpPrincipal httpPrincipal, long commercePricingClassId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommercePricingClassServiceUtil.class,
-				"fetchByExternalReferenceCode",
-				_fetchByExternalReferenceCodeParameterTypes3);
+				"fetchCommercePricingClass",
+				_fetchCommercePricingClassParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, externalReferenceCode, companyId);
+				methodKey, commercePricingClassId);
 
 			Object returnObj = null;
 
@@ -224,18 +223,19 @@ public class CommercePricingClassServiceHttp {
 	}
 
 	public static com.liferay.commerce.pricing.model.CommercePricingClass
-			fetchCommercePricingClass(
-				HttpPrincipal httpPrincipal, long commercePricingClassId)
+			fetchCommercePricingClassByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommercePricingClassServiceUtil.class,
-				"fetchCommercePricingClass",
-				_fetchCommercePricingClassParameterTypes4);
+				"fetchCommercePricingClassByExternalReferenceCode",
+				_fetchCommercePricingClassByExternalReferenceCodeParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, commercePricingClassId);
+				methodKey, externalReferenceCode, companyId);
 
 			Object returnObj = null;
 
@@ -682,12 +682,11 @@ public class CommercePricingClassServiceHttp {
 		};
 	private static final Class<?>[] _deleteCommercePricingClassParameterTypes2 =
 		new Class[] {long.class};
-	private static final Class<?>[]
-		_fetchByExternalReferenceCodeParameterTypes3 = new Class[] {
-			String.class, long.class
-		};
-	private static final Class<?>[] _fetchCommercePricingClassParameterTypes4 =
+	private static final Class<?>[] _fetchCommercePricingClassParameterTypes3 =
 		new Class[] {long.class};
+	private static final Class<?>[]
+		_fetchCommercePricingClassByExternalReferenceCodeParameterTypes4 =
+			new Class[] {String.class, long.class};
 	private static final Class<?>[] _getCommercePricingClassParameterTypes5 =
 		new Class[] {long.class};
 	private static final Class<?>[]

--- a/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/impl/CommercePriceModifierLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/impl/CommercePriceModifierLocalServiceImpl.java
@@ -331,18 +331,6 @@ public class CommercePriceModifierLocalServiceImpl
 	}
 
 	@Override
-	public CommercePriceModifier fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		if (Validator.isBlank(externalReferenceCode)) {
-			return null;
-		}
-
-		return commercePriceModifierPersistence.fetchByERC_C(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public List<CommercePriceModifier> getCommercePriceModifiers(
 		long commercePriceListId) {
 

--- a/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/impl/CommercePriceModifierServiceImpl.java
+++ b/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/impl/CommercePriceModifierServiceImpl.java
@@ -106,13 +106,13 @@ public class CommercePriceModifierServiceImpl
 	}
 
 	@Override
-	public CommercePriceModifier fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
+	public CommercePriceModifier fetchCommercePriceModifier(
+			long commercePriceModifierId)
 		throws PortalException {
 
 		CommercePriceModifier commercePriceModifier =
-			commercePriceModifierLocalService.fetchByExternalReferenceCode(
-				externalReferenceCode, companyId);
+			commercePriceModifierLocalService.fetchCommercePriceModifier(
+				commercePriceModifierId);
 
 		if (commercePriceModifier != null) {
 			_commercePriceListModelResourcePermission.check(
@@ -125,13 +125,15 @@ public class CommercePriceModifierServiceImpl
 	}
 
 	@Override
-	public CommercePriceModifier fetchCommercePriceModifier(
-			long commercePriceModifierId)
+	public CommercePriceModifier
+			fetchCommercePriceModifierByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		CommercePriceModifier commercePriceModifier =
-			commercePriceModifierLocalService.fetchCommercePriceModifier(
-				commercePriceModifierId);
+			commercePriceModifierLocalService.
+				fetchCommercePriceModifierByExternalReferenceCode(
+					externalReferenceCode, companyId);
 
 		if (commercePriceModifier != null) {
 			_commercePriceListModelResourcePermission.check(

--- a/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/impl/CommercePricingClassLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/impl/CommercePricingClassLocalServiceImpl.java
@@ -218,18 +218,6 @@ public class CommercePricingClassLocalServiceImpl
 	}
 
 	@Override
-	public CommercePricingClass fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		if (Validator.isBlank(externalReferenceCode)) {
-			return null;
-		}
-
-		return commercePricingClassPersistence.fetchByERC_C(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public long[] getCommercePricingClassByCPDefinition(long cpDefinitionId) {
 		return TransformUtil.transformToLongArray(
 			_commercePricingClassCPDefinitionRelLocalService.

--- a/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/impl/CommercePricingClassServiceImpl.java
+++ b/modules/apps/commerce/commerce-pricing-service/src/main/java/com/liferay/commerce/pricing/service/impl/CommercePricingClassServiceImpl.java
@@ -114,13 +114,13 @@ public class CommercePricingClassServiceImpl
 	}
 
 	@Override
-	public CommercePricingClass fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
+	public CommercePricingClass fetchCommercePricingClass(
+			long commercePricingClassId)
 		throws PortalException {
 
 		CommercePricingClass commercePricingClass =
-			commercePricingClassLocalService.fetchByExternalReferenceCode(
-				externalReferenceCode, companyId);
+			commercePricingClassLocalService.fetchCommercePricingClass(
+				commercePricingClassId);
 
 		if (commercePricingClass != null) {
 			_commercePricingClassResourcePermission.check(
@@ -131,13 +131,15 @@ public class CommercePricingClassServiceImpl
 	}
 
 	@Override
-	public CommercePricingClass fetchCommercePricingClass(
-			long commercePricingClassId)
+	public CommercePricingClass
+			fetchCommercePricingClassByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		CommercePricingClass commercePricingClass =
-			commercePricingClassLocalService.fetchCommercePricingClass(
-				commercePricingClassId);
+			commercePricingClassLocalService.
+				fetchCommercePricingClassByExternalReferenceCode(
+					externalReferenceCode, companyId);
 
 		if (commercePricingClass != null) {
 			_commercePricingClassResourcePermission.check(

--- a/modules/apps/commerce/commerce-product-api/bnd.bnd
+++ b/modules/apps/commerce/commerce-product-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Commerce Product API
 Bundle-SymbolicName: com.liferay.commerce.product.api
-Bundle-Version: 85.1.0
+Bundle-Version: 86.0.0
 Export-Package:\
 	com.liferay.commerce.product.availability,\
 	com.liferay.commerce.product.catalog,\

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPAttachmentFileEntryLocalService.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPAttachmentFileEntryLocalService.java
@@ -249,10 +249,6 @@ public interface CPAttachmentFileEntryLocalService
 		DynamicQuery dynamicQuery, Projection projection);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CPAttachmentFileEntry fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId);
-
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CPAttachmentFileEntry fetchCPAttachmentFileEntry(
 		long CPAttachmentFileEntryId);
 

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPAttachmentFileEntryLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPAttachmentFileEntryLocalServiceUtil.java
@@ -281,13 +281,6 @@ public class CPAttachmentFileEntryLocalServiceUtil {
 		return getService().dynamicQueryCount(dynamicQuery, projection);
 	}
 
-	public static CPAttachmentFileEntry fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CPAttachmentFileEntry fetchCPAttachmentFileEntry(
 		long CPAttachmentFileEntryId) {
 

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPAttachmentFileEntryLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPAttachmentFileEntryLocalServiceWrapper.java
@@ -315,14 +315,6 @@ public class CPAttachmentFileEntryLocalServiceWrapper
 	}
 
 	@Override
-	public CPAttachmentFileEntry fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return _cpAttachmentFileEntryLocalService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CPAttachmentFileEntry fetchCPAttachmentFileEntry(
 		long CPAttachmentFileEntryId) {
 

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPAttachmentFileEntryService.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPAttachmentFileEntryService.java
@@ -77,13 +77,14 @@ public interface CPAttachmentFileEntryService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CPAttachmentFileEntry fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
+	public CPAttachmentFileEntry fetchCPAttachmentFileEntry(
+			long cpAttachmentFileEntryId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CPAttachmentFileEntry fetchCPAttachmentFileEntry(
-			long cpAttachmentFileEntryId)
+	public CPAttachmentFileEntry
+			fetchCPAttachmentFileEntryByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPAttachmentFileEntryServiceUtil.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPAttachmentFileEntryServiceUtil.java
@@ -84,19 +84,20 @@ public class CPAttachmentFileEntryServiceUtil {
 		getService().deleteCPAttachmentFileEntry(cpAttachmentFileEntryId);
 	}
 
-	public static CPAttachmentFileEntry fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CPAttachmentFileEntry fetchCPAttachmentFileEntry(
 			long cpAttachmentFileEntryId)
 		throws PortalException {
 
 		return getService().fetchCPAttachmentFileEntry(cpAttachmentFileEntryId);
+	}
+
+	public static CPAttachmentFileEntry
+			fetchCPAttachmentFileEntryByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		return getService().fetchCPAttachmentFileEntryByExternalReferenceCode(
+			externalReferenceCode, companyId);
 	}
 
 	public static List<CPAttachmentFileEntry> getCPAttachmentFileEntries(

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPAttachmentFileEntryServiceWrapper.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPAttachmentFileEntryServiceWrapper.java
@@ -86,21 +86,23 @@ public class CPAttachmentFileEntryServiceWrapper
 	}
 
 	@Override
-	public CPAttachmentFileEntry fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _cpAttachmentFileEntryService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CPAttachmentFileEntry fetchCPAttachmentFileEntry(
 			long cpAttachmentFileEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _cpAttachmentFileEntryService.fetchCPAttachmentFileEntry(
 			cpAttachmentFileEntryId);
+	}
+
+	@Override
+	public CPAttachmentFileEntry
+			fetchCPAttachmentFileEntryByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _cpAttachmentFileEntryService.
+			fetchCPAttachmentFileEntryByExternalReferenceCode(
+				externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPInstanceLocalService.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPInstanceLocalService.java
@@ -278,10 +278,6 @@ public interface CPInstanceLocalService
 		DynamicQuery dynamicQuery, Projection projection);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CPInstance fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId);
-
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CPInstance fetchCPInstance(long CPInstanceId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPInstanceLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPInstanceLocalServiceUtil.java
@@ -326,13 +326,6 @@ public class CPInstanceLocalServiceUtil {
 		return getService().dynamicQueryCount(dynamicQuery, projection);
 	}
 
-	public static CPInstance fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CPInstance fetchCPInstance(long CPInstanceId) {
 		return getService().fetchCPInstance(CPInstanceId);
 	}

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPInstanceLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPInstanceLocalServiceWrapper.java
@@ -350,14 +350,6 @@ public class CPInstanceLocalServiceWrapper
 	}
 
 	@Override
-	public CPInstance fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return _cpInstanceLocalService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CPInstance fetchCPInstance(long CPInstanceId) {
 		return _cpInstanceLocalService.fetchCPInstance(CPInstanceId);
 	}

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPInstanceService.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPInstanceService.java
@@ -109,12 +109,12 @@ public interface CPInstanceService extends BaseService {
 	public void deleteCPInstance(long cpInstanceId) throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CPInstance fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException;
+	public CPInstance fetchCPInstance(long cpInstanceId) throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CPInstance fetchCPInstance(long cpInstanceId) throws PortalException;
+	public CPInstance fetchCPInstanceByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CPInstance fetchCProductInstance(

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPInstanceServiceUtil.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPInstanceServiceUtil.java
@@ -138,18 +138,18 @@ public class CPInstanceServiceUtil {
 		getService().deleteCPInstance(cpInstanceId);
 	}
 
-	public static CPInstance fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CPInstance fetchCPInstance(long cpInstanceId)
 		throws PortalException {
 
 		return getService().fetchCPInstance(cpInstanceId);
+	}
+
+	public static CPInstance fetchCPInstanceByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		return getService().fetchCPInstanceByExternalReferenceCode(
+			externalReferenceCode, companyId);
 	}
 
 	public static CPInstance fetchCProductInstance(

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPInstanceServiceWrapper.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPInstanceServiceWrapper.java
@@ -138,19 +138,19 @@ public class CPInstanceServiceWrapper
 	}
 
 	@Override
-	public CPInstance fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _cpInstanceService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CPInstance fetchCPInstance(long cpInstanceId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _cpInstanceService.fetchCPInstance(cpInstanceId);
+	}
+
+	@Override
+	public CPInstance fetchCPInstanceByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _cpInstanceService.fetchCPInstanceByExternalReferenceCode(
+			externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPOptionLocalService.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPOptionLocalService.java
@@ -221,10 +221,6 @@ public interface CPOptionLocalService
 		DynamicQuery dynamicQuery, Projection projection);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CPOption fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId);
-
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CPOption fetchCPOption(long CPOptionId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPOptionLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPOptionLocalServiceUtil.java
@@ -235,13 +235,6 @@ public class CPOptionLocalServiceUtil {
 		return getService().dynamicQueryCount(dynamicQuery, projection);
 	}
 
-	public static CPOption fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CPOption fetchCPOption(long CPOptionId) {
 		return getService().fetchCPOption(CPOptionId);
 	}

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPOptionLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPOptionLocalServiceWrapper.java
@@ -257,14 +257,6 @@ public class CPOptionLocalServiceWrapper
 	}
 
 	@Override
-	public CPOption fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return _cpOptionLocalService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CPOption fetchCPOption(long CPOptionId) {
 		return _cpOptionLocalService.fetchCPOption(CPOptionId);
 	}

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPOptionService.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPOptionService.java
@@ -66,15 +66,15 @@ public interface CPOptionService extends BaseService {
 	public void deleteCPOption(long cpOptionId) throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CPOption fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException;
-
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CPOption fetchCPOption(long cpOptionId) throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CPOption fetchCPOption(long companyId, String key)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public CPOption fetchCPOptionByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	public List<CPOption> findCPOptionByCompanyId(

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPOptionServiceUtil.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPOptionServiceUtil.java
@@ -63,14 +63,6 @@ public class CPOptionServiceUtil {
 		getService().deleteCPOption(cpOptionId);
 	}
 
-	public static CPOption fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CPOption fetchCPOption(long cpOptionId)
 		throws PortalException {
 
@@ -81,6 +73,14 @@ public class CPOptionServiceUtil {
 		throws PortalException {
 
 		return getService().fetchCPOption(companyId, key);
+	}
+
+	public static CPOption fetchCPOptionByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		return getService().fetchCPOptionByExternalReferenceCode(
+			externalReferenceCode, companyId);
 	}
 
 	public static List<CPOption> findCPOptionByCompanyId(

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPOptionServiceWrapper.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPOptionServiceWrapper.java
@@ -64,15 +64,6 @@ public class CPOptionServiceWrapper
 	}
 
 	@Override
-	public CPOption fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _cpOptionService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CPOption fetchCPOption(long cpOptionId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -84,6 +75,15 @@ public class CPOptionServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _cpOptionService.fetchCPOption(companyId, key);
+	}
+
+	@Override
+	public CPOption fetchCPOptionByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _cpOptionService.fetchCPOptionByExternalReferenceCode(
+			externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPOptionValueLocalService.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPOptionValueLocalService.java
@@ -230,10 +230,6 @@ public interface CPOptionValueLocalService
 		DynamicQuery dynamicQuery, Projection projection);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CPOptionValue fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId);
-
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CPOptionValue fetchCPOptionValue(long CPOptionValueId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPOptionValueLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPOptionValueLocalServiceUtil.java
@@ -239,13 +239,6 @@ public class CPOptionValueLocalServiceUtil {
 		return getService().dynamicQueryCount(dynamicQuery, projection);
 	}
 
-	public static CPOptionValue fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CPOptionValue fetchCPOptionValue(long CPOptionValueId) {
 		return getService().fetchCPOptionValue(CPOptionValueId);
 	}

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPOptionValueLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPOptionValueLocalServiceWrapper.java
@@ -264,14 +264,6 @@ public class CPOptionValueLocalServiceWrapper
 	}
 
 	@Override
-	public CPOptionValue fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return _cpOptionValueLocalService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CPOptionValue fetchCPOptionValue(long CPOptionValueId) {
 		return _cpOptionValueLocalService.fetchCPOptionValue(CPOptionValueId);
 	}

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPOptionValueService.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPOptionValueService.java
@@ -64,12 +64,12 @@ public interface CPOptionValueService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CPOptionValue fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
+	public CPOptionValue fetchCPOptionValue(long cpOptionValueId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CPOptionValue fetchCPOptionValue(long cpOptionValueId)
+	public CPOptionValue fetchCPOptionValueByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPOptionValueServiceUtil.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPOptionValueServiceUtil.java
@@ -58,18 +58,18 @@ public class CPOptionValueServiceUtil {
 		getService().deleteCPOptionValue(cpOptionValueId);
 	}
 
-	public static CPOptionValue fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CPOptionValue fetchCPOptionValue(long cpOptionValueId)
 		throws PortalException {
 
 		return getService().fetchCPOptionValue(cpOptionValueId);
+	}
+
+	public static CPOptionValue fetchCPOptionValueByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		return getService().fetchCPOptionValueByExternalReferenceCode(
+			externalReferenceCode, companyId);
 	}
 
 	public static CPOptionValue getCPOptionValue(long cpOptionValueId)

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPOptionValueServiceWrapper.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CPOptionValueServiceWrapper.java
@@ -60,19 +60,19 @@ public class CPOptionValueServiceWrapper
 	}
 
 	@Override
-	public CPOptionValue fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _cpOptionValueService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CPOptionValue fetchCPOptionValue(long cpOptionValueId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _cpOptionValueService.fetchCPOptionValue(cpOptionValueId);
+	}
+
+	@Override
+	public CPOptionValue fetchCPOptionValueByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _cpOptionValueService.fetchCPOptionValueByExternalReferenceCode(
+			externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceCatalogLocalService.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceCatalogLocalService.java
@@ -224,10 +224,6 @@ public interface CommerceCatalogLocalService
 		DynamicQuery dynamicQuery, Projection projection);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceCatalog fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId);
-
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceCatalog fetchCommerceCatalog(long commerceCatalogId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceCatalogLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceCatalogLocalServiceUtil.java
@@ -240,13 +240,6 @@ public class CommerceCatalogLocalServiceUtil {
 		return getService().dynamicQueryCount(dynamicQuery, projection);
 	}
 
-	public static CommerceCatalog fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CommerceCatalog fetchCommerceCatalog(long commerceCatalogId) {
 		return getService().fetchCommerceCatalog(commerceCatalogId);
 	}

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceCatalogLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceCatalogLocalServiceWrapper.java
@@ -265,14 +265,6 @@ public class CommerceCatalogLocalServiceWrapper
 	}
 
 	@Override
-	public CommerceCatalog fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return _commerceCatalogLocalService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CommerceCatalog fetchCommerceCatalog(long commerceCatalogId) {
 		return _commerceCatalogLocalService.fetchCommerceCatalog(
 			commerceCatalogId);

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceCatalogService.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceCatalogService.java
@@ -56,12 +56,12 @@ public interface CommerceCatalogService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceCatalog fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
+	public CommerceCatalog fetchCommerceCatalog(long commerceCatalogId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceCatalog fetchCommerceCatalog(long commerceCatalogId)
+	public CommerceCatalog fetchCommerceCatalogByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceCatalogServiceUtil.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceCatalogServiceUtil.java
@@ -47,18 +47,18 @@ public class CommerceCatalogServiceUtil {
 		return getService().deleteCommerceCatalog(commerceCatalogId);
 	}
 
-	public static CommerceCatalog fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CommerceCatalog fetchCommerceCatalog(long commerceCatalogId)
 		throws PortalException {
 
 		return getService().fetchCommerceCatalog(commerceCatalogId);
+	}
+
+	public static CommerceCatalog fetchCommerceCatalogByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		return getService().fetchCommerceCatalogByExternalReferenceCode(
+			externalReferenceCode, companyId);
 	}
 
 	public static CommerceCatalog fetchCommerceCatalogByGroupId(long groupId)

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceCatalogServiceWrapper.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceCatalogServiceWrapper.java
@@ -48,19 +48,20 @@ public class CommerceCatalogServiceWrapper
 	}
 
 	@Override
-	public CommerceCatalog fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _commerceCatalogService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CommerceCatalog fetchCommerceCatalog(long commerceCatalogId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commerceCatalogService.fetchCommerceCatalog(commerceCatalogId);
+	}
+
+	@Override
+	public CommerceCatalog fetchCommerceCatalogByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _commerceCatalogService.
+			fetchCommerceCatalogByExternalReferenceCode(
+				externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceChannelLocalService.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceChannelLocalService.java
@@ -225,10 +225,6 @@ public interface CommerceChannelLocalService
 		DynamicQuery dynamicQuery, Projection projection);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceChannel fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId);
-
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public CommerceChannel fetchCommerceChannel(long commerceChannelId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceChannelLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceChannelLocalServiceUtil.java
@@ -241,13 +241,6 @@ public class CommerceChannelLocalServiceUtil {
 		return getService().dynamicQueryCount(dynamicQuery, projection);
 	}
 
-	public static CommerceChannel fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CommerceChannel fetchCommerceChannel(long commerceChannelId) {
 		return getService().fetchCommerceChannel(commerceChannelId);
 	}

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceChannelLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceChannelLocalServiceWrapper.java
@@ -264,14 +264,6 @@ public class CommerceChannelLocalServiceWrapper
 	}
 
 	@Override
-	public CommerceChannel fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return _commerceChannelLocalService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CommerceChannel fetchCommerceChannel(long commerceChannelId) {
 		return _commerceChannelLocalService.fetchCommerceChannel(
 			commerceChannelId);

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceChannelService.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceChannelService.java
@@ -65,12 +65,12 @@ public interface CommerceChannelService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceChannel fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
+	public CommerceChannel fetchCommerceChannel(long commerceChannelId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceChannel fetchCommerceChannel(long commerceChannelId)
+	public CommerceChannel fetchCommerceChannelByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceChannelServiceUtil.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceChannelServiceUtil.java
@@ -66,18 +66,18 @@ public class CommerceChannelServiceUtil {
 		return getService().deleteCommerceChannel(commerceChannelId);
 	}
 
-	public static CommerceChannel fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		return getService().fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
 	public static CommerceChannel fetchCommerceChannel(long commerceChannelId)
 		throws PortalException {
 
 		return getService().fetchCommerceChannel(commerceChannelId);
+	}
+
+	public static CommerceChannel fetchCommerceChannelByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		return getService().fetchCommerceChannelByExternalReferenceCode(
+			externalReferenceCode, companyId);
 	}
 
 	public static CommerceChannel getCommerceChannel(long commerceChannelId)

--- a/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceChannelServiceWrapper.java
+++ b/modules/apps/commerce/commerce-product-api/src/main/java/com/liferay/commerce/product/service/CommerceChannelServiceWrapper.java
@@ -68,19 +68,20 @@ public class CommerceChannelServiceWrapper
 	}
 
 	@Override
-	public CommerceChannel fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _commerceChannelService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CommerceChannel fetchCommerceChannel(long commerceChannelId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commerceChannelService.fetchCommerceChannel(commerceChannelId);
+	}
+
+	@Override
+	public CommerceChannel fetchCommerceChannelByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _commerceChannelService.
+			fetchCommerceChannelByExternalReferenceCode(
+				externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-product-api/src/main/resources/com/liferay/commerce/product/service/packageinfo
+++ b/modules/apps/commerce/commerce-product-api/src/main/resources/com/liferay/commerce/product/service/packageinfo
@@ -1,1 +1,1 @@
-version 46.1.0
+version 47.0.0

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/http/CPAttachmentFileEntryServiceHttp.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/http/CPAttachmentFileEntryServiceHttp.java
@@ -197,19 +197,18 @@ public class CPAttachmentFileEntryServiceHttp {
 	}
 
 	public static com.liferay.commerce.product.model.CPAttachmentFileEntry
-			fetchByExternalReferenceCode(
-				HttpPrincipal httpPrincipal, String externalReferenceCode,
-				long companyId)
+			fetchCPAttachmentFileEntry(
+				HttpPrincipal httpPrincipal, long cpAttachmentFileEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
 				CPAttachmentFileEntryServiceUtil.class,
-				"fetchByExternalReferenceCode",
-				_fetchByExternalReferenceCodeParameterTypes3);
+				"fetchCPAttachmentFileEntry",
+				_fetchCPAttachmentFileEntryParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, externalReferenceCode, companyId);
+				methodKey, cpAttachmentFileEntryId);
 
 			Object returnObj = null;
 
@@ -241,18 +240,19 @@ public class CPAttachmentFileEntryServiceHttp {
 	}
 
 	public static com.liferay.commerce.product.model.CPAttachmentFileEntry
-			fetchCPAttachmentFileEntry(
-				HttpPrincipal httpPrincipal, long cpAttachmentFileEntryId)
+			fetchCPAttachmentFileEntryByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
 				CPAttachmentFileEntryServiceUtil.class,
-				"fetchCPAttachmentFileEntry",
-				_fetchCPAttachmentFileEntryParameterTypes4);
+				"fetchCPAttachmentFileEntryByExternalReferenceCode",
+				_fetchCPAttachmentFileEntryByExternalReferenceCodeParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, cpAttachmentFileEntryId);
+				methodKey, externalReferenceCode, companyId);
 
 			Object returnObj = null;
 
@@ -634,12 +634,11 @@ public class CPAttachmentFileEntryServiceHttp {
 		};
 	private static final Class<?>[]
 		_deleteCPAttachmentFileEntryParameterTypes2 = new Class[] {long.class};
-	private static final Class<?>[]
-		_fetchByExternalReferenceCodeParameterTypes3 = new Class[] {
-			String.class, long.class
-		};
-	private static final Class<?>[] _fetchCPAttachmentFileEntryParameterTypes4 =
+	private static final Class<?>[] _fetchCPAttachmentFileEntryParameterTypes3 =
 		new Class[] {long.class};
+	private static final Class<?>[]
+		_fetchCPAttachmentFileEntryByExternalReferenceCodeParameterTypes4 =
+			new Class[] {String.class, long.class};
 	private static final Class<?>[] _getCPAttachmentFileEntriesParameterTypes5 =
 		new Class[] {
 			long.class, long.class, int.class, int.class, int.class, int.class

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/http/CPInstanceServiceHttp.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/http/CPInstanceServiceHttp.java
@@ -280,19 +280,17 @@ public class CPInstanceServiceHttp {
 		}
 	}
 
-	public static com.liferay.commerce.product.model.CPInstance
-			fetchByExternalReferenceCode(
-				HttpPrincipal httpPrincipal, String externalReferenceCode,
-				long companyId)
+	public static com.liferay.commerce.product.model.CPInstance fetchCPInstance(
+			HttpPrincipal httpPrincipal, long cpInstanceId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				CPInstanceServiceUtil.class, "fetchByExternalReferenceCode",
-				_fetchByExternalReferenceCodeParameterTypes4);
+				CPInstanceServiceUtil.class, "fetchCPInstance",
+				_fetchCPInstanceParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, externalReferenceCode, companyId);
+				methodKey, cpInstanceId);
 
 			Object returnObj = null;
 
@@ -322,17 +320,20 @@ public class CPInstanceServiceHttp {
 		}
 	}
 
-	public static com.liferay.commerce.product.model.CPInstance fetchCPInstance(
-			HttpPrincipal httpPrincipal, long cpInstanceId)
+	public static com.liferay.commerce.product.model.CPInstance
+			fetchCPInstanceByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				CPInstanceServiceUtil.class, "fetchCPInstance",
-				_fetchCPInstanceParameterTypes5);
+				CPInstanceServiceUtil.class,
+				"fetchCPInstanceByExternalReferenceCode",
+				_fetchCPInstanceByExternalReferenceCodeParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, cpInstanceId);
+				methodKey, externalReferenceCode, companyId);
 
 			Object returnObj = null;
 
@@ -1148,12 +1149,12 @@ public class CPInstanceServiceHttp {
 		};
 	private static final Class<?>[] _deleteCPInstanceParameterTypes3 =
 		new Class[] {long.class};
+	private static final Class<?>[] _fetchCPInstanceParameterTypes4 =
+		new Class[] {long.class};
 	private static final Class<?>[]
-		_fetchByExternalReferenceCodeParameterTypes4 = new Class[] {
+		_fetchCPInstanceByExternalReferenceCodeParameterTypes5 = new Class[] {
 			String.class, long.class
 		};
-	private static final Class<?>[] _fetchCPInstanceParameterTypes5 =
-		new Class[] {long.class};
 	private static final Class<?>[] _fetchCProductInstanceParameterTypes6 =
 		new Class[] {long.class, String.class};
 	private static final Class<?>[] _getCPDefinitionInstancesParameterTypes7 =

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/http/CPOptionServiceHttp.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/http/CPOptionServiceHttp.java
@@ -171,48 +171,6 @@ public class CPOptionServiceHttp {
 		}
 	}
 
-	public static com.liferay.commerce.product.model.CPOption
-			fetchByExternalReferenceCode(
-				HttpPrincipal httpPrincipal, String externalReferenceCode,
-				long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		try {
-			MethodKey methodKey = new MethodKey(
-				CPOptionServiceUtil.class, "fetchByExternalReferenceCode",
-				_fetchByExternalReferenceCodeParameterTypes3);
-
-			MethodHandler methodHandler = new MethodHandler(
-				methodKey, externalReferenceCode, companyId);
-
-			Object returnObj = null;
-
-			try {
-				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
-			}
-			catch (Exception exception) {
-				if (exception instanceof
-						com.liferay.portal.kernel.exception.PortalException) {
-
-					throw (com.liferay.portal.kernel.exception.PortalException)
-						exception;
-				}
-
-				throw new com.liferay.portal.kernel.exception.SystemException(
-					exception);
-			}
-
-			return (com.liferay.commerce.product.model.CPOption)returnObj;
-		}
-		catch (com.liferay.portal.kernel.exception.SystemException
-					systemException) {
-
-			_log.error(systemException, systemException);
-
-			throw systemException;
-		}
-	}
-
 	public static com.liferay.commerce.product.model.CPOption fetchCPOption(
 			HttpPrincipal httpPrincipal, long cpOptionId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -220,7 +178,7 @@ public class CPOptionServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CPOptionServiceUtil.class, "fetchCPOption",
-				_fetchCPOptionParameterTypes4);
+				_fetchCPOptionParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, cpOptionId);
@@ -260,10 +218,53 @@ public class CPOptionServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CPOptionServiceUtil.class, "fetchCPOption",
-				_fetchCPOptionParameterTypes5);
+				_fetchCPOptionParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, key);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.commerce.product.model.CPOption)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.commerce.product.model.CPOption
+			fetchCPOptionByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				CPOptionServiceUtil.class,
+				"fetchCPOptionByExternalReferenceCode",
+				_fetchCPOptionByExternalReferenceCodeParameterTypes5);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, externalReferenceCode, companyId);
 
 			Object returnObj = null;
 
@@ -526,14 +527,14 @@ public class CPOptionServiceHttp {
 		};
 	private static final Class<?>[] _deleteCPOptionParameterTypes2 =
 		new Class[] {long.class};
+	private static final Class<?>[] _fetchCPOptionParameterTypes3 =
+		new Class[] {long.class};
+	private static final Class<?>[] _fetchCPOptionParameterTypes4 =
+		new Class[] {long.class, String.class};
 	private static final Class<?>[]
-		_fetchByExternalReferenceCodeParameterTypes3 = new Class[] {
+		_fetchCPOptionByExternalReferenceCodeParameterTypes5 = new Class[] {
 			String.class, long.class
 		};
-	private static final Class<?>[] _fetchCPOptionParameterTypes4 =
-		new Class[] {long.class};
-	private static final Class<?>[] _fetchCPOptionParameterTypes5 =
-		new Class[] {long.class, String.class};
 	private static final Class<?>[] _findCPOptionByCompanyIdParameterTypes6 =
 		new Class[] {
 			long.class, int.class, int.class,

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/http/CPOptionValueServiceHttp.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/http/CPOptionValueServiceHttp.java
@@ -168,18 +168,17 @@ public class CPOptionValueServiceHttp {
 	}
 
 	public static com.liferay.commerce.product.model.CPOptionValue
-			fetchByExternalReferenceCode(
-				HttpPrincipal httpPrincipal, String externalReferenceCode,
-				long companyId)
+			fetchCPOptionValue(
+				HttpPrincipal httpPrincipal, long cpOptionValueId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				CPOptionValueServiceUtil.class, "fetchByExternalReferenceCode",
-				_fetchByExternalReferenceCodeParameterTypes3);
+				CPOptionValueServiceUtil.class, "fetchCPOptionValue",
+				_fetchCPOptionValueParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, externalReferenceCode, companyId);
+				methodKey, cpOptionValueId);
 
 			Object returnObj = null;
 
@@ -210,17 +209,19 @@ public class CPOptionValueServiceHttp {
 	}
 
 	public static com.liferay.commerce.product.model.CPOptionValue
-			fetchCPOptionValue(
-				HttpPrincipal httpPrincipal, long cpOptionValueId)
+			fetchCPOptionValueByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				CPOptionValueServiceUtil.class, "fetchCPOptionValue",
-				_fetchCPOptionValueParameterTypes4);
+				CPOptionValueServiceUtil.class,
+				"fetchCPOptionValueByExternalReferenceCode",
+				_fetchCPOptionValueByExternalReferenceCodeParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, cpOptionValueId);
+				methodKey, externalReferenceCode, companyId);
 
 			Object returnObj = null;
 
@@ -518,12 +519,11 @@ public class CPOptionValueServiceHttp {
 		};
 	private static final Class<?>[] _deleteCPOptionValueParameterTypes2 =
 		new Class[] {long.class};
-	private static final Class<?>[]
-		_fetchByExternalReferenceCodeParameterTypes3 = new Class[] {
-			String.class, long.class
-		};
-	private static final Class<?>[] _fetchCPOptionValueParameterTypes4 =
+	private static final Class<?>[] _fetchCPOptionValueParameterTypes3 =
 		new Class[] {long.class};
+	private static final Class<?>[]
+		_fetchCPOptionValueByExternalReferenceCodeParameterTypes4 =
+			new Class[] {String.class, long.class};
 	private static final Class<?>[] _getCPOptionValueParameterTypes5 =
 		new Class[] {long.class};
 	private static final Class<?>[] _getCPOptionValuesParameterTypes6 =

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/http/CommerceCatalogServiceHttp.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/http/CommerceCatalogServiceHttp.java
@@ -130,19 +130,17 @@ public class CommerceCatalogServiceHttp {
 	}
 
 	public static com.liferay.commerce.product.model.CommerceCatalog
-			fetchByExternalReferenceCode(
-				HttpPrincipal httpPrincipal, String externalReferenceCode,
-				long companyId)
+			fetchCommerceCatalog(
+				HttpPrincipal httpPrincipal, long commerceCatalogId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				CommerceCatalogServiceUtil.class,
-				"fetchByExternalReferenceCode",
-				_fetchByExternalReferenceCodeParameterTypes2);
+				CommerceCatalogServiceUtil.class, "fetchCommerceCatalog",
+				_fetchCommerceCatalogParameterTypes2);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, externalReferenceCode, companyId);
+				methodKey, commerceCatalogId);
 
 			Object returnObj = null;
 
@@ -174,17 +172,19 @@ public class CommerceCatalogServiceHttp {
 	}
 
 	public static com.liferay.commerce.product.model.CommerceCatalog
-			fetchCommerceCatalog(
-				HttpPrincipal httpPrincipal, long commerceCatalogId)
+			fetchCommerceCatalogByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				CommerceCatalogServiceUtil.class, "fetchCommerceCatalog",
-				_fetchCommerceCatalogParameterTypes3);
+				CommerceCatalogServiceUtil.class,
+				"fetchCommerceCatalogByExternalReferenceCode",
+				_fetchCommerceCatalogByExternalReferenceCodeParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, commerceCatalogId);
+				methodKey, externalReferenceCode, companyId);
 
 			Object returnObj = null;
 
@@ -517,12 +517,11 @@ public class CommerceCatalogServiceHttp {
 		};
 	private static final Class<?>[] _deleteCommerceCatalogParameterTypes1 =
 		new Class[] {long.class};
-	private static final Class<?>[]
-		_fetchByExternalReferenceCodeParameterTypes2 = new Class[] {
-			String.class, long.class
-		};
-	private static final Class<?>[] _fetchCommerceCatalogParameterTypes3 =
+	private static final Class<?>[] _fetchCommerceCatalogParameterTypes2 =
 		new Class[] {long.class};
+	private static final Class<?>[]
+		_fetchCommerceCatalogByExternalReferenceCodeParameterTypes3 =
+			new Class[] {String.class, long.class};
 	private static final Class<?>[]
 		_fetchCommerceCatalogByGroupIdParameterTypes4 = new Class[] {
 			long.class

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/http/CommerceChannelServiceHttp.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/http/CommerceChannelServiceHttp.java
@@ -182,19 +182,17 @@ public class CommerceChannelServiceHttp {
 	}
 
 	public static com.liferay.commerce.product.model.CommerceChannel
-			fetchByExternalReferenceCode(
-				HttpPrincipal httpPrincipal, String externalReferenceCode,
-				long companyId)
+			fetchCommerceChannel(
+				HttpPrincipal httpPrincipal, long commerceChannelId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				CommerceChannelServiceUtil.class,
-				"fetchByExternalReferenceCode",
-				_fetchByExternalReferenceCodeParameterTypes3);
+				CommerceChannelServiceUtil.class, "fetchCommerceChannel",
+				_fetchCommerceChannelParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, externalReferenceCode, companyId);
+				methodKey, commerceChannelId);
 
 			Object returnObj = null;
 
@@ -226,17 +224,19 @@ public class CommerceChannelServiceHttp {
 	}
 
 	public static com.liferay.commerce.product.model.CommerceChannel
-			fetchCommerceChannel(
-				HttpPrincipal httpPrincipal, long commerceChannelId)
+			fetchCommerceChannelByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				CommerceChannelServiceUtil.class, "fetchCommerceChannel",
-				_fetchCommerceChannelParameterTypes4);
+				CommerceChannelServiceUtil.class,
+				"fetchCommerceChannelByExternalReferenceCode",
+				_fetchCommerceChannelByExternalReferenceCodeParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, commerceChannelId);
+				methodKey, externalReferenceCode, companyId);
 
 			Object returnObj = null;
 
@@ -672,12 +672,11 @@ public class CommerceChannelServiceHttp {
 		};
 	private static final Class<?>[] _deleteCommerceChannelParameterTypes2 =
 		new Class[] {long.class};
-	private static final Class<?>[]
-		_fetchByExternalReferenceCodeParameterTypes3 = new Class[] {
-			String.class, long.class
-		};
-	private static final Class<?>[] _fetchCommerceChannelParameterTypes4 =
+	private static final Class<?>[] _fetchCommerceChannelParameterTypes3 =
 		new Class[] {long.class};
+	private static final Class<?>[]
+		_fetchCommerceChannelByExternalReferenceCodeParameterTypes4 =
+			new Class[] {String.class, long.class};
 	private static final Class<?>[] _getCommerceChannelParameterTypes5 =
 		new Class[] {long.class};
 	private static final Class<?>[]

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPAttachmentFileEntryLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPAttachmentFileEntryLocalServiceImpl.java
@@ -253,8 +253,9 @@ public class CPAttachmentFileEntryLocalServiceImpl
 		}
 		else if (Validator.isNotNull(externalReferenceCode)) {
 			cpAttachmentFileEntry =
-				cpAttachmentFileEntryLocalService.fetchByExternalReferenceCode(
-					externalReferenceCode, serviceContext.getCompanyId());
+				cpAttachmentFileEntryLocalService.
+					fetchCPAttachmentFileEntryByExternalReferenceCode(
+						externalReferenceCode, serviceContext.getCompanyId());
 		}
 
 		if ((cpAttachmentFileEntry != null) &&
@@ -438,14 +439,6 @@ public class CPAttachmentFileEntryLocalServiceImpl
 
 		return cpAttachmentFileEntryLocalService.deleteCPAttachmentFileEntry(
 			cpAttachmentFileEntry);
-	}
-
-	@Override
-	public CPAttachmentFileEntry fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		return cpAttachmentFileEntryPersistence.fetchByERC_C(
-			externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPAttachmentFileEntryServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPAttachmentFileEntryServiceImpl.java
@@ -134,33 +134,6 @@ public class CPAttachmentFileEntryServiceImpl
 	}
 
 	@Override
-	public CPAttachmentFileEntry fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		CPAttachmentFileEntry cpAttachmentFileEntry =
-			cpAttachmentFileEntryLocalService.fetchByExternalReferenceCode(
-				externalReferenceCode, companyId);
-
-		if (cpAttachmentFileEntry != null) {
-			long cpDefinitionClassNameId = _portal.getClassNameId(
-				CPDefinition.class);
-
-			if (cpDefinitionClassNameId ==
-					cpAttachmentFileEntry.getClassNameId()) {
-
-				_checkCommerceCatalog(
-					cpAttachmentFileEntry.getClassPK(), ActionKeys.VIEW);
-			}
-			else {
-				_checkCPAttachmentFileEntryPermissions(cpAttachmentFileEntry);
-			}
-		}
-
-		return cpAttachmentFileEntry;
-	}
-
-	@Override
 	public CPAttachmentFileEntry fetchCPAttachmentFileEntry(
 			long cpAttachmentFileEntryId)
 		throws PortalException {
@@ -191,6 +164,35 @@ public class CPAttachmentFileEntryServiceImpl
 			}
 			else {
 				_checkCPAttachmentFileEntryPermissions(cpAttachmentFileEntryId);
+			}
+		}
+
+		return cpAttachmentFileEntry;
+	}
+
+	@Override
+	public CPAttachmentFileEntry
+			fetchCPAttachmentFileEntryByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		CPAttachmentFileEntry cpAttachmentFileEntry =
+			cpAttachmentFileEntryLocalService.
+				fetchCPAttachmentFileEntryByExternalReferenceCode(
+					externalReferenceCode, companyId);
+
+		if (cpAttachmentFileEntry != null) {
+			long cpDefinitionClassNameId = _portal.getClassNameId(
+				CPDefinition.class);
+
+			if (cpDefinitionClassNameId ==
+					cpAttachmentFileEntry.getClassNameId()) {
+
+				_checkCommerceCatalog(
+					cpAttachmentFileEntry.getClassPK(), ActionKeys.VIEW);
+			}
+			else {
+				_checkCPAttachmentFileEntryPermissions(cpAttachmentFileEntry);
 			}
 		}
 

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPInstanceLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPInstanceLocalServiceImpl.java
@@ -591,18 +591,6 @@ public class CPInstanceLocalServiceImpl extends CPInstanceLocalServiceBaseImpl {
 	}
 
 	@Override
-	public CPInstance fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		if (Validator.isBlank(externalReferenceCode)) {
-			return null;
-		}
-
-		return cpInstancePersistence.fetchByERC_C(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CPInstance fetchCPInstance(long cProductId, String cpInstanceUuid) {
 		CProduct cProduct = _cProductLocalService.fetchCProduct(cProductId);
 

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPInstanceServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPInstanceServiceImpl.java
@@ -166,13 +166,11 @@ public class CPInstanceServiceImpl extends CPInstanceServiceBaseImpl {
 	}
 
 	@Override
-	public CPInstance fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
+	public CPInstance fetchCPInstance(long cpInstanceId)
 		throws PortalException {
 
-		CPInstance cpInstance =
-			cpInstanceLocalService.fetchByExternalReferenceCode(
-				externalReferenceCode, companyId);
+		CPInstance cpInstance = cpInstanceLocalService.fetchCPInstance(
+			cpInstanceId);
 
 		if (cpInstance != null) {
 			_checkCommerceCatalogByCPDefinitionId(
@@ -183,11 +181,13 @@ public class CPInstanceServiceImpl extends CPInstanceServiceBaseImpl {
 	}
 
 	@Override
-	public CPInstance fetchCPInstance(long cpInstanceId)
+	public CPInstance fetchCPInstanceByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		CPInstance cpInstance = cpInstanceLocalService.fetchCPInstance(
-			cpInstanceId);
+		CPInstance cpInstance =
+			cpInstanceLocalService.fetchCPInstanceByExternalReferenceCode(
+				externalReferenceCode, companyId);
 
 		if (cpInstance != null) {
 			_checkCommerceCatalogByCPDefinitionId(

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPOptionLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPOptionLocalServiceImpl.java
@@ -179,18 +179,6 @@ public class CPOptionLocalServiceImpl extends CPOptionLocalServiceBaseImpl {
 	}
 
 	@Override
-	public CPOption fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		if (Validator.isBlank(externalReferenceCode)) {
-			return null;
-		}
-
-		return cpOptionPersistence.fetchByERC_C(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CPOption fetchCPOption(long companyId, String key) {
 		return cpOptionPersistence.fetchByC_K(companyId, key);
 	}

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPOptionServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPOptionServiceImpl.java
@@ -64,8 +64,9 @@ public class CPOptionServiceImpl extends CPOptionServiceBaseImpl {
 			String key, ServiceContext serviceContext)
 		throws PortalException {
 
-		CPOption cpOption = cpOptionLocalService.fetchByExternalReferenceCode(
-			externalReferenceCode, serviceContext.getCompanyId());
+		CPOption cpOption =
+			cpOptionLocalService.fetchCPOptionByExternalReferenceCode(
+				externalReferenceCode, serviceContext.getCompanyId());
 
 		if (cpOption == null) {
 			PortletResourcePermission portletResourcePermission =
@@ -91,22 +92,6 @@ public class CPOptionServiceImpl extends CPOptionServiceBaseImpl {
 	}
 
 	@Override
-	public CPOption fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		CPOption cpOption = cpOptionLocalService.fetchByExternalReferenceCode(
-			externalReferenceCode, companyId);
-
-		if (cpOption != null) {
-			_cpOptionModelResourcePermission.check(
-				getPermissionChecker(), cpOption, ActionKeys.VIEW);
-		}
-
-		return cpOption;
-	}
-
-	@Override
 	public CPOption fetchCPOption(long cpOptionId) throws PortalException {
 		CPOption cpOption = cpOptionLocalService.fetchCPOption(cpOptionId);
 
@@ -123,6 +108,23 @@ public class CPOptionServiceImpl extends CPOptionServiceBaseImpl {
 		throws PortalException {
 
 		CPOption cpOption = cpOptionLocalService.fetchCPOption(companyId, key);
+
+		if (cpOption != null) {
+			_cpOptionModelResourcePermission.check(
+				getPermissionChecker(), cpOption, ActionKeys.VIEW);
+		}
+
+		return cpOption;
+	}
+
+	@Override
+	public CPOption fetchCPOptionByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		CPOption cpOption =
+			cpOptionLocalService.fetchCPOptionByExternalReferenceCode(
+				externalReferenceCode, companyId);
 
 		if (cpOption != null) {
 			_cpOptionModelResourcePermission.check(

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPOptionValueLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPOptionValueLocalServiceImpl.java
@@ -184,18 +184,6 @@ public class CPOptionValueLocalServiceImpl
 	}
 
 	@Override
-	public CPOptionValue fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		if (Validator.isBlank(externalReferenceCode)) {
-			return null;
-		}
-
-		return cpOptionValuePersistence.fetchByERC_C(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CPOptionValue getCPOptionValue(long cpOptionId, String key)
 		throws PortalException {
 

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPOptionValueServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPOptionValueServiceImpl.java
@@ -56,7 +56,7 @@ public class CPOptionValueServiceImpl extends CPOptionValueServiceBaseImpl {
 		throws PortalException {
 
 		CPOptionValue cpOptionValue =
-			cpOptionValueLocalService.fetchByExternalReferenceCode(
+			cpOptionValueLocalService.fetchCPOptionValueByExternalReferenceCode(
 				externalReferenceCode, serviceContext.getCompanyId());
 
 		if (cpOptionValue == null) {
@@ -84,13 +84,11 @@ public class CPOptionValueServiceImpl extends CPOptionValueServiceBaseImpl {
 	}
 
 	@Override
-	public CPOptionValue fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
+	public CPOptionValue fetchCPOptionValue(long cpOptionValueId)
 		throws PortalException {
 
 		CPOptionValue cpOptionValue =
-			cpOptionValueLocalService.fetchByExternalReferenceCode(
-				externalReferenceCode, companyId);
+			cpOptionValueLocalService.fetchCPOptionValue(cpOptionValueId);
 
 		if (cpOptionValue != null) {
 			_cpOptionModelResourcePermission.check(
@@ -102,11 +100,13 @@ public class CPOptionValueServiceImpl extends CPOptionValueServiceBaseImpl {
 	}
 
 	@Override
-	public CPOptionValue fetchCPOptionValue(long cpOptionValueId)
+	public CPOptionValue fetchCPOptionValueByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		CPOptionValue cpOptionValue =
-			cpOptionValueLocalService.fetchCPOptionValue(cpOptionValueId);
+			cpOptionValueLocalService.fetchCPOptionValueByExternalReferenceCode(
+				externalReferenceCode, companyId);
 
 		if (cpOptionValue != null) {
 			_cpOptionModelResourcePermission.check(

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CommerceCatalogLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CommerceCatalogLocalServiceImpl.java
@@ -46,7 +46,6 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
@@ -195,18 +194,6 @@ public class CommerceCatalogLocalServiceImpl
 			commerceCatalogLocalService.forceDeleteCommerceCatalog(
 				commerceCatalog);
 		}
-	}
-
-	@Override
-	public CommerceCatalog fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		if (Validator.isBlank(externalReferenceCode)) {
-			return null;
-		}
-
-		return commerceCatalogPersistence.fetchByERC_C(
-			externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CommerceCatalogServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CommerceCatalogServiceImpl.java
@@ -75,13 +75,11 @@ public class CommerceCatalogServiceImpl extends CommerceCatalogServiceBaseImpl {
 	}
 
 	@Override
-	public CommerceCatalog fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
+	public CommerceCatalog fetchCommerceCatalog(long commerceCatalogId)
 		throws PortalException {
 
 		CommerceCatalog commerceCatalog =
-			commerceCatalogLocalService.fetchByExternalReferenceCode(
-				externalReferenceCode, companyId);
+			commerceCatalogLocalService.fetchCommerceCatalog(commerceCatalogId);
 
 		if (commerceCatalog != null) {
 			_commerceCatalogModelResourcePermission.check(
@@ -92,11 +90,14 @@ public class CommerceCatalogServiceImpl extends CommerceCatalogServiceBaseImpl {
 	}
 
 	@Override
-	public CommerceCatalog fetchCommerceCatalog(long commerceCatalogId)
+	public CommerceCatalog fetchCommerceCatalogByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		CommerceCatalog commerceCatalog =
-			commerceCatalogLocalService.fetchCommerceCatalog(commerceCatalogId);
+			commerceCatalogLocalService.
+				fetchCommerceCatalogByExternalReferenceCode(
+					externalReferenceCode, companyId);
 
 		if (commerceCatalog != null) {
 			_commerceCatalogModelResourcePermission.check(

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CommerceChannelLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CommerceChannelLocalServiceImpl.java
@@ -172,8 +172,9 @@ public class CommerceChannelLocalServiceImpl
 			User user = _userLocalService.getUser(userId);
 
 			commerceChannel =
-				commerceChannelLocalService.fetchByExternalReferenceCode(
-					externalReferenceCode, user.getCompanyId());
+				commerceChannelLocalService.
+					fetchCommerceChannelByExternalReferenceCode(
+						externalReferenceCode, user.getCompanyId());
 		}
 
 		if (commerceChannel == null) {
@@ -242,18 +243,6 @@ public class CommerceChannelLocalServiceImpl
 		for (CommerceChannel commerceChannel : commerceChannels) {
 			commerceChannelLocalService.deleteCommerceChannel(commerceChannel);
 		}
-	}
-
-	@Override
-	public CommerceChannel fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		if (Validator.isBlank(externalReferenceCode)) {
-			return null;
-		}
-
-		return commerceChannelPersistence.fetchByERC_C(
-			externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CommerceChannelServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CommerceChannelServiceImpl.java
@@ -91,24 +91,6 @@ public class CommerceChannelServiceImpl extends CommerceChannelServiceBaseImpl {
 	}
 
 	@Override
-	public CommerceChannel fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		CommerceChannel commerceChannel =
-			commerceChannelLocalService.fetchByExternalReferenceCode(
-				externalReferenceCode, companyId);
-
-		if (commerceChannel != null) {
-			_commerceChannelModelResourcePermission.check(
-				getPermissionChecker(), commerceChannel.getCommerceChannelId(),
-				ActionKeys.VIEW);
-		}
-
-		return commerceChannel;
-	}
-
-	@Override
 	public CommerceChannel fetchCommerceChannel(long commerceChannelId)
 		throws PortalException {
 
@@ -118,6 +100,25 @@ public class CommerceChannelServiceImpl extends CommerceChannelServiceBaseImpl {
 		if (commerceChannel != null) {
 			_commerceChannelModelResourcePermission.check(
 				getPermissionChecker(), commerceChannelId, ActionKeys.VIEW);
+		}
+
+		return commerceChannel;
+	}
+
+	@Override
+	public CommerceChannel fetchCommerceChannelByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		CommerceChannel commerceChannel =
+			commerceChannelLocalService.
+				fetchCommerceChannelByExternalReferenceCode(
+					externalReferenceCode, companyId);
+
+		if (commerceChannel != null) {
+			_commerceChannelModelResourcePermission.check(
+				getPermissionChecker(), commerceChannel.getCommerceChannelId(),
+				ActionKeys.VIEW);
 		}
 
 		return commerceChannel;

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/http/CommerceAddressServiceHttp.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/http/CommerceAddressServiceHttp.java
@@ -218,19 +218,17 @@ public class CommerceAddressServiceHttp {
 	}
 
 	public static com.liferay.commerce.model.CommerceAddress
-			fetchByExternalReferenceCode(
-				HttpPrincipal httpPrincipal, String externalReferenceCode,
-				long companyId)
+			fetchCommerceAddress(
+				HttpPrincipal httpPrincipal, long commerceAddressId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				CommerceAddressServiceUtil.class,
-				"fetchByExternalReferenceCode",
-				_fetchByExternalReferenceCodeParameterTypes4);
+				CommerceAddressServiceUtil.class, "fetchCommerceAddress",
+				_fetchCommerceAddressParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, externalReferenceCode, companyId);
+				methodKey, commerceAddressId);
 
 			Object returnObj = null;
 
@@ -261,17 +259,19 @@ public class CommerceAddressServiceHttp {
 	}
 
 	public static com.liferay.commerce.model.CommerceAddress
-			fetchCommerceAddress(
-				HttpPrincipal httpPrincipal, long commerceAddressId)
+			fetchCommerceAddressByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				CommerceAddressServiceUtil.class, "fetchCommerceAddress",
-				_fetchCommerceAddressParameterTypes5);
+				CommerceAddressServiceUtil.class,
+				"fetchCommerceAddressByExternalReferenceCode",
+				_fetchCommerceAddressByExternalReferenceCodeParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, commerceAddressId);
+				methodKey, externalReferenceCode, companyId);
 
 			Object returnObj = null;
 
@@ -1342,12 +1342,11 @@ public class CommerceAddressServiceHttp {
 		};
 	private static final Class<?>[] _deleteCommerceAddressParameterTypes3 =
 		new Class[] {long.class};
-	private static final Class<?>[]
-		_fetchByExternalReferenceCodeParameterTypes4 = new Class[] {
-			String.class, long.class
-		};
-	private static final Class<?>[] _fetchCommerceAddressParameterTypes5 =
+	private static final Class<?>[] _fetchCommerceAddressParameterTypes4 =
 		new Class[] {long.class};
+	private static final Class<?>[]
+		_fetchCommerceAddressByExternalReferenceCodeParameterTypes5 =
+			new Class[] {String.class, long.class};
 	private static final Class<?>[]
 		_getBillingCommerceAddressesParameterTypes6 = new Class[] {
 			long.class, String.class, long.class

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/http/CommerceOrderItemServiceHttp.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/http/CommerceOrderItemServiceHttp.java
@@ -328,19 +328,17 @@ public class CommerceOrderItemServiceHttp {
 	}
 
 	public static com.liferay.commerce.model.CommerceOrderItem
-			fetchByExternalReferenceCode(
-				HttpPrincipal httpPrincipal, String externalReferenceCode,
-				long companyId)
+			fetchCommerceOrderItem(
+				HttpPrincipal httpPrincipal, long commerceOrderItemId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				CommerceOrderItemServiceUtil.class,
-				"fetchByExternalReferenceCode",
-				_fetchByExternalReferenceCodeParameterTypes7);
+				CommerceOrderItemServiceUtil.class, "fetchCommerceOrderItem",
+				_fetchCommerceOrderItemParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, externalReferenceCode, companyId);
+				methodKey, commerceOrderItemId);
 
 			Object returnObj = null;
 
@@ -371,17 +369,19 @@ public class CommerceOrderItemServiceHttp {
 	}
 
 	public static com.liferay.commerce.model.CommerceOrderItem
-			fetchCommerceOrderItem(
-				HttpPrincipal httpPrincipal, long commerceOrderItemId)
+			fetchCommerceOrderItemByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				CommerceOrderItemServiceUtil.class, "fetchCommerceOrderItem",
-				_fetchCommerceOrderItemParameterTypes8);
+				CommerceOrderItemServiceUtil.class,
+				"fetchCommerceOrderItemByExternalReferenceCode",
+				_fetchCommerceOrderItemByExternalReferenceCodeParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, commerceOrderItemId);
+				methodKey, externalReferenceCode, companyId);
 
 			Object returnObj = null;
 
@@ -1749,12 +1749,11 @@ public class CommerceOrderItemServiceHttp {
 		_deleteMissingCommerceOrderItemsParameterTypes6 = new Class[] {
 			long.class, Long[].class, String[].class
 		};
-	private static final Class<?>[]
-		_fetchByExternalReferenceCodeParameterTypes7 = new Class[] {
-			String.class, long.class
-		};
-	private static final Class<?>[] _fetchCommerceOrderItemParameterTypes8 =
+	private static final Class<?>[] _fetchCommerceOrderItemParameterTypes7 =
 		new Class[] {long.class};
+	private static final Class<?>[]
+		_fetchCommerceOrderItemByExternalReferenceCodeParameterTypes8 =
+			new Class[] {String.class, long.class};
 	private static final Class<?>[]
 		_getAvailableForShipmentCommerceOrderItemsParameterTypes9 =
 			new Class[] {long.class};

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/http/CommerceOrderNoteServiceHttp.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/http/CommerceOrderNoteServiceHttp.java
@@ -168,19 +168,17 @@ public class CommerceOrderNoteServiceHttp {
 	}
 
 	public static com.liferay.commerce.model.CommerceOrderNote
-			fetchByExternalReferenceCode(
-				HttpPrincipal httpPrincipal, String externalReferenceCode,
-				long companyId)
+			fetchCommerceOrderNote(
+				HttpPrincipal httpPrincipal, long commerceOrderNoteId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				CommerceOrderNoteServiceUtil.class,
-				"fetchByExternalReferenceCode",
-				_fetchByExternalReferenceCodeParameterTypes3);
+				CommerceOrderNoteServiceUtil.class, "fetchCommerceOrderNote",
+				_fetchCommerceOrderNoteParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, externalReferenceCode, companyId);
+				methodKey, commerceOrderNoteId);
 
 			Object returnObj = null;
 
@@ -211,17 +209,19 @@ public class CommerceOrderNoteServiceHttp {
 	}
 
 	public static com.liferay.commerce.model.CommerceOrderNote
-			fetchCommerceOrderNote(
-				HttpPrincipal httpPrincipal, long commerceOrderNoteId)
+			fetchCommerceOrderNoteByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				CommerceOrderNoteServiceUtil.class, "fetchCommerceOrderNote",
-				_fetchCommerceOrderNoteParameterTypes4);
+				CommerceOrderNoteServiceUtil.class,
+				"fetchCommerceOrderNoteByExternalReferenceCode",
+				_fetchCommerceOrderNoteByExternalReferenceCodeParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, commerceOrderNoteId);
+				methodKey, externalReferenceCode, companyId);
 
 			Object returnObj = null;
 
@@ -561,12 +561,11 @@ public class CommerceOrderNoteServiceHttp {
 		};
 	private static final Class<?>[] _deleteCommerceOrderNoteParameterTypes2 =
 		new Class[] {long.class};
-	private static final Class<?>[]
-		_fetchByExternalReferenceCodeParameterTypes3 = new Class[] {
-			String.class, long.class
-		};
-	private static final Class<?>[] _fetchCommerceOrderNoteParameterTypes4 =
+	private static final Class<?>[] _fetchCommerceOrderNoteParameterTypes3 =
 		new Class[] {long.class};
+	private static final Class<?>[]
+		_fetchCommerceOrderNoteByExternalReferenceCodeParameterTypes4 =
+			new Class[] {String.class, long.class};
 	private static final Class<?>[] _getCommerceOrderNoteParameterTypes5 =
 		new Class[] {long.class};
 	private static final Class<?>[] _getCommerceOrderNotesParameterTypes6 =

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/http/CommerceOrderServiceHttp.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/http/CommerceOrderServiceHttp.java
@@ -412,48 +412,6 @@ public class CommerceOrderServiceHttp {
 		}
 	}
 
-	public static com.liferay.commerce.model.CommerceOrder
-			fetchByExternalReferenceCode(
-				HttpPrincipal httpPrincipal, String externalReferenceCode,
-				long companyId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		try {
-			MethodKey methodKey = new MethodKey(
-				CommerceOrderServiceUtil.class, "fetchByExternalReferenceCode",
-				_fetchByExternalReferenceCodeParameterTypes8);
-
-			MethodHandler methodHandler = new MethodHandler(
-				methodKey, externalReferenceCode, companyId);
-
-			Object returnObj = null;
-
-			try {
-				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
-			}
-			catch (Exception exception) {
-				if (exception instanceof
-						com.liferay.portal.kernel.exception.PortalException) {
-
-					throw (com.liferay.portal.kernel.exception.PortalException)
-						exception;
-				}
-
-				throw new com.liferay.portal.kernel.exception.SystemException(
-					exception);
-			}
-
-			return (com.liferay.commerce.model.CommerceOrder)returnObj;
-		}
-		catch (com.liferay.portal.kernel.exception.SystemException
-					systemException) {
-
-			_log.error(systemException, systemException);
-
-			throw systemException;
-		}
-	}
-
 	public static com.liferay.commerce.model.CommerceOrder fetchCommerceOrder(
 			HttpPrincipal httpPrincipal, long commerceOrderId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -461,7 +419,7 @@ public class CommerceOrderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceOrderServiceUtil.class, "fetchCommerceOrder",
-				_fetchCommerceOrderParameterTypes9);
+				_fetchCommerceOrderParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commerceOrderId);
@@ -502,7 +460,7 @@ public class CommerceOrderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceOrderServiceUtil.class, "fetchCommerceOrder",
-				_fetchCommerceOrderParameterTypes10);
+				_fetchCommerceOrderParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commerceAccountId, groupId, orderStatus);
@@ -543,7 +501,7 @@ public class CommerceOrderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceOrderServiceUtil.class, "fetchCommerceOrder",
-				_fetchCommerceOrderParameterTypes11);
+				_fetchCommerceOrderParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, commerceAccountId, groupId, userId, orderStatus);
@@ -583,10 +541,53 @@ public class CommerceOrderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CommerceOrderServiceUtil.class, "fetchCommerceOrder",
-				_fetchCommerceOrderParameterTypes12);
+				_fetchCommerceOrderParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, uuid, groupId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.commerce.model.CommerceOrder)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.commerce.model.CommerceOrder
+			fetchCommerceOrderByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				CommerceOrderServiceUtil.class,
+				"fetchCommerceOrderByExternalReferenceCode",
+				_fetchCommerceOrderByExternalReferenceCodeParameterTypes12);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, externalReferenceCode, companyId);
 
 			Object returnObj = null;
 
@@ -2779,18 +2780,17 @@ public class CommerceOrderServiceHttp {
 		new Class[] {long.class};
 	private static final Class<?>[] _executeWorkflowTransitionParameterTypes7 =
 		new Class[] {long.class, long.class, String.class, String.class};
-	private static final Class<?>[]
-		_fetchByExternalReferenceCodeParameterTypes8 = new Class[] {
-			String.class, long.class
-		};
-	private static final Class<?>[] _fetchCommerceOrderParameterTypes9 =
+	private static final Class<?>[] _fetchCommerceOrderParameterTypes8 =
 		new Class[] {long.class};
-	private static final Class<?>[] _fetchCommerceOrderParameterTypes10 =
+	private static final Class<?>[] _fetchCommerceOrderParameterTypes9 =
 		new Class[] {long.class, long.class, int.class};
-	private static final Class<?>[] _fetchCommerceOrderParameterTypes11 =
+	private static final Class<?>[] _fetchCommerceOrderParameterTypes10 =
 		new Class[] {long.class, long.class, long.class, int.class};
-	private static final Class<?>[] _fetchCommerceOrderParameterTypes12 =
+	private static final Class<?>[] _fetchCommerceOrderParameterTypes11 =
 		new Class[] {String.class, long.class};
+	private static final Class<?>[]
+		_fetchCommerceOrderByExternalReferenceCodeParameterTypes12 =
+			new Class[] {String.class, long.class};
 	private static final Class<?>[] _getCommerceOrderParameterTypes13 =
 		new Class[] {long.class};
 	private static final Class<?>[]

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/http/CommerceOrderTypeServiceHttp.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/http/CommerceOrderTypeServiceHttp.java
@@ -138,19 +138,17 @@ public class CommerceOrderTypeServiceHttp {
 	}
 
 	public static com.liferay.commerce.model.CommerceOrderType
-			fetchByExternalReferenceCode(
-				HttpPrincipal httpPrincipal, String externalReferenceCode,
-				long companyId)
+			fetchCommerceOrderType(
+				HttpPrincipal httpPrincipal, long commerceOrderTypeId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				CommerceOrderTypeServiceUtil.class,
-				"fetchByExternalReferenceCode",
-				_fetchByExternalReferenceCodeParameterTypes2);
+				CommerceOrderTypeServiceUtil.class, "fetchCommerceOrderType",
+				_fetchCommerceOrderTypeParameterTypes2);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, externalReferenceCode, companyId);
+				methodKey, commerceOrderTypeId);
 
 			Object returnObj = null;
 
@@ -181,17 +179,19 @@ public class CommerceOrderTypeServiceHttp {
 	}
 
 	public static com.liferay.commerce.model.CommerceOrderType
-			fetchCommerceOrderType(
-				HttpPrincipal httpPrincipal, long commerceOrderTypeId)
+			fetchCommerceOrderTypeByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				CommerceOrderTypeServiceUtil.class, "fetchCommerceOrderType",
-				_fetchCommerceOrderTypeParameterTypes3);
+				CommerceOrderTypeServiceUtil.class,
+				"fetchCommerceOrderTypeByExternalReferenceCode",
+				_fetchCommerceOrderTypeByExternalReferenceCodeParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, commerceOrderTypeId);
+				methodKey, externalReferenceCode, companyId);
 
 			Object returnObj = null;
 
@@ -459,12 +459,11 @@ public class CommerceOrderTypeServiceHttp {
 		};
 	private static final Class<?>[] _deleteCommerceOrderTypeParameterTypes1 =
 		new Class[] {long.class};
-	private static final Class<?>[]
-		_fetchByExternalReferenceCodeParameterTypes2 = new Class[] {
-			String.class, long.class
-		};
-	private static final Class<?>[] _fetchCommerceOrderTypeParameterTypes3 =
+	private static final Class<?>[] _fetchCommerceOrderTypeParameterTypes2 =
 		new Class[] {long.class};
+	private static final Class<?>[]
+		_fetchCommerceOrderTypeByExternalReferenceCodeParameterTypes3 =
+			new Class[] {String.class, long.class};
 	private static final Class<?>[] _getCommerceOrderTypeParameterTypes4 =
 		new Class[] {long.class};
 	private static final Class<?>[] _getCommerceOrderTypesParameterTypes5 =

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceAddressLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceAddressLocalServiceImpl.java
@@ -208,18 +208,18 @@ public class CommerceAddressLocalServiceImpl
 	}
 
 	@Override
-	public CommerceAddress fetchByExternalReferenceCode(
+	public CommerceAddress fetchCommerceAddress(long commerceAddressId) {
+		return CommerceAddressImpl.fromAddress(
+			_addressLocalService.fetchAddress(commerceAddressId));
+	}
+
+	@Override
+	public CommerceAddress fetchCommerceAddressByExternalReferenceCode(
 		String externalReferenceCode, long companyId) {
 
 		return CommerceAddressImpl.fromAddress(
 			_addressLocalService.fetchAddressByExternalReferenceCode(
 				externalReferenceCode, companyId));
-	}
-
-	@Override
-	public CommerceAddress fetchCommerceAddress(long commerceAddressId) {
-		return CommerceAddressImpl.fromAddress(
-			_addressLocalService.fetchAddress(commerceAddressId));
 	}
 
 	@Indexable(type = IndexableType.REINDEX)

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceAddressServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceAddressServiceImpl.java
@@ -102,13 +102,11 @@ public class CommerceAddressServiceImpl extends CommerceAddressServiceBaseImpl {
 	}
 
 	@Override
-	public CommerceAddress fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
+	public CommerceAddress fetchCommerceAddress(long commerceAddressId)
 		throws PortalException {
 
 		CommerceAddress commerceAddress =
-			commerceAddressLocalService.fetchByExternalReferenceCode(
-				externalReferenceCode, companyId);
+			commerceAddressLocalService.fetchCommerceAddress(commerceAddressId);
 
 		if (commerceAddress != null) {
 			_checkPermission(commerceAddress);
@@ -118,11 +116,14 @@ public class CommerceAddressServiceImpl extends CommerceAddressServiceBaseImpl {
 	}
 
 	@Override
-	public CommerceAddress fetchCommerceAddress(long commerceAddressId)
+	public CommerceAddress fetchCommerceAddressByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		CommerceAddress commerceAddress =
-			commerceAddressLocalService.fetchCommerceAddress(commerceAddressId);
+			commerceAddressLocalService.
+				fetchCommerceAddressByExternalReferenceCode(
+					externalReferenceCode, companyId);
 
 		if (commerceAddress != null) {
 			_checkPermission(commerceAddress);

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderItemLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderItemLocalServiceImpl.java
@@ -403,18 +403,6 @@ public class CommerceOrderItemLocalServiceImpl
 	}
 
 	@Override
-	public CommerceOrderItem fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		if (Validator.isBlank(externalReferenceCode)) {
-			return null;
-		}
-
-		return commerceOrderItemPersistence.fetchByERC_C(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public CommerceOrderItem
 		fetchCommerceOrderItemByCommerceInventoryBookedQuantityId(
 			long commerceInventoryBookedQuantityId) {

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderItemServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderItemServiceImpl.java
@@ -155,13 +155,12 @@ public class CommerceOrderItemServiceImpl
 	}
 
 	@Override
-	public CommerceOrderItem fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
+	public CommerceOrderItem fetchCommerceOrderItem(long commerceOrderItemId)
 		throws PortalException {
 
 		CommerceOrderItem commerceOrderItem =
-			commerceOrderItemLocalService.fetchByExternalReferenceCode(
-				externalReferenceCode, companyId);
+			commerceOrderItemLocalService.fetchCommerceOrderItem(
+				commerceOrderItemId);
 
 		if (commerceOrderItem != null) {
 			_commerceOrderModelResourcePermission.check(
@@ -173,12 +172,14 @@ public class CommerceOrderItemServiceImpl
 	}
 
 	@Override
-	public CommerceOrderItem fetchCommerceOrderItem(long commerceOrderItemId)
+	public CommerceOrderItem fetchCommerceOrderItemByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
 		throws PortalException {
 
 		CommerceOrderItem commerceOrderItem =
-			commerceOrderItemLocalService.fetchCommerceOrderItem(
-				commerceOrderItemId);
+			commerceOrderItemLocalService.
+				fetchCommerceOrderItemByExternalReferenceCode(
+					externalReferenceCode, companyId);
 
 		if (commerceOrderItem != null) {
 			_commerceOrderModelResourcePermission.check(

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
@@ -690,18 +690,6 @@ public class CommerceOrderLocalServiceImpl
 		return commerceOrder;
 	}
 
-	@Override
-	public CommerceOrder fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		if (Validator.isBlank(externalReferenceCode)) {
-			return null;
-		}
-
-		return commerceOrderPersistence.fetchByERC_C(
-			externalReferenceCode, companyId);
-	}
-
 	/**
 	 * @deprecated As of Athanasius (7.3.x)
 	 */

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderNoteLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderNoteLocalServiceImpl.java
@@ -107,18 +107,6 @@ public class CommerceOrderNoteLocalServiceImpl
 	}
 
 	@Override
-	public CommerceOrderNote fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		if (Validator.isBlank(externalReferenceCode)) {
-			return null;
-		}
-
-		return commerceOrderNotePersistence.fetchByERC_C(
-			externalReferenceCode, companyId);
-	}
-
-	@Override
 	public List<CommerceOrderNote> getCommerceOrderNotes(
 		long commerceOrderId, boolean restricted) {
 

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderNoteServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderNoteServiceImpl.java
@@ -100,24 +100,6 @@ public class CommerceOrderNoteServiceImpl
 	}
 
 	@Override
-	public CommerceOrderNote fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		CommerceOrderNote commerceOrderNote =
-			commerceOrderNoteLocalService.fetchByExternalReferenceCode(
-				externalReferenceCode, companyId);
-
-		if (commerceOrderNote != null) {
-			_commerceOrderModelResourcePermission.check(
-				getPermissionChecker(), commerceOrderNote.getCommerceOrderId(),
-				CommerceOrderActionKeys.MANAGE_COMMERCE_ORDER_RESTRICTED_NOTES);
-		}
-
-		return commerceOrderNote;
-	}
-
-	@Override
 	public CommerceOrderNote fetchCommerceOrderNote(long commerceOrderNoteId)
 		throws PortalException {
 
@@ -126,6 +108,25 @@ public class CommerceOrderNoteServiceImpl
 				commerceOrderNoteId);
 
 		_checkCommerceOrderNotePermissions(commerceOrderNote);
+
+		return commerceOrderNote;
+	}
+
+	@Override
+	public CommerceOrderNote fetchCommerceOrderNoteByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		CommerceOrderNote commerceOrderNote =
+			commerceOrderNoteLocalService.
+				fetchCommerceOrderNoteByExternalReferenceCode(
+					externalReferenceCode, companyId);
+
+		if (commerceOrderNote != null) {
+			_commerceOrderModelResourcePermission.check(
+				getPermissionChecker(), commerceOrderNote.getCommerceOrderId(),
+				CommerceOrderActionKeys.MANAGE_COMMERCE_ORDER_RESTRICTED_NOTES);
+		}
 
 		return commerceOrderNote;
 	}

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderServiceImpl.java
@@ -103,7 +103,7 @@ public class CommerceOrderServiceImpl extends CommerceOrderServiceBaseImpl {
 		throws PortalException {
 
 		CommerceOrder commerceOrder =
-			commerceOrderLocalService.fetchByExternalReferenceCode(
+			commerceOrderLocalService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, serviceContext.getCompanyId());
 
 		if (commerceOrder == null) {
@@ -208,23 +208,6 @@ public class CommerceOrderServiceImpl extends CommerceOrderServiceBaseImpl {
 	}
 
 	@Override
-	public CommerceOrder fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		CommerceOrder commerceOrder =
-			commerceOrderLocalService.fetchByExternalReferenceCode(
-				externalReferenceCode, companyId);
-
-		if (commerceOrder != null) {
-			_commerceOrderModelResourcePermission.check(
-				getPermissionChecker(), commerceOrder, ActionKeys.VIEW);
-		}
-
-		return commerceOrder;
-	}
-
-	@Override
 	public CommerceOrder fetchCommerceOrder(long commerceOrderId)
 		throws PortalException {
 
@@ -284,6 +267,23 @@ public class CommerceOrderServiceImpl extends CommerceOrderServiceBaseImpl {
 		CommerceOrder commerceOrder =
 			commerceOrderLocalService.fetchCommerceOrderByUuidAndGroupId(
 				uuid, groupId);
+
+		if (commerceOrder != null) {
+			_commerceOrderModelResourcePermission.check(
+				getPermissionChecker(), commerceOrder, ActionKeys.VIEW);
+		}
+
+		return commerceOrder;
+	}
+
+	@Override
+	public CommerceOrder fetchCommerceOrderByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		CommerceOrder commerceOrder =
+			commerceOrderLocalService.fetchCommerceOrderByExternalReferenceCode(
+				externalReferenceCode, companyId);
 
 		if (commerceOrder != null) {
 			_commerceOrderModelResourcePermission.check(

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderTypeLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderTypeLocalServiceImpl.java
@@ -41,7 +41,6 @@ import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowHandlerRegistryUtil;
 
@@ -182,18 +181,6 @@ public class CommerceOrderTypeLocalServiceImpl
 
 		return commerceOrderTypeLocalService.deleteCommerceOrderType(
 			commerceOrderType);
-	}
-
-	@Override
-	public CommerceOrderType fetchByExternalReferenceCode(
-		String externalReferenceCode, long companyId) {
-
-		if (Validator.isBlank(externalReferenceCode)) {
-			return null;
-		}
-
-		return commerceOrderTypePersistence.fetchByERC_C(
-			externalReferenceCode, companyId);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderTypeServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderTypeServiceImpl.java
@@ -76,23 +76,6 @@ public class CommerceOrderTypeServiceImpl
 	}
 
 	@Override
-	public CommerceOrderType fetchByExternalReferenceCode(
-			String externalReferenceCode, long companyId)
-		throws PortalException {
-
-		CommerceOrderType commerceOrderType =
-			commerceOrderTypeLocalService.fetchByExternalReferenceCode(
-				externalReferenceCode, companyId);
-
-		if (commerceOrderType != null) {
-			_commerceOrderTypeModelResourcePermission.check(
-				getPermissionChecker(), commerceOrderType, ActionKeys.VIEW);
-		}
-
-		return commerceOrderType;
-	}
-
-	@Override
 	public CommerceOrderType fetchCommerceOrderType(long commerceOrderTypeId)
 		throws PortalException {
 
@@ -103,6 +86,24 @@ public class CommerceOrderTypeServiceImpl
 		if (commerceOrderType != null) {
 			_commerceOrderTypeModelResourcePermission.check(
 				getPermissionChecker(), commerceOrderTypeId, ActionKeys.VIEW);
+		}
+
+		return commerceOrderType;
+	}
+
+	@Override
+	public CommerceOrderType fetchCommerceOrderTypeByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		CommerceOrderType commerceOrderType =
+			commerceOrderTypeLocalService.
+				fetchCommerceOrderTypeByExternalReferenceCode(
+					externalReferenceCode, companyId);
+
+		if (commerceOrderType != null) {
+			_commerceOrderTypeModelResourcePermission.check(
+				getPermissionChecker(), commerceOrderType, ActionKeys.VIEW);
 		}
 
 		return commerceOrderType;

--- a/modules/apps/commerce/commerce-site-initializer/commerce-site-initializer-extender/src/main/java/com/liferay/commerce/site/initializer/extender/CommerceSiteInitializerImpl.java
+++ b/modules/apps/commerce/commerce-site-initializer/commerce-site-initializer-extender/src/main/java/com/liferay/commerce/site/initializer/extender/CommerceSiteInitializerImpl.java
@@ -550,7 +550,7 @@ public class CommerceSiteInitializerImpl implements CommerceSiteInitializer {
 
 			_addOrUpdateCommercePriceEntries(
 				cpDefinition,
-				_cpInstanceLocalService.fetchByExternalReferenceCode(
+				_cpInstanceLocalService.fetchCPInstanceByExternalReferenceCode(
 					subscriptionPropertiesJSONObject.getString(
 						"cpDefinitionExternalReferenceCode"),
 					serviceContext.getCompanyId()),

--- a/modules/apps/commerce/commerce-term-api/bnd.bnd
+++ b/modules/apps/commerce/commerce-term-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Commerce Term API
 Bundle-SymbolicName: com.liferay.commerce.term.api
-Bundle-Version: 7.0.1
+Bundle-Version: 8.0.0
 Export-Package:\
 	com.liferay.commerce.term.configuration,\
 	com.liferay.commerce.term.constants,\

--- a/modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/service/CommerceTermEntryService.java
+++ b/modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/service/CommerceTermEntryService.java
@@ -61,12 +61,12 @@ public interface CommerceTermEntryService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceTermEntry fetchByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+	public CommerceTermEntry fetchCommerceTermEntry(long commerceTermEntryId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public CommerceTermEntry fetchCommerceTermEntry(long commerceTermEntryId)
+	public CommerceTermEntry fetchCommerceTermEntryByExternalReferenceCode(
+			long companyId, String externalReferenceCode)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/service/CommerceTermEntryServiceUtil.java
+++ b/modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/service/CommerceTermEntryServiceUtil.java
@@ -58,19 +58,20 @@ public class CommerceTermEntryServiceUtil {
 		return getService().deleteCommerceTermEntry(commerceTermEntryId);
 	}
 
-	public static CommerceTermEntry fetchByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
-		throws PortalException {
-
-		return getService().fetchByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
 	public static CommerceTermEntry fetchCommerceTermEntry(
 			long commerceTermEntryId)
 		throws PortalException {
 
 		return getService().fetchCommerceTermEntry(commerceTermEntryId);
+	}
+
+	public static CommerceTermEntry
+			fetchCommerceTermEntryByExternalReferenceCode(
+				long companyId, String externalReferenceCode)
+		throws PortalException {
+
+		return getService().fetchCommerceTermEntryByExternalReferenceCode(
+			companyId, externalReferenceCode);
 	}
 
 	public static List<CommerceTermEntry> getCommerceTermEntries(

--- a/modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/service/CommerceTermEntryServiceWrapper.java
+++ b/modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/service/CommerceTermEntryServiceWrapper.java
@@ -62,21 +62,22 @@ public class CommerceTermEntryServiceWrapper
 
 	@Override
 	public com.liferay.commerce.term.model.CommerceTermEntry
-			fetchByExternalReferenceCode(
-				long companyId, String externalReferenceCode)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _commerceTermEntryService.fetchByExternalReferenceCode(
-			companyId, externalReferenceCode);
-	}
-
-	@Override
-	public com.liferay.commerce.term.model.CommerceTermEntry
 			fetchCommerceTermEntry(long commerceTermEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commerceTermEntryService.fetchCommerceTermEntry(
 			commerceTermEntryId);
+	}
+
+	@Override
+	public com.liferay.commerce.term.model.CommerceTermEntry
+			fetchCommerceTermEntryByExternalReferenceCode(
+				long companyId, String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _commerceTermEntryService.
+			fetchCommerceTermEntryByExternalReferenceCode(
+				companyId, externalReferenceCode);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-term-api/src/main/resources/com/liferay/commerce/term/service/packageinfo
+++ b/modules/apps/commerce/commerce-term-api/src/main/resources/com/liferay/commerce/term/service/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 5.0.0

--- a/modules/apps/commerce/commerce-term-service/src/main/java/com/liferay/commerce/term/service/http/CommerceTermEntryServiceHttp.java
+++ b/modules/apps/commerce/commerce-term-service/src/main/java/com/liferay/commerce/term/service/http/CommerceTermEntryServiceHttp.java
@@ -139,19 +139,17 @@ public class CommerceTermEntryServiceHttp {
 	}
 
 	public static com.liferay.commerce.term.model.CommerceTermEntry
-			fetchByExternalReferenceCode(
-				HttpPrincipal httpPrincipal, long companyId,
-				String externalReferenceCode)
+			fetchCommerceTermEntry(
+				HttpPrincipal httpPrincipal, long commerceTermEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				CommerceTermEntryServiceUtil.class,
-				"fetchByExternalReferenceCode",
-				_fetchByExternalReferenceCodeParameterTypes2);
+				CommerceTermEntryServiceUtil.class, "fetchCommerceTermEntry",
+				_fetchCommerceTermEntryParameterTypes2);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, companyId, externalReferenceCode);
+				methodKey, commerceTermEntryId);
 
 			Object returnObj = null;
 
@@ -182,17 +180,19 @@ public class CommerceTermEntryServiceHttp {
 	}
 
 	public static com.liferay.commerce.term.model.CommerceTermEntry
-			fetchCommerceTermEntry(
-				HttpPrincipal httpPrincipal, long commerceTermEntryId)
+			fetchCommerceTermEntryByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, long companyId,
+				String externalReferenceCode)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				CommerceTermEntryServiceUtil.class, "fetchCommerceTermEntry",
-				_fetchCommerceTermEntryParameterTypes3);
+				CommerceTermEntryServiceUtil.class,
+				"fetchCommerceTermEntryByExternalReferenceCode",
+				_fetchCommerceTermEntryByExternalReferenceCodeParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, commerceTermEntryId);
+				methodKey, companyId, externalReferenceCode);
 
 			Object returnObj = null;
 
@@ -466,12 +466,11 @@ public class CommerceTermEntryServiceHttp {
 		};
 	private static final Class<?>[] _deleteCommerceTermEntryParameterTypes1 =
 		new Class[] {long.class};
-	private static final Class<?>[]
-		_fetchByExternalReferenceCodeParameterTypes2 = new Class[] {
-			long.class, String.class
-		};
-	private static final Class<?>[] _fetchCommerceTermEntryParameterTypes3 =
+	private static final Class<?>[] _fetchCommerceTermEntryParameterTypes2 =
 		new Class[] {long.class};
+	private static final Class<?>[]
+		_fetchCommerceTermEntryByExternalReferenceCodeParameterTypes3 =
+			new Class[] {long.class, String.class};
 	private static final Class<?>[] _getCommerceTermEntriesParameterTypes4 =
 		new Class[] {long.class, long.class, String.class};
 	private static final Class<?>[] _getCommerceTermEntryParameterTypes5 =

--- a/modules/apps/commerce/commerce-term-service/src/main/java/com/liferay/commerce/term/service/impl/CommerceTermEntryServiceImpl.java
+++ b/modules/apps/commerce/commerce-term-service/src/main/java/com/liferay/commerce/term/service/impl/CommerceTermEntryServiceImpl.java
@@ -79,14 +79,12 @@ public class CommerceTermEntryServiceImpl
 	}
 
 	@Override
-	public CommerceTermEntry fetchByExternalReferenceCode(
-			long companyId, String externalReferenceCode)
+	public CommerceTermEntry fetchCommerceTermEntry(long commerceTermEntryId)
 		throws PortalException {
 
 		CommerceTermEntry commerceTermEntry =
-			commerceTermEntryLocalService.
-				fetchCommerceTermEntryByExternalReferenceCode(
-					externalReferenceCode, companyId);
+			commerceTermEntryLocalService.fetchCommerceTermEntry(
+				commerceTermEntryId);
 
 		if (commerceTermEntry != null) {
 			_commerceTermEntryModelResourcePermission.check(
@@ -97,12 +95,14 @@ public class CommerceTermEntryServiceImpl
 	}
 
 	@Override
-	public CommerceTermEntry fetchCommerceTermEntry(long commerceTermEntryId)
+	public CommerceTermEntry fetchCommerceTermEntryByExternalReferenceCode(
+			long companyId, String externalReferenceCode)
 		throws PortalException {
 
 		CommerceTermEntry commerceTermEntry =
-			commerceTermEntryLocalService.fetchCommerceTermEntry(
-				commerceTermEntryId);
+			commerceTermEntryLocalService.
+				fetchCommerceTermEntryByExternalReferenceCode(
+					externalReferenceCode, companyId);
 
 		if (commerceTermEntry != null) {
 			_commerceTermEntryModelResourcePermission.check(

--- a/modules/apps/commerce/commerce-test-util/src/main/java/com/liferay/commerce/test/util/price/list/CommerceTierPriceEntryTestUtil.java
+++ b/modules/apps/commerce/commerce-test-util/src/main/java/com/liferay/commerce/test/util/price/list/CommerceTierPriceEntryTestUtil.java
@@ -82,8 +82,9 @@ public class CommerceTierPriceEntryTestUtil {
 
 		if (priceEntryExternalReferenceCode != null) {
 			CommercePriceEntry commercePriceEntry =
-				CommercePriceEntryLocalServiceUtil.fetchByExternalReferenceCode(
-					priceEntryExternalReferenceCode, companyId);
+				CommercePriceEntryLocalServiceUtil.
+					fetchCommercePriceEntryByExternalReferenceCode(
+						priceEntryExternalReferenceCode, companyId);
 
 			if (commercePriceEntry != null) {
 				CommercePriceList commercePriceList =

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/AccountAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/AccountAddressResourceImpl.java
@@ -63,7 +63,7 @@ public class AccountAddressResourceImpl extends BaseAccountAddressResourceImpl {
 		throws Exception {
 
 		CommerceAddress commerceAddress =
-			_commerceAddressService.fetchByExternalReferenceCode(
+			_commerceAddressService.fetchCommerceAddressByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceAddress == null) {
@@ -92,7 +92,7 @@ public class AccountAddressResourceImpl extends BaseAccountAddressResourceImpl {
 		throws Exception {
 
 		CommerceAddress commerceAddress =
-			_commerceAddressService.fetchByExternalReferenceCode(
+			_commerceAddressService.fetchCommerceAddressByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceAddress == null) {
@@ -185,7 +185,7 @@ public class AccountAddressResourceImpl extends BaseAccountAddressResourceImpl {
 		throws Exception {
 
 		CommerceAddress commerceAddress =
-			_commerceAddressService.fetchByExternalReferenceCode(
+			_commerceAddressService.fetchCommerceAddressByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceAddress == null) {
@@ -257,9 +257,10 @@ public class AccountAddressResourceImpl extends BaseAccountAddressResourceImpl {
 		}
 		else if (accountAddress.getExternalReferenceCode() != null) {
 			commerceAddress =
-				_commerceAddressService.fetchByExternalReferenceCode(
-					accountAddress.getExternalReferenceCode(),
-					contextCompany.getCompanyId());
+				_commerceAddressService.
+					fetchCommerceAddressByExternalReferenceCode(
+						accountAddress.getExternalReferenceCode(),
+						contextCompany.getCompanyId());
 		}
 
 		if (commerceAddress != null) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/AccountChannelEntryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/AccountChannelEntryResourceImpl.java
@@ -999,10 +999,12 @@ public class AccountChannelEntryResourceImpl
 				CommerceChannelAccountEntryRelConstants.TYPE_BILLING_ADDRESS) {
 
 			CommerceAddress commerceAddress =
-				_commerceAddressService.fetchByExternalReferenceCode(
-					GetterUtil.getString(
-						accountChannelEntry.getClassExternalReferenceCode()),
-					contextCompany.getCompanyId());
+				_commerceAddressService.
+					fetchCommerceAddressByExternalReferenceCode(
+						GetterUtil.getString(
+							accountChannelEntry.
+								getClassExternalReferenceCode()),
+						contextCompany.getCompanyId());
 
 			if (commerceAddress == null) {
 				commerceAddress = _commerceAddressService.getCommerceAddress(
@@ -1037,10 +1039,12 @@ public class AccountChannelEntryResourceImpl
 						TYPE_DELIVERY_TERM) {
 
 			CommerceTermEntry commerceTermEntry =
-				_commerceTermEntryService.fetchByExternalReferenceCode(
-					contextCompany.getCompanyId(),
-					GetterUtil.getString(
-						accountChannelEntry.getClassExternalReferenceCode()));
+				_commerceTermEntryService.
+					fetchCommerceTermEntryByExternalReferenceCode(
+						contextCompany.getCompanyId(),
+						GetterUtil.getString(
+							accountChannelEntry.
+								getClassExternalReferenceCode()));
 
 			if (commerceTermEntry == null) {
 				commerceTermEntry =
@@ -1058,10 +1062,12 @@ public class AccountChannelEntryResourceImpl
 					CommerceChannelAccountEntryRelConstants.TYPE_DISCOUNT) {
 
 			CommerceDiscount commerceDiscount =
-				_commerceDiscountService.fetchByExternalReferenceCode(
-					GetterUtil.getString(
-						accountChannelEntry.getClassExternalReferenceCode()),
-					contextCompany.getCompanyId());
+				_commerceDiscountService.
+					fetchCommerceDiscountByExternalReferenceCode(
+						GetterUtil.getString(
+							accountChannelEntry.
+								getClassExternalReferenceCode()),
+						contextCompany.getCompanyId());
 
 			if (commerceDiscount == null) {
 				commerceDiscount = _commerceDiscountService.getCommerceDiscount(
@@ -1118,10 +1124,12 @@ public class AccountChannelEntryResourceImpl
 					CommerceChannelAccountEntryRelConstants.TYPE_PAYMENT_TERM) {
 
 			CommerceTermEntry commerceTermEntry =
-				_commerceTermEntryService.fetchByExternalReferenceCode(
-					contextCompany.getCompanyId(),
-					GetterUtil.getString(
-						accountChannelEntry.getClassExternalReferenceCode()));
+				_commerceTermEntryService.
+					fetchCommerceTermEntryByExternalReferenceCode(
+						contextCompany.getCompanyId(),
+						GetterUtil.getString(
+							accountChannelEntry.
+								getClassExternalReferenceCode()));
 
 			if (commerceTermEntry == null) {
 				commerceTermEntry =
@@ -1139,10 +1147,12 @@ public class AccountChannelEntryResourceImpl
 					CommerceChannelAccountEntryRelConstants.TYPE_PRICE_LIST) {
 
 			CommercePriceList commercePriceList =
-				_commercePriceListService.fetchByExternalReferenceCode(
-					GetterUtil.getString(
-						accountChannelEntry.getClassExternalReferenceCode()),
-					contextCompany.getCompanyId());
+				_commercePriceListService.
+					fetchCommercePriceListByExternalReferenceCode(
+						GetterUtil.getString(
+							accountChannelEntry.
+								getClassExternalReferenceCode()),
+						contextCompany.getCompanyId());
 
 			if (commercePriceList == null) {
 				commercePriceList =
@@ -1161,10 +1171,12 @@ public class AccountChannelEntryResourceImpl
 						TYPE_SHIPPING_ADDRESS) {
 
 			CommerceAddress commerceAddress =
-				_commerceAddressService.fetchByExternalReferenceCode(
-					GetterUtil.getString(
-						accountChannelEntry.getClassExternalReferenceCode()),
-					contextCompany.getCompanyId());
+				_commerceAddressService.
+					fetchCommerceAddressByExternalReferenceCode(
+						GetterUtil.getString(
+							accountChannelEntry.
+								getClassExternalReferenceCode()),
+						contextCompany.getCompanyId());
 
 			if (commerceAddress == null) {
 				commerceAddress = _commerceAddressService.getCommerceAddress(
@@ -1223,7 +1235,7 @@ public class AccountChannelEntryResourceImpl
 		throws Exception {
 
 		CommerceChannel commerceChannel =
-			_commerceChannelService.fetchByExternalReferenceCode(
+			_commerceChannelService.fetchCommerceChannelByExternalReferenceCode(
 				GetterUtil.getString(
 					accountChannelEntry.getChannelExternalReferenceCode()),
 				contextCompany.getCompanyId());

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/AccountChannelShippingOptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/AccountChannelShippingOptionResourceImpl.java
@@ -342,11 +342,12 @@ public class AccountChannelShippingOptionResourceImpl
 		throws Exception {
 
 		CommerceChannel commerceChannel =
-			_commerceChannelLocalService.fetchByExternalReferenceCode(
-				GetterUtil.getString(
-					accountChannelShippingOption.
-						getChannelExternalReferenceCode()),
-				contextCompany.getCompanyId());
+			_commerceChannelLocalService.
+				fetchCommerceChannelByExternalReferenceCode(
+					GetterUtil.getString(
+						accountChannelShippingOption.
+							getChannelExternalReferenceCode()),
+					contextCompany.getCompanyId());
 
 		if (commerceChannel == null) {
 			commerceChannel = _commerceChannelLocalService.fetchCommerceChannel(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/AttachmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/AttachmentResourceImpl.java
@@ -83,8 +83,9 @@ public class AttachmentResourceImpl extends BaseAttachmentResourceImpl {
 		throws Exception {
 
 		CPAttachmentFileEntry cpAttachmentFileEntry =
-			_cpAttachmentFileEntryService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_cpAttachmentFileEntryService.
+				fetchCPAttachmentFileEntryByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (cpAttachmentFileEntry == null) {
 			throw new NoSuchCPAttachmentFileEntryException(
@@ -102,8 +103,9 @@ public class AttachmentResourceImpl extends BaseAttachmentResourceImpl {
 		throws Exception {
 
 		CPAttachmentFileEntry cpAttachmentFileEntry =
-			_cpAttachmentFileEntryService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_cpAttachmentFileEntryService.
+				fetchCPAttachmentFileEntryByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (cpAttachmentFileEntry == null) {
 			throw new NoSuchCPAttachmentFileEntryException(
@@ -201,8 +203,9 @@ public class AttachmentResourceImpl extends BaseAttachmentResourceImpl {
 		throws Exception {
 
 		CPAttachmentFileEntry cpAttachmentFileEntry =
-			_cpAttachmentFileEntryService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_cpAttachmentFileEntryService.
+				fetchCPAttachmentFileEntryByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (cpAttachmentFileEntry == null) {
 			throw new NoSuchCPAttachmentFileEntryException(
@@ -429,8 +432,9 @@ public class AttachmentResourceImpl extends BaseAttachmentResourceImpl {
 		throws Exception {
 
 		CPAttachmentFileEntry cpAttachmentFileEntry =
-			_cpAttachmentFileEntryService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_cpAttachmentFileEntryService.
+				fetchCPAttachmentFileEntryByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (cpAttachmentFileEntry == null) {
 			throw new NoSuchCPAttachmentFileEntryException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/CatalogResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/CatalogResourceImpl.java
@@ -69,7 +69,7 @@ public class CatalogResourceImpl extends BaseCatalogResourceImpl {
 		throws Exception {
 
 		CommerceCatalog commerceCatalog =
-			_commerceCatalogService.fetchByExternalReferenceCode(
+			_commerceCatalogService.fetchCommerceCatalogByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceCatalog == null) {
@@ -97,7 +97,7 @@ public class CatalogResourceImpl extends BaseCatalogResourceImpl {
 		throws Exception {
 
 		CommerceCatalog commerceCatalog =
-			_commerceCatalogService.fetchByExternalReferenceCode(
+			_commerceCatalogService.fetchCommerceCatalogByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceCatalog == null) {
@@ -187,7 +187,7 @@ public class CatalogResourceImpl extends BaseCatalogResourceImpl {
 		throws Exception {
 
 		CommerceCatalog commerceCatalog =
-			_commerceCatalogService.fetchByExternalReferenceCode(
+			_commerceCatalogService.fetchCommerceCatalogByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceCatalog == null) {
@@ -206,7 +206,7 @@ public class CatalogResourceImpl extends BaseCatalogResourceImpl {
 	@Override
 	public Catalog postCatalog(Catalog catalog) throws Exception {
 		CommerceCatalog commerceCatalog =
-			_commerceCatalogService.fetchByExternalReferenceCode(
+			_commerceCatalogService.fetchCommerceCatalogByExternalReferenceCode(
 				catalog.getExternalReferenceCode(),
 				contextCompany.getCompanyId());
 
@@ -244,7 +244,7 @@ public class CatalogResourceImpl extends BaseCatalogResourceImpl {
 		throws Exception {
 
 		CommerceCatalog commerceCatalog =
-			_commerceCatalogService.fetchByExternalReferenceCode(
+			_commerceCatalogService.fetchCommerceCatalogByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceCatalog == null) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/OptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/OptionResourceImpl.java
@@ -72,8 +72,9 @@ public class OptionResourceImpl extends BaseOptionResourceImpl {
 			String externalReferenceCode)
 		throws Exception {
 
-		CPOption cpOption = _cpOptionService.fetchByExternalReferenceCode(
-			externalReferenceCode, contextCompany.getCompanyId());
+		CPOption cpOption =
+			_cpOptionService.fetchCPOptionByExternalReferenceCode(
+				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (cpOption == null) {
 			throw new NoSuchCPOptionException(
@@ -104,8 +105,9 @@ public class OptionResourceImpl extends BaseOptionResourceImpl {
 	public Option getOptionByExternalReferenceCode(String externalReferenceCode)
 		throws Exception {
 
-		CPOption cpOption = _cpOptionService.fetchByExternalReferenceCode(
-			externalReferenceCode, contextCompany.getCompanyId());
+		CPOption cpOption =
+			_cpOptionService.fetchCPOptionByExternalReferenceCode(
+				externalReferenceCode, contextCompany.getCompanyId());
 
 		return _toOption(cpOption.getCPOptionId());
 	}
@@ -142,8 +144,9 @@ public class OptionResourceImpl extends BaseOptionResourceImpl {
 			String externalReferenceCode, Option option)
 		throws Exception {
 
-		CPOption cpOption = _cpOptionService.fetchByExternalReferenceCode(
-			externalReferenceCode, contextCompany.getCompanyId());
+		CPOption cpOption =
+			_cpOptionService.fetchCPOptionByExternalReferenceCode(
+				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (cpOption == null) {
 			throw new NoSuchCPOptionException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/OptionValueResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/OptionValueResourceImpl.java
@@ -79,7 +79,7 @@ public class OptionValueResourceImpl extends BaseOptionValueResourceImpl {
 		throws Exception {
 
 		CPOptionValue cpOptionValue =
-			_cpOptionValueService.fetchByExternalReferenceCode(
+			_cpOptionValueService.fetchCPOptionValueByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (cpOptionValue == null) {
@@ -102,8 +102,9 @@ public class OptionValueResourceImpl extends BaseOptionValueResourceImpl {
 			Sort[] sorts)
 		throws Exception {
 
-		CPOption cpOption = _cpOptionService.fetchByExternalReferenceCode(
-			externalReferenceCode, contextCompany.getCompanyId());
+		CPOption cpOption =
+			_cpOptionService.fetchCPOptionByExternalReferenceCode(
+				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (cpOption == null) {
 			throw new NoSuchCPOptionException(
@@ -160,7 +161,7 @@ public class OptionValueResourceImpl extends BaseOptionValueResourceImpl {
 		throws Exception {
 
 		CPOptionValue cpOptionValue =
-			_cpOptionValueService.fetchByExternalReferenceCode(
+			_cpOptionValueService.fetchCPOptionValueByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (cpOptionValue == null) {
@@ -190,7 +191,7 @@ public class OptionValueResourceImpl extends BaseOptionValueResourceImpl {
 		throws Exception {
 
 		CPOptionValue cpOptionValue =
-			_cpOptionValueService.fetchByExternalReferenceCode(
+			_cpOptionValueService.fetchCPOptionValueByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (cpOptionValue == null) {
@@ -211,8 +212,9 @@ public class OptionValueResourceImpl extends BaseOptionValueResourceImpl {
 			String externalReferenceCode, OptionValue optionValue)
 		throws Exception {
 
-		CPOption cpOption = _cpOptionService.fetchByExternalReferenceCode(
-			externalReferenceCode, contextCompany.getCompanyId());
+		CPOption cpOption =
+			_cpOptionService.fetchCPOptionByExternalReferenceCode(
+				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (cpOption == null) {
 			throw new NoSuchCPOptionException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/PinResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/PinResourceImpl.java
@@ -186,7 +186,7 @@ public class PinResourceImpl extends BasePinResourceImpl {
 			long skuId = GetterUtil.getLong(mappedProduct.getSkuId());
 
 			CPInstance cpInstance =
-				_cpInstanceService.fetchByExternalReferenceCode(
+				_cpInstanceService.fetchCPInstanceByExternalReferenceCode(
 					mappedProduct.getSkuExternalReferenceCode(),
 					contextCompany.getCompanyId());
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/ProductGroupProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/ProductGroupProductResourceImpl.java
@@ -52,8 +52,9 @@ public class ProductGroupProductResourceImpl
 		throws Exception {
 
 		CommercePricingClass commercePricingClass =
-			_commercePricingClassService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePricingClassService.
+				fetchCommercePricingClassByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePricingClass == null) {
 			throw new NoSuchPricingClassException(
@@ -108,8 +109,9 @@ public class ProductGroupProductResourceImpl
 		throws Exception {
 
 		CommercePricingClass commercePricingClass =
-			_commercePricingClassService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePricingClassService.
+				fetchCommercePricingClassByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePricingClass == null) {
 			throw new NoSuchPricingClassException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/ProductGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/ProductGroupResourceImpl.java
@@ -63,8 +63,9 @@ public class ProductGroupResourceImpl extends BaseProductGroupResourceImpl {
 		throws Exception {
 
 		CommercePricingClass commercePricingClass =
-			_commercePricingClassService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePricingClassService.
+				fetchCommercePricingClassByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePricingClass == null) {
 			throw new NoSuchPricingClassException(
@@ -94,8 +95,9 @@ public class ProductGroupResourceImpl extends BaseProductGroupResourceImpl {
 		throws Exception {
 
 		CommercePricingClass commercePricingClass =
-			_commercePricingClassService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePricingClassService.
+				fetchCommercePricingClassByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePricingClass == null) {
 			throw new NoSuchPricingClassException(
@@ -143,8 +145,9 @@ public class ProductGroupResourceImpl extends BaseProductGroupResourceImpl {
 		throws Exception {
 
 		CommercePricingClass commercePricingClass =
-			_commercePricingClassService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePricingClassService.
+				fetchCommercePricingClassByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePricingClass == null) {
 			throw new NoSuchPricingClassException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/ProductOptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/ProductOptionResourceImpl.java
@@ -325,9 +325,10 @@ public class ProductOptionResourceImpl extends BaseProductOptionResourceImpl {
 			return optionId;
 		}
 
-		CPOption cpOption = _cpOptionService.fetchByExternalReferenceCode(
-			productOption.getOptionExternalReferenceCode(),
-			contextCompany.getCompanyId());
+		CPOption cpOption =
+			_cpOptionService.fetchCPOptionByExternalReferenceCode(
+				productOption.getOptionExternalReferenceCode(),
+				contextCompany.getCompanyId());
 
 		if (cpOption != null) {
 			return cpOption.getCPOptionId();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/ProductOptionValueResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/ProductOptionValueResourceImpl.java
@@ -104,9 +104,10 @@ public class ProductOptionValueResourceImpl
 
 		long cpInstanceId = 0;
 
-		CPInstance cpInstance = _cpInstanceService.fetchByExternalReferenceCode(
-			productOptionValue.getSkuExternalReferenceCode(),
-			contextCompany.getCompanyId());
+		CPInstance cpInstance =
+			_cpInstanceService.fetchCPInstanceByExternalReferenceCode(
+				productOptionValue.getSkuExternalReferenceCode(),
+				contextCompany.getCompanyId());
 
 		if (cpInstance == null) {
 			cpInstance = _cpInstanceService.fetchCPInstance(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/ProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/ProductResourceImpl.java
@@ -1195,10 +1195,11 @@ public class ProductResourceImpl extends BaseProductResourceImpl {
 
 			for (ProductChannel productChannel : productChannels) {
 				CommerceChannel commerceChannel =
-					_commerceChannelService.fetchByExternalReferenceCode(
-						GetterUtil.getString(
-							productChannel.getExternalReferenceCode()),
-						contextCompany.getCompanyId());
+					_commerceChannelService.
+						fetchCommerceChannelByExternalReferenceCode(
+							GetterUtil.getString(
+								productChannel.getExternalReferenceCode()),
+							contextCompany.getCompanyId());
 
 				if (commerceChannel == null) {
 					commerceChannel =

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/SkuResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/SkuResourceImpl.java
@@ -115,8 +115,9 @@ public class SkuResourceImpl extends BaseSkuResourceImpl {
 			String externalReferenceCode)
 		throws Exception {
 
-		CPInstance cpInstance = _cpInstanceService.fetchByExternalReferenceCode(
-			externalReferenceCode, contextCompany.getCompanyId());
+		CPInstance cpInstance =
+			_cpInstanceService.fetchCPInstanceByExternalReferenceCode(
+				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (cpInstance == null) {
 			throw new NoSuchCPInstanceException(
@@ -176,8 +177,9 @@ public class SkuResourceImpl extends BaseSkuResourceImpl {
 	public Sku getSkuByExternalReferenceCode(String externalReferenceCode)
 		throws Exception {
 
-		CPInstance cpInstance = _cpInstanceService.fetchByExternalReferenceCode(
-			externalReferenceCode, contextCompany.getCompanyId());
+		CPInstance cpInstance =
+			_cpInstanceService.fetchCPInstanceByExternalReferenceCode(
+				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (cpInstance == null) {
 			throw new NoSuchCPInstanceException(
@@ -244,8 +246,9 @@ public class SkuResourceImpl extends BaseSkuResourceImpl {
 			String externalReferenceCode, Sku sku)
 		throws Exception {
 
-		CPInstance cpInstance = _cpInstanceService.fetchByExternalReferenceCode(
-			externalReferenceCode, contextCompany.getCompanyId());
+		CPInstance cpInstance =
+			_cpInstanceService.fetchCPInstanceByExternalReferenceCode(
+				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (cpInstance == null) {
 			throw new NoSuchCPInstanceException(
@@ -293,8 +296,9 @@ public class SkuResourceImpl extends BaseSkuResourceImpl {
 			String externalReferenceCode, Sku sku)
 		throws Exception {
 
-		CPInstance cpInstance = _cpInstanceService.fetchByExternalReferenceCode(
-			externalReferenceCode, contextCompany.getCompanyId());
+		CPInstance cpInstance =
+			_cpInstanceService.fetchCPInstanceByExternalReferenceCode(
+				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (cpInstance == null) {
 			throw new NoSuchCPInstanceException(
@@ -338,7 +342,7 @@ public class SkuResourceImpl extends BaseSkuResourceImpl {
 					sku.getReplacementSkuExternalReferenceCode())) {
 
 				discontinuedCPInstance =
-					_cpInstanceService.fetchByExternalReferenceCode(
+					_cpInstanceService.fetchCPInstanceByExternalReferenceCode(
 						sku.getReplacementSkuExternalReferenceCode(),
 						contextCompany.getCompanyId());
 			}
@@ -733,7 +737,7 @@ public class SkuResourceImpl extends BaseSkuResourceImpl {
 					sku.getReplacementSkuExternalReferenceCode())) {
 
 				discontinuedCPInstance =
-					_cpInstanceService.fetchByExternalReferenceCode(
+					_cpInstanceService.fetchCPInstanceByExternalReferenceCode(
 						sku.getReplacementSkuExternalReferenceCode(),
 						contextCompany.getCompanyId());
 			}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/SkuSubscriptionConfigurationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/SkuSubscriptionConfigurationResourceImpl.java
@@ -38,8 +38,9 @@ public class SkuSubscriptionConfigurationResourceImpl
 				String externalReferenceCode)
 		throws Exception {
 
-		CPInstance cpInstance = _cpInstanceService.fetchByExternalReferenceCode(
-			externalReferenceCode, contextCompany.getCompanyId());
+		CPInstance cpInstance =
+			_cpInstanceService.fetchCPInstanceByExternalReferenceCode(
+				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (cpInstance == null) {
 			throw new NoSuchCPInstanceException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/SkuUnitOfMeasureResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/SkuUnitOfMeasureResourceImpl.java
@@ -57,8 +57,9 @@ public class SkuUnitOfMeasureResourceImpl
 				String externalReferenceCode, Pagination pagination)
 		throws Exception {
 
-		CPInstance cpInstance = _cpInstanceService.fetchByExternalReferenceCode(
-			externalReferenceCode, contextCompany.getCompanyId());
+		CPInstance cpInstance =
+			_cpInstanceService.fetchCPInstanceByExternalReferenceCode(
+				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (cpInstance == null) {
 			throw new NoSuchCPInstanceException(
@@ -176,8 +177,9 @@ public class SkuUnitOfMeasureResourceImpl
 			String externalReferenceCode, SkuUnitOfMeasure skuUnitOfMeasure)
 		throws Exception {
 
-		CPInstance cpInstance = _cpInstanceService.fetchByExternalReferenceCode(
-			externalReferenceCode, contextCompany.getCompanyId());
+		CPInstance cpInstance =
+			_cpInstanceService.fetchCPInstanceByExternalReferenceCode(
+				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (cpInstance == null) {
 			throw new NoSuchCPInstanceException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/SkuVirtualSettingsResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/SkuVirtualSettingsResourceImpl.java
@@ -36,8 +36,9 @@ public class SkuVirtualSettingsResourceImpl
 			String externalReferenceCode)
 		throws Exception {
 
-		CPInstance cpInstance = _cpInstanceService.fetchByExternalReferenceCode(
-			externalReferenceCode, contextCompany.getCompanyId());
+		CPInstance cpInstance =
+			_cpInstanceService.fetchCPInstanceByExternalReferenceCode(
+				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (cpInstance == null) {
 			throw new NoSuchCPInstanceException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/util/v1_0/MappedProductUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/util/v1_0/MappedProductUtil.java
@@ -40,8 +40,9 @@ public class MappedProductUtil {
 
 		long skuId = GetterUtil.getLong(mappedProduct.getSkuId());
 
-		CPInstance cpInstance = cpInstanceService.fetchByExternalReferenceCode(
-			mappedProduct.getSkuExternalReferenceCode(), companyId);
+		CPInstance cpInstance =
+			cpInstanceService.fetchCPInstanceByExternalReferenceCode(
+				mappedProduct.getSkuExternalReferenceCode(), companyId);
 
 		if (cpInstance != null) {
 			skuId = cpInstance.getCPInstanceId();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/util/v1_0/ProductOptionUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/util/v1_0/ProductOptionUtil.java
@@ -40,7 +40,7 @@ public class ProductOptionUtil {
 			cpOption = cpOptionService.getCPOption(optionId);
 		}
 		else {
-			cpOption = cpOptionService.fetchByExternalReferenceCode(
+			cpOption = cpOptionService.fetchCPOptionByExternalReferenceCode(
 				productOption.getOptionExternalReferenceCode(),
 				serviceContext.getCompanyId());
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/util/v1_0/ProductOptionValueUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/util/v1_0/ProductOptionValueUtil.java
@@ -41,9 +41,10 @@ public class ProductOptionValueUtil {
 
 		long cpInstanceId = 0;
 
-		CPInstance cpInstance = cpInstanceService.fetchByExternalReferenceCode(
-			productOptionValue.getSkuExternalReferenceCode(),
-			serviceContext.getCompanyId());
+		CPInstance cpInstance =
+			cpInstanceService.fetchCPInstanceByExternalReferenceCode(
+				productOptionValue.getSkuExternalReferenceCode(),
+				serviceContext.getCompanyId());
 
 		if (cpInstance == null) {
 			cpInstance = cpInstanceService.fetchCPInstance(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/util/v1_0/SkuUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/util/v1_0/SkuUtil.java
@@ -74,7 +74,7 @@ public class SkuUtil {
 					sku.getReplacementSkuExternalReferenceCode())) {
 
 				discontinuedCPInstance =
-					cpInstanceService.fetchByExternalReferenceCode(
+					cpInstanceService.fetchCPInstanceByExternalReferenceCode(
 						sku.getReplacementSkuExternalReferenceCode(),
 						cpDefinition.getCompanyId());
 			}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/AccountAddressChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/AccountAddressChannelResourceImpl.java
@@ -179,8 +179,9 @@ public class AccountAddressChannelResourceImpl
 				accountAddressChannel.getAddressChannelExternalReferenceCode();
 
 			commerceChannel =
-				_commerceChannelService.fetchByExternalReferenceCode(
-					externalReferenceCode, serviceContext.getCompanyId());
+				_commerceChannelService.
+					fetchCommerceChannelByExternalReferenceCode(
+						externalReferenceCode, serviceContext.getCompanyId());
 
 			if (commerceChannel == null) {
 				throw new NoSuchChannelException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/ChannelAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/ChannelAccountResourceImpl.java
@@ -63,8 +63,9 @@ public class ChannelAccountResourceImpl extends BaseChannelAccountResourceImpl {
 		throws Exception {
 
 		CommerceChannel commerceChannel =
-			_commerceChannelLocalService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceChannelLocalService.
+				fetchCommerceChannelByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceChannel == null) {
 			throw new NoSuchChannelException(
@@ -190,8 +191,9 @@ public class ChannelAccountResourceImpl extends BaseChannelAccountResourceImpl {
 				_serviceContextHelper.getServiceContext();
 
 			commerceChannel =
-				_commerceChannelService.fetchByExternalReferenceCode(
-					externalReferenceCode, serviceContext.getCompanyId());
+				_commerceChannelService.
+					fetchCommerceChannelByExternalReferenceCode(
+						externalReferenceCode, serviceContext.getCompanyId());
 
 			if (commerceChannel == null) {
 				throw new NoSuchChannelException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/ChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/ChannelResourceImpl.java
@@ -59,7 +59,7 @@ public class ChannelResourceImpl extends BaseChannelResourceImpl {
 		throws Exception {
 
 		CommerceChannel commerceChannel =
-			_commerceChannelService.fetchByExternalReferenceCode(
+			_commerceChannelService.fetchCommerceChannelByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceChannel == null) {
@@ -102,7 +102,7 @@ public class ChannelResourceImpl extends BaseChannelResourceImpl {
 		throws Exception {
 
 		CommerceChannel commerceChannel =
-			_commerceChannelService.fetchByExternalReferenceCode(
+			_commerceChannelService.fetchCommerceChannelByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceChannel == null) {
@@ -168,7 +168,7 @@ public class ChannelResourceImpl extends BaseChannelResourceImpl {
 		throws Exception {
 
 		CommerceChannel commerceChannel =
-			_commerceChannelService.fetchByExternalReferenceCode(
+			_commerceChannelService.fetchCommerceChannelByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceChannel == null) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/PaymentMethodGroupRelOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/PaymentMethodGroupRelOrderTypeResourceImpl.java
@@ -121,10 +121,11 @@ public class PaymentMethodGroupRelOrderTypeResourceImpl
 		}
 		else {
 			commerceOrderType =
-				_commerceOrderTypeService.fetchByExternalReferenceCode(
-					paymentMethodGroupRelOrderType.
-						getOrderTypeExternalReferenceCode(),
-					contextCompany.getCompanyId());
+				_commerceOrderTypeService.
+					fetchCommerceOrderTypeByExternalReferenceCode(
+						paymentMethodGroupRelOrderType.
+							getOrderTypeExternalReferenceCode(),
+						contextCompany.getCompanyId());
 		}
 
 		return commerceOrderType;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/PaymentMethodGroupRelTermResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/PaymentMethodGroupRelTermResourceImpl.java
@@ -120,9 +120,11 @@ public class PaymentMethodGroupRelTermResourceImpl
 		}
 		else {
 			commerceTerm =
-				_commerceTermEntryService.fetchByExternalReferenceCode(
-					contextCompany.getCompanyId(),
-					paymentMethodGroupRelTerm.getTermExternalReferenceCode());
+				_commerceTermEntryService.
+					fetchCommerceTermEntryByExternalReferenceCode(
+						contextCompany.getCompanyId(),
+						paymentMethodGroupRelTerm.
+							getTermExternalReferenceCode());
 		}
 
 		return commerceTerm;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/ShippingFixedOptionOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/ShippingFixedOptionOrderTypeResourceImpl.java
@@ -121,10 +121,11 @@ public class ShippingFixedOptionOrderTypeResourceImpl
 		}
 		else {
 			commerceOrderType =
-				_commerceOrderTypeService.fetchByExternalReferenceCode(
-					shippingFixedOptionOrderType.
-						getOrderTypeExternalReferenceCode(),
-					contextCompany.getCompanyId());
+				_commerceOrderTypeService.
+					fetchCommerceOrderTypeByExternalReferenceCode(
+						shippingFixedOptionOrderType.
+							getOrderTypeExternalReferenceCode(),
+						contextCompany.getCompanyId());
 		}
 
 		return commerceOrderType;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/ShippingFixedOptionTermResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/ShippingFixedOptionTermResourceImpl.java
@@ -120,9 +120,10 @@ public class ShippingFixedOptionTermResourceImpl
 		}
 		else {
 			commerceTerm =
-				_commerceTermEntryService.fetchByExternalReferenceCode(
-					contextCompany.getCompanyId(),
-					shippingFixedOptionTerm.getTermExternalReferenceCode());
+				_commerceTermEntryService.
+					fetchCommerceTermEntryByExternalReferenceCode(
+						contextCompany.getCompanyId(),
+						shippingFixedOptionTerm.getTermExternalReferenceCode());
 		}
 
 		return commerceTerm;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/CategoryDisplayPageResourceTest.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/CategoryDisplayPageResourceTest.java
@@ -233,8 +233,9 @@ public class CategoryDisplayPageResourceTest
 		throws Exception {
 
 		CommerceChannel commerceChannel =
-			_commerceChannelLocalService.fetchByExternalReferenceCode(
-				externalReferenceCode, testCompany.getCompanyId());
+			_commerceChannelLocalService.
+				fetchCommerceChannelByExternalReferenceCode(
+					externalReferenceCode, testCompany.getCompanyId());
 
 		if (commerceChannel == null) {
 			commerceChannel = CommerceTestUtil.addCommerceChannel(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/ProductDisplayPageResourceTest.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/ProductDisplayPageResourceTest.java
@@ -238,8 +238,9 @@ public class ProductDisplayPageResourceTest
 		throws Exception {
 
 		CommerceChannel commerceChannel =
-			_commerceChannelLocalService.fetchByExternalReferenceCode(
-				externalReferenceCode, testCompany.getCompanyId());
+			_commerceChannelLocalService.
+				fetchCommerceChannelByExternalReferenceCode(
+					externalReferenceCode, testCompany.getCompanyId());
 
 		if (commerceChannel == null) {
 			commerceChannel = CommerceTestUtil.addCommerceChannel(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/WarehouseChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/WarehouseChannelResourceImpl.java
@@ -62,8 +62,9 @@ public class WarehouseChannelResourceImpl
 		throws Exception {
 
 		CommerceInventoryWarehouse commerceInventoryWarehouse =
-			_commerceInventoryWarehouseService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceInventoryWarehouseService.
+				fetchCommerceInventoryWarehouseByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceInventoryWarehouse == null) {
 			throw new NoSuchWarehouseException(
@@ -120,8 +121,9 @@ public class WarehouseChannelResourceImpl
 		throws Exception {
 
 		CommerceInventoryWarehouse commerceInventoryWarehouse =
-			_commerceInventoryWarehouseService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceInventoryWarehouseService.
+				fetchCommerceInventoryWarehouseByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceInventoryWarehouse == null) {
 			throw new NoSuchWarehouseException(
@@ -174,9 +176,10 @@ public class WarehouseChannelResourceImpl
 		}
 		else {
 			commerceChannel =
-				_commerceChannelService.fetchByExternalReferenceCode(
-					warehouseChannel.getChannelExternalReferenceCode(),
-					serviceContext.getCompanyId());
+				_commerceChannelService.
+					fetchCommerceChannelByExternalReferenceCode(
+						warehouseChannel.getChannelExternalReferenceCode(),
+						serviceContext.getCompanyId());
 
 			if (commerceChannel == null) {
 				throw new NoSuchChannelException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/WarehouseItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/WarehouseItemResourceImpl.java
@@ -90,8 +90,9 @@ public class WarehouseItemResourceImpl extends BaseWarehouseItemResourceImpl {
 		throws Exception {
 
 		CommerceInventoryWarehouse commerceInventoryWarehouse =
-			_commerceInventoryWarehouseService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceInventoryWarehouseService.
+				fetchCommerceInventoryWarehouseByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceInventoryWarehouse == null) {
 			throw new NoSuchInventoryWarehouseException(
@@ -265,8 +266,9 @@ public class WarehouseItemResourceImpl extends BaseWarehouseItemResourceImpl {
 		throws Exception {
 
 		CommerceInventoryWarehouse commerceInventoryWarehouse =
-			_commerceInventoryWarehouseService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceInventoryWarehouseService.
+				fetchCommerceInventoryWarehouseByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceInventoryWarehouse == null) {
 			throw new NoSuchInventoryWarehouseException(
@@ -334,9 +336,10 @@ public class WarehouseItemResourceImpl extends BaseWarehouseItemResourceImpl {
 		}
 		else if (warehouseItem.getWarehouseExternalReferenceCode() != null) {
 			commerceInventoryWarehouse =
-				_commerceInventoryWarehouseService.fetchByExternalReferenceCode(
-					warehouseItem.getWarehouseExternalReferenceCode(),
-					contextUser.getCompanyId());
+				_commerceInventoryWarehouseService.
+					fetchCommerceInventoryWarehouseByExternalReferenceCode(
+						warehouseItem.getWarehouseExternalReferenceCode(),
+						contextUser.getCompanyId());
 		}
 
 		if (commerceInventoryWarehouse == null) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/WarehouseOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/WarehouseOrderTypeResourceImpl.java
@@ -56,8 +56,9 @@ public class WarehouseOrderTypeResourceImpl
 		throws Exception {
 
 		CommerceInventoryWarehouse commerceInventoryWarehouse =
-			_commerceInventoryWarehouseService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceInventoryWarehouseService.
+				fetchCommerceInventoryWarehouseByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceInventoryWarehouse == null) {
 			throw new NoSuchInventoryWarehouseException(
@@ -121,8 +122,9 @@ public class WarehouseOrderTypeResourceImpl
 		throws Exception {
 
 		CommerceInventoryWarehouse commerceInventoryWarehouse =
-			_commerceInventoryWarehouseService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceInventoryWarehouseService.
+				fetchCommerceInventoryWarehouseByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceInventoryWarehouse == null) {
 			throw new NoSuchInventoryWarehouseException(
@@ -182,9 +184,10 @@ public class WarehouseOrderTypeResourceImpl
 		}
 		else {
 			commerceOrderType =
-				_commerceOrderTypeService.fetchByExternalReferenceCode(
-					warehouseOrderType.getOrderTypeExternalReferenceCode(),
-					contextCompany.getCompanyId());
+				_commerceOrderTypeService.
+					fetchCommerceOrderTypeByExternalReferenceCode(
+						warehouseOrderType.getOrderTypeExternalReferenceCode(),
+						contextCompany.getCompanyId());
 		}
 
 		return commerceOrderType;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/WarehouseResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/WarehouseResourceImpl.java
@@ -57,8 +57,9 @@ public class WarehouseResourceImpl extends BaseWarehouseResourceImpl {
 		throws Exception {
 
 		CommerceInventoryWarehouse commerceInventoryWarehouse =
-			_commerceInventoryWarehouseService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceInventoryWarehouseService.
+				fetchCommerceInventoryWarehouseByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceInventoryWarehouse == null) {
 			throw new NoSuchInventoryWarehouseException(
@@ -88,8 +89,9 @@ public class WarehouseResourceImpl extends BaseWarehouseResourceImpl {
 		throws Exception {
 
 		CommerceInventoryWarehouse commerceInventoryWarehouse =
-			_commerceInventoryWarehouseService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceInventoryWarehouseService.
+				fetchCommerceInventoryWarehouseByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceInventoryWarehouse == null) {
 			throw new NoSuchInventoryWarehouseException(
@@ -132,8 +134,9 @@ public class WarehouseResourceImpl extends BaseWarehouseResourceImpl {
 		throws Exception {
 
 		CommerceInventoryWarehouse commerceInventoryWarehouse =
-			_commerceInventoryWarehouseService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceInventoryWarehouseService.
+				fetchCommerceInventoryWarehouseByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceInventoryWarehouse == null) {
 			throw new NoSuchInventoryWarehouseException(
@@ -165,9 +168,10 @@ public class WarehouseResourceImpl extends BaseWarehouseResourceImpl {
 	@Override
 	public Warehouse postWarehouse(Warehouse warehouse) throws Exception {
 		CommerceInventoryWarehouse commerceInventoryWarehouse =
-			_commerceInventoryWarehouseService.fetchByExternalReferenceCode(
-				warehouse.getExternalReferenceCode(),
-				contextCompany.getCompanyId());
+			_commerceInventoryWarehouseService.
+				fetchCommerceInventoryWarehouseByExternalReferenceCode(
+					warehouse.getExternalReferenceCode(),
+					contextCompany.getCompanyId());
 
 		if (commerceInventoryWarehouse == null) {
 			commerceInventoryWarehouse =
@@ -204,8 +208,9 @@ public class WarehouseResourceImpl extends BaseWarehouseResourceImpl {
 		throws Exception {
 
 		CommerceInventoryWarehouse commerceInventoryWarehouse =
-			_commerceInventoryWarehouseService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceInventoryWarehouseService.
+				fetchCommerceInventoryWarehouseByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceInventoryWarehouse == null) {
 			commerceInventoryWarehouse =

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/AccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/AccountResourceImpl.java
@@ -40,7 +40,7 @@ public class AccountResourceImpl extends BaseAccountResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BillingAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BillingAddressResourceImpl.java
@@ -42,7 +42,7 @@ public class BillingAddressResourceImpl extends BaseBillingAddressResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {
@@ -87,7 +87,7 @@ public class BillingAddressResourceImpl extends BaseBillingAddressResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/ChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/ChannelResourceImpl.java
@@ -43,7 +43,7 @@ public class ChannelResourceImpl extends BaseChannelResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OrderItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OrderItemResourceImpl.java
@@ -97,8 +97,9 @@ public class OrderItemResourceImpl extends BaseOrderItemResourceImpl {
 		throws Exception {
 
 		CommerceOrderItem commerceOrderItem =
-			_commerceOrderItemService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceOrderItemService.
+				fetchCommerceOrderItemByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrderItem == null) {
 			throw new NoSuchOrderItemException(
@@ -138,7 +139,7 @@ public class OrderItemResourceImpl extends BaseOrderItemResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {
@@ -198,8 +199,9 @@ public class OrderItemResourceImpl extends BaseOrderItemResourceImpl {
 		throws Exception {
 
 		CommerceOrderItem commerceOrderItem =
-			_commerceOrderItemService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceOrderItemService.
+				fetchCommerceOrderItemByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrderItem == null) {
 			throw new NoSuchOrderItemException(
@@ -245,8 +247,9 @@ public class OrderItemResourceImpl extends BaseOrderItemResourceImpl {
 		throws Exception {
 
 		CommerceOrderItem commerceOrderItem =
-			_commerceOrderItemService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceOrderItemService.
+				fetchCommerceOrderItemByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrderItem == null) {
 			throw new NoSuchOrderItemException(
@@ -267,7 +270,7 @@ public class OrderItemResourceImpl extends BaseOrderItemResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {
@@ -387,8 +390,9 @@ public class OrderItemResourceImpl extends BaseOrderItemResourceImpl {
 			GetterUtil.getLong(orderItem.getOrderId()));
 
 		CommerceOrderItem commerceOrderItem =
-			_commerceOrderItemService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceOrderItemService.
+				fetchCommerceOrderItemByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrderItem == null) {
 			commerceOrderItem = OrderItemUtil.addCommerceOrderItem(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OrderNoteResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OrderNoteResourceImpl.java
@@ -44,8 +44,9 @@ public class OrderNoteResourceImpl extends BaseOrderNoteResourceImpl {
 		throws Exception {
 
 		CommerceOrderNote commerceOrderNote =
-			_commerceOrderNoteService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceOrderNoteService.
+				fetchCommerceOrderNoteByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrderNote == null) {
 			throw new NoSuchOrderNoteException(
@@ -64,7 +65,7 @@ public class OrderNoteResourceImpl extends BaseOrderNoteResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {
@@ -115,8 +116,9 @@ public class OrderNoteResourceImpl extends BaseOrderNoteResourceImpl {
 		throws Exception {
 
 		CommerceOrderNote commerceOrderNote =
-			_commerceOrderNoteService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceOrderNoteService.
+				fetchCommerceOrderNoteByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrderNote == null) {
 			throw new NoSuchOrderNoteException(
@@ -148,8 +150,9 @@ public class OrderNoteResourceImpl extends BaseOrderNoteResourceImpl {
 		throws Exception {
 
 		CommerceOrderNote commerceOrderNote =
-			_commerceOrderNoteService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceOrderNoteService.
+				fetchCommerceOrderNoteByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrderNote == null) {
 			throw new NoSuchOrderNoteException(
@@ -170,7 +173,7 @@ public class OrderNoteResourceImpl extends BaseOrderNoteResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OrderResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OrderResourceImpl.java
@@ -122,7 +122,7 @@ public class OrderResourceImpl extends BaseOrderResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {
@@ -160,7 +160,7 @@ public class OrderResourceImpl extends BaseOrderResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {
@@ -214,7 +214,7 @@ public class OrderResourceImpl extends BaseOrderResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {
@@ -299,9 +299,10 @@ public class OrderResourceImpl extends BaseOrderResourceImpl {
 
 		if (billingAddressId == 0) {
 			CommerceAddress commerceAddress =
-				_commerceAddressService.fetchByExternalReferenceCode(
-					order.getBillingAddressExternalReferenceCode(),
-					contextCompany.getCompanyId());
+				_commerceAddressService.
+					fetchCommerceAddressByExternalReferenceCode(
+						order.getBillingAddressExternalReferenceCode(),
+						contextCompany.getCompanyId());
 
 			if (commerceAddress != null) {
 				billingAddressId = commerceAddress.getCommerceAddressId();
@@ -348,9 +349,10 @@ public class OrderResourceImpl extends BaseOrderResourceImpl {
 
 		if (shippingAddressId == 0) {
 			CommerceAddress commerceAddress =
-				_commerceAddressService.fetchByExternalReferenceCode(
-					order.getShippingAddressExternalReferenceCode(),
-					contextCompany.getCompanyId());
+				_commerceAddressService.
+					fetchCommerceAddressByExternalReferenceCode(
+						order.getShippingAddressExternalReferenceCode(),
+						contextCompany.getCompanyId());
 
 			if (commerceAddress != null) {
 				shippingAddressId = commerceAddress.getCommerceAddressId();
@@ -515,9 +517,10 @@ public class OrderResourceImpl extends BaseOrderResourceImpl {
 		}
 
 		CommerceOrderType commerceOrderType =
-			_commerceOrderTypeService.fetchByExternalReferenceCode(
-				order.getOrderTypeExternalReferenceCode(),
-				contextCompany.getCompanyId());
+			_commerceOrderTypeService.
+				fetchCommerceOrderTypeByExternalReferenceCode(
+					order.getOrderTypeExternalReferenceCode(),
+					contextCompany.getCompanyId());
 
 		if (commerceOrderType == null) {
 			return 0;
@@ -738,9 +741,10 @@ public class OrderResourceImpl extends BaseOrderResourceImpl {
 
 		if (billingAddressId == 0) {
 			CommerceAddress commerceAddress =
-				_commerceAddressService.fetchByExternalReferenceCode(
-					order.getBillingAddressExternalReferenceCode(),
-					contextCompany.getCompanyId());
+				_commerceAddressService.
+					fetchCommerceAddressByExternalReferenceCode(
+						order.getBillingAddressExternalReferenceCode(),
+						contextCompany.getCompanyId());
 
 			if (commerceAddress == null) {
 				billingAddressId = commerceOrder.getBillingAddressId();
@@ -767,9 +771,10 @@ public class OrderResourceImpl extends BaseOrderResourceImpl {
 
 		if (shippingAddressId == 0) {
 			CommerceAddress commerceAddress =
-				_commerceAddressService.fetchByExternalReferenceCode(
-					order.getShippingAddressExternalReferenceCode(),
-					contextCompany.getCompanyId());
+				_commerceAddressService.
+					fetchCommerceAddressByExternalReferenceCode(
+						order.getShippingAddressExternalReferenceCode(),
+						contextCompany.getCompanyId());
 
 			if (commerceAddress == null) {
 				shippingAddressId = commerceOrder.getShippingAddressId();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OrderRuleAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OrderRuleAccountGroupResourceImpl.java
@@ -54,8 +54,9 @@ public class OrderRuleAccountGroupResourceImpl
 				String externalReferenceCode, Pagination pagination)
 		throws Exception {
 
-		COREntry corEntry = _corEntryService.fetchByExternalReferenceCode(
-			contextCompany.getCompanyId(), externalReferenceCode);
+		COREntry corEntry =
+			_corEntryService.fetchCOREntryByExternalReferenceCode(
+				contextCompany.getCompanyId(), externalReferenceCode);
 
 		if (corEntry == null) {
 			throw new NoSuchCOREntryException(
@@ -107,8 +108,9 @@ public class OrderRuleAccountGroupResourceImpl
 				OrderRuleAccountGroup orderRuleAccountGroup)
 		throws Exception {
 
-		COREntry corEntry = _corEntryService.fetchByExternalReferenceCode(
-			contextCompany.getCompanyId(), externalReferenceCode);
+		COREntry corEntry =
+			_corEntryService.fetchCOREntryByExternalReferenceCode(
+				contextCompany.getCompanyId(), externalReferenceCode);
 
 		if (corEntry == null) {
 			throw new NoSuchCOREntryException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OrderRuleAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OrderRuleAccountResourceImpl.java
@@ -54,8 +54,9 @@ public class OrderRuleAccountResourceImpl
 				String externalReferenceCode, Pagination pagination)
 		throws Exception {
 
-		COREntry corEntry = _corEntryService.fetchByExternalReferenceCode(
-			contextCompany.getCompanyId(), externalReferenceCode);
+		COREntry corEntry =
+			_corEntryService.fetchCOREntryByExternalReferenceCode(
+				contextCompany.getCompanyId(), externalReferenceCode);
 
 		if (corEntry == null) {
 			throw new NoSuchCOREntryException(
@@ -104,8 +105,9 @@ public class OrderRuleAccountResourceImpl
 				String externalReferenceCode, OrderRuleAccount orderRuleAccount)
 		throws Exception {
 
-		COREntry corEntry = _corEntryService.fetchByExternalReferenceCode(
-			contextCompany.getCompanyId(), externalReferenceCode);
+		COREntry corEntry =
+			_corEntryService.fetchCOREntryByExternalReferenceCode(
+				contextCompany.getCompanyId(), externalReferenceCode);
 
 		if (corEntry == null) {
 			throw new NoSuchCOREntryException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OrderRuleChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OrderRuleChannelResourceImpl.java
@@ -54,8 +54,9 @@ public class OrderRuleChannelResourceImpl
 				String externalReferenceCode, Pagination pagination)
 		throws Exception {
 
-		COREntry corEntry = _corEntryService.fetchByExternalReferenceCode(
-			contextCompany.getCompanyId(), externalReferenceCode);
+		COREntry corEntry =
+			_corEntryService.fetchCOREntryByExternalReferenceCode(
+				contextCompany.getCompanyId(), externalReferenceCode);
 
 		if (corEntry == null) {
 			throw new NoSuchCOREntryException(
@@ -105,8 +106,9 @@ public class OrderRuleChannelResourceImpl
 				String externalReferenceCode, OrderRuleChannel orderRuleChannel)
 		throws Exception {
 
-		COREntry corEntry = _corEntryService.fetchByExternalReferenceCode(
-			contextCompany.getCompanyId(), externalReferenceCode);
+		COREntry corEntry =
+			_corEntryService.fetchCOREntryByExternalReferenceCode(
+				contextCompany.getCompanyId(), externalReferenceCode);
 
 		if (corEntry == null) {
 			throw new NoSuchCOREntryException(
@@ -160,9 +162,10 @@ public class OrderRuleChannelResourceImpl
 		}
 		else {
 			commerceChannel =
-				_commerceChannelService.fetchByExternalReferenceCode(
-					orderRuleChannel.getChannelExternalReferenceCode(),
-					contextCompany.getCompanyId());
+				_commerceChannelService.
+					fetchCommerceChannelByExternalReferenceCode(
+						orderRuleChannel.getChannelExternalReferenceCode(),
+						contextCompany.getCompanyId());
 		}
 
 		return commerceChannel;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OrderRuleOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OrderRuleOrderTypeResourceImpl.java
@@ -52,8 +52,9 @@ public class OrderRuleOrderTypeResourceImpl
 				String externalReferenceCode, Pagination pagination)
 		throws Exception {
 
-		COREntry corEntry = _corEntryService.fetchByExternalReferenceCode(
-			contextCompany.getCompanyId(), externalReferenceCode);
+		COREntry corEntry =
+			_corEntryService.fetchCOREntryByExternalReferenceCode(
+				contextCompany.getCompanyId(), externalReferenceCode);
 
 		if (corEntry == null) {
 			throw new NoSuchCOREntryException(
@@ -103,8 +104,9 @@ public class OrderRuleOrderTypeResourceImpl
 				OrderRuleOrderType orderRuleOrderType)
 		throws Exception {
 
-		COREntry corEntry = _corEntryService.fetchByExternalReferenceCode(
-			contextCompany.getCompanyId(), externalReferenceCode);
+		COREntry corEntry =
+			_corEntryService.fetchCOREntryByExternalReferenceCode(
+				contextCompany.getCompanyId(), externalReferenceCode);
 
 		if (corEntry == null) {
 			throw new NoSuchCOREntryException(
@@ -160,9 +162,10 @@ public class OrderRuleOrderTypeResourceImpl
 		}
 		else {
 			commerceOrderType =
-				_commerceOrderTypeService.fetchByExternalReferenceCode(
-					orderRuleOrderType.getOrderTypeExternalReferenceCode(),
-					contextCompany.getCompanyId());
+				_commerceOrderTypeService.
+					fetchCommerceOrderTypeByExternalReferenceCode(
+						orderRuleOrderType.getOrderTypeExternalReferenceCode(),
+						contextCompany.getCompanyId());
 		}
 
 		return commerceOrderType;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OrderRuleResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OrderRuleResourceImpl.java
@@ -74,8 +74,9 @@ public class OrderRuleResourceImpl extends BaseOrderRuleResourceImpl {
 			String externalReferenceCode)
 		throws Exception {
 
-		COREntry corEntry = _corEntryService.fetchByExternalReferenceCode(
-			contextCompany.getCompanyId(), externalReferenceCode);
+		COREntry corEntry =
+			_corEntryService.fetchCOREntryByExternalReferenceCode(
+				contextCompany.getCompanyId(), externalReferenceCode);
 
 		if (corEntry == null) {
 			throw new NoSuchCOREntryException(
@@ -103,8 +104,9 @@ public class OrderRuleResourceImpl extends BaseOrderRuleResourceImpl {
 			String externalReferenceCode)
 		throws Exception {
 
-		COREntry corEntry = _corEntryService.fetchByExternalReferenceCode(
-			contextCompany.getCompanyId(), externalReferenceCode);
+		COREntry corEntry =
+			_corEntryService.fetchCOREntryByExternalReferenceCode(
+				contextCompany.getCompanyId(), externalReferenceCode);
 
 		if (corEntry == null) {
 			throw new NoSuchCOREntryException(
@@ -148,8 +150,9 @@ public class OrderRuleResourceImpl extends BaseOrderRuleResourceImpl {
 			String externalReferenceCode, OrderRule orderRule)
 		throws Exception {
 
-		COREntry corEntry = _corEntryService.fetchByExternalReferenceCode(
-			contextCompany.getCompanyId(), externalReferenceCode);
+		COREntry corEntry =
+			_corEntryService.fetchCOREntryByExternalReferenceCode(
+				contextCompany.getCompanyId(), externalReferenceCode);
 
 		if (corEntry == null) {
 			throw new NoSuchCOREntryException(
@@ -173,8 +176,9 @@ public class OrderRuleResourceImpl extends BaseOrderRuleResourceImpl {
 			String externalReferenceCode, OrderRule orderRule)
 		throws Exception {
 
-		COREntry corEntry = _corEntryService.fetchByExternalReferenceCode(
-			contextCompany.getCompanyId(), externalReferenceCode);
+		COREntry corEntry =
+			_corEntryService.fetchCOREntryByExternalReferenceCode(
+				contextCompany.getCompanyId(), externalReferenceCode);
 
 		if (corEntry == null) {
 			corEntry = _addCOREntry(externalReferenceCode, orderRule);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OrderTypeChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OrderTypeChannelResourceImpl.java
@@ -59,8 +59,9 @@ public class OrderTypeChannelResourceImpl
 		throws Exception {
 
 		CommerceOrderType commerceOrderType =
-			_commerceOrderTypeService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceOrderTypeService.
+				fetchCommerceOrderTypeByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrderType == null) {
 			throw new NoSuchOrderTypeException(
@@ -116,8 +117,9 @@ public class OrderTypeChannelResourceImpl
 		throws Exception {
 
 		CommerceOrderType commerceOrderType =
-			_commerceOrderTypeService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceOrderTypeService.
+				fetchCommerceOrderTypeByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrderType == null) {
 			throw new NoSuchOrderTypeException(
@@ -154,9 +156,10 @@ public class OrderTypeChannelResourceImpl
 		}
 		else {
 			commerceChannel =
-				_commerceChannelService.fetchByExternalReferenceCode(
-					orderTypeChannel.getChannelExternalReferenceCode(),
-					serviceContext.getCompanyId());
+				_commerceChannelService.
+					fetchCommerceChannelByExternalReferenceCode(
+						orderTypeChannel.getChannelExternalReferenceCode(),
+						serviceContext.getCompanyId());
 
 			if (commerceChannel == null) {
 				throw new NoSuchChannelException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OrderTypeResourceImpl.java
@@ -67,8 +67,9 @@ public class OrderTypeResourceImpl extends BaseOrderTypeResourceImpl {
 		throws Exception {
 
 		CommerceOrderType commerceOrderType =
-			_commerceOrderTypeService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceOrderTypeService.
+				fetchCommerceOrderTypeByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrderType == null) {
 			throw new NoSuchOrderTypeException(
@@ -110,8 +111,9 @@ public class OrderTypeResourceImpl extends BaseOrderTypeResourceImpl {
 		throws Exception {
 
 		CommerceOrderType commerceOrderType =
-			_commerceOrderTypeService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceOrderTypeService.
+				fetchCommerceOrderTypeByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrderType == null) {
 			throw new NoSuchOrderTypeException(
@@ -170,8 +172,9 @@ public class OrderTypeResourceImpl extends BaseOrderTypeResourceImpl {
 		throws Exception {
 
 		CommerceOrderType commerceOrderType =
-			_commerceOrderTypeService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceOrderTypeService.
+				fetchCommerceOrderTypeByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrderType == null) {
 			throw new NoSuchOrderTypeException(
@@ -196,8 +199,9 @@ public class OrderTypeResourceImpl extends BaseOrderTypeResourceImpl {
 		throws Exception {
 
 		CommerceOrderType commerceOrderType =
-			_commerceOrderTypeService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceOrderTypeService.
+				fetchCommerceOrderTypeByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrderType == null) {
 			commerceOrderType = _addCommerceOrderType(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/ShippingAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/ShippingAddressResourceImpl.java
@@ -46,7 +46,7 @@ public class ShippingAddressResourceImpl
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {
@@ -109,7 +109,7 @@ public class ShippingAddressResourceImpl
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/TermOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/TermOrderTypeResourceImpl.java
@@ -51,8 +51,9 @@ public class TermOrderTypeResourceImpl extends BaseTermOrderTypeResourceImpl {
 		throws Exception {
 
 		CommerceTermEntry commerceTermEntry =
-			_commerceTermEntryService.fetchByExternalReferenceCode(
-				contextCompany.getCompanyId(), externalReferenceCode);
+			_commerceTermEntryService.
+				fetchCommerceTermEntryByExternalReferenceCode(
+					contextCompany.getCompanyId(), externalReferenceCode);
 
 		if (commerceTermEntry == null) {
 			throw new NoSuchTermEntryException(
@@ -106,8 +107,9 @@ public class TermOrderTypeResourceImpl extends BaseTermOrderTypeResourceImpl {
 		throws Exception {
 
 		CommerceTermEntry commerceTermEntry =
-			_commerceTermEntryService.fetchByExternalReferenceCode(
-				contextCompany.getCompanyId(), externalReferenceCode);
+			_commerceTermEntryService.
+				fetchCommerceTermEntryByExternalReferenceCode(
+					contextCompany.getCompanyId(), externalReferenceCode);
 
 		if (commerceTermEntry == null) {
 			throw new NoSuchTermEntryException(
@@ -163,9 +165,10 @@ public class TermOrderTypeResourceImpl extends BaseTermOrderTypeResourceImpl {
 		}
 		else {
 			commerceOrderType =
-				_commerceOrderTypeService.fetchByExternalReferenceCode(
-					termOrderType.getOrderTypeExternalReferenceCode(),
-					contextCompany.getCompanyId());
+				_commerceOrderTypeService.
+					fetchCommerceOrderTypeByExternalReferenceCode(
+						termOrderType.getOrderTypeExternalReferenceCode(),
+						contextCompany.getCompanyId());
 		}
 
 		return commerceOrderType;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/TermResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/TermResourceImpl.java
@@ -63,8 +63,9 @@ public class TermResourceImpl extends BaseTermResourceImpl {
 		throws Exception {
 
 		CommerceTermEntry commerceTermEntry =
-			_commerceTermEntryService.fetchByExternalReferenceCode(
-				contextCompany.getCompanyId(), externalReferenceCode);
+			_commerceTermEntryService.
+				fetchCommerceTermEntryByExternalReferenceCode(
+					contextCompany.getCompanyId(), externalReferenceCode);
 
 		if (commerceTermEntry == null) {
 			throw new NoSuchTermEntryException(
@@ -93,8 +94,9 @@ public class TermResourceImpl extends BaseTermResourceImpl {
 		throws Exception {
 
 		CommerceTermEntry commerceTermEntry =
-			_commerceTermEntryService.fetchByExternalReferenceCode(
-				contextCompany.getCompanyId(), externalReferenceCode);
+			_commerceTermEntryService.
+				fetchCommerceTermEntryByExternalReferenceCode(
+					contextCompany.getCompanyId(), externalReferenceCode);
 
 		if (commerceTermEntry == null) {
 			throw new NoSuchTermEntryException(
@@ -138,8 +140,9 @@ public class TermResourceImpl extends BaseTermResourceImpl {
 		throws Exception {
 
 		CommerceTermEntry commerceTermEntry =
-			_commerceTermEntryService.fetchByExternalReferenceCode(
-				contextCompany.getCompanyId(), externalReferenceCode);
+			_commerceTermEntryService.
+				fetchCommerceTermEntryByExternalReferenceCode(
+					contextCompany.getCompanyId(), externalReferenceCode);
 
 		if (commerceTermEntry == null) {
 			throw new NoSuchTermEntryException(
@@ -161,8 +164,9 @@ public class TermResourceImpl extends BaseTermResourceImpl {
 		throws Exception {
 
 		CommerceTermEntry commerceTermEntry =
-			_commerceTermEntryService.fetchByExternalReferenceCode(
-				contextCompany.getCompanyId(), externalReferenceCode);
+			_commerceTermEntryService.
+				fetchCommerceTermEntryByExternalReferenceCode(
+					contextCompany.getCompanyId(), externalReferenceCode);
 
 		if (commerceTermEntry == null) {
 			return postTerm(term);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/util/v1_0/OrderItemUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/util/v1_0/OrderItemUtil.java
@@ -58,9 +58,10 @@ public class OrderItemUtil {
 		if ((cpInstance == null) &&
 			(orderItem.getSkuExternalReferenceCode() != null)) {
 
-			cpInstance = cpInstanceService.fetchByExternalReferenceCode(
-				orderItem.getSkuExternalReferenceCode(),
-				serviceContext.getCompanyId());
+			cpInstance =
+				cpInstanceService.fetchCPInstanceByExternalReferenceCode(
+					orderItem.getSkuExternalReferenceCode(),
+					serviceContext.getCompanyId());
 		}
 
 		if (cpInstance == null) {
@@ -73,7 +74,7 @@ public class OrderItemUtil {
 
 		if (replacedSkuId == 0) {
 			CPInstance replacedCPInstance =
-				cpInstanceService.fetchByExternalReferenceCode(
+				cpInstanceService.fetchCPInstanceByExternalReferenceCode(
 					orderItem.getReplacedSkuExternalReferenceCode(),
 					serviceContext.getCompanyId());
 
@@ -113,9 +114,10 @@ public class OrderItemUtil {
 
 		if (shippingAddressId == 0) {
 			CommerceAddress commerceAddress =
-				commerceAddressService.fetchByExternalReferenceCode(
-					orderItem.getShippingAddressExternalReferenceCode(),
-					serviceContext.getCompanyId());
+				commerceAddressService.
+					fetchCommerceAddressByExternalReferenceCode(
+						orderItem.getShippingAddressExternalReferenceCode(),
+						serviceContext.getCompanyId());
 
 			if (commerceAddress != null) {
 				shippingAddressId = commerceAddress.getCommerceAddressId();
@@ -234,9 +236,10 @@ public class OrderItemUtil {
 		}
 
 		if (orderItem.getSkuExternalReferenceCode() != null) {
-			cpInstance = cpInstanceService.fetchByExternalReferenceCode(
-				orderItem.getSkuExternalReferenceCode(),
-				serviceContext.getCompanyId());
+			cpInstance =
+				cpInstanceService.fetchCPInstanceByExternalReferenceCode(
+					orderItem.getSkuExternalReferenceCode(),
+					serviceContext.getCompanyId());
 		}
 
 		if (cpInstance == null) {
@@ -257,9 +260,10 @@ public class OrderItemUtil {
 			!Validator.isBlank(orderItem.getExternalReferenceCode())) {
 
 			commerceOrderItem =
-				commerceOrderItemService.fetchByExternalReferenceCode(
-					orderItem.getExternalReferenceCode(),
-					serviceContext.getCompanyId());
+				commerceOrderItemService.
+					fetchCommerceOrderItemByExternalReferenceCode(
+						orderItem.getExternalReferenceCode(),
+						serviceContext.getCompanyId());
 		}
 
 		if (commerceOrderItem != null) {
@@ -274,7 +278,7 @@ public class OrderItemUtil {
 
 		if (replacedSkuId == 0) {
 			CPInstance replacedSku =
-				cpInstanceService.fetchByExternalReferenceCode(
+				cpInstanceService.fetchCPInstanceByExternalReferenceCode(
 					orderItem.getReplacedSkuExternalReferenceCode(),
 					serviceContext.getCompanyId());
 
@@ -338,9 +342,10 @@ public class OrderItemUtil {
 
 		if (shippingAddressId == 0) {
 			CommerceAddress commerceAddress =
-				commerceAddressService.fetchByExternalReferenceCode(
-					orderItem.getShippingAddressExternalReferenceCode(),
-					serviceContext.getCompanyId());
+				commerceAddressService.
+					fetchCommerceAddressByExternalReferenceCode(
+						orderItem.getShippingAddressExternalReferenceCode(),
+						serviceContext.getCompanyId());
 
 			if (commerceAddress != null) {
 				shippingAddressId = commerceAddress.getCommerceAddressId();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/util/v1_0/OrderRuleChannelUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/util/v1_0/OrderRuleChannelUtil.java
@@ -36,9 +36,10 @@ public class OrderRuleChannelUtil {
 		}
 		else {
 			commerceChannel =
-				commerceChannelService.fetchByExternalReferenceCode(
-					orderRuleChannel.getChannelExternalReferenceCode(),
-					corEntry.getCompanyId());
+				commerceChannelService.
+					fetchCommerceChannelByExternalReferenceCode(
+						orderRuleChannel.getChannelExternalReferenceCode(),
+						corEntry.getCompanyId());
 
 			if (commerceChannel == null) {
 				throw new NoSuchChannelException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/util/v1_0/OrderRuleOrderTypeUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/util/v1_0/OrderRuleOrderTypeUtil.java
@@ -36,9 +36,10 @@ public class OrderRuleOrderTypeUtil {
 		}
 		else {
 			commerceOrderType =
-				commerceOrderTypeService.fetchByExternalReferenceCode(
-					orderRuleOrderType.getOrderTypeExternalReferenceCode(),
-					corEntry.getCompanyId());
+				commerceOrderTypeService.
+					fetchCommerceOrderTypeByExternalReferenceCode(
+						orderRuleOrderType.getOrderTypeExternalReferenceCode(),
+						corEntry.getCompanyId());
 
 			if (commerceOrderType == null) {
 				String orderTypeExternalReferenceCode =

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/util/v1_0/TermOrderTypeUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/util/v1_0/TermOrderTypeUtil.java
@@ -37,9 +37,10 @@ public class TermOrderTypeUtil {
 		}
 		else {
 			commerceOrderType =
-				commerceOrderTypeService.fetchByExternalReferenceCode(
-					termOrderType.getOrderTypeExternalReferenceCode(),
-					commerceTermEntry.getCompanyId());
+				commerceOrderTypeService.
+					fetchCommerceOrderTypeByExternalReferenceCode(
+						termOrderType.getOrderTypeExternalReferenceCode(),
+						commerceTermEntry.getCompanyId());
 
 			if (commerceOrderType == null) {
 				String orderTypeExternalReferenceCode =

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/DiscountAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/DiscountAccountGroupResourceImpl.java
@@ -56,8 +56,9 @@ public class DiscountAccountGroupResourceImpl
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(
@@ -112,8 +113,9 @@ public class DiscountAccountGroupResourceImpl
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/DiscountCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/DiscountCategoryResourceImpl.java
@@ -56,8 +56,9 @@ public class DiscountCategoryResourceImpl
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(
@@ -107,8 +108,9 @@ public class DiscountCategoryResourceImpl
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/DiscountProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/DiscountProductResourceImpl.java
@@ -56,8 +56,9 @@ public class DiscountProductResourceImpl
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(
@@ -104,8 +105,9 @@ public class DiscountProductResourceImpl
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/DiscountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/DiscountResourceImpl.java
@@ -83,8 +83,9 @@ public class DiscountResourceImpl extends BaseDiscountResourceImpl {
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(
@@ -111,8 +112,9 @@ public class DiscountResourceImpl extends BaseDiscountResourceImpl {
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(
@@ -156,8 +158,9 @@ public class DiscountResourceImpl extends BaseDiscountResourceImpl {
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/DiscountRuleResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/DiscountRuleResourceImpl.java
@@ -55,8 +55,9 @@ public class DiscountRuleResourceImpl extends BaseDiscountRuleResourceImpl {
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(
@@ -125,8 +126,9 @@ public class DiscountRuleResourceImpl extends BaseDiscountRuleResourceImpl {
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/PriceEntryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/PriceEntryResourceImpl.java
@@ -64,8 +64,9 @@ public class PriceEntryResourceImpl extends BasePriceEntryResourceImpl {
 		throws Exception {
 
 		CommercePriceEntry commercePriceEntry =
-			_commercePriceEntryService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceEntryService.
+				fetchCommercePriceEntryByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceEntry == null) {
 			throw new NoSuchPriceEntryException(
@@ -95,8 +96,9 @@ public class PriceEntryResourceImpl extends BasePriceEntryResourceImpl {
 		throws Exception {
 
 		CommercePriceEntry commercePriceEntry =
-			_commercePriceEntryService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceEntryService.
+				fetchCommercePriceEntryByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceEntry == null) {
 			throw new NoSuchPriceEntryException(
@@ -113,8 +115,9 @@ public class PriceEntryResourceImpl extends BasePriceEntryResourceImpl {
 		throws Exception {
 
 		CommercePriceList commercePriceList =
-			_commercePriceListService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceListService.
+				fetchCommercePriceListByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceList == null) {
 			throw new NoSuchPriceListException(
@@ -177,8 +180,9 @@ public class PriceEntryResourceImpl extends BasePriceEntryResourceImpl {
 		throws Exception {
 
 		CommercePriceEntry commercePriceEntry =
-			_commercePriceEntryService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceEntryService.
+				fetchCommercePriceEntryByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceEntry == null) {
 			throw new NoSuchPriceEntryException(
@@ -199,8 +203,9 @@ public class PriceEntryResourceImpl extends BasePriceEntryResourceImpl {
 		throws Exception {
 
 		CommercePriceList commercePriceList =
-			_commercePriceListService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceListService.
+				fetchCommercePriceListByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceList == null) {
 			throw new NoSuchPriceListException(
@@ -245,8 +250,9 @@ public class PriceEntryResourceImpl extends BasePriceEntryResourceImpl {
 			cpInstance = _cpInstanceService.fetchCPInstance(skuId);
 		}
 		else if (Validator.isNotNull(skuExternalReferenceCode)) {
-			cpInstance = _cpInstanceService.fetchByExternalReferenceCode(
-				skuExternalReferenceCode, serviceContext.getCompanyId());
+			cpInstance =
+				_cpInstanceService.fetchCPInstanceByExternalReferenceCode(
+					skuExternalReferenceCode, serviceContext.getCompanyId());
 		}
 
 		if (cpInstance != null) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/PriceListAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/PriceListAccountGroupResourceImpl.java
@@ -58,8 +58,9 @@ public class PriceListAccountGroupResourceImpl
 		throws Exception {
 
 		CommercePriceList commercePriceList =
-			_commercePriceListService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceListService.
+				fetchCommercePriceListByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceList == null) {
 			throw new NoSuchPriceListException(
@@ -124,8 +125,9 @@ public class PriceListAccountGroupResourceImpl
 		throws Exception {
 
 		CommercePriceList commercePriceList =
-			_commercePriceListService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceListService.
+				fetchCommercePriceListByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceList == null) {
 			throw new NoSuchPriceListException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/PriceListResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/PriceListResourceImpl.java
@@ -82,8 +82,9 @@ public class PriceListResourceImpl extends BasePriceListResourceImpl {
 		throws Exception {
 
 		CommercePriceList commercePriceList =
-			_commercePriceListService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceListService.
+				fetchCommercePriceListByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceList == null) {
 			throw new NoSuchPriceListException(
@@ -117,8 +118,9 @@ public class PriceListResourceImpl extends BasePriceListResourceImpl {
 		throws Exception {
 
 		CommercePriceList commercePriceList =
-			_commercePriceListService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceListService.
+				fetchCommercePriceListByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceList == null) {
 			throw new NoSuchPriceListException(
@@ -165,8 +167,9 @@ public class PriceListResourceImpl extends BasePriceListResourceImpl {
 		throws Exception {
 
 		CommercePriceList commercePriceList =
-			_commercePriceListService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceListService.
+				fetchCommercePriceListByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceList == null) {
 			throw new NoSuchPriceListException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/TierPriceResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/TierPriceResourceImpl.java
@@ -57,8 +57,9 @@ public class TierPriceResourceImpl extends BaseTierPriceResourceImpl {
 		throws Exception {
 
 		CommerceTierPriceEntry commerceTierPriceEntry =
-			_commerceTierPriceEntryService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceTierPriceEntryService.
+				fetchCommerceTierPriceEntryByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceTierPriceEntry == null) {
 			throw new NoSuchTierPriceEntryException(
@@ -80,8 +81,9 @@ public class TierPriceResourceImpl extends BaseTierPriceResourceImpl {
 		throws Exception {
 
 		CommercePriceEntry commercePriceEntry =
-			_commercePriceEntryService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceEntryService.
+				fetchCommercePriceEntryByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceEntry == null) {
 			throw new NoSuchPriceEntryException(
@@ -137,8 +139,9 @@ public class TierPriceResourceImpl extends BaseTierPriceResourceImpl {
 		throws Exception {
 
 		CommerceTierPriceEntry commerceTierPriceEntry =
-			_commerceTierPriceEntryService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceTierPriceEntryService.
+				fetchCommerceTierPriceEntryByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceTierPriceEntry == null) {
 			throw new NoSuchTierPriceEntryException(
@@ -169,8 +172,9 @@ public class TierPriceResourceImpl extends BaseTierPriceResourceImpl {
 		throws Exception {
 
 		CommerceTierPriceEntry commerceTierPriceEntry =
-			_commerceTierPriceEntryService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceTierPriceEntryService.
+				fetchCommerceTierPriceEntryByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceTierPriceEntry == null) {
 			throw new NoSuchTierPriceEntryException(
@@ -191,8 +195,9 @@ public class TierPriceResourceImpl extends BaseTierPriceResourceImpl {
 		throws Exception {
 
 		CommercePriceEntry commercePriceEntry =
-			_commercePriceEntryService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceEntryService.
+				fetchCommercePriceEntryByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceEntry == null) {
 			throw new NoSuchPriceEntryException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/DiscountAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/DiscountAccountGroupResourceImpl.java
@@ -59,8 +59,9 @@ public class DiscountAccountGroupResourceImpl
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(
@@ -117,8 +118,9 @@ public class DiscountAccountGroupResourceImpl
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/DiscountAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/DiscountAccountResourceImpl.java
@@ -58,8 +58,9 @@ public class DiscountAccountResourceImpl
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(
@@ -110,8 +111,9 @@ public class DiscountAccountResourceImpl
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/DiscountCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/DiscountCategoryResourceImpl.java
@@ -59,8 +59,9 @@ public class DiscountCategoryResourceImpl
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(
@@ -111,8 +112,9 @@ public class DiscountCategoryResourceImpl
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/DiscountChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/DiscountChannelResourceImpl.java
@@ -59,8 +59,9 @@ public class DiscountChannelResourceImpl
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(
@@ -114,8 +115,9 @@ public class DiscountChannelResourceImpl
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/DiscountOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/DiscountOrderTypeResourceImpl.java
@@ -58,8 +58,9 @@ public class DiscountOrderTypeResourceImpl
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(
@@ -113,8 +114,9 @@ public class DiscountOrderTypeResourceImpl
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/DiscountProductGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/DiscountProductGroupResourceImpl.java
@@ -59,8 +59,9 @@ public class DiscountProductGroupResourceImpl
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(
@@ -115,8 +116,9 @@ public class DiscountProductGroupResourceImpl
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/DiscountProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/DiscountProductResourceImpl.java
@@ -61,8 +61,9 @@ public class DiscountProductResourceImpl
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(
@@ -116,8 +117,9 @@ public class DiscountProductResourceImpl
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/DiscountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/DiscountResourceImpl.java
@@ -98,8 +98,9 @@ public class DiscountResourceImpl extends BaseDiscountResourceImpl {
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(
@@ -122,8 +123,9 @@ public class DiscountResourceImpl extends BaseDiscountResourceImpl {
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(
@@ -176,8 +178,9 @@ public class DiscountResourceImpl extends BaseDiscountResourceImpl {
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/DiscountRuleResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/DiscountRuleResourceImpl.java
@@ -54,8 +54,9 @@ public class DiscountRuleResourceImpl extends BaseDiscountRuleResourceImpl {
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(
@@ -125,8 +126,9 @@ public class DiscountRuleResourceImpl extends BaseDiscountRuleResourceImpl {
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceDiscountService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceDiscount == null) {
 			throw new NoSuchDiscountException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/PriceEntryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/PriceEntryResourceImpl.java
@@ -69,8 +69,9 @@ public class PriceEntryResourceImpl extends BasePriceEntryResourceImpl {
 		throws Exception {
 
 		CommercePriceEntry commercePriceEntry =
-			_commercePriceEntryService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceEntryService.
+				fetchCommercePriceEntryByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceEntry == null) {
 			throw new NoSuchPriceEntryException(
@@ -103,8 +104,9 @@ public class PriceEntryResourceImpl extends BasePriceEntryResourceImpl {
 		throws Exception {
 
 		CommercePriceEntry commercePriceEntry =
-			_commercePriceEntryService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceEntryService.
+				fetchCommercePriceEntryByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceEntry == null) {
 			throw new NoSuchPriceEntryException(
@@ -122,8 +124,9 @@ public class PriceEntryResourceImpl extends BasePriceEntryResourceImpl {
 		throws Exception {
 
 		CommercePriceList commercePriceList =
-			_commercePriceListService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceListService.
+				fetchCommercePriceListByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceList == null) {
 			throw new NoSuchPriceListException(
@@ -180,8 +183,9 @@ public class PriceEntryResourceImpl extends BasePriceEntryResourceImpl {
 		throws Exception {
 
 		CommercePriceEntry commercePriceEntry =
-			_commercePriceEntryService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceEntryService.
+				fetchCommercePriceEntryByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceEntry == null) {
 			throw new NoSuchPriceEntryException(
@@ -198,8 +202,9 @@ public class PriceEntryResourceImpl extends BasePriceEntryResourceImpl {
 		throws Exception {
 
 		CommercePriceList commercePriceList =
-			_commercePriceListService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceListService.
+				fetchCommercePriceListByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceList == null) {
 			throw new NoSuchPriceListException(
@@ -244,8 +249,9 @@ public class PriceEntryResourceImpl extends BasePriceEntryResourceImpl {
 			cpInstance = _cpInstanceService.fetchCPInstance(skuId);
 		}
 		else if (Validator.isNotNull(skuExternalReferenceCode)) {
-			cpInstance = _cpInstanceService.fetchByExternalReferenceCode(
-				skuExternalReferenceCode, serviceContext.getCompanyId());
+			cpInstance =
+				_cpInstanceService.fetchCPInstanceByExternalReferenceCode(
+					skuExternalReferenceCode, serviceContext.getCompanyId());
 		}
 
 		if (cpInstance != null) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/PriceListAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/PriceListAccountGroupResourceImpl.java
@@ -60,8 +60,9 @@ public class PriceListAccountGroupResourceImpl
 		throws Exception {
 
 		CommercePriceList commercePriceList =
-			_commercePriceListService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceListService.
+				fetchCommercePriceListByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceList == null) {
 			throw new NoSuchPriceListException(
@@ -130,8 +131,9 @@ public class PriceListAccountGroupResourceImpl
 		throws Exception {
 
 		CommercePriceList commercePriceList =
-			_commercePriceListService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceListService.
+				fetchCommercePriceListByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceList == null) {
 			throw new NoSuchPriceListException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/PriceListAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/PriceListAccountResourceImpl.java
@@ -59,8 +59,9 @@ public class PriceListAccountResourceImpl
 		throws Exception {
 
 		CommercePriceList commercePriceList =
-			_commercePriceListService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceListService.
+				fetchCommercePriceListByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceList == null) {
 			throw new NoSuchPriceListException(
@@ -112,8 +113,9 @@ public class PriceListAccountResourceImpl
 		throws Exception {
 
 		CommercePriceList commercePriceList =
-			_commercePriceListService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceListService.
+				fetchCommercePriceListByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceList == null) {
 			throw new NoSuchPriceListException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/PriceListChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/PriceListChannelResourceImpl.java
@@ -59,8 +59,9 @@ public class PriceListChannelResourceImpl
 		throws Exception {
 
 		CommercePriceList commercePriceList =
-			_commercePriceListService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceListService.
+				fetchCommercePriceListByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceList == null) {
 			throw new NoSuchPriceListException(
@@ -112,8 +113,9 @@ public class PriceListChannelResourceImpl
 		throws Exception {
 
 		CommercePriceList commercePriceList =
-			_commercePriceListService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceListService.
+				fetchCommercePriceListByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceList == null) {
 			throw new NoSuchPriceListException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/PriceListDiscountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/PriceListDiscountResourceImpl.java
@@ -53,8 +53,9 @@ public class PriceListDiscountResourceImpl
 		throws Exception {
 
 		CommercePriceList commercePriceList =
-			_commercePriceListService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceListService.
+				fetchCommercePriceListByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceList == null) {
 			throw new NoSuchPriceListException(
@@ -108,8 +109,9 @@ public class PriceListDiscountResourceImpl
 		throws Exception {
 
 		CommercePriceList commercePriceList =
-			_commercePriceListService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceListService.
+				fetchCommercePriceListByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceList == null) {
 			throw new NoSuchPriceListException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/PriceListOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/PriceListOrderTypeResourceImpl.java
@@ -56,8 +56,9 @@ public class PriceListOrderTypeResourceImpl
 		throws Exception {
 
 		CommercePriceList commercePriceList =
-			_commercePriceListService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceListService.
+				fetchCommercePriceListByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceList == null) {
 			throw new NoSuchPriceListException(
@@ -110,8 +111,9 @@ public class PriceListOrderTypeResourceImpl
 		throws Exception {
 
 		CommercePriceList commercePriceList =
-			_commercePriceListService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceListService.
+				fetchCommercePriceListByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceList == null) {
 			throw new NoSuchPriceListException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/PriceListResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/PriceListResourceImpl.java
@@ -104,8 +104,9 @@ public class PriceListResourceImpl extends BasePriceListResourceImpl {
 		throws Exception {
 
 		CommercePriceList commercePriceList =
-			_commercePriceListService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceListService.
+				fetchCommercePriceListByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceList == null) {
 			throw new NoSuchPriceListException(
@@ -135,8 +136,9 @@ public class PriceListResourceImpl extends BasePriceListResourceImpl {
 		throws Exception {
 
 		CommercePriceList commercePriceList =
-			_commercePriceListService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceListService.
+				fetchCommercePriceListByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceList == null) {
 			throw new NoSuchPriceListException(
@@ -182,8 +184,9 @@ public class PriceListResourceImpl extends BasePriceListResourceImpl {
 		throws Exception {
 
 		CommercePriceList commercePriceList =
-			_commercePriceListService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceListService.
+				fetchCommercePriceListByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceList == null) {
 			throw new NoSuchPriceListException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/PriceModifierCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/PriceModifierCategoryResourceImpl.java
@@ -59,8 +59,9 @@ public class PriceModifierCategoryResourceImpl
 		throws Exception {
 
 		CommercePriceModifier commercePriceModifier =
-			_commercePriceModifierService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceModifierService.
+				fetchCommercePriceModifierByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceModifier == null) {
 			throw new NoSuchPriceModifierException(
@@ -117,8 +118,9 @@ public class PriceModifierCategoryResourceImpl
 		throws Exception {
 
 		CommercePriceModifier commercePriceModifier =
-			_commercePriceModifierService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceModifierService.
+				fetchCommercePriceModifierByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceModifier == null) {
 			throw new NoSuchPriceModifierException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/PriceModifierProductGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/PriceModifierProductGroupResourceImpl.java
@@ -59,8 +59,9 @@ public class PriceModifierProductGroupResourceImpl
 		throws Exception {
 
 		CommercePriceModifier commercePriceModifier =
-			_commercePriceModifierService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceModifierService.
+				fetchCommercePriceModifierByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceModifier == null) {
 			throw new NoSuchPriceModifierException(
@@ -119,8 +120,9 @@ public class PriceModifierProductGroupResourceImpl
 		throws Exception {
 
 		CommercePriceModifier commercePriceModifier =
-			_commercePriceModifierService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceModifierService.
+				fetchCommercePriceModifierByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceModifier == null) {
 			throw new NoSuchPriceModifierException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/PriceModifierProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/PriceModifierProductResourceImpl.java
@@ -61,8 +61,9 @@ public class PriceModifierProductResourceImpl
 		throws Exception {
 
 		CommercePriceModifier commercePriceModifier =
-			_commercePriceModifierService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceModifierService.
+				fetchCommercePriceModifierByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceModifier == null) {
 			throw new NoSuchPriceModifierException(
@@ -124,8 +125,9 @@ public class PriceModifierProductResourceImpl
 		throws Exception {
 
 		CommercePriceModifier commercePriceModifier =
-			_commercePriceModifierService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceModifierService.
+				fetchCommercePriceModifierByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceModifier == null) {
 			throw new NoSuchPriceModifierException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/PriceModifierResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/PriceModifierResourceImpl.java
@@ -62,8 +62,9 @@ public class PriceModifierResourceImpl extends BasePriceModifierResourceImpl {
 		throws Exception {
 
 		CommercePriceModifier commercePriceModifier =
-			_commercePriceModifierService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceModifierService.
+				fetchCommercePriceModifierByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceModifier == null) {
 			throw new NoSuchPriceModifierException(
@@ -82,8 +83,9 @@ public class PriceModifierResourceImpl extends BasePriceModifierResourceImpl {
 		throws Exception {
 
 		CommercePriceList commercePriceList =
-			_commercePriceListService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceListService.
+				fetchCommercePriceListByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceList == null) {
 			throw new NoSuchPriceListException(
@@ -138,8 +140,9 @@ public class PriceModifierResourceImpl extends BasePriceModifierResourceImpl {
 		throws Exception {
 
 		CommercePriceModifier commercePriceModifier =
-			_commercePriceModifierService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceModifierService.
+				fetchCommercePriceModifierByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceModifier == null) {
 			throw new NoSuchPriceModifierException(
@@ -170,8 +173,9 @@ public class PriceModifierResourceImpl extends BasePriceModifierResourceImpl {
 		throws Exception {
 
 		CommercePriceModifier commercePriceModifier =
-			_commercePriceModifierService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceModifierService.
+				fetchCommercePriceModifierByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceModifier == null) {
 			throw new NoSuchPriceModifierException(
@@ -192,8 +196,9 @@ public class PriceModifierResourceImpl extends BasePriceModifierResourceImpl {
 		throws Exception {
 
 		CommercePriceList commercePriceList =
-			_commercePriceListService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceListService.
+				fetchCommercePriceListByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceList == null) {
 			throw new NoSuchPriceListException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/TierPriceResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/TierPriceResourceImpl.java
@@ -59,8 +59,9 @@ public class TierPriceResourceImpl extends BaseTierPriceResourceImpl {
 		throws Exception {
 
 		CommerceTierPriceEntry commerceTierPriceEntry =
-			_commerceTierPriceEntryService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceTierPriceEntryService.
+				fetchCommerceTierPriceEntryByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceTierPriceEntry == null) {
 			throw new NoSuchTierPriceEntryException(
@@ -78,8 +79,9 @@ public class TierPriceResourceImpl extends BaseTierPriceResourceImpl {
 		throws Exception {
 
 		CommercePriceEntry commercePriceEntry =
-			_commercePriceEntryService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceEntryService.
+				fetchCommercePriceEntryByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceEntry == null) {
 			throw new NoSuchPriceEntryException(
@@ -135,8 +137,9 @@ public class TierPriceResourceImpl extends BaseTierPriceResourceImpl {
 		throws Exception {
 
 		CommerceTierPriceEntry commerceTierPriceEntry =
-			_commerceTierPriceEntryService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceTierPriceEntryService.
+				fetchCommerceTierPriceEntryByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceTierPriceEntry == null) {
 			throw new NoSuchTierPriceEntryException(
@@ -167,8 +170,9 @@ public class TierPriceResourceImpl extends BaseTierPriceResourceImpl {
 		throws Exception {
 
 		CommerceTierPriceEntry commerceTierPriceEntry =
-			_commerceTierPriceEntryService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceTierPriceEntryService.
+				fetchCommerceTierPriceEntryByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceTierPriceEntry == null) {
 			throw new NoSuchTierPriceEntryException(
@@ -189,8 +193,9 @@ public class TierPriceResourceImpl extends BaseTierPriceResourceImpl {
 		throws Exception {
 
 		CommercePriceEntry commercePriceEntry =
-			_commercePriceEntryService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commercePriceEntryService.
+				fetchCommercePriceEntryByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commercePriceEntry == null) {
 			throw new NoSuchPriceEntryException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/util/v2_0/DiscountChannelUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/util/v2_0/DiscountChannelUtil.java
@@ -42,9 +42,10 @@ public class DiscountChannelUtil {
 		}
 		else {
 			commerceChannel =
-				commerceChannelService.fetchByExternalReferenceCode(
-					discountChannel.getChannelExternalReferenceCode(),
-					serviceContext.getCompanyId());
+				commerceChannelService.
+					fetchCommerceChannelByExternalReferenceCode(
+						discountChannel.getChannelExternalReferenceCode(),
+						serviceContext.getCompanyId());
 
 			if (commerceChannel == null) {
 				throw new NoSuchChannelException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/util/v2_0/DiscountOrderTypeUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/util/v2_0/DiscountOrderTypeUtil.java
@@ -45,9 +45,10 @@ public class DiscountOrderTypeUtil {
 		}
 		else {
 			commerceOrderType =
-				commerceOrderTypeService.fetchByExternalReferenceCode(
-					discountOrderType.getOrderTypeExternalReferenceCode(),
-					serviceContext.getCompanyId());
+				commerceOrderTypeService.
+					fetchCommerceOrderTypeByExternalReferenceCode(
+						discountOrderType.getOrderTypeExternalReferenceCode(),
+						serviceContext.getCompanyId());
 
 			if (commerceOrderType == null) {
 				String orderTypeExternalReferenceCode =

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/util/v2_0/DiscountProductGroupUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/util/v2_0/DiscountProductGroupUtil.java
@@ -44,9 +44,11 @@ public class DiscountProductGroupUtil {
 		}
 		else {
 			commercePricingClass =
-				commercePricingClassService.fetchByExternalReferenceCode(
-					discountProductGroup.getProductGroupExternalReferenceCode(),
-					serviceContext.getCompanyId());
+				commercePricingClassService.
+					fetchCommercePricingClassByExternalReferenceCode(
+						discountProductGroup.
+							getProductGroupExternalReferenceCode(),
+						serviceContext.getCompanyId());
 
 			if (commercePricingClass == null) {
 				String productGroupExternalReferenceCode =

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/util/v2_0/PriceListChannelUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/util/v2_0/PriceListChannelUtil.java
@@ -45,9 +45,10 @@ public class PriceListChannelUtil {
 		}
 		else {
 			commerceChannel =
-				commerceChannelService.fetchByExternalReferenceCode(
-					priceListChannel.getChannelExternalReferenceCode(),
-					serviceContext.getCompanyId());
+				commerceChannelService.
+					fetchCommerceChannelByExternalReferenceCode(
+						priceListChannel.getChannelExternalReferenceCode(),
+						serviceContext.getCompanyId());
 
 			if (commerceChannel == null) {
 				throw new NoSuchChannelException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/util/v2_0/PriceListDiscountUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/util/v2_0/PriceListDiscountUtil.java
@@ -45,9 +45,10 @@ public class PriceListDiscountUtil {
 		}
 		else {
 			commerceDiscount =
-				commerceDiscountService.fetchByExternalReferenceCode(
-					priceListDiscount.getDiscountExternalReferenceCode(),
-					serviceContext.getCompanyId());
+				commerceDiscountService.
+					fetchCommerceDiscountByExternalReferenceCode(
+						priceListDiscount.getDiscountExternalReferenceCode(),
+						serviceContext.getCompanyId());
 
 			if (commerceDiscount == null) {
 				throw new NoSuchDiscountException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/util/v2_0/PriceListOrderTypeUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/util/v2_0/PriceListOrderTypeUtil.java
@@ -46,9 +46,10 @@ public class PriceListOrderTypeUtil {
 		}
 		else {
 			commerceOrderType =
-				commerceOrderTypeService.fetchByExternalReferenceCode(
-					priceListOrderType.getOrderTypeExternalReferenceCode(),
-					serviceContext.getCompanyId());
+				commerceOrderTypeService.
+					fetchCommerceOrderTypeByExternalReferenceCode(
+						priceListOrderType.getOrderTypeExternalReferenceCode(),
+						serviceContext.getCompanyId());
 
 			if (commerceOrderType == null) {
 				String orderTypeExternalReferenceCode =

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/util/v2_0/PriceModifierProductGroupUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/util/v2_0/PriceModifierProductGroupUtil.java
@@ -45,10 +45,11 @@ public class PriceModifierProductGroupUtil {
 		}
 		else {
 			commercePricingClass =
-				commercePricingClassService.fetchByExternalReferenceCode(
-					priceModifierProductGroup.
-						getProductGroupExternalReferenceCode(),
-					serviceContext.getCompanyId());
+				commercePricingClassService.
+					fetchCommercePricingClassByExternalReferenceCode(
+						priceModifierProductGroup.
+							getProductGroupExternalReferenceCode(),
+						serviceContext.getCompanyId());
 
 			if (commercePricingClass == null) {
 				String productGroupExternalReferenceCode =

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/DiscountAccountGroupResourceTest.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/DiscountAccountGroupResourceTest.java
@@ -93,8 +93,9 @@ public class DiscountAccountGroupResourceTest
 		}
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountLocalService.fetchByExternalReferenceCode(
-				"external-reference-code-test", testCompany.getCompanyId());
+			_commerceDiscountLocalService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					"external-reference-code-test", testCompany.getCompanyId());
 
 		if (commerceDiscount != null) {
 			_commerceDiscountLocalService.deleteCommerceDiscount(
@@ -141,8 +142,9 @@ public class DiscountAccountGroupResourceTest
 		}
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountLocalService.fetchByExternalReferenceCode(
-				"external-reference-code-test", testCompany.getCompanyId());
+			_commerceDiscountLocalService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					"external-reference-code-test", testCompany.getCompanyId());
 
 		if (commerceDiscount != null) {
 			_commerceDiscountLocalService.deleteCommerceDiscount(
@@ -278,8 +280,9 @@ public class DiscountAccountGroupResourceTest
 		throws Exception {
 
 		CommerceDiscount commerceDiscount =
-			_commerceDiscountLocalService.fetchByExternalReferenceCode(
-				externalReferenceCode, testCompany.getCompanyId());
+			_commerceDiscountLocalService.
+				fetchCommerceDiscountByExternalReferenceCode(
+					externalReferenceCode, testCompany.getCompanyId());
 
 		CommerceDiscountCommerceAccountGroupRel
 			commerceDiscountCommerceAccountGroupRel =

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/ShipmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/ShipmentResourceImpl.java
@@ -185,9 +185,10 @@ public class ShipmentResourceImpl extends BaseShipmentResourceImpl {
 				shipment.getOrderId());
 		}
 		else {
-			commerceOrder = _commerceOrderService.fetchByExternalReferenceCode(
-				shipment.getOrderExternalReferenceCode(),
-				contextCompany.getCompanyId());
+			commerceOrder =
+				_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
+					shipment.getOrderExternalReferenceCode(),
+					contextCompany.getCompanyId());
 
 			if (commerceOrder == null) {
 				throw new NoSuchOrderException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/util/v1_0/ShipmentItemUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/util/v1_0/ShipmentItemUtil.java
@@ -88,8 +88,10 @@ public class ShipmentItemUtil {
 		}
 
 		CommerceInventoryWarehouse commerceInventoryWarehouse =
-			commerceInventoryWarehouseService.fetchByExternalReferenceCode(
-				shipmentItem.getWarehouseExternalReferenceCode(), companyId);
+			commerceInventoryWarehouseService.
+				fetchCommerceInventoryWarehouseByExternalReferenceCode(
+					shipmentItem.getWarehouseExternalReferenceCode(),
+					companyId);
 
 		if (commerceInventoryWarehouse != null) {
 			return commerceInventoryWarehouse.getCommerceInventoryWarehouseId();
@@ -111,8 +113,10 @@ public class ShipmentItemUtil {
 		}
 
 		CommerceOrderItem commerceOrderItem =
-			commerceOrderItemService.fetchByExternalReferenceCode(
-				shipmentItem.getOrderItemExternalReferenceCode(), companyId);
+			commerceOrderItemService.
+				fetchCommerceOrderItemByExternalReferenceCode(
+					shipmentItem.getOrderItemExternalReferenceCode(),
+					companyId);
 
 		if (commerceOrderItem != null) {
 			return commerceOrderItem.getCommerceOrderItemId();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/AddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/AddressResourceImpl.java
@@ -56,7 +56,7 @@ public class AddressResourceImpl extends BaseAddressResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {
@@ -81,7 +81,7 @@ public class AddressResourceImpl extends BaseAddressResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/CartCommentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/CartCommentResourceImpl.java
@@ -51,8 +51,9 @@ public class CartCommentResourceImpl extends BaseCartCommentResourceImpl {
 		throws Exception {
 
 		CommerceOrderNote commerceOrderNote =
-			_commerceOrderNoteService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceOrderNoteService.
+				fetchCommerceOrderNoteByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrderNote == null) {
 			throw new NoSuchOrderNoteException(
@@ -69,7 +70,7 @@ public class CartCommentResourceImpl extends BaseCartCommentResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {
@@ -100,8 +101,9 @@ public class CartCommentResourceImpl extends BaseCartCommentResourceImpl {
 		throws Exception {
 
 		CommerceOrderNote commerceOrderNote =
-			_commerceOrderNoteService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceOrderNoteService.
+				fetchCommerceOrderNoteByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrderNote == null) {
 			throw new NoSuchOrderNoteException(
@@ -134,7 +136,7 @@ public class CartCommentResourceImpl extends BaseCartCommentResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {
@@ -175,8 +177,9 @@ public class CartCommentResourceImpl extends BaseCartCommentResourceImpl {
 		throws Exception {
 
 		CommerceOrderNote commerceOrderNote =
-			_commerceOrderNoteService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceOrderNoteService.
+				fetchCommerceOrderNoteByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrderNote == null) {
 			throw new NoSuchOrderNoteException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/CartItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/CartItemResourceImpl.java
@@ -80,8 +80,9 @@ public class CartItemResourceImpl extends BaseCartItemResourceImpl {
 		throws Exception {
 
 		CommerceOrderItem commerceOrderItem =
-			_commerceOrderItemService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceOrderItemService.
+				fetchCommerceOrderItemByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrderItem == null) {
 			throw new NoSuchOrderItemException(
@@ -98,7 +99,7 @@ public class CartItemResourceImpl extends BaseCartItemResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {
@@ -144,8 +145,9 @@ public class CartItemResourceImpl extends BaseCartItemResourceImpl {
 		throws Exception {
 
 		CommerceOrderItem commerceOrderItem =
-			_commerceOrderItemService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceOrderItemService.
+				fetchCommerceOrderItemByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrderItem == null) {
 			throw new NoSuchOrderItemException(
@@ -201,8 +203,9 @@ public class CartItemResourceImpl extends BaseCartItemResourceImpl {
 		throws Exception {
 
 		CommerceOrderItem commerceOrderItem =
-			_commerceOrderItemService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceOrderItemService.
+				fetchCommerceOrderItemByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrderItem == null) {
 			throw new NoSuchOrderItemException(
@@ -220,7 +223,7 @@ public class CartItemResourceImpl extends BaseCartItemResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {
@@ -274,8 +277,9 @@ public class CartItemResourceImpl extends BaseCartItemResourceImpl {
 		throws Exception {
 
 		CommerceOrderItem commerceOrderItem =
-			_commerceOrderItemService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceOrderItemService.
+				fetchCommerceOrderItemByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrderItem == null) {
 			throw new NoSuchOrderItemException(
@@ -349,7 +353,7 @@ public class CartItemResourceImpl extends BaseCartItemResourceImpl {
 
 		if (replacedSkuId == 0) {
 			CPInstance replacedSku =
-				_cpInstanceService.fetchByExternalReferenceCode(
+				_cpInstanceService.fetchCPInstanceByExternalReferenceCode(
 					cartItem.getReplacedSkuExternalReferenceCode(),
 					contextCompany.getCompanyId());
 
@@ -376,9 +380,10 @@ public class CartItemResourceImpl extends BaseCartItemResourceImpl {
 
 		if (shippingAddressId == 0) {
 			CommerceAddress commerceAddress =
-				_commerceAddressService.fetchByExternalReferenceCode(
-					cartItem.getShippingAddressExternalReferenceCode(),
-					contextCompany.getCompanyId());
+				_commerceAddressService.
+					fetchCommerceAddressByExternalReferenceCode(
+						cartItem.getShippingAddressExternalReferenceCode(),
+						contextCompany.getCompanyId());
 
 			if (commerceAddress != null) {
 				shippingAddressId = commerceAddress.getCommerceAddressId();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/CartResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/CartResourceImpl.java
@@ -140,7 +140,7 @@ public class CartResourceImpl extends BaseCartResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {
@@ -167,7 +167,7 @@ public class CartResourceImpl extends BaseCartResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {
@@ -187,7 +187,7 @@ public class CartResourceImpl extends BaseCartResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {
@@ -315,7 +315,7 @@ public class CartResourceImpl extends BaseCartResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {
@@ -340,7 +340,7 @@ public class CartResourceImpl extends BaseCartResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {
@@ -358,7 +358,7 @@ public class CartResourceImpl extends BaseCartResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {
@@ -449,7 +449,7 @@ public class CartResourceImpl extends BaseCartResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {
@@ -803,9 +803,10 @@ public class CartResourceImpl extends BaseCartResourceImpl {
 		}
 
 		CommerceOrderType commerceOrderType =
-			_commerceOrderTypeService.fetchByExternalReferenceCode(
-				cart.getOrderTypeExternalReferenceCode(),
-				contextCompany.getCompanyId());
+			_commerceOrderTypeService.
+				fetchCommerceOrderTypeByExternalReferenceCode(
+					cart.getOrderTypeExternalReferenceCode(),
+					contextCompany.getCompanyId());
 
 		if (commerceOrderType == null) {
 			return 0;
@@ -1036,9 +1037,10 @@ public class CartResourceImpl extends BaseCartResourceImpl {
 
 		if (billingAddressId == 0) {
 			CommerceAddress commerceAddress =
-				_commerceAddressService.fetchByExternalReferenceCode(
-					cart.getBillingAddressExternalReferenceCode(),
-					contextCompany.getCompanyId());
+				_commerceAddressService.
+					fetchCommerceAddressByExternalReferenceCode(
+						cart.getBillingAddressExternalReferenceCode(),
+						contextCompany.getCompanyId());
 
 			if (commerceAddress == null) {
 				billingAddressId = commerceOrder.getBillingAddressId();
@@ -1065,9 +1067,10 @@ public class CartResourceImpl extends BaseCartResourceImpl {
 
 		if (shippingAddressId == 0) {
 			CommerceAddress commerceAddress =
-				_commerceAddressService.fetchByExternalReferenceCode(
-					cart.getShippingAddressExternalReferenceCode(),
-					contextCompany.getCompanyId());
+				_commerceAddressService.
+					fetchCommerceAddressByExternalReferenceCode(
+						cart.getShippingAddressExternalReferenceCode(),
+						contextCompany.getCompanyId());
 
 			if (commerceAddress == null) {
 				shippingAddressId = commerceOrder.getShippingAddressId();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/PaymentMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/PaymentMethodResourceImpl.java
@@ -51,7 +51,7 @@ public class PaymentMethodResourceImpl extends BasePaymentMethodResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/ShippingMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/ShippingMethodResourceImpl.java
@@ -49,7 +49,7 @@ public class ShippingMethodResourceImpl extends BaseShippingMethodResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/PlacedOrderAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/PlacedOrderAddressResourceImpl.java
@@ -40,7 +40,7 @@ public class PlacedOrderAddressResourceImpl
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {
@@ -60,7 +60,7 @@ public class PlacedOrderAddressResourceImpl
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/PlacedOrderCommentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/PlacedOrderCommentResourceImpl.java
@@ -44,7 +44,7 @@ public class PlacedOrderCommentResourceImpl
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {
@@ -81,8 +81,9 @@ public class PlacedOrderCommentResourceImpl
 		throws Exception {
 
 		CommerceOrderNote commerceOrderNote =
-			_commerceOrderNoteService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceOrderNoteService.
+				fetchCommerceOrderNoteByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrderNote == null) {
 			throw new NoSuchOrderNoteException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/PlacedOrderItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/PlacedOrderItemResourceImpl.java
@@ -53,7 +53,7 @@ public class PlacedOrderItemResourceImpl
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {
@@ -90,8 +90,9 @@ public class PlacedOrderItemResourceImpl
 		throws Exception {
 
 		CommerceOrderItem commerceOrderItem =
-			_commerceOrderItemService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceOrderItemService.
+				fetchCommerceOrderItemByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrderItem == null) {
 			throw new NoSuchOrderItemException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/PlacedOrderItemShipmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/PlacedOrderItemShipmentResourceImpl.java
@@ -49,8 +49,9 @@ public class PlacedOrderItemShipmentResourceImpl
 		throws Exception {
 
 		CommerceOrderItem commerceOrderItem =
-			_commerceOrderItemService.fetchByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId());
+			_commerceOrderItemService.
+				fetchCommerceOrderItemByExternalReferenceCode(
+					externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrderItem == null) {
 			throw new NoSuchOrderItemException(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/PlacedOrderResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/PlacedOrderResourceImpl.java
@@ -139,7 +139,7 @@ public class PlacedOrderResourceImpl extends BasePlacedOrderResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {
@@ -157,7 +157,7 @@ public class PlacedOrderResourceImpl extends BasePlacedOrderResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {
@@ -247,7 +247,7 @@ public class PlacedOrderResourceImpl extends BasePlacedOrderResourceImpl {
 		throws Exception {
 
 		CommerceOrder commerceOrder =
-			_commerceOrderService.fetchByExternalReferenceCode(
+			_commerceOrderService.fetchCommerceOrderByExternalReferenceCode(
 				externalReferenceCode, contextCompany.getCompanyId());
 
 		if (commerceOrder == null) {

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
@@ -1563,8 +1563,9 @@ public class ObjectActionLocalServiceTest {
 			commerceOrder1.getOrderStatus());
 
 		CommerceOrder commerceOrder2 =
-			_commerceOrderLocalService.fetchByExternalReferenceCode(
-				"newCommerceOrder", TestPropsValues.getCompanyId());
+			_commerceOrderLocalService.
+				fetchCommerceOrderByExternalReferenceCode(
+					"newCommerceOrder", TestPropsValues.getCompanyId());
 
 		Assert.assertNotNull(commerceOrder2);
 

--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -3783,9 +3783,9 @@
 			"CommercePriceListLocalService",
 			"CommercePriceListLocalServiceUtil"
 		],
-		"from": "fetchByExternalReferenceCode(long paramName, String paramName)",
+		"from": "fetchCommercePriceListByExternalReferenceCode(long paramName, String paramName)",
 		"issueKey": "LPS-196611",
-		"to": "fetchByExternalReferenceCode(param#1#, param#0#)"
+		"to": "fetchCommercePriceListByExternalReferenceCode(param#1#, param#0#)"
 	},
 	{
 		"from": "AssetCategory::getLeftCategoryId",
@@ -3940,15 +3940,6 @@
 			"CPInstanceLocalServiceUtil",
 			"CPInstanceService",
 			"CPInstanceServiceUtil"
-		],
-		"from": "fetchByExternalReferenceCode(long paramName, String paramName)",
-		"issueKey": "LPS-197965",
-		"to": "fetchByExternalReferenceCode(param#1#, param#0#)"
-	},
-	{
-		"classNames": [
-			"CPInstanceLocalService",
-			"CPInstanceLocalServiceUtil"
 		],
 		"from": "fetchCPInstanceByExternalReferenceCode(long paramName, String paramName)",
 		"issueKey": "LPS-197965",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeCatchAllCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeCatchAllCheck.testjava
@@ -1082,22 +1082,19 @@ public class UpgradeCatchAllCheck implements ConfigurationBeanDeclaration {
 		_commerceCatalogLocalService.fetchCommerceCatalogByExternalReferenceCode(123, "test123");
 		_commerceCatalogLocalService.fetchCommerceCatalogByExternalReferenceCode(externalReferenceCode, companyId);
 
-		CommercePriceListLocalServiceUtil.fetchByExternalReferenceCode(externalReferenceCode, companyId);
-		_commercePriceListLocalService.fetchByExternalReferenceCode(123, "test123");
-		_commercePriceListLocalService.fetchByExternalReferenceCode(externalReferenceCode, companyId);
+		CommercePriceListLocalServiceUtil.fetchCommercePriceListByExternalReferenceCode(externalReferenceCode, companyId);
+		_commercePriceListLocalService.fetchCommercePriceListByExternalReferenceCode(123, "test123");
+		_commercePriceListLocalService.fetchCommercePriceListByExternalReferenceCode(externalReferenceCode, companyId);
 
 		_cpDefinitionLocalService.fetchCPDefinitionByCProductExternalReferenceCode(externalReferenceCode, companyId);
 		_cpDefinitionService.fetchCPDefinitionByCProductExternalReferenceCode(123, "test123");
 		_cpDefinitionService.fetchCPDefinitionByCProductExternalReferenceCode(externalReferenceCode, companyId);
 
-		CPInstanceLocalServiceUtil.fetchByExternalReferenceCode(123, "test123");
-		CPInstanceLocalServiceUtil.fetchByExternalReferenceCode(externalReferenceCode, companyId);
 		CPInstanceLocalServiceUtil.fetchCPInstanceByExternalReferenceCode(123, "test123");
 		CPInstanceLocalServiceUtil.fetchCPInstanceByExternalReferenceCode(externalReferenceCode, companyId);
-		CPInstanceServiceUtil.fetchByExternalReferenceCode(externalReferenceCode, companyId);
-		_cpInstanceLocalService.fetchByExternalReferenceCode(externalReferenceCode, companyId);
+		CPInstanceServiceUtil.fetchCPInstanceByExternalReferenceCode(externalReferenceCode, companyId);
 		_cpInstanceLocalService.fetchCPInstanceByExternalReferenceCode(externalReferenceCode, companyId);
-		_cpInstanceService.fetchByExternalReferenceCode(externalReferenceCode, companyId);
+		_cpInstanceService.fetchCPInstanceByExternalReferenceCode(externalReferenceCode, companyId);
 	}
 
 	public void method(

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeCatchAllCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeCatchAllCheck.testjava
@@ -1067,22 +1067,19 @@ public class UpgradeCatchAllCheck implements ConfigurationBeanDeclaration {
 		_commerceCatalogLocalService.fetchCommerceCatalogByExternalReferenceCode(123, "test123");
 		_commerceCatalogLocalService.fetchCommerceCatalogByExternalReferenceCode(companyId, externalReferenceCode);
 
-		CommercePriceListLocalServiceUtil.fetchByExternalReferenceCode(companyId, externalReferenceCode);
-		_commercePriceListLocalService.fetchByExternalReferenceCode(123, "test123");
-		_commercePriceListLocalService.fetchByExternalReferenceCode(companyId, externalReferenceCode);
+		CommercePriceListLocalServiceUtil.fetchCommercePriceListByExternalReferenceCode(companyId, externalReferenceCode);
+		_commercePriceListLocalService.fetchCommercePriceListByExternalReferenceCode(123, "test123");
+		_commercePriceListLocalService.fetchCommercePriceListByExternalReferenceCode(companyId, externalReferenceCode);
 
 		_cpDefinitionLocalService.fetchCPDefinitionByCProductExternalReferenceCode(companyId, externalReferenceCode);
 		_cpDefinitionService.fetchCPDefinitionByCProductExternalReferenceCode(123, "test123");
 		_cpDefinitionService.fetchCPDefinitionByCProductExternalReferenceCode(companyId, externalReferenceCode);
 
-		CPInstanceLocalServiceUtil.fetchByExternalReferenceCode(123, "test123");
-		CPInstanceLocalServiceUtil.fetchByExternalReferenceCode(companyId, externalReferenceCode);
 		CPInstanceLocalServiceUtil.fetchCPInstanceByExternalReferenceCode(123, "test123");
 		CPInstanceLocalServiceUtil.fetchCPInstanceByExternalReferenceCode(companyId, externalReferenceCode);
-		CPInstanceServiceUtil.fetchByExternalReferenceCode(companyId, externalReferenceCode);
-		_cpInstanceLocalService.fetchByExternalReferenceCode(companyId, externalReferenceCode);
+		CPInstanceServiceUtil.fetchCPInstanceByExternalReferenceCode(companyId, externalReferenceCode);
 		_cpInstanceLocalService.fetchCPInstanceByExternalReferenceCode(companyId, externalReferenceCode);
-		_cpInstanceService.fetchByExternalReferenceCode(companyId, externalReferenceCode);
+		_cpInstanceService.fetchCPInstanceByExternalReferenceCode(companyId, externalReferenceCode);
 	}
 
 	public void method(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-37502

Hey @brianchandotcom , I was working on your request to put the `if (Validator.isNull(erc))` statement for the _fetchByExternalReferenceCode_ method inside the service builder but in reality this check is only in some commerce services. And these _fetchByExternalReferenceCode_ methods are also an old pattern because now in the base classes there are already the _fetch< EntityName > ByExternalReferenceCode_ methods, so I deleted all of them.
I know it's a big PR (300 files) but a lot of them are autogenerated and the others are just deletion and renaming (and update of usage).

Sent directly to you because I cannot forward:force due to SF fails but the error is not related (test run here https://github.com/liferay-commerce/liferay-portal/pull/5433) like the errors in the other suites (stable is fine)