### PR TITLE
LPD-37253 modules-functional-jdk8 test batch should have been stripped

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -5622,7 +5622,7 @@ information. Make sure to commit in all format-javadoc results.
 		</run-batch-test>
 	</target>
 
-	<target name="modules-functional-jdk8">
+	<target name="modules-functional">
 		<run-batch-test>
 			<test-action>
 				<antcall target="run-selenium-test">


### PR DESCRIPTION
@brianchandotcom I sent this PR directly because I noticed a mistake I made in https://github.com/julschong/liferay-portal/commit/ea46d510329d3a6398242de625c5918255696d06

batch name was stripped on usage but not on the batch itself