### PR TITLE
LPD-32230 Fix playwright test

### DIFF
--- a/modules/test/playwright/tests/commerce/commerceLayouts.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerceLayouts.spec.ts
@@ -1588,7 +1588,7 @@ test('LPD-32230 Billing and shipping address order info box fragment configurati
 		await commerceLayoutsPage.infoBoxLabelInput.fill('Billing Address');
 		await commerceLayoutsPage.publishButton.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			page,
 			'The display page template was published successfully.'
 		);
@@ -1596,7 +1596,7 @@ test('LPD-32230 Billing and shipping address order info box fragment configurati
 		await commerceLayoutsPage.moreActionsButton.click();
 		await commerceLayoutsPage.markAsDefaultMenuItem.click();
 
-		await waitForSuccessAlert(page);
+		await waitForAlert(page);
 
 		await expect(
 			commerceLayoutsPage.defaultDisplayPageTemplateIcon
@@ -1659,7 +1659,7 @@ test('LPD-32230 Billing and shipping address order info box fragment configurati
 		await commerceLayoutsPage.infoBoxLabelInput.fill('Shipping Address');
 		await commerceLayoutsPage.publishButton.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			page,
 			'The display page template was published successfully.'
 		);


### PR DESCRIPTION
Hi @brianchandotcom 
I'm sending this because the `waitForSuccessAlert` utility was renamed during the merge process to `waitForAlert`, so we didn't have the chance to rename it before.

Here is the Slack thread: https://liferay.slack.com/archives/C1SJ64S9X/p1728040776548799