### PR TITLE
Revert "LPD-37443 SF"

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/openapi/DTOProperty.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/openapi/DTOProperty.java
@@ -47,12 +47,12 @@ public class DTOProperty {
 		return _name;
 	}
 
-	public String getType() {
-		return _type;
+	public Boolean getReadOnly() {
+		return _readOnly;
 	}
 
-	public boolean isReadOnly() {
-		return _readOnly;
+	public String getType() {
+		return _type;
 	}
 
 	public boolean isRequired() {

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/OpenAPIResourceImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/OpenAPIResourceImpl.java
@@ -1131,7 +1131,7 @@ public class OpenAPIResourceImpl implements OpenAPIResource {
 				schema.setDescription(dtoProperty.getDescription());
 				schema.setExtensions(dtoProperty.getExtensions());
 				schema.setName(dtoProperty.getName());
-				schema.setReadOnly(dtoProperty.isReadOnly());
+				schema.setReadOnly(dtoProperty.getReadOnly());
 
 				if (type.equals("Boolean")) {
 					schema.setType("boolean");


### PR DESCRIPTION
This reverts commit 08c04c6bf8636144364f07a7bf9697f0c786dcf9.

As we want to support the null value, true and false, we need to use the Boolean class instead of the primitive type. The purpose of the revert is to keep the `Boolean getReadOnly` method. It is causing several failures in the CI, as now with the null value is throwing a NullPointerException when trying to build the primitive from the null value

I checked the usage of get<Boolean> is more common than is<Boolean>:

![image](https://github.com/user-attachments/assets/4b56cde4-1847-49fb-bd42-98d430d7b794)
