### PR TITLE
LPD-38600 Add z-index for context menu when maximized

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/main.scss
@@ -250,6 +250,10 @@
 	}
 }
 
+.cke_combopanel.lfr-maximized {
+	z-index: 10000 !important;
+}
+
 .cke_editable_inline a {
 	cursor: pointer;
 }
@@ -263,8 +267,8 @@
 	z-index: 100 !important;
 }
 
-.cke_combopanel.lfr-maximized {
-	z-index: 10000 !important;
+.cke_panel.cke_menu_panel {
+	z-index: 10001 !important;
 }
 
 .cke_panel_block {

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/classic.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/classic.spec.ts
@@ -81,3 +81,63 @@ test(
 		});
 	}
 );
+
+test(
+	'Context menu is displayed when maximized',
+	{tag: '@LPD-38600'},
+	async ({apiHelpers, page, site}) => {
+		let layout: Layout;
+
+		await test.step('Create a content site and the ckeditor sample widget', async () => {
+			const widgetDefinition = getWidgetDefinition({
+				id: getRandomString(),
+				widgetName:
+					'com_liferay_editor_ckeditor_sample_web_internal_portlet_CKEditorSamplePortlet',
+			});
+
+			layout = await apiHelpers.headlessDelivery.createSitePage({
+				pageDefinition: getPageDefinition([widgetDefinition]),
+				siteId: site.id,
+				title: getRandomString(),
+			});
+		});
+
+		await test.step('Select Maximized button and check context menu', async () => {
+			await page.goto(
+				`${liferayConfig.environment.baseUrl}/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`
+			);
+
+			const ckeditorSampleWidgetClassicTab = page.getByRole('tab', {
+				name: 'Classic',
+			});
+
+			await ckeditorSampleWidgetClassicTab.waitFor({state: 'visible'});
+			await ckeditorSampleWidgetClassicTab.click();
+
+			const maximizedButton = page.getByLabel('Maximize');
+
+			await maximizedButton.waitFor({state: 'visible'});
+			await maximizedButton.click();
+
+			const ckeditorEditorBody = page
+				.getByRole('tabpanel', {name: 'Classic'})
+				.frameLocator('iframe[title="editor"]')
+				.getByRole('heading', {name: 'Classic Editor'});
+
+			await ckeditorEditorBody.click({button: 'right'});
+
+			const contextMenuZIndex = await page.evaluate(() => {
+				const stylesComboElement = document.querySelector(
+					'.cke_panel.cke_menu_panel'
+				);
+
+				const contextMenuElementStyles =
+					window.getComputedStyle(stylesComboElement);
+
+				return contextMenuElementStyles.getPropertyValue('z-index');
+			});
+
+			expect(contextMenuZIndex).toEqual('10001');
+		});
+	}
+);


### PR DESCRIPTION
FWD: https://github.com/brianchandotcom/liferay-portal/pull/154962

Fixed sorting. Let me know if this is what was meant to be changed.
Thank you!

Original pull request comment:
https://liferay.atlassian.net/browse/LPD-38600
https://liferay.atlassian.net/browse/LPP-55736

The context menu does not appear when CKEditor is maximized.
I added z-index to make the context menu appear.

Please let me know if there are any questions or comments about this.
Thank you!