### PR TITLE
LPD-37767 | Fix SQLDSLTest failure "DSLFunctionFactoryUtil is not fully covered

### DIFF
--- a/modules/core/petra/petra-sql-dsl-spi/src/test/java/com/liferay/petra/sql/dsl/spi/SQLDSLTest.java
+++ b/modules/core/petra/petra-sql-dsl-spi/src/test/java/com/liferay/petra/sql/dsl/spi/SQLDSLTest.java
@@ -1515,15 +1515,15 @@ public class SQLDSLTest {
 		Assert.assertEquals(columns.toString(), 5, columns.size());
 
 		Assert.assertTrue(
-			columns.contains(MainExampleTable.INSTANCE.mainExampleIdColumn));
-		Assert.assertTrue(
-			columns.contains(MainExampleTable.INSTANCE.nameColumn));
+			columns.contains(MainExampleTable.INSTANCE.dateColumn));
 		Assert.assertTrue(
 			columns.contains(MainExampleTable.INSTANCE.descriptionColumn));
 		Assert.assertTrue(
 			columns.contains(MainExampleTable.INSTANCE.flagColumn));
 		Assert.assertTrue(
-			columns.contains(MainExampleTable.INSTANCE.dateColumn));
+			columns.contains(MainExampleTable.INSTANCE.mainExampleIdColumn));
+		Assert.assertTrue(
+			columns.contains(MainExampleTable.INSTANCE.nameColumn));
 
 		try {
 			columns.remove(MainExampleTable.INSTANCE.mainExampleIdColumn);

--- a/modules/core/petra/petra-sql-dsl-spi/src/test/java/com/liferay/petra/sql/dsl/spi/SQLDSLTest.java
+++ b/modules/core/petra/petra-sql-dsl-spi/src/test/java/com/liferay/petra/sql/dsl/spi/SQLDSLTest.java
@@ -68,6 +68,7 @@ import java.sql.Types;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Consumer;
@@ -568,6 +569,11 @@ public class SQLDSLTest {
 			String.valueOf(
 				DSLFunctionFactoryUtil.sum(
 					MainExampleTable.INSTANCE.mainExampleIdColumn)));
+		Assert.assertEquals(
+			"TRUNCATE_TO_SECONDS(MainExample.date)",
+			String.valueOf(
+				DSLFunctionFactoryUtil.truncateToSeconds(
+					MainExampleTable.INSTANCE.dateColumn)));
 		Assert.assertEquals(
 			"(MainExample.mainExampleId + ReferenceExample.referenceExampleId)",
 			String.valueOf(
@@ -1092,9 +1098,15 @@ public class SQLDSLTest {
 
 		columns = (Collection<Column<?, ?>>)table4.getColumns();
 
-		Assert.assertEquals(columns.toString(), 4, columns.size());
+		Assert.assertEquals(columns.toString(), 5, columns.size());
 
 		iterator = columns.iterator();
+
+		column = iterator.next();
+
+		Assert.assertSame(table4, column.getTable());
+		Assert.assertEquals(
+			MainExampleTable.INSTANCE.dateColumn.getName(), column.getName());
 
 		column = iterator.next();
 
@@ -1500,7 +1512,7 @@ public class SQLDSLTest {
 		Collection<Column<MainExampleTable, ?>> columns =
 			MainExampleTable.INSTANCE.getColumns();
 
-		Assert.assertEquals(columns.toString(), 4, columns.size());
+		Assert.assertEquals(columns.toString(), 5, columns.size());
 
 		Assert.assertTrue(
 			columns.contains(MainExampleTable.INSTANCE.mainExampleIdColumn));
@@ -1510,6 +1522,8 @@ public class SQLDSLTest {
 			columns.contains(MainExampleTable.INSTANCE.descriptionColumn));
 		Assert.assertTrue(
 			columns.contains(MainExampleTable.INSTANCE.flagColumn));
+		Assert.assertTrue(
+			columns.contains(MainExampleTable.INSTANCE.dateColumn));
 
 		try {
 			columns.remove(MainExampleTable.INSTANCE.mainExampleIdColumn);
@@ -1610,6 +1624,8 @@ public class SQLDSLTest {
 
 		public static final MainExampleTable INSTANCE = new MainExampleTable();
 
+		public final Column<MainExampleTable, Date> dateColumn = createColumn(
+			"date", Date.class, Types.TIMESTAMP, Column.FLAG_DEFAULT);
 		public final Column<MainExampleTable, Clob> descriptionColumn =
 			createColumn(
 				"description", Clob.class, Types.CLOB, Column.FLAG_DEFAULT);

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogic.java
@@ -98,13 +98,13 @@ public abstract class BaseSQLTransformerLogic implements SQLTransformerLogic {
 		return sqlFunctionTransformer::transform;
 	}
 
-	protected Function<String, String> getDateFormatFunction() {
-		Pattern pattern = getDateFormatPattern();
+	protected Function<String, String> getTruncateToSecondsFunction() {
+		Pattern pattern = getTruncateToSecondsPattern();
 
-		return (String sql) -> replaceDateFormat(pattern.matcher(sql));
+		return (String sql) -> replaceTruncateToSeconds(pattern.matcher(sql));
 	}
 
-	protected Pattern getDateFormatPattern() {
+	protected Pattern getTruncateToSecondsPattern() {
 		return Pattern.compile(
 			"TRUNCATE_TO_SECONDS\\((.+?)\\)", Pattern.CASE_INSENSITIVE);
 	}
@@ -235,7 +235,7 @@ public abstract class BaseSQLTransformerLogic implements SQLTransformerLogic {
 		return matcher.replaceAll("$1");
 	}
 
-	protected String replaceDateFormat(Matcher matcher) {
+	protected String replaceTruncateToSeconds(Matcher matcher) {
 		return matcher.replaceAll("$1");
 	}
 

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogic.java
@@ -236,7 +236,7 @@ public abstract class BaseSQLTransformerLogic implements SQLTransformerLogic {
 	}
 
 	protected String replaceDateFormat(Matcher matcher) {
-		return matcher.replaceAll("DATE_FORMAT($1, '%Y-%m-%dT%H:%i:%sZ')");
+		return matcher.replaceAll("$1");
 	}
 
 	protected String replaceDropTableIfExistsText(Matcher matcher) {

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogic.java
@@ -98,17 +98,6 @@ public abstract class BaseSQLTransformerLogic implements SQLTransformerLogic {
 		return sqlFunctionTransformer::transform;
 	}
 
-	protected Function<String, String> getTruncateToSecondsFunction() {
-		Pattern pattern = getTruncateToSecondsPattern();
-
-		return (String sql) -> replaceTruncateToSeconds(pattern.matcher(sql));
-	}
-
-	protected Pattern getTruncateToSecondsPattern() {
-		return Pattern.compile(
-			"TRUNCATE_TO_SECONDS\\((.+?)\\)", Pattern.CASE_INSENSITIVE);
-	}
-
 	protected Function<String, String> getDropTableIfExistsTextFunction() {
 		Pattern pattern = getDropTableIfExistsTextPattern();
 
@@ -215,6 +204,17 @@ public abstract class BaseSQLTransformerLogic implements SQLTransformerLogic {
 			Pattern.CASE_INSENSITIVE);
 	}
 
+	protected Function<String, String> getTruncateToSecondsFunction() {
+		Pattern pattern = getTruncateToSecondsPattern();
+
+		return (String sql) -> replaceTruncateToSeconds(pattern.matcher(sql));
+	}
+
+	protected Pattern getTruncateToSecondsPattern() {
+		return Pattern.compile(
+			"TRUNCATE_TO_SECONDS\\((.+?)\\)", Pattern.CASE_INSENSITIVE);
+	}
+
 	protected String replaceAggregation(Matcher matcher) {
 		return matcher.replaceAll("$2($3)");
 	}
@@ -232,10 +232,6 @@ public abstract class BaseSQLTransformerLogic implements SQLTransformerLogic {
 	}
 
 	protected String replaceCastText(Matcher matcher) {
-		return matcher.replaceAll("$1");
-	}
-
-	protected String replaceTruncateToSeconds(Matcher matcher) {
 		return matcher.replaceAll("$1");
 	}
 
@@ -257,6 +253,10 @@ public abstract class BaseSQLTransformerLogic implements SQLTransformerLogic {
 
 	protected String replaceSubstr(Matcher matcher) {
 		return matcher.replaceAll("SUBSTRING($1, $2, $3)");
+	}
+
+	protected String replaceTruncateToSeconds(Matcher matcher) {
+		return matcher.replaceAll("$1");
 	}
 
 	protected void setFunctions(Function... functions) {

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/DB2SQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/DB2SQLTransformerLogic.java
@@ -27,7 +27,7 @@ public class DB2SQLTransformerLogic extends BaseSQLTransformerLogic {
 		Function[] functions = {
 			getAggregationFunction(), getBooleanFunction(),
 			getCastClobTextFunction(), getCastLongFunction(),
-			getCastTextFunction(), getConcatFunction(), getDateFormatFunction(),
+			getCastTextFunction(), getConcatFunction(), getTruncateToSecondsFunction(),
 			getDropTableIfExistsTextFunction(), getIntegerDivisionFunction(),
 			getNullDateFunction(), _getCaseWhenThenFunction(),
 			_getLikeFunction(), _getSelectFunction()

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/DB2SQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/DB2SQLTransformerLogic.java
@@ -27,10 +27,10 @@ public class DB2SQLTransformerLogic extends BaseSQLTransformerLogic {
 		Function[] functions = {
 			getAggregationFunction(), getBooleanFunction(),
 			getCastClobTextFunction(), getCastLongFunction(),
-			getCastTextFunction(), getConcatFunction(), getTruncateToSecondsFunction(),
-			getDropTableIfExistsTextFunction(), getIntegerDivisionFunction(),
-			getNullDateFunction(), _getCaseWhenThenFunction(),
-			_getLikeFunction(), _getSelectFunction()
+			getCastTextFunction(), getConcatFunction(),
+			getTruncateToSecondsFunction(), getDropTableIfExistsTextFunction(),
+			getIntegerDivisionFunction(), getNullDateFunction(),
+			_getCaseWhenThenFunction(), _getLikeFunction(), _getSelectFunction()
 		};
 
 		if (!db.isSupportsStringCaseSensitiveQuery()) {

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/HypersonicSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/HypersonicSQLTransformerLogic.java
@@ -24,7 +24,7 @@ public class HypersonicSQLTransformerLogic extends BaseSQLTransformerLogic {
 		Function[] functions = {
 			getAggregationFunction(), getBooleanFunction(),
 			getCastClobTextFunction(), getCastLongFunction(),
-			getCastTextFunction(), getDateFormatFunction(),
+			getCastTextFunction(), getTruncateToSecondsFunction(),
 			getDropTableIfExistsTextFunction(), getIntegerDivisionFunction(),
 			getNullDateFunction()
 		};

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/MySQLSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/MySQLSQLTransformerLogic.java
@@ -35,13 +35,13 @@ public class MySQLSQLTransformerLogic extends BaseSQLTransformerLogic {
 	}
 
 	@Override
-	protected String replaceTruncateToSeconds(Matcher matcher) {
-		return matcher.replaceAll("DATE_FORMAT($1, '%Y-%m-%dT%H:%i:%sZ')");
+	protected String replaceIntegerDivision(Matcher matcher) {
+		return matcher.replaceAll("$1 DIV $2");
 	}
 
 	@Override
-	protected String replaceIntegerDivision(Matcher matcher) {
-		return matcher.replaceAll("$1 DIV $2");
+	protected String replaceTruncateToSeconds(Matcher matcher) {
+		return matcher.replaceAll("DATE_FORMAT($1, '%Y-%m-%dT%H:%i:%sZ')");
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/MySQLSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/MySQLSQLTransformerLogic.java
@@ -23,7 +23,7 @@ public class MySQLSQLTransformerLogic extends BaseSQLTransformerLogic {
 			getAggregationFunction(), getBitwiseCheckFunction(),
 			getBooleanFunction(), getCastClobTextFunction(),
 			getCastLongFunction(), getCastTextFunction(),
-			getDateFormatFunction(), getDropTableIfExistsTextFunction(),
+			getTruncateToSecondsFunction(), getDropTableIfExistsTextFunction(),
 			getIntegerDivisionFunction(), getNullDateFunction()
 		};
 
@@ -35,7 +35,7 @@ public class MySQLSQLTransformerLogic extends BaseSQLTransformerLogic {
 	}
 
 	@Override
-	protected String replaceDateFormat(Matcher matcher) {
+	protected String replaceTruncateToSeconds(Matcher matcher) {
 		return matcher.replaceAll("DATE_FORMAT($1, '%Y-%m-%dT%H:%i:%sZ')");
 	}
 

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/MySQLSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/MySQLSQLTransformerLogic.java
@@ -35,6 +35,11 @@ public class MySQLSQLTransformerLogic extends BaseSQLTransformerLogic {
 	}
 
 	@Override
+	protected String replaceDateFormat(Matcher matcher) {
+		return matcher.replaceAll("DATE_FORMAT($1, '%Y-%m-%dT%H:%i:%sZ')");
+	}
+
+	@Override
 	protected String replaceIntegerDivision(Matcher matcher) {
 		return matcher.replaceAll("$1 DIV $2");
 	}

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/OracleSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/OracleSQLTransformerLogic.java
@@ -26,10 +26,10 @@ public class OracleSQLTransformerLogic extends BaseSQLTransformerLogic {
 		Function[] functions = {
 			getAggregationFunction(), getBooleanFunction(),
 			getCastClobTextFunction(), getCastLongFunction(),
-			getCastTextFunction(), getConcatFunction(), getTruncateToSecondsFunction(),
-			getDropTableIfExistsTextFunction(), getIntegerDivisionFunction(),
-			getNullDateFunction(), _getEscapeFunction(),
-			_getNotEqualsBlankStringFunction()
+			getCastTextFunction(), getConcatFunction(),
+			getTruncateToSecondsFunction(), getDropTableIfExistsTextFunction(),
+			getIntegerDivisionFunction(), getNullDateFunction(),
+			_getEscapeFunction(), _getNotEqualsBlankStringFunction()
 		};
 
 		if (!db.isSupportsStringCaseSensitiveQuery()) {

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/OracleSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/OracleSQLTransformerLogic.java
@@ -26,7 +26,7 @@ public class OracleSQLTransformerLogic extends BaseSQLTransformerLogic {
 		Function[] functions = {
 			getAggregationFunction(), getBooleanFunction(),
 			getCastClobTextFunction(), getCastLongFunction(),
-			getCastTextFunction(), getConcatFunction(), getDateFormatFunction(),
+			getCastTextFunction(), getConcatFunction(), getTruncateToSecondsFunction(),
 			getDropTableIfExistsTextFunction(), getIntegerDivisionFunction(),
 			getNullDateFunction(), _getEscapeFunction(),
 			_getNotEqualsBlankStringFunction()

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/PostgreSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/PostgreSQLTransformerLogic.java
@@ -26,7 +26,7 @@ public class PostgreSQLTransformerLogic extends BaseSQLTransformerLogic {
 			getAggregationFunction(), getBitwiseCheckFunction(),
 			getBooleanFunction(), getCastClobTextFunction(),
 			getCastLongFunction(), getCastTextFunction(),
-			getDateFormatFunction(), getDropTableIfExistsTextFunction(),
+			getTruncateToSecondsFunction(), getDropTableIfExistsTextFunction(),
 			getInstrFunction(), getIntegerDivisionFunction(),
 			_getNegativeComparisonFunction(), _getNullDateFunction()
 		};

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/SQLServerSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/SQLServerSQLTransformerLogic.java
@@ -23,7 +23,7 @@ public class SQLServerSQLTransformerLogic extends BaseSQLTransformerLogic {
 			getAggregationFunction(), getBitwiseCheckFunction(),
 			getBooleanFunction(), getCastClobTextFunction(),
 			getCastLongFunction(), getCastTextFunction(), getConcatFunction(),
-			getDateFormatFunction(), getDropTableIfExistsTextFunction(),
+			getTruncateToSecondsFunction(), getDropTableIfExistsTextFunction(),
 			getInstrFunction(), getIntegerDivisionFunction(),
 			getLengthFunction(), getModFunction(), getNullDateFunction(),
 			getSubstrFunction()

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/SybaseSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/SybaseSQLTransformerLogic.java
@@ -23,10 +23,10 @@ public class SybaseSQLTransformerLogic extends BaseSQLTransformerLogic {
 		super(db);
 
 		Function[] functions = {
-			getDateFormatFunction(), getAggregationFunction(),
+			getTruncateToSecondsFunction(), getAggregationFunction(),
 			getBitwiseCheckFunction(), getBooleanFunction(),
 			getCastClobTextFunction(), getCastLongFunction(),
-			getCastTextFunction(), getConcatFunction(), getDateFormatFunction(),
+			getCastTextFunction(), getConcatFunction(), getTruncateToSecondsFunction(),
 			getDropTableIfExistsTextFunction(), getInstrFunction(),
 			getIntegerDivisionFunction(), getLengthFunction(), getModFunction(),
 			getNullDateFunction(), getSubstrFunction(), _getCrossJoinFunction(),

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/SybaseSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/SybaseSQLTransformerLogic.java
@@ -26,11 +26,11 @@ public class SybaseSQLTransformerLogic extends BaseSQLTransformerLogic {
 			getTruncateToSecondsFunction(), getAggregationFunction(),
 			getBitwiseCheckFunction(), getBooleanFunction(),
 			getCastClobTextFunction(), getCastLongFunction(),
-			getCastTextFunction(), getConcatFunction(), getTruncateToSecondsFunction(),
-			getDropTableIfExistsTextFunction(), getInstrFunction(),
-			getIntegerDivisionFunction(), getLengthFunction(), getModFunction(),
-			getNullDateFunction(), getSubstrFunction(), _getCrossJoinFunction(),
-			_getReplaceFunction()
+			getCastTextFunction(), getConcatFunction(),
+			getTruncateToSecondsFunction(), getDropTableIfExistsTextFunction(),
+			getInstrFunction(), getIntegerDivisionFunction(),
+			getLengthFunction(), getModFunction(), getNullDateFunction(),
+			getSubstrFunction(), _getCrossJoinFunction(), _getReplaceFunction()
 		};
 
 		if (!db.isSupportsStringCaseSensitiveQuery()) {

--- a/portal-impl/test/unit/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogicTestCase.java
+++ b/portal-impl/test/unit/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogicTestCase.java
@@ -245,8 +245,7 @@ public abstract class BaseSQLTransformerLogicTestCase {
 	}
 
 	protected String getDateFormatTransformedSQL() {
-		return "select foo from Foo where DATE_FORMAT(foo, " +
-			"'%Y-%m-%dT%H:%i:%sZ') = 2024-10-04 12:34:56";
+		return "select foo from Foo where foo = 2024-10-04 12:34:56";
 	}
 
 	protected String getDropTableIfExistsTextOriginalSQL() {

--- a/portal-impl/test/unit/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogicTestCase.java
+++ b/portal-impl/test/unit/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogicTestCase.java
@@ -83,10 +83,10 @@ public abstract class BaseSQLTransformerLogicTestCase {
 	}
 
 	@Test
-	public void testReplaceDate() {
+	public void testReplaceTruncateToSeconds() {
 		Assert.assertEquals(
-			getDateFormatTransformedSQL(),
-			sqlTransformer.transform(getDateFormatOriginalSQL()));
+			getTruncateToSecondsTransformedSQL(),
+			sqlTransformer.transform(getTruncateToSecondsOriginalSQL()));
 	}
 
 	@Test
@@ -239,12 +239,12 @@ public abstract class BaseSQLTransformerLogicTestCase {
 		return getCrossJoinOriginalSQL();
 	}
 
-	protected String getDateFormatOriginalSQL() {
+	protected String getTruncateToSecondsOriginalSQL() {
 		return "select foo from Foo where TRUNCATE_TO_SECONDS(foo) = " +
 			"2024-10-04 12:34:56";
 	}
 
-	protected String getDateFormatTransformedSQL() {
+	protected String getTruncateToSecondsTransformedSQL() {
 		return "select foo from Foo where foo = 2024-10-04 12:34:56";
 	}
 

--- a/portal-impl/test/unit/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogicTestCase.java
+++ b/portal-impl/test/unit/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogicTestCase.java
@@ -83,13 +83,6 @@ public abstract class BaseSQLTransformerLogicTestCase {
 	}
 
 	@Test
-	public void testReplaceTruncateToSeconds() {
-		Assert.assertEquals(
-			getTruncateToSecondsTransformedSQL(),
-			sqlTransformer.transform(getTruncateToSecondsOriginalSQL()));
-	}
-
-	@Test
 	public void testReplaceDropTableIfExistsText() {
 		Assert.assertEquals(
 			getDropTableIfExistsTextTransformedSQL(),
@@ -172,6 +165,13 @@ public abstract class BaseSQLTransformerLogicTestCase {
 	}
 
 	@Test
+	public void testReplaceTruncateToSeconds() {
+		Assert.assertEquals(
+			getTruncateToSecondsTransformedSQL(),
+			sqlTransformer.transform(getTruncateToSecondsOriginalSQL()));
+	}
+
+	@Test
 	public void testTransform() {
 		String sql = "select * from Foo";
 
@@ -239,15 +239,6 @@ public abstract class BaseSQLTransformerLogicTestCase {
 		return getCrossJoinOriginalSQL();
 	}
 
-	protected String getTruncateToSecondsOriginalSQL() {
-		return "select foo from Foo where TRUNCATE_TO_SECONDS(foo) = " +
-			"2024-10-04 12:34:56";
-	}
-
-	protected String getTruncateToSecondsTransformedSQL() {
-		return "select foo from Foo where foo = 2024-10-04 12:34:56";
-	}
-
 	protected String getDropTableIfExistsTextOriginalSQL() {
 		return "DROP_TABLE_IF_EXISTS(Foo)";
 	}
@@ -296,6 +287,15 @@ public abstract class BaseSQLTransformerLogicTestCase {
 
 	protected String getSubstrTransformedSQL() {
 		return getSubstrOriginalSQL();
+	}
+
+	protected String getTruncateToSecondsOriginalSQL() {
+		return "select foo from Foo where TRUNCATE_TO_SECONDS(foo) = " +
+			"2024-10-04 12:34:56";
+	}
+
+	protected String getTruncateToSecondsTransformedSQL() {
+		return "select foo from Foo where foo = 2024-10-04 12:34:56";
 	}
 
 	protected SQLTransformer sqlTransformer;

--- a/portal-impl/test/unit/com/liferay/portal/dao/sql/transformer/MySQLSQLTransformerLogicTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/dao/sql/transformer/MySQLSQLTransformerLogicTest.java
@@ -105,7 +105,7 @@ public class MySQLSQLTransformerLogicTest
 	}
 
 	@Override
-	protected String getDateFormatTransformedSQL() {
+	protected String getTruncateToSecondsTransformedSQL() {
 		return "select foo from Foo where DATE_FORMAT(foo, " +
 			"'%Y-%m-%dT%H:%i:%sZ') = 2024-10-04 12:34:56";
 	}

--- a/portal-impl/test/unit/com/liferay/portal/dao/sql/transformer/MySQLSQLTransformerLogicTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/dao/sql/transformer/MySQLSQLTransformerLogicTest.java
@@ -105,6 +105,12 @@ public class MySQLSQLTransformerLogicTest
 	}
 
 	@Override
+	protected String getDateFormatTransformedSQL() {
+		return "select foo from Foo where DATE_FORMAT(foo, " +
+			"'%Y-%m-%dT%H:%i:%sZ') = 2024-10-04 12:34:56";
+	}
+
+	@Override
 	protected String getIntegerDivisionTransformedSQL() {
 		return "select foo DIV bar from Foo";
 	}

--- a/portal-impl/test/unit/com/liferay/portal/dao/sql/transformer/MySQLSQLTransformerLogicTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/dao/sql/transformer/MySQLSQLTransformerLogicTest.java
@@ -105,12 +105,6 @@ public class MySQLSQLTransformerLogicTest
 	}
 
 	@Override
-	protected String getTruncateToSecondsTransformedSQL() {
-		return "select foo from Foo where DATE_FORMAT(foo, " +
-			"'%Y-%m-%dT%H:%i:%sZ') = 2024-10-04 12:34:56";
-	}
-
-	@Override
 	protected String getIntegerDivisionTransformedSQL() {
 		return "select foo DIV bar from Foo";
 	}
@@ -118,6 +112,12 @@ public class MySQLSQLTransformerLogicTest
 	@Override
 	protected String getNullDateTransformedSQL() {
 		return "select NULL from Foo";
+	}
+
+	@Override
+	protected String getTruncateToSecondsTransformedSQL() {
+		return "select foo from Foo where DATE_FORMAT(foo, " +
+			"'%Y-%m-%dT%H:%i:%sZ') = 2024-10-04 12:34:56";
 	}
 
 }


### PR DESCRIPTION
**What's changed?**

When fixing [LPD-37767](https://liferay.atlassian.net/browse/LPD-37767), unit tets was not created for `DSLFunctionFactoryUtil.truncateToSeconds`. Causing the following failure at SQLDSLTest:

> classMethod: java.lang.AssertionError: com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil is not fully covered

The test has been adapted for the new method.

