### PR TITLE
LPD-35169 Binding a published object definition that has entries (follow up) 

### DIFF
--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
@@ -501,6 +501,12 @@ public class ObjectDefinitionResourceImpl
 
 		int statusInt = serviceBuilderObjectDefinition.getStatus();
 
+		if (objectDefinition.getStatus() != null) {
+			Status status = objectDefinition.getStatus();
+
+			statusInt = status.getCode();
+		}
+
 		if (serviceBuilderObjectDefinition.isUnmodifiableSystemObject()) {
 			serviceBuilderObjectDefinition =
 				_objectDefinitionService.updateSystemObjectDefinition(


### PR DESCRIPTION
Related issue : [LPD-35169](https://liferay.atlassian.net/browse/LPD-35169)

This follow-up is necessary because a piece of code was mistakenly removed in this [PR](https://github.com/brianchandotcom/liferay-portal/pull/154979). The primary purpose of the removed code is to preserve the status passed in the JSON response of the Object definition.


@marcelabc @guilhermedcamacho

