### PR TITLE
LPD-38849 Change StartupHelperUtil log level to INFO to display the '…

### DIFF
--- a/portal-impl/src/META-INF/portal-log4j.xml
+++ b/portal-impl/src/META-INF/portal-log4j.xml
@@ -74,7 +74,7 @@
 		<Logger level="ERROR" name="com.liferay.portal.events.LogoutPreAction" />
 		<Logger level="ERROR" name="com.liferay.portal.events.ServicePreAction" />
 		<Logger level="INFO" name="com.liferay.portal.events.StartupAction" />
-		<Logger level="WARN" name="com.liferay.portal.events.StartupHelperUtil" />
+		<Logger level="INFO" name="com.liferay.portal.events.StartupHelperUtil" />
 		<Logger level="ERROR" name="com.liferay.portal.image.ImageToolImpl" />
 		<Logger level="INFO" name="com.liferay.portal.internal.servlet.MainServlet" />
 		<Logger level="WARN" name="com.liferay.portal.json.jabsorb.serializer.LiferayJSONDeserializationWhitelist" />


### PR DESCRIPTION
…There are no patches installed' and 'The following patches are installed' missing traces