### PR TITLE
# What is this trying to solve?

### DIFF
--- a/modules/apps/message-boards/message-boards-web/build.gradle
+++ b/modules/apps/message-boards/message-boards-web/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	compileOnly project(":apps:message-boards:message-boards-service")
 	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	compileOnly project(":apps:portal-workflow:portal-workflow-taglib")
+	compileOnly project(":apps:product-navigation:product-navigation-control-menu-api")
 	compileOnly project(":apps:ratings:ratings-taglib")
 	compileOnly project(":apps:rss:rss-api")
 	compileOnly project(":apps:rss:rss-taglib")

--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/product/navigation/control/menu/DeprecatedMessageNavigationControlMenuEntry.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/product/navigation/control/menu/DeprecatedMessageNavigationControlMenuEntry.java
@@ -1,0 +1,74 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.message.boards.web.internal.product.navigation.control.menu;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.theme.PortletDisplay;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.product.navigation.control.menu.BaseJSPProductNavigationControlMenuEntry;
+import com.liferay.product.navigation.control.menu.ProductNavigationControlMenuEntry;
+import com.liferay.product.navigation.control.menu.constants.ProductNavigationControlMenuCategoryKeys;
+
+import java.util.Objects;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(
+	property = {
+		"product.navigation.control.menu.category.key=" + ProductNavigationControlMenuCategoryKeys.TOOLS,
+		"product.navigation.control.menu.entry.order:Integer=250"
+	},
+	service = ProductNavigationControlMenuEntry.class
+)
+public class DeprecatedMessageNavigationControlMenuEntry
+	extends BaseJSPProductNavigationControlMenuEntry {
+
+	@Override
+	public String getIconJspPath() {
+		return "/message_boards_admin/deprecated_message.jsp";
+	}
+
+	@Override
+	public boolean isShow(HttpServletRequest httpServletRequest)
+		throws PortalException {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		if ((portletDisplay != null) &&
+			Objects.equals(
+				portletDisplay.getPortletName(),
+				PortletKeys.MESSAGE_BOARDS_ADMIN)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
+	protected ServletContext getServletContext() {
+		return _servletContext;
+	}
+
+	@Reference(
+		target = "(osgi.web.symbolicname=com.liferay.message.boards.web)"
+	)
+	private ServletContext _servletContext;
+
+}

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/deprecated_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/deprecated_message.jsp
@@ -1,0 +1,14 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ include file="/message_boards/init.jsp" %>
+
+<liferay-frontend:feature-indicator
+	dark="<%= true %>"
+	interactive="<%= true %>"
+	type="deprecated"
+/>


### PR DESCRIPTION
>[!NOTE]
> This was manually forwarded from [#6001](https://github.com/liferay-content-management/liferay-portal/pull/6001). There's a known test failure in stable that prevents prs from being forwarded the usual way.

https://liferay.atlassian.net/browse/LPD-39410

Add a deprecation notice to the message boards admin widget.
![image](https://github.com/user-attachments/assets/51483cfb-b409-440f-a1f6-00c6d4ffb267)

# How can you verify that it works?

Go to Content & Data > Message boards; assert that the deprecation badge appears in the top bar.

# Why doesn't this include any test?

This is a visual change, where a badge is displayed in the top bar.