### PR TITLE
LPD-38015 Modify custom fields infrastructure to support hide model from the user interface

### DIFF
--- a/modules/apps/portlet/portlet-test/src/testIntegration/java/com/liferay/portlet/test/PortletLocalServiceTest.java
+++ b/modules/apps/portlet/portlet-test/src/testIntegration/java/com/liferay/portlet/test/PortletLocalServiceTest.java
@@ -8,6 +8,7 @@ package com.liferay.portlet.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.expando.kernel.model.BaseCustomAttributesDisplay;
 import com.liferay.expando.kernel.model.CustomAttributesDisplay;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -20,6 +21,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import javax.portlet.Portlet;
 
@@ -55,58 +57,82 @@ public class PortletLocalServiceTest {
 
 	@Test
 	public void testGetCustomAttributesDisplaysWithCustomAttributesDisplayDisabled() {
-		Props props = null;
-
 		List<ServiceRegistration<?>> serviceRegistrations = new ArrayList<>();
 
 		try {
+			PropsTestUtil.setProps(
+				"feature.flag.LPD-ENABLED", Boolean.TRUE.toString());
+
 			serviceRegistrations.add(
 				_bundleContext.registerService(
 					Portlet.class, new TestPortlet(),
 					MapUtil.singletonDictionary(
-						"javax.portlet.name",
-						"com_liferay_portal_kernel_service_TestPortlet")));
+						"javax.portlet.name", _TEST_PORTLET_NAME)));
 
-			TestCustomAttributesDisplay enabledTestCustomAttributesDisplay =
-				new TestCustomAttributesDisplay("LPD-XXXXX");
-
-			serviceRegistrations.add(
-				_bundleContext.registerService(
-					CustomAttributesDisplay.class,
-					enabledTestCustomAttributesDisplay,
-					MapUtil.singletonDictionary(
-						"javax.portlet.name",
-						"com_liferay_portal_kernel_service_TestPortlet")));
-
-			TestCustomAttributesDisplay disabledTestCustomAttributesDisplay =
-				new TestCustomAttributesDisplay(null);
+			TestCustomAttributesDisplay
+				testCustomAttributesDisplayWithEnabledFeatureFlag =
+					new TestCustomAttributesDisplay("LPD-ENABLED");
 
 			serviceRegistrations.add(
 				_bundleContext.registerService(
 					CustomAttributesDisplay.class,
-					new TestCustomAttributesDisplay(null),
+					testCustomAttributesDisplayWithEnabledFeatureFlag,
 					MapUtil.singletonDictionary(
-						"javax.portlet.name",
-						"com_liferay_portal_kernel_service_TestPortlet")));
+						"javax.portlet.name", _TEST_PORTLET_NAME)));
 
-			props = PropsTestUtil.setProps(
-				"feature.flag.LPD-XXXXX", Boolean.TRUE.toString());
+			TestCustomAttributesDisplay
+				testCustomAttributesDisplayWithNullFeatureFlag =
+					new TestCustomAttributesDisplay(null);
+
+			serviceRegistrations.add(
+				_bundleContext.registerService(
+					CustomAttributesDisplay.class,
+					testCustomAttributesDisplayWithNullFeatureFlag,
+					MapUtil.singletonDictionary(
+						"javax.portlet.name", _TEST_PORTLET_NAME)));
+
+			TestCustomAttributesDisplay
+				testCustomAttributesDisplayWithDisabledFeatureFlag =
+					new TestCustomAttributesDisplay("LPD-DISABLED");
+
+			serviceRegistrations.add(
+				_bundleContext.registerService(
+					CustomAttributesDisplay.class,
+					testCustomAttributesDisplayWithDisabledFeatureFlag,
+					MapUtil.singletonDictionary(
+						"javax.portlet.name", _TEST_PORTLET_NAME)));
 
 			List<CustomAttributesDisplay> customAttributesDisplays =
-				_portletLocalService.getCustomAttributesDisplays();
+				TransformUtil.transform(
+					_portletLocalService.getCustomAttributesDisplays(),
+					customAttributesDisplay -> {
+						if (Objects.equals(
+								TestCustomAttributesDisplay.class.getName(),
+								customAttributesDisplay.getClassName())) {
+
+							return customAttributesDisplay;
+						}
+
+						return null;
+					});
 
 			Assert.assertTrue(
 				customAttributesDisplays.toString(),
 				customAttributesDisplays.contains(
-					enabledTestCustomAttributesDisplay));
+					testCustomAttributesDisplayWithEnabledFeatureFlag));
+			Assert.assertTrue(
+				customAttributesDisplays.toString(),
+				customAttributesDisplays.contains(
+					testCustomAttributesDisplayWithNullFeatureFlag));
 			Assert.assertFalse(
 				customAttributesDisplays.toString(),
 				customAttributesDisplays.contains(
-					disabledTestCustomAttributesDisplay));
+					testCustomAttributesDisplayWithDisabledFeatureFlag));
+			Assert.assertEquals(
+				customAttributesDisplays.toString(), 2,
+				customAttributesDisplays.size());
 		}
 		finally {
-			props = null;
-
 			PropsUtil.setProps(_props);
 
 			for (ServiceRegistration<?> serviceRegistration :
@@ -116,6 +142,8 @@ public class PortletLocalServiceTest {
 			}
 		}
 	}
+
+	private static final String _TEST_PORTLET_NAME = "TEST_PORTLET_NAME";
 
 	private BundleContext _bundleContext;
 
@@ -128,18 +156,18 @@ public class PortletLocalServiceTest {
 	private class TestCustomAttributesDisplay
 		extends BaseCustomAttributesDisplay {
 
-		public TestCustomAttributesDisplay(String featureFlagKey) {
-			_featureFlagKey = featureFlagKey;
-		}
-
 		@Override
 		public String getClassName() {
-			return "test";
+			return TestCustomAttributesDisplay.class.getName();
 		}
 
 		@Override
 		public String getFeatureFlagKey() {
 			return _featureFlagKey;
+		}
+
+		private TestCustomAttributesDisplay(String featureFlagKey) {
+			_featureFlagKey = featureFlagKey;
 		}
 
 		private final String _featureFlagKey;

--- a/modules/apps/portlet/portlet-test/src/testIntegration/java/com/liferay/portlet/test/PortletLocalServiceTest.java
+++ b/modules/apps/portlet/portlet-test/src/testIntegration/java/com/liferay/portlet/test/PortletLocalServiceTest.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.PropsTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Props;
 import com.liferay.portal.kernel.util.PropsUtil;
@@ -60,25 +61,30 @@ public class PortletLocalServiceTest {
 		List<ServiceRegistration<?>> serviceRegistrations = new ArrayList<>();
 
 		try {
+			String featureFlagKeyEnabled = RandomTestUtil.randomString();
+
 			PropsTestUtil.setProps(
-				"feature.flag.LPD-ENABLED", Boolean.TRUE.toString());
+				"feature.flag." + featureFlagKeyEnabled,
+				Boolean.TRUE.toString());
+
+			String portletName = RandomTestUtil.randomString();
 
 			serviceRegistrations.add(
 				_bundleContext.registerService(
 					Portlet.class, new TestPortlet(),
 					MapUtil.singletonDictionary(
-						"javax.portlet.name", _TEST_PORTLET_NAME)));
+						"javax.portlet.name", portletName)));
 
 			TestCustomAttributesDisplay
 				testCustomAttributesDisplayWithEnabledFeatureFlag =
-					new TestCustomAttributesDisplay("LPD-ENABLED");
+					new TestCustomAttributesDisplay(featureFlagKeyEnabled);
 
 			serviceRegistrations.add(
 				_bundleContext.registerService(
 					CustomAttributesDisplay.class,
 					testCustomAttributesDisplayWithEnabledFeatureFlag,
 					MapUtil.singletonDictionary(
-						"javax.portlet.name", _TEST_PORTLET_NAME)));
+						"javax.portlet.name", portletName)));
 
 			TestCustomAttributesDisplay
 				testCustomAttributesDisplayWithNullFeatureFlag =
@@ -89,18 +95,19 @@ public class PortletLocalServiceTest {
 					CustomAttributesDisplay.class,
 					testCustomAttributesDisplayWithNullFeatureFlag,
 					MapUtil.singletonDictionary(
-						"javax.portlet.name", _TEST_PORTLET_NAME)));
+						"javax.portlet.name", portletName)));
 
 			TestCustomAttributesDisplay
 				testCustomAttributesDisplayWithDisabledFeatureFlag =
-					new TestCustomAttributesDisplay("LPD-DISABLED");
+					new TestCustomAttributesDisplay(
+						RandomTestUtil.randomString());
 
 			serviceRegistrations.add(
 				_bundleContext.registerService(
 					CustomAttributesDisplay.class,
 					testCustomAttributesDisplayWithDisabledFeatureFlag,
 					MapUtil.singletonDictionary(
-						"javax.portlet.name", _TEST_PORTLET_NAME)));
+						"javax.portlet.name", portletName)));
 
 			List<CustomAttributesDisplay> customAttributesDisplays =
 				TransformUtil.transform(
@@ -142,8 +149,6 @@ public class PortletLocalServiceTest {
 			}
 		}
 	}
-
-	private static final String _TEST_PORTLET_NAME = "TEST_PORTLET_NAME";
 
 	private BundleContext _bundleContext;
 

--- a/modules/apps/portlet/portlet-test/src/testIntegration/java/com/liferay/portlet/test/PortletLocalServiceTest.java
+++ b/modules/apps/portlet/portlet-test/src/testIntegration/java/com/liferay/portlet/test/PortletLocalServiceTest.java
@@ -1,0 +1,152 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portlet.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.expando.kernel.model.BaseCustomAttributesDisplay;
+import com.liferay.expando.kernel.model.CustomAttributesDisplay;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.service.PortletLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.PropsTestUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.portlet.Portlet;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Mikel Lorza
+ */
+@RunWith(Arquillian.class)
+public class PortletLocalServiceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		Bundle bundle = FrameworkUtil.getBundle(getClass());
+
+		_bundleContext = bundle.getBundleContext();
+	}
+
+	@Test
+	public void testGetCustomAttributesDisplaysWithCustomAttributesDisplayDisabled() {
+		Props props = null;
+
+		List<ServiceRegistration<?>> serviceRegistrations = new ArrayList<>();
+
+		try {
+			serviceRegistrations.add(
+				_bundleContext.registerService(
+					Portlet.class, new TestPortlet(),
+					MapUtil.singletonDictionary(
+						"javax.portlet.name",
+						"com_liferay_portal_kernel_service_TestPortlet")));
+
+			TestCustomAttributesDisplay enabledTestCustomAttributesDisplay =
+				new TestCustomAttributesDisplay("LPD-XXXXX");
+
+			serviceRegistrations.add(
+				_bundleContext.registerService(
+					CustomAttributesDisplay.class,
+					enabledTestCustomAttributesDisplay,
+					MapUtil.singletonDictionary(
+						"javax.portlet.name",
+						"com_liferay_portal_kernel_service_TestPortlet")));
+
+			TestCustomAttributesDisplay disabledTestCustomAttributesDisplay =
+				new TestCustomAttributesDisplay(null);
+
+			serviceRegistrations.add(
+				_bundleContext.registerService(
+					CustomAttributesDisplay.class,
+					new TestCustomAttributesDisplay(null),
+					MapUtil.singletonDictionary(
+						"javax.portlet.name",
+						"com_liferay_portal_kernel_service_TestPortlet")));
+
+			props = PropsTestUtil.setProps(
+				"feature.flag.LPD-XXXXX", Boolean.TRUE.toString());
+
+			List<CustomAttributesDisplay> customAttributesDisplays =
+				_portletLocalService.getCustomAttributesDisplays();
+
+			Assert.assertTrue(
+				customAttributesDisplays.toString(),
+				customAttributesDisplays.contains(
+					enabledTestCustomAttributesDisplay));
+			Assert.assertFalse(
+				customAttributesDisplays.toString(),
+				customAttributesDisplays.contains(
+					disabledTestCustomAttributesDisplay));
+		}
+		finally {
+			props = null;
+
+			PropsUtil.setProps(_props);
+
+			for (ServiceRegistration<?> serviceRegistration :
+					serviceRegistrations) {
+
+				serviceRegistration.unregister();
+			}
+		}
+	}
+
+	private BundleContext _bundleContext;
+
+	@Inject
+	private PortletLocalService _portletLocalService;
+
+	@Inject
+	private Props _props;
+
+	private class TestCustomAttributesDisplay
+		extends BaseCustomAttributesDisplay {
+
+		public TestCustomAttributesDisplay(String featureFlagKey) {
+			_featureFlagKey = featureFlagKey;
+		}
+
+		@Override
+		public String getClassName() {
+			return "test";
+		}
+
+		@Override
+		public String getFeatureFlagKey() {
+			return _featureFlagKey;
+		}
+
+		private final String _featureFlagKey;
+
+	}
+
+	private class TestPortlet extends MVCPortlet {
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -8,6 +8,7 @@ package com.liferay.portal.service.impl;
 import com.liferay.admin.kernel.util.PortalMyAccountApplicationType;
 import com.liferay.expando.kernel.model.CustomAttributesDisplay;
 import com.liferay.exportimport.kernel.staging.LayoutStagingUtil;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -24,6 +25,7 @@ import com.liferay.portal.kernel.configuration.ConfigurationFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.PortletIdException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -59,6 +61,7 @@ import com.liferay.portal.kernel.portlet.PortletQNameUtil;
 import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.TriggerConfiguration;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -515,7 +518,22 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 				!portletCustomAttributesDisplays.isEmpty()) {
 
 				customAttributesDisplays.addAll(
-					portletCustomAttributesDisplays);
+					TransformUtil.transform(
+						portletCustomAttributesDisplays,
+						customAttributesDisplay -> {
+							String featureFlagKey =
+								customAttributesDisplay.getFeatureFlagKey();
+
+							if ((featureFlagKey == null) ||
+								FeatureFlagManagerUtil.isEnabled(
+									CompanyThreadLocal.getCompanyId(),
+									featureFlagKey)) {
+
+								return customAttributesDisplay;
+							}
+
+							return null;
+						}));
 			}
 		}
 

--- a/portal-kernel/src/com/liferay/expando/kernel/model/CustomAttributesDisplay.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/model/CustomAttributesDisplay.java
@@ -12,6 +12,10 @@ public interface CustomAttributesDisplay {
 
 	public String getClassName();
 
+	public default String getFeatureFlagKey() {
+		return null;
+	}
+
 	public String getIconCssClass();
 
 	public String getPortletId();

--- a/portal-kernel/src/com/liferay/expando/kernel/model/packageinfo
+++ b/portal-kernel/src/com/liferay/expando/kernel/model/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0


### PR DESCRIPTION
see : https://github.com/brianchandotcom/liferay-portal/pull/155203#issuecomment-2416722014

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-38015

Hi team,

Working on deprecating wiki from the portal, we have the need to hide wiki from custom field creation. So, this PR include all necessary changes to support disable CustomAttributesDisplay's in order to do not show a model from the custom field creation.

We are only hiding wiki behind a feature flag and for that I need the component enabled always. The use case is that some customers that we are using wiki, they can normally use wiki knowing that they should change wiki to objects because someday will disappear.

# How am I fixing it?

 Hiding CustomAttributesDisplay from getCustomAttributesDisplays List if it has a feature flag and this feature flag is not enabled

# How can you verify that it works?

Run included tests.