### PR TITLE
LPD-39686 Bad default value. ERC is a string, need to default to null…

### DIFF
--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/java/com/liferay/site/navigation/menu/web/internal/configuration/SiteNavigationMenuPortletInstanceConfiguration.java
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/java/com/liferay/site/navigation/menu/web/internal/configuration/SiteNavigationMenuPortletInstanceConfiguration.java
@@ -44,8 +44,7 @@ public interface SiteNavigationMenuPortletInstanceConfiguration {
 	public String siteNavigationMenuName();
 
 	@Meta.AD(
-		deflt = "0", name = "display-style-group-external-reference-code",
-		required = false
+		name = "display-style-group-external-reference-code", required = false
 	)
 	public String displayStyleGroupExternalReferenceCode();
 


### PR DESCRIPTION
…, caused by d910d208 . Before LPD-30388, SiteNavigationMenuDisplayContext.getDisplayStyleGroupId() was fallback to ThemeDisplay.getSiteGroupId(), after LPD-30388, SiteNavigationMenuDisplayContext.getDisplayStyleGroupId() was fallback to 0, this was an unintended change. And it caused a meaningless Group db query for ERC value "0" which will always miss.

CC @JavierMoral @lfbesada