### PR TITLE
LPD-31242 Use plural since the resulting string will always contain 2 parameters

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaBaseModelListenerCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaBaseModelListenerCheck.java
@@ -145,22 +145,22 @@ public class UpgradeJavaBaseModelListenerCheck extends BaseUpgradeCheck {
 
 		String parameterName = parameterNames.get(0);
 
-		String newParameter = null;
+		String newParameters = null;
 
 		if (parameterUpgrade) {
-			newParameter = StringBundler.concat(
+			newParameters = StringBundler.concat(
 				"original", StringUtil.upperCaseFirstLetter(parameterName),
 				StringPool.COMMA_AND_SPACE, parameterName);
 		}
 		else {
-			newParameter = StringBundler.concat(
+			newParameters = StringBundler.concat(
 				StringPool.OPEN_PARENTHESIS, _modelType,
 				StringPool.CLOSE_PARENTHESIS, parameterName, ".clone(), ",
 				parameterName);
 		}
 
 		String newMethodCall = StringUtil.replace(
-			methodCall, parameterName, newParameter);
+			methodCall, parameterName, newParameters);
 
 		return StringUtil.replace(javaMethodContent, methodCall, newMethodCall);
 	}


### PR DESCRIPTION
Follow up of https://github.com/brianchandotcom/liferay-portal/commit/f18ec3c842231f6dfc44c98e4d1fbde3a39d5a00
Passed testing/sf locally
We upgrade the super method from 1 -> 2 parameters here so using newParameters over newParameter is more accurate