### PR TITLE
LPD-40139 Improve the performance of the approach responsible for checking if a user meets the assignment criteria before accessing the task via notification

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowTaskManagerImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowTaskManagerImpl.java
@@ -718,6 +718,55 @@ public class WorkflowTaskManagerImpl implements WorkflowTaskManager {
 	}
 
 	@Override
+	public boolean isNotifiableUser(long userId, long workflowTaskId)
+		throws PortalException {
+
+		KaleoTaskInstanceToken kaleoTaskInstanceToken =
+			_kaleoTaskInstanceTokenLocalService.getKaleoTaskInstanceToken(
+				workflowTaskId);
+
+		if (kaleoTaskInstanceToken.isCompleted()) {
+			return false;
+		}
+
+		Collection<KaleoTaskAssignment> kaleoTaskAssignments =
+			_aggregateKaleoTaskAssignmentSelector.getKaleoTaskAssignments(
+				_kaleoTaskAssignmentLocalService.getKaleoTaskAssignments(
+					kaleoTaskInstanceToken.getKaleoTaskId()),
+				_createExecutionContext(kaleoTaskInstanceToken));
+
+		for (KaleoTaskAssignment kaleoTaskAssignment : kaleoTaskAssignments) {
+			if (_isNotifiableUser(
+					kaleoTaskAssignment, kaleoTaskInstanceToken, userId)) {
+
+				return true;
+			}
+		}
+
+		// TODO Temporary workaround for LPS-188796
+
+		for (KaleoTaskAssignmentInstance kaleoTaskAssignmentInstance :
+				kaleoTaskInstanceToken.getKaleoTaskAssignmentInstances()) {
+
+			KaleoTaskAssignment kaleoTaskAssignment =
+				_kaleoTaskAssignmentLocalService.createKaleoTaskAssignment(0L);
+
+			kaleoTaskAssignment.setAssigneeClassName(
+				kaleoTaskAssignmentInstance.getAssigneeClassName());
+			kaleoTaskAssignment.setAssigneeClassPK(
+				kaleoTaskAssignmentInstance.getAssigneeClassPK());
+
+			if (_isNotifiableUser(
+					kaleoTaskAssignment, kaleoTaskInstanceToken, userId)) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	@Override
 	public List<WorkflowTask> search(
 			long companyId, long userId, String assetTitle, String[] taskNames,
 			String[] assetTypes, Long[] assetPrimaryKeys,
@@ -1056,6 +1105,44 @@ public class WorkflowTaskManagerImpl implements WorkflowTaskManager {
 				if (user.isActive() && (user.getUserId() != assignedUserId)) {
 					return true;
 				}
+			}
+		}
+
+		return false;
+	}
+
+	private boolean _isNotifiableUser(
+			KaleoTaskAssignment kaleoTaskAssignment,
+			KaleoTaskInstanceToken kaleoTaskInstanceToken, long userId)
+		throws PortalException {
+
+		if (Objects.equals(
+				kaleoTaskAssignment.getAssigneeClassName(),
+				User.class.getName())) {
+
+			List<KaleoTaskAssignmentInstance> kaleoTaskAssignmentInstances =
+				_kaleoTaskAssignmentInstanceLocalService.
+					getKaleoTaskAssignmentInstances(
+						kaleoTaskInstanceToken.getKaleoTaskInstanceTokenId());
+
+			for (KaleoTaskAssignmentInstance kaleoTaskAssignmentInstance :
+					kaleoTaskAssignmentInstances) {
+
+				if (kaleoTaskAssignmentInstance.getAssigneeClassPK() ==
+						userId) {
+
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		User user = _userLocalService.getUser(userId);
+
+		for (Role role : user.getAllRoles()) {
+			if (role.getRoleId() == kaleoTaskAssignment.getAssigneeClassPK()) {
+				return true;
 			}
 		}
 

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowTaskManagerImplTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowTaskManagerImplTest.java
@@ -969,6 +969,30 @@ public class WorkflowTaskManagerImplTest extends BaseWorkflowManagerTestCase {
 	}
 
 	@Test
+	public void testIsNotifiableUser() throws Exception {
+		User user = UserTestUtil.addUser(RandomTestUtil.randomString());
+
+		_activateSingleApproverWorkflow(BlogsEntry.class.getName(), 0, 0);
+
+		_addBlogsEntry();
+
+		WorkflowTask workflowTask = _getWorkflowTask();
+
+		Assert.assertFalse(
+			_workflowTaskManager.isNotifiableUser(
+				user.getUserId(), workflowTask.getWorkflowTaskId()));
+
+		Role role = _roleLocalService.getRole(
+			_company.getCompanyId(), RoleConstants.ADMINISTRATOR);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user.getUserId());
+
+		Assert.assertTrue(
+			_workflowTaskManager.isNotifiableUser(
+				user.getUserId(), workflowTask.getWorkflowTaskId()));
+	}
+
+	@Test
 	public void testMovetoTrashAndRestoreFromTrashPendingDLFileEntryInDLFolderWithWorkflow()
 		throws Exception {
 

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandler.java
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandler.java
@@ -17,7 +17,6 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserNotificationEvent;
 import com.liferay.portal.kernel.notifications.BaseUserNotificationHandler;
 import com.liferay.portal.kernel.notifications.UserNotificationFeedEntry;
@@ -276,14 +275,9 @@ public class WorkflowTaskUserNotificationHandler
 					CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
 						ctCollectionId)) {
 
-				for (User user :
-						WorkflowTaskManagerUtil.getNotifiableUsers(
-							jsonObject.getLong("workflowTaskId"))) {
-
-					if (user.getUserId() == serviceContext.getUserId()) {
-						return true;
-					}
-				}
+				return WorkflowTaskManagerUtil.isNotifiableUser(
+					serviceContext.getUserId(),
+					jsonObject.getLong("workflowTaskId"));
 			}
 		}
 		catch (PortalException portalException) {

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/test/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandlerTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/test/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandlerTest.java
@@ -184,6 +184,14 @@ public class WorkflowTaskUserNotificationHandlerTest {
 	public void testValidWorkflowTaskIdNotAllowedUserShouldReturnBlankLink()
 		throws Exception {
 
+		Mockito.doReturn(
+			false
+		).when(
+			_workflowTaskManager
+		).isNotifiableUser(
+			Mockito.anyLong(), Mockito.anyLong()
+		);
+
 		Assert.assertEquals(
 			StringPool.BLANK,
 			_workflowTaskUserNotificationHandler.getLink(
@@ -240,8 +248,7 @@ public class WorkflowTaskUserNotificationHandlerTest {
 	}
 
 	private static void _setUpWorkflowTaskManagerUtil() throws Exception {
-		WorkflowTaskManager workflowTaskManager = Mockito.spy(
-			WorkflowTaskManager.class);
+		_workflowTaskManager = Mockito.spy(WorkflowTaskManager.class);
 
 		WorkflowTask workflowTask = new DefaultWorkflowTask() {
 
@@ -255,17 +262,17 @@ public class WorkflowTaskUserNotificationHandlerTest {
 		Mockito.doReturn(
 			workflowTask
 		).when(
-			workflowTaskManager
+			_workflowTaskManager
 		).fetchWorkflowTask(
 			_VALID_WORKFLOW_TASK_ID
 		);
 
 		Mockito.doReturn(
-			_allowedUsers
+			true
 		).when(
-			workflowTaskManager
-		).getNotifiableUsers(
-			Mockito.anyLong()
+			_workflowTaskManager
+		).isNotifiableUser(
+			Mockito.anyLong(), Mockito.anyLong()
 		);
 
 		Snapshot<WorkflowTaskManager> workflowTaskManagerSnapshot = Mockito.spy(
@@ -273,7 +280,7 @@ public class WorkflowTaskUserNotificationHandlerTest {
 				WorkflowTaskManagerUtil.class, WorkflowTaskManager.class));
 
 		Mockito.doReturn(
-			workflowTaskManager
+			_workflowTaskManager
 		).when(
 			workflowTaskManagerSnapshot
 		).get();
@@ -379,6 +386,7 @@ public class WorkflowTaskUserNotificationHandlerTest {
 
 	};
 
+	private static WorkflowTaskManager _workflowTaskManager;
 	private static final WorkflowTaskUserNotificationHandler
 		_workflowTaskUserNotificationHandler =
 			new WorkflowTaskUserNotificationHandler();

--- a/portal-kernel/src/com/liferay/portal/kernel/workflow/WorkflowTaskManager.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/workflow/WorkflowTaskManager.java
@@ -149,6 +149,12 @@ public interface WorkflowTaskManager {
 	public boolean hasAssignableUsers(long workflowTaskId)
 		throws WorkflowException;
 
+	public default boolean isNotifiableUser(long userId, long workflowTaskId)
+		throws PortalException {
+
+		throw new UnsupportedOperationException();
+	}
+
 	public default List<WorkflowTask> search(
 			long companyId, long userId, String assetTitle, String[] taskNames,
 			String[] assetTypes, Long[] assetPrimaryKeys,

--- a/portal-kernel/src/com/liferay/portal/kernel/workflow/WorkflowTaskManagerUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/workflow/WorkflowTaskManagerUtil.java
@@ -303,6 +303,15 @@ public class WorkflowTaskManagerUtil {
 		return workflowTaskManager.hasAssignableUsers(workflowTaskId);
 	}
 
+	public static boolean isNotifiableUser(long userId, long workflowTaskId)
+		throws PortalException {
+
+		WorkflowTaskManager workflowTaskManager =
+			_workflowTaskManagerSnapshot.get();
+
+		return workflowTaskManager.isNotifiableUser(userId, workflowTaskId);
+	}
+
 	public static List<WorkflowTask> search(
 			long companyId, long userId, String assetTitle, String[] taskNames,
 			String[] assetTypes, Long[] assetPrimaryKeys,

--- a/portal-kernel/src/com/liferay/portal/kernel/workflow/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/workflow/packageinfo
@@ -1,1 +1,1 @@
-version 22.0.0
+version 22.1.0


### PR DESCRIPTION
Related: https://liferay.atlassian.net/browse/LPD-40139

## Summary

Get all roles of the current user and check if some of them meets the assignment criteria instead of getting all notifiable users based on the assignment criteria and check if the current user is in this list.