### PR TITLE
LPD-41235 Fix portal-test bnd.bnd confliction with common.bnd on Requ…

### DIFF
--- a/portal-test/bnd.bnd
+++ b/portal-test/bnd.bnd
@@ -48,9 +48,11 @@ Include-Resource:\
 	@${project.dir}/../lib/development/sling-testing-osgi-mock-core.jar,\
 	@${project.dir}/../lib/development/spring-test.jar
 Require-Capability:\
+	osgi.ee;\
+		filter:= "(&(osgi.ee=JavaSE)(version=${ant.build.javac.target}))",\
 	osgi.extender;\
-		filter := "(&(osgi.extender=osgi.configurator)(version>=1.0)(!(version>=2.0)))"
--include ../common.bnd
+		filter:= "(&(osgi.extender=osgi.configurator)(version>=1.0)(!(version>=2.0)))"
+-include ~../common.bnd
 -removeheaders:\
 	Bnd-LastModified,\
 	DSTAMP,\


### PR DESCRIPTION
…ire-Capability

@ling-alan-huang can you add a SF check fix bad bnd directive `filter :=` ? It should be `filter:=`, there is no space between `filter` and the `:`.

For `filter :=`, if you run bnd process, it warns with `[bnd-invoker]  Unknown directive filter : in Require-Capability, allowed directives are effective:,resolution:,filter:,cardinality:, and 'x-*'.`

This does not functionally break anything, since it blindly copies what it does not understand, and runtime OSGi header reading is more forgiving. But still this build time warning is very annoying.
