### PR TITLE
LPD-41227 Handle the cases where the recipient property is retrieved as Object[] instead of List<Map<String, String>>

### DIFF
--- a/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/type/BaseNotificationType.java
+++ b/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/type/BaseNotificationType.java
@@ -122,11 +122,20 @@ public abstract class BaseNotificationType implements NotificationType {
 					continue;
 				}
 
+				List<Map<String, String>> roles = new ArrayList<>();
+
+				if (entry.getValue() instanceof Object[]) {
+					for (Object object : (Object[])entry.getValue()) {
+						roles.add((Map<String, String>)object);
+					}
+				}
+				else {
+					roles = (List<Map<String, String>>)entry.getValue();
+				}
+
 				Set<String> roleNames = new HashSet<>();
 
-				for (Map<String, String> roleMap :
-						(List<Map<String, String>>)entry.getValue()) {
-
+				for (Map<String, String> roleMap : roles) {
 					String roleName = roleMap.get(
 						NotificationRecipientSettingConstants.NAME_ROLE_NAME);
 

--- a/modules/apps/notification/notification-rest-test/src/testIntegration/java/com/liferay/notification/rest/resource/v1_0/test/NotificationTemplateResourceTest.java
+++ b/modules/apps/notification/notification-rest-test/src/testIntegration/java/com/liferay/notification/rest/resource/v1_0/test/NotificationTemplateResourceTest.java
@@ -12,6 +12,7 @@ import com.liferay.notification.constants.NotificationRecipientConstants;
 import com.liferay.notification.constants.NotificationRecipientSettingConstants;
 import com.liferay.notification.constants.NotificationTemplateConstants;
 import com.liferay.notification.rest.client.dto.v1_0.NotificationTemplate;
+import com.liferay.notification.rest.resource.v1_0.NotificationTemplateResource;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
@@ -20,12 +21,14 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -188,6 +191,52 @@ public class NotificationTemplateResourceTest
 			Http.Method.POST);
 	}
 
+	@Test
+	public void testPostNotificationTemplateViaRestNotificationTemplateResource()
+		throws Exception {
+
+		String json = JSONUtil.put(
+			"editorType", NotificationTemplateConstants.EDITOR_TYPE_RICH_TEXT
+		).put(
+			"name", RandomTestUtil.randomString()
+		).put(
+			"recipients",
+			JSONUtil.putAll(
+				JSONUtil.put(
+					"from", RandomTestUtil.randomString()
+				).put(
+					"fromName",
+					JSONUtil.put("en_US", RandomTestUtil.randomString())
+				).put(
+					"to",
+					() -> JSONUtil.putAll(
+						JSONUtil.put("roleName", "Administrator"))
+				).put(
+					"toType", "role"
+				))
+		).put(
+			"recipientType", NotificationRecipientConstants.TYPE_EMAIL
+		).put(
+			"subject", JSONUtil.put("en_US", RandomTestUtil.randomString())
+		).put(
+			"type", NotificationConstants.TYPE_EMAIL
+		).toString();
+
+		NotificationTemplateResource.Builder
+			notificationTemplateResourceBuilder =
+				_notificationTemplateResourceFactory.create();
+
+		NotificationTemplateResource restNotificationTemplateResource =
+			notificationTemplateResourceBuilder.user(
+				TestPropsValues.getUser()
+			).build();
+
+		Assert.assertNotNull(
+			restNotificationTemplateResource.postNotificationTemplate(
+				com.liferay.notification.rest.dto.v1_0.NotificationTemplate.
+					toDTO(json)));
+	}
+
 	@Override
 	protected NotificationTemplate randomNotificationTemplate()
 		throws Exception {
@@ -308,5 +357,9 @@ public class NotificationTemplateResourceTest
 
 	@Inject
 	private JSONFactory _jsonFactory;
+
+	@Inject
+	private NotificationTemplateResource.Factory
+		_notificationTemplateResourceFactory;
 
 }


### PR DESCRIPTION
Related: https://liferay.atlassian.net/browse/LPD-41227

## Summary

When the NotificationTemplate DTO is build by `notification.rest.resource` will retrieve an `Object[]` instead of a `List<Map<String, String>>` for the recipient `To` if this one has the `toType` as `role`