### PR TITLE
LPD-41227 Handle the cases where the recipient property is retrieved as Object[] instead of List<Map<String, String>>

### DIFF
--- a/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/type/BaseNotificationType.java
+++ b/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/type/BaseNotificationType.java
@@ -122,11 +122,20 @@ public abstract class BaseNotificationType implements NotificationType {
 					continue;
 				}
 
+				List<Map<String, String>> roles = new ArrayList<>();
+
+				if (entry.getValue() instanceof Object[]) {
+					for (Object object : (Object[])entry.getValue()) {
+						roles.add((Map<String, String>)object);
+					}
+				}
+				else {
+					roles = (List<Map<String, String>>)entry.getValue();
+				}
+
 				Set<String> roleNames = new HashSet<>();
 
-				for (Map<String, String> roleMap :
-						(List<Map<String, String>>)entry.getValue()) {
-
+				for (Map<String, String> roleMap : roles) {
 					String roleName = roleMap.get(
 						NotificationRecipientSettingConstants.NAME_ROLE_NAME);
 

--- a/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/type/BaseNotificationType.java
+++ b/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/type/BaseNotificationType.java
@@ -122,20 +122,20 @@ public abstract class BaseNotificationType implements NotificationType {
 					continue;
 				}
 
-				List<Map<String, String>> roles = new ArrayList<>();
+				List<Map<String, String>> roleMaps = new ArrayList<>();
 
 				if (entry.getValue() instanceof Object[]) {
 					for (Object object : (Object[])entry.getValue()) {
-						roles.add((Map<String, String>)object);
+						roleMaps.add((Map<String, String>)object);
 					}
 				}
 				else {
-					roles = (List<Map<String, String>>)entry.getValue();
+					roleMaps = (List<Map<String, String>>)entry.getValue();
 				}
 
 				Set<String> roleNames = new HashSet<>();
 
-				for (Map<String, String> roleMap : roles) {
+				for (Map<String, String> roleMap : roleMaps) {
 					String roleName = roleMap.get(
 						NotificationRecipientSettingConstants.NAME_ROLE_NAME);
 

--- a/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/type/BaseNotificationType.java
+++ b/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/type/BaseNotificationType.java
@@ -46,6 +46,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -122,20 +123,9 @@ public abstract class BaseNotificationType implements NotificationType {
 					continue;
 				}
 
-				List<Map<String, String>> roleMaps = new ArrayList<>();
-
-				if (entry.getValue() instanceof Object[]) {
-					for (Object object : (Object[])entry.getValue()) {
-						roleMaps.add((Map<String, String>)object);
-					}
-				}
-				else {
-					roleMaps = (List<Map<String, String>>)entry.getValue();
-				}
-
 				Set<String> roleNames = new HashSet<>();
 
-				for (Map<String, String> roleMap : roleMaps) {
+				for (Map<String, String> roleMap : _toList(entry.getValue())) {
 					String roleName = roleMap.get(
 						NotificationRecipientSettingConstants.NAME_ROLE_NAME);
 
@@ -463,6 +453,14 @@ public abstract class BaseNotificationType implements NotificationType {
 		}
 
 		notificationRecipientSettings.add(notificationRecipientSetting);
+	}
+
+	private List<Map<String, String>> _toList(Object value) {
+		if (value instanceof Object[]) {
+			value = Arrays.asList((Object[])value);
+		}
+
+		return (List<Map<String, String>>)value;
 	}
 
 }

--- a/modules/apps/notification/notification-rest-test/src/testIntegration/java/com/liferay/notification/rest/resource/v1_0/test/NotificationTemplateResourceTest.java
+++ b/modules/apps/notification/notification-rest-test/src/testIntegration/java/com/liferay/notification/rest/resource/v1_0/test/NotificationTemplateResourceTest.java
@@ -224,7 +224,7 @@ public class NotificationTemplateResourceTest
 										"en_US", RandomTestUtil.randomString())
 								).put(
 									"to",
-									() -> JSONUtil.putAll(
+									JSONUtil.putAll(
 										JSONUtil.put(
 											"roleName", "Administrator"))
 								).put(

--- a/modules/apps/notification/notification-rest-test/src/testIntegration/java/com/liferay/notification/rest/resource/v1_0/test/NotificationTemplateResourceTest.java
+++ b/modules/apps/notification/notification-rest-test/src/testIntegration/java/com/liferay/notification/rest/resource/v1_0/test/NotificationTemplateResourceTest.java
@@ -12,6 +12,7 @@ import com.liferay.notification.constants.NotificationRecipientConstants;
 import com.liferay.notification.constants.NotificationRecipientSettingConstants;
 import com.liferay.notification.constants.NotificationTemplateConstants;
 import com.liferay.notification.rest.client.dto.v1_0.NotificationTemplate;
+import com.liferay.notification.rest.resource.v1_0.NotificationTemplateResource;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
@@ -20,12 +21,14 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -188,6 +191,56 @@ public class NotificationTemplateResourceTest
 			Http.Method.POST);
 	}
 
+	@Test
+	public void testPostNotificationTemplateViaRestNotificationTemplateResource()
+		throws Exception {
+
+		NotificationTemplateResource.Builder
+			notificationTemplateResourceBuilder =
+				_notificationTemplateResourceFactory.create();
+
+		NotificationTemplateResource restNotificationTemplateResource =
+			notificationTemplateResourceBuilder.user(
+				TestPropsValues.getUser()
+			).build();
+
+		Assert.assertNotNull(
+			restNotificationTemplateResource.postNotificationTemplate(
+				com.liferay.notification.rest.dto.v1_0.NotificationTemplate.
+					toDTO(
+						JSONUtil.put(
+							"editorType",
+							NotificationTemplateConstants.EDITOR_TYPE_RICH_TEXT
+						).put(
+							"name", RandomTestUtil.randomString()
+						).put(
+							"recipients",
+							JSONUtil.putAll(
+								JSONUtil.put(
+									"from", RandomTestUtil.randomString()
+								).put(
+									"fromName",
+									JSONUtil.put(
+										"en_US", RandomTestUtil.randomString())
+								).put(
+									"to",
+									() -> JSONUtil.putAll(
+										JSONUtil.put(
+											"roleName", "Administrator"))
+								).put(
+									"toType", "role"
+								))
+						).put(
+							"recipientType",
+							NotificationRecipientConstants.TYPE_EMAIL
+						).put(
+							"subject",
+							JSONUtil.put("en_US", RandomTestUtil.randomString())
+						).put(
+							"type", NotificationConstants.TYPE_EMAIL
+						).toString())));
+	}
+
 	@Override
 	protected NotificationTemplate randomNotificationTemplate()
 		throws Exception {
@@ -308,5 +361,9 @@ public class NotificationTemplateResourceTest
 
 	@Inject
 	private JSONFactory _jsonFactory;
+
+	@Inject
+	private NotificationTemplateResource.Factory
+		_notificationTemplateResourceFactory;
 
 }


### PR DESCRIPTION
Related: https://liferay.atlassian.net/browse/LPD-41227

## Summary

When the NotificationTemplate DTO is build by `notification.rest.resource` will retrieve an `Object[]` instead of a `List<Map<String, String>>` for the recipient `To` if this one has the `toType` as `role`