### PR TITLE
Wordsmithed AI Content Wizard descriptions

### DIFF
--- a/workspaces/liferay-aicontentwizard-workspace/client-extensions/liferay-aicontentwizard-etc-spring-boot/src/main/java/com/liferay/ai/content/wizard/langchain4j/descriptions/AccountDescriptions.java
+++ b/workspaces/liferay-aicontentwizard-workspace/client-extensions/liferay-aicontentwizard-etc-spring-boot/src/main/java/com/liferay/ai/content/wizard/langchain4j/descriptions/AccountDescriptions.java
@@ -20,20 +20,20 @@ public class AccountDescriptions {
 	public String name;
 
 	@Description(
-		"Liferay provides three account types: Business, Person, and Supplier"
+		"Liferay provides three account types: Business, Person, and Supplier."
 	)
 	public Type type;
 
 	public enum Type {
 
 		@Description(
-			"Business accounts are used in B2C or B2X sites, default option."
+			"Business accounts are used by default in B2C or B2X sites."
 		)
 		business,
 		@Description("Used based on the site type (i.e., B2B, or B2C)")
 		person,
 		@Description(
-			"For accounts that are catalog suppliers, can publish products on their behalf"
+			"Can publish products on behalf of catalog supplier accounts."
 		)
 		supplier
 

--- a/workspaces/liferay-aicontentwizard-workspace/client-extensions/liferay-aicontentwizard-etc-spring-boot/src/main/java/com/liferay/ai/content/wizard/langchain4j/descriptions/BlogPostingDescriptions.java
+++ b/workspaces/liferay-aicontentwizard-workspace/client-extensions/liferay-aicontentwizard-etc-spring-boot/src/main/java/com/liferay/ai/content/wizard/langchain4j/descriptions/BlogPostingDescriptions.java
@@ -13,24 +13,24 @@ import dev.langchain4j.model.output.structured.Description;
  */
 public class BlogPostingDescriptions {
 
-	@Description("A headline that is a summary of the blog")
+	@Description("The blog entry's subtitle")
 	public String alternativeHeadline;
 
 	@Description(
-		"The content of the blog article, the output must be HTML format."
+		"The blog entry's content in HTML"
 	)
 	public String articleBody;
 
-	@Description("The title of the blog article")
+	@Description("The blog entry's title")
 	public String headline;
 
 	@Description(
-		"Identify the content of the blog and add meaningful keywords using the following format: hyphen-case'"
+		"Add keywords in hyphen-case to help users find this blog entry."
 	)
 	public String[] keywords;
 
 	@Description(
-		"A description of an appropriate image for this blog in three sentences."
+		"Describe this image for the visually impaired in at most three sentences."
 	)
 	public String pictureDescription;
 

--- a/workspaces/liferay-aicontentwizard-workspace/client-extensions/liferay-aicontentwizard-etc-spring-boot/src/main/java/com/liferay/ai/content/wizard/langchain4j/descriptions/KnowledgeBaseArticleDescriptions.java
+++ b/workspaces/liferay-aicontentwizard-workspace/client-extensions/liferay-aicontentwizard-etc-spring-boot/src/main/java/com/liferay/ai/content/wizard/langchain4j/descriptions/KnowledgeBaseArticleDescriptions.java
@@ -14,16 +14,16 @@ import dev.langchain4j.model.output.structured.Description;
 public class KnowledgeBaseArticleDescriptions {
 
 	@Description(
-		"The knowledge base article body, the output is plain text, without HTML tags or Markdown."
+		"The knowledge base article's content in plain text, without HTML tags or Markdown."
 	)
 	public String articleBody;
 
 	@Description(
-		"Identify the content of the blog and add meaningful keywords using the following format: hyphen-case'"
+		"Add keywords in hyphen-case to help users find this knowledge base article."
 	)
 	public String[] keywords;
 
-	@Description("Title of knowledge base article")
+	@Description("Knowledge Base article title")
 	public String title;
 
 }

--- a/workspaces/liferay-aicontentwizard-workspace/client-extensions/liferay-aicontentwizard-etc-spring-boot/src/main/java/com/liferay/ai/content/wizard/langchain4j/descriptions/KnowledgeBaseDescriptions.java
+++ b/workspaces/liferay-aicontentwizard-workspace/client-extensions/liferay-aicontentwizard-etc-spring-boot/src/main/java/com/liferay/ai/content/wizard/langchain4j/descriptions/KnowledgeBaseDescriptions.java
@@ -13,7 +13,7 @@ import dev.langchain4j.model.output.structured.Description;
  */
 public class KnowledgeBaseDescriptions {
 
-	@Description("A list of Knowledge Bases related to a given topic")
+	@Description("A list of folder descriptions in a Knowledge Base")
 	public KnowledgeBaseFolderDescriptions[]
 		knowledgeBaseFolderDescriptionsArray;
 

--- a/workspaces/liferay-aicontentwizard-workspace/client-extensions/liferay-aicontentwizard-etc-spring-boot/src/main/java/com/liferay/ai/content/wizard/langchain4j/descriptions/KnowledgeBaseFolderDescriptions.java
+++ b/workspaces/liferay-aicontentwizard-workspace/client-extensions/liferay-aicontentwizard-etc-spring-boot/src/main/java/com/liferay/ai/content/wizard/langchain4j/descriptions/KnowledgeBaseFolderDescriptions.java
@@ -14,16 +14,16 @@ import dev.langchain4j.model.output.structured.Description;
 public class KnowledgeBaseFolderDescriptions {
 
 	@Description(
-		"Articles related to this Knowledge Base, create a variety of articles between 1 and 3"
+		"An array of this folder's article descriptions"
 	)
 	public KnowledgeBaseArticleDescriptions[]
 		knowledgeBaseArticleDescriptionsArray;
 
-	@Description("Name of the knowledge base category")
+	@Description("The name of this Knowledge Base folder")
 	public String name;
 
 	@Description(
-		"The Knowledge Base can be viewed by one of these options, consider anyone if not specified."
+		"Shows whether this folder can be viewed by anyone, members, or only its owner."
 	)
 	public ViewableBy viewableBy;
 

--- a/workspaces/liferay-aicontentwizard-workspace/client-extensions/liferay-aicontentwizard-etc-spring-boot/src/main/java/com/liferay/ai/content/wizard/langchain4j/descriptions/SiteDescriptions.java
+++ b/workspaces/liferay-aicontentwizard-workspace/client-extensions/liferay-aicontentwizard-etc-spring-boot/src/main/java/com/liferay/ai/content/wizard/langchain4j/descriptions/SiteDescriptions.java
@@ -14,33 +14,33 @@ import dev.langchain4j.model.output.structured.Description;
 public class SiteDescriptions {
 
 	@Description(
-		"Site ERC, if not specified by the user is auto generated UUID"
+		"The site's external reference code; auto-generated if not specified"
 	)
 	public String externalReferenceCode;
 
 	@Description(
-		"Membership type, value is lower case, default option is 'OPEN'"
+		"Membership type (open, restricted, or private). Defaults to 'open'."
 	)
 	public MembershipType membershipType;
 
-	@Description("Site Name")
+	@Description("Site name")
 	public String name;
 
-	@Description("Site Template Key, default is BLANK")
+	@Description("Foreign key to a linked site template")
 	public TemplateKey templateKey;
 
 	public enum MembershipType {
 
 		@Description(
-			"Users can join and leave whenever they want. The site is visible to all users in the My Sites tab"
+			"The site appears in My Sites. Users can join and leave at will."
 		)
 		Open,
 		@Description(
-			"The site appears in the My Sites application, but users must request membership to join"
+			"The site appears in My Sites. Users must request membership to join."
 		)
 		Private,
 		@Description(
-			"A site administrator must explicitly add users to the site. Private membership sites don’t appear in the My Sites app"
+			"The site is not in My Sites. Users cannot join or request membership; site administrators must add them."
 		)
 		Restricted
 

--- a/workspaces/liferay-aicontentwizard-workspace/client-extensions/liferay-aicontentwizard-etc-spring-boot/src/main/java/com/liferay/ai/content/wizard/langchain4j/descriptions/SitePageDescriptions.java
+++ b/workspaces/liferay-aicontentwizard-workspace/client-extensions/liferay-aicontentwizard-etc-spring-boot/src/main/java/com/liferay/ai/content/wizard/langchain4j/descriptions/SitePageDescriptions.java
@@ -14,12 +14,12 @@ import dev.langchain4j.model.output.structured.Description;
 public class SitePageDescriptions {
 
 	@Description(
-		"where each object either has a \"name\" key or a \"components\" key. \n" +
-			"When an object has only one element, it should simply use the \"name\" key to define it, like \"name\": \"heading\" or \"name\": \"carousel\".\n" +
+		"where each object has a \"name\" key or a \"components\" key. \n" +
+			"When an object has only one element, it should use the \"name\" key to define it, like \"name\": \"heading\" or \"name\": \"carousel\".\n" +
 				"For cases where multiple elements are involved, the \"components\" key is used. \n" +
-					"This key will hold an array of objects, each with its own \"name\" key to specify the type of the component, such as \"name\": \"paragraph\" or \"name\": \"card\". \n" +
-						"When any social components are present in a group, they must be consolidated into a single object with the \"name\" key set to \"social\", rather than listing multiple social elements. This ensures that all social elements are grouped together under one \"social\" entry.\n" +
-							"When components of the same type appear more than once, they should still be represented as individual objects within the \"components\" array, as seen with repeated \"card\" components."
+					"This key holds an array of objects with their own \"name\" keys that specify the type of the component, such as \"name\": \"paragraph\" or \"name\": \"card\". \n" +
+						"When a group has social components, they must be consolidated into a single object with the \"name\" key set to \"social\", rather than listing multiple social elements. This ensures that all social elements are grouped together under one \"social\" entry.\n" +
+							"When components of the same type appear more than once, they are represented as individual objects within the \"components\" array, as seen with repeated \"card\" components."
 	)
 	public Structure[] structures;
 
@@ -28,7 +28,7 @@ public class SitePageDescriptions {
 
 	public class Component {
 
-		@Description("The content description based on the parent instructions")
+		@Description("The name of this component")
 		public String name;
 
 	}
@@ -36,11 +36,11 @@ public class SitePageDescriptions {
 	public class Structure {
 
 		@Description(
-			"For cases where multiple elements are involved, the \"pageComponents\" key is used."
+			"An array of components in this structure. Use the \"pageComponents\" key when there are multiple elements."
 		)
 		public Component[] components;
 
-		@Description("The only available components for the JSON structure")
+		@Description("The name of this structure")
 		public StructureName name;
 
 	}
@@ -48,7 +48,7 @@ public class SitePageDescriptions {
 	public enum StructureName {
 
 		@Description(
-			"A small, darker rectangle with rounded corners, typically placed next to a paragraph or text."
+			"A small, dark rectangle with rounded corners, typically placed next to a paragraph or text."
 		)
 		button,
 		card,
@@ -57,11 +57,11 @@ public class SitePageDescriptions {
 		)
 		carousel,
 		@Description(
-			"A component containing an image (either square or circular), with a title beneath the image, a paragraph under the title, and a button after the paragraph. Multiple cards can appear in the same row."
+			"A component containing an image (square or circular), with a title beneath the image, a paragraph under the title, and a button after the paragraph. Multiple cards can appear in the same row."
 		)
 		footer,
 		@Description(
-			"Located at the top of the page, usually consisting of links, buttons, and sometimes an image."
+			"A component located at the top of the page, usually consisting of links, buttons, and sometimes an image."
 		)
 		header,
 		@Description(
@@ -69,12 +69,12 @@ public class SitePageDescriptions {
 		)
 		heading,
 		@Description(
-			"A block of content with controls that allow users to navigate through it."
+			"A block of content with controls for user navigation."
 		)
 		hero_banner,
 		@Description("A simple image component.")
 		image,
-		@Description("A component designed for displaying multiline text.")
+		@Description("A component that displays multiline text.")
 		paragraph,
 		@Description("A group of social media icons with links.")
 		social,

--- a/workspaces/liferay-aicontentwizard-workspace/client-extensions/liferay-aicontentwizard-etc-spring-boot/src/main/java/com/liferay/ai/content/wizard/langchain4j/descriptions/TaxonomyCategoryDescriptions.java
+++ b/workspaces/liferay-aicontentwizard-workspace/client-extensions/liferay-aicontentwizard-etc-spring-boot/src/main/java/com/liferay/ai/content/wizard/langchain4j/descriptions/TaxonomyCategoryDescriptions.java
@@ -15,14 +15,14 @@ import java.util.Map;
  */
 public class TaxonomyCategoryDescriptions {
 
-	@Description("A list of child categories")
+	@Description("An array of child categories")
 	public TaxonomyCategoryDescriptions[]
 		childTaxonomyCategoryDescriptionsArray;
 
-	@Description("Name of the category")
+	@Description("Category name")
 	public String name;
 
-	@Description("Name of the category in BPC47 format, like en-US: Book")
+	@Description("Category name in BPC47 format, like en-US: Book")
 	public Map<String, String> name_i18n;
 
 }

--- a/workspaces/liferay-aicontentwizard-workspace/client-extensions/liferay-aicontentwizard-etc-spring-boot/src/main/java/com/liferay/ai/content/wizard/langchain4j/descriptions/TaxonomyVocabularyDescriptions.java
+++ b/workspaces/liferay-aicontentwizard-workspace/client-extensions/liferay-aicontentwizard-etc-spring-boot/src/main/java/com/liferay/ai/content/wizard/langchain4j/descriptions/TaxonomyVocabularyDescriptions.java
@@ -15,13 +15,13 @@ import java.util.Map;
  */
 public class TaxonomyVocabularyDescriptions {
 
-	@Description("Name of the vocabulary")
+	@Description("Vocabulary name")
 	public String name;
 
-	@Description("Name of the vocabulary in BPC47 format, like en-US: Book")
+	@Description("Vocabulary name in BPC47 format, like en-US: Book")
 	public Map<String, String> name_i18n;
 
-	@Description("A list of categories")
+	@Description("An array of categories")
 	public TaxonomyCategoryDescriptions[] taxonomyCategoryDescriptionsArray;
 
 }

--- a/workspaces/liferay-aicontentwizard-workspace/client-extensions/liferay-aicontentwizard-etc-spring-boot/src/main/java/com/liferay/ai/content/wizard/langchain4j/tools/AccountTools.java
+++ b/workspaces/liferay-aicontentwizard-workspace/client-extensions/liferay-aicontentwizard-etc-spring-boot/src/main/java/com/liferay/ai/content/wizard/langchain4j/tools/AccountTools.java
@@ -36,7 +36,7 @@ public class AccountTools extends BaseTools {
 	}
 
 	@Tool(
-		"Account Deletion,use this tool only if you know the account external reference code, if you are uncertain call the list of accounts to retrieve this information"
+		"Deletes an account by its external reference code"
 	)
 	public void deleteAccountByExternalReferenceCode(
 			@P(value = "The account external reference code") String
@@ -53,7 +53,7 @@ public class AccountTools extends BaseTools {
 			"", "", Pagination.of(1, 20), "");
 	}
 
-	@Tool("Create Liferay Account")
+	@Tool("Creates an account")
 	public Account postAccount(AccountDescriptions accountDescriptions)
 		throws Exception {
 

--- a/workspaces/liferay-aicontentwizard-workspace/client-extensions/liferay-aicontentwizard-etc-spring-boot/src/main/java/com/liferay/ai/content/wizard/langchain4j/tools/BlogPostingTools.java
+++ b/workspaces/liferay-aicontentwizard-workspace/client-extensions/liferay-aicontentwizard-etc-spring-boot/src/main/java/com/liferay/ai/content/wizard/langchain4j/tools/BlogPostingTools.java
@@ -36,14 +36,14 @@ public class BlogPostingTools extends BaseTools {
 		).build();
 	}
 
-	@Tool("Returns a list of blog posts")
+	@Tool("Returns a list of blog entries")
 	public Page<BlogPosting> getSiteBlogPostingsPage() throws Exception {
 		return _blogPostingResource.getSiteBlogPostingsPage(
 			toolsContext.siteId, "", new ArrayList<String>(), "",
 			Pagination.of(1, 20), "");
 	}
 
-	@Tool("Create blog posts")
+	@Tool("Creates a blog entry")
 	public BlogPosting postSiteBlogPosting(
 			BlogPostingDescriptions blogPostingDescriptions)
 		throws Exception {

--- a/workspaces/liferay-aicontentwizard-workspace/client-extensions/liferay-aicontentwizard-etc-spring-boot/src/main/java/com/liferay/ai/content/wizard/langchain4j/tools/KnowledgeBaseTools.java
+++ b/workspaces/liferay-aicontentwizard-workspace/client-extensions/liferay-aicontentwizard-etc-spring-boot/src/main/java/com/liferay/ai/content/wizard/langchain4j/tools/KnowledgeBaseTools.java
@@ -42,7 +42,7 @@ public class KnowledgeBaseTools extends BaseTools {
 		).build();
 	}
 
-	@Tool("Creates a Knowledge Base")
+	@Tool("Creates a Knowledge Base folder")
 	public void postSiteKnowledgeBaseFolder(
 			KnowledgeBaseDescriptions knowledgeBaseDescriptions)
 		throws Exception {

--- a/workspaces/liferay-aicontentwizard-workspace/client-extensions/liferay-aicontentwizard-etc-spring-boot/src/main/java/com/liferay/ai/content/wizard/langchain4j/tools/SitePageTools.java
+++ b/workspaces/liferay-aicontentwizard-workspace/client-extensions/liferay-aicontentwizard-etc-spring-boot/src/main/java/com/liferay/ai/content/wizard/langchain4j/tools/SitePageTools.java
@@ -37,7 +37,7 @@ public class SitePageTools extends BaseTools {
 		).build();
 	}
 
-	@Tool("Create page based on the image url provided by the user")
+	@Tool("Creates a page in the site with the specified description")
 	public SitePage postSiteSitePage(SitePageDescriptions sitePageDescriptions)
 		throws Exception {
 
@@ -310,7 +310,7 @@ public class SitePageTools extends BaseTools {
 							"BASIC_COMPONENT-paragraph", null,
 							StringBundler.concat(
 								"<span class=\"lead\">This is a simple banner ",
-								"component that you can use when you need ",
+								"component to call ",
 								"extra attention to featured content or ",
 								"information.</span>"))
 					).put(


### PR DESCRIPTION
@brianchandotcom, 

Here are the descriptions. The only ones I wasn't quite sure of were in `SitePageDescriptions.java`. 

- **LPD-41296 Create Enums**
- **LPD-41296 Create OpenAI Config**
- **LPD-41296 Create AIContext Model**
- **LPD-41296 Create LiferayAssistant Interface**
- **LPD-41296 Create Page Creation Utils**
- **LPD-41296 Create Schemas to be used as interface when creating content**
- **LPD-41296 Create Services**
- **LPD-41296 Create Tools**
- **LPD-41296 Create AI and Setting Rest Controller**
- **LPD-41296 auto SF**
- **LPD-41296 Inline**
- **LPD-41296 Rename**
- **LPD-41296 Inline/rename**
- **LPD-41296 Rename**
- **LPD-41296 Rename**
- **LPD-41296 Simplify**
- **LPD-41296 Simplify**
- **LPD-41296 Simplify**
- **LPD-41296 Refactor**
- **LPD-41296 Refactor**
- **LPD-41296 Refactor**
- **LPD-41296 Rename**
- **LPD-41296 Rename**
- **LPD-41296 Refactor**
- **LPD-41296 categories can also have children, keep nesting. I'm not sure if we need to check for null or if langchain4j is smart enough to never populate null arrays**
- **LPD-41296 Add /**
- **LPD-41296 Refactor**
- **LPD-41296 Not used for now**
- **LPD-41296 SF**
- **LPD-41015 Update CODEOWNERS file with search infra modules**
- **LPD-41707 remove stray </div>**
- **LPD-40851 Check if a reference to the recurrenceDialog portlet exists in the global object before calling destroy and deleting it**
- **LPD-40851 After clicking the add event button, we need to wait for all the network calls to complete**
- **LPD-40851 Change publishEvent method so it takes care of choosing a recurrence option (if passed by the caller) and make the call to waitForAlert optional**
- **LPD-40851 Refactor test so it uses page methods instead of calling locators direct from test. Also, add proper assertions with expect calls instead of calling waitForAlert**
- **LPD-40851 Add steps to uncheck and check repeat checkbox before publishing again, covering the case for this LDP**
- **LPD-40851 Use method for clicking add event button because it already includes the waitForLoadState call**
- **LRCI-4875 Modify gradle-plugins-test batch to test one plugin if specified**
- **LPD-41653 Uses itemId instead namespace, since itemId is unique and cannot be null**
- **LPD-41653 Adds tests**
- **LPD-41653 baseline**
- **LPD-39724 View and Donwload permissions should behave the same way when the view role is changed**
- **LPD-39724 Add functional test**
- **Wordsmithing.**
