### PR TITLE
LPD-41435 Hide wiki from widget templates

### DIFF
--- a/modules/apps/wiki/wiki-web-test/build.gradle
+++ b/modules/apps/wiki/wiki-web-test/build.gradle
@@ -1,5 +1,7 @@
 dependencies {
 	testIntegrationImplementation project(":apps:export-import:export-import-test-util")
+	testIntegrationImplementation project(":apps:portal:portal-props-test-util")
+	testIntegrationImplementation project(":apps:portlet-display-template:portlet-display-template-api")
 	testIntegrationImplementation project(":apps:wiki:wiki-api")
 	testIntegrationImplementation project(":apps:wiki:wiki-test-util")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/wiki/wiki-web-test/src/testIntegration/java/com/liferay/wiki/web/internal/portlet/display/template/test/WikiPortletDisplayTemplateHandlerTest.java
+++ b/modules/apps/wiki/wiki-web-test/src/testIntegration/java/com/liferay/wiki/web/internal/portlet/display/template/test/WikiPortletDisplayTemplateHandlerTest.java
@@ -1,0 +1,71 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.wiki.web.internal.portlet.display.template.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.template.TemplateHandler;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.props.test.util.PropsTemporarySwapper;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portlet.display.template.PortletDisplayTemplate;
+import com.liferay.wiki.model.WikiPage;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Mikel Lorza
+ */
+@RunWith(Arquillian.class)
+public class WikiPortletDisplayTemplateHandlerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testGetPortletDisplayTemplateHandlers() {
+		Assert.assertTrue(
+			_contains(
+				WikiPage.class.getName(),
+				_portletDisplayTemplate.getPortletDisplayTemplateHandlers()));
+
+		try (PropsTemporarySwapper propsTemporarySwapper =
+				new PropsTemporarySwapper(
+					"feature.flag.LPD-35013", Boolean.FALSE.toString())) {
+
+			Assert.assertFalse(
+				_contains(
+					WikiPage.class.getName(),
+					_portletDisplayTemplate.
+						getPortletDisplayTemplateHandlers()));
+		}
+	}
+
+	private boolean _contains(
+		String className, List<TemplateHandler> templateHandlers) {
+
+		for (TemplateHandler templateHandler : templateHandlers) {
+			if (Objects.equals(templateHandler.getClassName(), className)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	@Inject
+	private PortletDisplayTemplate _portletDisplayTemplate;
+
+}

--- a/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/portlet/display/template/WikiPortletDisplayTemplateHandler.java
+++ b/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/portlet/display/template/WikiPortletDisplayTemplateHandler.java
@@ -6,6 +6,7 @@
 package com.liferay.wiki.web.internal.portlet.display.template;
 
 import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.template.TemplateHandler;
@@ -92,6 +93,15 @@ public class WikiPortletDisplayTemplateHandler
 			wikiServicesTemplateVariableGroup);
 
 		return templateVariableGroups;
+	}
+
+	@Override
+	public boolean isEnabled(long companyId) {
+		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-35013")) {
+			return false;
+		}
+
+		return true;
 	}
 
 	@Override


### PR DESCRIPTION
coming from: https://github.com/brianchandotcom/liferay-portal/pull/156088#issuecomment-2470199350

Hey @brianchandotcom ,

I think that make sense to use the PropsTemporarySwapper in this case. Let me know your feedback.

thanks!

----------------------------------------

# What is this trying to solve?

This pr depends on [this other one](https://github.com/liferay-page-management/liferay-portal/pull/16532/commits) in page-management repository, so, we can't move forward until page-management pr is on master.

https://liferay.atlassian.net/browse/LPD-41435

# How am I fixing it?

Hide wiki  from widget template creation.


# How can you verify that it works?

Run included tests