### PR TITLE
LPD-37583 Hide wiki from custom fields, export import and staging, and workflow

### DIFF
--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiAdminPortletDataHandler.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiAdminPortletDataHandler.java
@@ -18,6 +18,7 @@ import com.liferay.exportimport.kernel.staging.Staging;
 import com.liferay.portal.kernel.cache.MultiVMPool;
 import com.liferay.portal.kernel.cache.PortalCache;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.wiki.constants.WikiConstants;
@@ -104,6 +105,15 @@ public class WikiAdminPortletDataHandler extends BasePortletDataHandler {
 
 			_portalCache.removeAll();
 		}
+	}
+
+	@Override
+	public boolean isEnabled(long companyId) {
+		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-35013")) {
+			return false;
+		}
+
+		return true;
 	}
 
 	@Activate

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiDisplayPortletDataHandler.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiDisplayPortletDataHandler.java
@@ -11,6 +11,7 @@ import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.PortletDataHandler;
 import com.liferay.exportimport.kernel.lar.PortletDataHandlerControl;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.wiki.constants.WikiPortletKeys;
 
@@ -35,6 +36,15 @@ public class WikiDisplayPortletDataHandler extends BasePortletDataHandler {
 	@Override
 	public String getSchemaVersion() {
 		return SCHEMA_VERSION;
+	}
+
+	@Override
+	public boolean isEnabled(long companyId) {
+		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-35013")) {
+			return false;
+		}
+
+		return true;
 	}
 
 	@Activate

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiNodeStagedModelDataHandler.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiNodeStagedModelDataHandler.java
@@ -13,6 +13,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.trash.TrashHandler;
 import com.liferay.portal.kernel.trash.TrashHandlerRegistryUtil;
@@ -76,6 +77,15 @@ public class WikiNodeStagedModelDataHandler
 	@Override
 	public String[] getClassNames() {
 		return CLASS_NAMES;
+	}
+
+	@Override
+	public boolean isEnabled(long companyId) {
+		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-35013")) {
+			return false;
+		}
+
+		return true;
 	}
 
 	@Activate

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiPageStagedModelDataHandler.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiPageStagedModelDataHandler.java
@@ -17,6 +17,7 @@ import com.liferay.exportimport.kernel.lar.StagedModelModifiedDateComparator;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
@@ -106,6 +107,15 @@ public class WikiPageStagedModelDataHandler
 	@Override
 	public String[] getClassNames() {
 		return CLASS_NAMES;
+	}
+
+	@Override
+	public boolean isEnabled(long companyId) {
+		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-35013")) {
+			return false;
+		}
+
+		return true;
 	}
 
 	@Override

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiPortletDataHandler.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiPortletDataHandler.java
@@ -13,6 +13,7 @@ import com.liferay.exportimport.kernel.lar.PortletDataHandler;
 import com.liferay.exportimport.kernel.lar.PortletDataHandlerBoolean;
 import com.liferay.exportimport.kernel.lar.PortletDataHandlerControl;
 import com.liferay.exportimport.kernel.lar.StagedModelType;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.wiki.constants.WikiPortletKeys;
 import com.liferay.wiki.model.WikiNode;
@@ -82,6 +83,15 @@ public class WikiPortletDataHandler extends BasePortletDataHandler {
 
 		return _wikiAdminPortletDataHandler.importData(
 			portletDataContext, portletId, portletPreferences, data);
+	}
+
+	@Override
+	public boolean isEnabled(long companyId) {
+		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-35013")) {
+			return false;
+		}
+
+		return true;
 	}
 
 	@Override

--- a/modules/apps/wiki/wiki-test/build.gradle
+++ b/modules/apps/wiki/wiki-test/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-search:portal-search-api")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-notifications-test-util")
+	testIntegrationImplementation project(":apps:portal:portal-props-test-util")
 	testIntegrationImplementation project(":apps:ratings:ratings-test-util")
 	testIntegrationImplementation project(":apps:social:social-activity-test-util")
 	testIntegrationImplementation project(":apps:subscription:subscription-test-util")

--- a/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/internal/exportimport/data/handler/test/WikiAdminPortletDataHandlerTest.java
+++ b/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/internal/exportimport/data/handler/test/WikiAdminPortletDataHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -23,11 +23,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * @author Zoltan Csaszi
- * @author Gergely Mathe
+ * @author Mikel Lorza
  */
 @RunWith(Arquillian.class)
-public class WikiDisplayPortletDataHandlerTest
+public class WikiAdminPortletDataHandlerTest
 	extends BasePortletDataHandlerTestCase {
 
 	@ClassRule
@@ -66,17 +65,17 @@ public class WikiDisplayPortletDataHandlerTest
 
 	@Override
 	protected DataLevel getDataLevel() {
-		return DataLevel.PORTLET_INSTANCE;
+		return DataLevel.SITE;
 	}
 
 	@Override
 	protected String[] getDataPortletPreferences() {
-		return new String[] {"title", "nodeId"};
+		return new String[0];
 	}
 
 	@Override
 	protected String getPortletId() {
-		return WikiPortletKeys.WIKI_DISPLAY;
+		return WikiPortletKeys.WIKI_ADMIN;
 	}
 
 	@Override
@@ -86,12 +85,12 @@ public class WikiDisplayPortletDataHandlerTest
 
 	@Override
 	protected boolean isDataPortletInstanceLevel() {
-		return true;
+		return false;
 	}
 
 	@Override
 	protected boolean isDataSiteLevel() {
-		return false;
+		return true;
 	}
 
 }

--- a/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/internal/exportimport/data/handler/test/WikiNodeStagedModelDataHandlerTest.java
+++ b/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/internal/exportimport/data/handler/test/WikiNodeStagedModelDataHandlerTest.java
@@ -6,11 +6,13 @@
 package com.liferay.wiki.internal.exportimport.data.handler.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.test.util.lar.BaseStagedModelDataHandlerTestCase;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.StagedModel;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.props.test.util.PropsTemporarySwapper;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.wiki.model.WikiNode;
 import com.liferay.wiki.service.WikiNodeLocalServiceUtil;
@@ -22,6 +24,7 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
@@ -37,10 +40,134 @@ public class WikiNodeStagedModelDataHandlerTest
 		new LiferayIntegrationTestRule();
 
 	@Override
+	@Test
+	public void testCleanStagedModelDataHandler() throws Exception {
+		super.testCleanStagedModelDataHandler();
+
+		try (PropsTemporarySwapper propsTemporarySwapper =
+				new PropsTemporarySwapper(
+					"feature.flag.LPD-35013", Boolean.FALSE.toString())) {
+
+			initExport();
+
+			Map<String, List<StagedModel>> dependentStagedModelsMap =
+				addDependentStagedModelsMap(stagingGroup);
+
+			StagedModel stagedModel = addStagedModel(
+				stagingGroup, dependentStagedModelsMap);
+
+			addComments(stagedModel);
+
+			addRatings(stagedModel);
+
+			StagedModelDataHandlerUtil.exportStagedModel(
+				portletDataContext, stagedModel);
+
+			validateExport(
+				portletDataContext, stagedModel, dependentStagedModelsMap);
+
+			initImport();
+
+			deleteStagedModel(
+				stagedModel, dependentStagedModelsMap, stagingGroup);
+
+			StagedModel exportedStagedModel = readExportedStagedModel(
+				stagedModel);
+
+			Assert.assertNull(exportedStagedModel);
+		}
+	}
+
+	@Override
+	@Test
+	public void testExportImportWithDefaultData() throws Exception {
+		super.testExportImportWithDefaultData();
+
+		try (PropsTemporarySwapper propsTemporarySwapper =
+				new PropsTemporarySwapper(
+					"feature.flag.LPD-35013", Boolean.FALSE.toString())) {
+
+			initExport();
+
+			Map<String, List<StagedModel>> defaultDependentStagedModelsMap =
+				addDefaultDependentStagedModelsMap(stagingGroup);
+
+			StagedModel stagedModel = addDefaultStagedModel(
+				stagingGroup, defaultDependentStagedModelsMap);
+
+			if (stagedModel == null) {
+				return;
+			}
+
+			StagedModelDataHandlerUtil.exportStagedModel(
+				portletDataContext, stagedModel);
+
+			validateExport(
+				portletDataContext, stagedModel,
+				defaultDependentStagedModelsMap);
+
+			Map<String, List<StagedModel>> secondDependentStagedModelsMap =
+				addDefaultDependentStagedModelsMap(liveGroup);
+
+			addDefaultStagedModel(liveGroup, secondDependentStagedModelsMap);
+
+			initImport();
+
+			StagedModel exportedStagedModel = readExportedStagedModel(
+				stagedModel);
+
+			Assert.assertNull(exportedStagedModel);
+		}
+	}
+
+	@Override
+	@Test
+	public void testStagedModelDataHandler() throws Exception {
+		super.testStagedModelDataHandler();
+
+		try (PropsTemporarySwapper propsTemporarySwapper =
+				new PropsTemporarySwapper(
+					"feature.flag.LPD-35013", Boolean.FALSE.toString())) {
+
+			initExport();
+
+			Map<String, List<StagedModel>> dependentStagedModelsMap =
+				addDependentStagedModelsMap(stagingGroup);
+
+			StagedModel stagedModel = addStagedModel(
+				stagingGroup, dependentStagedModelsMap);
+
+			addComments(stagedModel);
+
+			addRatings(stagedModel);
+
+			StagedModelDataHandlerUtil.exportStagedModel(
+				portletDataContext, stagedModel);
+
+			validateExport(
+				portletDataContext, stagedModel, dependentStagedModelsMap);
+
+			initImport();
+
+			StagedModel exportedStagedModel = readExportedStagedModel(
+				stagedModel);
+
+			Assert.assertNull(exportedStagedModel);
+		}
+	}
+
+	@Override
 	protected StagedModel addDefaultStagedModel(
 			Group group,
 			Map<String, List<StagedModel>> dependentStagedModelsMap)
 		throws Exception {
+
+		WikiNode wikiNode = WikiNodeLocalServiceUtil.fetchNode(
+			group.getGroupId(), "Main");
+
+		if (wikiNode != null) {
+			return wikiNode;
+		}
 
 		return WikiTestUtil.addDefaultNode(group.getGroupId());
 	}

--- a/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/internal/exportimport/data/handler/test/WikiPortletDataHandlerTest.java
+++ b/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/internal/exportimport/data/handler/test/WikiPortletDataHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -23,12 +23,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * @author Zoltan Csaszi
- * @author Gergely Mathe
+ * @author Mikel Lorza
  */
 @RunWith(Arquillian.class)
-public class WikiDisplayPortletDataHandlerTest
-	extends BasePortletDataHandlerTestCase {
+public class WikiPortletDataHandlerTest extends BasePortletDataHandlerTestCase {
 
 	@ClassRule
 	@Rule
@@ -66,17 +64,17 @@ public class WikiDisplayPortletDataHandlerTest
 
 	@Override
 	protected DataLevel getDataLevel() {
-		return DataLevel.PORTLET_INSTANCE;
+		return DataLevel.SITE;
 	}
 
 	@Override
 	protected String[] getDataPortletPreferences() {
-		return new String[] {"title", "nodeId"};
+		return new String[0];
 	}
 
 	@Override
 	protected String getPortletId() {
-		return WikiPortletKeys.WIKI_DISPLAY;
+		return WikiPortletKeys.WIKI_ADMIN;
 	}
 
 	@Override
@@ -86,12 +84,12 @@ public class WikiDisplayPortletDataHandlerTest
 
 	@Override
 	protected boolean isDataPortletInstanceLevel() {
-		return true;
+		return false;
 	}
 
 	@Override
 	protected boolean isDataSiteLevel() {
-		return false;
+		return true;
 	}
 
 }

--- a/modules/apps/wiki/wiki-web-test/src/testIntegration/java/com/liferay/wiki/web/internal/custom/attributes/test/WikiPageCustomAttributesDisplayTest.java
+++ b/modules/apps/wiki/wiki-web-test/src/testIntegration/java/com/liferay/wiki/web/internal/custom/attributes/test/WikiPageCustomAttributesDisplayTest.java
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.wiki.web.internal.custom.attributes.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.expando.kernel.model.CustomAttributesDisplay;
+import com.liferay.portal.kernel.service.PortletLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.props.test.util.PropsTemporarySwapper;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.wiki.model.WikiPage;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Mikel Lorza
+ */
+@RunWith(Arquillian.class)
+public class WikiPageCustomAttributesDisplayTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testGetCustomAttributesDisplays() {
+		Assert.assertTrue(
+			_contains(
+				WikiPage.class.getName(),
+				_portletLocalService.getCustomAttributesDisplays()));
+
+		try (PropsTemporarySwapper propsTemporarySwapper =
+				new PropsTemporarySwapper(
+					"feature.flag.LPD-35013", Boolean.FALSE.toString())) {
+
+			Assert.assertFalse(
+				_contains(
+					WikiPage.class.getName(),
+					_portletLocalService.getCustomAttributesDisplays()));
+		}
+	}
+
+	private boolean _contains(
+		String className,
+		List<CustomAttributesDisplay> customAttributesDisplays) {
+
+		for (CustomAttributesDisplay customAttributesDisplay :
+				customAttributesDisplays) {
+
+			if (Objects.equals(
+					customAttributesDisplay.getClassName(), className)) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	@Inject
+	private PortletLocalService _portletLocalService;
+
+}

--- a/modules/apps/wiki/wiki-web-test/src/testIntegration/java/com/liferay/wiki/web/internal/workflow/test/WikiPageWorkflowHandlerTest.java
+++ b/modules/apps/wiki/wiki-web-test/src/testIntegration/java/com/liferay/wiki/web/internal/workflow/test/WikiPageWorkflowHandlerTest.java
@@ -1,0 +1,60 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.wiki.web.internal.workflow.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.workflow.WorkflowHandler;
+import com.liferay.portal.props.test.util.PropsTemporarySwapper;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.wiki.model.WikiPage;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Mikel Lorza
+ */
+@RunWith(Arquillian.class)
+public class WikiPageWorkflowHandlerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testIsVisible() {
+		Assert.assertTrue(_workflowHandler.isVisible(_group));
+
+		try (PropsTemporarySwapper propsTemporarySwapper =
+				new PropsTemporarySwapper(
+					"feature.flag.LPD-35013", Boolean.FALSE.toString())) {
+
+			Assert.assertFalse(_workflowHandler.isVisible(_group));
+		}
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject(filter = "model.class.name=com.liferay.wiki.model.WikiPage")
+	private WorkflowHandler<WikiPage> _workflowHandler;
+
+}

--- a/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/custom/attributes/WikiPageCustomAttributesDisplay.java
+++ b/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/custom/attributes/WikiPageCustomAttributesDisplay.java
@@ -28,6 +28,11 @@ public class WikiPageCustomAttributesDisplay
 	}
 
 	@Override
+	public String getFeatureFlagKey() {
+		return "LPD-35013";
+	}
+
+	@Override
 	public String getIconCssClass() {
 		return "wiki-page";
 	}

--- a/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/workflow/WikiPageWorkflowHandler.java
+++ b/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/workflow/WikiPageWorkflowHandler.java
@@ -6,6 +6,8 @@
 package com.liferay.wiki.web.internal.workflow;
 
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.portlet.PortletURLFactory;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
@@ -66,6 +68,17 @@ public class WikiPageWorkflowHandler extends BaseWorkflowHandler<WikiPage> {
 	@Override
 	public String getType(Locale locale) {
 		return ResourceActionsUtil.getModelResource(locale, getClassName());
+	}
+
+	@Override
+	public boolean isVisible(Group group) {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				group.getCompanyId(), "LPD-35013")) {
+
+			return false;
+		}
+
+		return true;
 	}
 
 	@Override


### PR DESCRIPTION
Coming from : https://github.com/brianchandotcom/liferay-portal/pull/156183#issuecomment-2477140408

Hi @brianchandotcom ,

Yes, it makes sense to have that order because first we should export data, for then import it, and, for that reason it's okay to keep the line breaks to show that order matters.

thanks

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-37583

# How am I fixing it?

Hide wiki  from custom fields, export import and staging, and workflow


# How can you verify that it works?

Run included tests