### PR TITLE
LPD-37354 Revert "LPD-37354 Just once" because the data method is run before the setup method

### DIFF
--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/UpgradeCatchAllCheckTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/UpgradeCatchAllCheckTest.java
@@ -46,6 +46,10 @@ public class UpgradeCatchAllCheckTest extends BaseSourceProcessorTestCase {
 
 		ClassLoader classLoader = UpgradeCatchAllCheck.class.getClassLoader();
 
+		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
+
+		jsonFactoryUtil.setJSONFactory(new JSONFactoryImpl());
+
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray(
 			StringUtil.read(
 				classLoader.getResourceAsStream(
@@ -81,10 +85,6 @@ public class UpgradeCatchAllCheckTest extends BaseSourceProcessorTestCase {
 
 	@Before
 	public void setUp() {
-		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
-
-		jsonFactoryUtil.setJSONFactory(new JSONFactoryImpl());
-
 		UpgradeCatchAllCheck.setIssueKey(_issueKey);
 		UpgradeCatchAllCheck.setTestMode(true);
 	}


### PR DESCRIPTION
Follow up of: https://github.com/brianchandotcom/liferay-portal/pull/156215
cc: @drewbrokke