### PR TITLE
LPD-41969 Fix the test comment

### DIFF
--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/DataDefinitionResourceTest.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/DataDefinitionResourceTest.java
@@ -554,7 +554,7 @@ public class DataDefinitionResourceTest
 				problem.getType());
 		}
 
-		// Provide default data layout name when no one is informed
+		// Provide default data layout name when no name is provided
 
 		DataDefinition dataDefinition =
 			dataDefinitionResource.postSiteDataDefinitionByContentType(
@@ -570,7 +570,7 @@ public class DataDefinitionResourceTest
 		dataDefinitionResource.deleteDataDefinition(dataDefinition.getId());
 
 		// Provide empty string as the data definition field default value when
-		// no one is informed
+		// no value is provided
 
 		dataDefinition = DataDefinition.toDTO(
 			DataDefinitionTestUtil.read("data-definition-basic.json"));


### PR DESCRIPTION
Follow up: https://github.com/brianchandotcom/liferay-portal/pull/156174

Hey Brian,
I improved the test comment. The test scenario is when the user does not pass a specific property in the request body: in the first test is the `data layout name`, and in the other is the `data definition field default value`.

I hope it is clearer now :smile: 