### PR TITLE
LPD-42541 When DB Partition is enabled, portal caches should be sharded by default. It is safer and never hurts 

### DIFF
--- a/modules/apps/portal-cache/portal-cache-ehcache-impl/src/main/java/com/liferay/portal/cache/ehcache/internal/BaseEhcachePortalCacheManager.java
+++ b/modules/apps/portal-cache/portal-cache-ehcache-impl/src/main/java/com/liferay/portal/cache/ehcache/internal/BaseEhcachePortalCacheManager.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.cache.PortalCacheListener;
 import com.liferay.portal.kernel.cache.PortalCacheListenerScope;
 import com.liferay.portal.kernel.cache.PortalCacheManager;
 import com.liferay.portal.kernel.cache.PortalCacheManagerListener;
+import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.MVCCModel;
@@ -119,7 +120,8 @@ public abstract class BaseEhcachePortalCacheManager<K extends Serializable, V>
 			String portalCacheName, boolean mvcc)
 		throws PortalCacheException {
 
-		return getPortalCache(portalCacheName, mvcc, false);
+		return getPortalCache(
+			portalCacheName, mvcc, DBPartition.isPartitionEnabled());
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/tools/ToolDependencies.java
+++ b/portal-impl/src/com/liferay/portal/tools/ToolDependencies.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.cache.PortalCacheManagerNames;
 import com.liferay.portal.kernel.cache.PortalCacheManagerProvider;
 import com.liferay.portal.kernel.cache.SingleVMPool;
 import com.liferay.portal.kernel.cache.key.CacheKeyGeneratorUtil;
+import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
@@ -375,7 +376,8 @@ public class ToolDependencies {
 				String portalCacheName, boolean mvcc)
 			throws PortalCacheException {
 
-			return getPortalCache(portalCacheName, mvcc, false);
+			return getPortalCache(
+				portalCacheName, mvcc, DBPartition.isPartitionEnabled());
 		}
 
 		@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/cache/DynamicPortalCacheManager.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/cache/DynamicPortalCacheManager.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.kernel.cache;
 
+import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.util.ProxyFactory;
 
 import java.io.Serializable;
@@ -70,7 +71,8 @@ public class DynamicPortalCacheManager<K extends Serializable, V>
 			String portalCacheName, boolean mvcc)
 		throws PortalCacheException {
 
-		return getPortalCache(portalCacheName, mvcc, false);
+		return getPortalCache(
+			portalCacheName, mvcc, DBPartition.isPartitionEnabled());
 	}
 
 	@Override


### PR DESCRIPTION
When DB Partition is enabled, most of the portal caches should be sharded. Developers with no sharded caches should indicate it explicitly.

cc/ @tinatian 