### PR TITLE
LPD-40974 Inconsistent Deprecation Feature Flag Behavior in New Installations

### DIFF
--- a/modules/apps/feature-flag/feature-flag-test/src/testIntegration/java/com/liferay/feature/flag/test/CompanyModelListenerTest.java
+++ b/modules/apps/feature-flag/feature-flag-test/src/testIntegration/java/com/liferay/feature/flag/test/CompanyModelListenerTest.java
@@ -10,15 +10,8 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlag;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManager;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagType;
 import com.liferay.portal.kernel.model.Company;
-import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
-import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -43,30 +36,15 @@ public class CompanyModelListenerTest {
 
 	@Test
 	public void testOnAfterCreate() throws Exception {
-		String originalName = PrincipalThreadLocal.getName();
+		Company company = CompanyTestUtil.addCompany();
 
-		try {
-			Company company = CompanyTestUtil.addCompany();
+		List<FeatureFlag> deprecationFeatureFlags =
+			_featureFlagManager.getFeatureFlags(
+				company.getCompanyId(),
+				FeatureFlagType.DEPRECATION.getPredicate());
 
-			User user = UserTestUtil.addUser(
-				company.getCompanyId(), TestPropsValues.getUserId(),
-				RandomTestUtil.randomString(), LocaleUtil.getDefault(),
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				new long[0], ServiceContextTestUtil.getServiceContext());
-
-			PrincipalThreadLocal.setName(user.getUserId());
-
-			List<FeatureFlag> deprecationFeatureFlags =
-				_featureFlagManager.getFeatureFlags(
-					company.getCompanyId(),
-					FeatureFlagType.DEPRECATION.getPredicate());
-
-			for (FeatureFlag deprecationFeatureFlag : deprecationFeatureFlags) {
-				Assert.assertFalse(deprecationFeatureFlag.isEnabled());
-			}
-		}
-		finally {
-			PrincipalThreadLocal.setName(originalName);
+		for (FeatureFlag deprecationFeatureFlag : deprecationFeatureFlags) {
+			Assert.assertFalse(deprecationFeatureFlag.isEnabled());
 		}
 	}
 

--- a/modules/apps/feature-flag/feature-flag-web-test/bnd.bnd
+++ b/modules/apps/feature-flag/feature-flag-web-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Feature Flag Web Test
+Bundle-SymbolicName: com.liferay.feature.flag.web.test
+Bundle-Version: 1.0.0

--- a/modules/apps/feature-flag/feature-flag-web-test/build.gradle
+++ b/modules/apps/feature-flag/feature-flag-web-test/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
+	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
+	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/feature-flag/feature-flag-web-test/src/testIntegration/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_0/test/FeatureFlagUpgradeProcessTest.java
+++ b/modules/apps/feature-flag/feature-flag-web-test/src/testIntegration/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_0/test/FeatureFlagUpgradeProcessTest.java
@@ -1,0 +1,92 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.feature.flag.web.internal.upgrade.v1_0_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.feature.flag.constants.FeatureFlagConstants;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.portlet.PortalPreferences;
+import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+import com.liferay.portlet.PortalPreferencesWrapper;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Thiago Buarque
+ */
+@RunWith(Arquillian.class)
+public class FeatureFlagUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testDeprecationFeatureFlagPortalPreference() throws Exception {
+		Company company = CompanyTestUtil.addCompany();
+
+		PortalPreferences portalPreferences = _getPortalPreferences(
+			company.getCompanyId());
+
+		portalPreferences.setValue(
+			FeatureFlagConstants.FEATURE_FLAG,
+			FeatureFlagConstants.PREFERENCE_KEY_DEPRECATION_PROCESSED, "false");
+
+		_portalPreferencesLocalService.updatePreferences(
+			company.getCompanyId(), PortletKeys.PREFS_OWNER_TYPE_COMPANY,
+			portalPreferences);
+
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator, _CLASS_NAME);
+
+		upgradeProcess.upgrade();
+
+		portalPreferences = _getPortalPreferences(company.getCompanyId());
+
+		Assert.assertTrue(
+			GetterUtil.getBoolean(
+				portalPreferences.getValue(
+					FeatureFlagConstants.FEATURE_FLAG,
+					FeatureFlagConstants.
+						PREFERENCE_KEY_DEPRECATION_PROCESSED)));
+	}
+
+	private PortalPreferences _getPortalPreferences(long companyId) {
+		PortalPreferencesWrapper portalPreferencesWrapper =
+			(PortalPreferencesWrapper)
+				_portalPreferencesLocalService.getPreferences(
+					companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY);
+
+		return portalPreferencesWrapper.getPortalPreferencesImpl();
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.feature.flag.web.internal.upgrade.v1_0_0." +
+			"FeatureFlagUpgradeProcess";
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.feature.flag.web.internal.upgrade.registry.FeatureFlagUpgradeStepRegistrator))"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@Inject
+	private PortalPreferencesLocalService _portalPreferencesLocalService;
+
+}

--- a/modules/apps/feature-flag/feature-flag-web-test/src/testIntegration/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_0/test/FeatureFlagUpgradeProcessTest.java
+++ b/modules/apps/feature-flag/feature-flag-web-test/src/testIntegration/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_0/test/FeatureFlagUpgradeProcessTest.java
@@ -39,14 +39,14 @@ public class FeatureFlagUpgradeProcessTest {
 		new LiferayIntegrationTestRule();
 
 	@Test
-	public void testDeprecationFeatureFlagPortalPreference() throws Exception {
+	public void testDoUpgrade() throws Exception {
 		Company company = CompanyTestUtil.addCompany();
 
 		PortalPreferences portalPreferences = _getPortalPreferences(
 			company.getCompanyId());
 
 		portalPreferences.setValue(
-			FeatureFlagConstants.FEATURE_FLAG,
+			_OLD_NAMESPACE,
 			FeatureFlagConstants.PREFERENCE_KEY_DEPRECATION_PROCESSED, "false");
 
 		_portalPreferencesLocalService.updatePreferences(
@@ -60,10 +60,15 @@ public class FeatureFlagUpgradeProcessTest {
 
 		portalPreferences = _getPortalPreferences(company.getCompanyId());
 
+		Assert.assertNull(
+			portalPreferences.getValue(
+				_OLD_NAMESPACE,
+				FeatureFlagConstants.PREFERENCE_KEY_DEPRECATION_PROCESSED));
+
 		Assert.assertTrue(
 			GetterUtil.getBoolean(
 				portalPreferences.getValue(
-					FeatureFlagConstants.FEATURE_FLAG,
+					FeatureFlagConstants.PREFERENCE_NAMESPACE,
 					FeatureFlagConstants.
 						PREFERENCE_KEY_DEPRECATION_PROCESSED)));
 	}
@@ -80,6 +85,9 @@ public class FeatureFlagUpgradeProcessTest {
 	private static final String _CLASS_NAME =
 		"com.liferay.feature.flag.web.internal.upgrade.v1_0_0." +
 			"FeatureFlagUpgradeProcess";
+
+	private static final String _OLD_NAMESPACE =
+		FeatureFlagConstants.FEATURE_FLAG;
 
 	@Inject(
 		filter = "(&(component.name=com.liferay.feature.flag.web.internal.upgrade.registry.FeatureFlagUpgradeStepRegistrator))"

--- a/modules/apps/feature-flag/feature-flag-web-test/src/testIntegration/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_0/test/FeatureFlagUpgradeProcessTest.java
+++ b/modules/apps/feature-flag/feature-flag-web-test/src/testIntegration/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_0/test/FeatureFlagUpgradeProcessTest.java
@@ -87,7 +87,7 @@ public class FeatureFlagUpgradeProcessTest {
 			"FeatureFlagUpgradeProcess";
 
 	private static final String _OLD_NAMESPACE =
-		FeatureFlagConstants.FEATURE_FLAG;
+		FeatureFlagConstants.PORTAL_PROPERTY_KEY_FEATURE_FLAG;
 
 	@Inject(
 		filter = "(&(component.name=com.liferay.feature.flag.web.internal.upgrade.registry.FeatureFlagUpgradeStepRegistrator))"

--- a/modules/apps/feature-flag/feature-flag-web/build.gradle
+++ b/modules/apps/feature-flag/feature-flag-web/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":apps:static:portal:portal-upgrade-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/feature/flag/FeatureFlagsBagProviderImpl.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/feature/flag/FeatureFlagsBagProviderImpl.java
@@ -250,7 +250,9 @@ public class FeatureFlagsBagProviderImpl
 		Map<String, FeatureFlag> systemFeatureFlags) {
 
 		Properties properties = PropsUtil.getProperties(
-			FeatureFlagConstants.FEATURE_FLAG + StringPool.PERIOD, true);
+			FeatureFlagConstants.PORTAL_PROPERTY_KEY_FEATURE_FLAG +
+				StringPool.PERIOD,
+			true);
 
 		for (String stringPropertyName : properties.stringPropertyNames()) {
 			if (!_isFeatureFlagKey(stringPropertyName)) {

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/manager/FeatureFlagPreferencesManager.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/manager/FeatureFlagPreferencesManager.java
@@ -32,7 +32,8 @@ public class FeatureFlagPreferencesManager {
 
 		PortalPreferences portalPreferences = _getPortalPreferences(companyId);
 
-		String value = portalPreferences.getValue(_NAMESPACE, key);
+		String value = portalPreferences.getValue(
+			FeatureFlagConstants.FEATURE_FLAG, key);
 
 		if (value == null) {
 			return null;
@@ -44,7 +45,8 @@ public class FeatureFlagPreferencesManager {
 	public void setEnabled(long companyId, String key, boolean enabled) {
 		PortalPreferences portalPreferences = _getPortalPreferences(companyId);
 
-		portalPreferences.setValue(_NAMESPACE, key, String.valueOf(enabled));
+		portalPreferences.setValue(
+			FeatureFlagConstants.FEATURE_FLAG, key, String.valueOf(enabled));
 
 		_portalPreferencesLocalService.updatePreferences(
 			companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY, portalPreferences);
@@ -58,8 +60,6 @@ public class FeatureFlagPreferencesManager {
 
 		return portalPreferencesWrapper.getPortalPreferencesImpl();
 	}
-
-	private static final String _NAMESPACE = FeatureFlagConstants.FEATURE_FLAG;
 
 	@Reference
 	private PortalPreferencesLocalService _portalPreferencesLocalService;

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/manager/FeatureFlagPreferencesManager.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/manager/FeatureFlagPreferencesManager.java
@@ -33,7 +33,7 @@ public class FeatureFlagPreferencesManager {
 		PortalPreferences portalPreferences = _getPortalPreferences(companyId);
 
 		String value = portalPreferences.getValue(
-			FeatureFlagConstants.FEATURE_FLAG, key);
+			FeatureFlagConstants.PREFERENCE_NAMESPACE, key);
 
 		if (value == null) {
 			return null;
@@ -46,7 +46,8 @@ public class FeatureFlagPreferencesManager {
 		PortalPreferences portalPreferences = _getPortalPreferences(companyId);
 
 		portalPreferences.setValue(
-			FeatureFlagConstants.FEATURE_FLAG, key, String.valueOf(enabled));
+			FeatureFlagConstants.PREFERENCE_NAMESPACE, key,
+			String.valueOf(enabled));
 
 		_portalPreferencesLocalService.updatePreferences(
 			companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY, portalPreferences);

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/model/listener/CompanyModelListener.java
@@ -62,7 +62,7 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 
 		boolean processed = GetterUtil.getBoolean(
 			portalPreferences.getValue(
-				FeatureFlagConstants.FEATURE_FLAG,
+				FeatureFlagConstants.PREFERENCE_NAMESPACE,
 				FeatureFlagConstants.PREFERENCE_KEY_DEPRECATION_PROCESSED));
 
 		if (processed) {
@@ -82,7 +82,7 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 		}
 
 		portalPreferences.setValue(
-			FeatureFlagConstants.FEATURE_FLAG,
+			FeatureFlagConstants.PREFERENCE_NAMESPACE,
 			FeatureFlagConstants.PREFERENCE_KEY_DEPRECATION_PROCESSED, "true");
 
 		_portalPreferencesLocalService.updatePreferences(

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/model/listener/CompanyModelListener.java
@@ -10,13 +10,21 @@ import com.liferay.feature.flag.web.internal.feature.flag.FeatureFlagsBagProvide
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlag;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagType;
+import com.liferay.portal.kernel.feature.flag.constants.FeatureFlagConstants;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.portlet.PortalPreferences;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portlet.PortalPreferencesWrapper;
 
 import java.util.List;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -31,27 +39,63 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 	public void onAfterCreate(Company company) throws ModelListenerException {
 		TransactionCommitCallbackUtil.registerCallback(
 			() -> {
-				FeatureFlagsBag featureFlagsBag =
-					_featureFlagsBagProvider.getOrCreateFeatureFlagsBag(
-						company.getCompanyId());
-
-				List<FeatureFlag> deprecationFeatureFlags =
-					featureFlagsBag.getFeatureFlags(
-						FeatureFlagType.DEPRECATION.getPredicate());
-
-				for (FeatureFlag deprecationFeatureFlag :
-						deprecationFeatureFlags) {
-
-					_featureFlagsBagProvider.setEnabled(
-						company.getCompanyId(), deprecationFeatureFlag.getKey(),
-						false);
-				}
+				_processDeprecationFeatureFlags(company.getCompanyId());
 
 				return null;
 			});
 	}
 
+	@Activate
+	protected void activate() {
+		_companyLocalService.forEachCompanyId(
+			this::_processDeprecationFeatureFlags);
+	}
+
+	private void _processDeprecationFeatureFlags(long companyId) {
+		PortalPreferencesWrapper portalPreferencesWrapper =
+			(PortalPreferencesWrapper)
+				_portalPreferencesLocalService.getPreferences(
+					companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY);
+
+		PortalPreferences portalPreferences =
+			portalPreferencesWrapper.getPortalPreferencesImpl();
+
+		boolean processed = GetterUtil.getBoolean(
+			portalPreferences.getValue(
+				FeatureFlagConstants.FEATURE_FLAG,
+				FeatureFlagConstants.PREFERENCE_KEY_DEPRECATION_PROCESSED));
+
+		if (processed) {
+			return;
+		}
+
+		FeatureFlagsBag featureFlagsBag =
+			_featureFlagsBagProvider.getOrCreateFeatureFlagsBag(companyId);
+
+		List<FeatureFlag> deprecationFeatureFlags =
+			featureFlagsBag.getFeatureFlags(
+				FeatureFlagType.DEPRECATION.getPredicate());
+
+		for (FeatureFlag deprecationFeatureFlag : deprecationFeatureFlags) {
+			_featureFlagsBagProvider.setEnabled(
+				companyId, deprecationFeatureFlag.getKey(), false);
+		}
+
+		portalPreferences.setValue(
+			FeatureFlagConstants.FEATURE_FLAG,
+			FeatureFlagConstants.PREFERENCE_KEY_DEPRECATION_PROCESSED, "true");
+
+		_portalPreferencesLocalService.updatePreferences(
+			companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY, portalPreferences);
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
 	@Reference
 	private FeatureFlagsBagProvider _featureFlagsBagProvider;
+
+	@Reference
+	private PortalPreferencesLocalService _portalPreferencesLocalService;
 
 }

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/upgrade/registry/FeatureFlagUpgradeStepRegistrator.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/upgrade/registry/FeatureFlagUpgradeStepRegistrator.java
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.feature.flag.web.internal.upgrade.registry;
+
+import com.liferay.feature.flag.web.internal.upgrade.v1_0_0.FeatureFlagUpgradeProcess;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Thiago Buarque
+ */
+@Component(service = UpgradeStepRegistrator.class)
+public class FeatureFlagUpgradeStepRegistrator
+	implements UpgradeStepRegistrator {
+
+	@Override
+	public void register(Registry registry) {
+		registry.registerInitialization();
+
+		registry.register(
+			"0.0.1", "1.0.0",
+			new FeatureFlagUpgradeProcess(
+				_companyLocalService, _portalPreferencesLocalService));
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private PortalPreferencesLocalService _portalPreferencesLocalService;
+
+}

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_0/FeatureFlagUpgradeProcess.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_0/FeatureFlagUpgradeProcess.java
@@ -68,7 +68,7 @@ public class FeatureFlagUpgradeProcess extends UpgradeProcess {
 	}
 
 	private static final String _OLD_NAMESPACE =
-		FeatureFlagConstants.FEATURE_FLAG;
+		FeatureFlagConstants.PORTAL_PROPERTY_KEY_FEATURE_FLAG;
 
 	private final CompanyLocalService _companyLocalService;
 	private final PortalPreferencesLocalService _portalPreferencesLocalService;

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_0/FeatureFlagUpgradeProcess.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_0/FeatureFlagUpgradeProcess.java
@@ -6,12 +6,14 @@
 package com.liferay.feature.flag.web.internal.upgrade.v1_0_0;
 
 import com.liferay.portal.kernel.feature.flag.constants.FeatureFlagConstants;
-import com.liferay.portal.kernel.portlet.PortalPreferences;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portlet.PortalPreferencesImpl;
 import com.liferay.portlet.PortalPreferencesWrapper;
+
+import java.util.Enumeration;
 
 /**
  * @author Thiago Buarque
@@ -35,19 +37,38 @@ public class FeatureFlagUpgradeProcess extends UpgradeProcess {
 						_portalPreferencesLocalService.getPreferences(
 							companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY);
 
-				PortalPreferences portalPreferences =
+				PortalPreferencesImpl portalPreferencesImpl =
 					portalPreferencesWrapper.getPortalPreferencesImpl();
 
-				portalPreferences.setValue(
-					FeatureFlagConstants.FEATURE_FLAG,
+				Enumeration<String> enumeration =
+					portalPreferencesImpl.getNames(_OLD_NAMESPACE);
+
+				while (enumeration.hasMoreElements()) {
+					String featureFlag = enumeration.nextElement();
+
+					String value = portalPreferencesImpl.getValue(
+						_OLD_NAMESPACE, featureFlag);
+
+					portalPreferencesImpl.reset(_OLD_NAMESPACE, featureFlag);
+
+					portalPreferencesImpl.setValue(
+						FeatureFlagConstants.PREFERENCE_NAMESPACE, featureFlag,
+						value);
+				}
+
+				portalPreferencesImpl.setValue(
+					FeatureFlagConstants.PREFERENCE_NAMESPACE,
 					FeatureFlagConstants.PREFERENCE_KEY_DEPRECATION_PROCESSED,
 					"true");
 
 				_portalPreferencesLocalService.updatePreferences(
 					companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY,
-					portalPreferences);
+					portalPreferencesImpl);
 			});
 	}
+
+	private static final String _OLD_NAMESPACE =
+		FeatureFlagConstants.FEATURE_FLAG;
 
 	private final CompanyLocalService _companyLocalService;
 	private final PortalPreferencesLocalService _portalPreferencesLocalService;

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_0/FeatureFlagUpgradeProcess.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_0/FeatureFlagUpgradeProcess.java
@@ -1,0 +1,55 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.feature.flag.web.internal.upgrade.v1_0_0;
+
+import com.liferay.portal.kernel.feature.flag.constants.FeatureFlagConstants;
+import com.liferay.portal.kernel.portlet.PortalPreferences;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portlet.PortalPreferencesWrapper;
+
+/**
+ * @author Thiago Buarque
+ */
+public class FeatureFlagUpgradeProcess extends UpgradeProcess {
+
+	public FeatureFlagUpgradeProcess(
+		CompanyLocalService companyLocalService,
+		PortalPreferencesLocalService portalPreferencesLocalService) {
+
+		_companyLocalService = companyLocalService;
+		_portalPreferencesLocalService = portalPreferencesLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() {
+		_companyLocalService.forEachCompanyId(
+			companyId -> {
+				PortalPreferencesWrapper portalPreferencesWrapper =
+					(PortalPreferencesWrapper)
+						_portalPreferencesLocalService.getPreferences(
+							companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY);
+
+				PortalPreferences portalPreferences =
+					portalPreferencesWrapper.getPortalPreferencesImpl();
+
+				portalPreferences.setValue(
+					FeatureFlagConstants.FEATURE_FLAG,
+					FeatureFlagConstants.PREFERENCE_KEY_DEPRECATION_PROCESSED,
+					"true");
+
+				_portalPreferencesLocalService.updatePreferences(
+					companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY,
+					portalPreferences);
+			});
+	}
+
+	private final CompanyLocalService _companyLocalService;
+	private final PortalPreferencesLocalService _portalPreferencesLocalService;
+
+}

--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/v1_4_4/LayoutPrivateLayoutsUpgradeProcess.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/v1_4_4/LayoutPrivateLayoutsUpgradeProcess.java
@@ -61,8 +61,8 @@ public class LayoutPrivateLayoutsUpgradeProcess extends UpgradeProcess {
 							portalPreferencesWrapper.getPortalPreferencesImpl();
 
 						portalPreferences.setValue(
-							FeatureFlagConstants.FEATURE_FLAG, "LPD-38869",
-							value);
+							FeatureFlagConstants.PREFERENCE_NAMESPACE,
+							"LPD-38869", value);
 
 						_portalPreferencesLocalService.updatePreferences(
 							companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY,

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/internal/upgrade/v1_4_4/test/LayoutPrivateLayoutsUpgradeProcessTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/internal/upgrade/v1_4_4/test/LayoutPrivateLayoutsUpgradeProcessTest.java
@@ -92,7 +92,7 @@ public class LayoutPrivateLayoutsUpgradeProcessTest {
 		Assert.assertEquals(
 			value,
 			portalPreferences.getValue(
-				FeatureFlagConstants.FEATURE_FLAG, "LPD-38869", null));
+				FeatureFlagConstants.PREFERENCE_NAMESPACE, "LPD-38869", null));
 	}
 
 	private void _runUpgrade() throws Exception {
@@ -118,12 +118,12 @@ public class LayoutPrivateLayoutsUpgradeProcessTest {
 			portalPreferencesWrapper.getPortalPreferencesImpl();
 
 		String previousValue = portalPreferences.getValue(
-			FeatureFlagConstants.FEATURE_FLAG, "LPD-38869", null);
+			FeatureFlagConstants.PREFERENCE_NAMESPACE, "LPD-38869", null);
 
 		portalPreferences = portalPreferencesWrapper.getPortalPreferencesImpl();
 
 		portalPreferences.setValue(
-			FeatureFlagConstants.FEATURE_FLAG, "LPD-38869", value);
+			FeatureFlagConstants.PREFERENCE_NAMESPACE, "LPD-38869", value);
 
 		_portalPreferencesLocalService.updatePreferences(
 			TestPropsValues.getCompanyId(),

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -515,6 +515,11 @@ public class PortalUpgradeProcessRegistryImpl
 				}
 
 			});
+
+		upgradeVersionTreeMap.put(
+			new Version(31, 12, 1),
+			UpgradeModulesFactory.create(
+				new String[] {"com.liferay.feature.flag.web"}, null));
 	}
 
 }

--- a/portal-impl/test/unit/com/liferay/portal/test/rule/FeatureFlagTestRuleTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/test/rule/FeatureFlagTestRuleTest.java
@@ -33,7 +33,9 @@ public class FeatureFlagTestRuleTest {
 	public static void setUpClass() throws PortalException {
 		PropsUtil.addProperties(
 			UnicodePropertiesBuilder.setProperty(
-				FeatureFlagConstants.FEATURE_FLAG + ".METHOD-456", "true"
+				FeatureFlagConstants.PORTAL_PROPERTY_KEY_FEATURE_FLAG +
+					".METHOD-456",
+				"true"
 			).build());
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/feature/flag/constants/FeatureFlagConstants.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/feature/flag/constants/FeatureFlagConstants.java
@@ -16,7 +16,8 @@ import com.liferay.portal.kernel.util.ArrayUtil;
  */
 public class FeatureFlagConstants {
 
-	public static final String FEATURE_FLAG = "feature.flag";
+	public static final String PORTAL_PROPERTY_KEY_FEATURE_FLAG =
+		"feature.flag";
 
 	public static final String PREFERENCE_KEY_DEPRECATION_PROCESSED =
 		"deprecationProcessed";
@@ -26,11 +27,11 @@ public class FeatureFlagConstants {
 
 	public static String getKey(String... parts) {
 		if (ArrayUtil.isEmpty(parts)) {
-			return FEATURE_FLAG;
+			return PORTAL_PROPERTY_KEY_FEATURE_FLAG;
 		}
 
 		return StringBundler.concat(
-			FEATURE_FLAG, StringPool.PERIOD,
+			PORTAL_PROPERTY_KEY_FEATURE_FLAG, StringPool.PERIOD,
 			StringUtil.merge(parts, StringPool.PERIOD));
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/feature/flag/constants/FeatureFlagConstants.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/feature/flag/constants/FeatureFlagConstants.java
@@ -8,6 +8,7 @@ package com.liferay.portal.kernel.feature.flag.constants;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
+import com.liferay.portal.kernel.feature.flag.FeatureFlag;
 import com.liferay.portal.kernel.util.ArrayUtil;
 
 /**
@@ -19,6 +20,9 @@ public class FeatureFlagConstants {
 
 	public static final String PREFERENCE_KEY_DEPRECATION_PROCESSED =
 		"deprecationProcessed";
+
+	public static final String PREFERENCE_NAMESPACE =
+		FeatureFlag.class.getName();
 
 	public static String getKey(String... parts) {
 		if (ArrayUtil.isEmpty(parts)) {

--- a/portal-kernel/src/com/liferay/portal/kernel/feature/flag/constants/FeatureFlagConstants.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/feature/flag/constants/FeatureFlagConstants.java
@@ -17,6 +17,9 @@ public class FeatureFlagConstants {
 
 	public static final String FEATURE_FLAG = "feature.flag";
 
+	public static final String PREFERENCE_KEY_DEPRECATION_PROCESSED =
+		"deprecationProcessed";
+
 	public static String getKey(String... parts) {
 		if (ArrayUtil.isEmpty(parts)) {
 			return FEATURE_FLAG;

--- a/portal-kernel/src/com/liferay/portal/kernel/feature/flag/constants/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/feature/flag/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/feature/flag/constants/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/feature/flag/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 2.0.0


### PR DESCRIPTION
SF for https://github.com/brianchandotcom/liferay-portal/pull/156365

--

https://liferay.atlassian.net/browse/LPD-40974

Fixing release blocker introduced in https://github.com/brianchandotcom/liferay-portal/commit/4fb37b76791574f475fb2c54ddf43877936fd73d. Since the component starts after portal is UP, the default company addition wouldn't trigger the CompanyModelListener

Related [slack thread](https://liferay.slack.com/archives/C049XG98GQL/p1730305021159829)