### PR TITLE
LPD-42409 Set a backURL for the notification link

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-test/src/testIntegration/java/com/liferay/portal/workflow/task/web/internal/notification/test/WorkflowTaskUserNotificationHandlerTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-test/src/testIntegration/java/com/liferay/portal/workflow/task/web/internal/notification/test/WorkflowTaskUserNotificationHandlerTest.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -130,6 +131,8 @@ public class WorkflowTaskUserNotificationHandlerTest {
 					expectedPlid, PortletRequest.RENDER_PHASE)
 			).setMVCPath(
 				"/edit_workflow_task.jsp"
+			).setBackURL(
+				_CURRENT_URL
 			).setParameter(
 				"workflowTaskId",
 				() -> {
@@ -155,6 +158,7 @@ public class WorkflowTaskUserNotificationHandlerTest {
 		themeDisplay.setPermissionChecker(
 			PermissionThreadLocal.getPermissionChecker());
 		themeDisplay.setSiteGroupId(group.getGroupId());
+		themeDisplay.setURLCurrent(_CURRENT_URL);
 		themeDisplay.setUser(TestPropsValues.getUser());
 
 		return themeDisplay;
@@ -196,6 +200,8 @@ public class WorkflowTaskUserNotificationHandlerTest {
 		return _userNotificationHandler.interpret(
 			userNotificationEvent, serviceContext);
 	}
+
+	private static final String _CURRENT_URL = RandomTestUtil.randomString();
 
 	@Inject
 	private BlogsEntryLocalService _blogsEntryLocalService;

--- a/portal-kernel/src/com/liferay/portal/kernel/workflow/BaseWorkflowHandler.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/workflow/BaseWorkflowHandler.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalServiceUtil;
@@ -106,16 +107,19 @@ public abstract class BaseWorkflowHandler<T> implements WorkflowHandler<T> {
 					themeDisplay.getPlid());
 			}
 
-			PortletURL portletURL = PortletURLFactoryUtil.create(
-				serviceContext.getRequest(), PortletKeys.MY_WORKFLOW_TASK,
-				layout.getPlid(), PortletRequest.RENDER_PHASE);
-
-			portletURL.setParameter("mvcPath", "/edit_workflow_task.jsp");
-			portletURL.setParameter(
-				"workflowTaskId", String.valueOf(workflowTaskId));
-			portletURL.setWindowState(WindowState.MAXIMIZED);
-
-			return portletURL.toString();
+			return PortletURLBuilder.create(
+				PortletURLFactoryUtil.create(
+					serviceContext.getRequest(), PortletKeys.MY_WORKFLOW_TASK,
+					layout.getPlid(), PortletRequest.RENDER_PHASE)
+			).setMVCPath(
+				"/edit_workflow_task.jsp"
+			).setBackURL(
+				themeDisplay.getURLCurrent()
+			).setParameter(
+				"workflowTaskId", String.valueOf(workflowTaskId)
+			).setWindowState(
+				WindowState.MAXIMIZED
+			).buildString();
 		}
 		catch (Exception exception) {
 			if (_log.isWarnEnabled()) {


### PR DESCRIPTION
Related [Ticket](https://liferay.atlassian.net/browse/LPD-42409)

This PR introduces a backURL parameter to workflow task links displayed on the notifications screen. This will allow users to return to the previous screen after completing a task.