### PR TITLE
LPD-40974 follow up

### DIFF
--- a/modules/apps/feature-flag/feature-flag-test/src/testIntegration/java/com/liferay/feature/flag/test/CompanyModelListenerTest.java
+++ b/modules/apps/feature-flag/feature-flag-test/src/testIntegration/java/com/liferay/feature/flag/test/CompanyModelListenerTest.java
@@ -9,11 +9,16 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.kernel.feature.flag.FeatureFlag;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManager;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagType;
+import com.liferay.portal.kernel.feature.flag.constants.FeatureFlagConstants;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.portlet.PortalPreferences;
+import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portlet.PortalPreferencesWrapper;
 
 import java.util.List;
 
@@ -38,17 +43,34 @@ public class CompanyModelListenerTest {
 	public void testOnAfterCreate() throws Exception {
 		Company company = CompanyTestUtil.addCompany();
 
+		PortalPreferencesWrapper portalPreferencesWrapper =
+			(PortalPreferencesWrapper)
+				_portalPreferencesLocalService.getPreferences(
+					company.getCompanyId(),
+					PortletKeys.PREFS_OWNER_TYPE_COMPANY);
+
+		PortalPreferences portalPreferences =
+			portalPreferencesWrapper.getPortalPreferencesImpl();
+
 		List<FeatureFlag> deprecationFeatureFlags =
 			_featureFlagManager.getFeatureFlags(
 				company.getCompanyId(),
 				FeatureFlagType.DEPRECATION.getPredicate());
 
 		for (FeatureFlag deprecationFeatureFlag : deprecationFeatureFlags) {
+			Assert.assertEquals(
+				"false",
+				portalPreferences.getValue(
+					FeatureFlagConstants.PREFERENCE_NAMESPACE,
+					deprecationFeatureFlag.getKey()));
 			Assert.assertFalse(deprecationFeatureFlag.isEnabled());
 		}
 	}
 
 	@Inject
 	private FeatureFlagManager _featureFlagManager;
+
+	@Inject
+	private PortalPreferencesLocalService _portalPreferencesLocalService;
 
 }

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/model/listener/CompanyModelListener.java
@@ -51,14 +51,17 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 			this::_processDeprecationFeatureFlags);
 	}
 
-	private void _processDeprecationFeatureFlags(long companyId) {
+	private PortalPreferences _getPortalPreferences(long companyId) {
 		PortalPreferencesWrapper portalPreferencesWrapper =
 			(PortalPreferencesWrapper)
 				_portalPreferencesLocalService.getPreferences(
 					companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY);
 
-		PortalPreferences portalPreferences =
-			portalPreferencesWrapper.getPortalPreferencesImpl();
+		return portalPreferencesWrapper.getPortalPreferencesImpl();
+	}
+
+	private void _processDeprecationFeatureFlags(long companyId) {
+		PortalPreferences portalPreferences = _getPortalPreferences(companyId);
 
 		boolean processed = GetterUtil.getBoolean(
 			portalPreferences.getValue(
@@ -80,6 +83,8 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 			_featureFlagsBagProvider.setEnabled(
 				companyId, deprecationFeatureFlag.getKey(), false);
 		}
+
+		portalPreferences = _getPortalPreferences(companyId);
 
 		portalPreferences.setValue(
 			FeatureFlagConstants.PREFERENCE_NAMESPACE,


### PR DESCRIPTION
[Approved by BPM as well](https://github.com/liferay-bpm/liferay-portal/pull/3922). Sending directly here because CI is having issues lately ([slack thread](https://liferay.slack.com/archives/C19PWQ74J/p1733224766797639))

--

https://liferay.atlassian.net/browse/LPD-40974
https://liferay.atlassian.net/browse/LPD-43078

There was a bug in the fix I sent here https://github.com/liferay-platform-experience/liferay-portal/pull/781

I was using the outdated preferences to update the database. `_featureFlagsBagProvider.setEnabled` updates the flags portal preferences, but the reference got in the beginning of the method is outdated. Getting the updated preferences after setting the flags to false.