### PR TITLE
LRCI-5052 Temporarily ignore osb-faro in modules-compile batch

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -653,6 +653,7 @@
 ##
 
     modules.excludes[modules-compile]=\
+        dxp/apps/osb/osb-faro,\
         third-party/**
 
     #modules.excludes[modules-semantic-versioning]=

--- a/test.properties
+++ b/test.properties
@@ -654,6 +654,7 @@
 
     modules.excludes[modules-compile]=\
         dxp/apps/osb/osb-faro,\
+        dxp/apps/osb/osb-faro/**,\
         third-party/**
 
     #modules.excludes[modules-semantic-versioning]=


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-5052

Some of the frontend changes recently have resulted in some CI only issues related to Yarn/npm. We're still investigating the bigger issue and updating on this slack thread. https://liferay.slack.com/archives/C19PWQ74J/p1733224766797639 

One of the things we did was reset all the yarn/npm caches (local caches, private registry, and yarn packages in the binaries cache repo). The cache reset likely exposed a misconfiguration of the osb-faro-theme's npm module dependencies. It should be using the binaries cache dependencies, but was hitting the private registry across CI, resulting in a modules-compile failure in the stable job. To fix stable, we're temporarily removing osb-faro just from the modules-compile job. 

cc: @pyoo47, @marcellustavares