### PR TITLE
LPD-40979 - Pass in itemIdKey and remove the key from Row to fix expa…

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/ClayTable.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/ClayTable.tsx
@@ -61,6 +61,7 @@ type Props = {
 	itemInlineChanges?: Array<any>;
 	items: Array<any>;
 	itemsActions: Array<IItemsActions>;
+	nestedItemsKey?: string;
 	nestedItemsReferenceKey?: string;
 	selectItems: Function;
 	selectable?: boolean;
@@ -88,6 +89,7 @@ export function ClayTable({
 	itemInlineChanges,
 	items,
 	itemsActions,
+	nestedItemsKey = 'id',
 	nestedItemsReferenceKey,
 	selectItems,
 	selectable,
@@ -140,6 +142,7 @@ export function ClayTable({
 			alwaysVisibleColumns={
 				selectable ? defaultAlwaysVisibleColumns : undefined
 			}
+			itemIdKey={nestedItemsKey}
 			messages={{
 				columnsVisibility: Liferay.Language.get(
 					'manage-columns-visibility'
@@ -254,7 +257,6 @@ export function ClayTable({
 									? [{fieldName: 'select'}, ...items]
 									: items
 							}
-							key={id}
 						>
 							{(cell) => {
 								const cellColumnName = getCellColumnClassName(

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
@@ -440,6 +440,7 @@ const Table = ({
 					itemInlineChanges={itemsChanges}
 					items={items}
 					itemsActions={itemsActions}
+					nestedItemsKey={nestedItemsKey}
 					nestedItemsReferenceKey={nestedItemsReferenceKey}
 					selectItems={selectItems}
 					selectable={selectable}


### PR DESCRIPTION
Manually forwarding from https://github.com/liferay-frontend/liferay-portal/pull/4597 due to CI errors.

_Original Message_

https://liferay.atlassian.net/browse/LPD-40979

## Steps to Reproduce:
1. Enable the Feature Flag LPS-193005
2. Create a new site using the Minium template in order to propagate commerce products.
3. Follow the steps here to create a Commerce Product Bundle.
4. Add the product bundle to your cart and check out.
5. Navigate to Pending Orders.
6. Select the created order.
7. Scroll down to view the products contained in the order and try to expand the Product Bundle.

## How it was fixed
The Clay Table api was updated to allow for entries to have unique keys identified by properties other than `id`. For instance Commerce uses `orderItemId`. This key can be passed into the Clay Table via the `itemIdKey` prop. When this prop is used with nested rows we have to remove the `key` prop from the `Row` since this overrides the key provided via `itemIdKey`.
