### PR TITLE
LPD-42915 - The 'Get definition page' endpoint fails when a related object uses the Status system field as entry title

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -830,7 +830,7 @@ public class ObjectFieldLocalServiceImpl
 
 		objectField.setExternalReferenceCode(externalReferenceCode);
 
-		_setBusinessTypeAndDBType(businessType, dbType, objectField);
+		_setBusinessTypeAndDBType(businessType, dbType, objectField, name);
 
 		User user = _userLocalService.getUser(userId);
 
@@ -1272,7 +1272,8 @@ public class ObjectFieldLocalServiceImpl
 	}
 
 	private void _setBusinessTypeAndDBType(
-			String businessType, String dbType, ObjectField objectField)
+			String businessType, String dbType, ObjectField objectField,
+			String name)
 		throws PortalException {
 
 		ObjectFieldBusinessType objectFieldBusinessType =
@@ -1284,7 +1285,13 @@ public class ObjectFieldLocalServiceImpl
 
 		if (objectFieldBusinessType != null) {
 			objectField.setBusinessType(businessType);
-			objectField.setDBType(objectFieldBusinessType.getDBType());
+
+			if (ObjectFieldUtil.isMetadata(name)) {
+				objectField.setDBType(dbType);
+			}
+			else {
+				objectField.setDBType(objectFieldBusinessType.getDBType());
+			}
 		}
 		else if (objectFieldDBTypes.contains(dbType) &&
 				 _businessTypes.containsKey(dbType)) {
@@ -1396,7 +1403,7 @@ public class ObjectFieldLocalServiceImpl
 			return newObjectField;
 		}
 
-		_setBusinessTypeAndDBType(businessType, dbType, newObjectField);
+		_setBusinessTypeAndDBType(businessType, dbType, newObjectField, name);
 
 		newObjectField.setListTypeDefinitionId(listTypeDefinitionId);
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
@@ -1063,8 +1063,9 @@ public class ObjectFieldLocalServiceTest {
 
 		ObjectField systemObjectField = _addOrUpdateSystemObjectField(
 			null, modifiableSystemObjectDefinition.getObjectDefinitionId(),
-			null, null, false, false, LocalizedMapUtil.getLocalizedMap("Able"),
-			false, "able", false);
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT, null, null,
+			ObjectFieldConstants.DB_TYPE_STRING, false, false,
+			LocalizedMapUtil.getLocalizedMap("Able"), false, "able", false);
 
 		_assertSystemObjectField(
 			"able_", false, false, LocalizedMapUtil.getLocalizedMap("Able"),
@@ -1075,14 +1076,18 @@ public class ObjectFieldLocalServiceTest {
 			_addOrUpdateSystemObjectField(
 				systemObjectField.getExternalReferenceCode(),
 				modifiableSystemObjectDefinition.getObjectDefinitionId(),
+				ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				true, true, LocalizedMapUtil.getLocalizedMap("Baker"), false,
-				"able", true));
+				ObjectFieldConstants.DB_TYPE_STRING, true, true,
+				LocalizedMapUtil.getLocalizedMap("Baker"), false, "able",
+				true));
 
 		ObjectField localizedSystemObjectField = _addOrUpdateSystemObjectField(
 			null, modifiableSystemObjectDefinition.getObjectDefinitionId(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,
-			false, LocalizedMapUtil.getLocalizedMap("Charlie"), true, "charlie",
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			ObjectFieldConstants.DB_TYPE_STRING, false, false,
+			LocalizedMapUtil.getLocalizedMap("Charlie"), true, "charlie",
 			false);
 
 		Assert.assertTrue(localizedSystemObjectField.isLocalized());
@@ -1104,8 +1109,8 @@ public class ObjectFieldLocalServiceTest {
 				_addOrUpdateSystemObjectField(
 					systemObjectField.getExternalReferenceCode(),
 					modifiableSystemObjectDefinition.getObjectDefinitionId(),
-					RandomTestUtil.randomString(),
-					RandomTestUtil.randomString(), false, false,
+					null, RandomTestUtil.randomString(),
+					RandomTestUtil.randomString(), null, false, false,
 					LocalizedMapUtil.getLocalizedMap("Dog"), false, "able",
 					false));
 		}
@@ -1986,6 +1991,29 @@ public class ObjectFieldLocalServiceTest {
 	}
 
 	@Test
+	public void testStatusFieldDBType() throws Exception {
+		ObjectDefinition modifiableSystemObjectDefinition =
+			ObjectDefinitionTestUtil.addModifiableSystemObjectDefinition(
+				TestPropsValues.getUserId(), null, true,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				"Test" + RandomTestUtil.randomString(), null, null,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				ObjectDefinitionConstants.SCOPE_SITE, null, 1,
+				Collections.emptyList());
+
+		ObjectField systemObjectField = _addOrUpdateSystemObjectField(
+			null, modifiableSystemObjectDefinition.getObjectDefinitionId(),
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT, null, null,
+			ObjectFieldConstants.DB_TYPE_INTEGER, false, false,
+			LocalizedMapUtil.getLocalizedMap("Status"), false, "status", false);
+
+		Assert.assertTrue(
+			Objects.equals(
+				ObjectFieldConstants.DB_TYPE_INTEGER,
+				systemObjectField.getDBType()));
+	}
+
+	@Test
 	public void testUpdateRequired() throws Exception {
 
 		// Deletion type cascade
@@ -2203,16 +2231,16 @@ public class ObjectFieldLocalServiceTest {
 
 	private ObjectField _addOrUpdateSystemObjectField(
 			String externalReferenceCode, long objectDefinitionId,
-			String dbColumnName, String dbTableName, boolean indexed,
-			boolean indexedAsKeyword, Map<Locale, String> labelMap,
-			boolean localized, String name, boolean required)
+			String fieldBusinessType, String dbColumnName, String dbTableName,
+			String dbType, boolean indexed, boolean indexedAsKeyword,
+			Map<Locale, String> labelMap, boolean localized, String name,
+			boolean required)
 		throws Exception {
 
 		return _objectFieldLocalService.addOrUpdateSystemObjectField(
 			externalReferenceCode, TestPropsValues.getUserId(), 0L,
-			objectDefinitionId, ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-			dbColumnName, dbTableName, ObjectFieldConstants.DB_TYPE_STRING,
-			indexed, indexedAsKeyword, "", labelMap, localized, name,
+			objectDefinitionId, fieldBusinessType, dbColumnName, dbTableName,
+			dbType, indexed, indexedAsKeyword, "", labelMap, localized, name,
 			ObjectFieldConstants.READ_ONLY_FALSE, null, required, false,
 			Collections.emptyList());
 	}


### PR DESCRIPTION
We are ensuring that meta fields that have some specificities are receiving the right data type.wq
