### PR TITLE
LPD-43400 Remove ServiceTracker usage to improve startup time

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/display/context/FDSAdminDisplayContext.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/display/context/FDSAdminDisplayContext.java
@@ -36,7 +36,7 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.RenderRequest;
@@ -214,35 +214,41 @@ public class FDSAdminDisplayContext {
 	}
 
 	public JSONArray getSystemFDSEntryJSONArray() throws Exception {
-		Map<String, SystemFDSEntry> systemFDSEntries =
-			_systemFDSEntryRegistry.getSystemFDSEntries();
+		Set<String> systemFDSNames =
+			_systemFDSEntryRegistry.getSystemFDSNames();
 
-		if (systemFDSEntries == null) {
+		if (systemFDSNames == null) {
 			return JSONFactoryUtil.createJSONArray();
 		}
 
 		return JSONUtil.toJSONArray(
-			systemFDSEntries.values(),
-			systemFDSEntry -> JSONUtil.put(
-				"additionalAPIURLParameters",
-				systemFDSEntry.getAdditionalAPIURLParameters()
-			).put(
-				"defaultItemsPerPage", systemFDSEntry.getDefaultItemsPerPage()
-			).put(
-				"description", systemFDSEntry.getDescription()
-			).put(
-				"name", systemFDSEntry.getName()
-			).put(
-				"restApplication", systemFDSEntry.getRESTApplication()
-			).put(
-				"restEndpoint", systemFDSEntry.getRESTEndpoint()
-			).put(
-				"restSchema", systemFDSEntry.getRESTSchema()
-			).put(
-				"symbol", systemFDSEntry.getSymbol()
-			).put(
-				"title", systemFDSEntry.getTitle()
-			));
+			systemFDSNames,
+			systemFDSName -> {
+				SystemFDSEntry systemFDSEntry =
+					_systemFDSEntryRegistry.getSystemFDSEntry(systemFDSName);
+
+				return JSONUtil.put(
+					"additionalAPIURLParameters",
+					systemFDSEntry.getAdditionalAPIURLParameters()
+				).put(
+					"defaultItemsPerPage",
+					systemFDSEntry.getDefaultItemsPerPage()
+				).put(
+					"description", systemFDSEntry.getDescription()
+				).put(
+					"name", systemFDSEntry.getName()
+				).put(
+					"restApplication", systemFDSEntry.getRESTApplication()
+				).put(
+					"restEndpoint", systemFDSEntry.getRESTEndpoint()
+				).put(
+					"restSchema", systemFDSEntry.getRESTSchema()
+				).put(
+					"symbol", systemFDSEntry.getSymbol()
+				).put(
+					"title", systemFDSEntry.getTitle()
+				);
+			});
 	}
 
 	public boolean hasAddDataSetObjectEntryPermission() {

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/SystemFDSEntryRegistry.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/SystemFDSEntryRegistry.java
@@ -5,15 +5,15 @@
 
 package com.liferay.frontend.data.set;
 
-import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Daniel Sanz
  */
 public interface SystemFDSEntryRegistry {
 
-	public Map<String, SystemFDSEntry> getSystemFDSEntries();
-
 	public SystemFDSEntry getSystemFDSEntry(String fdsName);
+
+	public Set<String> getSystemFDSNames();
 
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/SystemFDSEntryRegistryImpl.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/SystemFDSEntryRegistryImpl.java
@@ -9,13 +9,9 @@ import com.liferay.frontend.data.set.SystemFDSEntry;
 import com.liferay.frontend.data.set.SystemFDSEntryRegistry;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
-import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapListener;
-import com.liferay.petra.string.StringPool;
 
 import java.util.Collections;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
+import java.util.Set;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
@@ -29,19 +25,13 @@ import org.osgi.service.component.annotations.Deactivate;
 public class SystemFDSEntryRegistryImpl implements SystemFDSEntryRegistry {
 
 	@Override
-	public Map<String, SystemFDSEntry> getSystemFDSEntries() {
-		if (!_opened) {
-			getSystemFDSEntry(StringPool.BLANK);
-
-			_opened = true;
-		}
-
-		return Collections.unmodifiableMap(_systemFDSEntries);
+	public SystemFDSEntry getSystemFDSEntry(String fdsName) {
+		return _serviceTrackerMap.getService(fdsName);
 	}
 
 	@Override
-	public SystemFDSEntry getSystemFDSEntry(String fdsName) {
-		return _serviceTrackerMap.getService(fdsName);
+	public Set<String> getSystemFDSNames() {
+		return Collections.unmodifiableSet(_serviceTrackerMap.keySet());
 	}
 
 	@Activate
@@ -49,44 +39,15 @@ public class SystemFDSEntryRegistryImpl implements SystemFDSEntryRegistry {
 		_bundleContext = bundleContext;
 
 		_serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
-			bundleContext, SystemFDSEntry.class, "frontend.data.set.name",
-			new ServiceTrackerMapListener
-				<String, SystemFDSEntry, SystemFDSEntry>() {
-
-				@Override
-				public void keyEmitted(
-					ServiceTrackerMap<String, SystemFDSEntry> serviceTrackerMap,
-					String key, SystemFDSEntry service,
-					SystemFDSEntry content) {
-
-					_systemFDSEntries.put(key, service);
-				}
-
-				@Override
-				public void keyRemoved(
-					ServiceTrackerMap<String, SystemFDSEntry> serviceTrackerMap,
-					String key, SystemFDSEntry service,
-					SystemFDSEntry content) {
-
-					_systemFDSEntries.remove(key);
-				}
-
-			});
+			bundleContext, SystemFDSEntry.class, "frontend.data.set.name");
 	}
 
 	@Deactivate
 	protected void deactivate() {
 		_serviceTrackerMap.close();
-
-		_opened = false;
-
-		_systemFDSEntries.clear();
 	}
 
 	private BundleContext _bundleContext;
-	private boolean _opened;
 	private ServiceTrackerMap<String, SystemFDSEntry> _serviceTrackerMap;
-	private final ConcurrentMap<String, SystemFDSEntry> _systemFDSEntries =
-		new ConcurrentHashMap<>();
 
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/SystemFDSEntryRegistryImpl.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/SystemFDSEntryRegistryImpl.java
@@ -7,24 +7,20 @@ package com.liferay.frontend.data.set.internal;
 
 import com.liferay.frontend.data.set.SystemFDSEntry;
 import com.liferay.frontend.data.set.SystemFDSEntryRegistry;
-import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerCustomizerFactory;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapListener;
+import com.liferay.petra.string.StringPool;
 
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.util.tracker.ServiceTracker;
-import org.osgi.util.tracker.ServiceTrackerCustomizer;
 
 /**
  * @author Daniel Sanz
@@ -34,125 +30,63 @@ public class SystemFDSEntryRegistryImpl implements SystemFDSEntryRegistry {
 
 	@Override
 	public Map<String, SystemFDSEntry> getSystemFDSEntries() {
-		return _systemFDSEntries.get();
+		if (!_opened) {
+			getSystemFDSEntry(StringPool.BLANK);
+
+			_opened = true;
+		}
+
+		return Collections.unmodifiableMap(_systemFDSEntries);
 	}
 
 	@Override
 	public SystemFDSEntry getSystemFDSEntry(String fdsName) {
-		ServiceTrackerCustomizerFactory.ServiceWrapper<SystemFDSEntry>
-			serviceWrapper = _serviceTrackerMap.getService(fdsName);
-
-		if (serviceWrapper == null) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(
-					"No frontend data set system entry is associated with " +
-						fdsName);
-			}
-
-			return null;
-		}
-
-		return serviceWrapper.getService();
+		return _serviceTrackerMap.getService(fdsName);
 	}
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		_bundleContext = bundleContext;
 
-		_serviceTracker = new ServiceTracker<>(
-			_bundleContext, SystemFDSEntry.class,
-			new DataSetServiceTrackerCustomizer());
-
-		_serviceTracker.open();
-
 		_serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
 			bundleContext, SystemFDSEntry.class, "frontend.data.set.name",
-			ServiceTrackerCustomizerFactory.<SystemFDSEntry>serviceWrapper(
-				bundleContext));
+			new ServiceTrackerMapListener
+				<String, SystemFDSEntry, SystemFDSEntry>() {
+
+				@Override
+				public void keyEmitted(
+					ServiceTrackerMap<String, SystemFDSEntry> serviceTrackerMap,
+					String key, SystemFDSEntry service,
+					SystemFDSEntry content) {
+
+					_systemFDSEntries.put(key, service);
+				}
+
+				@Override
+				public void keyRemoved(
+					ServiceTrackerMap<String, SystemFDSEntry> serviceTrackerMap,
+					String key, SystemFDSEntry service,
+					SystemFDSEntry content) {
+
+					_systemFDSEntries.remove(key);
+				}
+
+			});
 	}
 
 	@Deactivate
 	protected void deactivate() {
-		_serviceTracker.close();
-
 		_serviceTrackerMap.close();
-	}
 
-	private static final Log _log = LogFactoryUtil.getLog(
-		SystemFDSEntryRegistryImpl.class);
+		_opened = false;
+
+		_systemFDSEntries.clear();
+	}
 
 	private BundleContext _bundleContext;
-	private ServiceTracker<SystemFDSEntry, SystemFDSEntry> _serviceTracker;
-	private ServiceTrackerMap
-		<String, ServiceTrackerCustomizerFactory.ServiceWrapper<SystemFDSEntry>>
-			_serviceTrackerMap;
-	private final AtomicReference<Map<String, SystemFDSEntry>>
-		_systemFDSEntries = new AtomicReference<>();
-
-	private class DataSetServiceTrackerCustomizer
-		implements ServiceTrackerCustomizer<SystemFDSEntry, SystemFDSEntry> {
-
-		@Override
-		public SystemFDSEntry addingService(
-			ServiceReference<SystemFDSEntry> serviceReference) {
-
-			SystemFDSEntry systemFDSEntry = _bundleContext.getService(
-				serviceReference);
-
-			String fdsName = GetterUtil.getString(
-				serviceReference.getProperty("frontend.data.set.name"));
-
-			_systemFDSEntries.updateAndGet(
-				systemFDSEntries -> {
-					if (systemFDSEntries == null) {
-						systemFDSEntries = new HashMap<>();
-					}
-					else {
-						systemFDSEntries = new HashMap<>(systemFDSEntries);
-					}
-
-					systemFDSEntries.put(fdsName, systemFDSEntry);
-
-					return systemFDSEntries;
-				});
-
-			return systemFDSEntry;
-		}
-
-		@Override
-		public void modifiedService(
-			ServiceReference<SystemFDSEntry> serviceReference,
-			SystemFDSEntry dataSet) {
-
-			removedService(serviceReference, dataSet);
-
-			addingService(serviceReference);
-		}
-
-		@Override
-		public void removedService(
-			ServiceReference<SystemFDSEntry> serviceReference,
-			SystemFDSEntry dataSet) {
-
-			String fdsName = GetterUtil.getString(
-				serviceReference.getProperty("frontend.data.set.name"));
-
-			_bundleContext.ungetService(serviceReference);
-
-			_systemFDSEntries.updateAndGet(
-				systemFDSEntries -> {
-					systemFDSEntries = new HashMap<>(systemFDSEntries);
-
-					systemFDSEntries.remove(fdsName);
-
-					if (systemFDSEntries.isEmpty()) {
-						return null;
-					}
-
-					return systemFDSEntries;
-				});
-		}
-
-	}
+	private boolean _opened;
+	private ServiceTrackerMap<String, SystemFDSEntry> _serviceTrackerMap;
+	private final ConcurrentMap<String, SystemFDSEntry> _systemFDSEntries =
+		new ConcurrentHashMap<>();
 
 }


### PR DESCRIPTION
Reviewed by Tina Tian in https://github.com/liferay-core-infra/liferay-portal/pull/7716
[Original PR](https://github.com/liferay-frontend/liferay-portal/pull/4593) in frontend-infra repo

https://liferay.atlassian.net/browse/LPD-43400

In this PR we are optimizing the new SystemFDSRegistry usage of ServiceTracker as per Core Infrastructure indications.

Essentially, we'd like the service trackers to initialize lazily, not at startup time. This means no ServiceTracker use as it needs to be open() in the consuming module's activate() method.

@markocikos