### PR TITLE
LPD-43121 Using ancestors when we are using fetchDDMTemplateByExternalReferenceCode

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
@@ -405,7 +405,7 @@ public class JournalContentDisplayContext {
 					_ddmTemplateLocalService.
 						fetchDDMTemplateByExternalReferenceCode(
 							ddmTemplateExternalReferenceCode,
-							_themeDisplay.getScopeGroupId());
+							_themeDisplay.getScopeGroupId(), true);
 
 				if (ddmTemplate != null) {
 					ddmTemplateKey = ddmTemplate.getTemplateKey();

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java
@@ -306,7 +306,7 @@ public class JournalContentExportImportPortletPreferencesProcessor
 					_ddmTemplateLocalService.
 						fetchDDMTemplateByExternalReferenceCode(
 							preferenceDDMTemplateExternalReferenceCode,
-							article.getGroupId());
+							article.getGroupId(), true);
 
 				if (ddmTemplate != null) {
 					preferenceDDMTemplateKey = ddmTemplate.getTemplateKey();

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/JournalContentPortlet.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/JournalContentPortlet.java
@@ -217,7 +217,7 @@ public class JournalContentPortlet extends MVCPortlet {
 						_ddmTemplateLocalService.
 							fetchDDMTemplateByExternalReferenceCode(
 								ddmTemplateExternalReferenceCode,
-								article.getGroupId());
+								article.getGroupId(), true);
 
 					if (ddmTemplate != null) {
 						ddmTemplateKey = ddmTemplate.getTemplateKey();

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/action/JournalContentConfigurationAction.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/action/JournalContentConfigurationAction.java
@@ -337,7 +337,7 @@ public class JournalContentConfigurationAction
 				_ddmTemplateLocalService.
 					fetchDDMTemplateByExternalReferenceCode(
 						ddmTemplateExternalReferenceCode,
-						_getArticleGroupId(portletRequest));
+						_getArticleGroupId(portletRequest), true);
 		}
 		else {
 			String ddmTemplateKey = getParameter(


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-43121

Here in this PR there are commits from three PRs, 

1. LPD-42376 : this is already in brian, you can see it [here](https://github.com/brianchandotcom/liferay-portal/pull/156546).
2. LPD-43040 : this is in bpm repository pending to review it, see [here](https://liferay.atlassian.net/browse/LPD-43040)
3. LPD-43121 : finally, there is a commit related to the changes of this PR

# How am I fixing it?

Fetch template including ancestors since we can have the template in an AssetLibrary, in the site or in the global site

# How can you verify that it works?

There is already a test to cover this, added in the las pr:  https://github.com/liferay-content-management/liferay-portal/pull/6077/commits/8504492706478a916dbe3714d1aa4225f3792749
