### PR TITLE
LPD-40094 Create tests to verify it is possible to import object entries with permissions using Batch Engine

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ImportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ImportTaskResourceTest.java
@@ -50,7 +50,9 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 		waitForFinish(
 			"COMPLETED", true,
 			HTTPTestUtil.invokeToJSONObject(
-				StringBundler.concat("[", beforeImportJSONObject1, "]"),
+				JSONUtil.putAll(
+					beforeImportJSONObject1
+				).toString(),
 				StringBundler.concat(
 					"headless-batch-engine/v1.0/import-task",
 					"/com.liferay.object.rest.dto.v1_0.ObjectEntry",
@@ -79,7 +81,9 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 		waitForFinish(
 			"COMPLETED", true,
 			HTTPTestUtil.invokeToJSONObject(
-				StringBundler.concat("[", beforeImportJSONObject2, "]"),
+				JSONUtil.putAll(
+					beforeImportJSONObject2
+				).toString(),
 				StringBundler.concat(
 					"headless-batch-engine/v1.0/import-task",
 					"/com.liferay.object.rest.dto.v1_0.ObjectEntry",
@@ -121,7 +125,9 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 		waitForFinish(
 			"COMPLETED", true,
 			HTTPTestUtil.invokeToJSONObject(
-				StringBundler.concat("[", beforeImportJSONObject3, "]"),
+				JSONUtil.putAll(
+					beforeImportJSONObject3
+				).toString(),
 				StringBundler.concat(
 					"headless-batch-engine/v1.0/import-task",
 					"/com.liferay.object.rest.dto.v1_0.ObjectEntry",
@@ -167,7 +173,9 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 		waitForFinish(
 			"COMPLETED", true,
 			HTTPTestUtil.invokeToJSONObject(
-				StringBundler.concat("[", jsonObject1, "]"),
+				JSONUtil.putAll(
+					jsonObject1
+				).toString(),
 				StringBundler.concat(
 					"headless-batch-engine/v1.0/import-task",
 					"/com.liferay.object.rest.dto.v1_0.ObjectEntry",
@@ -207,7 +215,9 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 		waitForFinish(
 			"COMPLETED", true,
 			HTTPTestUtil.invokeToJSONObject(
-				StringBundler.concat("[", jsonObject2, "]"),
+				JSONUtil.putAll(
+					jsonObject2
+				).toString(),
 				StringBundler.concat(
 					"headless-batch-engine/v1.0/import-task",
 					"/com.liferay.object.rest.dto.v1_0.ObjectEntry",
@@ -256,7 +266,9 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 		waitForFinish(
 			"COMPLETED", true,
 			HTTPTestUtil.invokeToJSONObject(
-				StringBundler.concat("[", jsonObject3, "]"),
+				JSONUtil.putAll(
+					jsonObject3
+				).toString(),
 				StringBundler.concat(
 					"headless-batch-engine/v1.0/import-task",
 					"/com.liferay.object.rest.dto.v1_0.ObjectEntry",
@@ -299,9 +311,9 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 		waitForFinish(
 			"COMPLETED", true,
 			HTTPTestUtil.invokeToJSONObject(
-				StringBundler.concat(
-					"[", _addViewPermission(beforeImportJSONObject4, role),
-					"]"),
+				JSONUtil.putAll(
+					_addViewPermission(beforeImportJSONObject4, role)
+				).toString(),
 				StringBundler.concat(
 					"headless-batch-engine/v1.0/import-task",
 					"/com.liferay.object.rest.dto.v1_0.ObjectEntry",
@@ -332,9 +344,9 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 		waitForFinish(
 			"COMPLETED", true,
 			HTTPTestUtil.invokeToJSONObject(
-				StringBundler.concat(
-					"[", _addViewPermission(beforeImportJSONObject4, role),
-					"]"),
+				JSONUtil.putAll(
+					_addViewPermission(beforeImportJSONObject4, role)
+				).toString(),
 				StringBundler.concat(
 					"headless-batch-engine/v1.0/import-task",
 					"/com.liferay.object.rest.dto.v1_0.ObjectEntry",

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ImportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ImportTaskResourceTest.java
@@ -59,15 +59,15 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 					objectDefinition.getName()),
 				Http.Method.POST));
 
-		JSONObject afterImportJSONObject1 = _getJSONObject(
-			beforeImportJSONObject1.getString("externalReferenceCode"));
-
 		JSONAssert.assertEquals(
 			JSONUtil.merge(
 				beforeImportJSONObject1,
 				JSONUtil.put("permissions", JSONFactoryUtil.createJSONArray())
 			).toString(),
-			afterImportJSONObject1.toString(), JSONCompareMode.LENIENT);
+			_getJSONObject(
+				beforeImportJSONObject1.getString("externalReferenceCode")
+			).toString(),
+			JSONCompareMode.LENIENT);
 
 		// With no permissions
 
@@ -88,9 +88,6 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 					objectDefinition.getName()),
 				Http.Method.POST));
 
-		JSONObject afterImportJSONObject2 = _getJSONObject(
-			beforeImportJSONObject2.getString("externalReferenceCode"));
-
 		JSONAssert.assertEquals(
 			JSONUtil.merge(
 				beforeImportJSONObject2,
@@ -105,7 +102,10 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 							"roleName", "Owner"
 						)))
 			).toString(),
-			afterImportJSONObject2.toString(), JSONCompareMode.LENIENT);
+			_getJSONObject(
+				beforeImportJSONObject2.getString("externalReferenceCode")
+			).toString(),
+			JSONCompareMode.LENIENT);
 
 		// With permissions
 
@@ -130,9 +130,6 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 					objectDefinition.getName()),
 				Http.Method.POST));
 
-		JSONObject afterImportJSONObject3 = _getJSONObject(
-			beforeImportJSONObject3.getString("externalReferenceCode"));
-
 		JSONAssert.assertEquals(
 			JSONUtil.merge(
 				beforeImportJSONObject3,
@@ -145,7 +142,10 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 							"roleName", role.getName()
 						)))
 			).toString(),
-			afterImportJSONObject3.toString(), JSONCompareMode.LENIENT);
+			_getJSONObject(
+				beforeImportJSONObject3.getString("externalReferenceCode")
+			).toString(),
+			JSONCompareMode.LENIENT);
 	}
 
 	@Test
@@ -181,15 +181,15 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 					objectDefinition.getName()),
 				Http.Method.POST));
 
-		JSONObject afterUpsertJSONObject1 = _getJSONObject(
-			jsonObject1.getString("externalReferenceCode"));
-
 		JSONAssert.assertEquals(
 			JSONUtil.merge(
 				jsonObject1,
 				JSONUtil.put("permissions", JSONFactoryUtil.createJSONArray())
 			).toString(),
-			afterUpsertJSONObject1.toString(), JSONCompareMode.LENIENT);
+			_getJSONObject(
+				jsonObject1.getString("externalReferenceCode")
+			).toString(),
+			JSONCompareMode.LENIENT);
 
 		// With no permissions
 
@@ -221,9 +221,6 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 					objectDefinition.getName()),
 				Http.Method.POST));
 
-		JSONObject afterUpsertJSONObject2 = _getJSONObject(
-			jsonObject2.getString("externalReferenceCode"));
-
 		JSONAssert.assertEquals(
 			JSONUtil.merge(
 				jsonObject2,
@@ -238,7 +235,10 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 							"roleName", "Owner"
 						)))
 			).toString(),
-			afterUpsertJSONObject2.toString(), JSONCompareMode.LENIENT);
+			_getJSONObject(
+				jsonObject2.getString("externalReferenceCode")
+			).toString(),
+			JSONCompareMode.LENIENT);
 
 		// With permissions
 
@@ -272,9 +272,6 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 					objectDefinition.getName()),
 				Http.Method.POST));
 
-		JSONObject afterUpsertJSONObject3 = _getJSONObject(
-			jsonObject3.getString("externalReferenceCode"));
-
 		JSONAssert.assertEquals(
 			JSONUtil.merge(
 				jsonObject3,
@@ -294,7 +291,10 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 							"roleName", role.getName()
 						)))
 			).toString(),
-			afterUpsertJSONObject3.toString(), JSONCompareMode.LENIENT);
+			_getJSONObject(
+				jsonObject3.getString("externalReferenceCode")
+			).toString(),
+			JSONCompareMode.LENIENT);
 	}
 
 	@Test
@@ -324,9 +324,6 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 					OBJECT_FIELD_NAME_TEXT),
 				Http.Method.POST));
 
-		JSONObject afterImport1JSONObject = _getJSONObject(
-			objectEntry.getExternalReferenceCode());
-
 		JSONAssert.assertEquals(
 			JSONUtil.put(
 				"permissions",
@@ -339,7 +336,10 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 						"roleName", "Owner"
 					))
 			).toString(),
-			afterImport1JSONObject.toString(), JSONCompareMode.LENIENT);
+			_getJSONObject(
+				objectEntry.getExternalReferenceCode()
+			).toString(),
+			JSONCompareMode.LENIENT);
 
 		// Without 'restrictedFieldNames' query parameter
 
@@ -354,9 +354,6 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 					"?taskItemDelegateName=", objectDefinition.getName(),
 					"&createStrategy=UPSERT"),
 				Http.Method.POST));
-
-		JSONObject afterImport2JSONObject = _getJSONObject(
-			objectEntry.getExternalReferenceCode());
 
 		JSONAssert.assertEquals(
 			JSONUtil.put(
@@ -375,7 +372,10 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 						"roleName", role.getName()
 					))
 			).toString(),
-			afterImport2JSONObject.toString(), JSONCompareMode.LENIENT);
+			_getJSONObject(
+				objectEntry.getExternalReferenceCode()
+			).toString(),
+			JSONCompareMode.LENIENT);
 	}
 
 	private JSONObject _addViewPermission(JSONObject jsonObject, Role role) {

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ImportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ImportTaskResourceTest.java
@@ -59,14 +59,8 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 					objectDefinition.getName()),
 				Http.Method.POST));
 
-		JSONObject afterImportJSONObject1 = HTTPTestUtil.invokeToJSONObject(
-			null,
-			StringBundler.concat(
-				objectDefinition.getRESTContextPath(),
-				"/by-external-reference-code/",
-				beforeImportJSONObject1.getString("externalReferenceCode"),
-				"?nestedFields=permissions"),
-			Http.Method.GET);
+		JSONObject afterImportJSONObject1 = _getJSONObject(
+			beforeImportJSONObject1.getString("externalReferenceCode"));
 
 		JSONAssert.assertEquals(
 			JSONUtil.merge(
@@ -94,14 +88,8 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 					objectDefinition.getName()),
 				Http.Method.POST));
 
-		JSONObject afterImportJSONObject2 = HTTPTestUtil.invokeToJSONObject(
-			null,
-			StringBundler.concat(
-				objectDefinition.getRESTContextPath(),
-				"/by-external-reference-code/",
-				beforeImportJSONObject2.getString("externalReferenceCode"),
-				"?nestedFields=permissions"),
-			Http.Method.GET);
+		JSONObject afterImportJSONObject2 = _getJSONObject(
+			beforeImportJSONObject2.getString("externalReferenceCode"));
 
 		JSONAssert.assertEquals(
 			JSONUtil.merge(
@@ -142,14 +130,8 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 					objectDefinition.getName()),
 				Http.Method.POST));
 
-		JSONObject afterImportJSONObject3 = HTTPTestUtil.invokeToJSONObject(
-			null,
-			StringBundler.concat(
-				objectDefinition.getRESTContextPath(),
-				"/by-external-reference-code/",
-				beforeImportJSONObject3.getString("externalReferenceCode"),
-				"?nestedFields=permissions"),
-			Http.Method.GET);
+		JSONObject afterImportJSONObject3 = _getJSONObject(
+			beforeImportJSONObject3.getString("externalReferenceCode"));
 
 		JSONAssert.assertEquals(
 			JSONUtil.merge(
@@ -199,14 +181,8 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 					objectDefinition.getName()),
 				Http.Method.POST));
 
-		JSONObject afterUpsertJSONObject1 = HTTPTestUtil.invokeToJSONObject(
-			null,
-			StringBundler.concat(
-				objectDefinition.getRESTContextPath(),
-				"/by-external-reference-code/",
-				jsonObject1.getString("externalReferenceCode"),
-				"?nestedFields=permissions"),
-			Http.Method.GET);
+		JSONObject afterUpsertJSONObject1 = _getJSONObject(
+			jsonObject1.getString("externalReferenceCode"));
 
 		JSONAssert.assertEquals(
 			JSONUtil.merge(
@@ -245,14 +221,8 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 					objectDefinition.getName()),
 				Http.Method.POST));
 
-		JSONObject afterUpsertJSONObject2 = HTTPTestUtil.invokeToJSONObject(
-			null,
-			StringBundler.concat(
-				objectDefinition.getRESTContextPath(),
-				"/by-external-reference-code/",
-				jsonObject2.getString("externalReferenceCode"),
-				"?nestedFields=permissions"),
-			Http.Method.GET);
+		JSONObject afterUpsertJSONObject2 = _getJSONObject(
+			jsonObject2.getString("externalReferenceCode"));
 
 		JSONAssert.assertEquals(
 			JSONUtil.merge(
@@ -302,14 +272,8 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 					objectDefinition.getName()),
 				Http.Method.POST));
 
-		JSONObject afterUpsertJSONObject3 = HTTPTestUtil.invokeToJSONObject(
-			null,
-			StringBundler.concat(
-				objectDefinition.getRESTContextPath(),
-				"/by-external-reference-code/",
-				jsonObject3.getString("externalReferenceCode"),
-				"?nestedFields=permissions"),
-			Http.Method.GET);
+		JSONObject afterUpsertJSONObject3 = _getJSONObject(
+			jsonObject3.getString("externalReferenceCode"));
 
 		JSONAssert.assertEquals(
 			JSONUtil.merge(
@@ -342,14 +306,8 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 
 		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
 
-		JSONObject beforeImportJSONObject = HTTPTestUtil.invokeToJSONObject(
-			null,
-			StringBundler.concat(
-				objectDefinition.getRESTContextPath(),
-				"/by-external-reference-code/",
-				objectEntry.getExternalReferenceCode(),
-				"?nestedFields=permissions"),
-			Http.Method.GET);
+		JSONObject beforeImportJSONObject = _getJSONObject(
+			objectEntry.getExternalReferenceCode());
 
 		// With "restrictedFieldNames" query parameter
 
@@ -366,14 +324,8 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 					OBJECT_FIELD_NAME_TEXT),
 				Http.Method.POST));
 
-		JSONObject afterImport1JSONObject = HTTPTestUtil.invokeToJSONObject(
-			null,
-			StringBundler.concat(
-				objectDefinition.getRESTContextPath(),
-				"/by-external-reference-code/",
-				objectEntry.getExternalReferenceCode(),
-				"?nestedFields=permissions"),
-			Http.Method.GET);
+		JSONObject afterImport1JSONObject = _getJSONObject(
+			objectEntry.getExternalReferenceCode());
 
 		JSONAssert.assertEquals(
 			JSONUtil.put(
@@ -403,14 +355,8 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 					"&createStrategy=UPSERT"),
 				Http.Method.POST));
 
-		JSONObject afterImport2JSONObject = HTTPTestUtil.invokeToJSONObject(
-			null,
-			StringBundler.concat(
-				objectDefinition.getRESTContextPath(),
-				"/by-external-reference-code/",
-				objectEntry.getExternalReferenceCode(),
-				"?nestedFields=permissions"),
-			Http.Method.GET);
+		JSONObject afterImport2JSONObject = _getJSONObject(
+			objectEntry.getExternalReferenceCode());
 
 		JSONAssert.assertEquals(
 			JSONUtil.put(
@@ -447,6 +393,18 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 			));
 
 		return jsonObject;
+	}
+
+	private JSONObject _getJSONObject(String externalReferenceCode)
+		throws Exception {
+
+		return HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				objectDefinition.getRESTContextPath(),
+				"/by-external-reference-code/", externalReferenceCode,
+				"?nestedFields=permissions"),
+			Http.Method.GET);
 	}
 
 }

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ImportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ImportTaskResourceTest.java
@@ -39,7 +39,7 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 
 		// With empty "permissions" and "createStrategy" INSERT
 
-		JSONObject beforeImportJSONObject1 = JSONUtil.put(
+		JSONObject beforeImportJSONObject = JSONUtil.put(
 			OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
 		).put(
 			"externalReferenceCode", RandomTestUtil.randomString()
@@ -51,7 +51,7 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 			"COMPLETED", true,
 			HTTPTestUtil.invokeToJSONObject(
 				JSONUtil.putAll(
-					beforeImportJSONObject1
+					beforeImportJSONObject
 				).toString(),
 				StringBundler.concat(
 					"headless-batch-engine/v1.0/import-task",
@@ -62,17 +62,17 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 
 		JSONAssert.assertEquals(
 			JSONUtil.merge(
-				beforeImportJSONObject1,
+				beforeImportJSONObject,
 				JSONUtil.put("permissions", JSONFactoryUtil.createJSONArray())
 			).toString(),
 			_getJSONObject(
-				beforeImportJSONObject1.getString("externalReferenceCode")
+				beforeImportJSONObject.getString("externalReferenceCode")
 			).toString(),
 			JSONCompareMode.LENIENT);
 
 		// With no "permissions" and "createStrategy" INSERT
 
-		JSONObject beforeImportJSONObject2 = JSONUtil.put(
+		beforeImportJSONObject = JSONUtil.put(
 			OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
 		).put(
 			"externalReferenceCode", RandomTestUtil.randomString()
@@ -82,7 +82,7 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 			"COMPLETED", true,
 			HTTPTestUtil.invokeToJSONObject(
 				JSONUtil.putAll(
-					beforeImportJSONObject2
+					beforeImportJSONObject
 				).toString(),
 				StringBundler.concat(
 					"headless-batch-engine/v1.0/import-task",
@@ -93,7 +93,7 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 
 		JSONAssert.assertEquals(
 			JSONUtil.merge(
-				beforeImportJSONObject2,
+				beforeImportJSONObject,
 				JSONUtil.put(
 					"permissions",
 					JSONUtil.putAll(
@@ -106,7 +106,7 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 						)))
 			).toString(),
 			_getJSONObject(
-				beforeImportJSONObject2.getString("externalReferenceCode")
+				beforeImportJSONObject.getString("externalReferenceCode")
 			).toString(),
 			JSONCompareMode.LENIENT);
 
@@ -114,7 +114,7 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 
 		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
 
-		JSONObject beforeImportJSONObject3 = _addViewPermission(
+		beforeImportJSONObject = _addViewPermission(
 			JSONUtil.put(
 				OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
 			).put(
@@ -126,7 +126,7 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 			"COMPLETED", true,
 			HTTPTestUtil.invokeToJSONObject(
 				JSONUtil.putAll(
-					beforeImportJSONObject3
+					beforeImportJSONObject
 				).toString(),
 				StringBundler.concat(
 					"headless-batch-engine/v1.0/import-task",
@@ -137,7 +137,7 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 
 		JSONAssert.assertEquals(
 			JSONUtil.merge(
-				beforeImportJSONObject3,
+				beforeImportJSONObject,
 				JSONUtil.put(
 					"permissions",
 					JSONUtil.putAll(
@@ -148,13 +148,13 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 						)))
 			).toString(),
 			_getJSONObject(
-				beforeImportJSONObject3.getString("externalReferenceCode")
+				beforeImportJSONObject.getString("externalReferenceCode")
 			).toString(),
 			JSONCompareMode.LENIENT);
 
 		// With empty "permissions" and "createStrategy" UPSERT
 
-		JSONObject beforeUpsertJSONObject1 = HTTPTestUtil.invokeToJSONObject(
+		beforeImportJSONObject = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
 				OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
 			).put(
@@ -166,15 +166,15 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 				"&restrictFields=dateCreated,dateModified"),
 			Http.Method.POST);
 
-		JSONObject jsonObject1 = JSONUtil.merge(
-			beforeUpsertJSONObject1,
+		beforeImportJSONObject = JSONUtil.merge(
+			beforeImportJSONObject,
 			JSONUtil.put("permissions", JSONFactoryUtil.createJSONArray()));
 
 		waitForFinish(
 			"COMPLETED", true,
 			HTTPTestUtil.invokeToJSONObject(
 				JSONUtil.putAll(
-					jsonObject1
+					beforeImportJSONObject
 				).toString(),
 				StringBundler.concat(
 					"headless-batch-engine/v1.0/import-task",
@@ -185,17 +185,17 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 
 		JSONAssert.assertEquals(
 			JSONUtil.merge(
-				jsonObject1,
+				beforeImportJSONObject,
 				JSONUtil.put("permissions", JSONFactoryUtil.createJSONArray())
 			).toString(),
 			_getJSONObject(
-				jsonObject1.getString("externalReferenceCode")
+				beforeImportJSONObject.getString("externalReferenceCode")
 			).toString(),
 			JSONCompareMode.LENIENT);
 
 		// With no "permissions" and "createStrategy" UPSERT
 
-		JSONObject beforeUpsertJSONObject2 = HTTPTestUtil.invokeToJSONObject(
+		beforeImportJSONObject = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
 				OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
 			).put(
@@ -205,18 +205,16 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 				objectDefinition.getRESTContextPath(),
 				"?nestedFields=permissions",
 				"&restrictFields=dateCreated,dateModified"),
-			Http.Method.POST);
-
-		JSONObject jsonObject2 = JSONFactoryUtil.createJSONObject(
-			beforeUpsertJSONObject2.toString());
-
-		jsonObject2.remove("permissions");
+			Http.Method.POST
+		).put(
+			"permissions", (JSONObject)null
+		);
 
 		waitForFinish(
 			"COMPLETED", true,
 			HTTPTestUtil.invokeToJSONObject(
 				JSONUtil.putAll(
-					jsonObject2
+					beforeImportJSONObject
 				).toString(),
 				StringBundler.concat(
 					"headless-batch-engine/v1.0/import-task",
@@ -227,7 +225,7 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 
 		JSONAssert.assertEquals(
 			JSONUtil.merge(
-				jsonObject2,
+				beforeImportJSONObject,
 				JSONUtil.put(
 					"permissions",
 					JSONUtil.putAll(
@@ -240,34 +238,31 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 						)))
 			).toString(),
 			_getJSONObject(
-				jsonObject2.getString("externalReferenceCode")
+				beforeImportJSONObject.getString("externalReferenceCode")
 			).toString(),
 			JSONCompareMode.LENIENT);
 
 		// With "permissions" and "createStrategy" UPSERT
 
-		JSONObject beforeUpsertJSONObject3 = HTTPTestUtil.invokeToJSONObject(
-			JSONUtil.put(
-				OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
-			).put(
-				"externalReferenceCode", RandomTestUtil.randomString()
-			).toString(),
-			StringBundler.concat(
-				objectDefinition.getRESTContextPath(),
-				"?nestedFields=permissions",
-				"&restrictFields=dateCreated,dateModified"),
-			Http.Method.POST);
-
-		JSONObject jsonObject3 = _addViewPermission(
-			JSONFactoryUtil.createJSONObject(
-				beforeUpsertJSONObject3.toString()),
+		beforeImportJSONObject = _addViewPermission(
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
+				).put(
+					"externalReferenceCode", RandomTestUtil.randomString()
+				).toString(),
+				StringBundler.concat(
+					objectDefinition.getRESTContextPath(),
+					"?nestedFields=permissions",
+					"&restrictFields=dateCreated,dateModified"),
+				Http.Method.POST),
 			role);
 
 		waitForFinish(
 			"COMPLETED", true,
 			HTTPTestUtil.invokeToJSONObject(
 				JSONUtil.putAll(
-					jsonObject3
+					beforeImportJSONObject
 				).toString(),
 				StringBundler.concat(
 					"headless-batch-engine/v1.0/import-task",
@@ -278,7 +273,7 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 
 		JSONAssert.assertEquals(
 			JSONUtil.merge(
-				jsonObject3,
+				beforeImportJSONObject,
 				JSONUtil.put(
 					"permissions",
 					JSONUtil.putAll(
@@ -296,14 +291,14 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 						)))
 			).toString(),
 			_getJSONObject(
-				jsonObject3.getString("externalReferenceCode")
+				beforeImportJSONObject.getString("externalReferenceCode")
 			).toString(),
 			JSONCompareMode.LENIENT);
 
 		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
 			objectDefinition, OBJECT_FIELD_NAME_TEXT, "TestObject");
 
-		JSONObject beforeImportJSONObject4 = _getJSONObject(
+		beforeImportJSONObject = _getJSONObject(
 			objectEntry.getExternalReferenceCode());
 
 		// With "restrictedFieldNames" query parameter
@@ -312,7 +307,7 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 			"COMPLETED", true,
 			HTTPTestUtil.invokeToJSONObject(
 				JSONUtil.putAll(
-					_addViewPermission(beforeImportJSONObject4, role)
+					_addViewPermission(beforeImportJSONObject, role)
 				).toString(),
 				StringBundler.concat(
 					"headless-batch-engine/v1.0/import-task",
@@ -345,7 +340,7 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 			"COMPLETED", true,
 			HTTPTestUtil.invokeToJSONObject(
 				JSONUtil.putAll(
-					_addViewPermission(beforeImportJSONObject4, role)
+					_addViewPermission(beforeImportJSONObject, role)
 				).toString(),
 				StringBundler.concat(
 					"headless-batch-engine/v1.0/import-task",

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ImportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ImportTaskResourceTest.java
@@ -35,10 +35,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 
 	@Test
-	public void testPostImportTask() throws Exception {
-
-		// With "restrictedFieldNames" query parameter
-
+	public void testPostImportTaskWithRestrictedFieldNamesParam() throws Exception {
 		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
 			objectDefinition, OBJECT_FIELD_NAME_TEXT, "TestObject");
 
@@ -52,6 +49,8 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 				objectEntry.getExternalReferenceCode(),
 				"?nestedFields=permissions"),
 			Http.Method.GET);
+
+		// With "restrictedFieldNames" query parameter
 
 		waitForFinish(
 			"COMPLETED", true,

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ImportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ImportTaskResourceTest.java
@@ -35,103 +35,6 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 
 	@Test
-	public void testPostImportTaskWithRestrictedFieldNamesParam() throws Exception {
-		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
-			objectDefinition, OBJECT_FIELD_NAME_TEXT, "TestObject");
-
-		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
-
-		JSONObject beforeImportJSONObject = HTTPTestUtil.invokeToJSONObject(
-			null,
-			StringBundler.concat(
-				objectDefinition.getRESTContextPath(),
-				"/by-external-reference-code/",
-				objectEntry.getExternalReferenceCode(),
-				"?nestedFields=permissions"),
-			Http.Method.GET);
-
-		// With "restrictedFieldNames" query parameter
-
-		waitForFinish(
-			"COMPLETED", true,
-			HTTPTestUtil.invokeToJSONObject(
-				StringBundler.concat(
-					"[", _addViewPermission(beforeImportJSONObject, role), "]"),
-				StringBundler.concat(
-					"headless-batch-engine/v1.0/import-task",
-					"/com.liferay.object.rest.dto.v1_0.ObjectEntry",
-					"?taskItemDelegateName=", objectDefinition.getName(),
-					"&createStrategy=UPSERT&restrictedFieldNames=permissions,",
-					OBJECT_FIELD_NAME_TEXT),
-				Http.Method.POST));
-
-		JSONObject afterImport1JSONObject = HTTPTestUtil.invokeToJSONObject(
-			null,
-			StringBundler.concat(
-				objectDefinition.getRESTContextPath(),
-				"/by-external-reference-code/",
-				objectEntry.getExternalReferenceCode(),
-				"?nestedFields=permissions"),
-			Http.Method.GET);
-
-		JSONAssert.assertEquals(
-			JSONUtil.put(
-				"permissions",
-				JSONUtil.putAll(
-					JSONUtil.put(
-						"actionIds",
-						JSONUtil.putAll(
-							"DELETE", "PERMISSIONS", "UPDATE", "VIEW")
-					).put(
-						"roleName", "Owner"
-					))
-			).toString(),
-			afterImport1JSONObject.toString(), JSONCompareMode.LENIENT);
-
-		// Without "restrictedFieldNames" query parameter
-
-		waitForFinish(
-			"COMPLETED", true,
-			HTTPTestUtil.invokeToJSONObject(
-				StringBundler.concat(
-					"[", _addViewPermission(beforeImportJSONObject, role), "]"),
-				StringBundler.concat(
-					"headless-batch-engine/v1.0/import-task",
-					"/com.liferay.object.rest.dto.v1_0.ObjectEntry",
-					"?taskItemDelegateName=", objectDefinition.getName(),
-					"&createStrategy=UPSERT"),
-				Http.Method.POST));
-
-		JSONObject afterImport2JSONObject = HTTPTestUtil.invokeToJSONObject(
-			null,
-			StringBundler.concat(
-				objectDefinition.getRESTContextPath(),
-				"/by-external-reference-code/",
-				objectEntry.getExternalReferenceCode(),
-				"?nestedFields=permissions"),
-			Http.Method.GET);
-
-		JSONAssert.assertEquals(
-			JSONUtil.put(
-				"permissions",
-				JSONUtil.putAll(
-					JSONUtil.put(
-						"actionIds",
-						JSONUtil.putAll(
-							"DELETE", "PERMISSIONS", "UPDATE", "VIEW")
-					).put(
-						"roleName", "Owner"
-					),
-					JSONUtil.put(
-						"actionIds", JSONUtil.putAll("VIEW")
-					).put(
-						"roleName", role.getName()
-					))
-			).toString(),
-			afterImport2JSONObject.toString(), JSONCompareMode.LENIENT);
-	}
-
-	@Test
 	public void testPostImportTaskInsertCreateStrategyWithPermissions()
 		throws Exception {
 
@@ -428,6 +331,105 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 						)))
 			).toString(),
 			afterUpsertJSONObject3.toString(), JSONCompareMode.LENIENT);
+	}
+
+	@Test
+	public void testPostImportTaskWithRestrictedFieldNamesParam()
+		throws Exception {
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			objectDefinition, OBJECT_FIELD_NAME_TEXT, "TestObject");
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		JSONObject beforeImportJSONObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				objectDefinition.getRESTContextPath(),
+				"/by-external-reference-code/",
+				objectEntry.getExternalReferenceCode(),
+				"?nestedFields=permissions"),
+			Http.Method.GET);
+
+		// With "restrictedFieldNames" query parameter
+
+		waitForFinish(
+			"COMPLETED", true,
+			HTTPTestUtil.invokeToJSONObject(
+				StringBundler.concat(
+					"[", _addViewPermission(beforeImportJSONObject, role), "]"),
+				StringBundler.concat(
+					"headless-batch-engine/v1.0/import-task",
+					"/com.liferay.object.rest.dto.v1_0.ObjectEntry",
+					"?taskItemDelegateName=", objectDefinition.getName(),
+					"&createStrategy=UPSERT&restrictedFieldNames=permissions,",
+					OBJECT_FIELD_NAME_TEXT),
+				Http.Method.POST));
+
+		JSONObject afterImport1JSONObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				objectDefinition.getRESTContextPath(),
+				"/by-external-reference-code/",
+				objectEntry.getExternalReferenceCode(),
+				"?nestedFields=permissions"),
+			Http.Method.GET);
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				"permissions",
+				JSONUtil.putAll(
+					JSONUtil.put(
+						"actionIds",
+						JSONUtil.putAll(
+							"DELETE", "PERMISSIONS", "UPDATE", "VIEW")
+					).put(
+						"roleName", "Owner"
+					))
+			).toString(),
+			afterImport1JSONObject.toString(), JSONCompareMode.LENIENT);
+
+		// Without 'restrictedFieldNames' query parameter
+
+		waitForFinish(
+			"COMPLETED", true,
+			HTTPTestUtil.invokeToJSONObject(
+				StringBundler.concat(
+					"[", _addViewPermission(beforeImportJSONObject, role), "]"),
+				StringBundler.concat(
+					"headless-batch-engine/v1.0/import-task",
+					"/com.liferay.object.rest.dto.v1_0.ObjectEntry",
+					"?taskItemDelegateName=", objectDefinition.getName(),
+					"&createStrategy=UPSERT"),
+				Http.Method.POST));
+
+		JSONObject afterImport2JSONObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				objectDefinition.getRESTContextPath(),
+				"/by-external-reference-code/",
+				objectEntry.getExternalReferenceCode(),
+				"?nestedFields=permissions"),
+			Http.Method.GET);
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				"permissions",
+				JSONUtil.putAll(
+					JSONUtil.put(
+						"actionIds",
+						JSONUtil.putAll(
+							"DELETE", "PERMISSIONS", "UPDATE", "VIEW")
+					).put(
+						"roleName", "Owner"
+					),
+					JSONUtil.put(
+						"actionIds", JSONUtil.putAll("VIEW")
+					).put(
+						"roleName", role.getName()
+					))
+			).toString(),
+			afterImport2JSONObject.toString(), JSONCompareMode.LENIENT);
 	}
 
 	private JSONObject _addViewPermission(JSONObject jsonObject, Role role) {

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ImportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ImportTaskResourceTest.java
@@ -35,10 +35,9 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 
 	@Test
-	public void testPostImportTaskInsertCreateStrategyWithPermissions()
-		throws Exception {
+	public void testPostImportTask() throws Exception {
 
-		// With empty "permissions"
+		// With empty "permissions" and "createStrategy" INSERT
 
 		JSONObject beforeImportJSONObject1 = JSONUtil.put(
 			OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
@@ -69,7 +68,7 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 			).toString(),
 			JSONCompareMode.LENIENT);
 
-		// With no "permissions"
+		// With no "permissions" and "createStrategy" INSERT
 
 		JSONObject beforeImportJSONObject2 = JSONUtil.put(
 			OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
@@ -107,7 +106,7 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 			).toString(),
 			JSONCompareMode.LENIENT);
 
-		// With "permissions"
+		// With "permissions" and "createStrategy" INSERT
 
 		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
 
@@ -146,13 +145,8 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 				beforeImportJSONObject3.getString("externalReferenceCode")
 			).toString(),
 			JSONCompareMode.LENIENT);
-	}
 
-	@Test
-	public void testPostImportTaskUpsertCreateStrategyWithPermissions()
-		throws Exception {
-
-		// With empty "permissions"
+		// With empty "permissions" and "createStrategy" UPSERT
 
 		JSONObject beforeUpsertJSONObject1 = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
@@ -191,7 +185,7 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 			).toString(),
 			JSONCompareMode.LENIENT);
 
-		// With no "permissions"
+		// With no "permissions" and "createStrategy" UPSERT
 
 		JSONObject beforeUpsertJSONObject2 = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
@@ -240,7 +234,7 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 			).toString(),
 			JSONCompareMode.LENIENT);
 
-		// With "permissions"
+		// With "permissions" and "createStrategy" UPSERT
 
 		JSONObject beforeUpsertJSONObject3 = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
@@ -253,8 +247,6 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 				"?nestedFields=permissions",
 				"&restrictFields=dateCreated,dateModified"),
 			Http.Method.POST);
-
-		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
 
 		JSONObject jsonObject3 = _addViewPermission(
 			JSONFactoryUtil.createJSONObject(
@@ -295,18 +287,11 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 				jsonObject3.getString("externalReferenceCode")
 			).toString(),
 			JSONCompareMode.LENIENT);
-	}
-
-	@Test
-	public void testPostImportTaskWithRestrictedFieldNamesParam()
-		throws Exception {
 
 		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
 			objectDefinition, OBJECT_FIELD_NAME_TEXT, "TestObject");
 
-		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
-
-		JSONObject beforeImportJSONObject = _getJSONObject(
+		JSONObject beforeImportJSONObject4 = _getJSONObject(
 			objectEntry.getExternalReferenceCode());
 
 		// With "restrictedFieldNames" query parameter
@@ -315,7 +300,8 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 			"COMPLETED", true,
 			HTTPTestUtil.invokeToJSONObject(
 				StringBundler.concat(
-					"[", _addViewPermission(beforeImportJSONObject, role), "]"),
+					"[", _addViewPermission(beforeImportJSONObject4, role),
+					"]"),
 				StringBundler.concat(
 					"headless-batch-engine/v1.0/import-task",
 					"/com.liferay.object.rest.dto.v1_0.ObjectEntry",
@@ -347,7 +333,8 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 			"COMPLETED", true,
 			HTTPTestUtil.invokeToJSONObject(
 				StringBundler.concat(
-					"[", _addViewPermission(beforeImportJSONObject, role), "]"),
+					"[", _addViewPermission(beforeImportJSONObject4, role),
+					"]"),
 				StringBundler.concat(
 					"headless-batch-engine/v1.0/import-task",
 					"/com.liferay.object.rest.dto.v1_0.ObjectEntry",

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ImportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ImportTaskResourceTest.java
@@ -10,11 +10,13 @@ import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.rest.test.util.ObjectEntryTestUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.test.rule.FeatureFlags;
@@ -130,7 +132,143 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 			afterImport2JSONObject.toString(), JSONCompareMode.LENIENT);
 	}
 
+	@Test
+	public void testPostImportTaskInsertCreateStrategyWithPermissions()
+		throws Exception {
+
+		// With empty permissions
+
+		JSONObject beforeImportJSONObject1 = JSONUtil.put(
+			OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
+		).put(
+			"externalReferenceCode", RandomTestUtil.randomString()
+		).put(
+			"permissions", JSONFactoryUtil.createJSONArray()
+		);
+
+		waitForFinish(
+			"COMPLETED", true,
+			HTTPTestUtil.invokeToJSONObject(
+				StringBundler.concat("[", beforeImportJSONObject1, "]"),
+				StringBundler.concat(
+					"headless-batch-engine/v1.0/import-task",
+					"/com.liferay.object.rest.dto.v1_0.ObjectEntry",
+					"?createStrategy=INSERT&taskItemDelegateName=",
+					objectDefinition.getName()),
+				Http.Method.POST));
+
+		JSONObject afterImportJSONObject1 = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				objectDefinition.getRESTContextPath(),
+				"/by-external-reference-code/",
+				beforeImportJSONObject1.getString("externalReferenceCode"),
+				"?nestedFields=permissions"),
+			Http.Method.GET);
+
+		JSONAssert.assertEquals(
+			JSONUtil.merge(
+				beforeImportJSONObject1,
+				JSONUtil.put("permissions", JSONFactoryUtil.createJSONArray())
+			).toString(),
+			afterImportJSONObject1.toString(), JSONCompareMode.LENIENT);
+
+		// With no permissions
+
+		JSONObject beforeImportJSONObject2 = JSONUtil.put(
+			OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
+		).put(
+			"externalReferenceCode", RandomTestUtil.randomString()
+		);
+
+		waitForFinish(
+			"COMPLETED", true,
+			HTTPTestUtil.invokeToJSONObject(
+				StringBundler.concat("[", beforeImportJSONObject2, "]"),
+				StringBundler.concat(
+					"headless-batch-engine/v1.0/import-task",
+					"/com.liferay.object.rest.dto.v1_0.ObjectEntry",
+					"?createStrategy=INSERT&taskItemDelegateName=",
+					objectDefinition.getName()),
+				Http.Method.POST));
+
+		JSONObject afterImportJSONObject2 = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				objectDefinition.getRESTContextPath(),
+				"/by-external-reference-code/",
+				beforeImportJSONObject2.getString("externalReferenceCode"),
+				"?nestedFields=permissions"),
+			Http.Method.GET);
+
+		JSONAssert.assertEquals(
+			JSONUtil.merge(
+				beforeImportJSONObject2,
+				JSONUtil.put(
+					"permissions",
+					JSONUtil.putAll(
+						JSONUtil.put(
+							"actionIds",
+							JSONUtil.putAll(
+								"DELETE", "PERMISSIONS", "UPDATE", "VIEW")
+						).put(
+							"roleName", "Owner"
+						)))
+			).toString(),
+			afterImportJSONObject2.toString(), JSONCompareMode.LENIENT);
+
+		// With permissions
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		JSONObject beforeImportJSONObject3 = _addViewPermission(
+			JSONUtil.put(
+				OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
+			).put(
+				"externalReferenceCode", RandomTestUtil.randomString()
+			),
+			role);
+
+		waitForFinish(
+			"COMPLETED", true,
+			HTTPTestUtil.invokeToJSONObject(
+				StringBundler.concat("[", beforeImportJSONObject3, "]"),
+				StringBundler.concat(
+					"headless-batch-engine/v1.0/import-task",
+					"/com.liferay.object.rest.dto.v1_0.ObjectEntry",
+					"?createStrategy=INSERT&taskItemDelegateName=",
+					objectDefinition.getName()),
+				Http.Method.POST));
+
+		JSONObject afterImportJSONObject3 = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				objectDefinition.getRESTContextPath(),
+				"/by-external-reference-code/",
+				beforeImportJSONObject3.getString("externalReferenceCode"),
+				"?nestedFields=permissions"),
+			Http.Method.GET);
+
+		JSONAssert.assertEquals(
+			JSONUtil.merge(
+				beforeImportJSONObject3,
+				JSONUtil.put(
+					"permissions",
+					JSONUtil.putAll(
+						JSONUtil.put(
+							"actionIds", JSONUtil.putAll("VIEW")
+						).put(
+							"roleName", role.getName()
+						)))
+			).toString(),
+			afterImportJSONObject3.toString(), JSONCompareMode.LENIENT);
+	}
+
 	private JSONObject _addViewPermission(JSONObject jsonObject, Role role) {
+		if (!jsonObject.has("permissions")) {
+			jsonObject.put("permissions", JSONFactoryUtil.createJSONArray());
+		}
+
 		JSONArray permissionsJSONArray = jsonObject.getJSONArray("permissions");
 
 		permissionsJSONArray.put(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ImportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ImportTaskResourceTest.java
@@ -9,7 +9,6 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.rest.test.util.ObjectEntryTestUtil;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -114,13 +113,19 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 
 		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
 
-		beforeImportJSONObject = _addViewPermission(
-			JSONUtil.put(
-				OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
-			).put(
-				"externalReferenceCode", RandomTestUtil.randomString()
-			),
-			role);
+		beforeImportJSONObject = JSONUtil.put(
+			OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
+		).put(
+			"externalReferenceCode", RandomTestUtil.randomString()
+		).put(
+			"permissions",
+			JSONUtil.putAll(
+				JSONUtil.put(
+					"actionIds", JSONUtil.putAll("VIEW")
+				).put(
+					"roleName", role.getName()
+				))
+		);
 
 		waitForFinish(
 			"COMPLETED", true,
@@ -164,11 +169,10 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 				objectDefinition.getRESTContextPath(),
 				"?nestedFields=permissions",
 				"&restrictFields=dateCreated,dateModified"),
-			Http.Method.POST);
-
-		beforeImportJSONObject = JSONUtil.merge(
-			beforeImportJSONObject,
-			JSONUtil.put("permissions", JSONFactoryUtil.createJSONArray()));
+			Http.Method.POST
+		).put(
+			"permissions", JSONFactoryUtil.createJSONArray()
+		);
 
 		waitForFinish(
 			"COMPLETED", true,
@@ -244,19 +248,29 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 
 		// With "permissions" and "createStrategy" UPSERT
 
-		beforeImportJSONObject = _addViewPermission(
-			HTTPTestUtil.invokeToJSONObject(
+		beforeImportJSONObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
+			).put(
+				"externalReferenceCode", RandomTestUtil.randomString()
+			).toString(),
+			StringBundler.concat(
+				objectDefinition.getRESTContextPath(),
+				"?nestedFields=permissions",
+				"&restrictFields=dateCreated,dateModified"),
+			Http.Method.POST);
+
+		beforeImportJSONObject = beforeImportJSONObject.put(
+			"permissions",
+			beforeImportJSONObject.getJSONArray(
+				"permissions"
+			).put(
 				JSONUtil.put(
-					OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
+					"actionIds", JSONUtil.putAll("VIEW")
 				).put(
-					"externalReferenceCode", RandomTestUtil.randomString()
-				).toString(),
-				StringBundler.concat(
-					objectDefinition.getRESTContextPath(),
-					"?nestedFields=permissions",
-					"&restrictFields=dateCreated,dateModified"),
-				Http.Method.POST),
-			role);
+					"roleName", role.getName()
+				)
+			));
 
 		waitForFinish(
 			"COMPLETED", true,
@@ -307,7 +321,17 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 			"COMPLETED", true,
 			HTTPTestUtil.invokeToJSONObject(
 				JSONUtil.putAll(
-					_addViewPermission(beforeImportJSONObject, role)
+					beforeImportJSONObject.put(
+						"permissions",
+						beforeImportJSONObject.getJSONArray(
+							"permissions"
+						).put(
+							JSONUtil.put(
+								"actionIds", JSONUtil.putAll("VIEW")
+							).put(
+								"roleName", role.getName()
+							)
+						))
 				).toString(),
 				StringBundler.concat(
 					"headless-batch-engine/v1.0/import-task",
@@ -340,7 +364,17 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 			"COMPLETED", true,
 			HTTPTestUtil.invokeToJSONObject(
 				JSONUtil.putAll(
-					_addViewPermission(beforeImportJSONObject, role)
+					beforeImportJSONObject.put(
+						"permissions",
+						beforeImportJSONObject.getJSONArray(
+							"permissions"
+						).put(
+							JSONUtil.put(
+								"actionIds", JSONUtil.putAll("VIEW")
+							).put(
+								"roleName", role.getName()
+							)
+						))
 				).toString(),
 				StringBundler.concat(
 					"headless-batch-engine/v1.0/import-task",
@@ -370,23 +404,6 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 				objectEntry.getExternalReferenceCode()
 			).toString(),
 			JSONCompareMode.LENIENT);
-	}
-
-	private JSONObject _addViewPermission(JSONObject jsonObject, Role role) {
-		if (!jsonObject.has("permissions")) {
-			jsonObject.put("permissions", JSONFactoryUtil.createJSONArray());
-		}
-
-		JSONArray permissionsJSONArray = jsonObject.getJSONArray("permissions");
-
-		permissionsJSONArray.put(
-			JSONUtil.put(
-				"actionIds", JSONUtil.putAll("VIEW")
-			).put(
-				"roleName", role.getName()
-			));
-
-		return jsonObject;
 	}
 
 	private JSONObject _getJSONObject(String externalReferenceCode)

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ImportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ImportTaskResourceTest.java
@@ -38,7 +38,7 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 	public void testPostImportTaskInsertCreateStrategyWithPermissions()
 		throws Exception {
 
-		// With empty permissions
+		// With empty "permissions"
 
 		JSONObject beforeImportJSONObject1 = JSONUtil.put(
 			OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
@@ -69,7 +69,7 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 			).toString(),
 			JSONCompareMode.LENIENT);
 
-		// With no permissions
+		// With no "permissions"
 
 		JSONObject beforeImportJSONObject2 = JSONUtil.put(
 			OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
@@ -107,7 +107,7 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 			).toString(),
 			JSONCompareMode.LENIENT);
 
-		// With permissions
+		// With "permissions"
 
 		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
 
@@ -152,7 +152,7 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 	public void testPostImportTaskUpsertCreateStrategyWithPermissions()
 		throws Exception {
 
-		// With empty permissions
+		// With empty "permissions"
 
 		JSONObject beforeUpsertJSONObject1 = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
@@ -191,7 +191,7 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 			).toString(),
 			JSONCompareMode.LENIENT);
 
-		// With no permissions
+		// With no "permissions"
 
 		JSONObject beforeUpsertJSONObject2 = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
@@ -240,7 +240,7 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 			).toString(),
 			JSONCompareMode.LENIENT);
 
-		// With permissions
+		// With "permissions"
 
 		JSONObject beforeUpsertJSONObject3 = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
@@ -341,7 +341,7 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 			).toString(),
 			JSONCompareMode.LENIENT);
 
-		// Without 'restrictedFieldNames' query parameter
+		// Without "restrictedFieldNames" query parameter
 
 		waitForFinish(
 			"COMPLETED", true,

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ImportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ImportTaskResourceTest.java
@@ -264,6 +264,173 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 			afterImportJSONObject3.toString(), JSONCompareMode.LENIENT);
 	}
 
+	@Test
+	public void testPostImportTaskUpsertCreateStrategyWithPermissions()
+		throws Exception {
+
+		// With empty permissions
+
+		JSONObject beforeUpsertJSONObject1 = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
+			).put(
+				"externalReferenceCode", RandomTestUtil.randomString()
+			).toString(),
+			StringBundler.concat(
+				objectDefinition.getRESTContextPath(),
+				"?nestedFields=permissions",
+				"&restrictFields=dateCreated,dateModified"),
+			Http.Method.POST);
+
+		JSONObject jsonObject1 = JSONUtil.merge(
+			beforeUpsertJSONObject1,
+			JSONUtil.put("permissions", JSONFactoryUtil.createJSONArray()));
+
+		waitForFinish(
+			"COMPLETED", true,
+			HTTPTestUtil.invokeToJSONObject(
+				StringBundler.concat("[", jsonObject1, "]"),
+				StringBundler.concat(
+					"headless-batch-engine/v1.0/import-task",
+					"/com.liferay.object.rest.dto.v1_0.ObjectEntry",
+					"?createStrategy=UPSERT&taskItemDelegateName=",
+					objectDefinition.getName()),
+				Http.Method.POST));
+
+		JSONObject afterUpsertJSONObject1 = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				objectDefinition.getRESTContextPath(),
+				"/by-external-reference-code/",
+				jsonObject1.getString("externalReferenceCode"),
+				"?nestedFields=permissions"),
+			Http.Method.GET);
+
+		JSONAssert.assertEquals(
+			JSONUtil.merge(
+				jsonObject1,
+				JSONUtil.put("permissions", JSONFactoryUtil.createJSONArray())
+			).toString(),
+			afterUpsertJSONObject1.toString(), JSONCompareMode.LENIENT);
+
+		// With no permissions
+
+		JSONObject beforeUpsertJSONObject2 = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
+			).put(
+				"externalReferenceCode", RandomTestUtil.randomString()
+			).toString(),
+			StringBundler.concat(
+				objectDefinition.getRESTContextPath(),
+				"?nestedFields=permissions",
+				"&restrictFields=dateCreated,dateModified"),
+			Http.Method.POST);
+
+		JSONObject jsonObject2 = JSONFactoryUtil.createJSONObject(
+			beforeUpsertJSONObject2.toString());
+
+		jsonObject2.remove("permissions");
+
+		waitForFinish(
+			"COMPLETED", true,
+			HTTPTestUtil.invokeToJSONObject(
+				StringBundler.concat("[", jsonObject2, "]"),
+				StringBundler.concat(
+					"headless-batch-engine/v1.0/import-task",
+					"/com.liferay.object.rest.dto.v1_0.ObjectEntry",
+					"?createStrategy=UPSERT&taskItemDelegateName=",
+					objectDefinition.getName()),
+				Http.Method.POST));
+
+		JSONObject afterUpsertJSONObject2 = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				objectDefinition.getRESTContextPath(),
+				"/by-external-reference-code/",
+				jsonObject2.getString("externalReferenceCode"),
+				"?nestedFields=permissions"),
+			Http.Method.GET);
+
+		JSONAssert.assertEquals(
+			JSONUtil.merge(
+				jsonObject2,
+				JSONUtil.put(
+					"permissions",
+					JSONUtil.putAll(
+						JSONUtil.put(
+							"actionIds",
+							JSONUtil.putAll(
+								"DELETE", "PERMISSIONS", "UPDATE", "VIEW")
+						).put(
+							"roleName", "Owner"
+						)))
+			).toString(),
+			afterUpsertJSONObject2.toString(), JSONCompareMode.LENIENT);
+
+		// With permissions
+
+		JSONObject beforeUpsertJSONObject3 = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				OBJECT_FIELD_NAME_TEXT, RandomTestUtil.randomString()
+			).put(
+				"externalReferenceCode", RandomTestUtil.randomString()
+			).toString(),
+			StringBundler.concat(
+				objectDefinition.getRESTContextPath(),
+				"?nestedFields=permissions",
+				"&restrictFields=dateCreated,dateModified"),
+			Http.Method.POST);
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		JSONObject jsonObject3 = _addViewPermission(
+			JSONFactoryUtil.createJSONObject(
+				beforeUpsertJSONObject3.toString()),
+			role);
+
+		waitForFinish(
+			"COMPLETED", true,
+			HTTPTestUtil.invokeToJSONObject(
+				StringBundler.concat("[", jsonObject3, "]"),
+				StringBundler.concat(
+					"headless-batch-engine/v1.0/import-task",
+					"/com.liferay.object.rest.dto.v1_0.ObjectEntry",
+					"?createStrategy=UPSERT&taskItemDelegateName=",
+					objectDefinition.getName()),
+				Http.Method.POST));
+
+		JSONObject afterUpsertJSONObject3 = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				objectDefinition.getRESTContextPath(),
+				"/by-external-reference-code/",
+				jsonObject3.getString("externalReferenceCode"),
+				"?nestedFields=permissions"),
+			Http.Method.GET);
+
+		JSONAssert.assertEquals(
+			JSONUtil.merge(
+				jsonObject3,
+				JSONUtil.put(
+					"permissions",
+					JSONUtil.putAll(
+						JSONUtil.put(
+							"actionIds",
+							JSONUtil.putAll(
+								"DELETE", "PERMISSIONS", "UPDATE", "VIEW")
+						).put(
+							"roleName", "Owner"
+						),
+						JSONUtil.put(
+							"actionIds", JSONUtil.putAll("VIEW")
+						).put(
+							"roleName", role.getName()
+						)))
+			).toString(),
+			afterUpsertJSONObject3.toString(), JSONCompareMode.LENIENT);
+	}
+
 	private JSONObject _addViewPermission(JSONObject jsonObject, Role role) {
 		if (!jsonObject.has("permissions")) {
 			jsonObject.put("permissions", JSONFactoryUtil.createJSONArray());


### PR DESCRIPTION
Forwarded manually from: https://github.com/liferay-headless/liferay-portal/pull/2372

---

Related ticket: https://liferay.atlassian.net/browse/LPD-40094

---

The purpose of this ticket is to create integration tests to verify it is possible to import object entries (using both INSERT and UPSERT create strategies) along with permissions in the same request

NOTE: This PR has been created on top of https://github.com/brianchandotcom/liferay-portal/pull/156545 (because it uses some data from the previous integration tests). So it is only required to review the commits that starts with "LPD-40094"