### PR TITLE
LPD-34931 - Export Custom and Modifiable System Objects with permissions in Batch

### DIFF
--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
@@ -36,23 +36,19 @@ import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
-import com.liferay.portal.util.PropsValues;
 import com.liferay.portal.vulcan.fields.NestedFieldsContext;
 import com.liferay.portal.vulcan.fields.NestedFieldsContextThreadLocal;
+import com.liferay.portal.vulcan.util.NestedFieldsContextUtil;
 
 import java.io.Serializable;
 
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -141,28 +137,26 @@ public class BatchEngineExportTaskExecutorImpl
 		Map<String, Serializable> parameters = _getParameters(
 			batchEngineExportTask);
 
-		if (FeatureFlagManagerUtil.isEnabled("LPD-29367")) {
-			String nestedFieldNames = (String)parameters.get(
-				"nestedFieldNames");
-
-			int depth = Math.max(
-				Math.min(
-					GetterUtil.getInteger(
-						parameters.get("nestedFieldsDepth"), 1),
-					PropsValues.OBJECT_NESTED_FIELDS_MAX_QUERY_DEPTH),
-				1);
-
-			NestedFieldsContext nestedFieldsContext = new NestedFieldsContext(
-				depth, _toList(nestedFieldNames));
-
-			NestedFieldsContextThreadLocal.setNestedFieldsContext(
-				nestedFieldsContext);
-		}
+		NestedFieldsContext oldNestedFieldsContext = null;
 
 		try (BatchEngineExportTaskItemWriter batchEngineExportTaskItemWriter =
 				_getBatchEngineExportTaskItemWriter(
 					batchEngineExportTask, parameters,
 					unsyncByteArrayOutputStream)) {
+
+			if (FeatureFlagManagerUtil.isEnabled("LPD-29367")) {
+				oldNestedFieldsContext =
+					NestedFieldsContextThreadLocal.getNestedFieldsContext();
+
+				NestedFieldsContextThreadLocal.setNestedFieldsContext(
+					new NestedFieldsContext(
+						NestedFieldsContextUtil.limitDepth(
+							GetterUtil.getInteger(
+								parameters.get("nestedFieldsDepth"))),
+						NestedFieldsContextUtil.toNestedFields(
+							MapUtil.getString(
+								parameters, "nestedFieldNames"))));
+			}
 
 			int exportBatchSize = _getExportBatchSize(
 				batchEngineExportTask.getCompanyId());
@@ -209,6 +203,12 @@ public class BatchEngineExportTaskExecutorImpl
 					(int)page.getPage() + 1, exportBatchSize);
 
 				items = page.getItems();
+			}
+		}
+		finally {
+			if (FeatureFlagManagerUtil.isEnabled("LPD-29367")) {
+				NestedFieldsContextThreadLocal.setNestedFieldsContext(
+					oldNestedFieldsContext);
 			}
 		}
 
@@ -312,14 +312,6 @@ public class BatchEngineExportTaskExecutorImpl
 		zipOutputStream.putNextEntry(zipEntry);
 
 		return zipOutputStream;
-	}
-
-	private List<String> _toList(String fieldNamesString) {
-		if (Validator.isNull(fieldNamesString)) {
-			return Collections.emptyList();
-		}
-
-		return Arrays.asList(StringUtil.split(fieldNamesString, ','));
 	}
 
 	private void _updateBatchEngineExportTask(

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
@@ -35,15 +35,23 @@ import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.vulcan.fields.NestedFieldsContext;
+import com.liferay.portal.vulcan.fields.NestedFieldsContextThreadLocal;
 
 import java.io.Serializable;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -131,6 +139,20 @@ public class BatchEngineExportTaskExecutorImpl
 
 		Map<String, Serializable> parameters = _getParameters(
 			batchEngineExportTask);
+
+		String nestedFieldNames = (String)parameters.get("nestedFieldNames");
+
+		int depth = Math.max(
+			Math.min(
+				GetterUtil.getInteger(parameters.get("nestedFieldsDepth"), 1),
+				PropsValues.OBJECT_NESTED_FIELDS_MAX_QUERY_DEPTH),
+			1);
+
+		NestedFieldsContext nestedFieldsContext = new NestedFieldsContext(
+			depth, _toList(nestedFieldNames));
+
+		NestedFieldsContextThreadLocal.setNestedFieldsContext(
+			nestedFieldsContext);
 
 		try (BatchEngineExportTaskItemWriter batchEngineExportTaskItemWriter =
 				_getBatchEngineExportTaskItemWriter(
@@ -285,6 +307,14 @@ public class BatchEngineExportTaskExecutorImpl
 		zipOutputStream.putNextEntry(zipEntry);
 
 		return zipOutputStream;
+	}
+
+	private List<String> _toList(String fieldNamesString) {
+		if (Validator.isNull(fieldNamesString)) {
+			return Collections.emptyList();
+		}
+
+		return Arrays.asList(StringUtil.split(fieldNamesString, ','));
 	}
 
 	private void _updateBatchEngineExportTask(

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.configuration.module.configuration.ConfigurationProvid
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.dao.jdbc.OutputBlob;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
@@ -140,19 +141,23 @@ public class BatchEngineExportTaskExecutorImpl
 		Map<String, Serializable> parameters = _getParameters(
 			batchEngineExportTask);
 
-		String nestedFieldNames = (String)parameters.get("nestedFieldNames");
+		if (FeatureFlagManagerUtil.isEnabled("LPD-29367")) {
+			String nestedFieldNames = (String)parameters.get(
+				"nestedFieldNames");
 
-		int depth = Math.max(
-			Math.min(
-				GetterUtil.getInteger(parameters.get("nestedFieldsDepth"), 1),
-				PropsValues.OBJECT_NESTED_FIELDS_MAX_QUERY_DEPTH),
-			1);
+			int depth = Math.max(
+				Math.min(
+					GetterUtil.getInteger(
+						parameters.get("nestedFieldsDepth"), 1),
+					PropsValues.OBJECT_NESTED_FIELDS_MAX_QUERY_DEPTH),
+				1);
 
-		NestedFieldsContext nestedFieldsContext = new NestedFieldsContext(
-			depth, _toList(nestedFieldNames));
+			NestedFieldsContext nestedFieldsContext = new NestedFieldsContext(
+				depth, _toList(nestedFieldNames));
 
-		NestedFieldsContextThreadLocal.setNestedFieldsContext(
-			nestedFieldsContext);
+			NestedFieldsContextThreadLocal.setNestedFieldsContext(
+				nestedFieldsContext);
+		}
 
 		try (BatchEngineExportTaskItemWriter batchEngineExportTaskItemWriter =
 				_getBatchEngineExportTaskItemWriter(

--- a/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/internal/batch/engine/broker/BatchEngineBrokerImpl.java
+++ b/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/internal/batch/engine/broker/BatchEngineBrokerImpl.java
@@ -187,7 +187,7 @@ public class BatchEngineBrokerImpl implements BatchEngineBroker {
 						batchPlannerPlan.getBatchPlannerPlanId()),
 					BatchPlannerMappingModel::getInternalFieldName),
 				StringPool.COMMA),
-			batchPlannerPlan.getTaskItemDelegateName());
+			null, batchPlannerPlan.getTaskItemDelegateName());
 	}
 
 	private void _submitImportTask(BatchPlannerPlan batchPlannerPlan)

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/bnd.bnd
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Batch Engine API
 Bundle-SymbolicName: com.liferay.headless.batch.engine.api
-Bundle-Version: 21.0.1
+Bundle-Version: 22.0.0
 Export-Package:\
 	com.liferay.headless.batch.engine.dto.v1_0,\
 	com.liferay.headless.batch.engine.resource.v1_0

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/src/main/java/com/liferay/headless/batch/engine/resource/v1_0/ExportTaskResource.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/src/main/java/com/liferay/headless/batch/engine/resource/v1_0/ExportTaskResource.java
@@ -55,7 +55,7 @@ public interface ExportTaskResource {
 	public ExportTask postExportTask(
 			String className, String contentType, String callbackURL,
 			String externalReferenceCode, String fieldNames,
-			String taskItemDelegateName)
+			String nestedFieldNames, String taskItemDelegateName)
 		throws Exception;
 
 	public ExportTask getExportTask(Long exportTaskId) throws Exception;

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/src/main/resources/com/liferay/headless/batch/engine/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/src/main/resources/com/liferay/headless/batch/engine/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 9.0.0
+version 10.0.0

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-client/src/main/java/com/liferay/headless/batch/engine/client/resource/v1_0/ExportTaskResource.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-client/src/main/java/com/liferay/headless/batch/engine/client/resource/v1_0/ExportTaskResource.java
@@ -53,13 +53,13 @@ public interface ExportTaskResource {
 	public ExportTask postExportTask(
 			String className, String contentType, String callbackURL,
 			String externalReferenceCode, String fieldNames,
-			String taskItemDelegateName)
+			String nestedFieldNames, String taskItemDelegateName)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse postExportTaskHttpResponse(
 			String className, String contentType, String callbackURL,
 			String externalReferenceCode, String fieldNames,
-			String taskItemDelegateName)
+			String nestedFieldNames, String taskItemDelegateName)
 		throws Exception;
 
 	public ExportTask getExportTask(Long exportTaskId) throws Exception;
@@ -385,12 +385,12 @@ public interface ExportTaskResource {
 		public ExportTask postExportTask(
 				String className, String contentType, String callbackURL,
 				String externalReferenceCode, String fieldNames,
-				String taskItemDelegateName)
+				String nestedFieldNames, String taskItemDelegateName)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse = postExportTaskHttpResponse(
 				className, contentType, callbackURL, externalReferenceCode,
-				fieldNames, taskItemDelegateName);
+				fieldNames, nestedFieldNames, taskItemDelegateName);
 
 			String content = httpResponse.getContent();
 
@@ -454,7 +454,7 @@ public interface ExportTaskResource {
 		public HttpInvoker.HttpResponse postExportTaskHttpResponse(
 				String className, String contentType, String callbackURL,
 				String externalReferenceCode, String fieldNames,
-				String taskItemDelegateName)
+				String nestedFieldNames, String taskItemDelegateName)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -493,6 +493,11 @@ public interface ExportTaskResource {
 
 			if (fieldNames != null) {
 				httpInvoker.parameter("fieldNames", String.valueOf(fieldNames));
+			}
+
+			if (nestedFieldNames != null) {
+				httpInvoker.parameter(
+					"nestedFieldNames", String.valueOf(nestedFieldNames));
 			}
 
 			if (taskItemDelegateName != null) {

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/rest-openapi.yaml
@@ -234,6 +234,10 @@ paths:
                   schema:
                       type: string
                 - in: query
+                  name: nestedFieldNames
+                  schema:
+                      type: string
+                - in: query
                   name: taskItemDelegateName
                   schema:
                       type: string

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/BaseExportTaskResourceImpl.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/BaseExportTaskResourceImpl.java
@@ -146,6 +146,10 @@ public abstract class BaseExportTaskResourceImpl implements ExportTaskResource {
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "nestedFieldNames"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "taskItemDelegateName"
 			)
 		}
@@ -175,6 +179,9 @@ public abstract class BaseExportTaskResourceImpl implements ExportTaskResource {
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("fieldNames")
 			String fieldNames,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("nestedFieldNames")
+			String nestedFieldNames,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("taskItemDelegateName")
 			String taskItemDelegateName)

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/ExportTaskResourceImpl.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/ExportTaskResourceImpl.java
@@ -86,7 +86,7 @@ public class ExportTaskResourceImpl extends BaseExportTaskResourceImpl {
 	public ExportTask postExportTask(
 			String className, String contentType, String callbackURL,
 			String externalReferenceCode, String fieldNames,
-			String taskItemDelegateName)
+			String nestedFieldNames, String taskItemDelegateName)
 		throws Exception {
 
 		Class<?> clazz = _itemClassRegistry.getItemClass(className);

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/vulcan/openapi/contributor/BatchEngineOpenAPIContributor.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/vulcan/openapi/contributor/BatchEngineOpenAPIContributor.java
@@ -51,20 +51,28 @@ public class BatchEngineOpenAPIContributor implements OpenAPIContributor {
 			return;
 		}
 
+		_removeParameter(pathItem, "restrictedFieldNames");
+
+		pathItem = paths.get("/v1.0/export-task/{className}/{contentType}");
+
+		if (pathItem == null) {
+			return;
+		}
+
+		_removeParameter(pathItem, "nestedFieldNames");
+	}
+
+	private void _removeParameter(PathItem pathItem, String parameterName) {
 		Operation operation = pathItem.getPost();
 
-		if (operation == null) {
-			return;
+		if (operation != null) {
+			List<Parameter> parameters = operation.getParameters();
+
+			if (parameters != null) {
+				parameters.removeIf(
+					param -> Objects.equals(param.getName(), parameterName));
+			}
 		}
-
-		List<Parameter> parameters = operation.getParameters();
-
-		if (parameters == null) {
-			return;
-		}
-
-		parameters.removeIf(
-			param -> Objects.equals(param.getName(), "restrictedFieldNames"));
 	}
 
 }

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/vulcan/openapi/contributor/BatchEngineOpenAPIContributor.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/vulcan/openapi/contributor/BatchEngineOpenAPIContributor.java
@@ -46,13 +46,13 @@ public class BatchEngineOpenAPIContributor implements OpenAPIContributor {
 		}
 
 		_removeParameter(
-			paths.get("/v1.0/export-task/{className}/{contentType}"),
-			"nestedFieldNames");
+			"nestedFieldNames",
+			paths.get("/v1.0/export-task/{className}/{contentType}"));
 		_removeParameter(
-			paths.get("/v1.0/import-task/{className}"), "restrictedFieldNames");
+			"restrictedFieldNames", paths.get("/v1.0/import-task/{className}"));
 	}
 
-	private void _removeParameter(PathItem pathItem, String parameterName) {
+	private void _removeParameter(String parameterName, PathItem pathItem) {
 		if (pathItem == null) {
 			return;
 		}

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/vulcan/openapi/contributor/BatchEngineOpenAPIContributor.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/vulcan/openapi/contributor/BatchEngineOpenAPIContributor.java
@@ -45,24 +45,19 @@ public class BatchEngineOpenAPIContributor implements OpenAPIContributor {
 			return;
 		}
 
-		PathItem pathItem = paths.get("/v1.0/import-task/{className}");
+		_removeParameter(
+			paths.get("/v1.0/import-task/{className}"), "restrictedFieldNames");
 
-		if (pathItem == null) {
-			return;
-		}
-
-		_removeParameter(pathItem, "restrictedFieldNames");
-
-		pathItem = paths.get("/v1.0/export-task/{className}/{contentType}");
-
-		if (pathItem == null) {
-			return;
-		}
-
-		_removeParameter(pathItem, "nestedFieldNames");
+		_removeParameter(
+			paths.get("/v1.0/export-task/{className}/{contentType}"),
+			"nestedFieldNames");
 	}
 
 	private void _removeParameter(PathItem pathItem, String parameterName) {
+		if (pathItem == null) {
+			return;
+		}
+
 		Operation operation = pathItem.getPost();
 
 		if (operation != null) {

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/vulcan/openapi/contributor/BatchEngineOpenAPIContributor.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/vulcan/openapi/contributor/BatchEngineOpenAPIContributor.java
@@ -46,11 +46,10 @@ public class BatchEngineOpenAPIContributor implements OpenAPIContributor {
 		}
 
 		_removeParameter(
-			paths.get("/v1.0/import-task/{className}"), "restrictedFieldNames");
-
-		_removeParameter(
 			paths.get("/v1.0/export-task/{className}/{contentType}"),
 			"nestedFieldNames");
+		_removeParameter(
+			paths.get("/v1.0/import-task/{className}"), "restrictedFieldNames");
 	}
 
 	private void _removeParameter(PathItem pathItem, String parameterName) {

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/vulcan/openapi/contributor/BatchEngineOpenAPIContributor.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/vulcan/openapi/contributor/BatchEngineOpenAPIContributor.java
@@ -60,14 +60,18 @@ public class BatchEngineOpenAPIContributor implements OpenAPIContributor {
 
 		Operation operation = pathItem.getPost();
 
-		if (operation != null) {
-			List<Parameter> parameters = operation.getParameters();
-
-			if (parameters != null) {
-				parameters.removeIf(
-					param -> Objects.equals(param.getName(), parameterName));
-			}
+		if (operation == null) {
+			return;
 		}
+
+		List<Parameter> parameters = operation.getParameters();
+
+		if (parameters == null) {
+			return;
+		}
+
+		parameters.removeIf(
+			param -> Objects.equals(param.getName(), parameterName));
 	}
 
 }

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -235,7 +235,7 @@ public class ExportTaskResourceTest {
 		Map<String, String> classNamePartsMap = _splitClassName(className);
 
 		ExportTask exportTask = _exportTaskResource.postExportTask(
-			classNamePartsMap.get("className"), "jsont", null, null, null,
+			classNamePartsMap.get("className"), "jsont", null, null, null, null,
 			classNamePartsMap.get("taskItemDelegateName"));
 
 		String externalReferenceCode = exportTask.getExternalReferenceCode();

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -22,8 +22,6 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalServiceUtil;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.Http;

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -12,11 +12,9 @@ import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.rest.test.util.ObjectEntryTestUtil;
-import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONArray;
-import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -235,11 +233,5 @@ public class ExportTaskResourceTest extends BaseTaskResourceTestCase {
 
 	@Inject
 	private CompanyLocalService _companyLocalService;
-
-	@Inject
-	private JSONFactory _jsonFactory;
-
-	@Inject
-	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 }

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -15,11 +15,15 @@ import com.liferay.object.rest.test.util.ObjectEntryTestUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalServiceUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.Http;
@@ -27,10 +31,15 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.vulcan.permission.Permission;
+import com.liferay.portal.vulcan.permission.PermissionUtil;
 
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.zip.ZipInputStream;
 
 import org.junit.Assert;
@@ -142,6 +151,68 @@ public class ExportTaskResourceTest extends BaseTaskResourceTestCase {
 					objectEntry2.getExternalReferenceCode())
 			).toString(),
 			StringUtil.read(zipInputStream), JSONCompareMode.LENIENT);
+	}
+
+	@FeatureFlags("LPD-29367")
+	@Test
+	public void testPostExportTaskWithNestedFieldNames() throws Exception {
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			objectDefinition, OBJECT_FIELD_NAME_TEXT, "TestObject");
+
+		Collection<Permission> permissions = PermissionUtil.getPermissions(
+			objectDefinition.getCompanyId(),
+			ResourceActionLocalServiceUtil.getResourceActions(
+				objectDefinition.getClassName()),
+			objectEntry.getObjectEntryId(), objectDefinition.getClassName(),
+			null);
+
+		String nestedFieldNames = "permissions";
+
+		JSONObject jsonObject = _testPostExportTask(
+			"COMPLETED",
+			"nestedFieldNames=" + URLCodec.encodeURL(nestedFieldNames),
+			objectDefinition);
+
+		Assert.assertEquals(1, jsonObject.getInt("processedItemsCount"));
+
+		ZipInputStream zipInputStream = new ZipInputStream(
+			HTTPTestUtil.invokeToInputStream(
+				null,
+				StringBundler.concat(
+					"headless-batch-engine/v1.0/export-task",
+					"/by-external-reference-code/",
+					jsonObject.getString("externalReferenceCode"), "/content"),
+				Http.Method.GET));
+
+		zipInputStream.getNextEntry();
+
+		String content = StringUtil.read(zipInputStream);
+
+		JSONArray outerJSONArray = _jsonFactory.createJSONArray(content);
+
+		JSONObject firstJSONObject = _jsonFactory.createJSONObject(
+			outerJSONArray.get(
+				0
+			).toString());
+
+		JSONArray permissionsJSONArray = _jsonFactory.createJSONArray(
+			firstJSONObject.get(
+				"permissions"
+			).toString());
+
+		String roleName = _jsonFactory.createJSONObject(
+			permissionsJSONArray.get(
+				0
+			).toString()
+		).get(
+			"roleName"
+		).toString();
+
+		Assert.assertTrue(
+			permissions.stream(
+			).anyMatch(
+				n -> Objects.equals(n.getRoleName(), roleName)
+			));
 	}
 
 	private JSONObject _testPostExportTask(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -33,12 +33,10 @@ import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.util.PropsValues;
-import com.liferay.portal.vulcan.permission.Permission;
+import com.liferay.portal.vulcan.jackson.databind.ObjectMapperProviderUtil;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 
-import java.util.Collection;
 import java.util.Collections;
-import java.util.Objects;
 import java.util.zip.ZipInputStream;
 
 import org.junit.Assert;
@@ -150,44 +148,44 @@ public class ExportTaskResourceTest extends BaseTaskResourceTestCase {
 		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
 			objectDefinition, OBJECT_FIELD_NAME_TEXT, "TestObject");
 
-		Collection<Permission> permissions = PermissionUtil.getPermissions(
-			objectDefinition.getCompanyId(),
-			ResourceActionLocalServiceUtil.getResourceActions(
-				objectDefinition.getClassName()),
-			objectEntry.getObjectEntryId(), objectDefinition.getClassName(),
-			null);
+		// With "nestedFieldNames" query parameter
 
-		JSONObject jsonObject = _testPostExportTask(
+		JSONObject jsonObject1 = _testPostExportTask(
 			"COMPLETED", "nestedFieldNames=permissions", objectDefinition);
 
-		Assert.assertEquals(1, jsonObject.getInt("processedItemsCount"));
+		Assert.assertEquals(1, jsonObject1.getInt("processedItemsCount"));
 
-		JSONArray contentJSONArray = _getExportTaskContentJSONArray(
-			jsonObject.getString("externalReferenceCode"));
+		JSONArray contentJSONArray1 = _getExportTaskContentJSONArray(
+			jsonObject1.getString("externalReferenceCode"));
 
-		JSONObject firstJSONObject = _jsonFactory.createJSONObject(
-			contentJSONArray.get(
-				0
-			).toString());
+		JSONArray permissionsJSONArray = JSONUtil.getValueAsJSONArray(
+			contentJSONArray1, "JSONObject/0", "JSONArray/permissions");
 
-		JSONArray permissionsJSONArray = _jsonFactory.createJSONArray(
-			firstJSONObject.get(
-				"permissions"
-			).toString());
+		JSONAssert.assertEquals(
+			ObjectMapperProviderUtil.getObjectMapper(
+			).writeValueAsString(
+				PermissionUtil.getPermissions(
+					objectDefinition.getCompanyId(),
+					ResourceActionLocalServiceUtil.getResourceActions(
+						objectDefinition.getClassName()),
+					objectEntry.getObjectEntryId(),
+					objectDefinition.getClassName(), null)
+			),
+			permissionsJSONArray.toString(), JSONCompareMode.LENIENT);
 
-		String roleName = _jsonFactory.createJSONObject(
-			permissionsJSONArray.get(
-				0
-			).toString()
-		).get(
-			"roleName"
-		).toString();
+		// Without "nestedFieldNames" query parameter
 
-		Assert.assertTrue(
-			permissions.stream(
-			).anyMatch(
-				n -> Objects.equals(n.getRoleName(), roleName)
-			));
+		JSONObject jsonObject2 = _testPostExportTask(
+			"COMPLETED", null, objectDefinition);
+
+		Assert.assertEquals(1, jsonObject2.getInt("processedItemsCount"));
+
+		JSONArray contentJSONArray2 = _getExportTaskContentJSONArray(
+			jsonObject2.getString("externalReferenceCode"));
+
+		Assert.assertNull(
+			JSONUtil.getValueAsJSONArray(
+				contentJSONArray2, "JSONObject/0", "JSONArray/permissions"));
 	}
 
 	private JSONArray _getExportTaskContentJSONArray(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -192,18 +192,20 @@ public class ExportTaskResourceTest extends BaseTaskResourceTestCase {
 			String externalReferenceCode)
 		throws Exception {
 
-		ZipInputStream zipInputStream = new ZipInputStream(
-			HTTPTestUtil.invokeToInputStream(
-				null,
-				StringBundler.concat(
-					"headless-batch-engine/v1.0/export-task",
-					"/by-external-reference-code/", externalReferenceCode,
-					"/content"),
-				Http.Method.GET));
+		try (ZipInputStream zipInputStream = new ZipInputStream(
+				HTTPTestUtil.invokeToInputStream(
+					null,
+					StringBundler.concat(
+						"headless-batch-engine/v1.0/export-task",
+						"/by-external-reference-code/", externalReferenceCode,
+						"/content"),
+					Http.Method.GET))) {
 
-		zipInputStream.getNextEntry();
+			zipInputStream.getNextEntry();
 
-		return JSONFactoryUtil.createJSONArray(StringUtil.read(zipInputStream));
+			return JSONFactoryUtil.createJSONArray(
+				StringUtil.read(zipInputStream));
+		}
 	}
 
 	private JSONObject _testPostExportTask(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -157,12 +157,8 @@ public class ExportTaskResourceTest extends BaseTaskResourceTestCase {
 			objectEntry.getObjectEntryId(), objectDefinition.getClassName(),
 			null);
 
-		String nestedFieldNames = "permissions";
-
 		JSONObject jsonObject = _testPostExportTask(
-			"COMPLETED",
-			"nestedFieldNames=" + URLCodec.encodeURL(nestedFieldNames),
-			objectDefinition);
+			"COMPLETED", "nestedFieldNames=permissions", objectDefinition);
 
 		Assert.assertEquals(1, jsonObject.getInt("processedItemsCount"));
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -17,6 +17,7 @@ import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
@@ -128,17 +129,6 @@ public class ExportTaskResourceTest extends BaseTaskResourceTestCase {
 
 		Assert.assertEquals(2, jsonObject.getInt("processedItemsCount"));
 
-		ZipInputStream zipInputStream = new ZipInputStream(
-			HTTPTestUtil.invokeToInputStream(
-				null,
-				StringBundler.concat(
-					"headless-batch-engine/v1.0/export-task",
-					"/by-external-reference-code/",
-					jsonObject.getString("externalReferenceCode"), "/content"),
-				Http.Method.GET));
-
-		zipInputStream.getNextEntry();
-
 		JSONAssert.assertEquals(
 			JSONUtil.putAll(
 				JSONUtil.put(
@@ -148,7 +138,10 @@ public class ExportTaskResourceTest extends BaseTaskResourceTestCase {
 					"externalReferenceCode",
 					objectEntry2.getExternalReferenceCode())
 			).toString(),
-			StringUtil.read(zipInputStream), JSONCompareMode.LENIENT);
+			_getExportTaskContentJSONArray(
+				jsonObject.getString("externalReferenceCode")
+			).toString(),
+			JSONCompareMode.LENIENT);
 	}
 
 	@FeatureFlags("LPD-29367")
@@ -173,23 +166,11 @@ public class ExportTaskResourceTest extends BaseTaskResourceTestCase {
 
 		Assert.assertEquals(1, jsonObject.getInt("processedItemsCount"));
 
-		ZipInputStream zipInputStream = new ZipInputStream(
-			HTTPTestUtil.invokeToInputStream(
-				null,
-				StringBundler.concat(
-					"headless-batch-engine/v1.0/export-task",
-					"/by-external-reference-code/",
-					jsonObject.getString("externalReferenceCode"), "/content"),
-				Http.Method.GET));
-
-		zipInputStream.getNextEntry();
-
-		String content = StringUtil.read(zipInputStream);
-
-		JSONArray outerJSONArray = _jsonFactory.createJSONArray(content);
+		JSONArray contentJSONArray = _getExportTaskContentJSONArray(
+			jsonObject.getString("externalReferenceCode"));
 
 		JSONObject firstJSONObject = _jsonFactory.createJSONObject(
-			outerJSONArray.get(
+			contentJSONArray.get(
 				0
 			).toString());
 
@@ -211,6 +192,24 @@ public class ExportTaskResourceTest extends BaseTaskResourceTestCase {
 			).anyMatch(
 				n -> Objects.equals(n.getRoleName(), roleName)
 			));
+	}
+
+	private JSONArray _getExportTaskContentJSONArray(
+			String externalReferenceCode)
+		throws Exception {
+
+		ZipInputStream zipInputStream = new ZipInputStream(
+			HTTPTestUtil.invokeToInputStream(
+				null,
+				StringBundler.concat(
+					"headless-batch-engine/v1.0/export-task",
+					"/by-external-reference-code/", externalReferenceCode,
+					"/content"),
+				Http.Method.GET));
+
+		zipInputStream.getNextEntry();
+
+		return JSONFactoryUtil.createJSONArray(StringUtil.read(zipInputStream));
 	}
 
 	private JSONObject _testPostExportTask(

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/NestedFieldsContextUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/NestedFieldsContextUtil.java
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.vulcan.util;
+
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.util.PropsValues;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Daniel Szimko
+ */
+public class NestedFieldsContextUtil {
+
+	public static int limitDepth(int nestedFieldsDepth) {
+		return Math.max(
+			Math.min(
+				nestedFieldsDepth,
+				PropsValues.OBJECT_NESTED_FIELDS_MAX_QUERY_DEPTH),
+			1);
+	}
+
+	public static List<String> toNestedFields(String nestedFields) {
+		if (Validator.isNotNull(nestedFields)) {
+			return Arrays.asList(nestedFields.split("\\s*,\\s*"));
+		}
+
+		return Collections.emptyList();
+	}
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/resource/VulcanBatchEngineExportTaskResourceImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/resource/VulcanBatchEngineExportTaskResourceImpl.java
@@ -39,7 +39,7 @@ public class VulcanBatchEngineExportTaskResourceImpl
 
 		return exportTaskResource.postExportTask(
 			name, contentType, callbackURL,
-			_getQueryParameterValue("externalReferenceCode"), fieldNames,
+			_getQueryParameterValue("externalReferenceCode"), fieldNames, null,
 			_getTaskItemDelegateName());
 	}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/NestedFieldsContainerRequestFilter.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/NestedFieldsContainerRequestFilter.java
@@ -6,15 +6,12 @@
 package com.liferay.portal.vulcan.internal.jaxrs.container.request.filter;
 
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.util.PropsValues;
 import com.liferay.portal.vulcan.fields.NestedFieldsContext;
 import com.liferay.portal.vulcan.fields.NestedFieldsContextThreadLocal;
+import com.liferay.portal.vulcan.util.NestedFieldsContextUtil;
 
 import java.io.IOException;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import javax.ws.rs.container.ContainerRequestContext;
@@ -42,30 +39,16 @@ public class NestedFieldsContainerRequestFilter
 		MultivaluedMap<String, String> queryParameters =
 			uriInfo.getQueryParameters();
 
-		String nestedFields = queryParameters.getFirst("nestedFields");
-
-		int depth = Math.max(
-			Math.min(
-				GetterUtil.getInteger(
-					queryParameters.getFirst("nestedFieldsDepth"), 1),
-				PropsValues.OBJECT_NESTED_FIELDS_MAX_QUERY_DEPTH),
-			1);
-
-		NestedFieldsContext nestedFieldsContext = new NestedFieldsContext(
-			depth, _getFieldNames(nestedFields), JAXRSUtils.getCurrentMessage(),
-			uriInfo.getPathParameters(),
-			_getResourceVersion(uriInfo.getPathSegments()), queryParameters);
-
 		NestedFieldsContextThreadLocal.setNestedFieldsContext(
-			nestedFieldsContext);
-	}
-
-	private List<String> _getFieldNames(String nestedFields) {
-		if (Validator.isNotNull(nestedFields)) {
-			return Arrays.asList(nestedFields.split("\\s*,\\s*"));
-		}
-
-		return Collections.emptyList();
+			new NestedFieldsContext(
+				NestedFieldsContextUtil.limitDepth(
+					GetterUtil.getInteger(
+						queryParameters.getFirst("nestedFieldsDepth"))),
+				NestedFieldsContextUtil.toNestedFields(
+					queryParameters.getFirst("nestedFields")),
+				JAXRSUtils.getCurrentMessage(), uriInfo.getPathParameters(),
+				_getResourceVersion(uriInfo.getPathSegments()),
+				queryParameters));
 	}
 
 	private String _getResourceVersion(List<PathSegment> pathSegments) {


### PR DESCRIPTION
JIRA ticket: https://liferay.atlassian.net/browse/LPD-34931

from https://github.com/liferay-headless/liferay-portal/pull/2345

Added an additional parameter called nestedFieldNames that lets clients to decide which additional data they would like to export. For example you can export the permissions of Custom and Modifiable System Objects in Batch Engine.

Forwarded manually based on [this](https://github.com/liferay-headless/liferay-portal/pull/2345#issuecomment-2535920695) comment
