### PR TITLE
LPD-43100 Inconsistencies in tags filter

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/AssetTagsNavigationDisplayContext.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/AssetTagsNavigationDisplayContext.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -192,7 +191,7 @@ public class AssetTagsNavigationDisplayContext {
 				_maxAssetTags, AssetTagCountComparator.getInstance(false));
 		}
 
-		return ListUtil.sort(assetTags);
+		return assetTags;
 	}
 
 	private double _getMultiplier() {

--- a/modules/apps/asset/asset-tags-test/build.gradle
+++ b/modules/apps/asset/asset-tags-test/build.gradle
@@ -3,6 +3,8 @@ dependencies {
 	testIntegrationImplementation project(":apps:asset:asset-api")
 	testIntegrationImplementation project(":apps:asset:asset-tags-api")
 	testIntegrationImplementation project(":apps:asset:asset-test-util")
+	testIntegrationImplementation project(":apps:blogs:blogs-api")
+	testIntegrationImplementation project(":apps:blogs:blogs-test-util")
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-test-util")
 	testIntegrationImplementation project(":apps:document-library:document-library-test-util")
 	testIntegrationImplementation project(":apps:export-import:export-import-test-util")

--- a/modules/apps/asset/asset-tags-test/src/testIntegration/java/com/liferay/asset/tags/service/test/AssetTagLocalServiceTest.java
+++ b/modules/apps/asset/asset-tags-test/src/testIntegration/java/com/liferay/asset/tags/service/test/AssetTagLocalServiceTest.java
@@ -16,6 +16,8 @@ import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.asset.util.AssetHelper;
+import com.liferay.blogs.model.BlogsEntry;
+import com.liferay.blogs.test.util.BlogsTestUtil;
 import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.test.util.JournalTestUtil;
@@ -363,12 +365,29 @@ public class AssetTagLocalServiceTest {
 
 		Arrays.sort(expectedTagNames);
 
+		_addBlogsEntry(expectedTagNames);
 		_addArticle(expectedTagNames);
 
-		_assertGetTags(expectedTagNames.length, expectedTagNames, "tag1");
-		_assertGetTags(expectedTagNames.length, expectedTagNames, "TAG1");
-		_assertGetTags(1, expectedTagNames, "TAG1", 0, 1);
-		_assertGetTags(1, expectedTagNames, "Tag1", 0, 1);
+		_assertGetTags(
+			BlogsEntry.class.getName(), expectedTagNames.length,
+			expectedTagNames, "tag1");
+		_assertGetTags(
+			BlogsEntry.class.getName(), expectedTagNames.length,
+			expectedTagNames, "TAG1");
+		_assertGetTags(
+			BlogsEntry.class.getName(), 1, expectedTagNames, "TAG1", 0, 1);
+		_assertGetTags(
+			BlogsEntry.class.getName(), 1, expectedTagNames, "Tag1", 0, 1);
+		_assertGetTags(
+			JournalArticle.class.getName(), expectedTagNames.length,
+			expectedTagNames, "tag1");
+		_assertGetTags(
+			JournalArticle.class.getName(), expectedTagNames.length,
+			expectedTagNames, "TAG1");
+		_assertGetTags(
+			JournalArticle.class.getName(), 1, expectedTagNames, "TAG1", 0, 1);
+		_assertGetTags(
+			JournalArticle.class.getName(), 1, expectedTagNames, "Tag1", 0, 1);
 	}
 
 	@Test
@@ -499,23 +518,30 @@ public class AssetTagLocalServiceTest {
 		return assetTags;
 	}
 
-	private void _assertGetTags(
-		long expectedLength, String[] expectedTagNames, String name) {
+	private void _addBlogsEntry(String[] tagNames) throws Exception {
+		_serviceContext.setAssetTagNames(tagNames);
 
-		_assertGetTags(
-			expectedLength, expectedTagNames, name, QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS);
+		BlogsTestUtil.addEntryWithWorkflow(
+			TestPropsValues.getUserId(), RandomTestUtil.randomString(), true,
+			_serviceContext);
 	}
 
 	private void _assertGetTags(
-		long expectedLength, String[] expectedTagNames, String name, int start,
-		int end) {
+		String className, long expectedLength, String[] expectedTagNames,
+		String name) {
+
+		_assertGetTags(
+			className, expectedLength, expectedTagNames, name,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+	}
+
+	private void _assertGetTags(
+		String className, long expectedLength, String[] expectedTagNames,
+		String name, int start, int end) {
 
 		List<AssetTag> actualAssetTags = _assetTagLocalService.getTags(
 			_group.getGroupId(),
-			_classNameLocalService.getClassNameId(
-				JournalArticle.class.getName()),
-			name, start, end);
+			_classNameLocalService.getClassNameId(className), name, start, end);
 
 		Assert.assertEquals(
 			actualAssetTags.toString(), expectedLength, actualAssetTags.size());

--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetTagFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetTagFinderImpl.java
@@ -97,24 +97,19 @@ public class AssetTagFinderImpl
 				AssetEntries_AssetTagsTable.INSTANCE,
 				AssetEntries_AssetTagsTable.INSTANCE.tagId.eq(
 					AssetTagTable.INSTANCE.tagId)
+			).innerJoinON(
+				AssetEntryTable.INSTANCE,
+				AssetEntryTable.INSTANCE.entryId.eq(
+					AssetEntries_AssetTagsTable.INSTANCE.entryId)
 			).where(
 				() -> {
-					Predicate predicate =
-						AssetEntries_AssetTagsTable.INSTANCE.entryId.in(
-							DSLQueryFactoryUtil.select(
-								AssetEntryTable.INSTANCE.entryId
-							).from(
-								AssetEntryTable.INSTANCE
-							).where(
-								AssetEntryTable.INSTANCE.groupId.eq(
-									groupId
-								).and(
-									AssetEntryTable.INSTANCE.classNameId.eq(
-										classNameId)
-								).and(
-									AssetEntryTable.INSTANCE.visible.eq(true)
-								)
-							));
+					Predicate predicate = AssetEntryTable.INSTANCE.groupId.eq(
+						groupId
+					).and(
+						AssetEntryTable.INSTANCE.classNameId.eq(classNameId)
+					).and(
+						AssetEntryTable.INSTANCE.visible.eq(true)
+					);
 
 					if (name == null) {
 						return predicate;

--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetTagFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetTagFinderImpl.java
@@ -11,11 +11,14 @@ import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.asset.kernel.model.AssetTagTable;
 import com.liferay.asset.kernel.service.persistence.AssetTagFinder;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.Table;
+import com.liferay.petra.sql.dsl.expression.Expression;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.sql.dsl.query.GroupByStep;
+import com.liferay.petra.sql.dsl.query.HavingStep;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.orm.SQLQuery;
 import com.liferay.portal.kernel.dao.orm.Session;
@@ -26,8 +29,10 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portlet.asset.model.impl.AssetTagImpl;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Brian Wing Shun Chan
@@ -203,7 +208,7 @@ public class AssetTagFinderImpl
 
 	private GroupByStep _getEmptyEntriesGroupByStep(String name) {
 		return DSLQueryFactoryUtil.select(
-			AssetTagTable.INSTANCE
+			_getExpressions(true, false)
 		).from(
 			AssetTagTable.INSTANCE
 		).where(
@@ -224,11 +229,41 @@ public class AssetTagFinderImpl
 		);
 	}
 
-	private GroupByStep _getTagEntriesGroupByStep(
+	private Expression<?>[] _getExpressions(
+		boolean includeAssetCount, boolean replaceAssetCount) {
+
+		Collection<Column<AssetTagTable, ?>> columns =
+			AssetTagTable.INSTANCE.getColumns();
+
+		Expression<?>[] expressions = new Expression<?>[0];
+
+		for (Iterator<?> iterator = columns.iterator(); iterator.hasNext();) {
+			Column<AssetTagTable, ?> column =
+				(Column<AssetTagTable, ?>)iterator.next();
+
+			Expression<?> expression = column;
+
+			if (Objects.equals(column.getName(), "assetCount")) {
+				if (!includeAssetCount) {
+					continue;
+				}
+
+				if (replaceAssetCount) {
+					expression = _entryCountExpression;
+				}
+			}
+
+			expressions = ArrayUtil.append(expressions, expression);
+		}
+
+		return expressions;
+	}
+
+	private HavingStep _getTagEntriesGroupByStep(
 		long groupId, long classNameId, String name) {
 
-		return DSLQueryFactoryUtil.selectDistinct(
-			AssetTagTable.INSTANCE
+		return DSLQueryFactoryUtil.select(
+			_getExpressions(true, true)
 		).from(
 			AssetTagTable.INSTANCE
 		).innerJoinON(
@@ -260,7 +295,16 @@ public class AssetTagFinderImpl
 						StringUtil.toLowerCase(name)
 					));
 			}
+		).groupBy(
+			_getExpressions(false, false)
 		);
 	}
+
+	private final Expression<Long> _entryCountExpression =
+		DSLFunctionFactoryUtil.count(
+			AssetTagTable.INSTANCE.tagId
+		).as(
+			"assetCount"
+		);
 
 }

--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetTagFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetTagFinderImpl.java
@@ -72,8 +72,14 @@ public class AssetTagFinderImpl
 							AssetEntryTable.INSTANCE.groupId.eq(
 								groupId
 							).and(
-								AssetEntryTable.INSTANCE.classNameId.eq(
-									classNameId)
+								() -> {
+									if (classNameId <= 0) {
+										return null;
+									}
+
+									return AssetEntryTable.INSTANCE.classNameId.
+										eq(classNameId);
+								}
 							).and(
 								AssetEntryTable.INSTANCE.visible.eq(true)
 							);

--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetTagFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetTagFinderImpl.java
@@ -13,8 +13,9 @@ import com.liferay.asset.kernel.service.persistence.AssetTagFinder;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
+import com.liferay.petra.sql.dsl.Table;
 import com.liferay.petra.sql.dsl.expression.Predicate;
-import com.liferay.petra.sql.dsl.query.DSLQuery;
+import com.liferay.petra.sql.dsl.query.GroupByStep;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.orm.SQLQuery;
 import com.liferay.portal.kernel.dao.orm.Session;
@@ -89,52 +90,32 @@ public class AssetTagFinderImpl
 		try {
 			session = openSession();
 
-			DSLQuery dslQuery = DSLQueryFactoryUtil.selectDistinct(
-				AssetTagTable.INSTANCE
-			).from(
-				AssetTagTable.INSTANCE
-			).innerJoinON(
-				AssetEntries_AssetTagsTable.INSTANCE,
-				AssetEntries_AssetTagsTable.INSTANCE.tagId.eq(
-					AssetTagTable.INSTANCE.tagId)
-			).innerJoinON(
-				AssetEntryTable.INSTANCE,
-				AssetEntryTable.INSTANCE.entryId.eq(
-					AssetEntries_AssetTagsTable.INSTANCE.entryId)
-			).where(
-				() -> {
-					Predicate predicate = AssetEntryTable.INSTANCE.groupId.eq(
-						groupId
-					).and(
-						AssetEntryTable.INSTANCE.classNameId.eq(classNameId)
-					).and(
-						AssetEntryTable.INSTANCE.visible.eq(true)
-					);
-
-					if (name == null) {
-						return predicate;
-					}
-
-					return predicate.and(
-						DSLFunctionFactoryUtil.lower(
-							AssetTagTable.INSTANCE.name
-						).like(
-							StringUtil.toLowerCase(name)
-						));
-				}
-			).orderBy(
-				orderByStep -> {
-					if (orderByComparator == null) {
-						return orderByStep.orderBy(
-							AssetTagTable.INSTANCE.name.ascending());
-					}
-
-					return orderByStep.orderBy(
-						AssetTagTable.INSTANCE, orderByComparator);
-				}
+			Table<AssetTagTable> tempAssetTagTable = _getTagEntriesGroupByStep(
+				groupId, classNameId, name
+			).unionAll(
+				_getEmptyEntriesGroupByStep(name)
+			).as(
+				AssetTagTable.INSTANCE.getName(), AssetTagTable.INSTANCE
 			);
 
-			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(dslQuery);
+			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(
+				DSLQueryFactoryUtil.selectDistinct(
+					tempAssetTagTable
+				).from(
+					tempAssetTagTable
+				).orderBy(
+					orderByStep -> {
+						if (orderByComparator == null) {
+							return orderByStep.orderBy(
+								AssetTagTable.INSTANCE.name.ascending());
+						}
+
+						return orderByStep.orderBy(
+							AssetTagTable.INSTANCE, orderByComparator);
+					}
+				).limit(
+					start, end
+				));
 
 			sqlQuery.addEntity("AssetTag", AssetTagImpl.class);
 
@@ -218,6 +199,68 @@ public class AssetTagFinderImpl
 		finally {
 			closeSession(session);
 		}
+	}
+
+	private GroupByStep _getEmptyEntriesGroupByStep(String name) {
+		return DSLQueryFactoryUtil.select(
+			AssetTagTable.INSTANCE
+		).from(
+			AssetTagTable.INSTANCE
+		).where(
+			() -> {
+				Predicate predicate = AssetTagTable.INSTANCE.assetCount.eq(0);
+
+				if (name == null) {
+					return predicate;
+				}
+
+				return predicate.and(
+					DSLFunctionFactoryUtil.lower(
+						AssetTagTable.INSTANCE.name
+					).like(
+						StringUtil.toLowerCase(name)
+					));
+			}
+		);
+	}
+
+	private GroupByStep _getTagEntriesGroupByStep(
+		long groupId, long classNameId, String name) {
+
+		return DSLQueryFactoryUtil.selectDistinct(
+			AssetTagTable.INSTANCE
+		).from(
+			AssetTagTable.INSTANCE
+		).innerJoinON(
+			AssetEntries_AssetTagsTable.INSTANCE,
+			AssetEntries_AssetTagsTable.INSTANCE.tagId.eq(
+				AssetTagTable.INSTANCE.tagId)
+		).innerJoinON(
+			AssetEntryTable.INSTANCE,
+			AssetEntryTable.INSTANCE.entryId.eq(
+				AssetEntries_AssetTagsTable.INSTANCE.entryId)
+		).where(
+			() -> {
+				Predicate predicate = AssetEntryTable.INSTANCE.groupId.eq(
+					groupId
+				).and(
+					AssetEntryTable.INSTANCE.classNameId.eq(classNameId)
+				).and(
+					AssetEntryTable.INSTANCE.visible.eq(true)
+				);
+
+				if (name == null) {
+					return predicate;
+				}
+
+				return predicate.and(
+					DSLFunctionFactoryUtil.lower(
+						AssetTagTable.INSTANCE.name
+					).like(
+						StringUtil.toLowerCase(name)
+					));
+			}
+		);
 	}
 
 }

--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetTagFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetTagFinderImpl.java
@@ -55,12 +55,37 @@ public class AssetTagFinderImpl
 			}
 
 			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(
-				DSLQueryFactoryUtil.countDistinct(
-					AssetEntries_AssetTagsTable.INSTANCE.entryId
+				DSLQueryFactoryUtil.count(
 				).from(
-					AssetEntries_AssetTagsTable.INSTANCE
+					AssetTagTable.INSTANCE
+				).innerJoinON(
+					AssetEntries_AssetTagsTable.INSTANCE,
+					AssetEntries_AssetTagsTable.INSTANCE.tagId.eq(
+						AssetTagTable.INSTANCE.tagId)
+				).innerJoinON(
+					AssetEntryTable.INSTANCE,
+					AssetEntryTable.INSTANCE.entryId.eq(
+						AssetEntries_AssetTagsTable.INSTANCE.entryId)
 				).where(
-					AssetEntries_AssetTagsTable.INSTANCE.tagId.in(assetTagIds)
+					() -> {
+						Predicate predicate =
+							AssetEntryTable.INSTANCE.groupId.eq(
+								groupId
+							).and(
+								AssetEntryTable.INSTANCE.classNameId.eq(
+									classNameId)
+							).and(
+								AssetEntryTable.INSTANCE.visible.eq(true)
+							);
+
+						if (name == null) {
+							return predicate;
+						}
+
+						return predicate.and(
+							AssetEntries_AssetTagsTable.INSTANCE.tagId.in(
+								assetTagIds));
+					}
 				));
 
 			sqlQuery.addScalar(COUNT_COLUMN_NAME, Type.LONG);

--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetTagFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetTagFinderImpl.java
@@ -126,13 +126,14 @@ public class AssetTagFinderImpl
 		try {
 			session = openSession();
 
-			Table<AssetTagTable> tempAssetTagTable = _getTagEntriesGroupByStep(
-				groupId, classNameId, name
-			).unionAll(
-				_getEmptyEntriesGroupByStep(name)
-			).as(
-				AssetTagTable.INSTANCE.getName(), AssetTagTable.INSTANCE
-			);
+			Table<AssetTagTable> tempAssetTagTable =
+				_getAssetTagEntriesGroupByStep(
+					groupId, classNameId, name
+				).unionAll(
+					_getAssetTagEmptyEntriesGroupByStep(name)
+				).as(
+					AssetTagTable.INSTANCE.getName(), AssetTagTable.INSTANCE
+				);
 
 			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(
 				DSLQueryFactoryUtil.selectDistinct(
@@ -164,6 +165,100 @@ public class AssetTagFinderImpl
 		finally {
 			closeSession(session);
 		}
+	}
+
+	private GroupByStep _getAssetTagEmptyEntriesGroupByStep(String name) {
+		return DSLQueryFactoryUtil.select(
+			_getAssetTagExpressions(true, false)
+		).from(
+			AssetTagTable.INSTANCE
+		).where(
+			() -> {
+				Predicate predicate = AssetTagTable.INSTANCE.assetCount.eq(0);
+
+				if (name == null) {
+					return predicate;
+				}
+
+				return predicate.and(
+					DSLFunctionFactoryUtil.lower(
+						AssetTagTable.INSTANCE.name
+					).like(
+						StringUtil.toLowerCase(name)
+					));
+			}
+		);
+	}
+
+	private HavingStep _getAssetTagEntriesGroupByStep(
+		long groupId, long classNameId, String name) {
+
+		return DSLQueryFactoryUtil.select(
+			_getAssetTagExpressions(true, true)
+		).from(
+			AssetTagTable.INSTANCE
+		).innerJoinON(
+			AssetEntries_AssetTagsTable.INSTANCE,
+			AssetEntries_AssetTagsTable.INSTANCE.tagId.eq(
+				AssetTagTable.INSTANCE.tagId)
+		).innerJoinON(
+			AssetEntryTable.INSTANCE,
+			AssetEntryTable.INSTANCE.entryId.eq(
+				AssetEntries_AssetTagsTable.INSTANCE.entryId)
+		).where(
+			() -> {
+				Predicate predicate = AssetEntryTable.INSTANCE.groupId.eq(
+					groupId
+				).and(
+					AssetEntryTable.INSTANCE.classNameId.eq(classNameId)
+				).and(
+					AssetEntryTable.INSTANCE.visible.eq(true)
+				);
+
+				if (name == null) {
+					return predicate;
+				}
+
+				return predicate.and(
+					DSLFunctionFactoryUtil.lower(
+						AssetTagTable.INSTANCE.name
+					).like(
+						StringUtil.toLowerCase(name)
+					));
+			}
+		).groupBy(
+			_getAssetTagExpressions(false, false)
+		);
+	}
+
+	private Expression<?>[] _getAssetTagExpressions(
+		boolean includeAssetCount, boolean replaceAssetCount) {
+
+		Collection<Column<AssetTagTable, ?>> columns =
+			AssetTagTable.INSTANCE.getColumns();
+
+		Expression<?>[] expressions = new Expression<?>[0];
+
+		for (Iterator<?> iterator = columns.iterator(); iterator.hasNext();) {
+			Column<AssetTagTable, ?> column =
+				(Column<AssetTagTable, ?>)iterator.next();
+
+			Expression<?> expression = column;
+
+			if (Objects.equals(column.getName(), "assetCount")) {
+				if (!includeAssetCount) {
+					continue;
+				}
+
+				if (replaceAssetCount) {
+					expression = _assetTagCountExpression;
+				}
+			}
+
+			expressions = ArrayUtil.append(expressions, expression);
+		}
+
+		return expressions;
 	}
 
 	private Long[] _getAssetTagIds(
@@ -237,101 +332,7 @@ public class AssetTagFinderImpl
 		}
 	}
 
-	private GroupByStep _getEmptyEntriesGroupByStep(String name) {
-		return DSLQueryFactoryUtil.select(
-			_getExpressions(true, false)
-		).from(
-			AssetTagTable.INSTANCE
-		).where(
-			() -> {
-				Predicate predicate = AssetTagTable.INSTANCE.assetCount.eq(0);
-
-				if (name == null) {
-					return predicate;
-				}
-
-				return predicate.and(
-					DSLFunctionFactoryUtil.lower(
-						AssetTagTable.INSTANCE.name
-					).like(
-						StringUtil.toLowerCase(name)
-					));
-			}
-		);
-	}
-
-	private Expression<?>[] _getExpressions(
-		boolean includeAssetCount, boolean replaceAssetCount) {
-
-		Collection<Column<AssetTagTable, ?>> columns =
-			AssetTagTable.INSTANCE.getColumns();
-
-		Expression<?>[] expressions = new Expression<?>[0];
-
-		for (Iterator<?> iterator = columns.iterator(); iterator.hasNext();) {
-			Column<AssetTagTable, ?> column =
-				(Column<AssetTagTable, ?>)iterator.next();
-
-			Expression<?> expression = column;
-
-			if (Objects.equals(column.getName(), "assetCount")) {
-				if (!includeAssetCount) {
-					continue;
-				}
-
-				if (replaceAssetCount) {
-					expression = _entryCountExpression;
-				}
-			}
-
-			expressions = ArrayUtil.append(expressions, expression);
-		}
-
-		return expressions;
-	}
-
-	private HavingStep _getTagEntriesGroupByStep(
-		long groupId, long classNameId, String name) {
-
-		return DSLQueryFactoryUtil.select(
-			_getExpressions(true, true)
-		).from(
-			AssetTagTable.INSTANCE
-		).innerJoinON(
-			AssetEntries_AssetTagsTable.INSTANCE,
-			AssetEntries_AssetTagsTable.INSTANCE.tagId.eq(
-				AssetTagTable.INSTANCE.tagId)
-		).innerJoinON(
-			AssetEntryTable.INSTANCE,
-			AssetEntryTable.INSTANCE.entryId.eq(
-				AssetEntries_AssetTagsTable.INSTANCE.entryId)
-		).where(
-			() -> {
-				Predicate predicate = AssetEntryTable.INSTANCE.groupId.eq(
-					groupId
-				).and(
-					AssetEntryTable.INSTANCE.classNameId.eq(classNameId)
-				).and(
-					AssetEntryTable.INSTANCE.visible.eq(true)
-				);
-
-				if (name == null) {
-					return predicate;
-				}
-
-				return predicate.and(
-					DSLFunctionFactoryUtil.lower(
-						AssetTagTable.INSTANCE.name
-					).like(
-						StringUtil.toLowerCase(name)
-					));
-			}
-		).groupBy(
-			_getExpressions(false, false)
-		);
-	}
-
-	private final Expression<Long> _entryCountExpression =
+	private final Expression<Long> _assetTagCountExpression =
 		DSLFunctionFactoryUtil.count(
 			AssetTagTable.INSTANCE.tagId
 		).as(


### PR DESCRIPTION

@brianchandotcom send directly to your repository with the changes about naming requested here https://github.com/brianchandotcom/liferay-portal/pull/157054#issuecomment-2548921562

Inconsistencies in tags filter

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-43100)

There are some inconsistencies when configuring the tags filter to show a specific asset type. For one, the count that is displayed is the global count, not the count for the specific asset type. The second is the ordering, it's sorted alphabetically and not by asset count.

Also, the tags that are not used are not taken into account

# How am I fixing it?

1. Retrieve also the empty tags in the response, with an union
2. For the count, don´t retrieve the global asset count, but calculate it by asset type

# How can you verify that it works?

Follow the steps on the ticket or run the adapted integration tests

