### PR TITLE
LPD-43786 Update Playwright FeatureFlagFixture to allow for setting system feature flags.

### DIFF
--- a/modules/test/playwright/fixtures/featureFlagsTest.ts
+++ b/modules/test/playwright/fixtures/featureFlagsTest.ts
@@ -48,7 +48,7 @@ const test = mergeTests(backendPageTest);
  *
  * export const testWithFF = mergeTests(
  *   featureFlagsTest({
- *     'LPS-148856': true,
+ *     'LPS-148856': {enabled: true},
  *   }),
  *   loginTest
  * );

--- a/modules/test/playwright/fixtures/featureFlagsTest.ts
+++ b/modules/test/playwright/fixtures/featureFlagsTest.ts
@@ -7,24 +7,19 @@ import {Page, mergeTests} from '@playwright/test';
 
 import {backendPageTest} from './backendPageTest';
 
-interface ScopedFeatureFlagValue {
+interface FeatureFlagValue {
 	enabled: boolean;
-	system: boolean;
+	system?: boolean;
 }
 
 export interface FeatureFlagsOptions {
-	[key: string]: boolean | ScopedFeatureFlagValue;
-}
-
-export interface FeatureFlagBody {
-	companyId?: number;
-	readonly enabled?: boolean;
-	readonly key: string;
+	[key: string]: FeatureFlagValue;
 }
 
 export interface FeatureFlag {
 	readonly enabled?: boolean;
 	readonly key: string;
+	readonly system?: boolean;
 }
 
 export interface FeatureFlags {
@@ -32,30 +27,6 @@ export interface FeatureFlags {
 }
 
 const test = mergeTests(backendPageTest);
-
-const getCompanyId = (value: boolean | ScopedFeatureFlagValue) => {
-	let companyId: number | undefined = undefined;
-
-	if (typeof value !== 'boolean') {
-		const scopedFeatureFlagValue = value as ScopedFeatureFlagValue;
-
-		if (scopedFeatureFlagValue.system) {
-			companyId = 0;
-		}
-	}
-
-	return companyId;
-};
-
-const isEnabled = (value: boolean | ScopedFeatureFlagValue) => {
-	if (typeof value === 'boolean') {
-		return value as boolean;
-	}
-
-	const scopedFeatureFlagValue = value as ScopedFeatureFlagValue;
-
-	return scopedFeatureFlagValue.enabled;
-};
 
 /**
  * Declare the FF needs of a test.
@@ -99,7 +70,7 @@ function featureFlagsTest(options: FeatureFlagsOptions) {
 						backendPage,
 						'/o/com-liferay-feature-flag-web/is-enabled',
 						{
-							companyId: getCompanyId(value),
+							...value,
 							key,
 						}
 					);
@@ -119,8 +90,7 @@ function featureFlagsTest(options: FeatureFlagsOptions) {
 							backendPage,
 							'/o/com-liferay-feature-flag-web/set-enabled',
 							{
-								companyId: getCompanyId(value),
-								enabled: isEnabled(value),
+								...value,
 								key,
 							}
 						);
@@ -136,7 +106,7 @@ function featureFlagsTest(options: FeatureFlagsOptions) {
 						Object.entries(options).reduce(
 							(featureFlags: FeatureFlag[], [key, value]) => {
 								featureFlags.push({
-									enabled: isEnabled(value),
+									...value,
 									key,
 								});
 
@@ -194,17 +164,16 @@ interface FeatureFlagResult {
 async function invokeServer<T>(
 	page: Page,
 	url: string,
-	partialBody: FeatureFlagBody
+	partialBody: FeatureFlag
 ): Promise<ServerReply<T>> {
-	if (partialBody.companyId === undefined) {
-		partialBody.companyId = Number(Liferay.ThemeDisplay.getCompanyId());
-	}
-
 	return await page.evaluate(
 		async ({partialBody, url}) =>
 			new Promise((resolve, reject) => {
 				Liferay.Util.fetch(url, {
 					body: Liferay.Util.objectToFormData({
+						companyId: partialBody.system
+							? 0
+							: Number(Liferay.ThemeDisplay.getCompanyId()),
 						...partialBody,
 					}),
 					method: 'POST',

--- a/modules/test/playwright/fixtures/featureFlagsTest.ts
+++ b/modules/test/playwright/fixtures/featureFlagsTest.ts
@@ -7,8 +7,19 @@ import {Page, mergeTests} from '@playwright/test';
 
 import {backendPageTest} from './backendPageTest';
 
+interface ScopedFeatureFlagValue {
+	enabled: boolean;
+	system: boolean;
+}
+
 export interface FeatureFlagsOptions {
-	[key: string]: boolean;
+	[key: string]: boolean | ScopedFeatureFlagValue;
+}
+
+export interface FeatureFlagBody {
+	companyId?: number;
+	readonly enabled?: boolean;
+	readonly key: string;
 }
 
 export interface FeatureFlag {
@@ -21,6 +32,30 @@ export interface FeatureFlags {
 }
 
 const test = mergeTests(backendPageTest);
+
+const getCompanyId = (value: boolean | ScopedFeatureFlagValue) => {
+	let companyId: number | undefined = undefined;
+
+	if (typeof value !== 'boolean') {
+		const scopedFeatureFlagValue = value as ScopedFeatureFlagValue;
+
+		if (scopedFeatureFlagValue.system) {
+			companyId = 0;
+		}
+	}
+
+	return companyId;
+};
+
+const isEnabled = (value: boolean | ScopedFeatureFlagValue) => {
+	if (typeof value === 'boolean') {
+		return value as boolean;
+	}
+
+	const scopedFeatureFlagValue = value as ScopedFeatureFlagValue;
+
+	return scopedFeatureFlagValue.enabled;
+};
 
 /**
  * Declare the FF needs of a test.
@@ -59,11 +94,12 @@ function featureFlagsTest(options: FeatureFlagsOptions) {
 
 				const originalFeatureFlags: FeatureFlagResult[] = [];
 
-				for (const key of Object.keys(options)) {
+				for (const [key, value] of Object.entries(options)) {
 					const reply = await invokeServer<IsEnabledResult>(
 						backendPage,
 						'/o/com-liferay-feature-flag-web/is-enabled',
 						{
+							companyId: getCompanyId(value),
 							key,
 						}
 					);
@@ -78,12 +114,13 @@ function featureFlagsTest(options: FeatureFlagsOptions) {
 
 					// Set requested state of FFs
 
-					for (const [key, enabled] of Object.entries(options)) {
+					for (const [key, value] of Object.entries(options)) {
 						await invokeServer<SetEnabledResult>(
 							backendPage,
 							'/o/com-liferay-feature-flag-web/set-enabled',
 							{
-								enabled,
+								companyId: getCompanyId(value),
+								enabled: isEnabled(value),
 								key,
 							}
 						);
@@ -97,9 +134,9 @@ function featureFlagsTest(options: FeatureFlagsOptions) {
 
 					await use(
 						Object.entries(options).reduce(
-							(featureFlags: FeatureFlag[], [key, enabled]) => {
+							(featureFlags: FeatureFlag[], [key, value]) => {
 								featureFlags.push({
-									enabled,
+									enabled: isEnabled(value),
 									key,
 								});
 
@@ -157,14 +194,17 @@ interface FeatureFlagResult {
 async function invokeServer<T>(
 	page: Page,
 	url: string,
-	partialBody: FeatureFlag
+	partialBody: FeatureFlagBody
 ): Promise<ServerReply<T>> {
+	if (partialBody.companyId === undefined) {
+		partialBody.companyId = Number(Liferay.ThemeDisplay.getCompanyId());
+	}
+
 	return await page.evaluate(
 		async ({partialBody, url}) =>
 			new Promise((resolve, reject) => {
 				Liferay.Util.fetch(url, {
 					body: Liferay.Util.objectToFormData({
-						companyId: Liferay.ThemeDisplay.getCompanyId(),
 						...partialBody,
 					}),
 					method: 'POST',

--- a/modules/test/playwright/tests/account-admin-web/accountEntriesManagementPortlet.spec.ts
+++ b/modules/test/playwright/tests/account-admin-web/accountEntriesManagementPortlet.spec.ts
@@ -23,7 +23,7 @@ export const test = mergeTests(
 	commercePagesTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest(),
 	usersAndOrganizationsPagesTest

--- a/modules/test/playwright/tests/account-admin-web/accountPermissions.spec.ts
+++ b/modules/test/playwright/tests/account-admin-web/accountPermissions.spec.ts
@@ -23,7 +23,7 @@ export const test = mergeTests(
 	applicationsMenuPageTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest(),
 	usersAndOrganizationsPagesTest

--- a/modules/test/playwright/tests/analytics-reports-js-components-web/content-performance.spec.ts
+++ b/modules/test/playwright/tests/analytics-reports-js-components-web/content-performance.spec.ts
@@ -114,7 +114,7 @@ export const test = mergeTests(
 	blogsPagesTest,
 	contentDashboardPagesTest,
 	featureFlagsTest({
-		'LPD-28830': true,
+		'LPD-28830': {enabled: true},
 	}),
 	isolatedSiteTest,
 	journalPagesTest,

--- a/modules/test/playwright/tests/analytics-reports-js-components-web/interactions-by-page.spec.ts
+++ b/modules/test/playwright/tests/analytics-reports-js-components-web/interactions-by-page.spec.ts
@@ -31,7 +31,7 @@ const test = mergeTests(
 	dataApiHelpersTest,
 	isolatedSiteTest,
 	featureFlagsTest({
-		'LPD-28830': true,
+		'LPD-28830': {enabled: true},
 	}),
 	loginAnalyticsCloudTest(),
 	loginTest()

--- a/modules/test/playwright/tests/analytics-reports-js-components-web/overview-metrics.spec.ts
+++ b/modules/test/playwright/tests/analytics-reports-js-components-web/overview-metrics.spec.ts
@@ -27,7 +27,7 @@ export const test = mergeTests(
 	dataApiHelpersTest,
 	isolatedSiteTest,
 	featureFlagsTest({
-		'LPD-28830': true,
+		'LPD-28830': {enabled: true},
 	}),
 	loginAnalyticsCloudTest(),
 	loginTest()

--- a/modules/test/playwright/tests/analytics-reports-js-components-web/technology.spec.ts
+++ b/modules/test/playwright/tests/analytics-reports-js-components-web/technology.spec.ts
@@ -31,7 +31,7 @@ const test = mergeTests(
 	dataApiHelpersTest,
 	isolatedSiteTest,
 	featureFlagsTest({
-		'LPD-28830': true,
+		'LPD-28830': {enabled: true},
 	}),
 	loginAnalyticsCloudTest(),
 	loginTest()

--- a/modules/test/playwright/tests/analytics-reports-js-components-web/visitors-behavior.spec.ts
+++ b/modules/test/playwright/tests/analytics-reports-js-components-web/visitors-behavior.spec.ts
@@ -31,7 +31,7 @@ const test = mergeTests(
 	dataApiHelpersTest,
 	isolatedSiteTest,
 	featureFlagsTest({
-		'LPD-28830': true,
+		'LPD-28830': {enabled: true},
 	}),
 	loginAnalyticsCloudTest(),
 	loginTest()

--- a/modules/test/playwright/tests/analytics-settings-web/connection-information.spec.ts
+++ b/modules/test/playwright/tests/analytics-settings-web/connection-information.spec.ts
@@ -25,8 +25,8 @@ export const test = mergeTests(
 	apiHelpersTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPD-20640': true,
-		'LPS-178052': true,
+		'LPD-20640': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	loginAnalyticsCloudTest(),
 	loginTest()

--- a/modules/test/playwright/tests/analytics-settings-web/recommendations.spec.ts
+++ b/modules/test/playwright/tests/analytics-settings-web/recommendations.spec.ts
@@ -47,7 +47,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPD-20640': true,
+		'LPD-20640': {enabled: true},
 	}),
 	loginAnalyticsCloudTest(),
 	loginTest()

--- a/modules/test/playwright/tests/analytics-web/support-liferay-cookie-manager.spec.ts
+++ b/modules/test/playwright/tests/analytics-web/support-liferay-cookie-manager.spec.ts
@@ -28,7 +28,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPD-10588': true,
+		'LPD-10588': {enabled: true},
 	}),
 	loginAnalyticsCloudTest(),
 	loginTest()

--- a/modules/test/playwright/tests/announcements-web/announcements-web.spec.ts
+++ b/modules/test/playwright/tests/announcements-web/announcements-web.spec.ts
@@ -19,7 +19,7 @@ export const test = mergeTests(
 	announcementsPagesTest,
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/asset-publisher-web/assetPublisherConfiguration.spec.ts
+++ b/modules/test/playwright/tests/asset-publisher-web/assetPublisherConfiguration.spec.ts
@@ -24,8 +24,8 @@ const test = mergeTests(
 	apiHelpersTest,
 	collectionsPagesTest,
 	featureFlagsTest({
-		'LPD-39304': true,
-		'LPS-178052': true,
+		'LPD-39304': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/batch-planner/export.spec.ts
+++ b/modules/test/playwright/tests/batch-planner/export.spec.ts
@@ -19,7 +19,7 @@ export const test = mergeTests(
 	dataApiHelpersTest,
 	dataMigrationCenterPagesTest,
 	featureFlagsTest({
-		'COMMERCE-8087': true,
+		'COMMERCE-8087': {enabled: true},
 	}),
 	loginTest()
 );

--- a/modules/test/playwright/tests/batch-planner/import.spec.ts
+++ b/modules/test/playwright/tests/batch-planner/import.spec.ts
@@ -22,7 +22,7 @@ import {OBJECT_ENTRY_ENTITY_TYPE} from './utils/constants';
 export const test = mergeTests(
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'COMMERCE-8087': true,
+		'COMMERCE-8087': {enabled: true},
 	}),
 	loginTest(),
 	dataMigrationCenterPagesTest,

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -21,8 +21,8 @@ const test = mergeTests(
 	blogsPagesTest,
 	loginTest(),
 	featureFlagsTest({
-		'LPD-39304': true,
-		'LPS-178052': true,
+		'LPD-39304': {enabled: true},
+		'LPS-178052': {enabled: true},
 	})
 );
 

--- a/modules/test/playwright/tests/calendar-web/accessibility.spec.ts
+++ b/modules/test/playwright/tests/calendar-web/accessibility.spec.ts
@@ -19,7 +19,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	calendarPagesTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/calendar-web/calendarEvent.spec.ts
+++ b/modules/test/playwright/tests/calendar-web/calendarEvent.spec.ts
@@ -21,7 +21,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	calendarPagesTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/calendar-web/miniCalendar.spec.ts
+++ b/modules/test/playwright/tests/calendar-web/miniCalendar.spec.ts
@@ -20,7 +20,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	calendarPagesTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/change-tracking-web/changeTrackingTimeline.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/changeTrackingTimeline.spec.ts
@@ -22,7 +22,7 @@ export const test = mergeTests(
 	journalPagesTest,
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPD-20556': true,
+		'LPD-20556': {enabled: true},
 	}),
 	changeTrackingPagesTest
 );

--- a/modules/test/playwright/tests/change-tracking-web/changeTrackingTimelineModal.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/changeTrackingTimelineModal.spec.ts
@@ -20,7 +20,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	changeTrackingPagesTest,
 	featureFlagsTest({
-		'LPD-20556': true,
+		'LPD-20556': {enabled: true},
 	}),
 	journalPagesTest
 );

--- a/modules/test/playwright/tests/change-tracking-web/ctCollectionEmailConfiguration.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/ctCollectionEmailConfiguration.spec.ts
@@ -12,7 +12,7 @@ import {loginTest} from '../../fixtures/loginTest';
 export const test = mergeTests(
 	changeTrackingPagesTest,
 	featureFlagsTest({
-		'LPD-11212': true,
+		'LPD-11212': {enabled: true},
 	}),
 	loginTest()
 );

--- a/modules/test/playwright/tests/change-tracking-web/ctContextChange.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/ctContextChange.spec.ts
@@ -16,7 +16,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	changeTrackingPagesTest,
 	featureFlagsTest({
-		'LPD-20131': true,
+		'LPD-20131': {enabled: true},
 	}),
 	journalPagesTest,
 	loginTest()

--- a/modules/test/playwright/tests/change-tracking-web/reviewChanges.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/reviewChanges.spec.ts
@@ -19,7 +19,7 @@ export const test = mergeTests(
 	changeTrackingPagesTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPD-20131': true,
+		'LPD-20131': {enabled: true},
 	})
 );
 

--- a/modules/test/playwright/tests/change-tracking-web/sandboxMode.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/sandboxMode.spec.ts
@@ -15,7 +15,7 @@ import getBasicWebContentStructureId from '../../utils/structured-content/getBas
 
 export const test = mergeTests(
 	featureFlagsTest({
-		'LPD-20556': true,
+		'LPD-20556': {enabled: true},
 	}),
 	apiHelpersTest,
 	changeTrackingPagesTest,

--- a/modules/test/playwright/tests/change-tracking-web/unsupportedApplication.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/unsupportedApplication.spec.ts
@@ -11,7 +11,7 @@ import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 
 export const test = mergeTests(
 	featureFlagsTest({
-		'COMMERCE-8087': true,
+		'COMMERCE-8087': {enabled: true},
 	}),
 	changeTrackingPagesTest,
 	applicationsMenuPageTest

--- a/modules/test/playwright/tests/client-extension-web/editorConfigContributor.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/editorConfigContributor.spec.ts
@@ -24,7 +24,7 @@ export const test = mergeTests(
 	editEditorConfigContributorPageTest,
 	editorSamplesPageTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/client-extension-web/js.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/js.spec.ts
@@ -68,7 +68,7 @@ for (const sample of SAMPLES) {
 export const testInstanceScoped = mergeTests(
 	clientExtensionsPageTest,
 	featureFlagsTest({
-		'LPD-30371': true,
+		'LPD-30371': {enabled: true},
 	}),
 	loginTest(),
 	styleBookPageTest

--- a/modules/test/playwright/tests/client-extension-web/themeCSS.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/themeCSS.spec.ts
@@ -161,7 +161,7 @@ test('ThemeCSS client extension frontend token definition tokens appears stylebo
 const controlPanelScopedTest = mergeTests(
 	loginTest(),
 	featureFlagsTest({
-		'LPD-34650': true,
+		'LPD-34650': {enabled: true},
 	}),
 	clientExtensionsPageTest
 );

--- a/modules/test/playwright/tests/commerce/commerce-cart-content-web/commerceMiniCart.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-cart-content-web/commerceMiniCart.spec.ts
@@ -21,7 +21,7 @@ export const test = mergeTests(
 	commercePagesTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest()
 );

--- a/modules/test/playwright/tests/commerce/commerce-channel-web/commerceChannelDefaults.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-channel-web/commerceChannelDefaults.spec.ts
@@ -27,7 +27,7 @@ export const test = mergeTests(
 	commercePagesTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest()
 );

--- a/modules/test/playwright/tests/commerce/commerce-checkout-web/checkout.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-checkout-web/checkout.spec.ts
@@ -26,8 +26,8 @@ export const test = mergeTests(
 	commercePagesTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPD-20379': true,
-		'LPS-178052': true,
+		'LPD-20379': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest(),
 	notificationPagesTest,

--- a/modules/test/playwright/tests/commerce/commerce-order-content-web/commerceAdminReturns.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-order-content-web/commerceAdminReturns.spec.ts
@@ -18,7 +18,7 @@ export const test = mergeTests(
 	commercePagesTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPD-10562': true,
+		'LPD-10562': {enabled: true},
 	}),
 	loginTest()
 );

--- a/modules/test/playwright/tests/commerce/commerce-order-content-web/commerceLayouts.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-order-content-web/commerceLayouts.spec.ts
@@ -31,8 +31,8 @@ export const test = mergeTests(
 	dataApiHelpersTest,
 	displayPageTemplatesPagesTest,
 	featureFlagsTest({
-		'LPD-20379': true,
-		'LPS-178052': true,
+		'LPD-20379': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest()
 );

--- a/modules/test/playwright/tests/commerce/commerce-order-content-web/placedOrder.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-order-content-web/placedOrder.spec.ts
@@ -32,7 +32,7 @@ export const test = mergeTests(
 	commercePagesTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest(),
 	usersAndOrganizationsPagesTest,

--- a/modules/test/playwright/tests/commerce/commerce-order-content-web/return.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-order-content-web/return.spec.ts
@@ -21,7 +21,7 @@ export const test = mergeTests(
 	commercePagesTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPD-10562': true,
+		'LPD-10562': {enabled: true},
 	}),
 	loginTest()
 );

--- a/modules/test/playwright/tests/commerce/commerce-product-content-web/commerceProducts.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-product-content-web/commerceProducts.spec.ts
@@ -25,7 +25,7 @@ export const test = mergeTests(
 	commercePagesTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest()
 );

--- a/modules/test/playwright/tests/commerce/commerce-product-definitions-web/commerceAdminProductConfigurations.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-product-definitions-web/commerceAdminProductConfigurations.spec.ts
@@ -17,7 +17,7 @@ export const test = mergeTests(
 	dataApiHelpersTest,
 	commercePagesTest,
 	featureFlagsTest({
-		'LPD-10889': true,
+		'LPD-10889': {enabled: true},
 	}),
 	loginTest()
 );

--- a/modules/test/playwright/tests/commerce/commerce-site-initializer/commerceBaseFragments.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-site-initializer/commerceBaseFragments.spec.ts
@@ -24,7 +24,7 @@ export const test = mergeTests(
 	commercePagesTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPD-20379': true,
+		'LPD-20379': {enabled: true},
 	}),
 	loginTest(),
 	systemSettingsPageTest

--- a/modules/test/playwright/tests/commerce/commerce-site-initializer/guestCheckout.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-site-initializer/guestCheckout.spec.ts
@@ -21,9 +21,9 @@ export const test = mergeTests(
 	commercePagesTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPD-10562': true,
-		'LPD-20379': true,
-		'LPD-35678': true,
+		'LPD-10562': {enabled: true},
+		'LPD-20379': {enabled: true},
+		'LPD-35678': {enabled: true},
 	}),
 	loginTest()
 );

--- a/modules/test/playwright/tests/commerce/commerce-wish-list-web/commerceWishLists.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-wish-list-web/commerceWishLists.spec.ts
@@ -21,7 +21,7 @@ export const test = mergeTests(
 	commercePagesTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest()
 );

--- a/modules/test/playwright/tests/cookies-banner-web/cookiesBannerCookiePolicy.spec.ts
+++ b/modules/test/playwright/tests/cookies-banner-web/cookiesBannerCookiePolicy.spec.ts
@@ -12,7 +12,7 @@ import {waitForAlert} from '../../utils/waitForAlert';
 
 export const test = mergeTests(
 	featureFlagsTest({
-		'LPD-10588': true,
+		'LPD-10588': {enabled: true},
 	}),
 	loginTest(),
 	systemSettingsPageTest

--- a/modules/test/playwright/tests/document-library-web/dmSearch.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/dmSearch.spec.ts
@@ -13,7 +13,7 @@ import {loginTest} from '../../fixtures/loginTest';
 const test = mergeTests(
 	documentLibraryPagesTest,
 	featureFlagsTest({
-		'LPD-11313': true,
+		'LPD-11313': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest()

--- a/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
@@ -26,7 +26,7 @@ const test = mergeTests(
 	apiHelpersTest,
 	documentLibraryPagesTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest()

--- a/modules/test/playwright/tests/dynamic-data-mapping-form-web/formMultiplePages.spec.ts
+++ b/modules/test/playwright/tests/dynamic-data-mapping-form-web/formMultiplePages.spec.ts
@@ -27,7 +27,7 @@ declare global {
 export const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	formsPagesTest,
 	isolatedSiteTest,

--- a/modules/test/playwright/tests/dynamic-data-mapping-form-web/formRules.spec.ts
+++ b/modules/test/playwright/tests/dynamic-data-mapping-form-web/formRules.spec.ts
@@ -21,7 +21,7 @@ import {deleteItems} from './utils/deleteItems';
 const test = mergeTests(
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPD-31212': true,
+		'LPD-31212': {enabled: true},
 	}),
 	loginTest(),
 	formsPagesTest,

--- a/modules/test/playwright/tests/dynamic-data-mapping-form-web/formWidget.spec.ts
+++ b/modules/test/playwright/tests/dynamic-data-mapping-form-web/formWidget.spec.ts
@@ -23,7 +23,7 @@ import evaluateKeepCheckingAfterFound from '../object-web/utils/keepCheckingAfte
 const test = mergeTests(
 	applicationsMenuPageTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	dataApiHelpersTest,
 	formsPagesTest,

--- a/modules/test/playwright/tests/dynamic-data-mapping-form-web/richText.spec.ts
+++ b/modules/test/playwright/tests/dynamic-data-mapping-form-web/richText.spec.ts
@@ -13,7 +13,7 @@ import {deleteItems} from './utils/deleteItems';
 
 export const xssBypassTest = mergeTests(
 	featureFlagsTest({
-		'LPD-31212': true,
+		'LPD-31212': {enabled: true},
 	}),
 	loginTest(),
 	formsPagesTest
@@ -21,7 +21,7 @@ export const xssBypassTest = mergeTests(
 
 export const xssDisabledTest = mergeTests(
 	featureFlagsTest({
-		'LPD-31212': false,
+		'LPD-31212': {enabled: false},
 	}),
 	loginTest(),
 	formsPagesTest

--- a/modules/test/playwright/tests/export-import-web/import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/import.spec.ts
@@ -33,7 +33,7 @@ export const test = mergeTests(
 	dataApiHelpersTest,
 	documentLibraryPagesTest,
 	featureFlagsTest({
-		'LPD-35013': true,
+		'LPD-35013': {enabled: true},
 	}),
 	productMenuPageTest,
 	exportImportPagesTest,

--- a/modules/test/playwright/tests/feature-flag-web/featureFlag.spec.ts
+++ b/modules/test/playwright/tests/feature-flag-web/featureFlag.spec.ts
@@ -16,8 +16,8 @@ const DEPENDENT_FEATURE_FLAG = 'LPD-00001';
 export const test = mergeTests(
 	featureFlagPagesTest,
 	featureFlagsTest({
-		[DEPENDENCY_FEATURE_FLAG]: false,
-		[DEPENDENT_FEATURE_FLAG]: false,
+		[DEPENDENCY_FEATURE_FLAG]: {enabled: false},
+		[DEPENDENT_FEATURE_FLAG]: {enabled: false},
 	}),
 	loginTest()
 );

--- a/modules/test/playwright/tests/fragment-web/fragmentsAdmin.spec.ts
+++ b/modules/test/playwright/tests/fragment-web/fragmentsAdmin.spec.ts
@@ -34,7 +34,7 @@ const test = mergeTests(
 	apiHelpersTest,
 	isolatedSiteTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest(),
 	fragmentsPagesTest,

--- a/modules/test/playwright/tests/fragment-web/reactFragments.spec.ts
+++ b/modules/test/playwright/tests/fragment-web/reactFragments.spec.ts
@@ -19,7 +19,7 @@ const test = mergeTests(
 	apiHelpersTest,
 	isolatedSiteTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest(),
 	fragmentsPagesTest,

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/clientExtensionFilters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/clientExtensionFilters.spec.ts
@@ -16,7 +16,7 @@ const test = mergeTests(
 	dataSetManagerApiHelpersTest,
 	filtersPageTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest(),
 	dataSetManagerSetupTest

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/creationActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/creationActions.spec.ts
@@ -24,8 +24,8 @@ export const test = mergeTests(
 	actionsPageTest,
 	dataSetManagerApiHelpersTest,
 	featureFlagsTest({
-		'LPS-164563': true,
-		'LPS-178052': true,
+		'LPS-164563': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest(),
 	dataSetManagerSetupTest

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/customDataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/customDataSets.spec.ts
@@ -16,7 +16,7 @@ export const test = mergeTests(
 	dataSetManagerApiHelpersTest,
 	customDataSetsPageTest,
 	featureFlagsTest({
-		'LPS-164563': true,
+		'LPS-164563': {enabled: true},
 	}),
 	loginTest()
 );

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dataSetsPermissions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dataSetsPermissions.spec.ts
@@ -28,7 +28,7 @@ export const test = mergeTests(
 	dataApiHelpersTest,
 	dataSetManagerApiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	filtersPageTest,
 	sortingPageTest

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dateRangeFilters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dateRangeFilters.spec.ts
@@ -16,7 +16,7 @@ const test = mergeTests(
 	dataSetManagerApiHelpersTest,
 	customDataSetsPageTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	filtersPageTest,
 	loginTest()

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/details.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/details.spec.ts
@@ -18,7 +18,7 @@ import {visualizationModesPageTest} from './fixtures/visualizationModesPageTest'
 export const test = mergeTests(
 	dataSetManagerApiHelpersTest,
 	featureFlagsTest({
-		'LPS-164563': true,
+		'LPS-164563': {enabled: true},
 	}),
 	loginTest(),
 	dataSetManagerSetupTest,

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/featureFlag.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/featureFlag.spec.ts
@@ -14,7 +14,7 @@ export const test = mergeTests(
 	customDataSetsPageTest,
 	featureFlagPagesTest,
 	featureFlagsTest({
-		'LPS-164563': true,
+		'LPS-164563': {enabled: true},
 	}),
 	loginTest()
 );
@@ -104,7 +104,7 @@ export const disabledTest = mergeTests(
 	customDataSetsPageTest,
 	featureFlagPagesTest,
 	featureFlagsTest({
-		'LPS-164563': false,
+		'LPS-164563': {enabled: false},
 	}),
 	loginTest()
 );

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/itemActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/itemActions.spec.ts
@@ -29,8 +29,8 @@ export const test = mergeTests(
 	actionsPageTest,
 	dataSetManagerApiHelpersTest,
 	featureFlagsTest({
-		'LPS-164563': true,
-		'LPS-178052': true,
+		'LPS-164563': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest(),
 	dataSetManagerSetupTest

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/pagination.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/pagination.spec.ts
@@ -15,7 +15,7 @@ import {paginationPageTest} from './fixtures/paginationPageTest';
 export const test = mergeTests(
 	dataSetManagerApiHelpersTest,
 	featureFlagsTest({
-		'LPS-164563': true,
+		'LPS-164563': {enabled: true},
 	}),
 	loginTest(),
 	dataSetManagerSetupTest,

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/selectionFilters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/selectionFilters.spec.ts
@@ -26,7 +26,7 @@ const PICKLIST_VALUE_NAME = getRandomString();
 const test = mergeTests(
 	dataSetManagerApiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	filtersPageTest,
 	loginTest(),

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/settings.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/settings.spec.ts
@@ -16,7 +16,7 @@ import {visualizationModesPageTest} from './fixtures/visualizationModesPageTest'
 export const test = mergeTests(
 	dataSetManagerApiHelpersTest,
 	featureFlagsTest({
-		'LPS-164563': true,
+		'LPS-164563': {enabled: true},
 	}),
 	loginTest(),
 	dataSetManagerSetupTest,

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/sorting.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/sorting.spec.ts
@@ -18,8 +18,8 @@ export const test = mergeTests(
 	dataSetManagerApiHelpersTest,
 	customDataSetsPageTest,
 	featureFlagsTest({
-		'LPS-164563': true,
-		'LPS-178052': true,
+		'LPS-164563': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	sortingPageTest,
 	loginTest()
@@ -662,8 +662,8 @@ export const applicationPageTest = mergeTests(
 	dataSetManagerApiHelpersTest,
 	customDataSetsPageTest,
 	featureFlagsTest({
-		'LPS-164563': true,
-		'LPS-178052': true,
+		'LPS-164563': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest()
 );

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/systemDataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/systemDataSets.spec.ts
@@ -14,8 +14,8 @@ export const test = mergeTests(
 	dataSetManagerApiHelpersTest,
 	systemDataSetsPageTest,
 	featureFlagsTest({
-		'LPD-37531': true,
-		'LPS-164563': true,
+		'LPD-37531': {enabled: true},
+		'LPS-164563': {enabled: true},
 	}),
 	loginTest()
 );

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/visualizationModes.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/visualizationModes.spec.ts
@@ -19,7 +19,7 @@ import {visualizationModesPageTest} from './fixtures/visualizationModesPageTest'
 export const test = mergeTests(
 	dataSetManagerApiHelpersTest,
 	featureFlagsTest({
-		'LPS-164563': true,
+		'LPS-164563': {enabled: true},
 	}),
 	visualizationModesPageTest,
 	loginTest(),

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/clientExtensionFilters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/clientExtensionFilters.spec.ts
@@ -23,7 +23,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	dataSetManagerApiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedLayoutTest({publish: false}),
 	loginTest(),

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/creationActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/creationActions.spec.ts
@@ -21,8 +21,8 @@ export const test = mergeTests(
 	apiHelpersTest,
 	dataSetManagerApiHelpersTest,
 	featureFlagsTest({
-		'LPS-164563': true,
-		'LPS-178052': true,
+		'LPS-164563': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedLayoutTest({publish: false}),
 	loginTest(),

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/dataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/dataSets.spec.ts
@@ -23,8 +23,8 @@ export const test = mergeTests(
 	apiHelpersTest,
 	dataSetManagerApiHelpersTest,
 	featureFlagsTest({
-		'LPS-164563': true,
-		'LPS-178052': true,
+		'LPS-164563': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedLayoutTest({publish: false}),
 	loginTest(),

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/dateRangeFilters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/dateRangeFilters.spec.ts
@@ -21,7 +21,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	dataSetManagerApiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedLayoutTest({publish: false}),
 	loginTest(),

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/details.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/details.spec.ts
@@ -17,7 +17,7 @@ export const test = mergeTests(
 	accountSettingsPagesTest,
 	dataSetManagerApiHelpersTest,
 	featureFlagsTest({
-		'LPS-164563': true,
+		'LPS-164563': {enabled: true},
 	}),
 	isolatedLayoutTest({publish: false}),
 	loginTest(),

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/itemActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/itemActions.spec.ts
@@ -30,8 +30,8 @@ let dataSetLabel: string;
 export const test = mergeTests(
 	dataSetManagerApiHelpersTest,
 	featureFlagsTest({
-		'LPS-164563': true,
-		'LPS-178052': true,
+		'LPS-164563': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedLayoutTest({publish: false}),
 	loginTest(),

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/pagination.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/pagination.spec.ts
@@ -15,7 +15,7 @@ import {dataSetFragmentPageTest} from './fixtures/dataSetFragmentPageTest';
 export const test = mergeTests(
 	dataSetManagerApiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedLayoutTest({publish: false}),
 	loginTest(),

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/selectionFilters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/selectionFilters.spec.ts
@@ -36,7 +36,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	dataSetManagerApiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedLayoutTest({publish: false}),
 	loginTest(),

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/settings.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/settings.spec.ts
@@ -19,7 +19,7 @@ let dataSetLabel: string;
 export const test = mergeTests(
 	dataSetManagerApiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedLayoutTest({publish: false}),
 	loginTest(),

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/sorting.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/sorting.spec.ts
@@ -17,7 +17,7 @@ export const test = mergeTests(
 	accountSettingsPagesTest,
 	dataSetManagerApiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedLayoutTest({publish: false}),
 	loginTest(),

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/visualizationModes.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/visualizationModes.spec.ts
@@ -15,7 +15,7 @@ import {dataSetFragmentPageTest} from './fixtures/dataSetFragmentPageTest';
 export const test = mergeTests(
 	dataSetManagerApiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest(),
 	dataSetFragmentPageTest,

--- a/modules/test/playwright/tests/frontend-data-set-web/clayTable.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/clayTable.spec.ts
@@ -15,8 +15,8 @@ export const test = mergeTests(
 	apiHelpersTest,
 	fdsSamplePageTest,
 	featureFlagsTest({
-		'LPS-178052': true,
-		'LPS-193005': true,
+		'LPS-178052': {enabled: true},
+		'LPS-193005': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest()

--- a/modules/test/playwright/tests/frontend-data-set-web/customized.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/customized.spec.ts
@@ -18,7 +18,7 @@ const test = mergeTests(
 	apiHelpersTest,
 	fdsSamplePageTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest()

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/tests/ckeditor4/classic.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/tests/ckeditor4/classic.spec.ts
@@ -15,7 +15,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	ckeditorSamplePageTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest(),
 	isolatedSiteTest

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/tests/ckeditor4/legacy.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/tests/ckeditor4/legacy.spec.ts
@@ -15,7 +15,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	ckeditorSamplePageTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest()

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/tests/ckeditor4/react.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/tests/ckeditor4/react.spec.ts
@@ -15,7 +15,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	ckeditorSamplePageTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest()

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/tests/ckeditor5/classic.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/tests/ckeditor5/classic.spec.ts
@@ -15,8 +15,8 @@ export const test = mergeTests(
 	apiHelpersTest,
 	ckeditorSamplePageTest,
 	featureFlagsTest({
-		'LPD-11235': true,
-		'LPS-178052': true,
+		'LPD-11235': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest()

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/tests/ckeditor5/react.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/tests/ckeditor5/react.spec.ts
@@ -15,8 +15,8 @@ export const test = mergeTests(
 	apiHelpersTest,
 	ckeditorSamplePageTest,
 	featureFlagsTest({
-		'LPD-11235': true,
-		'LPS-178052': true,
+		'LPD-11235': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest()

--- a/modules/test/playwright/tests/frontend-taglib-clay/managementToolbar.spec.ts
+++ b/modules/test/playwright/tests/frontend-taglib-clay/managementToolbar.spec.ts
@@ -15,7 +15,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	claySamplePageTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest()

--- a/modules/test/playwright/tests/frontend-taglib-clay/panelGroupTag.spec.ts
+++ b/modules/test/playwright/tests/frontend-taglib-clay/panelGroupTag.spec.ts
@@ -15,7 +15,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	claySamplePageTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest()

--- a/modules/test/playwright/tests/frontend-taglib-clay/verticalNavTag.spec.ts
+++ b/modules/test/playwright/tests/frontend-taglib-clay/verticalNavTag.spec.ts
@@ -15,7 +15,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	claySamplePageTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest()

--- a/modules/test/playwright/tests/frontend-taglib/tests/frontend-taglib/fieldset.spec.ts
+++ b/modules/test/playwright/tests/frontend-taglib/tests/frontend-taglib/fieldset.spec.ts
@@ -13,7 +13,7 @@ import {samplePageTest} from '../../fixtures/samplePageTest';
 export const test = mergeTests(
 	isolatedSiteTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest(),
 	samplePageTest

--- a/modules/test/playwright/tests/headless-builder-web/fixtures/headlessBuilderTest.ts
+++ b/modules/test/playwright/tests/headless-builder-web/fixtures/headlessBuilderTest.ts
@@ -15,7 +15,7 @@ function headlessBuilderTest(featureFlags?: FeatureFlagsOptions) {
 	return mergeTests(
 		featureFlagsTest({
 			...featureFlags,
-			'LPS-178642': true,
+			'LPS-178642': {enabled: true},
 		}),
 		test.extend<{
 			headlessBuilder: void;

--- a/modules/test/playwright/tests/headless-builder-web/schemas.spec.ts
+++ b/modules/test/playwright/tests/headless-builder-web/schemas.spec.ts
@@ -19,7 +19,7 @@ import {headlessBuilderPagesTest} from './fixtures/headlessBuilderPagesTest';
 export const testFeatureFlagsEnabled = mergeTests(
 	dataApiHelpersTest,
 	headlessBuilderPagesTest({
-		'LPD-21414': true,
+		'LPD-21414': {enabled: true},
 	}),
 	loginTest()
 );
@@ -27,7 +27,7 @@ export const testFeatureFlagsEnabled = mergeTests(
 export const testFeatureFlagsDisabled = mergeTests(
 	dataApiHelpersTest,
 	headlessBuilderPagesTest({
-		'LPD-21414': false,
+		'LPD-21414': {enabled: false},
 	}),
 	loginTest()
 );

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -70,7 +70,7 @@ const expect = baseExpect.extend({
 const assetPublisherDeprecationTest = mergeTests(
 	baseTest,
 	featureFlagsTest({
-		'LPD-39304': true,
+		'LPD-39304': {enabled: true},
 	})
 );
 
@@ -81,7 +81,7 @@ const prefixUrlTest = mergeTests(baseTest);
 const translationAndAutosaveTest = mergeTests(
 	baseTest,
 	featureFlagsTest({
-		'LPD-11228': true,
+		'LPD-11228': {enabled: true},
 	})
 );
 

--- a/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
@@ -34,7 +34,7 @@ const autoSaveTest = mergeTests(
 	apiHelpersTest,
 	applicationsMenuPageTest,
 	featureFlagsTest({
-		'LPD-11228': true,
+		'LPD-11228': {enabled: true},
 	}),
 	isolatedSiteTest,
 	journalPagesTest,
@@ -45,7 +45,7 @@ const autoSaveTest = mergeTests(
 
 const autosaveWithoutPermissionsTest = mergeTests(
 	featureFlagsTest({
-		'LPD-11228': true,
+		'LPD-11228': {enabled: true},
 	}),
 	isolatedSiteTest,
 	journalPagesTest,

--- a/modules/test/playwright/tests/knowledge-base-web/knowledge-base-web.spec.ts
+++ b/modules/test/playwright/tests/knowledge-base-web/knowledge-base-web.spec.ts
@@ -23,7 +23,7 @@ const test = mergeTests(
 	isolatedSiteTest,
 	knowledgeBasePages,
 	featureFlagsTest({
-		'LPD-11003': true,
+		'LPD-11003': {enabled: true},
 	}),
 	loginTest()
 );

--- a/modules/test/playwright/tests/layout-admin-web/contentPage.spec.ts
+++ b/modules/test/playwright/tests/layout-admin-web/contentPage.spec.ts
@@ -35,7 +35,7 @@ const test = mergeTests(
 	apiHelpersTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/layout-admin-web/convertPage.spec.ts
+++ b/modules/test/playwright/tests/layout-admin-web/convertPage.spec.ts
@@ -18,7 +18,7 @@ import {pagesPagesTest} from './fixtures/pagesPagesTest';
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/layout-admin-web/pageConfiguration.spec.ts
+++ b/modules/test/playwright/tests/layout-admin-web/pageConfiguration.spec.ts
@@ -27,7 +27,7 @@ import {pagesPagesTest} from './fixtures/pagesPagesTest';
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/layout-admin-web/pageFriendlyURL.spec.ts
+++ b/modules/test/playwright/tests/layout-admin-web/pageFriendlyURL.spec.ts
@@ -19,7 +19,7 @@ import {pagesPagesTest} from './fixtures/pagesPagesTest';
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/layout-admin-web/pageTree.spec.ts
+++ b/modules/test/playwright/tests/layout-admin-web/pageTree.spec.ts
@@ -24,7 +24,7 @@ import {pagesPagesTest} from './fixtures/pagesPagesTest';
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),
@@ -36,8 +36,8 @@ const test = mergeTests(
 const testWithPrivatePages = mergeTests(
 	test,
 	featureFlagsTest({
-		'LPD-38869': true,
-		'LPS-178052': true,
+		'LPD-38869': {enabled: true},
+		'LPS-178052': {enabled: true},
 	})
 );
 

--- a/modules/test/playwright/tests/layout-admin-web/pageWithStagingPageVersioning.spec.ts
+++ b/modules/test/playwright/tests/layout-admin-web/pageWithStagingPageVersioning.spec.ts
@@ -19,7 +19,7 @@ import {stagingConfigurationPageTest} from '../staging-configuration-web/fixture
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/layout-admin-web/pageWithWorkflow.spec.ts
+++ b/modules/test/playwright/tests/layout-admin-web/pageWithWorkflow.spec.ts
@@ -23,7 +23,7 @@ import getPageDefinition from '../layout-content-page-editor-web/utils/getPageDe
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/layout-admin-web/pagesAdmin.spec.ts
+++ b/modules/test/playwright/tests/layout-admin-web/pagesAdmin.spec.ts
@@ -23,7 +23,7 @@ import getPageDefinition from '../layout-content-page-editor-web/utils/getPageDe
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/layout-admin-web/pagesSearch.spec.ts
+++ b/modules/test/playwright/tests/layout-admin-web/pagesSearch.spec.ts
@@ -19,7 +19,7 @@ import {openProductMenu} from '../../utils/productMenu';
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/layout-admin-web/simulationMenu.spec.ts
+++ b/modules/test/playwright/tests/layout-admin-web/simulationMenu.spec.ts
@@ -25,7 +25,7 @@ const test = mergeTests(
 	apiHelpersTest,
 	collectionsPagesTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/layout-content-page-editor-web/breadcrumbs.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/breadcrumbs.spec.ts
@@ -19,8 +19,8 @@ import getPageDefinition from './utils/getPageDefinition';
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPD-18221': true,
-		'LPS-178052': true,
+		'LPD-18221': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/layout-content-page-editor-web/collectionDisplayFragment.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/collectionDisplayFragment.spec.ts
@@ -24,7 +24,7 @@ const test = mergeTests(
 	apiHelpersTest,
 	collectionsPagesTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest(),
 	pageEditorPagesTest,

--- a/modules/test/playwright/tests/layout-content-page-editor-web/collectionFilterFragment.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/collectionFilterFragment.spec.ts
@@ -43,7 +43,7 @@ const test = mergeTests(
 	apiHelpersTest,
 	collectionsPagesTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	journalPagesTest,
 	loginTest(),

--- a/modules/test/playwright/tests/layout-content-page-editor-web/container.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/container.spec.ts
@@ -21,7 +21,7 @@ import getWidgetDefinition from './utils/getWidgetDefinition';
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/layout-content-page-editor-web/dragAndDrop.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/dragAndDrop.spec.ts
@@ -30,8 +30,8 @@ const test = mergeTests(
 	apiHelpersTest,
 	collectionsPagesTest,
 	featureFlagsTest({
-		'LPD-18221': true,
-		'LPS-178052': true,
+		'LPD-18221': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/layout-content-page-editor-web/editModes.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/editModes.spec.ts
@@ -17,7 +17,7 @@ import getPageDefinition from './utils/getPageDefinition';
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest(),
 	pageEditorPagesTest,

--- a/modules/test/playwright/tests/layout-content-page-editor-web/editables.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/editables.spec.ts
@@ -17,8 +17,8 @@ import getPageDefinition from './utils/getPageDefinition';
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPD-18221': true,
-		'LPS-178052': true,
+		'LPD-18221': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/layout-content-page-editor-web/experiences.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/experiences.spec.ts
@@ -21,7 +21,7 @@ import getPageDefinition from './utils/getPageDefinition';
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/layout-content-page-editor-web/formContainer.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/formContainer.spec.ts
@@ -44,8 +44,8 @@ const test = mergeTests(
 	displayPageTemplatesPagesTest,
 	documentLibraryPagesTest,
 	featureFlagsTest({
-		'LPD-37927': true,
-		'LPS-178052': true,
+		'LPD-37927': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest(),
 	masterPagesPagesTest,

--- a/modules/test/playwright/tests/layout-content-page-editor-web/fragmentComposition.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/fragmentComposition.spec.ts
@@ -23,7 +23,7 @@ import getPageDefinition from './utils/getPageDefinition';
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	fragmentsPagesTest,
 	isolatedSiteTest,

--- a/modules/test/playwright/tests/layout-content-page-editor-web/fragmentConfiguration.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/fragmentConfiguration.spec.ts
@@ -27,7 +27,7 @@ const test = mergeTests(
 	apiHelpersTest,
 	collectionsPagesTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	fragmentsPagesTest,
 	isolatedSiteTest,

--- a/modules/test/playwright/tests/layout-content-page-editor-web/fragments.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/fragments.spec.ts
@@ -47,8 +47,8 @@ const test = mergeTests(
 	displayPageTemplatesPagesTest,
 	documentLibraryPagesTest,
 	featureFlagsTest({
-		'LPD-39304': true,
-		'LPS-178052': true,
+		'LPD-39304': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	fragmentsPagesTest,
 	isolatedSiteTest,
@@ -63,9 +63,9 @@ const test = mergeTests(
 const testWithPrivatePages = mergeTests(
 	test,
 	featureFlagsTest({
-		'LPD-38869': true,
-		'LPD-39304': true,
-		'LPS-178052': true,
+		'LPD-38869': {enabled: true},
+		'LPD-39304': {enabled: true},
+		'LPS-178052': {enabled: true},
 	})
 );
 

--- a/modules/test/playwright/tests/layout-content-page-editor-web/grid.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/grid.spec.ts
@@ -21,8 +21,8 @@ import getPageDefinition from './utils/getPageDefinition';
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPD-18221': true,
-		'LPS-178052': true,
+		'LPD-18221': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest(),
 	isolatedSiteTest,

--- a/modules/test/playwright/tests/layout-content-page-editor-web/images.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/images.spec.ts
@@ -17,7 +17,7 @@ import getPageDefinition from './utils/getPageDefinition';
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest(),
 	pageEditorPagesTest,

--- a/modules/test/playwright/tests/layout-content-page-editor-web/keyboard.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/keyboard.spec.ts
@@ -18,8 +18,8 @@ import getPageDefinition from './utils/getPageDefinition';
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPD-18221': true,
-		'LPS-178052': true,
+		'LPD-18221': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/layout-content-page-editor-web/mapping.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/mapping.spec.ts
@@ -23,7 +23,7 @@ const test = mergeTests(
 	apiHelpersTest,
 	collectionsPagesTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest(),
 	pageEditorPagesTest,

--- a/modules/test/playwright/tests/layout-content-page-editor-web/permissions.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/permissions.spec.ts
@@ -22,7 +22,7 @@ import getPageDefinition from './utils/getPageDefinition';
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/layout-content-page-editor-web/preview.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/preview.spec.ts
@@ -18,7 +18,7 @@ import getPageDefinition from './utils/getPageDefinition';
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/layout-content-page-editor-web/sidebar.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/sidebar.spec.ts
@@ -38,9 +38,9 @@ const test = mergeTests(
 	applicationsMenuPageTest,
 	collectionsPagesTest,
 	featureFlagsTest({
-		'LPD-18221': true,
-		'LPS-169837': true,
-		'LPS-178052': true,
+		'LPD-18221': {enabled: true},
+		'LPS-169837': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	fragmentsPagesTest,
 	isolatedSiteTest,

--- a/modules/test/playwright/tests/layout-content-page-editor-web/topper.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/topper.spec.ts
@@ -22,8 +22,8 @@ const test = mergeTests(
 	apiHelpersTest,
 	collectionsPagesTest,
 	featureFlagsTest({
-		'LPD-18221': true,
-		'LPS-178052': true,
+		'LPD-18221': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/layout-content-page-editor-web/undoRedo.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/undoRedo.spec.ts
@@ -17,7 +17,7 @@ import getPageDefinition from './utils/getPageDefinition';
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/layout-content-page-editor-web/viewports.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/viewports.spec.ts
@@ -17,7 +17,7 @@ import getPageDefinition from './utils/getPageDefinition';
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/layout-content-page-editor-web/widgets.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/widgets.spec.ts
@@ -25,9 +25,9 @@ import getWidgetDefinition from './utils/getWidgetDefinition';
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPD-40533': true,
-		'LPD-40534': true,
-		'LPS-178052': true,
+		'LPD-40533': {enabled: true},
+		'LPD-40534': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/layout-locked-layouts-web/lockedPages.spec.ts
+++ b/modules/test/playwright/tests/layout-locked-layouts-web/lockedPages.spec.ts
@@ -19,7 +19,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	instanceSettingsPagesTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	pageEditorPagesTest,
 	loginTest()

--- a/modules/test/playwright/tests/layout-page-template-admin-web/displayPagesAdmin.spec.ts
+++ b/modules/test/playwright/tests/layout-page-template-admin-web/displayPagesAdmin.spec.ts
@@ -31,7 +31,7 @@ const test = mergeTests(
 	displayPageTemplatesPagesTest,
 	documentLibraryPagesTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	journalPagesTest,

--- a/modules/test/playwright/tests/layout-page-template-admin-web/masterPagesAdmin.spec.ts
+++ b/modules/test/playwright/tests/layout-page-template-admin-web/masterPagesAdmin.spec.ts
@@ -26,7 +26,7 @@ export const test = mergeTests(
 	pagesAdminPagesTest,
 	isolatedSiteTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest(),
 	masterPagesPagesTest,

--- a/modules/test/playwright/tests/layout-page-template-admin-web/pageTemplatesAdmin.spec.ts
+++ b/modules/test/playwright/tests/layout-page-template-admin-web/pageTemplatesAdmin.spec.ts
@@ -24,7 +24,7 @@ import getWidgetDefinition from '../layout-content-page-editor-web/utils/getWidg
 export const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/layout-set-prototype-web/siteTemplatesWithWebContent.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/siteTemplatesWithWebContent.spec.ts
@@ -52,7 +52,7 @@ export const test = mergeTests(
 	serverAdministrationPageTest,
 	loginTest(),
 	featureFlagsTest({
-		'LPD-39304': true,
+		'LPD-39304': {enabled: true},
 	}),
 	pagesAdminPagesTest
 );
@@ -60,7 +60,7 @@ export const test = mergeTests(
 const testWithPrivatePages = mergeTests(
 	test,
 	featureFlagsTest({
-		'LPD-38869': true,
+		'LPD-38869': {enabled: true},
 	})
 );
 

--- a/modules/test/playwright/tests/locked-items-web/locked-items-web.spec.ts
+++ b/modules/test/playwright/tests/locked-items-web/locked-items-web.spec.ts
@@ -14,7 +14,7 @@ const test = mergeTests(
 	loginTest(),
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPD-11003': true,
+		'LPD-11003': {enabled: true},
 	}),
 	lockedItemsPagesTest
 );

--- a/modules/test/playwright/tests/login-web/utilityPage.spec.ts
+++ b/modules/test/playwright/tests/login-web/utilityPage.spec.ts
@@ -13,7 +13,7 @@ import {utilityPagesPage} from './fixtures/utilityPageTest';
 
 export const test = mergeTests(
 	featureFlagsTest({
-		'LPD-6378': true,
+		'LPD-6378': {enabled: true},
 	}),
 	utilityPagesPage
 );

--- a/modules/test/playwright/tests/object-web/objectClientExtensions.spec.ts
+++ b/modules/test/playwright/tests/object-web/objectClientExtensions.spec.ts
@@ -23,7 +23,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	editObjectDefinitionPagesTest,
 	featureFlagsTest({
-		'LPS-135430': true,
+		'LPS-135430': {enabled: true},
 	}),
 	loginTest(),
 	objectPagesTest

--- a/modules/test/playwright/tests/object-web/objectDefinitions.spec.ts
+++ b/modules/test/playwright/tests/object-web/objectDefinitions.spec.ts
@@ -29,7 +29,7 @@ export const test = mergeTests(
 	collectionsPagesTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	fragmentsPagesTest,
 	isolatedSiteTest,

--- a/modules/test/playwright/tests/object-web/objectEntries.spec.ts
+++ b/modules/test/playwright/tests/object-web/objectEntries.spec.ts
@@ -38,7 +38,7 @@ export const test = mergeTests(
 	isolatedSiteTest,
 	editObjectDefinitionPagesTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	journalPagesTest,
 	loginTest(),

--- a/modules/test/playwright/tests/object-web/rootModels.spec.ts
+++ b/modules/test/playwright/tests/object-web/rootModels.spec.ts
@@ -19,7 +19,7 @@ import {pushToApiHelpersData} from '../../utils/pushToApiHelpersData';
 export const test = mergeTests(
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPS-187142': true,
+		'LPS-187142': {enabled: true},
 	}),
 	loginTest(),
 	objectPagesTest

--- a/modules/test/playwright/tests/openid-link/openid-link.spec.ts
+++ b/modules/test/playwright/tests/openid-link/openid-link.spec.ts
@@ -21,7 +21,7 @@ const test = mergeTests(
 	dataApiHelpersTest,
 	openIdSettingsPagesTest,
 	featureFlagsTest({
-		'LPD-6378': true,
+		'LPD-6378': {enabled: true},
 	}),
 	utilityPagesPage
 );

--- a/modules/test/playwright/tests/osb-faro-web/ab-test.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/ab-test.spec.ts
@@ -32,7 +32,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginAnalyticsCloudTest(),
 	loginTest()

--- a/modules/test/playwright/tests/osb-faro-web/acquisition.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/acquisition.spec.ts
@@ -23,7 +23,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginAnalyticsCloudTest(),
 	loginTest()

--- a/modules/test/playwright/tests/osb-faro-web/assetsWebContent.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/assetsWebContent.spec.ts
@@ -35,8 +35,8 @@ export const test = mergeTests(
 	journalPagesTest,
 	uiElementsPageTest,
 	featureFlagsTest({
-		'LPD-39304': true,
-		'LPS-178052': true,
+		'LPD-39304': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	loginAnalyticsCloudTest(),
 	loginTest()

--- a/modules/test/playwright/tests/osb-faro-web/connection.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/connection.spec.ts
@@ -24,7 +24,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginAnalyticsCloudTest(),
 	loginTest()

--- a/modules/test/playwright/tests/osb-faro-web/emptyState.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/emptyState.spec.ts
@@ -26,7 +26,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginAnalyticsCloudTest(),
 	loginTest()

--- a/modules/test/playwright/tests/osb-faro-web/eventAnalysis.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/eventAnalysis.spec.ts
@@ -43,7 +43,7 @@ export const test = mergeTests(
 	pagesPagesTest,
 	pagesAdminPagesTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginAnalyticsCloudTest(),
 	loginTest()

--- a/modules/test/playwright/tests/osb-faro-web/onboarding.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/onboarding.spec.ts
@@ -17,7 +17,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginAnalyticsCloudTest(),
 	loginTest()

--- a/modules/test/playwright/tests/osb-faro-web/page.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/page.spec.ts
@@ -53,8 +53,8 @@ export const test = mergeTests(
 	assetPublisherPagesTest,
 	pageEditorPagesTest,
 	featureFlagsTest({
-		'LPD-39304': true,
-		'LPS-178052': true,
+		'LPD-39304': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	loginAnalyticsCloudTest(),
 	loginTest()

--- a/modules/test/playwright/tests/osb-faro-web/search-term.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/search-term.spec.ts
@@ -23,7 +23,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginAnalyticsCloudTest(),
 	loginTest()

--- a/modules/test/playwright/tests/osb-faro-web/segment.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/segment.spec.ts
@@ -61,7 +61,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	instanceSettingsPagesTest,
 	loginAnalyticsCloudTest(),

--- a/modules/test/playwright/tests/osb-faro-web/userManagement.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/userManagement.spec.ts
@@ -18,7 +18,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginAnalyticsCloudTest(),
 	loginTest()

--- a/modules/test/playwright/tests/portal-default-permissions-web/defaultPermissionsConfiguration.spec.ts
+++ b/modules/test/playwright/tests/portal-default-permissions-web/defaultPermissionsConfiguration.spec.ts
@@ -15,8 +15,8 @@ import {waitForAlert} from '../../utils/waitForAlert';
 export const test = mergeTests(
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPD-21265': true,
-		'LPS-178052': true,
+		'LPD-21265': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest(),
 	portalDefaultPermissionsPagesTest

--- a/modules/test/playwright/tests/portal-search-web/customFilter.spec.ts
+++ b/modules/test/playwright/tests/portal-search-web/customFilter.spec.ts
@@ -19,7 +19,7 @@ export const test = mergeTests(
 	isolatedSiteTest,
 	loginTest(),
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	pageEditorPagesTest,
 	searchPageTest

--- a/modules/test/playwright/tests/portal-security-service-access-policy-service/systemRestClientTemplateObjectSAP.spec.ts
+++ b/modules/test/playwright/tests/portal-security-service-access-policy-service/systemRestClientTemplateObjectSAP.spec.ts
@@ -18,7 +18,7 @@ import performLogin, {performLogout} from '../../utils/performLogin';
 export const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	fragmentsPagesTest,
 	isolatedSiteTest,

--- a/modules/test/playwright/tests/portal-web/html/taglib/ui/inputLocalized.spec.ts
+++ b/modules/test/playwright/tests/portal-web/html/taglib/ui/inputLocalized.spec.ts
@@ -13,7 +13,7 @@ import {samplePageTest} from '../../../../frontend-taglib/fixtures/samplePageTes
 export const test = mergeTests(
 	isolatedSiteTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest(),
 	samplePageTest

--- a/modules/test/playwright/tests/portal-web/html/taglib/ui/searchIterator.spec.ts
+++ b/modules/test/playwright/tests/portal-web/html/taglib/ui/searchIterator.spec.ts
@@ -16,7 +16,7 @@ import {samplePageTest} from '../../../../frontend-taglib/fixtures/samplePageTes
 export const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/portal-web/html/taglib/ui/searchPaginator.spec.ts
+++ b/modules/test/playwright/tests/portal-web/html/taglib/ui/searchPaginator.spec.ts
@@ -12,7 +12,7 @@ import {samplePageTest} from '../../../../frontend-taglib/fixtures/samplePageTes
 
 export const test = mergeTests(
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/portal-workflow-task-web/assignments.spec.ts
+++ b/modules/test/playwright/tests/portal-workflow-task-web/assignments.spec.ts
@@ -28,7 +28,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	blogsPagesTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/roles-admin-web/exportRoles.spec.ts
+++ b/modules/test/playwright/tests/roles-admin-web/exportRoles.spec.ts
@@ -14,7 +14,7 @@ import {rolesPagesTest} from '../../fixtures/rolesPagesTest';
 export const test = mergeTests(
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPS-187142': true,
+		'LPS-187142': {enabled: true},
 	}),
 	loginTest(),
 	rolesPagesTest

--- a/modules/test/playwright/tests/roles-admin-web/objectsRolePermissions.spec.ts
+++ b/modules/test/playwright/tests/roles-admin-web/objectsRolePermissions.spec.ts
@@ -21,7 +21,7 @@ import {getRandomInt} from '../../utils/getRandomInt';
 export const test = mergeTests(
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPS-187142': true,
+		'LPS-187142': {enabled: true},
 	}),
 	loginTest(),
 	rolesPagesTest

--- a/modules/test/playwright/tests/scim-configuration-web/scim.spec.ts
+++ b/modules/test/playwright/tests/scim-configuration-web/scim.spec.ts
@@ -21,7 +21,7 @@ import performLogin, {performLogout} from '../../utils/performLogin';
 
 export const test = mergeTests(
 	featureFlagsTest({
-		'LPS-96845': true,
+		'LPS-96845': {enabled: true},
 	}),
 	loginTest(),
 	applicationsMenuPageTest,

--- a/modules/test/playwright/tests/site-navigation-admin-web/itemAddition.spec.ts
+++ b/modules/test/playwright/tests/site-navigation-admin-web/itemAddition.spec.ts
@@ -16,7 +16,7 @@ import {navigationMenusPagesTest} from './fixtures/navigationMenusPagesTest';
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/site-navigation-breadcrumb-web/breadcrumbWidget.spec.ts
+++ b/modules/test/playwright/tests/site-navigation-breadcrumb-web/breadcrumbWidget.spec.ts
@@ -16,7 +16,7 @@ import getWidgetDefinition from '../layout-content-page-editor-web/utils/getWidg
 export const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest()

--- a/modules/test/playwright/tests/style-book-web/backButtons.spec.ts
+++ b/modules/test/playwright/tests/style-book-web/backButtons.spec.ts
@@ -18,7 +18,7 @@ import {navigationMenusPagesTest} from '../site-navigation-admin-web/fixtures/na
 export const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	journalPagesTest,

--- a/modules/test/playwright/tests/style-book-web/stylebookEditor.spec.ts
+++ b/modules/test/playwright/tests/style-book-web/stylebookEditor.spec.ts
@@ -22,7 +22,7 @@ import {
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-178052': true,
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),

--- a/modules/test/playwright/tests/users-admin-web/gdpr.spec.ts
+++ b/modules/test/playwright/tests/users-admin-web/gdpr.spec.ts
@@ -25,8 +25,8 @@ export const test = mergeTests(
 	contactsCenterPagesTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPD-35013': true,
-		'LPS-178052': true,
+		'LPD-35013': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest({screenName: 'demo.company.admin'}),
 	usersAndOrganizationsPagesTest
@@ -37,8 +37,8 @@ export const testAdmin = mergeTests(
 	contactsCenterPagesTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
-		'LPD-35013': true,
-		'LPS-178052': true,
+		'LPD-35013': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	loginTest(),
 	productMenuPageTest,

--- a/modules/test/playwright/tests/wiki-web/wiki.spec.ts
+++ b/modules/test/playwright/tests/wiki-web/wiki.spec.ts
@@ -14,7 +14,7 @@ import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 
 export const test = mergeTests(
 	featureFlagsTest({
-		'LPD-35013': true,
+		'LPD-35013': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),
@@ -23,7 +23,7 @@ export const test = mergeTests(
 
 export const testWithWikiDeprecation = mergeTests(
 	featureFlagsTest({
-		'LPD-35013': false,
+		'LPD-35013': {enabled: false},
 	}),
 	loginTest(),
 	productMenuPageTest,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-43786

# Issue

Currently we cannot enable/disable system feature flags using the Playwright feature flag fixture

I used the following regex to replace the usages of the fixture

```regex
'((.*)-\d+)':\s*(true|false)
```