### PR TITLE
Feature: Adding help text to API GUI

### DIFF
--- a/learn-resources/data/headless-discovery-web.json
+++ b/learn-resources/data/headless-discovery-web.json
@@ -1,0 +1,14 @@
+{
+	"search": {
+		"en_US": {
+			"message": "Use this search to find specific results within your data.",
+			"url": "https://help.liferay.com/hc/en-us/articles/360031163631-Filter-Sort-and-Search"
+		}
+	},
+	"filter": {
+		"en_US": {
+			"message": "Use this filter to narrow down results using query conditions.",
+			"url": "https://help.liferay.com/hc/en-us/articles/360031163631-Filter-Sort-and-Search"
+		}
+	}
+}

--- a/modules/apps/headless/headless-discovery/headless-discovery-web/build.gradle
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/build.gradle
@@ -1,0 +1,3 @@
+packageRunBuild {
+	inputs.dir 'src'
+}

--- a/modules/apps/headless/headless-discovery/headless-discovery-web/src/css/main.css
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/src/css/main.css
@@ -69,3 +69,48 @@ h4 span {
 	line-height: 1.5;
 	padding: 0.5rem 2.5rem 0.5rem 0.5rem;
 }
+
+.tooltip-container {
+  position: relative;
+  display: inline-block;
+  margin-left: 5px;
+  cursor: pointer;
+}
+
+.tooltip-text {
+  visibility: hidden;
+  width: 250px;
+  background-color: #ffffff;
+  color: #000000;
+  text-align: left;
+  border-radius: 5px;
+  padding: 8px;
+  position: absolute;
+  z-index: 10;
+  bottom: 93%;
+  left: 50%;
+  transform: translateX(-50%);
+  opacity: 0;
+  transition: opacity 0.3s;
+  font-size: 12px;
+  border: 1px solid #d1d1d1;
+  line-height: 110%;
+}
+
+.tooltip-icon:hover + .tooltip-text,
+.tooltip-text:hover {
+  visibility: visible;
+  opacity: 1;
+}
+
+.tooltip-learn-more {
+  color: #0b5fff;
+  text-decoration: underline;
+  display: inline-block;
+  font-size: 12px;
+}
+
+.tooltip-learn-more:hover {
+  text-decoration: none;
+}
+

--- a/modules/apps/headless/headless-discovery/headless-discovery-web/src/css/main.css
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/src/css/main.css
@@ -71,46 +71,41 @@ h4 span {
 }
 
 .tooltip-container {
-  position: relative;
+  cursor: pointer;
   display: inline-block;
   margin-left: 5px;
-  cursor: pointer;
+  position: relative;
 }
 
 .tooltip-text {
-  visibility: hidden;
-  width: 250px;
   background-color: #ffffff;
-  color: #000000;
-  text-align: left;
+  border: 1px solid #d1d1d1;
   border-radius: 5px;
+  bottom: 93%;
+  color: #000000;
+  font-size: 12px;
+  left: 50%;
+  line-height: 110%;
+  opacity: 0;
   padding: 8px;
   position: absolute;
-  z-index: 10;
-  bottom: 93%;
-  left: 50%;
+  text-align: left;
   transform: translateX(-50%);
-  opacity: 0;
   transition: opacity 0.3s;
-  font-size: 12px;
-  border: 1px solid #d1d1d1;
-  line-height: 110%;
+  visibility: hidden;
+  width: 250px;
+  z-index: 10;
 }
 
 .tooltip-icon:hover + .tooltip-text,
 .tooltip-text:hover {
-  visibility: visible;
   opacity: 1;
+  visibility: visible;
 }
 
 .tooltip-learn-more {
   color: #0b5fff;
-  text-decoration: underline;
   display: inline-block;
   font-size: 12px;
+  text-decoration: underline;
 }
-
-.tooltip-learn-more:hover {
-  text-decoration: none;
-}
-

--- a/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/APIGUI.js
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/APIGUI.js
@@ -10,10 +10,10 @@ import ClayLayout from '@clayui/layout';
 import ClayModal, {useModal} from '@clayui/modal';
 import GraphiQL from 'graphiql';
 import React, {useCallback, useEffect, useState} from 'react';
-import SwaggerUI from 'swagger-ui-react';
 
 import Icon from './Icon';
 import apiFetch from './util/apiFetch';
+import CustomSwaggerUI from './CustomSwaggerUI';
 
 import 'graphiql/graphiql.css';
 
@@ -31,6 +31,7 @@ const APIGUI = () => {
 	const [showGraphQL, setShowGraphQL] = useState(false);
 	const [headers, setHeaders] = useState([{key: '', value: ''}]);
 	const [origin, setOrigin] = useState('');
+	const [learnResources, setLearnResources] = useState({});
 
 	const {observer, onClose} = useModal({
 		onClose: () => setShowHeaders(false),
@@ -56,6 +57,11 @@ const APIGUI = () => {
 					.map((url) => url.replace('openapi.yaml', 'openapi.json'))
 			);
 		});
+
+		apiFetch(contextPath + '/o/language/v1.0/learn-message/headless-discovery-web?languageId=en_US', 'get', {})
+			.then((response) => {
+				setLearnResources(response.items);
+			});
 	}, [contextPath]);
 
 	const graphQLFetcher = useCallback(
@@ -310,7 +316,8 @@ const APIGUI = () => {
 						Forbidden access.
 					</ClayAlert>
 				) : (
-					<SwaggerUI
+					<CustomSwaggerUI
+						learnResources={learnResources}
 						displayOperationId={true}
 						requestInterceptor={requestInterceptor}
 						supportedSubmitMethods={[

--- a/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/CustomSwaggerUI.js
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/CustomSwaggerUI.js
@@ -1,0 +1,90 @@
+import React, { useEffect, useCallback } from "react";
+import { createRoot } from 'react-dom/client';
+import SwaggerUI from "swagger-ui-react";
+import ClayLink from '@clayui/link';
+import Icon from './Icon';
+
+const CustomSwaggerUI = ({ learnResources = [], ...props }) => {
+  const addTooltips = useCallback(() => {
+
+    if (!Array.isArray(learnResources)) return;
+
+    learnResources.forEach(({ key, learnMessageDetails }) => {
+      const rows = document.querySelectorAll(`[data-param-name='${key}']`);
+      
+      rows.forEach((row) => {
+        if (row && !row.querySelector(".tooltip-container")) {
+          const inputContainer = row.querySelector("td.parameters-col_description");
+          
+          if (inputContainer) {
+            const tooltipContainer = document.createElement("div");
+            tooltipContainer.className = "tooltip-container";
+            
+            tooltipContainer.innerHTML = `
+              <span class="tooltip-icon">
+                <div id="tooltip-icon-wrapper-${key}"></div>
+              </span>
+              <span class="tooltip-text">
+                <div id="tooltip-content-${key}"></div>
+              </span>
+            `;
+            
+            inputContainer.appendChild(tooltipContainer);
+            
+            const iconWrapper = tooltipContainer.querySelector(`#tooltip-icon-wrapper-${key}`);
+            if (iconWrapper) {
+              const iconRoot = createRoot(iconWrapper);
+              iconRoot.render(<Icon symbol="question-circle" />);
+            }
+            
+            const tooltipContent = tooltipContainer.querySelector(`#tooltip-content-${key}`);
+            if (tooltipContent && learnMessageDetails?.[0]) {
+              const messageRoot = createRoot(tooltipContent);
+              messageRoot.render(
+                <ClayLink
+                  href={learnMessageDetails[0].url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {learnMessageDetails[0].message}
+                </ClayLink>
+              );
+            }
+          }
+        }
+      });
+    });
+  }, [learnResources]);
+
+  useEffect(() => {
+    const addTooltipsWithDelay = () => {
+      Promise.resolve().then(addTooltips);
+    };
+
+    addTooltipsWithDelay();
+
+    const swaggerContainer = document.getElementById("swagger-main");
+    const observer = new MutationObserver(addTooltipsWithDelay);
+
+    if (swaggerContainer) {
+      observer.observe(swaggerContainer, { 
+        childList: true, 
+        subtree: true 
+      });
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [addTooltips]);
+
+  const { learnResources: _, ...swaggerProps } = props;
+
+  return (
+    <div id="swagger-main">
+      <SwaggerUI {...swaggerProps} />
+    </div>
+  );
+};
+
+export default CustomSwaggerUI;

--- a/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/CustomSwaggerUI.js
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/CustomSwaggerUI.js
@@ -1,8 +1,8 @@
-import React, { useEffect, useCallback } from "react";
-import { createRoot } from 'react-dom/client';
-import SwaggerUI from "swagger-ui-react";
 import ClayLink from '@clayui/link';
 import Icon from './Icon';
+import React, { useEffect, useCallback } from "react";
+import SwaggerUI from "swagger-ui-react";
+import { createRoot } from 'react-dom/client';
 
 const CustomSwaggerUI = ({ learnResources = [], ...props }) => {
   const addTooltips = useCallback(() => {

--- a/modules/apps/portal-language/portal-language-rest-api/bnd.bnd
+++ b/modules/apps/portal-language/portal-language-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Language REST API
 Bundle-SymbolicName: com.liferay.portal.language.rest.api
-Bundle-Version: 1.0.4
+Bundle-Version: 1.1.0
 Export-Package:\
 	com.liferay.portal.language.rest.dto.v1_0,\
 	com.liferay.portal.language.rest.resource.v1_0

--- a/modules/apps/portal-language/portal-language-rest-api/src/main/java/com/liferay/portal/language/rest/dto/v1_0/LearnMessage.java
+++ b/modules/apps/portal-language/portal-language-rest-api/src/main/java/com/liferay/portal/language/rest/dto/v1_0/LearnMessage.java
@@ -1,0 +1,302 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.language.rest.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import javax.annotation.Generated;
+
+import javax.validation.Valid;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+@GraphQLName("LearnMessage")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "LearnMessage")
+public class LearnMessage implements Serializable {
+
+	public static LearnMessage toDTO(String json) {
+		return ObjectMapperUtil.readValue(LearnMessage.class, json);
+	}
+
+	public static LearnMessage unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(LearnMessage.class, json);
+	}
+
+	@Schema
+	public String getKey() {
+		if (_keySupplier != null) {
+			key = _keySupplier.get();
+
+			_keySupplier = null;
+		}
+
+		return key;
+	}
+
+	public void setKey(String key) {
+		this.key = key;
+
+		_keySupplier = null;
+	}
+
+	@JsonIgnore
+	public void setKey(UnsafeSupplier<String, Exception> keyUnsafeSupplier) {
+		_keySupplier = () -> {
+			try {
+				return keyUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String key;
+
+	@JsonIgnore
+	private Supplier<String> _keySupplier;
+
+	@Schema
+	@Valid
+	public LearnMessageDetail[] getLearnMessageDetails() {
+		if (_learnMessageDetailsSupplier != null) {
+			learnMessageDetails = _learnMessageDetailsSupplier.get();
+
+			_learnMessageDetailsSupplier = null;
+		}
+
+		return learnMessageDetails;
+	}
+
+	public void setLearnMessageDetails(
+		LearnMessageDetail[] learnMessageDetails) {
+
+		this.learnMessageDetails = learnMessageDetails;
+
+		_learnMessageDetailsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setLearnMessageDetails(
+		UnsafeSupplier<LearnMessageDetail[], Exception>
+			learnMessageDetailsUnsafeSupplier) {
+
+		_learnMessageDetailsSupplier = () -> {
+			try {
+				return learnMessageDetailsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected LearnMessageDetail[] learnMessageDetails;
+
+	@JsonIgnore
+	private Supplier<LearnMessageDetail[]> _learnMessageDetailsSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof LearnMessage)) {
+			return false;
+		}
+
+		LearnMessage learnMessage = (LearnMessage)object;
+
+		return Objects.equals(toString(), learnMessage.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		String key = getKey();
+
+		if (key != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"key\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(key));
+
+			sb.append("\"");
+		}
+
+		LearnMessageDetail[] learnMessageDetails = getLearnMessageDetails();
+
+		if (learnMessageDetails != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"learnMessageDetails\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < learnMessageDetails.length; i++) {
+				sb.append(String.valueOf(learnMessageDetails[i]));
+
+				if ((i + 1) < learnMessageDetails.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@Schema(
+		accessMode = Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.portal.language.rest.dto.v1_0.LearnMessage",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}

--- a/modules/apps/portal-language/portal-language-rest-api/src/main/java/com/liferay/portal/language/rest/dto/v1_0/LearnMessageDetail.java
+++ b/modules/apps/portal-language/portal-language-rest-api/src/main/java/com/liferay/portal/language/rest/dto/v1_0/LearnMessageDetail.java
@@ -1,0 +1,347 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.language.rest.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import javax.annotation.Generated;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+@GraphQLName("LearnMessageDetail")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "LearnMessageDetail")
+public class LearnMessageDetail implements Serializable {
+
+	public static LearnMessageDetail toDTO(String json) {
+		return ObjectMapperUtil.readValue(LearnMessageDetail.class, json);
+	}
+
+	public static LearnMessageDetail unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(LearnMessageDetail.class, json);
+	}
+
+	@Schema
+	public String getLanguageId() {
+		if (_languageIdSupplier != null) {
+			languageId = _languageIdSupplier.get();
+
+			_languageIdSupplier = null;
+		}
+
+		return languageId;
+	}
+
+	public void setLanguageId(String languageId) {
+		this.languageId = languageId;
+
+		_languageIdSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setLanguageId(
+		UnsafeSupplier<String, Exception> languageIdUnsafeSupplier) {
+
+		_languageIdSupplier = () -> {
+			try {
+				return languageIdUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String languageId;
+
+	@JsonIgnore
+	private Supplier<String> _languageIdSupplier;
+
+	@Schema
+	public String getMessage() {
+		if (_messageSupplier != null) {
+			message = _messageSupplier.get();
+
+			_messageSupplier = null;
+		}
+
+		return message;
+	}
+
+	public void setMessage(String message) {
+		this.message = message;
+
+		_messageSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setMessage(
+		UnsafeSupplier<String, Exception> messageUnsafeSupplier) {
+
+		_messageSupplier = () -> {
+			try {
+				return messageUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String message;
+
+	@JsonIgnore
+	private Supplier<String> _messageSupplier;
+
+	@Schema
+	public String getUrl() {
+		if (_urlSupplier != null) {
+			url = _urlSupplier.get();
+
+			_urlSupplier = null;
+		}
+
+		return url;
+	}
+
+	public void setUrl(String url) {
+		this.url = url;
+
+		_urlSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setUrl(UnsafeSupplier<String, Exception> urlUnsafeSupplier) {
+		_urlSupplier = () -> {
+			try {
+				return urlUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String url;
+
+	@JsonIgnore
+	private Supplier<String> _urlSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof LearnMessageDetail)) {
+			return false;
+		}
+
+		LearnMessageDetail learnMessageDetail = (LearnMessageDetail)object;
+
+		return Objects.equals(toString(), learnMessageDetail.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		String languageId = getLanguageId();
+
+		if (languageId != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"languageId\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(languageId));
+
+			sb.append("\"");
+		}
+
+		String message = getMessage();
+
+		if (message != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"message\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(message));
+
+			sb.append("\"");
+		}
+
+		String url = getUrl();
+
+		if (url != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"url\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(url));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@Schema(
+		accessMode = Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.portal.language.rest.dto.v1_0.LearnMessageDetail",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}

--- a/modules/apps/portal-language/portal-language-rest-api/src/main/java/com/liferay/portal/language/rest/resource/v1_0/LearnMessageResource.java
+++ b/modules/apps/portal-language/portal-language-rest-api/src/main/java/com/liferay/portal/language/rest/resource/v1_0/LearnMessageResource.java
@@ -1,0 +1,143 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.language.rest.resource.v1_0;
+
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.language.rest.dto.v1_0.LearnMessage;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.pagination.Page;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * To access this resource, run:
+ *
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/language/v1.0
+ *
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+@ProviderType
+public interface LearnMessageResource {
+
+	public Page<LearnMessage> getLearnMessagesResourcePage(
+			String resource, String languageId, String key)
+		throws Exception;
+
+	public default void setContextAcceptLanguage(
+		AcceptLanguage contextAcceptLanguage) {
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser);
+
+	public void setExpressionConvert(
+		ExpressionConvert<Filter> expressionConvert);
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider);
+
+	public void setGroupLocalService(GroupLocalService groupLocalService);
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService);
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService);
+
+	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider);
+
+	public void setVulcanBatchEngineExportTaskResource(
+		VulcanBatchEngineExportTaskResource
+			vulcanBatchEngineExportTaskResource);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
+
+	public default Filter toFilter(String filterString) {
+		return toFilter(
+			filterString, Collections.<String, List<String>>emptyMap());
+	}
+
+	public default Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		return null;
+	}
+
+	public default Sort[] toSorts(String sortsString) {
+		return new Sort[0];
+	}
+
+	@ProviderType
+	public interface Builder {
+
+		public LearnMessageResource build();
+
+		public Builder checkPermissions(boolean checkPermissions);
+
+		public Builder httpServletRequest(
+			HttpServletRequest httpServletRequest);
+
+		public Builder httpServletResponse(
+			HttpServletResponse httpServletResponse);
+
+		public Builder preferredLocale(Locale preferredLocale);
+
+		public Builder uriInfo(UriInfo uriInfo);
+
+		public Builder user(com.liferay.portal.kernel.model.User user);
+
+	}
+
+	@ProviderType
+	public interface Factory {
+
+		public Builder create();
+
+	}
+
+}

--- a/modules/apps/portal-language/portal-language-rest-api/src/main/resources/com/liferay/portal/language/rest/dto/v1_0/packageinfo
+++ b/modules/apps/portal-language/portal-language-rest-api/src/main/resources/com/liferay/portal/language/rest/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/portal-language/portal-language-rest-api/src/main/resources/com/liferay/portal/language/rest/resource/v1_0/packageinfo
+++ b/modules/apps/portal-language/portal-language-rest-api/src/main/resources/com/liferay/portal/language/rest/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/portal-language/portal-language-rest-client/src/main/java/com/liferay/portal/language/rest/client/dto/v1_0/LearnMessage.java
+++ b/modules/apps/portal-language/portal-language-rest-client/src/main/java/com/liferay/portal/language/rest/client/dto/v1_0/LearnMessage.java
@@ -1,0 +1,102 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.language.rest.client.dto.v1_0;
+
+import com.liferay.portal.language.rest.client.function.UnsafeSupplier;
+import com.liferay.portal.language.rest.client.serdes.v1_0.LearnMessageSerDes;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+public class LearnMessage implements Cloneable, Serializable {
+
+	public static LearnMessage toDTO(String json) {
+		return LearnMessageSerDes.toDTO(json);
+	}
+
+	public String getKey() {
+		return key;
+	}
+
+	public void setKey(String key) {
+		this.key = key;
+	}
+
+	public void setKey(UnsafeSupplier<String, Exception> keyUnsafeSupplier) {
+		try {
+			key = keyUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String key;
+
+	public LearnMessageDetail[] getLearnMessageDetails() {
+		return learnMessageDetails;
+	}
+
+	public void setLearnMessageDetails(
+		LearnMessageDetail[] learnMessageDetails) {
+
+		this.learnMessageDetails = learnMessageDetails;
+	}
+
+	public void setLearnMessageDetails(
+		UnsafeSupplier<LearnMessageDetail[], Exception>
+			learnMessageDetailsUnsafeSupplier) {
+
+		try {
+			learnMessageDetails = learnMessageDetailsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected LearnMessageDetail[] learnMessageDetails;
+
+	@Override
+	public LearnMessage clone() throws CloneNotSupportedException {
+		return (LearnMessage)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof LearnMessage)) {
+			return false;
+		}
+
+		LearnMessage learnMessage = (LearnMessage)object;
+
+		return Objects.equals(toString(), learnMessage.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return LearnMessageSerDes.toJSON(this);
+	}
+
+}

--- a/modules/apps/portal-language/portal-language-rest-client/src/main/java/com/liferay/portal/language/rest/client/dto/v1_0/LearnMessageDetail.java
+++ b/modules/apps/portal-language/portal-language-rest-client/src/main/java/com/liferay/portal/language/rest/client/dto/v1_0/LearnMessageDetail.java
@@ -1,0 +1,120 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.language.rest.client.dto.v1_0;
+
+import com.liferay.portal.language.rest.client.function.UnsafeSupplier;
+import com.liferay.portal.language.rest.client.serdes.v1_0.LearnMessageDetailSerDes;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+public class LearnMessageDetail implements Cloneable, Serializable {
+
+	public static LearnMessageDetail toDTO(String json) {
+		return LearnMessageDetailSerDes.toDTO(json);
+	}
+
+	public String getLanguageId() {
+		return languageId;
+	}
+
+	public void setLanguageId(String languageId) {
+		this.languageId = languageId;
+	}
+
+	public void setLanguageId(
+		UnsafeSupplier<String, Exception> languageIdUnsafeSupplier) {
+
+		try {
+			languageId = languageIdUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String languageId;
+
+	public String getMessage() {
+		return message;
+	}
+
+	public void setMessage(String message) {
+		this.message = message;
+	}
+
+	public void setMessage(
+		UnsafeSupplier<String, Exception> messageUnsafeSupplier) {
+
+		try {
+			message = messageUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String message;
+
+	public String getUrl() {
+		return url;
+	}
+
+	public void setUrl(String url) {
+		this.url = url;
+	}
+
+	public void setUrl(UnsafeSupplier<String, Exception> urlUnsafeSupplier) {
+		try {
+			url = urlUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String url;
+
+	@Override
+	public LearnMessageDetail clone() throws CloneNotSupportedException {
+		return (LearnMessageDetail)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof LearnMessageDetail)) {
+			return false;
+		}
+
+		LearnMessageDetail learnMessageDetail = (LearnMessageDetail)object;
+
+		return Objects.equals(toString(), learnMessageDetail.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return LearnMessageDetailSerDes.toJSON(this);
+	}
+
+}

--- a/modules/apps/portal-language/portal-language-rest-client/src/main/java/com/liferay/portal/language/rest/client/resource/v1_0/LearnMessageResource.java
+++ b/modules/apps/portal-language/portal-language-rest-client/src/main/java/com/liferay/portal/language/rest/client/resource/v1_0/LearnMessageResource.java
@@ -1,0 +1,278 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.language.rest.client.resource.v1_0;
+
+import com.liferay.portal.language.rest.client.dto.v1_0.LearnMessage;
+import com.liferay.portal.language.rest.client.http.HttpInvoker;
+import com.liferay.portal.language.rest.client.pagination.Page;
+import com.liferay.portal.language.rest.client.problem.Problem;
+import com.liferay.portal.language.rest.client.serdes.v1_0.LearnMessageSerDes;
+
+import java.net.URL;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+public interface LearnMessageResource {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public Page<LearnMessage> getLearnMessagesResourcePage(
+			String resource, String languageId, String key)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getLearnMessagesResourcePageHttpResponse(
+			String resource, String languageId, String key)
+		throws Exception;
+
+	public static class Builder {
+
+		public Builder authentication(String login, String password) {
+			_login = login;
+			_password = password;
+
+			return this;
+		}
+
+		public Builder bearerToken(String token) {
+			return header("Authorization", "Bearer " + token);
+		}
+
+		public LearnMessageResource build() {
+			return new LearnMessageResourceImpl(this);
+		}
+
+		public Builder contextPath(String contextPath) {
+			_contextPath = contextPath;
+
+			return this;
+		}
+
+		public Builder endpoint(String address, String scheme) {
+			String[] addressParts = address.split(":");
+
+			String host = addressParts[0];
+
+			int port = 443;
+
+			if (addressParts.length > 1) {
+				String portString = addressParts[1];
+
+				try {
+					port = Integer.parseInt(portString);
+				}
+				catch (NumberFormatException numberFormatException) {
+					throw new IllegalArgumentException(
+						"Unable to parse port from " + portString);
+				}
+			}
+
+			return endpoint(host, port, scheme);
+		}
+
+		public Builder endpoint(String host, int port, String scheme) {
+			_host = host;
+			_port = port;
+			_scheme = scheme;
+
+			return this;
+		}
+
+		public Builder endpoint(URL url) {
+			return endpoint(url.getHost(), url.getPort(), url.getProtocol());
+		}
+
+		public Builder header(String key, String value) {
+			_headers.put(key, value);
+
+			return this;
+		}
+
+		public Builder locale(Locale locale) {
+			_locale = locale;
+
+			return this;
+		}
+
+		public Builder parameter(String key, String value) {
+			_parameters.put(key, value);
+
+			return this;
+		}
+
+		public Builder parameters(String... parameters) {
+			if ((parameters.length % 2) != 0) {
+				throw new IllegalArgumentException(
+					"Parameters length is not an even number");
+			}
+
+			for (int i = 0; i < parameters.length; i += 2) {
+				String parameterName = String.valueOf(parameters[i]);
+				String parameterValue = String.valueOf(parameters[i + 1]);
+
+				_parameters.put(parameterName, parameterValue);
+			}
+
+			return this;
+		}
+
+		private Builder() {
+		}
+
+		private String _contextPath = "";
+		private Map<String, String> _headers = new LinkedHashMap<>();
+		private String _host = "localhost";
+		private Locale _locale;
+		private String _login = "";
+		private String _password = "";
+		private Map<String, String> _parameters = new LinkedHashMap<>();
+		private int _port = 8080;
+		private String _scheme = "http";
+
+	}
+
+	public static class LearnMessageResourceImpl
+		implements LearnMessageResource {
+
+		public Page<LearnMessage> getLearnMessagesResourcePage(
+				String resource, String languageId, String key)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getLearnMessagesResourcePageHttpResponse(
+					resource, languageId, key);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, LearnMessageSerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getLearnMessagesResourcePageHttpResponse(
+					String resource, String languageId, String key)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (languageId != null) {
+				httpInvoker.parameter("languageId", String.valueOf(languageId));
+			}
+
+			if (key != null) {
+				httpInvoker.parameter("key", String.valueOf(key));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/language/v1.0/learn-message/{resource}");
+
+			httpInvoker.path("resource", resource);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		private LearnMessageResourceImpl(Builder builder) {
+			_builder = builder;
+		}
+
+		private static final Logger _logger = Logger.getLogger(
+			LearnMessageResource.class.getName());
+
+		private Builder _builder;
+
+	}
+
+}

--- a/modules/apps/portal-language/portal-language-rest-client/src/main/java/com/liferay/portal/language/rest/client/serdes/v1_0/LearnMessageDetailSerDes.java
+++ b/modules/apps/portal-language/portal-language-rest-client/src/main/java/com/liferay/portal/language/rest/client/serdes/v1_0/LearnMessageDetailSerDes.java
@@ -1,0 +1,263 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.language.rest.client.serdes.v1_0;
+
+import com.liferay.portal.language.rest.client.dto.v1_0.LearnMessageDetail;
+import com.liferay.portal.language.rest.client.json.BaseJSONParser;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+public class LearnMessageDetailSerDes {
+
+	public static LearnMessageDetail toDTO(String json) {
+		LearnMessageDetailJSONParser learnMessageDetailJSONParser =
+			new LearnMessageDetailJSONParser();
+
+		return learnMessageDetailJSONParser.parseToDTO(json);
+	}
+
+	public static LearnMessageDetail[] toDTOs(String json) {
+		LearnMessageDetailJSONParser learnMessageDetailJSONParser =
+			new LearnMessageDetailJSONParser();
+
+		return learnMessageDetailJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(LearnMessageDetail learnMessageDetail) {
+		if (learnMessageDetail == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (learnMessageDetail.getLanguageId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"languageId\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(learnMessageDetail.getLanguageId()));
+
+			sb.append("\"");
+		}
+
+		if (learnMessageDetail.getMessage() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"message\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(learnMessageDetail.getMessage()));
+
+			sb.append("\"");
+		}
+
+		if (learnMessageDetail.getUrl() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"url\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(learnMessageDetail.getUrl()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		LearnMessageDetailJSONParser learnMessageDetailJSONParser =
+			new LearnMessageDetailJSONParser();
+
+		return learnMessageDetailJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(
+		LearnMessageDetail learnMessageDetail) {
+
+		if (learnMessageDetail == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (learnMessageDetail.getLanguageId() == null) {
+			map.put("languageId", null);
+		}
+		else {
+			map.put(
+				"languageId",
+				String.valueOf(learnMessageDetail.getLanguageId()));
+		}
+
+		if (learnMessageDetail.getMessage() == null) {
+			map.put("message", null);
+		}
+		else {
+			map.put("message", String.valueOf(learnMessageDetail.getMessage()));
+		}
+
+		if (learnMessageDetail.getUrl() == null) {
+			map.put("url", null);
+		}
+		else {
+			map.put("url", String.valueOf(learnMessageDetail.getUrl()));
+		}
+
+		return map;
+	}
+
+	public static class LearnMessageDetailJSONParser
+		extends BaseJSONParser<LearnMessageDetail> {
+
+		@Override
+		protected LearnMessageDetail createDTO() {
+			return new LearnMessageDetail();
+		}
+
+		@Override
+		protected LearnMessageDetail[] createDTOArray(int size) {
+			return new LearnMessageDetail[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "languageId")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "message")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "url")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			LearnMessageDetail learnMessageDetail, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "languageId")) {
+				if (jsonParserFieldValue != null) {
+					learnMessageDetail.setLanguageId(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "message")) {
+				if (jsonParserFieldValue != null) {
+					learnMessageDetail.setMessage((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "url")) {
+				if (jsonParserFieldValue != null) {
+					learnMessageDetail.setUrl((String)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}

--- a/modules/apps/portal-language/portal-language-rest-client/src/main/java/com/liferay/portal/language/rest/client/serdes/v1_0/LearnMessageSerDes.java
+++ b/modules/apps/portal-language/portal-language-rest-client/src/main/java/com/liferay/portal/language/rest/client/serdes/v1_0/LearnMessageSerDes.java
@@ -1,0 +1,258 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.language.rest.client.serdes.v1_0;
+
+import com.liferay.portal.language.rest.client.dto.v1_0.LearnMessage;
+import com.liferay.portal.language.rest.client.dto.v1_0.LearnMessageDetail;
+import com.liferay.portal.language.rest.client.json.BaseJSONParser;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+public class LearnMessageSerDes {
+
+	public static LearnMessage toDTO(String json) {
+		LearnMessageJSONParser learnMessageJSONParser =
+			new LearnMessageJSONParser();
+
+		return learnMessageJSONParser.parseToDTO(json);
+	}
+
+	public static LearnMessage[] toDTOs(String json) {
+		LearnMessageJSONParser learnMessageJSONParser =
+			new LearnMessageJSONParser();
+
+		return learnMessageJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(LearnMessage learnMessage) {
+		if (learnMessage == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (learnMessage.getKey() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"key\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(learnMessage.getKey()));
+
+			sb.append("\"");
+		}
+
+		if (learnMessage.getLearnMessageDetails() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"learnMessageDetails\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < learnMessage.getLearnMessageDetails().length;
+				 i++) {
+
+				sb.append(
+					String.valueOf(learnMessage.getLearnMessageDetails()[i]));
+
+				if ((i + 1) < learnMessage.getLearnMessageDetails().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		LearnMessageJSONParser learnMessageJSONParser =
+			new LearnMessageJSONParser();
+
+		return learnMessageJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(LearnMessage learnMessage) {
+		if (learnMessage == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (learnMessage.getKey() == null) {
+			map.put("key", null);
+		}
+		else {
+			map.put("key", String.valueOf(learnMessage.getKey()));
+		}
+
+		if (learnMessage.getLearnMessageDetails() == null) {
+			map.put("learnMessageDetails", null);
+		}
+		else {
+			map.put(
+				"learnMessageDetails",
+				String.valueOf(learnMessage.getLearnMessageDetails()));
+		}
+
+		return map;
+	}
+
+	public static class LearnMessageJSONParser
+		extends BaseJSONParser<LearnMessage> {
+
+		@Override
+		protected LearnMessage createDTO() {
+			return new LearnMessage();
+		}
+
+		@Override
+		protected LearnMessage[] createDTOArray(int size) {
+			return new LearnMessage[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "key")) {
+				return false;
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "learnMessageDetails")) {
+
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			LearnMessage learnMessage, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "key")) {
+				if (jsonParserFieldValue != null) {
+					learnMessage.setKey((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "learnMessageDetails")) {
+
+				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					LearnMessageDetail[] learnMessageDetailsArray =
+						new LearnMessageDetail[jsonParserFieldValues.length];
+
+					for (int i = 0; i < learnMessageDetailsArray.length; i++) {
+						learnMessageDetailsArray[i] =
+							LearnMessageDetailSerDes.toDTO(
+								(String)jsonParserFieldValues[i]);
+					}
+
+					learnMessage.setLearnMessageDetails(
+						learnMessageDetailsArray);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}

--- a/modules/apps/portal-language/portal-language-rest-impl/build.gradle
+++ b/modules/apps/portal-language/portal-language-rest-impl/build.gradle
@@ -17,4 +17,5 @@ dependencies {
 	compileOnly project(":apps:portal-search:portal-search-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":apps:learn:learn-api")
 }

--- a/modules/apps/portal-language/portal-language-rest-impl/rest-openapi.yaml
+++ b/modules/apps/portal-language/portal-language-rest-impl/rest-openapi.yaml
@@ -9,6 +9,24 @@ components:
                 value:
                     type: string
             type: object
+        LearnMessage:
+            properties:
+                key:
+                    type: string
+                learnMessageDetails:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/LearnMessageDetail'
+            type: object
+        LearnMessageDetail:
+            properties:
+                languageId:
+                    type: string
+                message:
+                    type: string
+                url:
+                    type: string
+            type: object
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
@@ -20,6 +38,37 @@ info:
     version: v1.0
 openapi: 3.0.1
 paths:
+    "/learn-message/{resource}":
+        get:
+            operationId: getLearnMessagesResourcePage
+            parameters:
+                - in: path
+                  name: resource
+                  required: true
+                  schema:
+                      type: string
+                - in: query
+                  name: languageId
+                  required: false
+                  schema:
+                      type: string
+                - in: query
+                  name: key
+                  required: false
+                  schema:
+                      type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/LearnMessage"
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/LearnMessage"
+            tags: [ "LearnMessage" ]
     "/messages":
         delete:
             operationId: deleteMessage

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/BaseLearnMessageResourceImpl.java
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/BaseLearnMessageResourceImpl.java
@@ -1,0 +1,510 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.language.rest.internal.resource.v1_0;
+
+import com.liferay.petra.function.UnsafeBiConsumer;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.language.rest.dto.v1_0.LearnMessage;
+import com.liferay.portal.language.rest.resource.v1_0.LearnMessageResource;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParser;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortField;
+import com.liferay.portal.odata.sort.SortParser;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+import com.liferay.portal.vulcan.util.ActionUtil;
+
+import java.io.Serializable;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+@javax.ws.rs.Path("/v1.0")
+public abstract class BaseLearnMessageResourceImpl
+	implements EntityModelResource, LearnMessageResource,
+			   VulcanBatchEngineTaskItemDelegate<LearnMessage> {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/language/v1.0/learn-message/{resource}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "resource"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "languageId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "key"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "LearnMessage")}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path("/learn-message/{resource}")
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<LearnMessage> getLearnMessagesResourcePage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("resource")
+			String resource,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("languageId")
+			String languageId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("key")
+			String key)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	@Override
+	@SuppressWarnings("PMD.UnusedLocalVariable")
+	public void create(
+			Collection<LearnMessage> learnMessages,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Override
+	public void delete(
+			Collection<LearnMessage> learnMessages,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	@Override
+	public EntityModel getEntityModel(Map<String, List<String>> multivaluedMap)
+		throws Exception {
+
+		return getEntityModel(
+			new MultivaluedHashMap<String, Object>(multivaluedMap));
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap)
+		throws Exception {
+
+		return null;
+	}
+
+	public String getResourceName() {
+		return "LearnMessage";
+	}
+
+	public String getVersion() {
+		return "v1.0";
+	}
+
+	@Override
+	public Page<LearnMessage> read(
+			Filter filter, Pagination pagination, Sort[] sorts,
+			Map<String, Serializable> parameters, String search)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Override
+	public void setLanguageId(String languageId) {
+		this.contextAcceptLanguage = new AcceptLanguage() {
+
+			@Override
+			public List<Locale> getLocales() {
+				return null;
+			}
+
+			@Override
+			public String getPreferredLanguageId() {
+				return languageId;
+			}
+
+			@Override
+			public Locale getPreferredLocale() {
+				return LocaleUtil.fromLanguageId(languageId);
+			}
+
+		};
+	}
+
+	@Override
+	public void update(
+			Collection<LearnMessage> learnMessages,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextBatchUnsafeBiConsumer(
+		UnsafeBiConsumer
+			<Collection<LearnMessage>,
+			 UnsafeFunction<LearnMessage, LearnMessage, Exception>, Exception>
+				contextBatchUnsafeBiConsumer) {
+
+		this.contextBatchUnsafeBiConsumer = contextBatchUnsafeBiConsumer;
+	}
+
+	public void setContextBatchUnsafeConsumer(
+		UnsafeBiConsumer
+			<Collection<LearnMessage>, UnsafeConsumer<LearnMessage, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
+
+		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany) {
+
+		this.contextCompany = contextCompany;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser) {
+
+		this.contextUser = contextUser;
+	}
+
+	public void setExpressionConvert(
+		ExpressionConvert<Filter> expressionConvert) {
+
+		this.expressionConvert = expressionConvert;
+	}
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider) {
+
+		this.filterParserProvider = filterParserProvider;
+	}
+
+	public void setGroupLocalService(GroupLocalService groupLocalService) {
+		this.groupLocalService = groupLocalService;
+	}
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService) {
+
+		this.resourceActionLocalService = resourceActionLocalService;
+	}
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		this.resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	public void setRoleLocalService(RoleLocalService roleLocalService) {
+		this.roleLocalService = roleLocalService;
+	}
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider) {
+		this.sortParserProvider = sortParserProvider;
+	}
+
+	public void setVulcanBatchEngineExportTaskResource(
+		VulcanBatchEngineExportTaskResource
+			vulcanBatchEngineExportTaskResource) {
+
+		this.vulcanBatchEngineExportTaskResource =
+			vulcanBatchEngineExportTaskResource;
+	}
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
+	@Override
+	public Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		try {
+			EntityModel entityModel = getEntityModel(multivaluedMap);
+
+			FilterParser filterParser = filterParserProvider.provide(
+				entityModel);
+
+			com.liferay.portal.odata.filter.Filter oDataFilter =
+				new com.liferay.portal.odata.filter.Filter(
+					filterParser.parse(filterString));
+
+			return expressionConvert.convert(
+				oDataFilter.getExpression(),
+				contextAcceptLanguage.getPreferredLocale(), entityModel);
+		}
+		catch (Exception exception) {
+			_log.error("Invalid filter " + filterString, exception);
+
+			return null;
+		}
+	}
+
+	@Override
+	public Sort[] toSorts(String sortString) {
+		if (Validator.isNull(sortString)) {
+			return null;
+		}
+
+		try {
+			SortParser sortParser = sortParserProvider.provide(
+				getEntityModel(Collections.emptyMap()));
+
+			if (sortParser == null) {
+				return null;
+			}
+
+			com.liferay.portal.odata.sort.Sort oDataSort =
+				new com.liferay.portal.odata.sort.Sort(
+					sortParser.parse(sortString));
+
+			List<SortField> sortFields = oDataSort.getSortFields();
+
+			Sort[] sorts = new Sort[sortFields.size()];
+
+			for (int i = 0; i < sortFields.size(); i++) {
+				SortField sortField = sortFields.get(i);
+
+				sorts[i] = new Sort(
+					sortField.getSortableFieldName(
+						contextAcceptLanguage.getPreferredLocale()),
+					!sortField.isAscending());
+			}
+
+			return sorts;
+		}
+		catch (Exception exception) {
+			_log.error("Invalid sort " + sortString, exception);
+
+			return new Sort[0];
+		}
+	}
+
+	protected Map<String, String> addAction(
+		String actionName,
+		com.liferay.portal.kernel.model.GroupedModel groupedModel,
+		String methodName) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), groupedModel, methodName,
+			contextScopeChecker, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName, Long ownerId,
+		String permissionName, Long siteId) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			ownerId, permissionName, siteId, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName,
+		ModelResourcePermission modelResourcePermission) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			modelResourcePermission, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, String methodName, String permissionName,
+		Long siteId) {
+
+		return addAction(
+			actionName, siteId, methodName, null, permissionName, siteId);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transform(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transform(collection, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> R[] transform(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transformToArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transformToList(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] transformToLongArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(collection, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransform(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransform(collection, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransform(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransformToList(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] unsafeTransformToLongArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(
+			collection, unsafeFunction);
+	}
+
+	protected AcceptLanguage contextAcceptLanguage;
+	protected UnsafeBiConsumer
+		<Collection<LearnMessage>,
+		 UnsafeFunction<LearnMessage, LearnMessage, Exception>, Exception>
+			contextBatchUnsafeBiConsumer;
+	protected UnsafeBiConsumer
+		<Collection<LearnMessage>, UnsafeConsumer<LearnMessage, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
+	protected com.liferay.portal.kernel.model.Company contextCompany;
+	protected HttpServletRequest contextHttpServletRequest;
+	protected HttpServletResponse contextHttpServletResponse;
+	protected Object contextScopeChecker;
+	protected UriInfo contextUriInfo;
+	protected com.liferay.portal.kernel.model.User contextUser;
+	protected ExpressionConvert<Filter> expressionConvert;
+	protected FilterParserProvider filterParserProvider;
+	protected GroupLocalService groupLocalService;
+	protected ResourceActionLocalService resourceActionLocalService;
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+	protected RoleLocalService roleLocalService;
+	protected SortParserProvider sortParserProvider;
+	protected VulcanBatchEngineExportTaskResource
+		vulcanBatchEngineExportTaskResource;
+	protected VulcanBatchEngineImportTaskResource
+		vulcanBatchEngineImportTaskResource;
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseLearnMessageResourceImpl.class);
+
+}

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/LearnMessageResourceImpl.java
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/LearnMessageResourceImpl.java
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.language.rest.internal.resource.v1_0;
+
+import com.liferay.portal.language.rest.resource.v1_0.LearnMessageResource;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * @author Thiago Buarque
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0/learn-message.properties",
+	scope = ServiceScope.PROTOTYPE, service = LearnMessageResource.class
+)
+public class LearnMessageResourceImpl extends BaseLearnMessageResourceImpl {
+}

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/LearnMessageResourceImpl.java
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/LearnMessageResourceImpl.java
@@ -5,10 +5,22 @@
 
 package com.liferay.portal.language.rest.internal.resource.v1_0;
 
+import com.liferay.learn.LearnMessageUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.language.rest.dto.v1_0.LearnMessage;
+import com.liferay.portal.language.rest.dto.v1_0.LearnMessageDetail;
 import com.liferay.portal.language.rest.resource.v1_0.LearnMessageResource;
 
+import com.liferay.portal.vulcan.pagination.Page;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ServiceScope;
+
+import javax.ws.rs.BadRequestException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * @author Thiago Buarque
@@ -18,4 +30,120 @@ import org.osgi.service.component.annotations.ServiceScope;
 	scope = ServiceScope.PROTOTYPE, service = LearnMessageResource.class
 )
 public class LearnMessageResourceImpl extends BaseLearnMessageResourceImpl {
+
+	@Override
+	public Page<LearnMessage> getLearnMessagesResourcePage(
+		String resource, String languageId, String key)
+		throws Exception {
+
+		JSONObject jsonObject = LearnMessageUtil.getJSONObject(resource);
+
+		if (Validator.isNull(jsonObject)) {
+			throw new BadRequestException(
+				"Learn-resource name must have a \"resource\" file");
+		}
+
+		if (Validator.isNotNull(key)) {
+			return Page.of(_getSingleLearnMessage(jsonObject, key, languageId));
+		}
+
+		return Page.of(_getAllLearnMessages(jsonObject, languageId));
+	}
+
+	private List<LearnMessage> _getSingleLearnMessage(
+		JSONObject jsonObject, String key, String languageId) {
+
+		JSONObject messageObject = jsonObject.getJSONObject(key);
+
+		if (Validator.isNull(messageObject)) {
+			return Collections.emptyList();
+		}
+
+		LearnMessageDetail detail = _getLearnMessageDetail(messageObject, languageId);
+
+		if (Validator.isNull(detail)) {
+			return Collections.emptyList();
+		}
+
+		return Collections.singletonList(_createLearnMessage(key, detail));
+	}
+
+	private List<LearnMessage> _getAllLearnMessages(
+		JSONObject jsonObject, String languageId) {
+
+		List<LearnMessage> learnMessages = new ArrayList<>();
+		Iterator<String> keys = jsonObject.keys();
+
+		while (keys.hasNext()) {
+			String currentKey = keys.next();
+			JSONObject messageObject = jsonObject.getJSONObject(currentKey);
+
+			if (Validator.isNull(messageObject)) {
+				continue;
+			}
+
+			LearnMessageDetail detail = _getLearnMessageDetail(messageObject, languageId);
+
+			if (Validator.isNull(detail)) {
+				continue;
+			}
+
+			learnMessages.add(_createLearnMessage(currentKey, detail));
+		}
+
+		return learnMessages;
+	}
+
+	private LearnMessageDetail _getLearnMessageDetail(
+		JSONObject messageObject, String languageId) {
+
+		JSONObject languageObject;
+
+		if (Validator.isNotNull(languageId)) {
+			languageObject = messageObject.getJSONObject(languageId);
+
+			if (Validator.isNull(languageObject)) {
+				return null;
+			}
+
+			return _createLearnMessageDetail(languageId, languageObject);
+		}
+
+		Iterator<String> languageKeys = messageObject.keys();
+
+		if (!languageKeys.hasNext()) {
+			return null;
+		}
+
+		String firstLanguageId = languageKeys.next();
+		languageObject = messageObject.getJSONObject(firstLanguageId);
+
+		if (Validator.isNull(languageObject)) {
+			return null;
+		}
+
+		return _createLearnMessageDetail(firstLanguageId, languageObject);
+	}
+
+	private static LearnMessage _createLearnMessage(
+		String key, LearnMessageDetail detail) {
+
+		LearnMessage learnMessage = new LearnMessage();
+		learnMessage.setKey(key);
+		learnMessage.setLearnMessageDetails(new LearnMessageDetail[]{detail});
+
+		return learnMessage;
+	}
+
+	private LearnMessageDetail _createLearnMessageDetail(
+		String languageId, JSONObject languageObject) {
+
+		LearnMessageDetail detail = new LearnMessageDetail();
+		detail.setLanguageId(languageId);
+		detail.setMessage(languageObject.getString("message"));
+		detail.setUrl(languageObject.getString("url"));
+
+		return detail;
+	}
+
 }

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/LearnMessageResourceImpl.java
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/LearnMessageResourceImpl.java
@@ -11,16 +11,17 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.language.rest.dto.v1_0.LearnMessage;
 import com.liferay.portal.language.rest.dto.v1_0.LearnMessageDetail;
 import com.liferay.portal.language.rest.resource.v1_0.LearnMessageResource;
-
 import com.liferay.portal.vulcan.pagination.Page;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ServiceScope;
 
-import javax.ws.rs.BadRequestException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+
+import javax.ws.rs.BadRequestException;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
 
 /**
  * @author Thiago Buarque

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -85,6 +85,8 @@ public class OpenAPIResourceImpl {
 
 	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
 		{
+			add(LearnMessageResourceImpl.class);
+
 			add(MessageResourceImpl.class);
 
 			add(OpenAPIResourceImpl.class);

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/factory/LearnMessageResourceFactoryImpl.java
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/factory/LearnMessageResourceFactoryImpl.java
@@ -1,0 +1,331 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.language.rest.internal.resource.v1_0.factory;
+
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.language.rest.internal.security.permission.LiberalPermissionChecker;
+import com.liferay.portal.language.rest.resource.v1_0.LearnMessageResource;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
+import org.osgi.service.component.ComponentServiceObjects;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceScope;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Component(
+	property = "resource.locator.key=/language/v1.0/LearnMessage",
+	service = LearnMessageResource.Factory.class
+)
+@Generated("")
+public class LearnMessageResourceFactoryImpl
+	implements LearnMessageResource.Factory {
+
+	@Override
+	public LearnMessageResource.Builder create() {
+		return new LearnMessageResource.Builder() {
+
+			@Override
+			public LearnMessageResource build() {
+				if (_user == null) {
+					throw new IllegalArgumentException("User is not set");
+				}
+
+				Function<InvocationHandler, LearnMessageResource>
+					learnMessageResourceProxyProviderFunction =
+						ResourceProxyProviderFunctionHolder.
+							_learnMessageResourceProxyProviderFunction;
+
+				return learnMessageResourceProxyProviderFunction.apply(
+					(proxy, method, arguments) -> _invoke(
+						method, arguments, _checkPermissions,
+						_httpServletRequest, _httpServletResponse,
+						_preferredLocale, _uriInfo, _user));
+			}
+
+			@Override
+			public LearnMessageResource.Builder checkPermissions(
+				boolean checkPermissions) {
+
+				_checkPermissions = checkPermissions;
+
+				return this;
+			}
+
+			@Override
+			public LearnMessageResource.Builder httpServletRequest(
+				HttpServletRequest httpServletRequest) {
+
+				_httpServletRequest = httpServletRequest;
+
+				return this;
+			}
+
+			@Override
+			public LearnMessageResource.Builder httpServletResponse(
+				HttpServletResponse httpServletResponse) {
+
+				_httpServletResponse = httpServletResponse;
+
+				return this;
+			}
+
+			@Override
+			public LearnMessageResource.Builder preferredLocale(
+				Locale preferredLocale) {
+
+				_preferredLocale = preferredLocale;
+
+				return this;
+			}
+
+			@Override
+			public LearnMessageResource.Builder uriInfo(UriInfo uriInfo) {
+				_uriInfo = uriInfo;
+
+				return this;
+			}
+
+			@Override
+			public LearnMessageResource.Builder user(User user) {
+				_user = user;
+
+				return this;
+			}
+
+			private boolean _checkPermissions = true;
+			private HttpServletRequest _httpServletRequest;
+			private HttpServletResponse _httpServletResponse;
+			private Locale _preferredLocale;
+			private UriInfo _uriInfo;
+			private User _user;
+
+		};
+	}
+
+	private static Function<InvocationHandler, LearnMessageResource>
+		_getProxyProviderFunction() {
+
+		Class<?> proxyClass = ProxyUtil.getProxyClass(
+			LearnMessageResource.class.getClassLoader(),
+			LearnMessageResource.class);
+
+		try {
+			Constructor<LearnMessageResource> constructor =
+				(Constructor<LearnMessageResource>)proxyClass.getConstructor(
+					InvocationHandler.class);
+
+			return invocationHandler -> {
+				try {
+					return constructor.newInstance(invocationHandler);
+				}
+				catch (ReflectiveOperationException
+							reflectiveOperationException) {
+
+					throw new InternalError(reflectiveOperationException);
+				}
+			};
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			throw new InternalError(noSuchMethodException);
+		}
+	}
+
+	private Object _invoke(
+			Method method, Object[] arguments, boolean checkPermissions,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Locale preferredLocale,
+			UriInfo uriInfo, User user)
+		throws Throwable {
+
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (checkPermissions) {
+			PermissionThreadLocal.setPermissionChecker(
+				_defaultPermissionCheckerFactory.create(user));
+		}
+		else {
+			PermissionThreadLocal.setPermissionChecker(
+				new LiberalPermissionChecker(user));
+		}
+
+		LearnMessageResource learnMessageResource =
+			_componentServiceObjects.getService();
+
+		learnMessageResource.setContextAcceptLanguage(
+			new AcceptLanguageImpl(httpServletRequest, preferredLocale, user));
+
+		Company company = _companyLocalService.getCompany(user.getCompanyId());
+
+		learnMessageResource.setContextCompany(company);
+
+		learnMessageResource.setContextHttpServletRequest(httpServletRequest);
+		learnMessageResource.setContextHttpServletResponse(httpServletResponse);
+		learnMessageResource.setContextUriInfo(uriInfo);
+		learnMessageResource.setContextUser(user);
+		learnMessageResource.setExpressionConvert(_expressionConvert);
+		learnMessageResource.setFilterParserProvider(_filterParserProvider);
+		learnMessageResource.setGroupLocalService(_groupLocalService);
+		learnMessageResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		learnMessageResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		learnMessageResource.setRoleLocalService(_roleLocalService);
+		learnMessageResource.setSortParserProvider(_sortParserProvider);
+
+		try {
+			return method.invoke(learnMessageResource, arguments);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			throw invocationTargetException.getTargetException();
+		}
+		finally {
+			_componentServiceObjects.ungetService(learnMessageResource);
+
+			PrincipalThreadLocal.setName(name);
+
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+		}
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<LearnMessageResource>
+		_componentServiceObjects;
+
+	@Reference
+	private PermissionCheckerFactory _defaultPermissionCheckerFactory;
+
+	@Reference(
+		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
+	)
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private SortParserProvider _sortParserProvider;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	private static class ResourceProxyProviderFunctionHolder {
+
+		private static final Function<InvocationHandler, LearnMessageResource>
+			_learnMessageResourceProxyProviderFunction =
+				_getProxyProviderFunction();
+
+	}
+
+	private class AcceptLanguageImpl implements AcceptLanguage {
+
+		public AcceptLanguageImpl(
+			HttpServletRequest httpServletRequest, Locale preferredLocale,
+			User user) {
+
+			_httpServletRequest = httpServletRequest;
+			_preferredLocale = preferredLocale;
+			_user = user;
+		}
+
+		@Override
+		public List<Locale> getLocales() {
+			return Arrays.asList(getPreferredLocale());
+		}
+
+		@Override
+		public String getPreferredLanguageId() {
+			return LocaleUtil.toLanguageId(getPreferredLocale());
+		}
+
+		@Override
+		public Locale getPreferredLocale() {
+			if (_preferredLocale != null) {
+				return _preferredLocale;
+			}
+
+			if (_httpServletRequest != null) {
+				Locale locale = (Locale)_httpServletRequest.getAttribute(
+					WebKeys.LOCALE);
+
+				if (locale != null) {
+					return locale;
+				}
+			}
+
+			return _user.getLocale();
+		}
+
+		@Override
+		public boolean isAcceptAllLanguages() {
+			return false;
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+		private final Locale _preferredLocale;
+		private final User _user;
+
+	}
+
+}

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/learn-message.properties
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/learn-message.properties
@@ -1,0 +1,12 @@
+#
+# This is a generated file.
+#
+
+api.version=v1.0
+batch.engine.entity.class.name=com.liferay.portal.language.rest.dto.v1_0.LearnMessage
+batch.engine.task.item.delegate=true
+batch.planner.export.enabled=false
+batch.planner.import.enabled=false
+entity.class.name=com.liferay.portal.language.rest.dto.v1_0.LearnMessage
+osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Language.REST)
+osgi.jaxrs.resource=true

--- a/modules/apps/portal-language/portal-language-rest-test/src/testIntegration/java/com/liferay/portal/language/rest/resource/v1_0/test/BaseLearnMessageResourceTestCase.java
+++ b/modules/apps/portal-language/portal-language-rest-test/src/testIntegration/java/com/liferay/portal/language/rest/resource/v1_0/test/BaseLearnMessageResourceTestCase.java
@@ -1,0 +1,920 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.language.rest.resource.v1_0.test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.language.rest.client.dto.v1_0.LearnMessage;
+import com.liferay.portal.language.rest.client.http.HttpInvoker;
+import com.liferay.portal.language.rest.client.pagination.Page;
+import com.liferay.portal.language.rest.client.resource.v1_0.LearnMessageResource;
+import com.liferay.portal.language.rest.client.serdes.v1_0.LearnMessageSerDes;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+
+import java.lang.reflect.Method;
+
+import java.text.DateFormat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+public abstract class BaseLearnMessageResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		irrelevantGroup = GroupTestUtil.addGroup();
+		testGroup = GroupTestUtil.addGroup();
+
+		testCompany = CompanyLocalServiceUtil.getCompany(
+			testGroup.getCompanyId());
+
+		_learnMessageResource.setContextCompany(testCompany);
+
+		com.liferay.portal.kernel.model.User testCompanyAdminUser =
+			UserTestUtil.getAdminUser(testCompany.getCompanyId());
+
+		LearnMessageResource.Builder builder = LearnMessageResource.builder();
+
+		learnMessageResource = builder.authentication(
+			testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(), 8080, "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		GroupTestUtil.deleteGroup(irrelevantGroup);
+		GroupTestUtil.deleteGroup(testGroup);
+	}
+
+	@Test
+	public void testClientSerDesToDTO() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		LearnMessage learnMessage1 = randomLearnMessage();
+
+		String json = objectMapper.writeValueAsString(learnMessage1);
+
+		LearnMessage learnMessage2 = LearnMessageSerDes.toDTO(json);
+
+		Assert.assertTrue(equals(learnMessage1, learnMessage2));
+	}
+
+	@Test
+	public void testClientSerDesToJSON() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		LearnMessage learnMessage = randomLearnMessage();
+
+		String json1 = objectMapper.writeValueAsString(learnMessage);
+		String json2 = LearnMessageSerDes.toJSON(learnMessage);
+
+		Assert.assertEquals(
+			objectMapper.readTree(json1), objectMapper.readTree(json2));
+	}
+
+	protected ObjectMapper getClientSerDesObjectMapper() {
+		return new ObjectMapper() {
+			{
+				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				configure(
+					SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+				enable(SerializationFeature.INDENT_OUTPUT);
+				setDateFormat(new ISO8601DateFormat());
+				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+				setSerializationInclusion(JsonInclude.Include.NON_NULL);
+				setVisibility(
+					PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+				setVisibility(
+					PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+			}
+		};
+	}
+
+	@Test
+	public void testEscapeRegexInStringFields() throws Exception {
+		String regex = "^[0-9]+(\\.[0-9]{1,2})\"?";
+
+		LearnMessage learnMessage = randomLearnMessage();
+
+		learnMessage.setKey(regex);
+
+		String json = LearnMessageSerDes.toJSON(learnMessage);
+
+		Assert.assertFalse(json.contains(regex));
+
+		learnMessage = LearnMessageSerDes.toDTO(json);
+
+		Assert.assertEquals(regex, learnMessage.getKey());
+	}
+
+	@Test
+	public void testGetLearnMessagesResourcePage() throws Exception {
+		String resource = testGetLearnMessagesResourcePage_getResource();
+		String irrelevantResource =
+			testGetLearnMessagesResourcePage_getIrrelevantResource();
+
+		Page<LearnMessage> page =
+			learnMessageResource.getLearnMessagesResourcePage(
+				resource, RandomTestUtil.randomString(),
+				RandomTestUtil.randomString());
+
+		long totalCount = page.getTotalCount();
+
+		if (irrelevantResource != null) {
+			LearnMessage irrelevantLearnMessage =
+				testGetLearnMessagesResourcePage_addLearnMessage(
+					irrelevantResource, randomIrrelevantLearnMessage());
+
+			page = learnMessageResource.getLearnMessagesResourcePage(
+				irrelevantResource, null, null);
+
+			Assert.assertEquals(totalCount + 1, page.getTotalCount());
+
+			assertContains(
+				irrelevantLearnMessage, (List<LearnMessage>)page.getItems());
+			assertValid(
+				page,
+				testGetLearnMessagesResourcePage_getExpectedActions(
+					irrelevantResource));
+		}
+
+		LearnMessage learnMessage1 =
+			testGetLearnMessagesResourcePage_addLearnMessage(
+				resource, randomLearnMessage());
+
+		LearnMessage learnMessage2 =
+			testGetLearnMessagesResourcePage_addLearnMessage(
+				resource, randomLearnMessage());
+
+		page = learnMessageResource.getLearnMessagesResourcePage(
+			resource, null, null);
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(learnMessage1, (List<LearnMessage>)page.getItems());
+		assertContains(learnMessage2, (List<LearnMessage>)page.getItems());
+		assertValid(
+			page,
+			testGetLearnMessagesResourcePage_getExpectedActions(resource));
+	}
+
+	protected Map<String, Map<String, String>>
+			testGetLearnMessagesResourcePage_getExpectedActions(String resource)
+		throws Exception {
+
+		Map<String, Map<String, String>> expectedActions = new HashMap<>();
+
+		return expectedActions;
+	}
+
+	protected LearnMessage testGetLearnMessagesResourcePage_addLearnMessage(
+			String resource, LearnMessage learnMessage)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String testGetLearnMessagesResourcePage_getResource()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String testGetLearnMessagesResourcePage_getIrrelevantResource()
+		throws Exception {
+
+		return null;
+	}
+
+	protected void assertContains(
+		LearnMessage learnMessage, List<LearnMessage> learnMessages) {
+
+		boolean contains = false;
+
+		for (LearnMessage item : learnMessages) {
+			if (equals(learnMessage, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			learnMessages + " does not contain " + learnMessage, contains);
+	}
+
+	protected void assertHttpResponseStatusCode(
+		int expectedHttpResponseStatusCode,
+		HttpInvoker.HttpResponse actualHttpResponse) {
+
+		Assert.assertEquals(
+			expectedHttpResponseStatusCode, actualHttpResponse.getStatusCode());
+	}
+
+	protected void assertEquals(
+		LearnMessage learnMessage1, LearnMessage learnMessage2) {
+
+		Assert.assertTrue(
+			learnMessage1 + " does not equal " + learnMessage2,
+			equals(learnMessage1, learnMessage2));
+	}
+
+	protected void assertEquals(
+		List<LearnMessage> learnMessages1, List<LearnMessage> learnMessages2) {
+
+		Assert.assertEquals(learnMessages1.size(), learnMessages2.size());
+
+		for (int i = 0; i < learnMessages1.size(); i++) {
+			LearnMessage learnMessage1 = learnMessages1.get(i);
+			LearnMessage learnMessage2 = learnMessages2.get(i);
+
+			assertEquals(learnMessage1, learnMessage2);
+		}
+	}
+
+	protected void assertEqualsIgnoringOrder(
+		List<LearnMessage> learnMessages1, List<LearnMessage> learnMessages2) {
+
+		Assert.assertEquals(learnMessages1.size(), learnMessages2.size());
+
+		for (LearnMessage learnMessage1 : learnMessages1) {
+			boolean contains = false;
+
+			for (LearnMessage learnMessage2 : learnMessages2) {
+				if (equals(learnMessage1, learnMessage2)) {
+					contains = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(
+				learnMessages2 + " does not contain " + learnMessage1,
+				contains);
+		}
+	}
+
+	protected void assertValid(LearnMessage learnMessage) throws Exception {
+		boolean valid = true;
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("key", additionalAssertFieldName)) {
+				if (learnMessage.getKey() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"learnMessageDetails", additionalAssertFieldName)) {
+
+				if (learnMessage.getLearnMessageDetails() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected void assertValid(Page<LearnMessage> page) {
+		assertValid(page, Collections.emptyMap());
+	}
+
+	protected void assertValid(
+		Page<LearnMessage> page,
+		Map<String, Map<String, String>> expectedActions) {
+
+		boolean valid = false;
+
+		java.util.Collection<LearnMessage> learnMessages = page.getItems();
+
+		int size = learnMessages.size();
+
+		if ((page.getLastPage() > 0) && (page.getPage() > 0) &&
+			(page.getPageSize() > 0) && (page.getTotalCount() > 0) &&
+			(size > 0)) {
+
+			valid = true;
+		}
+
+		Assert.assertTrue(valid);
+
+		assertValid(page.getActions(), expectedActions);
+	}
+
+	protected void assertValid(
+		Map<String, Map<String, String>> actions1,
+		Map<String, Map<String, String>> actions2) {
+
+		for (String key : actions2.keySet()) {
+			Map action = actions1.get(key);
+
+			Assert.assertNotNull(key + " does not contain an action", action);
+
+			Map<String, String> expectedAction = actions2.get(key);
+
+			Assert.assertEquals(
+				expectedAction.get("method"), action.get("method"));
+			Assert.assertEquals(expectedAction.get("href"), action.get("href"));
+		}
+	}
+
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[0];
+	}
+
+	protected List<GraphQLField> getGraphQLFields() throws Exception {
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field :
+				getDeclaredFields(
+					com.liferay.portal.language.rest.dto.v1_0.LearnMessage.
+						class)) {
+
+			if (!ArrayUtil.contains(
+					getAdditionalAssertFieldNames(), field.getName())) {
+
+				continue;
+			}
+
+			graphQLFields.addAll(getGraphQLFields(field));
+		}
+
+		return graphQLFields;
+	}
+
+	protected List<GraphQLField> getGraphQLFields(
+			java.lang.reflect.Field... fields)
+		throws Exception {
+
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field : fields) {
+			com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+				vulcanGraphQLField = field.getAnnotation(
+					com.liferay.portal.vulcan.graphql.annotation.GraphQLField.
+						class);
+
+			if (vulcanGraphQLField != null) {
+				Class<?> clazz = field.getType();
+
+				if (clazz.isArray()) {
+					clazz = clazz.getComponentType();
+				}
+
+				List<GraphQLField> childrenGraphQLFields = getGraphQLFields(
+					getDeclaredFields(clazz));
+
+				graphQLFields.add(
+					new GraphQLField(field.getName(), childrenGraphQLFields));
+			}
+		}
+
+		return graphQLFields;
+	}
+
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[0];
+	}
+
+	protected boolean equals(
+		LearnMessage learnMessage1, LearnMessage learnMessage2) {
+
+		if (learnMessage1 == learnMessage2) {
+			return true;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("key", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						learnMessage1.getKey(), learnMessage2.getKey())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"learnMessageDetails", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						learnMessage1.getLearnMessageDetails(),
+						learnMessage2.getLearnMessageDetails())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		return true;
+	}
+
+	protected boolean equals(
+		Map<String, Object> map1, Map<String, Object> map2) {
+
+		if (Objects.equals(map1.keySet(), map2.keySet())) {
+			for (Map.Entry<String, Object> entry : map1.entrySet()) {
+				if (entry.getValue() instanceof Map) {
+					if (!equals(
+							(Map)entry.getValue(),
+							(Map)map2.get(entry.getKey()))) {
+
+						return false;
+					}
+				}
+				else if (!Objects.deepEquals(
+							entry.getValue(), map2.get(entry.getKey()))) {
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	protected java.lang.reflect.Field[] getDeclaredFields(Class clazz)
+		throws Exception {
+
+		if (clazz.getClassLoader() == null) {
+			return new java.lang.reflect.Field[0];
+		}
+
+		return TransformUtil.transform(
+			ReflectionUtil.getDeclaredFields(clazz),
+			field -> {
+				if (field.isSynthetic()) {
+					return null;
+				}
+
+				return field;
+			},
+			java.lang.reflect.Field.class);
+	}
+
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
+		if (!(_learnMessageResource instanceof EntityModelResource)) {
+			throw new UnsupportedOperationException(
+				"Resource is not an instance of EntityModelResource");
+		}
+
+		EntityModelResource entityModelResource =
+			(EntityModelResource)_learnMessageResource;
+
+		EntityModel entityModel = entityModelResource.getEntityModel(
+			new MultivaluedHashMap());
+
+		if (entityModel == null) {
+			return Collections.emptyList();
+		}
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		return entityFieldsMap.values();
+	}
+
+	protected List<EntityField> getEntityFields(EntityField.Type type)
+		throws Exception {
+
+		return TransformUtil.transform(
+			getEntityFields(),
+			entityField -> {
+				if (!Objects.equals(entityField.getType(), type) ||
+					ArrayUtil.contains(
+						getIgnoredEntityFieldNames(), entityField.getName())) {
+
+					return null;
+				}
+
+				return entityField;
+			});
+	}
+
+	protected String getFilterString(
+		EntityField entityField, String operator, LearnMessage learnMessage) {
+
+		StringBundler sb = new StringBundler();
+
+		String entityFieldName = entityField.getName();
+
+		sb.append(entityFieldName);
+
+		sb.append(" ");
+		sb.append(operator);
+		sb.append(" ");
+
+		if (entityFieldName.equals("key")) {
+			Object object = learnMessage.getKey();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("learnMessageDetails")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid entity field " + entityFieldName);
+	}
+
+	protected String invoke(String query) throws Exception {
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(
+			JSONUtil.put(
+				"query", query
+			).toString(),
+			"application/json");
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+		httpInvoker.path("http://localhost:8080/o/graphql");
+		httpInvoker.userNameAndPassword(
+			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		return httpResponse.getContent();
+	}
+
+	protected JSONObject invokeGraphQLMutation(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField mutationGraphQLField = new GraphQLField(
+			"mutation", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(mutationGraphQLField.toString()));
+	}
+
+	protected JSONObject invokeGraphQLQuery(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField queryGraphQLField = new GraphQLField(
+			"query", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(queryGraphQLField.toString()));
+	}
+
+	protected LearnMessage randomLearnMessage() throws Exception {
+		return new LearnMessage() {
+			{
+				key = StringUtil.toLowerCase(RandomTestUtil.randomString());
+			}
+		};
+	}
+
+	protected LearnMessage randomIrrelevantLearnMessage() throws Exception {
+		LearnMessage randomIrrelevantLearnMessage = randomLearnMessage();
+
+		return randomIrrelevantLearnMessage;
+	}
+
+	protected LearnMessage randomPatchLearnMessage() throws Exception {
+		return randomLearnMessage();
+	}
+
+	protected LearnMessageResource learnMessageResource;
+	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected com.liferay.portal.kernel.model.Company testCompany;
+	protected com.liferay.portal.kernel.model.Group testGroup;
+
+	protected static class BeanTestUtil {
+
+		public static void copyProperties(Object source, Object target)
+			throws Exception {
+
+			Class<?> sourceClass = source.getClass();
+
+			Class<?> targetClass = target.getClass();
+
+			for (java.lang.reflect.Field field :
+					_getAllDeclaredFields(sourceClass)) {
+
+				if (field.isSynthetic()) {
+					continue;
+				}
+
+				Method getMethod = _getMethod(
+					sourceClass, field.getName(), "get");
+
+				try {
+					Method setMethod = _getMethod(
+						targetClass, field.getName(), "set",
+						getMethod.getReturnType());
+
+					setMethod.invoke(target, getMethod.invoke(source));
+				}
+				catch (Exception e) {
+					continue;
+				}
+			}
+		}
+
+		public static boolean hasProperty(Object bean, String name) {
+			Method setMethod = _getMethod(
+				bean.getClass(), "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod != null) {
+				return true;
+			}
+
+			return false;
+		}
+
+		public static void setProperty(Object bean, String name, Object value)
+			throws Exception {
+
+			Class<?> clazz = bean.getClass();
+
+			Method setMethod = _getMethod(
+				clazz, "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod == null) {
+				throw new NoSuchMethodException();
+			}
+
+			Class<?>[] parameterTypes = setMethod.getParameterTypes();
+
+			setMethod.invoke(bean, _translateValue(parameterTypes[0], value));
+		}
+
+		private static List<java.lang.reflect.Field> _getAllDeclaredFields(
+			Class<?> clazz) {
+
+			List<java.lang.reflect.Field> fields = new ArrayList<>();
+
+			while ((clazz != null) && (clazz != Object.class)) {
+				for (java.lang.reflect.Field field :
+						clazz.getDeclaredFields()) {
+
+					fields.add(field);
+				}
+
+				clazz = clazz.getSuperclass();
+			}
+
+			return fields;
+		}
+
+		private static Method _getMethod(Class<?> clazz, String name) {
+			for (Method method : clazz.getMethods()) {
+				if (name.equals(method.getName()) &&
+					(method.getParameterCount() == 1) &&
+					_parameterTypes.contains(method.getParameterTypes()[0])) {
+
+					return method;
+				}
+			}
+
+			return null;
+		}
+
+		private static Method _getMethod(
+				Class<?> clazz, String fieldName, String prefix,
+				Class<?>... parameterTypes)
+			throws Exception {
+
+			return clazz.getMethod(
+				prefix + StringUtil.upperCaseFirstLetter(fieldName),
+				parameterTypes);
+		}
+
+		private static Object _translateValue(
+			Class<?> parameterType, Object value) {
+
+			if ((value instanceof Integer) &&
+				parameterType.equals(Long.class)) {
+
+				Integer intValue = (Integer)value;
+
+				return intValue.longValue();
+			}
+
+			return value;
+		}
+
+		private static final Set<Class<?>> _parameterTypes = new HashSet<>(
+			Arrays.asList(
+				Boolean.class, Date.class, Double.class, Integer.class,
+				Long.class, Map.class, String.class));
+
+	}
+
+	protected class GraphQLField {
+
+		public GraphQLField(String key, GraphQLField... graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(String key, List<GraphQLField> graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			GraphQLField... graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = Arrays.asList(graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			List<GraphQLField> graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = graphQLFields;
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder(_key);
+
+			if (!_parameterMap.isEmpty()) {
+				sb.append("(");
+
+				for (Map.Entry<String, Object> entry :
+						_parameterMap.entrySet()) {
+
+					sb.append(entry.getKey());
+					sb.append(": ");
+					sb.append(entry.getValue());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append(")");
+			}
+
+			if (!_graphQLFields.isEmpty()) {
+				sb.append("{");
+
+				for (GraphQLField graphQLField : _graphQLFields) {
+					sb.append(graphQLField.toString());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append("}");
+			}
+
+			return sb.toString();
+		}
+
+		private final List<GraphQLField> _graphQLFields;
+		private final String _key;
+		private final Map<String, Object> _parameterMap;
+
+	}
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseLearnMessageResourceTestCase.class);
+
+	private static DateFormat _dateFormat;
+
+	@Inject
+	private com.liferay.portal.language.rest.resource.v1_0.LearnMessageResource
+		_learnMessageResource;
+
+}

--- a/modules/apps/portal-language/portal-language-rest-test/src/testIntegration/java/com/liferay/portal/language/rest/resource/v1_0/test/LearnMessageResourceTest.java
+++ b/modules/apps/portal-language/portal-language-rest-test/src/testIntegration/java/com/liferay/portal/language/rest/resource/v1_0/test/LearnMessageResourceTest.java
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.language.rest.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Thiago Buarque
+ */
+@Ignore
+@RunWith(Arquillian.class)
+public class LearnMessageResourceTest extends BaseLearnMessageResourceTestCase {
+}

--- a/modules/apps/portal-language/portal-language-rest-test/src/testIntegration/java/com/liferay/portal/language/rest/resource/v1_0/test/LearnMessageResourceTest.java
+++ b/modules/apps/portal-language/portal-language-rest-test/src/testIntegration/java/com/liferay/portal/language/rest/resource/v1_0/test/LearnMessageResourceTest.java
@@ -6,14 +6,129 @@
 package com.liferay.portal.language.rest.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.language.rest.client.dto.v1_0.LearnMessage;
+import com.liferay.portal.language.rest.client.dto.v1_0.LearnMessageDetail;
+import com.liferay.portal.language.rest.client.pagination.Page;
 
-import org.junit.Ignore;
+import org.junit.Assert;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
  * @author Thiago Buarque
  */
-@Ignore
 @RunWith(Arquillian.class)
 public class LearnMessageResourceTest extends BaseLearnMessageResourceTestCase {
+
+	@Override
+	protected String testGetLearnMessagesResourcePage_getResource() {
+		return "click-to-chat-web";
+	}
+
+	@Override
+	@Test
+	public void testGetLearnMessagesResourcePage() throws Exception {
+		String resource = testGetLearnMessagesResourcePage_getResource();
+
+		// Test with no filters
+		Page<LearnMessage> page = learnMessageResource.getLearnMessagesResourcePage(
+			resource, null, null);
+
+		assertValid(page);
+
+		// Test with language filter
+		String languageId = "en_US";
+		page = learnMessageResource.getLearnMessagesResourcePage(
+			resource, languageId, null);
+
+		assertValid(page);
+		_validateLanguageFilter(page, languageId);
+
+		// Test with specific key
+		String key = "chat-provider-account-id-hubspot";
+		page = learnMessageResource.getLearnMessagesResourcePage(
+			resource, null, key);
+
+		assertValid(page);
+		_validateKeyFilter(page, key);
+
+		// Test with both language and key filters
+		page = learnMessageResource.getLearnMessagesResourcePage(
+			resource, languageId, key);
+
+		assertValid(page);
+		_validateLanguageFilter(page, languageId);
+		_validateKeyFilter(page, key);
+	}
+
+	@Test
+	public void testGetLearnMessagesResourcePage_InvalidResource() throws Exception {
+		String invalidResource = RandomTestUtil.randomString();
+
+		Page<LearnMessage> page = learnMessageResource.getLearnMessagesResourcePage(
+			invalidResource, null, null);
+
+		_assertValidEmptyPage(page);
+	}
+
+	@Test
+	public void testGetLearnMessagesResourcePage_InvalidLanguage() throws Exception {
+		String resource = testGetLearnMessagesResourcePage_getResource();
+		String invalidLanguage = RandomTestUtil.randomString();
+
+		Page<LearnMessage> page = learnMessageResource.getLearnMessagesResourcePage(
+			resource, invalidLanguage, null);
+
+		_assertValidEmptyPage(page);
+	}
+
+	@Test
+	public void testGetLearnMessagesResourcePage_InvalidKey() throws Exception {
+		String resource = testGetLearnMessagesResourcePage_getResource();
+		String invalidKey = RandomTestUtil.randomString();
+
+		Page<LearnMessage> page = learnMessageResource.getLearnMessagesResourcePage(
+			resource, null, invalidKey);
+
+		_assertValidEmptyPage(page);
+	}
+
+	protected void _assertValidEmptyPage(Page<LearnMessage> page) {
+		Assert.assertNotNull("Page should not be null", page);
+		Assert.assertNotNull("Page items should not be null", page.getItems());
+		Assert.assertTrue("Page should be empty", page.getItems().isEmpty());
+	}
+
+	protected void _validateLanguageFilter(Page<LearnMessage> page, String languageId) {
+		for (LearnMessage message : page.getItems()) {
+			LearnMessageDetail[] details = message.getLearnMessageDetails();
+
+			Assert.assertNotNull("Message details should not be null", details);
+			Assert.assertTrue("Message should have details", details.length > 0);
+
+			boolean hasLanguage = false;
+			for (LearnMessageDetail detail : details) {
+				if (languageId.equals(detail.getLanguageId())) {
+					hasLanguage = true;
+					break;
+				}
+			}
+
+			Assert.assertTrue(
+				"Message should have requested language: " + languageId,
+				hasLanguage);
+		}
+	}
+
+	protected void _validateKeyFilter(Page<LearnMessage> page, String key) {
+		Assert.assertFalse("Page should have items", page.getItems().isEmpty());
+
+		for (LearnMessage message : page.getItems()) {
+			Assert.assertEquals(
+				"Message key should match filter",
+				key,
+				message.getKey());
+		}
+	}
 }


### PR DESCRIPTION
# Problem 

"/o/api"

Users are unable to understand how to use the search and filter parameters in the API effectively.

# Solution  

1. Integrated the Learn Resource to provide help text directly in the API GUI.
2. Wrapped the swagger-ui-react library with custom component to display help text alongside relevant fields.
3. Developed a new API to make the Learn Resource easily accessible for users.

# Verification Steps  

1. Navigate to /o/api.
2. Open any API that includes a search or filter parameter.
3. Observe a question mark icon near the input field. Hovering over it reveals a tooltip with helpful text and a link to the relevant documentation.

### Note  

1. Since `headless-discovery-web.json` is not available, refer to the following steps to run it locally:  [Liferay Learn Resources](https://github.com/liferay/liferay-portal/tree/master/learn-resources).
2. To add more help text to the GUI, update the JSON file (headless-discovery-web.json) with a valid key such as search, filter, sort, fields, nestedFields, or similar. These changes will automatically reflect in the GUI.