### PR TITLE
LPD-42587 UtilityPages: Mark as Default shouldn't work for Draft Version

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/jaxrs/exception/mapper/UtilityPageDefaultUtilityPageExceptionMapper.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/jaxrs/exception/mapper/UtilityPageDefaultUtilityPageExceptionMapper.java
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.jaxrs.exception.mapper;
+
+import com.liferay.layout.utility.page.exception.DefaultLayoutUtilityPageEntry;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.Site)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Headless.Admin.Site.UtilityPageDefaultUtilityPageExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+@Provider
+public class UtilityPageDefaultUtilityPageExceptionMapper
+	extends BaseExceptionMapper<DefaultLayoutUtilityPageEntry> {
+
+	@Override
+	protected Problem getProblem(
+		DefaultLayoutUtilityPageEntry defaultLayoutUtilityPageEntry) {
+
+		return new Problem(defaultLayoutUtilityPageEntry);
+	}
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/UtilityPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/UtilityPageResourceTest.java
@@ -17,6 +17,7 @@ import com.liferay.headless.admin.site.resource.v1_0.test.util.PageSpecification
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
 import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalService;
+import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -89,20 +90,13 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 					postUtilityPage.getExternalReferenceCode(),
 					testGroup.getGroupId()));
 
-		try {
-			utilityPageResource.
-				deleteSiteSiteByExternalReferenceCodeUtilityPage(
-					testGroup.getExternalReferenceCode(),
-					postUtilityPage.getExternalReferenceCode());
-
-			Assert.fail();
-		}
-		catch (Problem.ProblemException problemException) {
-			Problem problem = problemException.getProblem();
-
-			Assert.assertEquals("NOT_FOUND", problem.getStatus());
-			Assert.assertNull(problem.getTitle());
-		}
+		_assertProblemException(
+			"NOT_FOUND",
+			() ->
+				utilityPageResource.
+					deleteSiteSiteByExternalReferenceCodeUtilityPage(
+						testGroup.getExternalReferenceCode(),
+						postUtilityPage.getExternalReferenceCode()));
 	}
 
 	@Override
@@ -122,19 +116,13 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 		assertEquals(postUtilityPage, getUtilityPage);
 		assertValid(getUtilityPage);
 
-		try {
-			utilityPageResource.getSiteSiteByExternalReferenceCodeUtilityPage(
-				testGroup.getExternalReferenceCode(),
-				RandomTestUtil.randomString());
-
-			Assert.fail();
-		}
-		catch (Problem.ProblemException problemException) {
-			Problem problem = problemException.getProblem();
-
-			Assert.assertEquals("NOT_FOUND", problem.getStatus());
-			Assert.assertNull(problem.getTitle());
-		}
+		_assertProblemException(
+			"NOT_FOUND",
+			() ->
+				utilityPageResource.
+					getSiteSiteByExternalReferenceCodeUtilityPage(
+						testGroup.getExternalReferenceCode(),
+						RandomTestUtil.randomString()));
 
 		UtilityPageResource utilityPageResource = _getUtilityPageResource();
 
@@ -254,19 +242,13 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 			_getUtilityPage(
 				null, layoutUtilityPageEntry.getExternalReferenceCode()));
 
-		try {
-			utilityPageResource.patchSiteSiteByExternalReferenceCodeUtilityPage(
-				testGroup.getExternalReferenceCode(),
-				RandomTestUtil.randomString(), randomUtilityPage());
-
-			Assert.fail();
-		}
-		catch (Problem.ProblemException problemException) {
-			Problem problem = problemException.getProblem();
-
-			Assert.assertEquals("NOT_FOUND", problem.getStatus());
-			Assert.assertNull(problem.getTitle());
-		}
+		_assertProblemException(
+			"NOT_FOUND",
+			() ->
+				utilityPageResource.
+					patchSiteSiteByExternalReferenceCodeUtilityPage(
+						testGroup.getExternalReferenceCode(),
+						RandomTestUtil.randomString(), randomUtilityPage()));
 	}
 
 	@Override
@@ -319,20 +301,12 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 
 		Assert.assertFalse(layout.isPublished());
 
-		try {
-			_testPutSiteSiteByExternalReferenceCodeUtilityPage(
+		_assertProblemException(
+			"BAD_REQUEST",
+			() -> _testPutSiteSiteByExternalReferenceCodeUtilityPage(
 				_getUtilityPage(
 					Boolean.TRUE,
-					layoutUtilityPageEntry.getExternalReferenceCode()));
-
-			Assert.fail();
-		}
-		catch (Problem.ProblemException problemException) {
-			Problem problem = problemException.getProblem();
-
-			Assert.assertEquals("BAD_REQUEST", problem.getStatus());
-			Assert.assertNull(problem.getTitle());
-		}
+					layoutUtilityPageEntry.getExternalReferenceCode())));
 
 		ContentLayoutTestUtil.publishLayout(layout.fetchDraftLayout(), layout);
 
@@ -454,6 +428,23 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 
 		PageSpecificationsTestUtil.assertPageSpecifications(
 			layout, utilityPage.getPageSpecifications());
+	}
+
+	private void _assertProblemException(
+			String status, UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		try {
+			unsafeRunnable.run();
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals(status, problem.getStatus());
+			Assert.assertNull(problem.getTitle());
+		}
 	}
 
 	private UtilityPage _getUtilityPage(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/UtilityPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/UtilityPageResourceTest.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -302,6 +303,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 
 	@Override
 	@Test
+	@TestInfo("LPD-42587")
 	public void testPutSiteSiteByExternalReferenceCodeUtilityPage()
 		throws Exception {
 
@@ -314,6 +316,23 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 
 		Layout layout = _layoutLocalService.getLayout(
 			layoutUtilityPageEntry.getPlid());
+
+		Assert.assertFalse(layout.isPublished());
+
+		try {
+			_testPutSiteSiteByExternalReferenceCodeUtilityPage(
+				_getUtilityPage(
+					Boolean.TRUE,
+					layoutUtilityPageEntry.getExternalReferenceCode()));
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("BAD_REQUEST", problem.getStatus());
+			Assert.assertNull(problem.getTitle());
+		}
 
 		ContentLayoutTestUtil.publishLayout(layout.fetchDraftLayout(), layout);
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/UtilityPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/UtilityPageResourceTest.java
@@ -12,7 +12,9 @@ import com.liferay.headless.admin.site.client.pagination.Page;
 import com.liferay.headless.admin.site.client.pagination.Pagination;
 import com.liferay.headless.admin.site.client.problem.Problem;
 import com.liferay.headless.admin.site.client.resource.v1_0.UtilityPageResource;
+import com.liferay.headless.admin.site.resource.v1_0.test.util.LayoutUtilityPageEntryTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.PageSpecificationsTestUtil;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
 import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalService;
 import com.liferay.portal.kernel.json.JSONArray;
@@ -225,21 +227,31 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 	public void testPatchSiteSiteByExternalReferenceCodeUtilityPage()
 		throws Exception {
 
-		UtilityPage utilityPage =
-			testPostSiteSiteByExternalReferenceCodeUtilityPage_addUtilityPage(
-				randomUtilityPage());
+		LayoutUtilityPageEntry layoutUtilityPageEntry =
+			LayoutUtilityPageEntryTestUtil.getLayoutUtilityPageEntry(
+				ServiceContextTestUtil.getServiceContext(
+					testGroup.getGroupId(), TestPropsValues.getUserId()));
 
 		_testPatchSiteSiteByExternalReferenceCodeUtilityPage(
 			Boolean.FALSE,
 			_getUtilityPage(
-				Boolean.FALSE, utilityPage.getExternalReferenceCode()));
+				Boolean.FALSE,
+				layoutUtilityPageEntry.getExternalReferenceCode()));
+
+		Layout layout = _layoutLocalService.getLayout(
+			layoutUtilityPageEntry.getPlid());
+
+		ContentLayoutTestUtil.publishLayout(layout.fetchDraftLayout(), layout);
+
 		_testPatchSiteSiteByExternalReferenceCodeUtilityPage(
 			Boolean.TRUE,
 			_getUtilityPage(
-				Boolean.TRUE, utilityPage.getExternalReferenceCode()));
+				Boolean.TRUE,
+				layoutUtilityPageEntry.getExternalReferenceCode()));
 		_testPatchSiteSiteByExternalReferenceCodeUtilityPage(
 			Boolean.TRUE,
-			_getUtilityPage(null, utilityPage.getExternalReferenceCode()));
+			_getUtilityPage(
+				null, layoutUtilityPageEntry.getExternalReferenceCode()));
 
 		try {
 			utilityPageResource.patchSiteSiteByExternalReferenceCodeUtilityPage(
@@ -265,7 +277,8 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 
 		UtilityPage utilityPage =
 			utilityPageResource.postSiteSiteByExternalReferenceCodeUtilityPage(
-				testGroup.getExternalReferenceCode(), randomUtilityPage());
+				testGroup.getExternalReferenceCode(),
+				_getUtilityPage(Boolean.FALSE, RandomTestUtil.randomString()));
 
 		LayoutUtilityPageEntry layoutUtilityPageEntry =
 			_layoutUtilityPageEntryLocalService.
@@ -294,12 +307,29 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 
 		_testPutSiteSiteByExternalReferenceCodeUtilityPage(randomUtilityPage());
 
-		UtilityPage utilityPage =
-			testPostSiteSiteByExternalReferenceCodeUtilityPage_addUtilityPage(
-				randomUtilityPage());
+		LayoutUtilityPageEntry layoutUtilityPageEntry =
+			LayoutUtilityPageEntryTestUtil.getLayoutUtilityPageEntry(
+				ServiceContextTestUtil.getServiceContext(
+					testGroup.getGroupId(), TestPropsValues.getUserId()));
+
+		Layout layout = _layoutLocalService.getLayout(
+			layoutUtilityPageEntry.getPlid());
+
+		ContentLayoutTestUtil.publishLayout(layout.fetchDraftLayout(), layout);
 
 		_testPutSiteSiteByExternalReferenceCodeUtilityPage(
-			_getUtilityPage(null, utilityPage.getExternalReferenceCode()));
+			_getUtilityPage(
+				Boolean.TRUE,
+				layoutUtilityPageEntry.getExternalReferenceCode()));
+
+		_testPutSiteSiteByExternalReferenceCodeUtilityPage(
+			_getUtilityPage(
+				null, layoutUtilityPageEntry.getExternalReferenceCode()));
+
+		_testPutSiteSiteByExternalReferenceCodeUtilityPage(
+			_getUtilityPage(
+				Boolean.FALSE,
+				layoutUtilityPageEntry.getExternalReferenceCode()));
 	}
 
 	@Ignore

--- a/modules/apps/layout/layout-utility-page-api/bnd.bnd
+++ b/modules/apps/layout/layout-utility-page-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Layout Utility Page API
 Bundle-SymbolicName: com.liferay.layout.utility.page.api
-Bundle-Version: 8.2.1
+Bundle-Version: 8.3.0
 Export-Package:\
 	com.liferay.layout.utility.page.constants,\
 	com.liferay.layout.utility.page.converter,\

--- a/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/exception/DefaultLayoutUtilityPageEntry.java
+++ b/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/exception/DefaultLayoutUtilityPageEntry.java
@@ -1,0 +1,30 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.utility.page.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class DefaultLayoutUtilityPageEntry extends PortalException {
+
+	public DefaultLayoutUtilityPageEntry() {
+	}
+
+	public DefaultLayoutUtilityPageEntry(String msg) {
+		super(msg);
+	}
+
+	public DefaultLayoutUtilityPageEntry(String msg, Throwable throwable) {
+		super(msg, throwable);
+	}
+
+	public DefaultLayoutUtilityPageEntry(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/modules/apps/layout/layout-utility-page-api/src/main/resources/com/liferay/layout/utility/page/exception/packageinfo
+++ b/modules/apps/layout/layout-utility-page-api/src/main/resources/com/liferay/layout/utility/page/exception/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 4.1.0

--- a/modules/apps/layout/layout-utility-page-service/build.gradle
+++ b/modules/apps/layout/layout-utility-page-service/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 	compileOnly project(":apps:change-tracking:change-tracking-spi")
 	compileOnly project(":apps:document-library:document-library-api")
 	compileOnly project(":apps:layout:layout-admin-api")
+	compileOnly project(":apps:layout:layout-api")
 	compileOnly project(":apps:layout:layout-utility-page-api")
 	compileOnly project(":apps:portal:portal-aop-api")
 	compileOnly project(":apps:portal:portal-dao-orm-custom-sql-api")

--- a/modules/apps/layout/layout-utility-page-service/service.xml
+++ b/modules/apps/layout/layout-utility-page-service/service.xml
@@ -65,6 +65,7 @@
 		</finder>
 	</entity>
 	<exceptions>
+		<exception>DefaultLayoutUtilityPageEntry</exception>
 		<exception>LayoutUtilityPageEntryName</exception>
 	</exceptions>
 </service-builder>

--- a/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryLocalServiceImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.layout.utility.page.service.impl;
 
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
+import com.liferay.layout.constants.LayoutTypeSettingsConstants;
 import com.liferay.layout.utility.page.exception.LayoutUtilityPageEntryNameException;
 import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
 import com.liferay.layout.utility.page.service.base.LayoutUtilityPageEntryLocalServiceBaseImpl;
@@ -98,7 +99,8 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 
 		if (plid == 0) {
 			Layout layout = _addLayout(
-				userId, groupId, name, masterLayoutPlid, serviceContext);
+				userId, groupId, name, masterLayoutPlid,
+				defaultLayoutUtilityPageEntry, serviceContext);
 
 			if (layout != null) {
 				plid = layout.getPlid();
@@ -434,7 +436,7 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 
 	private Layout _addLayout(
 			long userId, long groupId, String name, long masterLayoutPlid,
-			ServiceContext serviceContext)
+			boolean published, ServiceContext serviceContext)
 		throws PortalException {
 
 		Map<Locale, String> titleMap = Collections.singletonMap(
@@ -454,6 +456,11 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 			typeSettingsUnicodeProperties.setProperty(
 				"lfr-theme:regular:wrap-widget-page-content",
 				Boolean.FALSE.toString());
+		}
+
+		if (published) {
+			typeSettingsUnicodeProperties.put(
+				LayoutTypeSettingsConstants.KEY_PUBLISHED, "true");
 		}
 
 		String typeSettings = typeSettingsUnicodeProperties.toString();
@@ -484,6 +491,10 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 			layout = _layoutLocalService.updateLookAndFeel(
 				groupId, false, layout.getLayoutId(), themeId, colorSchemeId,
 				StringPool.BLANK);
+		}
+
+		if (published) {
+			return layout;
 		}
 
 		return _layoutLocalService.updateStatus(

--- a/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryLocalServiceImpl.java
@@ -7,6 +7,7 @@ package com.liferay.layout.utility.page.service.impl;
 
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
 import com.liferay.layout.constants.LayoutTypeSettingsConstants;
+import com.liferay.layout.utility.page.exception.DefaultLayoutUtilityPageEntry;
 import com.liferay.layout.utility.page.exception.LayoutUtilityPageEntryNameException;
 import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
 import com.liferay.layout.utility.page.service.base.LayoutUtilityPageEntryLocalServiceBaseImpl;
@@ -341,6 +342,13 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 		LayoutUtilityPageEntry layoutUtilityPageEntry =
 			layoutUtilityPageEntryPersistence.findByPrimaryKey(
 				layoutUtilityPageEntryId);
+
+		Layout layout = _layoutLocalService.getLayout(
+			layoutUtilityPageEntry.getPlid());
+
+		if (!layout.isPublished()) {
+			throw new DefaultLayoutUtilityPageEntry();
+		}
 
 		LayoutUtilityPageEntry defaultLayoutUtilityPageEntry =
 			layoutUtilityPageEntryPersistence.fetchByG_D_T_First(

--- a/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/internal/exportimport/data/handler/test/LayoutUtilityPageEntryStagedModelDataHandlerTest.java
+++ b/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/internal/exportimport/data/handler/test/LayoutUtilityPageEntryStagedModelDataHandlerTest.java
@@ -12,11 +12,14 @@ import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.kernel.lifecycle.ExportImportLifecycleManagerUtil;
 import com.liferay.exportimport.kernel.lifecycle.constants.ExportImportLifecycleConstants;
 import com.liferay.exportimport.test.util.lar.BaseStagedModelDataHandlerTestCase;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.utility.page.kernel.constants.LayoutUtilityPageEntryConstants;
 import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
 import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalService;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.StagedModel;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.DateTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -141,6 +144,11 @@ public class LayoutUtilityPageEntryStagedModelDataHandlerTest
 			importedLayoutUtilityPageEntry.isDefaultLayoutUtilityPageEntry());
 
 		initExport();
+
+		Layout layout = _layoutLocalService.getLayout(
+			layoutUtilityPageEntry.getPlid());
+
+		ContentLayoutTestUtil.publishLayout(layout.fetchDraftLayout(), layout);
 
 		layoutUtilityPageEntry =
 			_layoutUtilityPageEntryLocalService.
@@ -301,6 +309,9 @@ public class LayoutUtilityPageEntryStagedModelDataHandlerTest
 	private static final String _TEST_NAME = "Test Layout Utility Page";
 
 	private static final String _TEST_TYPE = "test";
+
+	@Inject
+	private LayoutLocalService _layoutLocalService;
 
 	@Inject
 	private LayoutUtilityPageEntryLocalService

--- a/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/test/LayoutUtilityPageEntryLocalServiceTest.java
+++ b/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/test/LayoutUtilityPageEntryLocalServiceTest.java
@@ -10,6 +10,8 @@ import com.liferay.layout.utility.page.exception.DuplicateLayoutUtilityPageEntry
 import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
 import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalService;
 import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryService;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.Role;
@@ -101,24 +103,24 @@ public class LayoutUtilityPageEntryLocalServiceTest {
 
 		Assert.assertFalse(layout.isPublished());
 		Assert.assertEquals(WorkflowConstants.STATUS_DRAFT, layout.getStatus());
-	}
 
-	@Test(
-		expected = DuplicateLayoutUtilityPageEntryExternalReferenceCodeException.class
-	)
-	public void testAddLayoutUtilityPageEntryWithExistingExternalReferenceCode()
-		throws Exception {
+		try {
+			_layoutUtilityPageEntryLocalService.addLayoutUtilityPageEntry(
+				layoutUtilityPageEntry.getExternalReferenceCode(),
+				TestPropsValues.getUserId(), _group.getGroupId(), 0, 0, true,
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 0,
+				_serviceContext);
 
-		String externalReferenceCode = RandomTestUtil.randomString();
+			Assert.fail();
+		}
+		catch (DuplicateLayoutUtilityPageEntryExternalReferenceCodeException
+					duplicateLayoutUtilityPageEntryExternalReferenceCodeException) {
 
-		_layoutUtilityPageEntryLocalService.addLayoutUtilityPageEntry(
-			externalReferenceCode, TestPropsValues.getUserId(),
-			_group.getGroupId(), 0, 0, true, RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), 0, _serviceContext);
-		_layoutUtilityPageEntryLocalService.addLayoutUtilityPageEntry(
-			externalReferenceCode, TestPropsValues.getUserId(),
-			_group.getGroupId(), 0, 0, true, RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), 0, _serviceContext);
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					duplicateLayoutUtilityPageEntryExternalReferenceCodeException);
+			}
+		}
 	}
 
 	@Test
@@ -161,6 +163,9 @@ public class LayoutUtilityPageEntryLocalServiceTest {
 		Assert.assertEquals(
 			"ERC", layoutUtilityPageEntry.getExternalReferenceCode());
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		LayoutUtilityPageEntryLocalServiceTest.class);
 
 	@DeleteAfterTestRun
 	private Group _group;

--- a/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/test/LayoutUtilityPageEntryLocalServiceTest.java
+++ b/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/test/LayoutUtilityPageEntryLocalServiceTest.java
@@ -6,7 +6,10 @@
 package com.liferay.layout.utility.page.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
+import com.liferay.layout.utility.page.exception.DefaultLayoutUtilityPageEntry;
 import com.liferay.layout.utility.page.exception.DuplicateLayoutUtilityPageEntryExternalReferenceCodeException;
+import com.liferay.layout.utility.page.kernel.constants.LayoutUtilityPageEntryConstants;
 import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
 import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalService;
 import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryService;
@@ -162,6 +165,62 @@ public class LayoutUtilityPageEntryLocalServiceTest {
 
 		Assert.assertEquals(
 			"ERC", layoutUtilityPageEntry.getExternalReferenceCode());
+	}
+
+	@Test
+	public void testSetDefaultLayoutUtilityPageEntry() throws Exception {
+		LayoutUtilityPageEntry layoutUtilityPageEntry1 =
+			_layoutUtilityPageEntryLocalService.addLayoutUtilityPageEntry(
+				null, TestPropsValues.getUserId(), _group.getGroupId(), 0, 0,
+				true, RandomTestUtil.randomString(),
+				LayoutUtilityPageEntryConstants.TYPE_SC_NOT_FOUND, 0, _serviceContext);
+
+		Assert.assertTrue(
+			layoutUtilityPageEntry1.isDefaultLayoutUtilityPageEntry());
+
+		LayoutUtilityPageEntry layoutUtilityPageEntry2 =
+			_layoutUtilityPageEntryLocalService.addLayoutUtilityPageEntry(
+				null, TestPropsValues.getUserId(), _group.getGroupId(), 0, 0,
+				false, RandomTestUtil.randomString(),
+				LayoutUtilityPageEntryConstants.TYPE_SC_NOT_FOUND, 0, _serviceContext);
+
+		Assert.assertFalse(
+			layoutUtilityPageEntry2.isDefaultLayoutUtilityPageEntry());
+
+		Layout layout = _layoutLocalService.getLayout(
+			layoutUtilityPageEntry2.getPlid());
+
+		Assert.assertFalse(layout.isPublished());
+
+		try {
+			_layoutUtilityPageEntryLocalService.
+				setDefaultLayoutUtilityPageEntry(
+					layoutUtilityPageEntry2.getLayoutUtilityPageEntryId());
+
+			Assert.fail();
+		}
+		catch (DefaultLayoutUtilityPageEntry defaultLayoutUtilityPageEntry) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(defaultLayoutUtilityPageEntry);
+			}
+		}
+
+		ContentLayoutTestUtil.publishLayout(layout.fetchDraftLayout(), layout);
+
+		layoutUtilityPageEntry2 =
+			_layoutUtilityPageEntryLocalService.
+				setDefaultLayoutUtilityPageEntry(
+					layoutUtilityPageEntry2.getLayoutUtilityPageEntryId());
+
+		Assert.assertTrue(
+			layoutUtilityPageEntry2.isDefaultLayoutUtilityPageEntry());
+
+		layoutUtilityPageEntry1 =
+			_layoutUtilityPageEntryLocalService.getLayoutUtilityPageEntry(
+				layoutUtilityPageEntry1.getLayoutUtilityPageEntryId());
+
+		Assert.assertFalse(
+			layoutUtilityPageEntry1.isDefaultLayoutUtilityPageEntry());
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/test/LayoutUtilityPageEntryLocalServiceTest.java
+++ b/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/test/LayoutUtilityPageEntryLocalServiceTest.java
@@ -11,8 +11,10 @@ import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
 import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalService;
 import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryService;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -24,6 +26,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -75,6 +78,29 @@ public class LayoutUtilityPageEntryLocalServiceTest {
 		Assert.assertTrue(
 			Validator.isNotNull(
 				layoutUtilityPageEntry.getExternalReferenceCode()));
+
+		Layout layout = _layoutLocalService.getLayout(
+			layoutUtilityPageEntry.getPlid());
+
+		Assert.assertTrue(layout.isPublished());
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, layout.getStatus());
+
+		layoutUtilityPageEntry =
+			_layoutUtilityPageEntryLocalService.addLayoutUtilityPageEntry(
+				null, TestPropsValues.getUserId(), _group.getGroupId(), 0, 0,
+				false, RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(), 0, _serviceContext);
+
+		Assert.assertTrue(
+			Validator.isNotNull(
+				layoutUtilityPageEntry.getExternalReferenceCode()));
+
+		layout = _layoutLocalService.getLayout(
+			layoutUtilityPageEntry.getPlid());
+
+		Assert.assertFalse(layout.isPublished());
+		Assert.assertEquals(WorkflowConstants.STATUS_DRAFT, layout.getStatus());
 	}
 
 	@Test(
@@ -138,6 +164,9 @@ public class LayoutUtilityPageEntryLocalServiceTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private LayoutLocalService _layoutLocalService;
 
 	@Inject
 	private LayoutUtilityPageEntryLocalService

--- a/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/test/LayoutUtilityPageEntryLocalServiceTest.java
+++ b/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/test/LayoutUtilityPageEntryLocalServiceTest.java
@@ -157,6 +157,10 @@ public class LayoutUtilityPageEntryLocalServiceTest {
 			"test-layout-utility-page",
 			layoutUtilityPageEntry.getExternalReferenceCode());
 
+		_testGetExternalReferenceCode(
+			layoutUtilityPageEntry.getExternalReferenceCode(),
+			layoutUtilityPageEntry.getLayoutUtilityPageEntryId());
+
 		layoutUtilityPageEntry =
 			_layoutUtilityPageEntryService.addLayoutUtilityPageEntry(
 				"ERC", _group.getGroupId(), 0, 0, true,
@@ -165,6 +169,10 @@ public class LayoutUtilityPageEntryLocalServiceTest {
 
 		Assert.assertEquals(
 			"ERC", layoutUtilityPageEntry.getExternalReferenceCode());
+
+		_testGetExternalReferenceCode(
+			layoutUtilityPageEntry.getExternalReferenceCode(),
+			layoutUtilityPageEntry.getLayoutUtilityPageEntryId());
 	}
 
 	@Test
@@ -173,7 +181,8 @@ public class LayoutUtilityPageEntryLocalServiceTest {
 			_layoutUtilityPageEntryLocalService.addLayoutUtilityPageEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), 0, 0,
 				true, RandomTestUtil.randomString(),
-				LayoutUtilityPageEntryConstants.TYPE_SC_NOT_FOUND, 0, _serviceContext);
+				LayoutUtilityPageEntryConstants.TYPE_SC_NOT_FOUND, 0,
+				_serviceContext);
 
 		Assert.assertTrue(
 			layoutUtilityPageEntry1.isDefaultLayoutUtilityPageEntry());
@@ -182,7 +191,8 @@ public class LayoutUtilityPageEntryLocalServiceTest {
 			_layoutUtilityPageEntryLocalService.addLayoutUtilityPageEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), 0, 0,
 				false, RandomTestUtil.randomString(),
-				LayoutUtilityPageEntryConstants.TYPE_SC_NOT_FOUND, 0, _serviceContext);
+				LayoutUtilityPageEntryConstants.TYPE_SC_NOT_FOUND, 0,
+				_serviceContext);
 
 		Assert.assertFalse(
 			layoutUtilityPageEntry2.isDefaultLayoutUtilityPageEntry());
@@ -221,6 +231,20 @@ public class LayoutUtilityPageEntryLocalServiceTest {
 
 		Assert.assertFalse(
 			layoutUtilityPageEntry1.isDefaultLayoutUtilityPageEntry());
+	}
+
+	private void _testGetExternalReferenceCode(
+			String externalReferenceCode, long layoutUtilityPageEntryId)
+		throws Exception {
+
+		LayoutUtilityPageEntry layoutUtilityPageEntry =
+			_layoutUtilityPageEntryService.
+				getLayoutUtilityPageEntryByExternalReferenceCode(
+					externalReferenceCode, _group.getGroupId());
+
+		Assert.assertEquals(
+			layoutUtilityPageEntryId,
+			layoutUtilityPageEntry.getLayoutUtilityPageEntryId());
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/test/LayoutUtilityPageEntryServiceTest.java
+++ b/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/test/LayoutUtilityPageEntryServiceTest.java
@@ -15,6 +15,8 @@ import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalServic
 import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.Repository;
@@ -99,9 +101,8 @@ public class LayoutUtilityPageEntryServiceTest {
 	public void testAddLayoutUtilityPageEntryWithoutAddPermission()
 		throws Exception {
 
-		try {
-			UserTestUtil.setUser(
-				UserTestUtil.addGroupUser(_group, RoleConstants.SITE_MEMBER));
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_user, PermissionCheckerFactoryUtil.create(_user))) {
 
 			_layoutUtilityPageEntryService.addLayoutUtilityPageEntry(
 				RandomTestUtil.randomString(), _group.getGroupId(), 0, 0, true,
@@ -111,9 +112,9 @@ public class LayoutUtilityPageEntryServiceTest {
 			Assert.fail();
 		}
 		catch (PrincipalException principalException) {
-		}
-		finally {
-			UserTestUtil.setUser(TestPropsValues.getUser());
+			if (_log.isDebugEnabled()) {
+				_log.debug(principalException);
+			}
 		}
 	}
 
@@ -293,9 +294,8 @@ public class LayoutUtilityPageEntryServiceTest {
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 0,
 				_serviceContext);
 
-		try {
-			UserTestUtil.setUser(
-				UserTestUtil.addGroupUser(_group, RoleConstants.SITE_MEMBER));
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_user, PermissionCheckerFactoryUtil.create(_user))) {
 
 			_layoutUtilityPageEntryService.deleteLayoutUtilityPageEntry(
 				layoutUtilityPageEntry.getExternalReferenceCode(),
@@ -304,9 +304,9 @@ public class LayoutUtilityPageEntryServiceTest {
 			Assert.fail();
 		}
 		catch (PrincipalException principalException) {
-		}
-		finally {
-			UserTestUtil.setUser(TestPropsValues.getUser());
+			if (_log.isDebugEnabled()) {
+				_log.debug(principalException);
+			}
 		}
 	}
 
@@ -385,14 +385,15 @@ public class LayoutUtilityPageEntryServiceTest {
 				layoutUtilityPageEntry.getLayoutUtilityPageEntryId()),
 			ActionKeys.VIEW);
 
-		UserTestUtil.setUser(
-			UserTestUtil.addGroupUser(_group, RoleConstants.SITE_MEMBER));
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_user, PermissionCheckerFactoryUtil.create(_user))) {
 
-		Assert.assertNotNull(
-			_layoutUtilityPageEntryService.
-				getLayoutUtilityPageEntryByExternalReferenceCode(
-					layoutUtilityPageEntry.getExternalReferenceCode(),
-					layoutUtilityPageEntry.getGroupId()));
+			Assert.assertNotNull(
+				_layoutUtilityPageEntryService.
+					getLayoutUtilityPageEntryByExternalReferenceCode(
+						layoutUtilityPageEntry.getExternalReferenceCode(),
+						layoutUtilityPageEntry.getGroupId()));
+		}
 	}
 
 	@Test(expected = PrincipalException.MustHavePermission.class)
@@ -561,6 +562,9 @@ public class LayoutUtilityPageEntryServiceTest {
 			layoutUtilityPageEntry.getName(),
 			layout.getName(LocaleUtil.getSiteDefault()));
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		LayoutUtilityPageEntryServiceTest.class);
 
 	@DeleteAfterTestRun
 	private Group _group;

--- a/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/test/LayoutUtilityPageEntryServiceTest.java
+++ b/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/test/LayoutUtilityPageEntryServiceTest.java
@@ -8,6 +8,7 @@ package com.liferay.layout.utility.page.service.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.utility.page.constants.LayoutUtilityPageActionKeys;
 import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
 import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalService;
@@ -448,6 +449,12 @@ public class LayoutUtilityPageEntryServiceTest {
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_user, PermissionCheckerFactoryUtil.create(_user))) {
+
+			Layout layout = _layoutLocalService.getLayout(
+				layoutUtilityPageEntry2.getPlid());
+
+			ContentLayoutTestUtil.publishLayout(
+				layout.fetchDraftLayout(), layout);
 
 			_layoutUtilityPageEntryService.setDefaultLayoutUtilityPageEntry(
 				layoutUtilityPageEntry2.getLayoutUtilityPageEntryId());

--- a/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/test/LayoutUtilityPageEntryServiceTest.java
+++ b/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/test/LayoutUtilityPageEntryServiceTest.java
@@ -126,47 +126,6 @@ public class LayoutUtilityPageEntryServiceTest {
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 0,
 				_serviceContext);
 
-		LayoutUtilityPageEntry copiedLayoutUtilityPageEntry =
-			_layoutUtilityPageEntryService.copyLayoutUtilityPageEntry(
-				_group.getGroupId(),
-				layoutUtilityPageEntry.getLayoutUtilityPageEntryId(),
-				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
-
-		Assert.assertNotEquals(
-			layoutUtilityPageEntry.getExternalReferenceCode(),
-			copiedLayoutUtilityPageEntry.getExternalReferenceCode());
-		Assert.assertEquals(
-			layoutUtilityPageEntry.getGroupId(),
-			copiedLayoutUtilityPageEntry.getGroupId());
-		Assert.assertEquals(
-			layoutUtilityPageEntry.getCompanyId(),
-			copiedLayoutUtilityPageEntry.getCompanyId());
-		Assert.assertNotEquals(
-			layoutUtilityPageEntry.getPlid(),
-			copiedLayoutUtilityPageEntry.getPlid());
-		Assert.assertEquals(
-			0, copiedLayoutUtilityPageEntry.getPreviewFileEntryId());
-		Assert.assertTrue(
-			StringUtil.startsWith(
-				copiedLayoutUtilityPageEntry.getName(),
-				StringBundler.concat(
-					layoutUtilityPageEntry.getName(), " (",
-					_language.get(LocaleUtil.getSiteDefault(), "copy"), ")")));
-		Assert.assertEquals(
-			layoutUtilityPageEntry.getType(),
-			copiedLayoutUtilityPageEntry.getType());
-	}
-
-	@Test
-	public void testCopyLayoutUtilityPageEntryWithPreviewFileEntry()
-		throws Exception {
-
-		LayoutUtilityPageEntry layoutUtilityPageEntry =
-			_layoutUtilityPageEntryService.addLayoutUtilityPageEntry(
-				RandomTestUtil.randomString(), _group.getGroupId(), 0, 0, true,
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 0,
-				_serviceContext);
-
 		Repository repository = _portletFileRepository.addPortletRepository(
 			_group.getGroupId(), LayoutAdminPortletKeys.GROUP_PAGES,
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
@@ -190,6 +149,19 @@ public class LayoutUtilityPageEntryServiceTest {
 				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		Assert.assertNotEquals(
+			layoutUtilityPageEntry.getExternalReferenceCode(),
+			copiedLayoutUtilityPageEntry.getExternalReferenceCode());
+		Assert.assertEquals(
+			layoutUtilityPageEntry.getGroupId(),
+			copiedLayoutUtilityPageEntry.getGroupId());
+		Assert.assertEquals(
+			layoutUtilityPageEntry.getCompanyId(),
+			copiedLayoutUtilityPageEntry.getCompanyId());
+		Assert.assertNotEquals(
+			layoutUtilityPageEntry.getPlid(),
+			copiedLayoutUtilityPageEntry.getPlid());
+
+		Assert.assertNotEquals(
 			layoutUtilityPageEntry.getPreviewFileEntryId(),
 			copiedLayoutUtilityPageEntry.getPreviewFileEntryId());
 
@@ -207,12 +179,20 @@ public class LayoutUtilityPageEntryServiceTest {
 
 		Assert.assertEquals(
 			WorkflowConstants.STATUS_APPROVED, copiedFileVersion.getStatus());
+
+		Assert.assertTrue(
+			StringUtil.startsWith(
+				copiedLayoutUtilityPageEntry.getName(),
+				StringBundler.concat(
+					layoutUtilityPageEntry.getName(), " (",
+					_language.get(LocaleUtil.getSiteDefault(), "copy"), ")")));
+		Assert.assertEquals(
+			layoutUtilityPageEntry.getType(),
+			copiedLayoutUtilityPageEntry.getType());
 	}
 
-	@Test(expected = PrincipalException.MustHavePermission.class)
-	public void testDeleteDefaultLayoutUtilityPageEntryWithNoPermissions()
-		throws Exception {
-
+	@Test
+	public void testDeleteLayoutUtilityPage() throws Exception {
 		LayoutUtilityPageEntry layoutUtilityPageEntry =
 			_layoutUtilityPageEntryService.addLayoutUtilityPageEntry(
 				RandomTestUtil.randomString(), _group.getGroupId(), 0, 0, true,
@@ -224,18 +204,14 @@ public class LayoutUtilityPageEntryServiceTest {
 
 			_layoutUtilityPageEntryService.deleteLayoutUtilityPageEntry(
 				layoutUtilityPageEntry.getLayoutUtilityPageEntryId());
+
+			Assert.fail();
 		}
-	}
-
-	@Test
-	public void testDeleteDefaultLayoutUtilityPageEntryWithPermissions()
-		throws Exception {
-
-		LayoutUtilityPageEntry layoutUtilityPageEntry =
-			_layoutUtilityPageEntryService.addLayoutUtilityPageEntry(
-				RandomTestUtil.randomString(), _group.getGroupId(), 0, 0, true,
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 0,
-				_serviceContext);
+		catch (PrincipalException principalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(principalException);
+			}
+		}
 
 		_resourcePermissionLocalService.addResourcePermission(
 			_group.getCompanyId(), Group.class.getName(),
@@ -258,26 +234,29 @@ public class LayoutUtilityPageEntryServiceTest {
 				layoutUtilityPageEntry.getLayoutUtilityPageEntryId());
 		}
 
-		LayoutUtilityPageEntry persistedLayoutUtilityPageEntry =
+		Assert.assertNull(
 			_layoutUtilityPageEntryLocalService.fetchLayoutUtilityPageEntry(
-				layoutUtilityPageEntry.getLayoutUtilityPageEntryId());
+				layoutUtilityPageEntry.getLayoutUtilityPageEntryId()));
 
-		Assert.assertNull(persistedLayoutUtilityPageEntry);
-	}
-
-	@Test
-	public void testDeleteLayoutUtilityPageEntryByExternalReferenceCode()
-		throws Exception {
-
-		LayoutUtilityPageEntry layoutUtilityPageEntry =
+		layoutUtilityPageEntry =
 			_layoutUtilityPageEntryService.addLayoutUtilityPageEntry(
-				RandomTestUtil.randomString(), _group.getGroupId(), 0, 0, true,
+				RandomTestUtil.randomString(), _group.getGroupId(), 0, 0, false,
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 0,
 				_serviceContext);
 
-		_layoutUtilityPageEntryService.deleteLayoutUtilityPageEntry(
-			layoutUtilityPageEntry.getExternalReferenceCode(),
-			layoutUtilityPageEntry.getGroupId());
+		_resourcePermissionLocalService.setResourcePermissions(
+			_group.getCompanyId(), LayoutUtilityPageEntry.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(
+				layoutUtilityPageEntry.getLayoutUtilityPageEntryId()),
+			_role.getRoleId(), new String[] {ActionKeys.DELETE});
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_user, PermissionCheckerFactoryUtil.create(_user))) {
+
+			_layoutUtilityPageEntryService.deleteLayoutUtilityPageEntry(
+				layoutUtilityPageEntry.getLayoutUtilityPageEntryId());
+		}
 
 		Assert.assertNull(
 			_layoutUtilityPageEntryLocalService.fetchLayoutUtilityPageEntry(
@@ -285,7 +264,7 @@ public class LayoutUtilityPageEntryServiceTest {
 	}
 
 	@Test
-	public void testDeleteLayoutUtilityPageEntryByExternalReferenceCodeWithoutDeletePermission()
+	public void testDeleteLayoutUtilityPageEntryByExternalReferenceCode()
 		throws Exception {
 
 		LayoutUtilityPageEntry layoutUtilityPageEntry =
@@ -308,37 +287,14 @@ public class LayoutUtilityPageEntryServiceTest {
 				_log.debug(principalException);
 			}
 		}
-	}
 
-	@Test
-	public void testDeleteNondefaultLayoutUtilityPageEntryWithNoAssignPermissions()
-		throws Exception {
+		_layoutUtilityPageEntryService.deleteLayoutUtilityPageEntry(
+			layoutUtilityPageEntry.getExternalReferenceCode(),
+			layoutUtilityPageEntry.getGroupId());
 
-		LayoutUtilityPageEntry layoutUtilityPageEntry =
-			_layoutUtilityPageEntryService.addLayoutUtilityPageEntry(
-				RandomTestUtil.randomString(), _group.getGroupId(), 0, 0, false,
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 0,
-				_serviceContext);
-
-		_resourcePermissionLocalService.setResourcePermissions(
-			_group.getCompanyId(), LayoutUtilityPageEntry.class.getName(),
-			ResourceConstants.SCOPE_INDIVIDUAL,
-			String.valueOf(
-				layoutUtilityPageEntry.getLayoutUtilityPageEntryId()),
-			_role.getRoleId(), new String[] {ActionKeys.DELETE});
-
-		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_user, PermissionCheckerFactoryUtil.create(_user))) {
-
-			_layoutUtilityPageEntryService.deleteLayoutUtilityPageEntry(
-				layoutUtilityPageEntry.getLayoutUtilityPageEntryId());
-		}
-
-		LayoutUtilityPageEntry persistedLayoutUtilityPageEntry =
+		Assert.assertNull(
 			_layoutUtilityPageEntryLocalService.fetchLayoutUtilityPageEntry(
-				layoutUtilityPageEntry.getLayoutUtilityPageEntryId());
-
-		Assert.assertNull(persistedLayoutUtilityPageEntry);
+				layoutUtilityPageEntry.getLayoutUtilityPageEntryId()));
 	}
 
 	@Test
@@ -360,17 +316,6 @@ public class LayoutUtilityPageEntryServiceTest {
 		Assert.assertEquals(
 			layoutUtilityPageEntry.getLayoutUtilityPageEntryId(),
 			curLayoutUtilityPageEntry.getLayoutUtilityPageEntryId());
-	}
-
-	@Test
-	public void testGetLayoutUtilityPageEntryByExternalReferenceCodeWithoutViewPermission()
-		throws Exception {
-
-		LayoutUtilityPageEntry layoutUtilityPageEntry =
-			_layoutUtilityPageEntryService.addLayoutUtilityPageEntry(
-				RandomTestUtil.randomString(), _group.getGroupId(), 0, 0, true,
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 0,
-				_serviceContext);
 
 		RoleTestUtil.removeResourcePermission(
 			RoleConstants.GUEST, LayoutUtilityPageEntry.class.getName(),
@@ -396,28 +341,8 @@ public class LayoutUtilityPageEntryServiceTest {
 		}
 	}
 
-	@Test(expected = PrincipalException.MustHavePermission.class)
-	public void testSetDefaultLayoutUtilityPageEntryWithNoPermissions()
-		throws Exception {
-
-		LayoutUtilityPageEntry layoutUtilityPageEntry =
-			_layoutUtilityPageEntryService.addLayoutUtilityPageEntry(
-				RandomTestUtil.randomString(), _group.getGroupId(), 0, 0, true,
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 0,
-				_serviceContext);
-
-		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_user, PermissionCheckerFactoryUtil.create(_user))) {
-
-			_layoutUtilityPageEntryService.setDefaultLayoutUtilityPageEntry(
-				layoutUtilityPageEntry.getLayoutUtilityPageEntryId());
-		}
-	}
-
 	@Test
-	public void testSetDefaultLayoutUtilityPageEntryWithPermissions()
-		throws Exception {
-
+	public void testSetDefaultLayoutUtilityPageEntry() throws Exception {
 		String type = RandomTestUtil.randomString();
 
 		LayoutUtilityPageEntry layoutUtilityPageEntry1 =
@@ -429,6 +354,25 @@ public class LayoutUtilityPageEntryServiceTest {
 			_layoutUtilityPageEntryService.addLayoutUtilityPageEntry(
 				RandomTestUtil.randomString(), _group.getGroupId(), 0, 0, false,
 				RandomTestUtil.randomString(), type, 0, _serviceContext);
+
+		Layout layout = _layoutLocalService.getLayout(
+			layoutUtilityPageEntry2.getPlid());
+
+		ContentLayoutTestUtil.publishLayout(layout.fetchDraftLayout(), layout);
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_user, PermissionCheckerFactoryUtil.create(_user))) {
+
+			_layoutUtilityPageEntryService.setDefaultLayoutUtilityPageEntry(
+				layoutUtilityPageEntry2.getLayoutUtilityPageEntryId());
+
+			Assert.fail();
+		}
+		catch (PrincipalException principalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(principalException);
+			}
+		}
 
 		_resourcePermissionLocalService.addResourcePermission(
 			_group.getCompanyId(), Group.class.getName(),
@@ -453,12 +397,6 @@ public class LayoutUtilityPageEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_user, PermissionCheckerFactoryUtil.create(_user))) {
 
-			Layout layout = _layoutLocalService.getLayout(
-				layoutUtilityPageEntry2.getPlid());
-
-			ContentLayoutTestUtil.publishLayout(
-				layout.fetchDraftLayout(), layout);
-
 			_layoutUtilityPageEntryService.setDefaultLayoutUtilityPageEntry(
 				layoutUtilityPageEntry2.getLayoutUtilityPageEntryId());
 		}
@@ -478,10 +416,8 @@ public class LayoutUtilityPageEntryServiceTest {
 			persistedLayoutUtilityPageEntry2.isDefaultLayoutUtilityPageEntry());
 	}
 
-	@Test(expected = PrincipalException.MustHavePermission.class)
-	public void testUnsetDefaultLayoutUtilityPageEntryWithNoPermissions()
-		throws Exception {
-
+	@Test
+	public void testUnsetDefaultLayoutUtilityPageEntry() throws Exception {
 		LayoutUtilityPageEntry layoutUtilityPageEntry =
 			_layoutUtilityPageEntryService.addLayoutUtilityPageEntry(
 				RandomTestUtil.randomString(), _group.getGroupId(), 0, 0, true,
@@ -493,18 +429,14 @@ public class LayoutUtilityPageEntryServiceTest {
 
 			_layoutUtilityPageEntryService.unsetDefaultLayoutUtilityPageEntry(
 				layoutUtilityPageEntry.getLayoutUtilityPageEntryId());
+
+			Assert.fail();
 		}
-	}
-
-	@Test
-	public void testUnsetDefaultLayoutUtilityPageEntryWithPermissions()
-		throws Exception {
-
-		LayoutUtilityPageEntry layoutUtilityPageEntry =
-			_layoutUtilityPageEntryService.addLayoutUtilityPageEntry(
-				RandomTestUtil.randomString(), _group.getGroupId(), 0, 0, true,
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 0,
-				_serviceContext);
+		catch (PrincipalException principalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(principalException);
+			}
+		}
 
 		_resourcePermissionLocalService.addResourcePermission(
 			_group.getCompanyId(), Group.class.getName(),

--- a/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/test/LayoutUtilityPageEntryServiceTest.java
+++ b/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/test/LayoutUtilityPageEntryServiceTest.java
@@ -96,7 +96,9 @@ public class LayoutUtilityPageEntryServiceTest {
 	}
 
 	@Test
-	public void testAddFragmentEntryWithoutAddPermission() throws Exception {
+	public void testAddLayoutUtilityPageEntryWithoutAddPermission()
+		throws Exception {
+
 		try {
 			UserTestUtil.setUser(
 				UserTestUtil.addGroupUser(_group, RoleConstants.SITE_MEMBER));

--- a/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/initializer/BlankSiteInitializer.java
+++ b/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/initializer/BlankSiteInitializer.java
@@ -5,7 +5,6 @@
 
 package com.liferay.site.admin.web.internal.initializer;
 
-import com.liferay.layout.constants.LayoutTypeSettingsConstants;
 import com.liferay.layout.importer.LayoutsImporter;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
@@ -21,13 +20,10 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.site.exception.InitializationException;
 import com.liferay.site.initializer.SiteInitializer;
 
-import java.util.Date;
 import java.util.Locale;
 
 import org.osgi.service.component.annotations.Component;
@@ -105,9 +101,6 @@ public class BlankSiteInitializer implements SiteInitializer {
 			_importPageElement(draftLayout, pageElementJSON);
 
 			_importPageElement(layout, pageElementJSON);
-
-			_updateLayoutUtilityPageEntryLayouts(
-				draftLayout.getPlid(), layout.getPlid());
 		}
 		catch (Exception exception) {
 			_log.error(exception);
@@ -128,35 +121,6 @@ public class BlankSiteInitializer implements SiteInitializer {
 		_layoutsImporter.importPageElement(
 			layout, layoutStructure, layoutStructure.getMainItemId(),
 			pageElementJSON, 0, true);
-	}
-
-	private void _updateLayoutUtilityPageEntryLayouts(
-			long draftLayoutPlid, long layoutPlid)
-		throws Exception {
-
-		Layout draftLayout = _layoutLocalService.getLayout(draftLayoutPlid);
-
-		UnicodeProperties typeSettingsUnicodeProperties =
-			draftLayout.getTypeSettingsProperties();
-
-		typeSettingsUnicodeProperties.put(
-			LayoutTypeSettingsConstants.KEY_PUBLISHED, Boolean.TRUE.toString());
-
-		draftLayout.setTypeSettingsProperties(typeSettingsUnicodeProperties);
-
-		draftLayout.setStatus(WorkflowConstants.STATUS_APPROVED);
-
-		_layoutLocalService.updateLayout(draftLayout);
-
-		Layout layout = _layoutLocalService.getLayout(layoutPlid);
-
-		layout.setStatus(WorkflowConstants.STATUS_APPROVED);
-
-		layout = _layoutLocalService.updateLayout(layout);
-
-		_layoutLocalService.updateLayout(
-			layout.getGroupId(), layout.isPrivateLayout(), layout.getLayoutId(),
-			new Date());
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-42587

Previous PR: https://github.com/brianchandotcom/liferay-portal/pull/157335
Resent because of:  https://github.com/brianchandotcom/liferay-portal/pull/157335#issuecomment-2563870439

Rebased with only the exception naming change. I've noticed two naming patterns: namespace + parameter name, and parameter name only. I've changed using the parameter name only as the namespace is included in the parameter name.

Thanks!