### PR TITLE
LPD-42915 The 'Get definition page' endpoint fails when a related object uses the Status system field as entry title

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
@@ -8,6 +8,7 @@ package com.liferay.object.rest.internal.graphql.dto.v1_0;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.entry.util.ObjectEntryDTOConverterUtil;
+import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
@@ -116,6 +117,10 @@ public class ObjectDefinitionGraphQLDTOContributor
 		}
 
 		for (ObjectField objectField : objectFields) {
+			if (ObjectFieldUtil.isMetadata(objectField.getName())) {
+				continue;
+			}
+
 			if (Objects.equals(
 					objectField.getBusinessType(),
 					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
@@ -342,8 +342,9 @@
 						"type": "string"
 					},
 					"status": {
+						"format": "int32",
 						"readOnly": true,
-						"type": "string",
+						"type": "integer",
 						"x-batch-unsupported-formats": "CSV",
 						"x-parent-map": "properties"
 					},
@@ -489,8 +490,9 @@
 						"type": "string"
 					},
 					"status": {
+						"format": "int32",
 						"readOnly": true,
-						"type": "string",
+						"type": "integer",
 						"x-batch-unsupported-formats": "CSV",
 						"x-parent-map": "properties"
 					},

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
@@ -358,8 +358,9 @@
 						"type": "string"
 					},
 					"status": {
+						"format": "int32",
 						"readOnly": true,
-						"type": "string",
+						"type": "integer",
 						"x-batch-unsupported-formats": "CSV",
 						"x-parent-map": "properties"
 					},

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
@@ -370,8 +370,9 @@
 						"type": "string"
 					},
 					"status": {
+						"format": "int32",
 						"readOnly": true,
-						"type": "string",
+						"type": "integer",
 						"x-batch-unsupported-formats": "CSV",
 						"x-parent-map": "properties"
 					},

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_categorization_disabled.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_categorization_disabled.json
@@ -210,8 +210,9 @@
 						"type": "string"
 					},
 					"status": {
+						"format": "int32",
 						"readOnly": true,
-						"type": "string",
+						"type": "integer",
 						"x-batch-unsupported-formats": "CSV",
 						"x-parent-map": "properties"
 					},

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
@@ -343,8 +343,9 @@
 						"type": "string"
 					},
 					"status": {
+						"format": "int32",
 						"readOnly": true,
-						"type": "string",
+						"type": "integer",
 						"x-batch-unsupported-formats": "CSV",
 						"x-parent-map": "properties"
 					},
@@ -489,8 +490,9 @@
 						"type": "string"
 					},
 					"status": {
+						"format": "int32",
 						"readOnly": true,
-						"type": "string",
+						"type": "integer",
 						"x-batch-unsupported-formats": "CSV",
 						"x-parent-map": "properties"
 					},

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_site.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_site.json
@@ -219,8 +219,9 @@
 						"type": "string"
 					},
 					"status": {
+						"format": "int32",
 						"readOnly": true,
-						"type": "string",
+						"type": "integer",
 						"x-batch-unsupported-formats": "CSV",
 						"x-parent-map": "properties"
 					},

--- a/modules/apps/object/object-service/bnd.bnd
+++ b/modules/apps/object/object-service/bnd.bnd
@@ -2,6 +2,6 @@ Bundle-Name: Liferay Object Service
 Bundle-SymbolicName: com.liferay.object.service
 Bundle-Version: 1.0.206
 Liferay-Client-Extension-Batch: com/liferay/object/internal/batch
-Liferay-Require-SchemaVersion: 10.1.1
+Liferay-Require-SchemaVersion: 10.2.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/registry/ObjectServiceUpgradeStepRegistrator.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/registry/ObjectServiceUpgradeStepRegistrator.java
@@ -499,6 +499,12 @@ public class ObjectServiceUpgradeStepRegistrator
 			new ObjectDefinitionStaleUserIdUpgradeProcess(_userLocalService),
 			new ObjectFieldStaleUserIdUpgradeProcess(_userLocalService),
 			new ObjectRelationshipStaleUserIdUpgradeProcess(_userLocalService));
+
+		registry.register(
+			"10.1.1", "10.2.0",
+			UpgradeProcessFactory.runSQL(
+				"update ObjectField set dbType = 'Integer' where " +
+					"dbColumnName = 'status'"));
 	}
 
 	@Reference

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -847,7 +847,7 @@ public class ObjectFieldLocalServiceImpl
 
 		objectField.setExternalReferenceCode(externalReferenceCode);
 
-		_setBusinessTypeAndDBType(businessType, dbType, objectField);
+		_setBusinessTypeAndDBType(businessType, dbType, objectField, system);
 
 		ObjectFieldBusinessType objectFieldBusinessType =
 			_objectFieldBusinessTypeRegistry.getObjectFieldBusinessType(
@@ -1294,7 +1294,8 @@ public class ObjectFieldLocalServiceImpl
 	}
 
 	private void _setBusinessTypeAndDBType(
-			String businessType, String dbType, ObjectField objectField)
+			String businessType, String dbType, ObjectField objectField,
+			Boolean system)
 		throws PortalException {
 
 		ObjectFieldBusinessType objectFieldBusinessType =
@@ -1306,7 +1307,13 @@ public class ObjectFieldLocalServiceImpl
 
 		if (objectFieldBusinessType != null) {
 			objectField.setBusinessType(businessType);
-			objectField.setDBType(objectFieldBusinessType.getDBType());
+
+			if (system) {
+				objectField.setDBType(dbType);
+			}
+			else {
+				objectField.setDBType(objectFieldBusinessType.getDBType());
+			}
 		}
 		else if (objectFieldDBTypes.contains(dbType) &&
 				 _businessTypes.containsKey(dbType)) {
@@ -1423,7 +1430,8 @@ public class ObjectFieldLocalServiceImpl
 			return newObjectField;
 		}
 
-		_setBusinessTypeAndDBType(businessType, dbType, newObjectField);
+		_setBusinessTypeAndDBType(
+			businessType, dbType, newObjectField, newObjectField.isSystem());
 
 		newObjectField.setListTypeDefinitionId(listTypeDefinitionId);
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -34,6 +34,7 @@ import com.liferay.object.exception.ObjectFieldRelationshipTypeException;
 import com.liferay.object.field.builder.BooleanObjectFieldBuilder;
 import com.liferay.object.field.builder.DateObjectFieldBuilder;
 import com.liferay.object.field.builder.LongIntegerObjectFieldBuilder;
+import com.liferay.object.field.builder.ObjectFieldBuilder;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectAction;
@@ -3371,11 +3372,15 @@ public class ObjectDefinitionLocalServiceTest {
 		Assert.assertTrue(iterator.hasNext());
 
 		_assertSystemObjectFields(
-			new TextObjectFieldBuilder(
+			new ObjectFieldBuilder(
 			).dbColumnName(
 				objectEntryTable.status.getName()
 			).dbTableName(
 				dbTableName
+			).dbType(
+				ObjectFieldConstants.DB_TYPE_INTEGER
+			).businessType(
+				ObjectFieldConstants.BUSINESS_TYPE_TEXT
 			).labelMap(
 				LocalizedMapUtil.getLocalizedMap(
 					LanguageUtil.get(LocaleUtil.getDefault(), "status"))

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
@@ -78,7 +78,6 @@ import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
-import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
@@ -99,7 +98,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -1063,8 +1061,9 @@ public class ObjectFieldLocalServiceTest {
 
 		ObjectField systemObjectField = _addOrUpdateSystemObjectField(
 			null, modifiableSystemObjectDefinition.getObjectDefinitionId(),
-			null, null, false, false, LocalizedMapUtil.getLocalizedMap("Able"),
-			false, "able", false);
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT, null, null,
+			ObjectFieldConstants.DB_TYPE_STRING, false, false,
+			LocalizedMapUtil.getLocalizedMap("Able"), false, "able", false);
 
 		_assertSystemObjectField(
 			"able_", false, false, LocalizedMapUtil.getLocalizedMap("Able"),
@@ -1075,14 +1074,18 @@ public class ObjectFieldLocalServiceTest {
 			_addOrUpdateSystemObjectField(
 				systemObjectField.getExternalReferenceCode(),
 				modifiableSystemObjectDefinition.getObjectDefinitionId(),
+				ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				true, true, LocalizedMapUtil.getLocalizedMap("Baker"), false,
-				"able", true));
+				ObjectFieldConstants.DB_TYPE_STRING, true, true,
+				LocalizedMapUtil.getLocalizedMap("Baker"), false, "able",
+				true));
 
 		ObjectField localizedSystemObjectField = _addOrUpdateSystemObjectField(
 			null, modifiableSystemObjectDefinition.getObjectDefinitionId(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,
-			false, LocalizedMapUtil.getLocalizedMap("Charlie"), true, "charlie",
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			ObjectFieldConstants.DB_TYPE_STRING, false, false,
+			LocalizedMapUtil.getLocalizedMap("Charlie"), true, "charlie",
 			false);
 
 		Assert.assertTrue(localizedSystemObjectField.isLocalized());
@@ -1104,8 +1107,10 @@ public class ObjectFieldLocalServiceTest {
 				_addOrUpdateSystemObjectField(
 					systemObjectField.getExternalReferenceCode(),
 					modifiableSystemObjectDefinition.getObjectDefinitionId(),
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 					RandomTestUtil.randomString(),
-					RandomTestUtil.randomString(), false, false,
+					RandomTestUtil.randomString(),
+					ObjectFieldConstants.DB_TYPE_STRING, false, false,
 					LocalizedMapUtil.getLocalizedMap("Dog"), false, "able",
 					false));
 		}
@@ -2203,15 +2208,15 @@ public class ObjectFieldLocalServiceTest {
 
 	private ObjectField _addOrUpdateSystemObjectField(
 			String externalReferenceCode, long objectDefinitionId,
-			String dbColumnName, String dbTableName, boolean indexed,
-			boolean indexedAsKeyword, Map<Locale, String> labelMap,
-			boolean localized, String name, boolean required)
+			String businessType, String dbColumnName, String dbTableName,
+			String dbType, boolean indexed, boolean indexedAsKeyword,
+			Map<Locale, String> labelMap, boolean localized, String name,
+			boolean required)
 		throws Exception {
 
 		return _objectFieldLocalService.addOrUpdateSystemObjectField(
 			externalReferenceCode, TestPropsValues.getUserId(), 0L,
-			objectDefinitionId, ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-			dbColumnName, dbTableName, ObjectFieldConstants.DB_TYPE_STRING,
+			objectDefinitionId, businessType, dbColumnName, dbTableName, dbType,
 			indexed, indexedAsKeyword, "", labelMap, localized, name,
 			ObjectFieldConstants.READ_ONLY_FALSE, null, required, false,
 			Collections.emptyList());
@@ -2614,11 +2619,20 @@ public class ObjectFieldLocalServiceTest {
 			ObjectDefinitionTestUtil.addCustomObjectDefinition(
 				false, Collections.emptyList());
 
-		for (String objectFieldName : _readOnlyObjectFieldNames) {
+		for (Map.Entry<String, String> readOnlyObjectFieldDbType :
+				_readOnlyObjectFieldDbTypes.entrySet()) {
+
 			_assertReadOnlyTrue(
 				_objectFieldLocalService.getObjectField(
 					objectDefinition1.getObjectDefinitionId(),
-					objectFieldName));
+					readOnlyObjectFieldDbType.getKey()));
+
+			ObjectField objectField = _objectFieldLocalService.getObjectField(
+				objectDefinition1.getObjectDefinitionId(),
+				readOnlyObjectFieldDbType.getKey());
+
+			Assert.assertEquals(
+				readOnlyObjectFieldDbType.getValue(), objectField.getDBType());
 		}
 
 		_assertReadOnlyFalse(
@@ -2816,7 +2830,17 @@ public class ObjectFieldLocalServiceTest {
 	@Inject
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;
 
-	private final Set<String> _readOnlyObjectFieldNames = SetUtil.fromArray(
-		"createDate", "creator", "id", "modifiedDate", "status");
+	private final Map<String, String> _readOnlyObjectFieldDbTypes =
+		HashMapBuilder.put(
+			"createDate", ObjectFieldConstants.DB_TYPE_DATE
+		).put(
+			"creator", ObjectFieldConstants.DB_TYPE_STRING
+		).put(
+			"id", ObjectFieldConstants.DB_TYPE_LONG
+		).put(
+			"modifiedDate", ObjectFieldConstants.DB_TYPE_DATE
+		).put(
+			"status", ObjectFieldConstants.DB_TYPE_INTEGER
+		).build();
 
 }

--- a/modules/apps/object/object-test/src/testIntegration/resources/com/liferay/object/web/internal/object/definitions/portlet/action/test/dependencies/test-account-entry-system-object-definition.json
+++ b/modules/apps/object/object-test/src/testIntegration/resources/com/liferay/object/web/internal/object/definitions/portlet/action/test/dependencies/test-account-entry-system-object-definition.json
@@ -124,7 +124,7 @@
 			"type": "Date"
 		},
 		{
-			"DBType": "String",
+			"DBType": "Integer",
 			"businessType": "Text",
 			"indexed": false,
 			"indexedAsKeyword": false,
@@ -138,7 +138,7 @@
 			"required": false,
 			"state": false,
 			"system": true,
-			"type": "String"
+			"type": "Integer"
 		},
 		{
 			"DBType": "String",

--- a/modules/apps/object/object-test/src/testIntegration/resources/com/liferay/object/web/internal/object/definitions/portlet/action/test/dependencies/test-modifiable-system-object-definition.portuguese-default-locale.json
+++ b/modules/apps/object/object-test/src/testIntegration/resources/com/liferay/object/web/internal/object/definitions/portlet/action/test/dependencies/test-modifiable-system-object-definition.portuguese-default-locale.json
@@ -102,7 +102,7 @@
 			"name": "name"
 		},
 		{
-			"DBType": "String",
+			"DBType": "Integer",
 			"businessType": "Text",
 			"label": {
 				"pt_BR": "Estado"

--- a/modules/apps/object/object-test/src/testIntegration/resources/com/liferay/object/web/internal/object/definitions/portlet/action/test/dependencies/test-modifiable-system-object-definition.site-default-locale.json
+++ b/modules/apps/object/object-test/src/testIntegration/resources/com/liferay/object/web/internal/object/definitions/portlet/action/test/dependencies/test-modifiable-system-object-definition.site-default-locale.json
@@ -111,7 +111,7 @@
 			"name": "name"
 		},
 		{
-			"DBType": "String",
+			"DBType": "Integer",
 			"businessType": "Text",
 			"label": {
 				"en_US": "Status",

--- a/modules/apps/object/object-test/src/testIntegration/resources/com/liferay/object/web/internal/object/definitions/portlet/action/test/dependencies/test-object-definition.default.json
+++ b/modules/apps/object/object-test/src/testIntegration/resources/com/liferay/object/web/internal/object/definitions/portlet/action/test/dependencies/test-object-definition.default.json
@@ -125,7 +125,7 @@
 			"unique": false
 		},
 		{
-			"DBType": "String",
+			"DBType": "Integer",
 			"businessType": "Text",
 			"indexed": false,
 			"indexedAsKeyword": false,
@@ -142,7 +142,7 @@
 			"required": false,
 			"state": false,
 			"system": true,
-			"type": "String",
+			"type": "Integer",
 			"unique": false
 		},
 		{

--- a/modules/apps/object/object-test/src/testIntegration/resources/com/liferay/object/web/internal/object/definitions/portlet/action/test/dependencies/test-object-definition.json
+++ b/modules/apps/object/object-test/src/testIntegration/resources/com/liferay/object/web/internal/object/definitions/portlet/action/test/dependencies/test-object-definition.json
@@ -147,7 +147,7 @@
 			"type": "Date"
 		},
 		{
-			"DBType": "String",
+			"DBType": "Integer",
 			"businessType": "Text",
 			"indexed": false,
 			"indexedAsKeyword": false,
@@ -161,7 +161,7 @@
 			"required": false,
 			"state": false,
 			"system": true,
-			"type": "String"
+			"type": "Integer"
 		},
 		{
 			"DBType": "String",

--- a/modules/apps/object/object-test/src/testIntegration/resources/com/liferay/object/web/internal/object/definitions/portlet/action/test/dependencies/test-object-definition.portuguese-default-locale.json
+++ b/modules/apps/object/object-test/src/testIntegration/resources/com/liferay/object/web/internal/object/definitions/portlet/action/test/dependencies/test-object-definition.portuguese-default-locale.json
@@ -103,7 +103,7 @@
 			"name": "name"
 		},
 		{
-			"DBType": "String",
+			"DBType": "Integer",
 			"businessType": "Text",
 			"label": {
 				"pt_BR": "Estado"

--- a/modules/apps/object/object-test/src/testIntegration/resources/com/liferay/object/web/internal/object/definitions/portlet/action/test/dependencies/test-object-definition.site-default-locale.json
+++ b/modules/apps/object/object-test/src/testIntegration/resources/com/liferay/object/web/internal/object/definitions/portlet/action/test/dependencies/test-object-definition.site-default-locale.json
@@ -111,7 +111,7 @@
 			"name": "name"
 		},
 		{
-			"DBType": "String",
+			"DBType": "Integer",
 			"businessType": "Text",
 			"label": {
 				"en_US": "Status",

--- a/modules/apps/object/object-test/src/testIntegration/resources/com/liferay/object/web/internal/object/definitions/portlet/action/test/dependencies/test-object-folder-2.json
+++ b/modules/apps/object/object-test/src/testIntegration/resources/com/liferay/object/web/internal/object/definitions/portlet/action/test/dependencies/test-object-folder-2.json
@@ -141,7 +141,7 @@
 						"unique": false
 					},
 					{
-						"DBType": "String",
+						"DBType": "Integer",
 						"businessType": "Text",
 						"indexed": false,
 						"indexedAsKeyword": false,
@@ -158,7 +158,7 @@
 						"required": false,
 						"state": false,
 						"system": true,
-						"type": "String",
+						"type": "Integer",
 						"unique": false
 					},
 					{

--- a/modules/apps/object/object-test/src/testIntegration/resources/com/liferay/object/web/internal/object/definitions/portlet/action/test/dependencies/test-object-folder-3.json
+++ b/modules/apps/object/object-test/src/testIntegration/resources/com/liferay/object/web/internal/object/definitions/portlet/action/test/dependencies/test-object-folder-3.json
@@ -174,7 +174,7 @@
 						"unique": false
 					},
 					{
-						"DBType": "String",
+						"DBType": "Integer",
 						"businessType": "Text",
 						"indexed": false,
 						"indexedAsKeyword": false,
@@ -191,7 +191,7 @@
 						"required": false,
 						"state": false,
 						"system": true,
-						"type": "String",
+						"type": "Integer",
 						"unique": false
 					}
 				],


### PR DESCRIPTION
We are ensuring that meta fields that have some specificities are receiving the right data type

Related issue: https://liferay.atlassian.net/browse/LPD-42915

**_Sending it directly because the https://github.com/brianchandotcom/liferay-portal/pull/157582 sent by CI conflicted with your master, so I rebased my local version with your remote version to correct the conflict._**