### PR TITLE
LPD-46069 Can add input fragment outside a form container when moving a container or when having a fragment composition with inputs

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
@@ -140,59 +140,15 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 			SetUtil.fromArray("text"), FragmentConstants.TYPE_INPUT,
 			"<div></div>", 1);
 
-		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
-			_getMockLiferayPortletActionRequest(
-				fragmentComposition.getFragmentCompositionKey(),
-				TestPropsValues.getUser());
-
-		try {
-			ReflectionTestUtil.invoke(
-				_mvcActionCommand, "_processAddFragmentEntryLinks",
-				new Class<?>[] {ActionRequest.class, ActionResponse.class},
-				mockLiferayPortletActionRequest,
-				new MockLiferayPortletActionResponse());
-
-			Assert.fail();
-		}
-		catch (Exception exception) {
-			JSONObject jsonObject = ReflectionTestUtil.invoke(
-				_mvcActionCommand, "processException",
-				new Class<?>[] {ActionRequest.class, Exception.class},
-				mockLiferayPortletActionRequest, exception);
-
-			Assert.assertEquals(jsonObject.toString(), 1, jsonObject.length());
-
-			Assert.assertEquals(
-				_language.get(
-					_portal.getSiteDefaultLocale(_group),
-					"form-components-can-only-be-placed-inside-a-mapped-form-" +
-						"container"),
-				jsonObject.getString("error"));
-		}
+		_testErrorMessage(fragmentComposition.getFragmentCompositionKey());
 
 		fragmentComposition = _addFragmentComposition(
-			SetUtil.fromArray("localizationSelect"), FragmentConstants.TYPE_INPUT,
-			"<div>localizationSelect</div>", 1);
+			SetUtil.fromArray("localizationSelect"),
+			FragmentConstants.TYPE_INPUT, "<div>localizationSelect</div>", 1);
 
-		mockLiferayPortletActionRequest.setParameter(
-			"fragmentEntryKey",
-			fragmentComposition.getFragmentCompositionKey());
-
-		List<FragmentEntryLink> originalFragmentEntryLinks =
-			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
-				_group.getGroupId(), _layout.getPlid());
-
-		MockLiferayPortletActionResponse mockLiferayPortletActionResponse =
-			new MockLiferayPortletActionResponse();
-
-		_assertJSONObject(
-			ReflectionTestUtil.invoke(
-				_mvcActionCommand, "_processAddFragmentEntryLinks",
-				new Class<?>[] {ActionRequest.class, ActionResponse.class},
-				mockLiferayPortletActionRequest,
-				mockLiferayPortletActionResponse),
-			mockLiferayPortletActionRequest, mockLiferayPortletActionResponse,
-			1, originalFragmentEntryLinks);
+		_testProcessAddFragmentEntryLinks(
+			fragmentComposition.getFragmentCompositionKey(), 1,
+			TestPropsValues.getUser());
 	}
 
 	private FragmentComposition _addFragmentComposition(
@@ -316,37 +272,6 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 		}
 	}
 
-	private void _assertJSONObject(
-			JSONObject jsonObject,
-			MockLiferayPortletActionRequest mockLiferayPortletActionRequest,
-			MockLiferayPortletActionResponse mockLiferayPortletActionResponse,
-			int numberOfFragmentEntryLinks,
-			List<FragmentEntryLink> originalFragmentEntryLinks)
-		throws Exception {
-
-		List<FragmentEntryLink> fragmentEntryLinks =
-			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
-				_group.getGroupId(), _layout.getPlid());
-
-		Assert.assertEquals(
-			fragmentEntryLinks.toString(),
-			originalFragmentEntryLinks.size() + numberOfFragmentEntryLinks,
-			fragmentEntryLinks.size());
-
-		JSONObject fragmentEntryLinksJSONObject = jsonObject.getJSONObject(
-			"fragmentEntryLinks");
-
-		Assert.assertEquals(
-			fragmentEntryLinksJSONObject.toString(), numberOfFragmentEntryLinks,
-			fragmentEntryLinksJSONObject.length());
-
-		_assertFragmentEntryLinksContent(
-			fragmentEntryLinksJSONObject, mockLiferayPortletActionRequest,
-			mockLiferayPortletActionResponse);
-
-		_assertLayoutData(jsonObject);
-	}
-
 	private void _assertLayoutData(JSONObject jsonObject) {
 		LayoutPageTemplateStructure layoutPageTemplateStructure =
 			_layoutPageTemplateStructureLocalService.
@@ -438,17 +363,6 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 
 		User user = UserTestUtil.addCompanyAdminUser(_company);
 
-		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
-			_getMockLiferayPortletActionRequest(
-				fragmentComposition.getFragmentCompositionKey(), user);
-
-		MockLiferayPortletActionResponse mockLiferayPortletActionResponse =
-			new MockLiferayPortletActionResponse();
-
-		List<FragmentEntryLink> originalFragmentEntryLinks =
-			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
-				_group.getGroupId(), _layout.getPlid());
-
 		try {
 			ServiceContextThreadLocal.pushServiceContext(
 				ServiceContextTestUtil.getServiceContext(
@@ -456,23 +370,93 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 
 			UserTestUtil.setUser(user);
 
-			_layoutLockManager.getLock(mockLiferayPortletActionRequest);
+			_layoutLockManager.getLock(_layout, user.getUserId());
 
-			_assertJSONObject(
-				ReflectionTestUtil.invoke(
-					_mvcActionCommand, "_processAddFragmentEntryLinks",
-					new Class<?>[] {ActionRequest.class, ActionResponse.class},
-					mockLiferayPortletActionRequest,
-					mockLiferayPortletActionResponse),
-				mockLiferayPortletActionRequest,
-				mockLiferayPortletActionResponse, numberOfFragmentEntryLinks,
-				originalFragmentEntryLinks);
+			_testProcessAddFragmentEntryLinks(
+				fragmentComposition.getFragmentCompositionKey(),
+				numberOfFragmentEntryLinks, user);
 		}
 		finally {
 			ServiceContextThreadLocal.popServiceContext();
 
 			UserTestUtil.setUser(TestPropsValues.getUser());
 		}
+	}
+
+	private void _testErrorMessage(String fragmentCompositionKey)
+		throws Exception {
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_getMockLiferayPortletActionRequest(
+				fragmentCompositionKey, TestPropsValues.getUser());
+
+		try {
+			ReflectionTestUtil.invoke(
+				_mvcActionCommand, "_processAddFragmentEntryLinks",
+				new Class<?>[] {ActionRequest.class, ActionResponse.class},
+				mockLiferayPortletActionRequest,
+				new MockLiferayPortletActionResponse());
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			JSONObject jsonObject = ReflectionTestUtil.invoke(
+				_mvcActionCommand, "processException",
+				new Class<?>[] {ActionRequest.class, Exception.class},
+				mockLiferayPortletActionRequest, exception);
+
+			Assert.assertEquals(jsonObject.toString(), 1, jsonObject.length());
+
+			Assert.assertEquals(
+				_language.get(
+					_portal.getSiteDefaultLocale(_group),
+					"form-components-can-only-be-placed-inside-a-mapped-form-" +
+						"container"),
+				jsonObject.getString("error"));
+		}
+	}
+
+	private void _testProcessAddFragmentEntryLinks(
+			String fragmentCompositionKey, int numberOfFragmentEntryLinks,
+			User user)
+		throws Exception {
+
+		List<FragmentEntryLink> originalFragmentEntryLinks =
+			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
+				_group.getGroupId(), _layout.getPlid());
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_getMockLiferayPortletActionRequest(fragmentCompositionKey, user);
+
+		MockLiferayPortletActionResponse mockLiferayPortletActionResponse =
+			new MockLiferayPortletActionResponse();
+
+		JSONObject jsonObject = ReflectionTestUtil.invoke(
+			_mvcActionCommand, "_processAddFragmentEntryLinks",
+			new Class<?>[] {ActionRequest.class, ActionResponse.class},
+			mockLiferayPortletActionRequest, mockLiferayPortletActionResponse);
+
+		List<FragmentEntryLink> fragmentEntryLinks =
+			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
+				_group.getGroupId(), _layout.getPlid());
+
+		Assert.assertEquals(
+			fragmentEntryLinks.toString(),
+			originalFragmentEntryLinks.size() + numberOfFragmentEntryLinks,
+			fragmentEntryLinks.size());
+
+		JSONObject fragmentEntryLinksJSONObject = jsonObject.getJSONObject(
+			"fragmentEntryLinks");
+
+		Assert.assertEquals(
+			fragmentEntryLinksJSONObject.toString(), numberOfFragmentEntryLinks,
+			fragmentEntryLinksJSONObject.length());
+
+		_assertFragmentEntryLinksContent(
+			fragmentEntryLinksJSONObject, mockLiferayPortletActionRequest,
+			mockLiferayPortletActionResponse);
+
+		_assertLayoutData(jsonObject);
 	}
 
 	private Company _company;

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
@@ -137,7 +137,7 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 	@Test
 	public void testAddFragmentEntryLinksInput() throws Exception {
 		FragmentComposition fragmentComposition = _addFragmentComposition(
-			FragmentConstants.TYPE_INPUT, SetUtil.fromArray("text"),
+			SetUtil.fromArray("text"), FragmentConstants.TYPE_INPUT,
 			"<div></div>", 1);
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
@@ -171,8 +171,7 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 		}
 
 		fragmentComposition = _addFragmentComposition(
-			FragmentConstants.TYPE_INPUT,
-			SetUtil.fromArray("localizationSelect"),
+			SetUtil.fromArray("localizationSelect"), FragmentConstants.TYPE_INPUT,
 			"<div>localizationSelect</div>", 1);
 
 		mockLiferayPortletActionRequest.setParameter(
@@ -197,7 +196,7 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 	}
 
 	private FragmentComposition _addFragmentComposition(
-			int fragmentEntryType, Set<String> fieldTypes, String html,
+			Set<String> fieldTypes, int fragmentEntryType, String html,
 			int numberOfFragmentEntryLinks)
 		throws Exception {
 
@@ -273,7 +272,7 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 		throws Exception {
 
 		return _addFragmentComposition(
-			FragmentConstants.TYPE_COMPONENT, Collections.emptySet(), html,
+			Collections.emptySet(), FragmentConstants.TYPE_COMPONENT, html,
 			numberOfFragmentEntryLinks);
 	}
 

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
@@ -187,32 +187,14 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 		MockLiferayPortletActionResponse mockLiferayPortletActionResponse =
 			new MockLiferayPortletActionResponse();
 
-		JSONObject jsonObject = ReflectionTestUtil.invoke(
-			_mvcActionCommand, "_processAddFragmentEntryLinks",
-			new Class<?>[] {ActionRequest.class, ActionResponse.class},
-			mockLiferayPortletActionRequest, mockLiferayPortletActionResponse);
-
-		List<FragmentEntryLink> actualFragmentEntryLinks =
-			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
-				_group.getGroupId(), _layout.getPlid());
-
-		Assert.assertEquals(
-			actualFragmentEntryLinks.toString(),
-			originalFragmentEntryLinks.size() + 1,
-			actualFragmentEntryLinks.size());
-
-		JSONObject fragmentEntryLinksJSONObject = jsonObject.getJSONObject(
-			"fragmentEntryLinks");
-
-		Assert.assertEquals(
-			fragmentEntryLinksJSONObject.toString(), 1,
-			fragmentEntryLinksJSONObject.length());
-
-		_assertFragmentEntryLinksContent(
-			fragmentEntryLinksJSONObject, mockLiferayPortletActionRequest,
-			mockLiferayPortletActionResponse);
-
-		_assertLayoutData(jsonObject);
+		_assertJSONObject(
+			ReflectionTestUtil.invoke(
+				_mvcActionCommand, "_processAddFragmentEntryLinks",
+				new Class<?>[] {ActionRequest.class, ActionResponse.class},
+				mockLiferayPortletActionRequest,
+				mockLiferayPortletActionResponse),
+			mockLiferayPortletActionRequest, mockLiferayPortletActionResponse,
+			1, originalFragmentEntryLinks);
 	}
 
 	private FragmentComposition _addFragmentComposition(
@@ -336,6 +318,37 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 		}
 	}
 
+	private void _assertJSONObject(
+			JSONObject jsonObject,
+			MockLiferayPortletActionRequest mockLiferayPortletActionRequest,
+			MockLiferayPortletActionResponse mockLiferayPortletActionResponse,
+			int numberOfFragmentEntryLinks,
+			List<FragmentEntryLink> originalFragmentEntryLinks)
+		throws Exception {
+
+		List<FragmentEntryLink> fragmentEntryLinks =
+			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
+				_group.getGroupId(), _layout.getPlid());
+
+		Assert.assertEquals(
+			fragmentEntryLinks.toString(),
+			originalFragmentEntryLinks.size() + numberOfFragmentEntryLinks,
+			fragmentEntryLinks.size());
+
+		JSONObject fragmentEntryLinksJSONObject = jsonObject.getJSONObject(
+			"fragmentEntryLinks");
+
+		Assert.assertEquals(
+			fragmentEntryLinksJSONObject.toString(), numberOfFragmentEntryLinks,
+			fragmentEntryLinksJSONObject.length());
+
+		_assertFragmentEntryLinksContent(
+			fragmentEntryLinksJSONObject, mockLiferayPortletActionRequest,
+			mockLiferayPortletActionResponse);
+
+		_assertLayoutData(jsonObject);
+	}
+
 	private void _assertLayoutData(JSONObject jsonObject) {
 		LayoutPageTemplateStructure layoutPageTemplateStructure =
 			_layoutPageTemplateStructureLocalService.
@@ -436,8 +449,6 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
 				_group.getGroupId(), _layout.getPlid());
 
-		JSONObject jsonObject = null;
-
 		try {
 			ServiceContextThreadLocal.pushServiceContext(
 				ServiceContextTestUtil.getServiceContext(
@@ -447,39 +458,21 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 
 			_layoutLockManager.getLock(mockLiferayPortletActionRequest);
 
-			jsonObject = ReflectionTestUtil.invoke(
-				_mvcActionCommand, "_processAddFragmentEntryLinks",
-				new Class<?>[] {ActionRequest.class, ActionResponse.class},
+			_assertJSONObject(
+				ReflectionTestUtil.invoke(
+					_mvcActionCommand, "_processAddFragmentEntryLinks",
+					new Class<?>[] {ActionRequest.class, ActionResponse.class},
+					mockLiferayPortletActionRequest,
+					mockLiferayPortletActionResponse),
 				mockLiferayPortletActionRequest,
-				mockLiferayPortletActionResponse);
+				mockLiferayPortletActionResponse, numberOfFragmentEntryLinks,
+				originalFragmentEntryLinks);
 		}
 		finally {
 			ServiceContextThreadLocal.popServiceContext();
 
 			UserTestUtil.setUser(TestPropsValues.getUser());
 		}
-
-		List<FragmentEntryLink> actualFragmentEntryLinks =
-			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
-				_group.getGroupId(), _layout.getPlid());
-
-		Assert.assertEquals(
-			actualFragmentEntryLinks.toString(),
-			originalFragmentEntryLinks.size() + numberOfFragmentEntryLinks,
-			actualFragmentEntryLinks.size());
-
-		JSONObject fragmentEntryLinksJSONObject = jsonObject.getJSONObject(
-			"fragmentEntryLinks");
-
-		Assert.assertEquals(
-			fragmentEntryLinksJSONObject.toString(), numberOfFragmentEntryLinks,
-			fragmentEntryLinksJSONObject.length());
-
-		_assertFragmentEntryLinksContent(
-			fragmentEntryLinksJSONObject, mockLiferayPortletActionRequest,
-			mockLiferayPortletActionResponse);
-
-		_assertLayoutData(jsonObject);
 	}
 
 	private Company _company;

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
@@ -170,25 +170,22 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 						"container"),
 				jsonObject.getString("error"));
 		}
-	}
 
-	@Test
-	public void testAddFragmentEntryLinksLocalizationSelect() throws Exception {
-		FragmentComposition fragmentComposition = _addFragmentComposition(
+		fragmentComposition = _addFragmentComposition(
 			FragmentConstants.TYPE_INPUT,
 			SetUtil.fromArray("localizationSelect"),
 			"<div>localizationSelect</div>", 1);
 
-		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
-			_getMockLiferayPortletActionRequest(
-				fragmentComposition.getFragmentCompositionKey());
-
-		MockLiferayPortletActionResponse mockLiferayPortletActionResponse =
-			new MockLiferayPortletActionResponse();
+		mockLiferayPortletActionRequest.setParameter(
+			"fragmentEntryKey",
+			fragmentComposition.getFragmentCompositionKey());
 
 		List<FragmentEntryLink> originalFragmentEntryLinks =
 			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
 				_group.getGroupId(), _layout.getPlid());
+
+		MockLiferayPortletActionResponse mockLiferayPortletActionResponse =
+			new MockLiferayPortletActionResponse();
 
 		JSONObject jsonObject = ReflectionTestUtil.invoke(
 			_mvcActionCommand, "_processAddFragmentEntryLinks",

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
@@ -154,11 +154,11 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 
 			Assert.fail();
 		}
-		catch (UnsupportedOperationException unsupportedOperationException) {
+		catch (Exception exception) {
 			JSONObject jsonObject = ReflectionTestUtil.invoke(
 				_mvcActionCommand, "processException",
 				new Class<?>[] {ActionRequest.class, Exception.class},
-				mockLiferayPortletActionRequest, unsupportedOperationException);
+				mockLiferayPortletActionRequest, exception);
 
 			Assert.assertEquals(jsonObject.toString(), 1, jsonObject.length());
 

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
@@ -143,7 +143,7 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 
 	@Test
 	@TestInfo("LPD-46069")
-	public void testAddFragmentEntryLinksInput() throws Exception {
+	public void testAddInputFragmentEntryLinks() throws Exception {
 		FragmentComposition fragmentComposition = _addFragmentComposition(
 			SetUtil.fromArray("text"), FragmentConstants.TYPE_INPUT,
 			"<div></div>", 1);

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
@@ -75,6 +75,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -106,6 +107,15 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 		_layout = layout.fetchDraftLayout();
 
 		_user = UserTestUtil.addCompanyAdminUser(_company);
+
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext(
+				_group, TestPropsValues.getUserId()));
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		ServiceContextThreadLocal.popServiceContext();
 	}
 
 	@Test
@@ -131,25 +141,12 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 			FragmentConstants.TYPE_INPUT, SetUtil.fromArray("text"),
 			"<div></div>", 1);
 
-		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
-			_getMockLiferayPortletActionRequest(
-				fragmentComposition.getFragmentCompositionKey());
-
-		MockLiferayPortletActionResponse mockLiferayPortletActionResponse =
-			new MockLiferayPortletActionResponse();
-
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext(
-				_group, _user.getUserId()));
-
-		UserTestUtil.setUser(_user);
-
-		_layoutLockManager.getLock(mockLiferayPortletActionRequest);
-
 		ReflectionTestUtil.invoke(
 			_mvcActionCommand, "_processAddFragmentEntryLinks",
 			new Class<?>[] {ActionRequest.class, ActionResponse.class},
-			mockLiferayPortletActionRequest, mockLiferayPortletActionResponse);
+			_getMockLiferayPortletActionRequest(
+				fragmentComposition.getFragmentCompositionKey()),
+			new MockLiferayPortletActionResponse());
 	}
 
 	@Test
@@ -170,28 +167,10 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
 				_group.getGroupId(), _layout.getPlid());
 
-		JSONObject jsonObject = null;
-
-		try {
-			ServiceContextThreadLocal.pushServiceContext(
-				ServiceContextTestUtil.getServiceContext(
-					_group, _user.getUserId()));
-
-			UserTestUtil.setUser(_user);
-
-			_layoutLockManager.getLock(mockLiferayPortletActionRequest);
-
-			jsonObject = ReflectionTestUtil.invoke(
-				_mvcActionCommand, "_processAddFragmentEntryLinks",
-				new Class<?>[] {ActionRequest.class, ActionResponse.class},
-				mockLiferayPortletActionRequest,
-				mockLiferayPortletActionResponse);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-
-			UserTestUtil.setUser(TestPropsValues.getUser());
-		}
+		JSONObject jsonObject = ReflectionTestUtil.invoke(
+			_mvcActionCommand, "_processAddFragmentEntryLinks",
+			new Class<?>[] {ActionRequest.class, ActionResponse.class},
+			mockLiferayPortletActionRequest, mockLiferayPortletActionResponse);
 
 		List<FragmentEntryLink> actualFragmentEntryLinks =
 			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
@@ -222,8 +201,7 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 		throws Exception {
 
 		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId());
+			ServiceContextThreadLocal.getServiceContext();
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
@@ -23,10 +23,15 @@ import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
 import com.liferay.layout.page.template.serializer.LayoutStructureItemJSONSerializer;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalServiceUtil;
+import com.liferay.layout.provider.LayoutStructureProvider;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -54,6 +59,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
@@ -142,12 +148,32 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 
 		_testErrorMessage(fragmentComposition.getFragmentCompositionKey());
 
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, "First Name",
+						"firstName")));
+
+		JSONObject jsonObject = ContentLayoutTestUtil.addFormToLayout(
+			false,
+			String.valueOf(
+				_portal.getClassNameId(objectDefinition.getClassName())),
+			"0", _layout, _layoutStructureProvider,
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				_layout.getPlid()));
+
+		_testProcessAddFragmentEntryLinks(
+			fragmentComposition.getFragmentCompositionKey(), 1,
+			jsonObject.getString("addedItemId"), TestPropsValues.getUser());
+
 		fragmentComposition = _addFragmentComposition(
 			SetUtil.fromArray("localizationSelect"),
 			FragmentConstants.TYPE_INPUT, "<div>localizationSelect</div>", 1);
 
 		_testProcessAddFragmentEntryLinks(
-			fragmentComposition.getFragmentCompositionKey(), 1,
+			fragmentComposition.getFragmentCompositionKey(), 1, null,
 			TestPropsValues.getUser());
 	}
 
@@ -293,7 +319,7 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 	}
 
 	private MockLiferayPortletActionRequest _getMockLiferayPortletActionRequest(
-			String fragmentEntryKey, User user)
+			String fragmentEntryKey, String parentItemId, User user)
 		throws Exception {
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
@@ -314,16 +340,21 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 			"segmentsExperienceId",
 			String.valueOf(defaultSegmentsExperienceId));
 
-		LayoutPageTemplateStructure layoutPageTemplateStructure =
-			LayoutPageTemplateStructureLocalServiceUtil.
-				fetchLayoutPageTemplateStructure(
-					_layout.getGroupId(), _layout.getPlid());
+		if (Validator.isNull(parentItemId)) {
+			LayoutPageTemplateStructure layoutPageTemplateStructure =
+				LayoutPageTemplateStructureLocalServiceUtil.
+					fetchLayoutPageTemplateStructure(
+						_layout.getGroupId(), _layout.getPlid());
 
-		LayoutStructure layoutStructure = LayoutStructure.of(
-			layoutPageTemplateStructure.getData(defaultSegmentsExperienceId));
+			LayoutStructure layoutStructure = LayoutStructure.of(
+				layoutPageTemplateStructure.getData(
+					defaultSegmentsExperienceId));
+
+			parentItemId = layoutStructure.getMainItemId();
+		}
 
 		mockLiferayPortletActionRequest.addParameter(
-			"parentItemId", layoutStructure.getMainItemId());
+			"parentItemId", parentItemId);
 
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)mockLiferayPortletActionRequest.getAttribute(
@@ -374,7 +405,7 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 
 			_testProcessAddFragmentEntryLinks(
 				fragmentComposition.getFragmentCompositionKey(),
-				numberOfFragmentEntryLinks, user);
+				numberOfFragmentEntryLinks, null, user);
 		}
 		finally {
 			ServiceContextThreadLocal.popServiceContext();
@@ -388,7 +419,7 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			_getMockLiferayPortletActionRequest(
-				fragmentCompositionKey, TestPropsValues.getUser());
+				fragmentCompositionKey, null, TestPropsValues.getUser());
 
 		try {
 			ReflectionTestUtil.invoke(
@@ -418,7 +449,7 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 
 	private void _testProcessAddFragmentEntryLinks(
 			String fragmentCompositionKey, int numberOfFragmentEntryLinks,
-			User user)
+			String parentItemId, User user)
 		throws Exception {
 
 		List<FragmentEntryLink> originalFragmentEntryLinks =
@@ -426,7 +457,8 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 				_group.getGroupId(), _layout.getPlid());
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
-			_getMockLiferayPortletActionRequest(fragmentCompositionKey, user);
+			_getMockLiferayPortletActionRequest(
+				fragmentCompositionKey, parentItemId, user);
 
 		MockLiferayPortletActionResponse mockLiferayPortletActionResponse =
 			new MockLiferayPortletActionResponse();
@@ -497,6 +529,9 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 	@Inject
 	private LayoutStructureItemJSONSerializer
 		_layoutStructureItemJSONSerializer;
+
+	@Inject
+	private LayoutStructureProvider _layoutStructureProvider;
 
 	@Inject(
 		filter = "mvc.command.name=/layout_content_page_editor/add_fragment_entry_links"

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
@@ -30,6 +30,7 @@ import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -135,18 +136,40 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 			RandomTestUtil.randomString(), numberOfFragmentEntryLinks);
 	}
 
-	@Test(expected = UnsupportedOperationException.class)
+	@Test
 	public void testAddFragmentEntryLinksInput() throws Exception {
 		FragmentComposition fragmentComposition = _addFragmentComposition(
 			FragmentConstants.TYPE_INPUT, SetUtil.fromArray("text"),
 			"<div></div>", 1);
 
-		ReflectionTestUtil.invoke(
-			_mvcActionCommand, "_processAddFragmentEntryLinks",
-			new Class<?>[] {ActionRequest.class, ActionResponse.class},
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			_getMockLiferayPortletActionRequest(
-				fragmentComposition.getFragmentCompositionKey()),
-			new MockLiferayPortletActionResponse());
+				fragmentComposition.getFragmentCompositionKey());
+
+		try {
+			ReflectionTestUtil.invoke(
+				_mvcActionCommand, "_processAddFragmentEntryLinks",
+				new Class<?>[] {ActionRequest.class, ActionResponse.class},
+				mockLiferayPortletActionRequest,
+				new MockLiferayPortletActionResponse());
+
+			Assert.fail();
+		}
+		catch (UnsupportedOperationException unsupportedOperationException) {
+			JSONObject jsonObject = ReflectionTestUtil.invoke(
+				_mvcActionCommand, "processException",
+				new Class<?>[] {ActionRequest.class, Exception.class},
+				mockLiferayPortletActionRequest, unsupportedOperationException);
+
+			Assert.assertEquals(jsonObject.toString(), 1, jsonObject.length());
+
+			Assert.assertEquals(
+				_language.get(
+					_portal.getSiteDefaultLocale(_group),
+					"form-components-can-only-be-placed-inside-a-mapped-form-" +
+						"container"),
+				jsonObject.getString("error"));
+		}
 	}
 
 	@Test
@@ -484,6 +507,9 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private Language _language;
 
 	private Layout _layout;
 

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
@@ -107,8 +107,6 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 
 		_layout = layout.fetchDraftLayout();
 
-		_user = UserTestUtil.addCompanyAdminUser(_company);
-
 		ServiceContextThreadLocal.pushServiceContext(
 			ServiceContextTestUtil.getServiceContext(
 				_group, TestPropsValues.getUserId()));
@@ -144,7 +142,8 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			_getMockLiferayPortletActionRequest(
-				fragmentComposition.getFragmentCompositionKey());
+				fragmentComposition.getFragmentCompositionKey(),
+				TestPropsValues.getUser());
 
 		try {
 			ReflectionTestUtil.invoke(
@@ -370,7 +369,7 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 	}
 
 	private MockLiferayPortletActionRequest _getMockLiferayPortletActionRequest(
-			String fragmentEntryKey)
+			String fragmentEntryKey, User user)
 		throws Exception {
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
@@ -406,8 +405,8 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 			(ThemeDisplay)mockLiferayPortletActionRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		themeDisplay.setRealUser(_user);
-		themeDisplay.setUser(_user);
+		themeDisplay.setRealUser(user);
+		themeDisplay.setUser(user);
 
 		HttpServletRequest httpServletRequest = _portal.getHttpServletRequest(
 			mockLiferayPortletActionRequest);
@@ -438,9 +437,11 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 		FragmentComposition fragmentComposition = _addFragmentComposition(
 			html, numberOfFragmentEntryLinks);
 
+		User user = UserTestUtil.addCompanyAdminUser(_company);
+
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			_getMockLiferayPortletActionRequest(
-				fragmentComposition.getFragmentCompositionKey());
+				fragmentComposition.getFragmentCompositionKey(), user);
 
 		MockLiferayPortletActionResponse mockLiferayPortletActionResponse =
 			new MockLiferayPortletActionResponse();
@@ -452,9 +453,9 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 		try {
 			ServiceContextThreadLocal.pushServiceContext(
 				ServiceContextTestUtil.getServiceContext(
-					_group, _user.getUserId()));
+					_group, user.getUserId()));
 
-			UserTestUtil.setUser(_user);
+			UserTestUtil.setUser(user);
 
 			_layoutLockManager.getLock(mockLiferayPortletActionRequest);
 
@@ -524,8 +525,5 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 
 	@Inject
 	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
-
-	@DeleteAfterTestRun
-	private User _user;
 
 }

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -141,6 +142,7 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 	}
 
 	@Test
+	@TestInfo("LPD-46069")
 	public void testAddFragmentEntryLinksInput() throws Exception {
 		FragmentComposition fragmentComposition = _addFragmentComposition(
 			SetUtil.fromArray("text"), FragmentConstants.TYPE_INPUT,

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
@@ -29,6 +29,7 @@ import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -50,6 +51,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -58,8 +60,10 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
@@ -121,8 +125,100 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 			RandomTestUtil.randomString(), numberOfFragmentEntryLinks);
 	}
 
+	@Test(expected = UnsupportedOperationException.class)
+	public void testAddFragmentEntryLinksInput() throws Exception {
+		FragmentComposition fragmentComposition = _addFragmentComposition(
+			FragmentConstants.TYPE_INPUT, SetUtil.fromArray("text"),
+			"<div></div>", 1);
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_getMockLiferayPortletActionRequest(
+				fragmentComposition.getFragmentCompositionKey());
+
+		MockLiferayPortletActionResponse mockLiferayPortletActionResponse =
+			new MockLiferayPortletActionResponse();
+
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext(
+				_group, _user.getUserId()));
+
+		UserTestUtil.setUser(_user);
+
+		_layoutLockManager.getLock(mockLiferayPortletActionRequest);
+
+		ReflectionTestUtil.invoke(
+			_mvcActionCommand, "_processAddFragmentEntryLinks",
+			new Class<?>[] {ActionRequest.class, ActionResponse.class},
+			mockLiferayPortletActionRequest, mockLiferayPortletActionResponse);
+	}
+
+	@Test
+	public void testAddFragmentEntryLinksLocalizationSelect() throws Exception {
+		FragmentComposition fragmentComposition = _addFragmentComposition(
+			FragmentConstants.TYPE_INPUT,
+			SetUtil.fromArray("localizationSelect"),
+			"<div>localizationSelect</div>", 1);
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_getMockLiferayPortletActionRequest(
+				fragmentComposition.getFragmentCompositionKey());
+
+		MockLiferayPortletActionResponse mockLiferayPortletActionResponse =
+			new MockLiferayPortletActionResponse();
+
+		List<FragmentEntryLink> originalFragmentEntryLinks =
+			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
+				_group.getGroupId(), _layout.getPlid());
+
+		JSONObject jsonObject = null;
+
+		try {
+			ServiceContextThreadLocal.pushServiceContext(
+				ServiceContextTestUtil.getServiceContext(
+					_group, _user.getUserId()));
+
+			UserTestUtil.setUser(_user);
+
+			_layoutLockManager.getLock(mockLiferayPortletActionRequest);
+
+			jsonObject = ReflectionTestUtil.invoke(
+				_mvcActionCommand, "_processAddFragmentEntryLinks",
+				new Class<?>[] {ActionRequest.class, ActionResponse.class},
+				mockLiferayPortletActionRequest,
+				mockLiferayPortletActionResponse);
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+
+			UserTestUtil.setUser(TestPropsValues.getUser());
+		}
+
+		List<FragmentEntryLink> actualFragmentEntryLinks =
+			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
+				_group.getGroupId(), _layout.getPlid());
+
+		Assert.assertEquals(
+			actualFragmentEntryLinks.toString(),
+			originalFragmentEntryLinks.size() + 1,
+			actualFragmentEntryLinks.size());
+
+		JSONObject fragmentEntryLinksJSONObject = jsonObject.getJSONObject(
+			"fragmentEntryLinks");
+
+		Assert.assertEquals(
+			fragmentEntryLinksJSONObject.toString(), 1,
+			fragmentEntryLinksJSONObject.length());
+
+		_assertFragmentEntryLinksContent(
+			fragmentEntryLinksJSONObject, mockLiferayPortletActionRequest,
+			mockLiferayPortletActionResponse);
+
+		_assertLayoutData(jsonObject);
+	}
+
 	private FragmentComposition _addFragmentComposition(
-			String html, int numberOfFragmentEntryLinks)
+			int fragmentEntryType, Set<String> fieldTypes, String html,
+			int numberOfFragmentEntryLinks)
 		throws Exception {
 
 		ServiceContext serviceContext =
@@ -140,8 +236,8 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 				fragmentCollection.getFragmentCollectionId(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				StringPool.BLANK, html, StringPool.BLANK, false,
-				StringPool.BLANK, null, 0, false,
-				FragmentConstants.TYPE_COMPONENT, null,
+				StringPool.BLANK, null, 0, false, fragmentEntryType,
+				JSONUtil.toString(JSONUtil.put("fieldTypes", fieldTypes)),
 				WorkflowConstants.STATUS_APPROVED, serviceContext);
 
 		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
@@ -191,6 +287,15 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), layoutStructureItemJSON, 0,
 			WorkflowConstants.STATUS_APPROVED, serviceContext);
+	}
+
+	private FragmentComposition _addFragmentComposition(
+			String html, int numberOfFragmentEntryLinks)
+		throws Exception {
+
+		return _addFragmentComposition(
+			FragmentConstants.TYPE_COMPONENT, Collections.emptySet(), html,
+			numberOfFragmentEntryLinks);
 	}
 
 	private void _assertFragmentEntryLinksContent(

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/CopyItemsMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/CopyItemsMVCActionCommandTest.java
@@ -16,6 +16,10 @@ import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.service.FragmentCollectionLocalService;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.fragment.service.FragmentEntryLocalService;
+import com.liferay.info.field.InfoField;
+import com.liferay.info.form.InfoForm;
+import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.info.item.provider.InfoItemFormProvider;
 import com.liferay.layout.content.page.editor.web.internal.portlet.constants.LayoutContentPageEditorWebPortletKeys;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
 import com.liferay.layout.provider.LayoutStructureProvider;
@@ -26,8 +30,11 @@ import com.liferay.layout.util.structure.FragmentDropZoneLayoutStructureItem;
 import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -52,6 +59,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -62,6 +70,9 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -245,6 +256,58 @@ public class CopyItemsMVCActionCommandTest {
 	}
 
 	@Test
+	@TestInfo("LPD-45944")
+	public void testCopyInputFragmentEntryLink() throws Exception {
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, "First Name",
+						"firstName")));
+
+		InfoItemFormProvider<?> infoItemFormProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoItemFormProvider.class, objectDefinition.getClassName());
+
+		InfoForm infoForm = infoItemFormProvider.getInfoForm(
+			StringPool.BLANK, _group.getGroupId());
+
+		List<InfoField<?>> allInfoFields = ListUtil.filter(
+			infoForm.getAllInfoFields(), InfoField::isEditable);
+
+		String classNameId = String.valueOf(
+			_portal.getClassNameId(objectDefinition.getClassName()));
+
+		JSONObject jsonObject = ContentLayoutTestUtil.addFormToLayout(
+			false, classNameId, "0", _layout, _layoutStructureProvider,
+			_segmentsExperienceId, allInfoFields.toArray(new InfoField<?>[0]));
+
+		FragmentStyledLayoutStructureItem fragmentStyledLayoutStructureItem =
+			_getFragmentStyledLayoutStructureItem(
+				(LayoutStructure)jsonObject.get("layoutData"));
+
+		jsonObject = ContentLayoutTestUtil.addItemToLayout(
+			"{}", LayoutDataItemTypeConstants.TYPE_ROW, _layout,
+			_layoutStructureProvider, _segmentsExperienceId);
+
+		String[] itemIds = {fragmentStyledLayoutStructureItem.getItemId()};
+
+		_testErrorMessage(
+			_language.get(
+				_portal.getSiteDefaultLocale(_group),
+				"form-components-can-only-be-placed-inside-a-mapped-form-" +
+					"container"),
+			itemIds, jsonObject.getString("addedItemId"));
+
+		jsonObject = ContentLayoutTestUtil.addFormToLayout(
+			false, classNameId, "0", _layout, _layoutStructureProvider,
+			_segmentsExperienceId);
+
+		_testCopyItems(itemIds, jsonObject.getString("addedItemId"));
+	}
+
+	@Test
 	public void testCopyMultipleItems() throws Exception {
 		LayoutStructure layoutStructure =
 			_layoutStructureProvider.getLayoutStructure(
@@ -311,53 +374,14 @@ public class CopyItemsMVCActionCommandTest {
 		LayoutStructureItem rowStyledLayoutStructureItem =
 			_addLayoutStructureItem(LayoutDataItemTypeConstants.TYPE_ROW);
 
-		LayoutStructure layoutStructure =
-			_layoutStructureProvider.getLayoutStructure(
-				_layout.getPlid(), _segmentsExperienceId);
-
-		List<LayoutStructureItem> layoutStructureItems =
-			layoutStructure.getLayoutStructureItems();
-
-		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
-			_getMockLiferayPortletActionRequest(
-				new String[] {fragmentStyledLayoutStructureItem.getItemId()},
-				rowStyledLayoutStructureItem.getItemId());
-
-		try {
-			ReflectionTestUtil.invoke(
-				_mvcActionCommand, "doTransactionalCommand",
-				new Class<?>[] {ActionRequest.class, ActionResponse.class},
-				mockLiferayPortletActionRequest,
-				new MockLiferayPortletActionResponse());
-
-			Assert.fail();
-		}
-		catch (ModelListenerException modelListenerException) {
-			JSONObject jsonObject = ReflectionTestUtil.invoke(
-				_mvcActionCommand, "processException",
-				new Class<?>[] {ActionRequest.class, Exception.class},
-				mockLiferayPortletActionRequest, modelListenerException);
-
-			Assert.assertEquals(jsonObject.toString(), 1, jsonObject.length());
-
-			Assert.assertEquals(
-				_language.format(
-					_portal.getSiteDefaultLocale(_group),
-					"the-layout-could-not-be-copied-because-it-contains-a-" +
-						"widget-x-that-can-only-appear-once-on-the-page",
-					"Noninstanciable Test"),
-				jsonObject.getString("error"));
-		}
-
-		layoutStructure = _layoutStructureProvider.getLayoutStructure(
-			_layout.getPlid(), _segmentsExperienceId);
-
-		List<LayoutStructureItem> curLayoutStructureItems =
-			layoutStructure.getLayoutStructureItems();
-
-		Assert.assertEquals(
-			curLayoutStructureItems.toString(), layoutStructureItems.size(),
-			curLayoutStructureItems.size());
+		_testErrorMessage(
+			_language.format(
+				_portal.getSiteDefaultLocale(_group),
+				"the-layout-could-not-be-copied-because-it-contains-a-widget-" +
+					"x-that-can-only-appear-once-on-the-page",
+				"Noninstanciable Test"),
+			new String[] {fragmentStyledLayoutStructureItem.getItemId()},
+			rowStyledLayoutStructureItem.getItemId());
 	}
 
 	@Test
@@ -586,6 +610,21 @@ public class CopyItemsMVCActionCommandTest {
 		return (FragmentStyledLayoutStructureItem)layoutStructureItem;
 	}
 
+	private FragmentStyledLayoutStructureItem
+		_getFragmentStyledLayoutStructureItem(LayoutStructure layoutStructure) {
+
+		Map<Long, LayoutStructureItem> fragmentLayoutStructureItems =
+			layoutStructure.getFragmentLayoutStructureItems();
+
+		Collection<LayoutStructureItem> layoutStructureItems =
+			fragmentLayoutStructureItems.values();
+
+		Iterator<LayoutStructureItem> iterator =
+			layoutStructureItems.iterator();
+
+		return (FragmentStyledLayoutStructureItem)iterator.next();
+	}
+
 	private MockLiferayPortletActionRequest _getMockLiferayPortletActionRequest(
 			String[] itemIds, String parentItemId)
 		throws Exception {
@@ -593,16 +632,16 @@ public class CopyItemsMVCActionCommandTest {
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
 
-		mockLiferayPortletActionRequest.addParameter("itemIds", itemIds);
-		mockLiferayPortletActionRequest.addParameter(
-			"parentItemId", parentItemId);
-		mockLiferayPortletActionRequest.addParameter(
-			"segmentsExperienceId", String.valueOf(_segmentsExperienceId));
 		mockLiferayPortletActionRequest.setAttribute(
 			JavaConstants.JAVAX_PORTLET_CONFIG, null);
 		mockLiferayPortletActionRequest.setAttribute(WebKeys.LAYOUT, _layout);
 		mockLiferayPortletActionRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, _themeDisplay);
+		mockLiferayPortletActionRequest.setParameter("itemIds", itemIds);
+		mockLiferayPortletActionRequest.setParameter(
+			"parentItemId", parentItemId);
+		mockLiferayPortletActionRequest.setParameter(
+			"segmentsExperienceId", String.valueOf(_segmentsExperienceId));
 
 		return mockLiferayPortletActionRequest;
 	}
@@ -658,6 +697,79 @@ public class CopyItemsMVCActionCommandTest {
 			childrenItemIds.toString(), count, childrenItemIds.size());
 	}
 
+	private void _testCopyItems(String[] itemIds, String parentItemId)
+		throws Exception {
+
+		LayoutStructure layoutStructure =
+			_layoutStructureProvider.getLayoutStructure(
+				_layout.getPlid(), _segmentsExperienceId);
+
+		List<LayoutStructureItem> layoutStructureItems =
+			layoutStructure.getLayoutStructureItems();
+
+		ReflectionTestUtil.invoke(
+			_mvcActionCommand, "doTransactionalCommand",
+			new Class<?>[] {ActionRequest.class, ActionResponse.class},
+			_getMockLiferayPortletActionRequest(itemIds, parentItemId),
+			new MockLiferayPortletActionResponse());
+
+		layoutStructure = _layoutStructureProvider.getLayoutStructure(
+			_layout.getPlid(), _segmentsExperienceId);
+
+		List<LayoutStructureItem> curLayoutStructureItems =
+			layoutStructure.getLayoutStructureItems();
+
+		Assert.assertEquals(
+			curLayoutStructureItems.toString(),
+			layoutStructureItems.size() + itemIds.length,
+			curLayoutStructureItems.size());
+	}
+
+	private void _testErrorMessage(
+			String expected, String[] itemIds, String parentItemId)
+		throws Exception {
+
+		LayoutStructure layoutStructure =
+			_layoutStructureProvider.getLayoutStructure(
+				_layout.getPlid(), _segmentsExperienceId);
+
+		List<LayoutStructureItem> layoutStructureItems =
+			layoutStructure.getLayoutStructureItems();
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_getMockLiferayPortletActionRequest(itemIds, parentItemId);
+
+		try {
+			ReflectionTestUtil.invoke(
+				_mvcActionCommand, "doTransactionalCommand",
+				new Class<?>[] {ActionRequest.class, ActionResponse.class},
+				mockLiferayPortletActionRequest,
+				new MockLiferayPortletActionResponse());
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			JSONObject jsonObject = ReflectionTestUtil.invoke(
+				_mvcActionCommand, "processException",
+				new Class<?>[] {ActionRequest.class, Exception.class},
+				mockLiferayPortletActionRequest, exception);
+
+			Assert.assertEquals(jsonObject.toString(), 1, jsonObject.length());
+
+			Assert.assertEquals(expected, jsonObject.getString("error"));
+		}
+
+		layoutStructure = _layoutStructureProvider.getLayoutStructure(
+			_layout.getPlid(), _segmentsExperienceId);
+
+		List<LayoutStructureItem> curLayoutStructureItems =
+			layoutStructure.getLayoutStructureItems();
+
+		Assert.assertEquals(
+			curLayoutStructureItems.toString(), layoutStructureItems.size(),
+			curLayoutStructureItems.size());
+	}
+
 	private Company _company;
 
 	@Inject
@@ -678,6 +790,9 @@ public class CopyItemsMVCActionCommandTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private InfoItemServiceRegistry _infoItemServiceRegistry;
 
 	@Inject
 	private JSONFactory _jsonFactory;

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/MoveFragmentEntryLinkMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/MoveFragmentEntryLinkMVCActionCommandTest.java
@@ -1,0 +1,369 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.content.page.editor.web.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.info.field.InfoField;
+import com.liferay.info.form.InfoForm;
+import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.info.item.provider.InfoItemFormProvider;
+import com.liferay.layout.provider.LayoutStructureProvider;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.layout.util.constants.LayoutDataItemTypeConstants;
+import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
+import com.liferay.layout.util.structure.LayoutStructure;
+import com.liferay.layout.util.structure.LayoutStructureItem;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+@RunWith(Arquillian.class)
+public class MoveFragmentEntryLinkMVCActionCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_company = _companyLocalService.getCompany(_group.getCompanyId());
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		_layout = layout.fetchDraftLayout();
+
+		_segmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				_layout.getPlid());
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_group.getGroupId(), TestPropsValues.getUserId());
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_RESPONSE,
+			new MockLiferayPortletActionResponse());
+		mockHttpServletRequest.setAttribute(WebKeys.LAYOUT, _layout);
+
+		_themeDisplay = ContentLayoutTestUtil.getThemeDisplay(
+			_company, _group, _layout);
+
+		_themeDisplay.setRequest(mockHttpServletRequest);
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _themeDisplay);
+
+		_serviceContext.setRequest(mockHttpServletRequest);
+
+		ServiceContextThreadLocal.pushServiceContext(_serviceContext);
+	}
+
+	@After
+	public void tearDown() {
+		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@Test
+	@TestInfo("LPD-46069")
+	public void testMoveInputFragmentEntryLink() throws Exception {
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, "First Name",
+						"firstName")));
+
+		InfoItemFormProvider<?> infoItemFormProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoItemFormProvider.class, objectDefinition.getClassName());
+
+		InfoForm infoForm = infoItemFormProvider.getInfoForm(
+			StringPool.BLANK, _group.getGroupId());
+
+		List<InfoField<?>> allInfoFields = ListUtil.filter(
+			infoForm.getAllInfoFields(), InfoField::isEditable);
+
+		String classNameId = String.valueOf(
+			_portal.getClassNameId(objectDefinition.getClassName()));
+
+		JSONObject jsonObject = ContentLayoutTestUtil.addFormToLayout(
+			false, classNameId, "0", _layout, _layoutStructureProvider,
+			_segmentsExperienceId, allInfoFields.toArray(new InfoField<?>[0]));
+
+		FragmentStyledLayoutStructureItem fragmentStyledLayoutStructureItem =
+			_getFragmentStyledLayoutStructureItem(
+				(LayoutStructure)jsonObject.get("layoutData"));
+
+		jsonObject = ContentLayoutTestUtil.addItemToLayout(
+			"{}", LayoutDataItemTypeConstants.TYPE_ROW, _layout,
+			_layoutStructureProvider, _segmentsExperienceId);
+
+		_testErrorMessage(
+			new String[] {fragmentStyledLayoutStructureItem.getItemId()},
+			new String[] {jsonObject.getString("addedItemId")});
+
+		jsonObject = ContentLayoutTestUtil.addFormToLayout(
+			false, classNameId, "0", _layout, _layoutStructureProvider,
+			_segmentsExperienceId);
+
+		_testMoveFragmentEntryLink(
+			fragmentStyledLayoutStructureItem,
+			(LayoutStructure)jsonObject.get("layoutData"),
+			jsonObject.getString("addedItemId"));
+	}
+
+	private FragmentStyledLayoutStructureItem
+		_getFragmentStyledLayoutStructureItem(LayoutStructure layoutStructure) {
+
+		Map<Long, LayoutStructureItem> fragmentLayoutStructureItems =
+			layoutStructure.getFragmentLayoutStructureItems();
+
+		Collection<LayoutStructureItem> layoutStructureItems =
+			fragmentLayoutStructureItems.values();
+
+		Iterator<LayoutStructureItem> iterator =
+			layoutStructureItems.iterator();
+
+		return (FragmentStyledLayoutStructureItem)iterator.next();
+	}
+
+	private MockLiferayPortletActionRequest _getMockLiferayPortletActionRequest(
+			String[] itemIds, String[] parentItemIds)
+		throws Exception {
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			new MockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_CONFIG, null);
+		mockLiferayPortletActionRequest.setAttribute(WebKeys.LAYOUT, _layout);
+		mockLiferayPortletActionRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _themeDisplay);
+		mockLiferayPortletActionRequest.setParameter("itemIds", itemIds);
+		mockLiferayPortletActionRequest.setParameter(
+			"parentItemIds", parentItemIds);
+		mockLiferayPortletActionRequest.setParameter(
+			"positions", new String[] {"0"});
+		mockLiferayPortletActionRequest.setParameter(
+			"segmentsExperienceId", String.valueOf(_segmentsExperienceId));
+
+		return mockLiferayPortletActionRequest;
+	}
+
+	private void _testErrorMessage(String[] itemIds, String[] parentItemIds)
+		throws Exception {
+
+		LayoutStructure layoutStructure =
+			_layoutStructureProvider.getLayoutStructure(
+				_layout.getPlid(), _segmentsExperienceId);
+
+		List<LayoutStructureItem> layoutStructureItems =
+			layoutStructure.getLayoutStructureItems();
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_getMockLiferayPortletActionRequest(itemIds, parentItemIds);
+
+		try {
+			ReflectionTestUtil.invoke(
+				_mvcActionCommand, "doTransactionalCommand",
+				new Class<?>[] {ActionRequest.class, ActionResponse.class},
+				mockLiferayPortletActionRequest,
+				new MockLiferayPortletActionResponse());
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			JSONObject jsonObject = ReflectionTestUtil.invoke(
+				_mvcActionCommand, "processException",
+				new Class<?>[] {ActionRequest.class, Exception.class},
+				mockLiferayPortletActionRequest, exception);
+
+			Assert.assertEquals(jsonObject.toString(), 1, jsonObject.length());
+
+			Assert.assertEquals(
+				_language.get(
+					_portal.getSiteDefaultLocale(_group),
+					"form-components-can-only-be-placed-inside-a-mapped-form-" +
+						"container"),
+				jsonObject.getString("error"));
+		}
+
+		layoutStructure = _layoutStructureProvider.getLayoutStructure(
+			_layout.getPlid(), _segmentsExperienceId);
+
+		List<LayoutStructureItem> curLayoutStructureItems =
+			layoutStructure.getLayoutStructureItems();
+
+		Assert.assertEquals(
+			curLayoutStructureItems.toString(), layoutStructureItems.size(),
+			curLayoutStructureItems.size());
+	}
+
+	private void _testMoveFragmentEntryLink(
+			FragmentStyledLayoutStructureItem fragmentStyledLayoutStructureItem,
+			LayoutStructure layoutStructure, String parentItemId)
+		throws Exception {
+
+		LayoutStructureItem originalParentLayoutStructureItem =
+			layoutStructure.getLayoutStructureItem(
+				fragmentStyledLayoutStructureItem.getParentItemId());
+
+		List<String> originalChildrenItemIds =
+			originalParentLayoutStructureItem.getChildrenItemIds();
+
+		LayoutStructureItem parentLayoutStructureItem =
+			layoutStructure.getLayoutStructureItem(parentItemId);
+
+		List<String> childrenItemIds =
+			parentLayoutStructureItem.getChildrenItemIds();
+
+		ReflectionTestUtil.invoke(
+			_mvcActionCommand, "doTransactionalCommand",
+			new Class<?>[] {ActionRequest.class, ActionResponse.class},
+			_getMockLiferayPortletActionRequest(
+				new String[] {fragmentStyledLayoutStructureItem.getItemId()},
+				new String[] {parentLayoutStructureItem.getItemId()}),
+			new MockLiferayPortletActionResponse());
+
+		layoutStructure = _layoutStructureProvider.getLayoutStructure(
+			_layout.getPlid(), _segmentsExperienceId);
+
+		FragmentStyledLayoutStructureItem curFragmentStyledLayoutStructureItem =
+			(FragmentStyledLayoutStructureItem)
+				layoutStructure.getLayoutStructureItem(
+					fragmentStyledLayoutStructureItem.getItemId());
+
+		Assert.assertEquals(
+			parentLayoutStructureItem.getItemId(),
+			curFragmentStyledLayoutStructureItem.getParentItemId());
+
+		LayoutStructureItem curParentLayoutStructureItem =
+			layoutStructure.getLayoutStructureItem(
+				parentLayoutStructureItem.getItemId());
+
+		List<String> curChildrenItemIds =
+			curParentLayoutStructureItem.getChildrenItemIds();
+
+		Assert.assertEquals(
+			curChildrenItemIds.toString(), childrenItemIds.size() + 1,
+			curChildrenItemIds.size());
+		Assert.assertTrue(
+			curChildrenItemIds.toString(),
+			curChildrenItemIds.contains(
+				fragmentStyledLayoutStructureItem.getItemId()));
+
+		originalParentLayoutStructureItem =
+			layoutStructure.getLayoutStructureItem(
+				originalParentLayoutStructureItem.getItemId());
+
+		curChildrenItemIds =
+			originalParentLayoutStructureItem.getChildrenItemIds();
+
+		Assert.assertEquals(
+			curChildrenItemIds.toString(), originalChildrenItemIds.size() - 1,
+			curChildrenItemIds.size());
+		Assert.assertFalse(
+			curChildrenItemIds.toString(),
+			curChildrenItemIds.contains(
+				fragmentStyledLayoutStructureItem.getItemId()));
+	}
+
+	private Company _company;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private InfoItemServiceRegistry _infoItemServiceRegistry;
+
+	@Inject
+	private Language _language;
+
+	private Layout _layout;
+
+	@Inject
+	private LayoutStructureProvider _layoutStructureProvider;
+
+	@Inject(
+		filter = "mvc.command.name=/layout_content_page_editor/move_fragment_entry_link"
+	)
+	private MVCActionCommand _mvcActionCommand;
+
+	@Inject
+	private Portal _portal;
+
+	private long _segmentsExperienceId;
+
+	@Inject
+	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
+
+	private ServiceContext _serviceContext;
+	private ThemeDisplay _themeDisplay;
+
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/exception/FormContainerParentItemRequiredException.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/exception/FormContainerParentItemRequiredException.java
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.content.page.editor.web.internal.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+public class FormContainerParentItemRequiredException extends PortalException {
+
+	public FormContainerParentItemRequiredException() {
+	}
+
+	public FormContainerParentItemRequiredException(String msg) {
+		super(msg);
+	}
+
+	public FormContainerParentItemRequiredException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public FormContainerParentItemRequiredException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/FormItemManager.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/FormItemManager.java
@@ -5,6 +5,7 @@
 
 package com.liferay.layout.content.page.editor.web.internal.manager;
 
+import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.contributor.FragmentCollectionContributor;
 import com.liferay.fragment.contributor.FragmentCollectionContributorRegistry;
 import com.liferay.fragment.entry.processor.constants.FragmentEntryProcessorConstants;
@@ -19,7 +20,9 @@ import com.liferay.info.form.InfoForm;
 import com.liferay.info.item.InfoItemServiceRegistry;
 import com.liferay.info.item.provider.InfoItemFormProvider;
 import com.liferay.info.search.InfoSearchClassMapperRegistry;
+import com.liferay.layout.content.page.editor.web.internal.exception.FormContainerParentItemRequiredException;
 import com.liferay.layout.content.page.editor.web.internal.util.layout.structure.LayoutStructureUtil;
+import com.liferay.layout.util.constants.LayoutDataItemTypeConstants;
 import com.liferay.layout.util.structure.DropZoneLayoutStructureItem;
 import com.liferay.layout.util.structure.FormStepContainerStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.FormStyledLayoutStructureItem;
@@ -48,6 +51,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -354,6 +358,22 @@ public class FormItemManager {
 		return layoutStructureItemChanges;
 	}
 
+	public void checkFormContainerParentItemRequired(
+			List<FragmentEntryLink> fragmentEntryLinks,
+			LayoutStructure layoutStructure, Locale locale, String parentItemId)
+		throws PortalException {
+
+		if (_hasFormStyledLayoutStructureItemParent(
+				parentItemId, layoutStructure)) {
+
+			return;
+		}
+
+		if (_existsTypeInputFragmentEntryLink(fragmentEntryLinks, locale)) {
+			throw new FormContainerParentItemRequiredException();
+		}
+	}
+
 	public LayoutStructureItemChanges removeFormStepLayoutStructureItems(
 		FormStyledLayoutStructureItem formStyledLayoutStructureItem,
 		LayoutStructure layoutStructure, int numberOfSteps) {
@@ -542,6 +562,26 @@ public class FormItemManager {
 		return fragmentEntryLink;
 	}
 
+	private boolean _existsTypeInputFragmentEntryLink(
+		List<FragmentEntryLink> fragmentEntryLinks, Locale locale) {
+
+		for (FragmentEntryLink fragmentEntryLink : fragmentEntryLinks) {
+			Set<String> fragmentEntryLinkFieldTypes =
+				_fragmentEntryLinkManager.getFragmentEntryLinkFieldTypes(
+					fragmentEntryLink.getFragmentEntryLinkId(), locale);
+
+			if (Objects.equals(
+					fragmentEntryLink.getType(),
+					FragmentConstants.TYPE_INPUT) &&
+				!fragmentEntryLinkFieldTypes.contains("localizationSelect")) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	private LayoutStructureItem _findFormStepContainerStyledLayoutStructureItem(
 		FormStyledLayoutStructureItem formStyledLayoutStructureItem,
 		LayoutStructure layoutStructure) {
@@ -650,6 +690,31 @@ public class FormItemManager {
 		}
 
 		return null;
+	}
+
+	private boolean _hasFormStyledLayoutStructureItemParent(
+		String itemId, LayoutStructure layoutStructure) {
+
+		LayoutStructureItem layoutStructureItem =
+			layoutStructure.getLayoutStructureItem(itemId);
+
+		if ((layoutStructureItem == null) ||
+			Objects.equals(
+				layoutStructureItem.getItemType(),
+				LayoutDataItemTypeConstants.TYPE_ROOT)) {
+
+			return false;
+		}
+
+		if (Objects.equals(
+				layoutStructureItem.getItemType(),
+				LayoutDataItemTypeConstants.TYPE_FORM)) {
+
+			return true;
+		}
+
+		return _hasFormStyledLayoutStructureItemParent(
+			layoutStructureItem.getParentItemId(), layoutStructure);
 	}
 
 	private boolean _isAllowedFragmentEntryKey(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/FormItemManager.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/FormItemManager.java
@@ -566,15 +566,18 @@ public class FormItemManager {
 		List<FragmentEntryLink> fragmentEntryLinks, Locale locale) {
 
 		for (FragmentEntryLink fragmentEntryLink : fragmentEntryLinks) {
+			if (!Objects.equals(
+					fragmentEntryLink.getType(),
+					FragmentConstants.TYPE_INPUT)) {
+
+				continue;
+			}
+
 			Set<String> fragmentEntryLinkFieldTypes =
 				_fragmentEntryLinkManager.getFragmentEntryLinkFieldTypes(
 					fragmentEntryLink.getFragmentEntryLinkId(), locale);
 
-			if (Objects.equals(
-					fragmentEntryLink.getType(),
-					FragmentConstants.TYPE_INPUT) &&
-				!fragmentEntryLinkFieldTypes.contains("localizationSelect")) {
-
+			if (!fragmentEntryLinkFieldTypes.contains("localizationSelect")) {
 				return true;
 			}
 		}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/FragmentEntryLinkManager.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/FragmentEntryLinkManager.java
@@ -61,6 +61,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -82,6 +83,37 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(service = FragmentEntryLinkManager.class)
 public class FragmentEntryLinkManager {
+
+	public List<FragmentEntryLink> getChildrenFragmentEntryLinks(
+			List<String> itemIds, LayoutStructure layoutStructure)
+		throws PortalException {
+
+		List<FragmentEntryLink> fragmentEntryLinks = new ArrayList<>();
+
+		for (String itemId : itemIds) {
+			LayoutStructureItem layoutStructureItem =
+				layoutStructure.getLayoutStructureItem(itemId);
+
+			if (layoutStructureItem instanceof
+					FragmentStyledLayoutStructureItem) {
+
+				FragmentStyledLayoutStructureItem
+					fragmentStyledLayoutStructureItem =
+						(FragmentStyledLayoutStructureItem)layoutStructureItem;
+
+				fragmentEntryLinks.add(
+					_fragmentEntryLinkLocalService.getFragmentEntryLink(
+						fragmentStyledLayoutStructureItem.
+							getFragmentEntryLinkId()));
+			}
+
+			fragmentEntryLinks.addAll(
+				getChildrenFragmentEntryLinks(
+					layoutStructureItem.getChildrenItemIds(), layoutStructure));
+		}
+
+		return fragmentEntryLinks;
+	}
 
 	public FragmentEntry getFragmentEntry(
 		long groupId, String fragmentEntryKey, Locale locale) {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddFragmentEntryLinksMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddFragmentEntryLinksMVCActionCommand.java
@@ -14,6 +14,7 @@ import com.liferay.fragment.model.FragmentComposition;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.service.FragmentCompositionService;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
+import com.liferay.layout.content.page.editor.web.internal.exception.FormContainerParentItemRequiredException;
 import com.liferay.layout.content.page.editor.web.internal.exception.NoninstanceablePortletException;
 import com.liferay.layout.content.page.editor.web.internal.manager.FragmentEntryLinkManager;
 import com.liferay.layout.content.page.editor.web.internal.util.layout.structure.LayoutStructureUtil;
@@ -87,7 +88,18 @@ public class AddFragmentEntryLinksMVCActionCommand
 
 		String errorMessage = "an-unexpected-error-occurred";
 
-		if (exception.getCause() instanceof NoninstanceablePortletException) {
+		if (exception instanceof FormContainerParentItemRequiredException) {
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)actionRequest.getAttribute(WebKeys.THEME_DISPLAY);
+
+			errorMessage = _language.get(
+				themeDisplay.getLocale(),
+				"form-components-can-only-be-placed-inside-a-mapped-form-" +
+					"container");
+		}
+		else if (exception.getCause() instanceof
+					NoninstanceablePortletException) {
+
 			ThemeDisplay themeDisplay =
 				(ThemeDisplay)actionRequest.getAttribute(WebKeys.THEME_DISPLAY);
 
@@ -117,9 +129,6 @@ public class AddFragmentEntryLinksMVCActionCommand
 			errorMessage =
 				"the-fragment-can-no-longer-be-added-because-it-has-been-" +
 					"deleted";
-		}
-		else if (exception instanceof UnsupportedOperationException) {
-			errorMessage = exception.getMessage();
 		}
 
 		return JSONUtil.put(
@@ -223,11 +232,7 @@ public class AddFragmentEntryLinksMVCActionCommand
 				_existTypeInputFragmentEntryLink(
 					fragmentEntryLinks, themeDisplay.getLocale())) {
 
-				throw new UnsupportedOperationException(
-					_language.get(
-						themeDisplay.getLocale(),
-						"form-components-can-only-be-placed-inside-a-mapped-" +
-							"form-container"));
+				throw new FormContainerParentItemRequiredException();
 			}
 
 			for (FragmentEntryLink fragmentEntryLink : fragmentEntryLinks) {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddFragmentEntryLinksMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddFragmentEntryLinksMVCActionCommand.java
@@ -5,7 +5,6 @@
 
 package com.liferay.layout.content.page.editor.web.internal.portlet.action;
 
-import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.contributor.FragmentCollectionContributorRegistry;
 import com.liferay.fragment.exception.NoSuchEntryException;
 import com.liferay.fragment.listener.FragmentEntryLinkListener;
@@ -16,11 +15,11 @@ import com.liferay.fragment.service.FragmentCompositionService;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.layout.content.page.editor.web.internal.exception.FormContainerParentItemRequiredException;
 import com.liferay.layout.content.page.editor.web.internal.exception.NoninstanceablePortletException;
+import com.liferay.layout.content.page.editor.web.internal.manager.FormItemManager;
 import com.liferay.layout.content.page.editor.web.internal.manager.FragmentEntryLinkManager;
 import com.liferay.layout.content.page.editor.web.internal.util.layout.structure.LayoutStructureUtil;
 import com.liferay.layout.importer.LayoutsImporter;
 import com.liferay.layout.util.CheckNoninstanceablePortletThreadLocal;
-import com.liferay.layout.util.constants.LayoutDataItemTypeConstants;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.petra.lang.SafeCloseable;
@@ -39,9 +38,6 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.List;
-import java.util.Locale;
-import java.util.Objects;
-import java.util.Set;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
@@ -137,51 +133,6 @@ public class AddFragmentEntryLinksMVCActionCommand
 				_portal.getHttpServletRequest(actionRequest), errorMessage));
 	}
 
-	private boolean _existTypeInputFragmentEntryLink(
-		List<FragmentEntryLink> fragmentEntryLinks, Locale locale) {
-
-		for (FragmentEntryLink fragmentEntryLink : fragmentEntryLinks) {
-			Set<String> fragmentEntryLinkFieldTypes =
-				_fragmentEntryLinkManager.getFragmentEntryLinkFieldTypes(
-					fragmentEntryLink.getFragmentEntryLinkId(), locale);
-
-			if (Objects.equals(
-					fragmentEntryLink.getType(),
-					FragmentConstants.TYPE_INPUT) &&
-				!fragmentEntryLinkFieldTypes.contains("localizationSelect")) {
-
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	private boolean _hasFormStyledLayoutStructureItemParent(
-		String parentItemId, LayoutStructure layoutStructure) {
-
-		LayoutStructureItem layoutStructureItem =
-			layoutStructure.getLayoutStructureItem(parentItemId);
-
-		if ((layoutStructureItem == null) ||
-			Objects.equals(
-				layoutStructureItem.getItemType(),
-				LayoutDataItemTypeConstants.TYPE_ROOT)) {
-
-			return false;
-		}
-
-		if (Objects.equals(
-				layoutStructureItem.getItemType(),
-				LayoutDataItemTypeConstants.TYPE_FORM)) {
-
-			return true;
-		}
-
-		return _hasFormStyledLayoutStructureItemParent(
-			layoutStructureItem.getParentItemId(), layoutStructure);
-	}
-
 	private JSONObject _processAddFragmentEntryLinks(
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {
@@ -227,13 +178,9 @@ public class AddFragmentEntryLinksMVCActionCommand
 					fragmentComposition.getData(), position, false,
 					segmentsExperienceId);
 
-			if (!_hasFormStyledLayoutStructureItemParent(
-					parentItemId, layoutStructure) &&
-				_existTypeInputFragmentEntryLink(
-					fragmentEntryLinks, themeDisplay.getLocale())) {
-
-				throw new FormContainerParentItemRequiredException();
-			}
+			_formItemManager.checkFormContainerParentItemRequired(
+				fragmentEntryLinks, layoutStructure, themeDisplay.getLocale(),
+				parentItemId);
 
 			for (FragmentEntryLink fragmentEntryLink : fragmentEntryLinks) {
 				for (FragmentEntryLinkListener fragmentEntryLinkListener :
@@ -280,6 +227,9 @@ public class AddFragmentEntryLinksMVCActionCommand
 			);
 		}
 	}
+
+	@Reference
+	private FormItemManager _formItemManager;
 
 	@Reference
 	private FragmentCollectionContributorRegistry

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddFragmentEntryLinksMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddFragmentEntryLinksMVCActionCommand.java
@@ -5,6 +5,7 @@
 
 package com.liferay.layout.content.page.editor.web.internal.portlet.action;
 
+import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.contributor.FragmentCollectionContributorRegistry;
 import com.liferay.fragment.exception.NoSuchEntryException;
 import com.liferay.fragment.listener.FragmentEntryLinkListener;
@@ -18,6 +19,7 @@ import com.liferay.layout.content.page.editor.web.internal.manager.FragmentEntry
 import com.liferay.layout.content.page.editor.web.internal.util.layout.structure.LayoutStructureUtil;
 import com.liferay.layout.importer.LayoutsImporter;
 import com.liferay.layout.util.CheckNoninstanceablePortletThreadLocal;
+import com.liferay.layout.util.constants.LayoutDataItemTypeConstants;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.petra.lang.SafeCloseable;
@@ -36,6 +38,9 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
@@ -113,11 +118,59 @@ public class AddFragmentEntryLinksMVCActionCommand
 				"the-fragment-can-no-longer-be-added-because-it-has-been-" +
 					"deleted";
 		}
+		else if (exception instanceof UnsupportedOperationException) {
+			errorMessage = exception.getMessage();
+		}
 
 		return JSONUtil.put(
 			"error",
 			_language.get(
 				_portal.getHttpServletRequest(actionRequest), errorMessage));
+	}
+
+	private boolean _existTypeInputFragmentEntryLink(
+		List<FragmentEntryLink> fragmentEntryLinks, Locale locale) {
+
+		for (FragmentEntryLink fragmentEntryLink : fragmentEntryLinks) {
+			Set<String> fragmentEntryLinkFieldTypes =
+				_fragmentEntryLinkManager.getFragmentEntryLinkFieldTypes(
+					fragmentEntryLink.getFragmentEntryLinkId(), locale);
+
+			if (Objects.equals(
+					fragmentEntryLink.getType(),
+					FragmentConstants.TYPE_INPUT) &&
+				!fragmentEntryLinkFieldTypes.contains("localizationSelect")) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private boolean _hasFormStyledLayoutStructureItemParent(
+		String parentItemId, LayoutStructure layoutStructure) {
+
+		LayoutStructureItem layoutStructureItem =
+			layoutStructure.getLayoutStructureItem(parentItemId);
+
+		if ((layoutStructureItem == null) ||
+			Objects.equals(
+				layoutStructureItem.getItemType(),
+				LayoutDataItemTypeConstants.TYPE_ROOT)) {
+
+			return false;
+		}
+
+		if (Objects.equals(
+				layoutStructureItem.getItemType(),
+				LayoutDataItemTypeConstants.TYPE_FORM)) {
+
+			return true;
+		}
+
+		return _hasFormStyledLayoutStructureItemParent(
+			layoutStructureItem.getParentItemId(), layoutStructure);
 	}
 
 	private JSONObject _processAddFragmentEntryLinks(
@@ -164,6 +217,18 @@ public class AddFragmentEntryLinksMVCActionCommand
 					themeDisplay.getLayout(), layoutStructure, parentItemId,
 					fragmentComposition.getData(), position, false,
 					segmentsExperienceId);
+
+			if (!_hasFormStyledLayoutStructureItemParent(
+					parentItemId, layoutStructure) &&
+				_existTypeInputFragmentEntryLink(
+					fragmentEntryLinks, themeDisplay.getLocale())) {
+
+				throw new UnsupportedOperationException(
+					_language.get(
+						themeDisplay.getLocale(),
+						"form-components-can-only-be-placed-inside-a-mapped-" +
+							"form-container"));
+			}
 
 			for (FragmentEntryLink fragmentEntryLink : fragmentEntryLinks) {
 				for (FragmentEntryLinkListener fragmentEntryLinkListener :

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/BaseContentPageEditorTransactionalMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/BaseContentPageEditorTransactionalMVCActionCommand.java
@@ -7,6 +7,7 @@ package com.liferay.layout.content.page.editor.web.internal.portlet.action;
 
 import com.liferay.fragment.exception.FragmentCompositionDescriptionException;
 import com.liferay.fragment.exception.FragmentCompositionNameException;
+import com.liferay.layout.content.page.editor.web.internal.exception.FormContainerParentItemRequiredException;
 import com.liferay.layout.content.page.editor.web.internal.exception.NoninstanceablePortletException;
 import com.liferay.layout.manager.LayoutLockManager;
 import com.liferay.portal.kernel.exception.LockedLayoutException;
@@ -96,7 +97,16 @@ public abstract class BaseContentPageEditorTransactionalMVCActionCommand
 
 		String errorMessage = "an-unexpected-error-occurred";
 
-		if (exception instanceof FragmentCompositionDescriptionException) {
+		if (exception instanceof FormContainerParentItemRequiredException) {
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)actionRequest.getAttribute(WebKeys.THEME_DISPLAY);
+
+			errorMessage = LanguageUtil.get(
+				themeDisplay.getLocale(),
+				"form-components-can-only-be-placed-inside-a-mapped-form-" +
+					"container");
+		}
+		else if (exception instanceof FragmentCompositionDescriptionException) {
 			errorMessage =
 				"please-enter-a-valid-fragment-composition-description";
 		}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/BaseDuplicateItemMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/BaseDuplicateItemMVCActionCommand.java
@@ -10,6 +10,7 @@ import com.liferay.fragment.exception.NoSuchEntryLinkException;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.fragment.service.FragmentEntryLinkService;
+import com.liferay.layout.content.page.editor.web.internal.exception.FormContainerParentItemRequiredException;
 import com.liferay.layout.content.page.editor.web.internal.exception.NoninstanceablePortletException;
 import com.liferay.layout.content.page.editor.web.internal.manager.FragmentEntryLinkManager;
 import com.liferay.layout.content.page.editor.web.internal.util.layout.structure.LayoutStructureUtil;
@@ -24,6 +25,7 @@ import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.PortletPreferencesIds;
 import com.liferay.portal.kernel.model.ResourceConstants;
@@ -179,7 +181,13 @@ public abstract class BaseDuplicateItemMVCActionCommand
 
 		String errorMessage = StringPool.BLANK;
 
-		if (exception instanceof NoninstanceablePortletException) {
+		if (exception instanceof FormContainerParentItemRequiredException) {
+			errorMessage = LanguageUtil.get(
+				themeDisplay.getLocale(),
+				"form-components-can-only-be-placed-inside-a-mapped-form-" +
+					"container");
+		}
+		else if (exception instanceof NoninstanceablePortletException) {
 			errorMessage = _getNoninstanceablePortletErrorMessage(
 				actionRequest, (NoninstanceablePortletException)exception,
 				themeDisplay);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/CopyItemsMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/CopyItemsMVCActionCommand.java
@@ -10,6 +10,8 @@ import com.liferay.fragment.listener.FragmentEntryLinkListenerRegistry;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.layout.content.page.editor.web.internal.manager.ContentManager;
+import com.liferay.layout.content.page.editor.web.internal.manager.FormItemManager;
+import com.liferay.layout.content.page.editor.web.internal.manager.FragmentEntryLinkManager;
 import com.liferay.layout.content.page.editor.web.internal.util.layout.structure.LayoutStructureUtil;
 import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
@@ -18,6 +20,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -81,6 +84,11 @@ public class CopyItemsMVCActionCommand
 			themeDisplay.getScopeGroupId(), segmentsExperienceId,
 			themeDisplay.getPlid(),
 			layoutStructure -> {
+				_formItemManager.checkFormContainerParentItemRequired(
+					_fragmentEntryLinkManager.getChildrenFragmentEntryLinks(
+						ListUtil.fromArray(finalItemIds), layoutStructure),
+					layoutStructure, themeDisplay.getLocale(), parentItemId);
+
 				List<LayoutStructureItem> copiedLayoutStructureItems =
 					layoutStructure.copyLayoutStructureItems(
 						Arrays.asList(finalItemIds), parentItemId);
@@ -177,7 +185,13 @@ public class CopyItemsMVCActionCommand
 	private ContentManager _contentManager;
 
 	@Reference
+	private FormItemManager _formItemManager;
+
+	@Reference
 	private FragmentEntryLinkListenerRegistry
 		_fragmentEntryLinkListenerRegistry;
+
+	@Reference
+	private FragmentEntryLinkManager _fragmentEntryLinkManager;
 
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/MoveFragmentEntryLinkMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/MoveFragmentEntryLinkMVCActionCommand.java
@@ -6,6 +6,8 @@
 package com.liferay.layout.content.page.editor.web.internal.portlet.action;
 
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
+import com.liferay.layout.content.page.editor.web.internal.manager.FormItemManager;
+import com.liferay.layout.content.page.editor.web.internal.manager.FragmentEntryLinkManager;
 import com.liferay.layout.content.page.editor.web.internal.util.layout.structure.LayoutStructureUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
@@ -15,11 +17,13 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Eudaldo Alonso
@@ -91,11 +95,24 @@ public class MoveFragmentEntryLinkMVCActionCommand
 			themeDisplay.getPlid(),
 			layoutStructure -> {
 				for (int i = 0; i < finalItemIds.length; i++) {
+					_formItemManager.checkFormContainerParentItemRequired(
+						_fragmentEntryLinkManager.getChildrenFragmentEntryLinks(
+							Collections.singletonList(finalItemIds[i]),
+							layoutStructure),
+						layoutStructure, themeDisplay.getLocale(),
+						finalParentItemIds[i]);
+
 					layoutStructure.moveLayoutStructureItem(
 						finalItemIds[i], finalParentItemIds[i],
 						finalPositions[i]);
 				}
 			});
 	}
+
+	@Reference
+	private FormItemManager _formItemManager;
+
+	@Reference
+	private FragmentEntryLinkManager _fragmentEntryLinkManager;
 
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/drag_and_drop/checkAllowedChild.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/drag_and_drop/checkAllowedChild.ts
@@ -176,14 +176,6 @@ export default function checkAllowedChild(
 			}
 		}
 		else {
-			if (
-				child.fragmentEntryType === FRAGMENT_ENTRY_TYPES.input &&
-				!formParent &&
-				!isLocalizationSelect(child)
-			) {
-				return {reason: 'input-outside-form', valid: false};
-			}
-
 			if (formParent && child.isWidget) {
 				return {reason: 'widget-inside-form', valid: false};
 			}
@@ -211,9 +203,49 @@ export default function checkAllowedChild(
 		}
 	}
 
+	if (!formParent && hasInputChild(child, layoutData, fragmentEntryLinks)) {
+		return {reason: 'input-outside-form', valid: false};
+	}
+
 	if (!LAYOUT_DATA_CHECK_ALLOWED_CHILDREN[parent.type](child, parent)) {
 		return {valid: false};
 	}
 
 	return {valid: true};
+}
+
+function hasInputChild(
+	child: MovementItem,
+	layoutData: LayoutData,
+	fragmentEntryLinks: FragmentEntryLinkMap
+): boolean {
+	if (child.fragmentEntryType === FRAGMENT_ENTRY_TYPES.input) {
+		return true;
+	}
+
+	const childItem = layoutData.items[child.itemId];
+
+	if (!childItem) {
+		return false;
+	}
+
+	if (childItem.type === LAYOUT_DATA_ITEM_TYPES.fragment) {
+		const fragment =
+			fragmentEntryLinks?.[childItem.config.fragmentEntryLinkId!];
+
+		return (
+			fragment.fragmentEntryType === FRAGMENT_ENTRY_TYPES.input &&
+			!isLocalizationSelect(fragment)
+		);
+	}
+
+	return childItem.children?.some((childId) => {
+		const child = layoutData.items[childId];
+
+		return hasInputChild(
+			child as MovementItem,
+			layoutData,
+			fragmentEntryLinks
+		);
+	});
 }

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/KeyboardMovementManager.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/KeyboardMovementManager.test.js
@@ -61,26 +61,48 @@ const renderComponent = ({dispatch = () => {}} = {}) =>
 		<StoreMother.Component
 			dispatch={dispatch}
 			getState={() => ({
-				fragmentEntryLinks: [],
+				fragmentEntryLinks: {
+					['item-1-fragment-entry-link']: {
+						fragmentEntryLinkId: 'item-1-fragment-entry-link',
+						fragmentEntryType: 'component',
+					},
+					['item-2-fragment-entry-link']: {
+						fragmentEntryLinkId: 'item-2-fragment-entry-link',
+						fragmentEntryType: 'component',
+					},
+					['item-3-fragment-entry-link']: {
+						fragmentEntryLinkId: 'item-3-fragment-entry-link',
+						fragmentEntryType: 'component',
+					},
+				},
 				layoutData: {
 					items: {
 						['item-1']: {
 							children: [],
-							config: {},
+							config: {
+								fragmentEntryLinkId:
+									'item-1-fragment-entry-link',
+							},
 							itemId: 'item-1',
 							parentId: 'root-id',
 							type: LAYOUT_DATA_ITEM_TYPES.fragment,
 						},
 						['item-2']: {
 							children: [],
-							config: {},
+							config: {
+								fragmentEntryLinkId:
+									'item-2-fragment-entry-link',
+							},
 							itemId: 'item-2',
 							parentId: 'root-id',
 							type: LAYOUT_DATA_ITEM_TYPES.fragment,
 						},
 						['item-3']: {
 							children: [],
-							config: {},
+							config: {
+								fragmentEntryLinkId:
+									'item-3-fragment-entry-link',
+							},
 							itemId: 'item-3',
 							parentId: 'root-id',
 							type: LAYOUT_DATA_ITEM_TYPES.fragment,

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/utils/drag_and_drop/checkAllowedChild.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/utils/drag_and_drop/checkAllowedChild.test.js
@@ -52,11 +52,11 @@ function getCollectionItem() {
 	};
 }
 
-function getContainer() {
+function getContainer({itemId = IDS.container, children = []} = {}) {
 	return {
-		children: [],
+		children,
 		config: {},
-		itemId: IDS.container,
+		itemId,
 		type: LAYOUT_DATA_ITEM_TYPES.container,
 	};
 }
@@ -218,8 +218,29 @@ describe('checkAllowedChild', () => {
 
 			const container = getContainer();
 
+			const layoutData = {
+				items: {
+					[input.itemId]: input,
+					[IDS.container]: container,
+				},
+			};
+
+			const fragmentEntryLinks = {
+				[input.config.fragmentEntryLinkId]: {
+					fieldTypes: ['text'],
+					fragmentEntryLinkId: input.config.fragmentEntryLinkId,
+					fragmentEntryType: 'input',
+				},
+			};
+
 			expect(
-				checkAllowedChild(input, container, {}, {}, () => []).valid
+				checkAllowedChild(
+					input,
+					container,
+					layoutData,
+					fragmentEntryLinks,
+					() => []
+				).valid
 			).toBe(false);
 		});
 
@@ -233,6 +254,101 @@ describe('checkAllowedChild', () => {
 			expect(checkAllowedChild(input, form, {}, {}, () => []).valid).toBe(
 				true
 			);
+		});
+
+		it('it is not possible to move a container with input fragment outside a form', () => {
+			const container = getContainer();
+
+			const existingInput = getFragment({
+				fragmentEntryLinkId: 'input-fragment-id',
+				itemId: 'input-stepper-id',
+				parentId: IDS.container,
+			});
+
+			const innerContainer = getContainer({
+				children: [existingInput.itemId],
+				itemId: 'inner-container-id',
+			});
+
+			const form = getForm({
+				children: [innerContainer.itemId],
+			});
+
+			const layoutData = {
+				items: {
+					[IDS.form]: form,
+					[existingInput.itemId]: existingInput,
+					[IDS.container]: container,
+					[innerContainer.itemId]: innerContainer,
+				},
+			};
+
+			const fragmentEntryLinks = {
+				[existingInput.config.fragmentEntryLinkId]: {
+					fieldTypes: ['text'],
+					fragmentEntryLinkId:
+						existingInput.config.fragmentEntryLinkId,
+					fragmentEntryType: 'input',
+				},
+			};
+
+			expect(
+				checkAllowedChild(
+					innerContainer,
+					container,
+					layoutData,
+					fragmentEntryLinks,
+					() => []
+				).valid
+			).toBe(false);
+		});
+
+		it('it is possible to move a container with localizationSelectinput fragment outside a form', () => {
+			const container = getContainer();
+
+			const existingInput = getFragment({
+				fieldTypes: ['localizationSelect'],
+				fragmentEntryLinkId: 'input-fragment-id',
+				itemId: 'input-stepper-id',
+				parentId: IDS.container,
+			});
+
+			const innerContainer = getContainer({
+				children: [existingInput.itemId],
+				itemId: 'inner-container-id',
+			});
+
+			const form = getForm({
+				children: [innerContainer.itemId],
+			});
+
+			const layoutData = {
+				items: {
+					[IDS.form]: form,
+					[existingInput.itemId]: existingInput,
+					[IDS.container]: container,
+					[innerContainer.itemId]: innerContainer,
+				},
+			};
+
+			const fragmentEntryLinks = {
+				[existingInput.config.fragmentEntryLinkId]: {
+					fieldTypes: ['localizationSelect'],
+					fragmentEntryLinkId:
+						existingInput.config.fragmentEntryLinkId,
+					fragmentEntryType: 'input',
+				},
+			};
+
+			expect(
+				checkAllowedChild(
+					innerContainer,
+					container,
+					layoutData,
+					fragmentEntryLinks,
+					() => []
+				).valid
+			).toBe(true);
 		});
 	});
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-46069

Previous PR: https://github.com/brianchandotcom/liferay-portal/pull/157902

The latest commit was added because of: https://github.com/brianchandotcom/liferay-portal/pull/157902#issuecomment-2603649241

FragmentEntryLinksInput was renamed to InputFragmentEntryLinks to align with the existing naming convention for InputFragmentEntry of type Input.

cc @victorg1991