### PR TITLE
Lpd 46807

### DIFF
--- a/modules/util/portal-tools-sample-sql-builder/build.gradle
+++ b/modules/util/portal-tools-sample-sql-builder/build.gradle
@@ -103,6 +103,16 @@ dependencies {
 	compileOnly project(":core:petra:petra-string")
 }
 
+test {
+	configurations.compileInclude.allDependencies.withType(ProjectDependency) {
+		test.dependsOn "${it.dependencyProject.path}:jar"
+	}
+
+	doFirst {
+		classpath = files(configurations.compileInclude.files + classpath)
+	}
+}
+
 writeReleases {
 	dependsOn configurations.compileInclude
 

--- a/modules/util/portal-tools-sample-sql-builder/build.gradle
+++ b/modules/util/portal-tools-sample-sql-builder/build.gradle
@@ -111,7 +111,7 @@ writeReleases {
 
 		List<String> lines = []
 
-		(configurations.compileClasspath + configurations.compileInclude).each {
+		configurations.compileInclude.each {
 			JarFile jarFile = new JarFile(it)
 
 			Attributes mainAttributes = jarFile.manifest.mainAttributes


### PR DESCRIPTION
@drewbrokke I am fixing this just for portal-tools-sample-sql-builder. but I think it is going to become a more general problem as we expand the jakarta test coverage.

To reproduce the issue. Just enable `build.jakarta.transformer.enabled=true` on master without this fix.

Then you will see failures when running `gw jar` and `gw test` for portal-tools-sample-sql-builder. This is caused by the issue you already knew. Due to https://github.com/brianchandotcom/liferay-portal/commit/d192cf3d56cad846964763021402ada0501633a6 , with `build.jakarta.transformer.enabled=true`, bnd is switched to 7.0 for all modules, even for those not opt-in modules. In this case, the `build.jakarta.transformer.include.dirs=` is completely blank.

And bnd 7.0 does not generate jar for project dependency for some reason, the generated class folder is missing all kinds of resource files and MANIFEST.MF comparing to the normal jars, therefore causing many resource lookup failures.