### PR TITLE
LPD-46024 Add defaultLanguageId property to all DSM object definitions

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/resources/com/liferay/frontend/data/set/internal/batch/01-object-definition.batch-engine-data.json
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/resources/com/liferay/frontend/data/set/internal/batch/01-object-definition.batch-engine-data.json
@@ -13,6 +13,7 @@
 	},
 	"items": [
 		{
+			"defaultLanguageId": "en_US",
 			"externalReferenceCode": "L_DATA_SET",
 			"label": {
 				"en_US": "Data Set"
@@ -390,6 +391,7 @@
 			"titleObjectFieldName": "label"
 		},
 		{
+			"defaultLanguageId": "en_US",
 			"enableLocalization": true,
 			"externalReferenceCode": "L_DATA_SET_ACTION",
 			"label": {
@@ -636,6 +638,7 @@
 			"system": true
 		},
 		{
+			"defaultLanguageId": "en_US",
 			"externalReferenceCode": "L_DATA_SET_CARDS_SECTION",
 			"label": {
 				"en_US": "Data Set Cards Section"
@@ -702,6 +705,7 @@
 			"system": true
 		},
 		{
+			"defaultLanguageId": "en_US",
 			"enableLocalization": true,
 			"externalReferenceCode": "L_DATA_SET_CLIENT_EXTENSION_FILTER",
 			"label": {
@@ -772,6 +776,7 @@
 			"system": true
 		},
 		{
+			"defaultLanguageId": "en_US",
 			"enableLocalization": true,
 			"externalReferenceCode": "L_DATA_SET_DATE_FILTER",
 			"label": {
@@ -874,6 +879,7 @@
 			"system": true
 		},
 		{
+			"defaultLanguageId": "en_US",
 			"externalReferenceCode": "L_DATA_SET_LIST_SECTION",
 			"label": {
 				"en_US": "Data Set List Section"
@@ -940,6 +946,7 @@
 			"system": true
 		},
 		{
+			"defaultLanguageId": "en_US",
 			"enableLocalization": true,
 			"externalReferenceCode": "L_DATA_SET_SELECTION_FILTER",
 			"label": {
@@ -1154,6 +1161,7 @@
 			"system": true
 		},
 		{
+			"defaultLanguageId": "en_US",
 			"enableLocalization": true,
 			"externalReferenceCode": "L_DATA_SET_SORT",
 			"label": {
@@ -1240,6 +1248,7 @@
 			"system": true
 		},
 		{
+			"defaultLanguageId": "en_US",
 			"enableLocalization": true,
 			"externalReferenceCode": "L_DATA_SET_TABLE_SECTION",
 			"label": {


### PR DESCRIPTION
Followup of https://github.com/brianchandotcom/liferay-portal/pull/157906

As spoken in Slack, I'm sending the fix in the object definitions JSON file. Test about importing the model belongs to the framework. Alex plans to add new module for testing this and that is the place where the assertions shall go. We'll tell you tomorrow on a call

Thanks

