### PR TITLE
[blocker] LPD-47651 add fixupmessage

### DIFF
--- a/modules/apps/shared-dependencies/shared-dependencies-netty/bnd.bnd
+++ b/modules/apps/shared-dependencies/shared-dependencies-netty/bnd.bnd
@@ -13,3 +13,4 @@ Import-Package:\
 	\
 	*
 -exportcontents: io.netty.*
+-fixupmessages: "^Classes found in the wrong directory: \\\\{META-INF/versions/9/";is:=warning


### PR DESCRIPTION
Hi @brianchandotcom , @tinatian,

This is for the [blocker reported in slack](https://liferay.slack.com/archives/CLCD3DQLF/p1738165152294709?thread_ts=1738164221.018959&cid=CLCD3DQLF)
[this commit](https://github.com/brianchandotcom/liferay-portal/commit/0f745805138d7f23839802d84f2c8a1e4060d97e) (Auto SF) affecting shared-dependencies-netty in [LPD-47045](https://liferay.atlassian.net/browse/LPD-47045). It is because shared-dependencies-netty is used to use `nimbus-jose-jwt:9.37.3` without version 9 stuff, after it was upgrade to `9.40`, it included the `META-INF/versions/9/module-info.class` in its jar.