### PR TITLE
LPD-44159 Rework data set serialization (actions)

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-api/bnd.bnd
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Data Set API
 Bundle-SymbolicName: com.liferay.frontend.data.set.api
-Bundle-Version: 17.1.0
+Bundle-Version: 18.0.0
 Export-Package:\
 	com.liferay.frontend.data.set,\
 	com.liferay.frontend.data.set.action,\

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/action/FDSBulkActionListSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/action/FDSBulkActionListSerializer.java
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.data.set.action;
+
+import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
+import com.liferay.frontend.data.set.serializer.FDSSerializer;
+
+import java.util.List;
+
+/**
+ * @author Daniel Sanz
+ */
+public interface FDSBulkActionListSerializer
+	extends FDSSerializer<List<FDSActionDropdownItem>> {
+
+	@Override
+	public default String getKey() {
+		return "bulkActions";
+	}
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/action/FDSCreationMenu.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/action/FDSCreationMenu.java
@@ -7,20 +7,15 @@ package com.liferay.frontend.data.set.action;
 
 import com.liferay.frontend.data.set.FDSEntryItemImportPolicy;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
-import com.liferay.portal.kernel.exception.PortalException;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 /**
  * @author Daniel Sanz
  */
 public interface FDSCreationMenu {
 
-	public CreationMenu getCreationMenu(
-			HttpServletRequest httpServletRequest,
-			HttpServletResponse httpServletResponse)
-		throws PortalException;
+	public CreationMenu getCreationMenu(HttpServletRequest httpServletRequest);
 
 	public default FDSEntryItemImportPolicy getFDSEntryItemImportPolicy() {
 		return FDSEntryItemImportPolicy.ITEM_PROXY;

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/action/FDSCreationMenuSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/action/FDSCreationMenuSerializer.java
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.data.set.action;
+
+import com.liferay.frontend.data.set.serializer.FDSSerializer;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
+
+/**
+ * @author Daniel Sanz
+ */
+public interface FDSCreationMenuSerializer extends FDSSerializer<CreationMenu> {
+
+	@Override
+	public default String getKey() {
+		return "creationMenu";
+	}
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/action/FDSItemActionList.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/action/FDSItemActionList.java
@@ -7,12 +7,10 @@ package com.liferay.frontend.data.set.action;
 
 import com.liferay.frontend.data.set.FDSEntryItemImportPolicy;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
-import com.liferay.portal.kernel.exception.PortalException;
 
 import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 /**
  * @author Daniel Sanz
@@ -20,9 +18,7 @@ import javax.servlet.http.HttpServletResponse;
 public interface FDSItemActionList {
 
 	public List<FDSActionDropdownItem> getFDSActionDropdownItems(
-			HttpServletRequest httpServletRequest,
-			HttpServletResponse httpServletResponse)
-		throws PortalException;
+		HttpServletRequest httpServletRequest);
 
 	public default FDSEntryItemImportPolicy getFDSEntryItemImportPolicy() {
 		return FDSEntryItemImportPolicy.ITEM_PROXY;

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/action/FDSItemActionListSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/action/FDSItemActionListSerializer.java
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.data.set.action;
+
+import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
+import com.liferay.frontend.data.set.serializer.FDSSerializer;
+
+import java.util.List;
+
+/**
+ * @author Daniel Sanz
+ */
+public interface FDSItemActionListSerializer
+	extends FDSSerializer<List<FDSActionDropdownItem>> {
+
+	@Override
+	public default String getKey() {
+		return "itemsActions";
+	}
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/action/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/action/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 2.0.0

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/action/CustomFDSBulkActionListSerializerImpl.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/action/CustomFDSBulkActionListSerializerImpl.java
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.data.set.internal.action;
+
+import com.liferay.frontend.data.set.action.FDSBulkActionListSerializer;
+import com.liferay.frontend.data.set.internal.serializer.BaseCustomFDSSerializer;
+import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
+import com.liferay.frontend.data.set.serializer.FDSSerializer;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Daniel Sanz
+ */
+@Component(
+	property = "frontend.data.set.serializer.type=" + FDSSerializer.TYPE_CUSTOM,
+	service = FDSBulkActionListSerializer.class
+)
+public class CustomFDSBulkActionListSerializerImpl
+	extends BaseCustomFDSSerializer implements FDSBulkActionListSerializer {
+
+	@Override
+	public List<FDSActionDropdownItem> serialize(
+		String fdsName, HttpServletRequest httpServletRequest) {
+
+		// TODO: add support for bulk actions in the DSM
+
+		return Collections.emptyList();
+	}
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/action/CustomFDSCreationMenuSerializerImpl.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/action/CustomFDSCreationMenuSerializerImpl.java
@@ -1,0 +1,69 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.data.set.internal.action;
+
+import com.liferay.frontend.data.set.action.FDSCreationMenuSerializer;
+import com.liferay.frontend.data.set.internal.serializer.BaseCustomFDSSerializer;
+import com.liferay.frontend.data.set.serializer.FDSSerializer;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemBuilder;
+import com.liferay.object.rest.dto.v1_0.ObjectEntry;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Daniel Sanz
+ * @author Marko Cikos
+ */
+@Component(
+	property = "frontend.data.set.serializer.type=" + FDSSerializer.TYPE_CUSTOM,
+	service = FDSCreationMenuSerializer.class
+)
+public class CustomFDSCreationMenuSerializerImpl
+	extends BaseCustomFDSSerializer implements FDSCreationMenuSerializer {
+
+	@Override
+	public CreationMenu serialize(
+		String fdsName, HttpServletRequest httpServletRequest) {
+
+		CreationMenu creationMenu = new CreationMenu();
+
+		for (ObjectEntry objectEntry :
+				getCreationActionObjectEntries(fdsName, httpServletRequest)) {
+
+			Map<String, Object> properties = objectEntry.getProperties();
+
+			creationMenu.addPrimaryDropdownItem(
+				DropdownItemBuilder.putData(
+					"disableHeader",
+					String.valueOf(Validator.isNull(properties.get("title")))
+				).putData(
+					"permissionKey",
+					String.valueOf(properties.get("permissionKey"))
+				).putData(
+					"size", String.valueOf(properties.get("modalSize"))
+				).putData(
+					"title", String.valueOf(properties.get("title"))
+				).setHref(
+					properties.get("url")
+				).setIcon(
+					String.valueOf(properties.get("icon"))
+				).setLabel(
+					String.valueOf(properties.get("label"))
+				).setTarget(
+					String.valueOf(properties.get("target"))
+				).build());
+		}
+
+		return creationMenu;
+	}
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/action/CustomFDSItemActionListSerializerImpl.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/action/CustomFDSItemActionListSerializerImpl.java
@@ -1,0 +1,80 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.data.set.internal.action;
+
+import com.liferay.frontend.data.set.action.FDSItemActionListSerializer;
+import com.liferay.frontend.data.set.internal.serializer.BaseCustomFDSSerializer;
+import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
+import com.liferay.frontend.data.set.serializer.FDSSerializer;
+import com.liferay.object.rest.dto.v1_0.ObjectEntry;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Daniel Sanz
+ * @author Marko Cikos
+ */
+@Component(
+	property = "frontend.data.set.serializer.type=" + FDSSerializer.TYPE_CUSTOM,
+	service = FDSItemActionListSerializer.class
+)
+public class CustomFDSItemActionListSerializerImpl
+	extends BaseCustomFDSSerializer implements FDSItemActionListSerializer {
+
+	@Override
+	public List<FDSActionDropdownItem> serialize(
+		String fdsName, HttpServletRequest httpServletRequest) {
+
+		List<FDSActionDropdownItem> dropdownItems = new ArrayList<>();
+
+		for (ObjectEntry objectEntry :
+				getItemActionObjectEntries(fdsName, httpServletRequest)) {
+
+			Map<String, Object> properties = objectEntry.getProperties();
+
+			FDSActionDropdownItem fdsActionDropdownItem =
+				new FDSActionDropdownItem(
+					String.valueOf(properties.get("confirmationMessage")),
+					String.valueOf(properties.get("url")),
+					String.valueOf(properties.get("icon")),
+					objectEntry.getExternalReferenceCode(),
+					String.valueOf(properties.get("label")),
+					String.valueOf(properties.get("method")),
+					String.valueOf(properties.get("permissionKey")),
+					String.valueOf(properties.get("target")));
+
+			fdsActionDropdownItem.putData(
+				"disableHeader",
+				(boolean)Validator.isNull(properties.get("title")));
+
+			fdsActionDropdownItem.putData(
+				"errorMessage", properties.get("errorMessage"));
+
+			fdsActionDropdownItem.putData(
+				"requestBody", properties.get("requestBody"));
+
+			fdsActionDropdownItem.putData("size", properties.get("modalSize"));
+
+			fdsActionDropdownItem.putData(
+				"status", properties.get("confirmationMessageType"));
+
+			fdsActionDropdownItem.putData(
+				"successMessage", properties.get("successMessage"));
+
+			dropdownItems.add(fdsActionDropdownItem);
+		}
+
+		return dropdownItems;
+	}
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/action/SystemFDSBulkActionListSerializerImpl.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/action/SystemFDSBulkActionListSerializerImpl.java
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.data.set.internal.action;
+
+import com.liferay.frontend.data.set.action.FDSBulkActionList;
+import com.liferay.frontend.data.set.action.FDSBulkActionListRegistry;
+import com.liferay.frontend.data.set.action.FDSBulkActionListSerializer;
+import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
+import com.liferay.frontend.data.set.serializer.FDSSerializer;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Daniel Sanz
+ */
+@Component(
+	property = "frontend.data.set.serializer.type=" + FDSSerializer.TYPE_SYSTEM,
+	service = FDSBulkActionListSerializer.class
+)
+public class SystemFDSBulkActionListSerializerImpl
+	implements FDSBulkActionListSerializer {
+
+	@Override
+	public List<FDSActionDropdownItem> serialize(
+		String fdsName, HttpServletRequest httpServletRequest) {
+
+		FDSBulkActionList fdsBulkActionList =
+			_fdsBulkActionListRegistry.getFDSBulkActionList(fdsName);
+
+		if (fdsBulkActionList == null) {
+			return Collections.emptyList();
+		}
+
+		return fdsBulkActionList.getFDSActionDropdownItems(httpServletRequest);
+	}
+
+	@Reference
+	private FDSBulkActionListRegistry _fdsBulkActionListRegistry;
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/action/SystemFDSCreationMenuSerializerImpl.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/action/SystemFDSCreationMenuSerializerImpl.java
@@ -1,0 +1,46 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.data.set.internal.action;
+
+import com.liferay.frontend.data.set.action.FDSCreationMenu;
+import com.liferay.frontend.data.set.action.FDSCreationMenuRegistry;
+import com.liferay.frontend.data.set.action.FDSCreationMenuSerializer;
+import com.liferay.frontend.data.set.serializer.FDSSerializer;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Daniel Sanz
+ */
+@Component(
+	property = "frontend.data.set.serializer.type=" + FDSSerializer.TYPE_SYSTEM,
+	service = FDSCreationMenuSerializer.class
+)
+public class SystemFDSCreationMenuSerializerImpl
+	implements FDSCreationMenuSerializer {
+
+	@Override
+	public CreationMenu serialize(
+		String fdsName, HttpServletRequest httpServletRequest) {
+
+		FDSCreationMenu fdsCreationMenu =
+			_fdsCreationMenuRegistry.getFDSCreationMenu(fdsName);
+
+		if (fdsCreationMenu == null) {
+			return new CreationMenu();
+		}
+
+		return fdsCreationMenu.getCreationMenu(httpServletRequest);
+	}
+
+	@Reference
+	private FDSCreationMenuRegistry _fdsCreationMenuRegistry;
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/action/SystemFDSItemActionListSerializerImpl.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/action/SystemFDSItemActionListSerializerImpl.java
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.data.set.internal.action;
+
+import com.liferay.frontend.data.set.action.FDSItemActionList;
+import com.liferay.frontend.data.set.action.FDSItemActionListRegistry;
+import com.liferay.frontend.data.set.action.FDSItemActionListSerializer;
+import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
+import com.liferay.frontend.data.set.serializer.FDSSerializer;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Daniel Sanz
+ */
+@Component(
+	property = "frontend.data.set.serializer.type=" + FDSSerializer.TYPE_SYSTEM,
+	service = FDSItemActionListSerializer.class
+)
+public class SystemFDSItemActionListSerializerImpl
+	implements FDSItemActionListSerializer {
+
+	@Override
+	public List<FDSActionDropdownItem> serialize(
+		String fdsName, HttpServletRequest httpServletRequest) {
+
+		FDSItemActionList fdsItemActionList =
+			_fdsItemActionListRegistry.getFDSItemActionList(fdsName);
+
+		if (fdsItemActionList == null) {
+			return Collections.emptyList();
+		}
+
+		return fdsItemActionList.getFDSActionDropdownItems(httpServletRequest);
+	}
+
+	@Reference
+	private FDSItemActionListRegistry _fdsItemActionListRegistry;
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/BaseCustomFDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/BaseCustomFDSSerializer.java
@@ -95,6 +95,18 @@ public abstract class BaseCustomFDSSerializer {
 			"dataSetToDataSetTableSections");
 	}
 
+	public Set<ObjectEntry> getItemActionObjectEntries(
+		String externalReferenceCode, HttpServletRequest httpServletRequest) {
+
+		return _getSortedRelatedObjectEntries(
+			getDataSetObjectDefinition(httpServletRequest),
+			getDataSetObjectEntry(externalReferenceCode, httpServletRequest),
+			"itemActionsOrder",
+			(ObjectEntry objectEntry) -> Objects.equals(
+				_getType(objectEntry), "item"),
+			"dataSetToDataSetActions");
+	}
+
 	@Reference
 	protected ObjectDefinitionLocalService dataSetObjectDefinitionLocalService;
 

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/BaseCustomFDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/BaseCustomFDSSerializer.java
@@ -31,6 +31,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Predicate;
@@ -43,6 +44,18 @@ import org.osgi.service.component.annotations.Reference;
  * @author Daniel Sanz
  */
 public abstract class BaseCustomFDSSerializer {
+
+	public Set<ObjectEntry> getCreationActionObjectEntries(
+		String externalReferenceCode, HttpServletRequest httpServletRequest) {
+
+		return _getSortedRelatedObjectEntries(
+			getDataSetObjectDefinition(httpServletRequest),
+			getDataSetObjectEntry(externalReferenceCode, httpServletRequest),
+			"creationActionsOrder",
+			(ObjectEntry objectEntry) -> Objects.equals(
+				_getType(objectEntry), "creation"),
+			"dataSetToDataSetActions");
+	}
 
 	public ObjectDefinition getDataSetObjectDefinition(
 		HttpServletRequest httpServletRequest) {
@@ -191,6 +204,12 @@ public abstract class BaseCustomFDSSerializer {
 		}
 
 		return objectEntries;
+	}
+
+	private String _getType(ObjectEntry objectEntry) {
+		Map<String, Object> properties = objectEntry.getProperties();
+
+		return GetterUtil.getString(properties.get("type"));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/BaseSystemFDSSerializerTestCase.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/BaseSystemFDSSerializerTestCase.java
@@ -1,0 +1,112 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.data.set.internal;
+
+import com.liferay.frontend.data.set.SystemFDSEntry;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.After;
+import org.junit.Before;
+
+import org.mockito.Mockito;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Daniel Sanz
+ */
+public abstract class BaseSystemFDSSerializerTestCase {
+
+	@Before
+	public void setUp() throws Exception {
+		bundleContext = SystemBundleUtil.getBundleContext();
+
+		systemFDSEntryserviceTrackerMap =
+			ServiceTrackerMapFactory.openSingleValueMap(
+				bundleContext, SystemFDSEntry.class, "frontend.data.set.name");
+
+		ReflectionTestUtil.setFieldValue(
+			systemFDSEntryRegistryImpl, "_serviceTrackerMap",
+			systemFDSEntryserviceTrackerMap);
+	}
+
+	@After
+	public void tearDown() {
+		systemFDSEntryserviceTrackerMap.close();
+	}
+
+	protected ServiceRegistration<SystemFDSEntry> registerSystemFDSEntry(
+		String fdsName, String restApplication, String restEndpoint,
+		String restSchema) {
+
+		return registerSystemFDSEntry(
+			fdsName, restApplication, restEndpoint, restSchema, null);
+	}
+
+	protected ServiceRegistration<SystemFDSEntry> registerSystemFDSEntry(
+		String fdsName, String restApplication, String restEndpoint,
+		String restSchema, String additionalURLParameters) {
+
+		return bundleContext.registerService(
+			SystemFDSEntry.class,
+			new SystemFDSEntry() {
+
+				@Override
+				public String getAdditionalAPIURLParameters() {
+					return additionalURLParameters;
+				}
+
+				@Override
+				public String getDescription() {
+					return "";
+				}
+
+				@Override
+				public String getName() {
+					return fdsName;
+				}
+
+				@Override
+				public String getRESTApplication() {
+					return restApplication;
+				}
+
+				@Override
+				public String getRESTEndpoint() {
+					return restEndpoint;
+				}
+
+				@Override
+				public String getRESTSchema() {
+					return restSchema;
+				}
+
+				@Override
+				public String getTitle() {
+					return "";
+				}
+
+			},
+			MapUtil.singletonDictionary("frontend.data.set.name", fdsName));
+	}
+
+	protected static BundleContext bundleContext =
+		SystemBundleUtil.getBundleContext();
+	protected static final HttpServletRequest httpServletRequest = Mockito.mock(
+		HttpServletRequest.class);
+	protected static final SystemFDSEntryRegistryImpl
+		systemFDSEntryRegistryImpl = new SystemFDSEntryRegistryImpl();
+	protected static ServiceTrackerMap<String, SystemFDSEntry>
+		systemFDSEntryserviceTrackerMap;
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/BaseSystemFDSSerializerTestCase.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/BaseSystemFDSSerializerTestCase.java
@@ -50,12 +50,12 @@ public abstract class BaseSystemFDSSerializerTestCase {
 		String restSchema) {
 
 		return registerSystemFDSEntry(
-			fdsName, restApplication, restEndpoint, restSchema, null);
+			null, fdsName, restApplication, restEndpoint, restSchema);
 	}
 
 	protected ServiceRegistration<SystemFDSEntry> registerSystemFDSEntry(
-		String fdsName, String restApplication, String restEndpoint,
-		String restSchema, String additionalURLParameters) {
+		String additionalURLParameters, String fdsName, String restApplication,
+		String restEndpoint, String restSchema) {
 
 		return bundleContext.registerService(
 			SystemFDSEntry.class,

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/action/CustomFDSCreationMenuSerializerImplTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/action/CustomFDSCreationMenuSerializerImplTest.java
@@ -41,43 +41,18 @@ public class CustomFDSCreationMenuSerializerImplTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_customFDSCreationMenuSerializerImpl = Mockito.mock(
-			CustomFDSCreationMenuSerializerImpl.class);
+		_resetSerializer();
 	}
 
 	@Test
-	public void testFDSCreationMenuSerialization() throws Exception {
-		_mockFDSCreationActionObjectEntry("fdsName", new String[] {"New"});
+	public void testSerialization() throws Exception {
 
-		CreationMenu creationMenu =
-			_customFDSCreationMenuSerializerImpl.serialize(
-				"fdsName", _httpServletRequest);
+		// different creation menus
 
-		Assert.assertTrue(_containsTitle(creationMenu, "New"));
+		_mockFDSCreationActionObjectEntries(
+			new String[] {"New 1.1", "New 1.2"}, "fdsName1");
 
-		Assert.assertEquals(1, _itemCount(creationMenu));
-	}
-
-	@Test
-	public void testFDSCreationMenuSerializationNoCreationMenu()
-		throws Exception {
-
-		_mockFDSCreationActionObjectEntry("fdsName", null);
-
-		Assert.assertTrue(
-			_customFDSCreationMenuSerializerImpl.serialize(
-				"fdsName", _httpServletRequest
-			).isEmpty());
-	}
-
-	@Test
-	public void testFDSCreationMenuSerializationSeparateCreationMenus()
-		throws Exception {
-
-		_mockFDSCreationActionObjectEntry(
-			"fdsName1", new String[] {"New 1.1", "New 1.2"});
-
-		_mockFDSCreationActionObjectEntry("fdsName2", new String[] {"New 2"});
+		_mockFDSCreationActionObjectEntries(new String[] {"New 2"}, "fdsName2");
 
 		CreationMenu creationMenu1 =
 			_customFDSCreationMenuSerializerImpl.serialize(
@@ -97,18 +72,28 @@ public class CustomFDSCreationMenuSerializerImplTest {
 		Assert.assertFalse(_containsTitle(creationMenu1, "New 2"));
 		Assert.assertFalse(_containsTitle(creationMenu2, "New 1.1"));
 		Assert.assertFalse(_containsTitle(creationMenu2, "New 1.2"));
-	}
 
-	@Test
-	public void testFDSCreationMenuSerializationSharingCreationMenu()
-		throws Exception {
+		_resetSerializer();
+
+		// no creation menu
+
+		_mockFDSCreationActionObjectEntries(null, "fdsName");
+
+		Assert.assertTrue(
+			_customFDSCreationMenuSerializerImpl.serialize(
+				"fdsName", _httpServletRequest
+			).isEmpty());
+
+		_resetSerializer();
+
+		// shared creation menu
 
 		String[] titles = {"New A", "New B"};
 
 		String[] fdsNames = {"fdsName1", "fdsName2"};
 
 		for (String fdsName : fdsNames) {
-			_mockFDSCreationActionObjectEntry(fdsName, titles);
+			_mockFDSCreationActionObjectEntries(titles, fdsName);
 
 			CreationMenu creationMenu =
 				_customFDSCreationMenuSerializerImpl.serialize(
@@ -144,8 +129,8 @@ public class CustomFDSCreationMenuSerializerImplTest {
 		return dropdownItems.size();
 	}
 
-	private void _mockFDSCreationActionObjectEntry(
-		String fdsName, String[] dropdownItemTitles) {
+	private void _mockFDSCreationActionObjectEntries(
+		String[] dropdownItemTitles, String fdsName) {
 
 		Mockito.when(
 			_customFDSCreationMenuSerializerImpl.serialize(
@@ -185,6 +170,11 @@ public class CustomFDSCreationMenuSerializerImplTest {
 		).thenReturn(
 			objectEntries
 		);
+	}
+
+	private void _resetSerializer() {
+		_customFDSCreationMenuSerializerImpl = Mockito.mock(
+			CustomFDSCreationMenuSerializerImpl.class);
 	}
 
 	private static CustomFDSCreationMenuSerializerImpl

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/action/CustomFDSCreationMenuSerializerImplTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/action/CustomFDSCreationMenuSerializerImplTest.java
@@ -1,0 +1,195 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.data.set.internal.action;
+
+import com.liferay.frontend.data.set.internal.serializer.BaseCustomFDSSerializer;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.object.rest.dto.v1_0.ObjectEntry;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Daniel Sanz
+ */
+public class CustomFDSCreationMenuSerializerImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		_customFDSCreationMenuSerializerImpl = Mockito.mock(
+			CustomFDSCreationMenuSerializerImpl.class);
+	}
+
+	@Test
+	public void testFDSCreationMenuSerialization() throws Exception {
+		_mockFDSCreationActionObjectEntry("fdsName", new String[] {"New"});
+
+		CreationMenu creationMenu =
+			_customFDSCreationMenuSerializerImpl.serialize(
+				"fdsName", _httpServletRequest);
+
+		Assert.assertTrue(_containsTitle(creationMenu, "New"));
+
+		Assert.assertEquals(1, _itemCount(creationMenu));
+	}
+
+	@Test
+	public void testFDSCreationMenuSerializationNoCreationMenu()
+		throws Exception {
+
+		_mockFDSCreationActionObjectEntry("fdsName", null);
+
+		Assert.assertTrue(
+			_customFDSCreationMenuSerializerImpl.serialize(
+				"fdsName", _httpServletRequest
+			).isEmpty());
+	}
+
+	@Test
+	public void testFDSCreationMenuSerializationSeparateCreationMenus()
+		throws Exception {
+
+		_mockFDSCreationActionObjectEntry(
+			"fdsName1", new String[] {"New 1.1", "New 1.2"});
+
+		_mockFDSCreationActionObjectEntry("fdsName2", new String[] {"New 2"});
+
+		CreationMenu creationMenu1 =
+			_customFDSCreationMenuSerializerImpl.serialize(
+				"fdsName1", _httpServletRequest);
+
+		CreationMenu creationMenu2 =
+			_customFDSCreationMenuSerializerImpl.serialize(
+				"fdsName2", _httpServletRequest);
+
+		Assert.assertTrue(_containsTitle(creationMenu1, "New 1.1"));
+		Assert.assertTrue(_containsTitle(creationMenu1, "New 1.2"));
+		Assert.assertEquals(2, _itemCount(creationMenu1));
+
+		Assert.assertTrue(_containsTitle(creationMenu2, "New 2"));
+		Assert.assertEquals(1, _itemCount(creationMenu2));
+
+		Assert.assertFalse(_containsTitle(creationMenu1, "New 2"));
+		Assert.assertFalse(_containsTitle(creationMenu2, "New 1.1"));
+		Assert.assertFalse(_containsTitle(creationMenu2, "New 1.2"));
+	}
+
+	@Test
+	public void testFDSCreationMenuSerializationSharingCreationMenu()
+		throws Exception {
+
+		String[] titles = {"New A", "New B"};
+
+		String[] fdsNames = {"fdsName1", "fdsName2"};
+
+		for (String fdsName : fdsNames) {
+			_mockFDSCreationActionObjectEntry(fdsName, titles);
+
+			CreationMenu creationMenu =
+				_customFDSCreationMenuSerializerImpl.serialize(
+					fdsName, _httpServletRequest);
+
+			for (String title : titles) {
+				Assert.assertTrue(_containsTitle(creationMenu, title));
+			}
+
+			Assert.assertEquals(titles.length, _itemCount(creationMenu));
+		}
+	}
+
+	private boolean _containsTitle(CreationMenu creationMenu, String title) {
+		for (DropdownItem dropdownItem :
+				(List<DropdownItem>)creationMenu.get("primaryItems")) {
+
+			Map<String, Object> data = (Map<String, Object>)dropdownItem.get(
+				"data");
+
+			if (title.equals((String)data.get("title"))) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private int _itemCount(CreationMenu creationMenu) {
+		List<DropdownItem> dropdownItems = (List<DropdownItem>)creationMenu.get(
+			"primaryItems");
+
+		return dropdownItems.size();
+	}
+
+	private void _mockFDSCreationActionObjectEntry(
+		String fdsName, String[] dropdownItemTitles) {
+
+		Mockito.when(
+			_customFDSCreationMenuSerializerImpl.serialize(
+				fdsName, _httpServletRequest)
+		).thenCallRealMethod();
+
+		BaseCustomFDSSerializer baseCustomFDSSerializer =
+			(BaseCustomFDSSerializer)_customFDSCreationMenuSerializerImpl;
+
+		if (ArrayUtil.isEmpty(dropdownItemTitles)) {
+			Mockito.when(
+				baseCustomFDSSerializer.getCreationActionObjectEntries(
+					fdsName, _httpServletRequest)
+			).thenReturn(
+				Collections.emptySet()
+			);
+
+			return;
+		}
+
+		Set<ObjectEntry> objectEntries = new HashSet<>();
+
+		for (String dropdownItemTitle : dropdownItemTitles) {
+			ObjectEntry objectEntry = new ObjectEntry();
+
+			objectEntry.setProperties(
+				HashMapBuilder.put(
+					"title", (Object)dropdownItemTitle
+				).build());
+
+			objectEntries.add(objectEntry);
+		}
+
+		Mockito.when(
+			baseCustomFDSSerializer.getCreationActionObjectEntries(
+				fdsName, _httpServletRequest)
+		).thenReturn(
+			objectEntries
+		);
+	}
+
+	private static CustomFDSCreationMenuSerializerImpl
+		_customFDSCreationMenuSerializerImpl;
+	private static final HttpServletRequest _httpServletRequest = Mockito.mock(
+		HttpServletRequest.class);
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/action/CustomFDSItemActionListSerializerImplTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/action/CustomFDSItemActionListSerializerImplTest.java
@@ -1,0 +1,184 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.data.set.internal.action;
+
+import com.liferay.frontend.data.set.internal.serializer.BaseCustomFDSSerializer;
+import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.object.rest.dto.v1_0.ObjectEntry;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Daniel Sanz
+ */
+public class CustomFDSItemActionListSerializerImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		_customFDSItemActionListSerializerImpl = Mockito.mock(
+			CustomFDSItemActionListSerializerImpl.class);
+	}
+
+	@Test
+	public void testFDSItemActionListSerialization() throws Exception {
+		_mockFDSItemActionObjectEntry("fdsName", new String[] {"New"});
+
+		List<FDSActionDropdownItem> actionDropdownItems =
+			_customFDSItemActionListSerializerImpl.serialize(
+				"fdsName", _httpServletRequest);
+
+		Assert.assertTrue(_containsLabel(actionDropdownItems, "New"));
+
+		Assert.assertTrue(actionDropdownItems.size() == 1);
+	}
+
+	@Test
+	public void testFDSItemActionListSerializationNoItemActionList()
+		throws Exception {
+
+		_mockFDSItemActionObjectEntry("fdsName", null);
+
+		Assert.assertTrue(
+			_customFDSItemActionListSerializerImpl.serialize(
+				"fdsName", _httpServletRequest
+			).isEmpty());
+	}
+
+	@Test
+	public void testFDSItemActionListSerializationSeparateItemActionLists()
+		throws Exception {
+
+		_mockFDSItemActionObjectEntry(
+			"fdsName1", new String[] {"New 1.1", "New 1.2"});
+
+		_mockFDSItemActionObjectEntry("fdsName2", new String[] {"New 2"});
+
+		List<FDSActionDropdownItem> actionDropdownItems1 =
+			_customFDSItemActionListSerializerImpl.serialize(
+				"fdsName1", _httpServletRequest);
+
+		List<FDSActionDropdownItem> actionDropdownItems2 =
+			_customFDSItemActionListSerializerImpl.serialize(
+				"fdsName2", _httpServletRequest);
+
+		Assert.assertTrue(_containsLabel(actionDropdownItems1, "New 1.1"));
+		Assert.assertTrue(_containsLabel(actionDropdownItems1, "New 1.2"));
+		Assert.assertTrue(actionDropdownItems1.size() == 2);
+
+		Assert.assertTrue(_containsLabel(actionDropdownItems2, "New 2"));
+		Assert.assertTrue(actionDropdownItems2.size() == 1);
+
+		Assert.assertFalse(_containsLabel(actionDropdownItems1, "New 2"));
+		Assert.assertFalse(_containsLabel(actionDropdownItems2, "New 1.1"));
+		Assert.assertFalse(_containsLabel(actionDropdownItems2, "New 1.2"));
+	}
+
+	@Test
+	public void testFDSItemActionListSerializationSharingItemActionList()
+		throws Exception {
+
+		String[] labels = {"New A", "New B"};
+
+		String[] fdsNames = {"fdsName1", "fdsName2"};
+
+		for (String fdsName : fdsNames) {
+			_mockFDSItemActionObjectEntry(fdsName, labels);
+
+			List<FDSActionDropdownItem> actionDropdownItems =
+				_customFDSItemActionListSerializerImpl.serialize(
+					"fdsName1", _httpServletRequest);
+
+			for (String label : labels) {
+				Assert.assertTrue(_containsLabel(actionDropdownItems, label));
+			}
+
+			Assert.assertTrue(labels.length == actionDropdownItems.size());
+		}
+	}
+
+	private boolean _containsLabel(
+		List<FDSActionDropdownItem> itemActionList, String label) {
+
+		for (DropdownItem dropdownItem : itemActionList) {
+			if (label.equals((String)dropdownItem.get("label"))) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private void _mockFDSItemActionObjectEntry(
+		String fdsName, String[] dropdownItemLabels) {
+
+		Mockito.when(
+			_customFDSItemActionListSerializerImpl.serialize(
+				fdsName, _httpServletRequest)
+		).thenCallRealMethod();
+
+		BaseCustomFDSSerializer baseCustomFDSSerializer =
+			(BaseCustomFDSSerializer)_customFDSItemActionListSerializerImpl;
+
+		if (ArrayUtil.isEmpty(dropdownItemLabels)) {
+			Mockito.when(
+				baseCustomFDSSerializer.getItemActionObjectEntries(
+					fdsName, _httpServletRequest)
+			).thenReturn(
+				Collections.emptySet()
+			);
+
+			return;
+		}
+
+		Set<ObjectEntry> objectEntries = new HashSet<>();
+
+		for (String dropdownItemLabel : dropdownItemLabels) {
+			ObjectEntry objectEntry = new ObjectEntry();
+
+			objectEntry.setProperties(
+				HashMapBuilder.put(
+					"label", (Object)dropdownItemLabel
+				).build());
+
+			objectEntries.add(objectEntry);
+		}
+
+		Mockito.when(
+			baseCustomFDSSerializer.getItemActionObjectEntries(
+				fdsName, _httpServletRequest)
+		).thenReturn(
+			objectEntries
+		);
+	}
+
+	private static CustomFDSItemActionListSerializerImpl
+		_customFDSItemActionListSerializerImpl;
+	private static final HttpServletRequest _httpServletRequest = Mockito.mock(
+		HttpServletRequest.class);
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/action/CustomFDSItemActionListSerializerImplTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/action/CustomFDSItemActionListSerializerImplTest.java
@@ -40,43 +40,18 @@ public class CustomFDSItemActionListSerializerImplTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_customFDSItemActionListSerializerImpl = Mockito.mock(
-			CustomFDSItemActionListSerializerImpl.class);
+		_resetSerializer();
 	}
 
 	@Test
-	public void testFDSItemActionListSerialization() throws Exception {
-		_mockFDSItemActionObjectEntry("fdsName", new String[] {"New"});
+	public void testSerialization() throws Exception {
 
-		List<FDSActionDropdownItem> actionDropdownItems =
-			_customFDSItemActionListSerializerImpl.serialize(
-				"fdsName", _httpServletRequest);
-
-		Assert.assertTrue(_containsLabel(actionDropdownItems, "New"));
-
-		Assert.assertTrue(actionDropdownItems.size() == 1);
-	}
-
-	@Test
-	public void testFDSItemActionListSerializationNoItemActionList()
-		throws Exception {
-
-		_mockFDSItemActionObjectEntry("fdsName", null);
-
-		Assert.assertTrue(
-			_customFDSItemActionListSerializerImpl.serialize(
-				"fdsName", _httpServletRequest
-			).isEmpty());
-	}
-
-	@Test
-	public void testFDSItemActionListSerializationSeparateItemActionLists()
-		throws Exception {
+		// different action lists
 
 		_mockFDSItemActionObjectEntry(
-			"fdsName1", new String[] {"New 1.1", "New 1.2"});
+			new String[] {"New 1.1", "New 1.2"}, "fdsName1");
 
-		_mockFDSItemActionObjectEntry("fdsName2", new String[] {"New 2"});
+		_mockFDSItemActionObjectEntry(new String[] {"New 2"}, "fdsName2");
 
 		List<FDSActionDropdownItem> actionDropdownItems1 =
 			_customFDSItemActionListSerializerImpl.serialize(
@@ -96,22 +71,32 @@ public class CustomFDSItemActionListSerializerImplTest {
 		Assert.assertFalse(_containsLabel(actionDropdownItems1, "New 2"));
 		Assert.assertFalse(_containsLabel(actionDropdownItems2, "New 1.1"));
 		Assert.assertFalse(_containsLabel(actionDropdownItems2, "New 1.2"));
-	}
 
-	@Test
-	public void testFDSItemActionListSerializationSharingItemActionList()
-		throws Exception {
+		_resetSerializer();
+
+		// no item action list
+
+		_mockFDSItemActionObjectEntry(null, "fdsName");
+
+		Assert.assertTrue(
+			_customFDSItemActionListSerializerImpl.serialize(
+				"fdsName", _httpServletRequest
+			).isEmpty());
+
+		_resetSerializer();
+
+		// shared action lists
 
 		String[] labels = {"New A", "New B"};
 
 		String[] fdsNames = {"fdsName1", "fdsName2"};
 
 		for (String fdsName : fdsNames) {
-			_mockFDSItemActionObjectEntry(fdsName, labels);
+			_mockFDSItemActionObjectEntry(labels, fdsName);
 
 			List<FDSActionDropdownItem> actionDropdownItems =
 				_customFDSItemActionListSerializerImpl.serialize(
-					"fdsName1", _httpServletRequest);
+					fdsName, _httpServletRequest);
 
 			for (String label : labels) {
 				Assert.assertTrue(_containsLabel(actionDropdownItems, label));
@@ -134,7 +119,7 @@ public class CustomFDSItemActionListSerializerImplTest {
 	}
 
 	private void _mockFDSItemActionObjectEntry(
-		String fdsName, String[] dropdownItemLabels) {
+		String[] dropdownItemLabels, String fdsName) {
 
 		Mockito.when(
 			_customFDSItemActionListSerializerImpl.serialize(
@@ -174,6 +159,11 @@ public class CustomFDSItemActionListSerializerImplTest {
 		).thenReturn(
 			objectEntries
 		);
+	}
+
+	private void _resetSerializer() throws Exception {
+		_customFDSItemActionListSerializerImpl = Mockito.mock(
+			CustomFDSItemActionListSerializerImpl.class);
 	}
 
 	private static CustomFDSItemActionListSerializerImpl

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/action/SystemFDSBulkActionListSerializerImplTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/action/SystemFDSBulkActionListSerializerImplTest.java
@@ -1,0 +1,301 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.data.set.internal.action;
+
+import com.liferay.frontend.data.set.SystemFDSEntry;
+import com.liferay.frontend.data.set.action.FDSBulkActionList;
+import com.liferay.frontend.data.set.internal.SystemFDSEntryRegistryImpl;
+import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerCustomizerFactory;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Daniel Sanz
+ */
+public class SystemFDSBulkActionListSerializerImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		_bundleContext = SystemBundleUtil.getBundleContext();
+
+		_systemFDSEntryserviceTrackerMap =
+			ServiceTrackerMapFactory.openSingleValueMap(
+				_bundleContext, SystemFDSEntry.class, "frontend.data.set.name");
+
+		ReflectionTestUtil.setFieldValue(
+			_systemFDSEntryRegistryImpl, "_serviceTrackerMap",
+			_systemFDSEntryserviceTrackerMap);
+
+		_bulkActionListServiceTrackerMap =
+			ServiceTrackerMapFactory.openSingleValueMap(
+				_bundleContext, FDSBulkActionList.class,
+				"frontend.data.set.name",
+				ServiceTrackerCustomizerFactory.
+					<FDSBulkActionList>serviceWrapper(_bundleContext));
+
+		ReflectionTestUtil.setFieldValue(
+			_fdsBulkActionListRegistryImpl, "_serviceTrackerMap",
+			_bulkActionListServiceTrackerMap);
+
+		ReflectionTestUtil.setFieldValue(
+			_systemFDSBulkActionListSerializerImpl,
+			"_fdsBulkActionListRegistry", _fdsBulkActionListRegistryImpl);
+	}
+
+	@After
+	public void tearDown() {
+		_bulkActionListServiceTrackerMap.close();
+		_systemFDSEntryserviceTrackerMap.close();
+	}
+
+	@Test
+	public void testFDSBulkActionListSerialization() throws Exception {
+		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration =
+			_registerSystemFDSEntry("fdsName", "/app", "/endpoint", "schema");
+
+		List<FDSActionDropdownItem> dropDownItemList = ListUtil.fromArray(
+			new FDSActionDropdownItem(
+				null, "trash", "delete", "delete", "delete", "delete",
+				"headless"));
+
+		ServiceRegistration<FDSBulkActionList>
+			bulkActionListServiceRegistration = _registerBulkActionList(
+				"fdsName", dropDownItemList);
+
+		Assert.assertEquals(
+			dropDownItemList,
+			_systemFDSBulkActionListSerializerImpl.serialize(
+				"fdsName", _httpServletRequest));
+
+		bulkActionListServiceRegistration.unregister();
+
+		systemFDSEntryServiceRegistration.unregister();
+	}
+
+	@Test
+	public void testFDSBulkActionListSerializationNoBulkActionList()
+		throws Exception {
+
+		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration =
+			_registerSystemFDSEntry("fdsName", "/app", "/endpoint", "schema");
+
+		Assert.assertTrue(
+			_systemFDSBulkActionListSerializerImpl.serialize(
+				"fdsName", _httpServletRequest
+			).isEmpty());
+
+		systemFDSEntryServiceRegistration.unregister();
+	}
+
+	@Test
+	public void testFDSBulkActionListSerializationSeparateBulkActionLists()
+		throws Exception {
+
+		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration1 =
+			_registerSystemFDSEntry("fdsName1", "/app", "/endpoint", "schema");
+
+		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration2 =
+			_registerSystemFDSEntry("fdsName2", "/app", "/endpoint", "schema");
+
+		List<FDSActionDropdownItem> dropDownItemList1 = ListUtil.fromArray(
+			new FDSActionDropdownItem(
+				null, "trash", "delete", "delete", "delete", "delete",
+				"headless"));
+
+		ServiceRegistration<FDSBulkActionList>
+			bulkActionListServiceRegistration1 = _registerBulkActionList(
+				"fdsName1", dropDownItemList1);
+
+		List<FDSActionDropdownItem> dropDownItemList2 = ListUtil.fromArray(
+			new FDSActionDropdownItem(
+				null, "cog", "permissions", "permissions", "get", "permissions",
+				"modal-permissions"));
+
+		ServiceRegistration<FDSBulkActionList>
+			bulkActionListServiceRegistration2 = _registerBulkActionList(
+				"fdsName2", dropDownItemList2);
+
+		Assert.assertNotEquals(
+			_systemFDSBulkActionListSerializerImpl.serialize(
+				"fdsName1", _httpServletRequest),
+			_systemFDSBulkActionListSerializerImpl.serialize(
+				"fdsName2", _httpServletRequest));
+
+		Assert.assertEquals(
+			dropDownItemList1,
+			_systemFDSBulkActionListSerializerImpl.serialize(
+				"fdsName1", _httpServletRequest));
+
+		Assert.assertEquals(
+			dropDownItemList2,
+			_systemFDSBulkActionListSerializerImpl.serialize(
+				"fdsName2", _httpServletRequest));
+
+		bulkActionListServiceRegistration1.unregister();
+
+		bulkActionListServiceRegistration2.unregister();
+
+		systemFDSEntryServiceRegistration1.unregister();
+
+		systemFDSEntryServiceRegistration2.unregister();
+	}
+
+	@Test
+	public void testFDSBulkActionListSerializationSharingBulkActionList()
+		throws Exception {
+
+		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration1 =
+			_registerSystemFDSEntry("fdsName1", "/app", "/endpoint", "schema");
+
+		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration2 =
+			_registerSystemFDSEntry("fdsName2", "/app", "/endpoint", "schema");
+
+		List<FDSActionDropdownItem> dropDownItemList = ListUtil.fromArray(
+			new FDSActionDropdownItem(
+				null, "trash", "delete", "delete", "delete", "delete",
+				"headless"));
+
+		ServiceRegistration<FDSBulkActionList>
+			bulkActionListServiceRegistration1 = _registerBulkActionList(
+				"fdsName1", dropDownItemList);
+
+		ServiceRegistration<FDSBulkActionList>
+			bulkActionListServiceRegistration2 = _registerBulkActionList(
+				"fdsName2", dropDownItemList);
+
+		Assert.assertEquals(
+			_systemFDSBulkActionListSerializerImpl.serialize(
+				"fdsName1", _httpServletRequest),
+			_systemFDSBulkActionListSerializerImpl.serialize(
+				"fdsName2", _httpServletRequest));
+
+		bulkActionListServiceRegistration1.unregister();
+
+		bulkActionListServiceRegistration2.unregister();
+
+		systemFDSEntryServiceRegistration1.unregister();
+
+		systemFDSEntryServiceRegistration2.unregister();
+	}
+
+	private ServiceRegistration<FDSBulkActionList> _registerBulkActionList(
+		String fdsName, List<FDSActionDropdownItem> bulkActions) {
+
+		return _bundleContext.registerService(
+			FDSBulkActionList.class,
+			new FDSBulkActionList() {
+
+				@Override
+				public List<FDSActionDropdownItem> getFDSActionDropdownItems(
+					HttpServletRequest httpServletRequest) {
+
+					return bulkActions;
+				}
+
+			},
+			MapUtil.singletonDictionary("frontend.data.set.name", fdsName));
+	}
+
+	private ServiceRegistration<SystemFDSEntry> _registerSystemFDSEntry(
+		String fdsName, String restApplication, String restEndpoint,
+		String restSchema) {
+
+		return _registerSystemFDSEntry(
+			fdsName, restApplication, restEndpoint, restSchema, null);
+	}
+
+	private ServiceRegistration<SystemFDSEntry> _registerSystemFDSEntry(
+		String fdsName, String restApplication, String restEndpoint,
+		String restSchema, String additionalURLParameters) {
+
+		return _bundleContext.registerService(
+			SystemFDSEntry.class,
+			new SystemFDSEntry() {
+
+				@Override
+				public String getAdditionalAPIURLParameters() {
+					return additionalURLParameters;
+				}
+
+				@Override
+				public String getDescription() {
+					return "";
+				}
+
+				@Override
+				public String getName() {
+					return fdsName;
+				}
+
+				@Override
+				public String getRESTApplication() {
+					return restApplication;
+				}
+
+				@Override
+				public String getRESTEndpoint() {
+					return restEndpoint;
+				}
+
+				@Override
+				public String getRESTSchema() {
+					return restSchema;
+				}
+
+				@Override
+				public String getTitle() {
+					return "";
+				}
+
+			},
+			MapUtil.singletonDictionary("frontend.data.set.name", fdsName));
+	}
+
+	private static ServiceTrackerMap
+		<String,
+		 ServiceTrackerCustomizerFactory.ServiceWrapper<FDSBulkActionList>>
+			_bulkActionListServiceTrackerMap;
+	private static BundleContext _bundleContext;
+	private static final FDSBulkActionListRegistryImpl
+		_fdsBulkActionListRegistryImpl = new FDSBulkActionListRegistryImpl();
+	private static final HttpServletRequest _httpServletRequest = Mockito.mock(
+		HttpServletRequest.class);
+	private static final SystemFDSBulkActionListSerializerImpl
+		_systemFDSBulkActionListSerializerImpl =
+			new SystemFDSBulkActionListSerializerImpl();
+	private static final SystemFDSEntryRegistryImpl
+		_systemFDSEntryRegistryImpl = new SystemFDSEntryRegistryImpl();
+	private static ServiceTrackerMap<String, SystemFDSEntry>
+		_systemFDSEntryserviceTrackerMap;
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/action/SystemFDSBulkActionListSerializerImplTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/action/SystemFDSBulkActionListSerializerImplTest.java
@@ -7,12 +7,11 @@ package com.liferay.frontend.data.set.internal.action;
 
 import com.liferay.frontend.data.set.SystemFDSEntry;
 import com.liferay.frontend.data.set.action.FDSBulkActionList;
-import com.liferay.frontend.data.set.internal.SystemFDSEntryRegistryImpl;
+import com.liferay.frontend.data.set.internal.BaseSystemFDSSerializerTestCase;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerCustomizerFactory;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
-import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -29,15 +28,13 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
-import org.mockito.Mockito;
-
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 
 /**
  * @author Daniel Sanz
  */
-public class SystemFDSBulkActionListSerializerImplTest {
+public class SystemFDSBulkActionListSerializerImplTest
+	extends BaseSystemFDSSerializerTestCase {
 
 	@ClassRule
 	@Rule
@@ -46,22 +43,14 @@ public class SystemFDSBulkActionListSerializerImplTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_bundleContext = SystemBundleUtil.getBundleContext();
-
-		_systemFDSEntryserviceTrackerMap =
-			ServiceTrackerMapFactory.openSingleValueMap(
-				_bundleContext, SystemFDSEntry.class, "frontend.data.set.name");
-
-		ReflectionTestUtil.setFieldValue(
-			_systemFDSEntryRegistryImpl, "_serviceTrackerMap",
-			_systemFDSEntryserviceTrackerMap);
+		super.setUp();
 
 		_bulkActionListServiceTrackerMap =
 			ServiceTrackerMapFactory.openSingleValueMap(
-				_bundleContext, FDSBulkActionList.class,
+				bundleContext, FDSBulkActionList.class,
 				"frontend.data.set.name",
 				ServiceTrackerCustomizerFactory.
-					<FDSBulkActionList>serviceWrapper(_bundleContext));
+					<FDSBulkActionList>serviceWrapper(bundleContext));
 
 		ReflectionTestUtil.setFieldValue(
 			_fdsBulkActionListRegistryImpl, "_serviceTrackerMap",
@@ -74,14 +63,15 @@ public class SystemFDSBulkActionListSerializerImplTest {
 
 	@After
 	public void tearDown() {
+		super.tearDown();
+
 		_bulkActionListServiceTrackerMap.close();
-		_systemFDSEntryserviceTrackerMap.close();
 	}
 
 	@Test
 	public void testFDSBulkActionListSerialization() throws Exception {
 		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration =
-			_registerSystemFDSEntry("fdsName", "/app", "/endpoint", "schema");
+			registerSystemFDSEntry("fdsName", "/app", "/endpoint", "schema");
 
 		List<FDSActionDropdownItem> dropDownItemList = ListUtil.fromArray(
 			new FDSActionDropdownItem(
@@ -95,7 +85,7 @@ public class SystemFDSBulkActionListSerializerImplTest {
 		Assert.assertEquals(
 			dropDownItemList,
 			_systemFDSBulkActionListSerializerImpl.serialize(
-				"fdsName", _httpServletRequest));
+				"fdsName", httpServletRequest));
 
 		bulkActionListServiceRegistration.unregister();
 
@@ -107,11 +97,11 @@ public class SystemFDSBulkActionListSerializerImplTest {
 		throws Exception {
 
 		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration =
-			_registerSystemFDSEntry("fdsName", "/app", "/endpoint", "schema");
+			registerSystemFDSEntry("fdsName", "/app", "/endpoint", "schema");
 
 		Assert.assertTrue(
 			_systemFDSBulkActionListSerializerImpl.serialize(
-				"fdsName", _httpServletRequest
+				"fdsName", httpServletRequest
 			).isEmpty());
 
 		systemFDSEntryServiceRegistration.unregister();
@@ -122,10 +112,10 @@ public class SystemFDSBulkActionListSerializerImplTest {
 		throws Exception {
 
 		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration1 =
-			_registerSystemFDSEntry("fdsName1", "/app", "/endpoint", "schema");
+			registerSystemFDSEntry("fdsName1", "/app", "/endpoint", "schema");
 
 		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration2 =
-			_registerSystemFDSEntry("fdsName2", "/app", "/endpoint", "schema");
+			registerSystemFDSEntry("fdsName2", "/app", "/endpoint", "schema");
 
 		List<FDSActionDropdownItem> dropDownItemList1 = ListUtil.fromArray(
 			new FDSActionDropdownItem(
@@ -147,19 +137,19 @@ public class SystemFDSBulkActionListSerializerImplTest {
 
 		Assert.assertNotEquals(
 			_systemFDSBulkActionListSerializerImpl.serialize(
-				"fdsName1", _httpServletRequest),
+				"fdsName1", httpServletRequest),
 			_systemFDSBulkActionListSerializerImpl.serialize(
-				"fdsName2", _httpServletRequest));
+				"fdsName2", httpServletRequest));
 
 		Assert.assertEquals(
 			dropDownItemList1,
 			_systemFDSBulkActionListSerializerImpl.serialize(
-				"fdsName1", _httpServletRequest));
+				"fdsName1", httpServletRequest));
 
 		Assert.assertEquals(
 			dropDownItemList2,
 			_systemFDSBulkActionListSerializerImpl.serialize(
-				"fdsName2", _httpServletRequest));
+				"fdsName2", httpServletRequest));
 
 		bulkActionListServiceRegistration1.unregister();
 
@@ -175,10 +165,10 @@ public class SystemFDSBulkActionListSerializerImplTest {
 		throws Exception {
 
 		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration1 =
-			_registerSystemFDSEntry("fdsName1", "/app", "/endpoint", "schema");
+			registerSystemFDSEntry("fdsName1", "/app", "/endpoint", "schema");
 
 		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration2 =
-			_registerSystemFDSEntry("fdsName2", "/app", "/endpoint", "schema");
+			registerSystemFDSEntry("fdsName2", "/app", "/endpoint", "schema");
 
 		List<FDSActionDropdownItem> dropDownItemList = ListUtil.fromArray(
 			new FDSActionDropdownItem(
@@ -195,9 +185,9 @@ public class SystemFDSBulkActionListSerializerImplTest {
 
 		Assert.assertEquals(
 			_systemFDSBulkActionListSerializerImpl.serialize(
-				"fdsName1", _httpServletRequest),
+				"fdsName1", httpServletRequest),
 			_systemFDSBulkActionListSerializerImpl.serialize(
-				"fdsName2", _httpServletRequest));
+				"fdsName2", httpServletRequest));
 
 		bulkActionListServiceRegistration1.unregister();
 
@@ -211,7 +201,7 @@ public class SystemFDSBulkActionListSerializerImplTest {
 	private ServiceRegistration<FDSBulkActionList> _registerBulkActionList(
 		String fdsName, List<FDSActionDropdownItem> bulkActions) {
 
-		return _bundleContext.registerService(
+		return bundleContext.registerService(
 			FDSBulkActionList.class,
 			new FDSBulkActionList() {
 
@@ -226,76 +216,14 @@ public class SystemFDSBulkActionListSerializerImplTest {
 			MapUtil.singletonDictionary("frontend.data.set.name", fdsName));
 	}
 
-	private ServiceRegistration<SystemFDSEntry> _registerSystemFDSEntry(
-		String fdsName, String restApplication, String restEndpoint,
-		String restSchema) {
-
-		return _registerSystemFDSEntry(
-			fdsName, restApplication, restEndpoint, restSchema, null);
-	}
-
-	private ServiceRegistration<SystemFDSEntry> _registerSystemFDSEntry(
-		String fdsName, String restApplication, String restEndpoint,
-		String restSchema, String additionalURLParameters) {
-
-		return _bundleContext.registerService(
-			SystemFDSEntry.class,
-			new SystemFDSEntry() {
-
-				@Override
-				public String getAdditionalAPIURLParameters() {
-					return additionalURLParameters;
-				}
-
-				@Override
-				public String getDescription() {
-					return "";
-				}
-
-				@Override
-				public String getName() {
-					return fdsName;
-				}
-
-				@Override
-				public String getRESTApplication() {
-					return restApplication;
-				}
-
-				@Override
-				public String getRESTEndpoint() {
-					return restEndpoint;
-				}
-
-				@Override
-				public String getRESTSchema() {
-					return restSchema;
-				}
-
-				@Override
-				public String getTitle() {
-					return "";
-				}
-
-			},
-			MapUtil.singletonDictionary("frontend.data.set.name", fdsName));
-	}
-
 	private static ServiceTrackerMap
 		<String,
 		 ServiceTrackerCustomizerFactory.ServiceWrapper<FDSBulkActionList>>
 			_bulkActionListServiceTrackerMap;
-	private static BundleContext _bundleContext;
 	private static final FDSBulkActionListRegistryImpl
 		_fdsBulkActionListRegistryImpl = new FDSBulkActionListRegistryImpl();
-	private static final HttpServletRequest _httpServletRequest = Mockito.mock(
-		HttpServletRequest.class);
 	private static final SystemFDSBulkActionListSerializerImpl
 		_systemFDSBulkActionListSerializerImpl =
 			new SystemFDSBulkActionListSerializerImpl();
-	private static final SystemFDSEntryRegistryImpl
-		_systemFDSEntryRegistryImpl = new SystemFDSEntryRegistryImpl();
-	private static ServiceTrackerMap<String, SystemFDSEntry>
-		_systemFDSEntryserviceTrackerMap;
 
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/action/SystemFDSBulkActionListSerializerImplTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/action/SystemFDSBulkActionListSerializerImplTest.java
@@ -69,47 +69,9 @@ public class SystemFDSBulkActionListSerializerImplTest
 	}
 
 	@Test
-	public void testFDSBulkActionListSerialization() throws Exception {
-		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration =
-			registerSystemFDSEntry("fdsName", "/app", "/endpoint", "schema");
+	public void testSerialization() throws Exception {
 
-		List<FDSActionDropdownItem> dropDownItemList = ListUtil.fromArray(
-			new FDSActionDropdownItem(
-				null, "trash", "delete", "delete", "delete", "delete",
-				"headless"));
-
-		ServiceRegistration<FDSBulkActionList>
-			bulkActionListServiceRegistration = _registerBulkActionList(
-				"fdsName", dropDownItemList);
-
-		Assert.assertEquals(
-			dropDownItemList,
-			_systemFDSBulkActionListSerializerImpl.serialize(
-				"fdsName", httpServletRequest));
-
-		bulkActionListServiceRegistration.unregister();
-
-		systemFDSEntryServiceRegistration.unregister();
-	}
-
-	@Test
-	public void testFDSBulkActionListSerializationNoBulkActionList()
-		throws Exception {
-
-		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration =
-			registerSystemFDSEntry("fdsName", "/app", "/endpoint", "schema");
-
-		Assert.assertTrue(
-			_systemFDSBulkActionListSerializerImpl.serialize(
-				"fdsName", httpServletRequest
-			).isEmpty());
-
-		systemFDSEntryServiceRegistration.unregister();
-	}
-
-	@Test
-	public void testFDSBulkActionListSerializationSeparateBulkActionLists()
-		throws Exception {
+		// different bulk action lists
 
 		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration1 =
 			registerSystemFDSEntry("fdsName1", "/app", "/endpoint", "schema");
@@ -124,7 +86,7 @@ public class SystemFDSBulkActionListSerializerImplTest
 
 		ServiceRegistration<FDSBulkActionList>
 			bulkActionListServiceRegistration1 = _registerBulkActionList(
-				"fdsName1", dropDownItemList1);
+				dropDownItemList1, "fdsName1");
 
 		List<FDSActionDropdownItem> dropDownItemList2 = ListUtil.fromArray(
 			new FDSActionDropdownItem(
@@ -133,7 +95,7 @@ public class SystemFDSBulkActionListSerializerImplTest
 
 		ServiceRegistration<FDSBulkActionList>
 			bulkActionListServiceRegistration2 = _registerBulkActionList(
-				"fdsName2", dropDownItemList2);
+				dropDownItemList2, "fdsName2");
 
 		Assert.assertNotEquals(
 			_systemFDSBulkActionListSerializerImpl.serialize(
@@ -158,30 +120,37 @@ public class SystemFDSBulkActionListSerializerImplTest
 		systemFDSEntryServiceRegistration1.unregister();
 
 		systemFDSEntryServiceRegistration2.unregister();
-	}
 
-	@Test
-	public void testFDSBulkActionListSerializationSharingBulkActionList()
-		throws Exception {
+		// no bulk action list
 
-		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration1 =
-			registerSystemFDSEntry("fdsName1", "/app", "/endpoint", "schema");
+		systemFDSEntryServiceRegistration1 = registerSystemFDSEntry(
+			"fdsName", "/app", "/endpoint", "schema");
 
-		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration2 =
-			registerSystemFDSEntry("fdsName2", "/app", "/endpoint", "schema");
+		Assert.assertTrue(
+			_systemFDSBulkActionListSerializerImpl.serialize(
+				"fdsName", httpServletRequest
+			).isEmpty());
 
-		List<FDSActionDropdownItem> dropDownItemList = ListUtil.fromArray(
+		systemFDSEntryServiceRegistration1.unregister();
+
+		// shared bulk action list
+
+		systemFDSEntryServiceRegistration1 = registerSystemFDSEntry(
+			"fdsName1", "/app", "/endpoint", "schema");
+
+		systemFDSEntryServiceRegistration2 = registerSystemFDSEntry(
+			"fdsName2", "/app", "/endpoint", "schema");
+
+		dropDownItemList1 = ListUtil.fromArray(
 			new FDSActionDropdownItem(
 				null, "trash", "delete", "delete", "delete", "delete",
 				"headless"));
 
-		ServiceRegistration<FDSBulkActionList>
-			bulkActionListServiceRegistration1 = _registerBulkActionList(
-				"fdsName1", dropDownItemList);
+		bulkActionListServiceRegistration1 = _registerBulkActionList(
+			dropDownItemList1, "fdsName1");
 
-		ServiceRegistration<FDSBulkActionList>
-			bulkActionListServiceRegistration2 = _registerBulkActionList(
-				"fdsName2", dropDownItemList);
+		bulkActionListServiceRegistration2 = _registerBulkActionList(
+			dropDownItemList1, "fdsName2");
 
 		Assert.assertEquals(
 			_systemFDSBulkActionListSerializerImpl.serialize(
@@ -199,7 +168,7 @@ public class SystemFDSBulkActionListSerializerImplTest
 	}
 
 	private ServiceRegistration<FDSBulkActionList> _registerBulkActionList(
-		String fdsName, List<FDSActionDropdownItem> bulkActions) {
+		List<FDSActionDropdownItem> bulkActions, String fdsName) {
 
 		return bundleContext.registerService(
 			FDSBulkActionList.class,

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/action/SystemFDSCreationMenuSerializerImplTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/action/SystemFDSCreationMenuSerializerImplTest.java
@@ -7,14 +7,13 @@ package com.liferay.frontend.data.set.internal.action;
 
 import com.liferay.frontend.data.set.SystemFDSEntry;
 import com.liferay.frontend.data.set.action.FDSCreationMenu;
-import com.liferay.frontend.data.set.internal.SystemFDSEntryRegistryImpl;
+import com.liferay.frontend.data.set.internal.BaseSystemFDSSerializerTestCase;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenuBuilder;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemBuilder;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerCustomizerFactory;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
-import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -28,15 +27,13 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
-import org.mockito.Mockito;
-
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 
 /**
  * @author Daniel Sanz
  */
-public class SystemFDSCreationMenuSerializerImplTest {
+public class SystemFDSCreationMenuSerializerImplTest
+	extends BaseSystemFDSSerializerTestCase {
 
 	@ClassRule
 	@Rule
@@ -45,21 +42,13 @@ public class SystemFDSCreationMenuSerializerImplTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_bundleContext = SystemBundleUtil.getBundleContext();
-
-		_systemFDSEntryserviceTrackerMap =
-			ServiceTrackerMapFactory.openSingleValueMap(
-				_bundleContext, SystemFDSEntry.class, "frontend.data.set.name");
-
-		ReflectionTestUtil.setFieldValue(
-			_systemFDSEntryRegistryImpl, "_serviceTrackerMap",
-			_systemFDSEntryserviceTrackerMap);
+		super.setUp();
 
 		_creationMenuServiceTrackerMap =
 			ServiceTrackerMapFactory.openSingleValueMap(
-				_bundleContext, FDSCreationMenu.class, "frontend.data.set.name",
+				bundleContext, FDSCreationMenu.class, "frontend.data.set.name",
 				ServiceTrackerCustomizerFactory.<FDSCreationMenu>serviceWrapper(
-					_bundleContext));
+					bundleContext));
 
 		ReflectionTestUtil.setFieldValue(
 			_fdsCreationMenuRegistryImpl, "_serviceTrackerMap",
@@ -72,14 +61,15 @@ public class SystemFDSCreationMenuSerializerImplTest {
 
 	@After
 	public void tearDown() {
+		super.tearDown();
+
 		_creationMenuServiceTrackerMap.close();
-		_systemFDSEntryserviceTrackerMap.close();
 	}
 
 	@Test
 	public void testFDSCreationMenuSerialization() throws Exception {
 		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration =
-			_registerSystemFDSEntry("fdsName", "/app", "/endpoint", "schema");
+			registerSystemFDSEntry("fdsName", "/app", "/endpoint", "schema");
 
 		CreationMenu creationMenu = CreationMenuBuilder.addDropdownItem(
 			DropdownItemBuilder.setIcon(
@@ -93,7 +83,7 @@ public class SystemFDSCreationMenuSerializerImplTest {
 		Assert.assertEquals(
 			creationMenu,
 			_systemFDSCreationMenuSerializerImpl.serialize(
-				"fdsName", _httpServletRequest));
+				"fdsName", httpServletRequest));
 
 		creationMenuServiceRegistration.unregister();
 
@@ -105,11 +95,11 @@ public class SystemFDSCreationMenuSerializerImplTest {
 		throws Exception {
 
 		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration =
-			_registerSystemFDSEntry("fdsName", "/app", "/endpoint", "schema");
+			registerSystemFDSEntry("fdsName", "/app", "/endpoint", "schema");
 
 		Assert.assertTrue(
 			_systemFDSCreationMenuSerializerImpl.serialize(
-				"fdsName", _httpServletRequest
+				"fdsName", httpServletRequest
 			).isEmpty());
 
 		systemFDSEntryServiceRegistration.unregister();
@@ -120,10 +110,10 @@ public class SystemFDSCreationMenuSerializerImplTest {
 		throws Exception {
 
 		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration1 =
-			_registerSystemFDSEntry("fdsName1", "/app", "/endpoint", "schema");
+			registerSystemFDSEntry("fdsName1", "/app", "/endpoint", "schema");
 
 		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration2 =
-			_registerSystemFDSEntry("fdsName2", "/app", "/endpoint", "schema");
+			registerSystemFDSEntry("fdsName2", "/app", "/endpoint", "schema");
 
 		CreationMenu creationMenu1 = CreationMenuBuilder.addDropdownItem(
 			DropdownItemBuilder.setIcon(
@@ -145,19 +135,19 @@ public class SystemFDSCreationMenuSerializerImplTest {
 
 		Assert.assertNotEquals(
 			_systemFDSCreationMenuSerializerImpl.serialize(
-				"fdsName1", _httpServletRequest),
+				"fdsName1", httpServletRequest),
 			_systemFDSCreationMenuSerializerImpl.serialize(
-				"fdsName2", _httpServletRequest));
+				"fdsName2", httpServletRequest));
 
 		Assert.assertEquals(
 			creationMenu1,
 			_systemFDSCreationMenuSerializerImpl.serialize(
-				"fdsName1", _httpServletRequest));
+				"fdsName1", httpServletRequest));
 
 		Assert.assertEquals(
 			creationMenu2,
 			_systemFDSCreationMenuSerializerImpl.serialize(
-				"fdsName2", _httpServletRequest));
+				"fdsName2", httpServletRequest));
 
 		creationMenuServiceRegistration1.unregister();
 
@@ -173,10 +163,10 @@ public class SystemFDSCreationMenuSerializerImplTest {
 		throws Exception {
 
 		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration1 =
-			_registerSystemFDSEntry("fdsName1", "/app", "/endpoint", "schema");
+			registerSystemFDSEntry("fdsName1", "/app", "/endpoint", "schema");
 
 		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration2 =
-			_registerSystemFDSEntry("fdsName2", "/app", "/endpoint", "schema");
+			registerSystemFDSEntry("fdsName2", "/app", "/endpoint", "schema");
 
 		CreationMenu creationMenu = CreationMenuBuilder.addDropdownItem(
 			DropdownItemBuilder.setIcon(
@@ -192,9 +182,9 @@ public class SystemFDSCreationMenuSerializerImplTest {
 
 		Assert.assertEquals(
 			_systemFDSCreationMenuSerializerImpl.serialize(
-				"fdsName1", _httpServletRequest),
+				"fdsName1", httpServletRequest),
 			_systemFDSCreationMenuSerializerImpl.serialize(
-				"fdsName2", _httpServletRequest));
+				"fdsName2", httpServletRequest));
 
 		creationMenuServiceRegistration1.unregister();
 
@@ -208,7 +198,7 @@ public class SystemFDSCreationMenuSerializerImplTest {
 	private ServiceRegistration<FDSCreationMenu> _registerCreationMenu(
 		String fdsName, CreationMenu creationMenu) {
 
-		return _bundleContext.registerService(
+		return bundleContext.registerService(
 			FDSCreationMenu.class,
 			new FDSCreationMenu() {
 
@@ -223,76 +213,14 @@ public class SystemFDSCreationMenuSerializerImplTest {
 			MapUtil.singletonDictionary("frontend.data.set.name", fdsName));
 	}
 
-	private ServiceRegistration<SystemFDSEntry> _registerSystemFDSEntry(
-		String fdsName, String restApplication, String restEndpoint,
-		String restSchema) {
-
-		return _registerSystemFDSEntry(
-			fdsName, restApplication, restEndpoint, restSchema, null);
-	}
-
-	private ServiceRegistration<SystemFDSEntry> _registerSystemFDSEntry(
-		String fdsName, String restApplication, String restEndpoint,
-		String restSchema, String additionalURLParameters) {
-
-		return _bundleContext.registerService(
-			SystemFDSEntry.class,
-			new SystemFDSEntry() {
-
-				@Override
-				public String getAdditionalAPIURLParameters() {
-					return additionalURLParameters;
-				}
-
-				@Override
-				public String getDescription() {
-					return "";
-				}
-
-				@Override
-				public String getName() {
-					return fdsName;
-				}
-
-				@Override
-				public String getRESTApplication() {
-					return restApplication;
-				}
-
-				@Override
-				public String getRESTEndpoint() {
-					return restEndpoint;
-				}
-
-				@Override
-				public String getRESTSchema() {
-					return restSchema;
-				}
-
-				@Override
-				public String getTitle() {
-					return "";
-				}
-
-			},
-			MapUtil.singletonDictionary("frontend.data.set.name", fdsName));
-	}
-
-	private static BundleContext _bundleContext;
 	private static ServiceTrackerMap
 		<String,
 		 ServiceTrackerCustomizerFactory.ServiceWrapper<FDSCreationMenu>>
 			_creationMenuServiceTrackerMap;
 	private static final FDSCreationMenuRegistryImpl
 		_fdsCreationMenuRegistryImpl = new FDSCreationMenuRegistryImpl();
-	private static final HttpServletRequest _httpServletRequest = Mockito.mock(
-		HttpServletRequest.class);
 	private static final SystemFDSCreationMenuSerializerImpl
 		_systemFDSCreationMenuSerializerImpl =
 			new SystemFDSCreationMenuSerializerImpl();
-	private static final SystemFDSEntryRegistryImpl
-		_systemFDSEntryRegistryImpl = new SystemFDSEntryRegistryImpl();
-	private static ServiceTrackerMap<String, SystemFDSEntry>
-		_systemFDSEntryserviceTrackerMap;
 
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/action/SystemFDSCreationMenuSerializerImplTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/action/SystemFDSCreationMenuSerializerImplTest.java
@@ -1,0 +1,298 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.data.set.internal.action;
+
+import com.liferay.frontend.data.set.SystemFDSEntry;
+import com.liferay.frontend.data.set.action.FDSCreationMenu;
+import com.liferay.frontend.data.set.internal.SystemFDSEntryRegistryImpl;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenuBuilder;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemBuilder;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerCustomizerFactory;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Daniel Sanz
+ */
+public class SystemFDSCreationMenuSerializerImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		_bundleContext = SystemBundleUtil.getBundleContext();
+
+		_systemFDSEntryserviceTrackerMap =
+			ServiceTrackerMapFactory.openSingleValueMap(
+				_bundleContext, SystemFDSEntry.class, "frontend.data.set.name");
+
+		ReflectionTestUtil.setFieldValue(
+			_systemFDSEntryRegistryImpl, "_serviceTrackerMap",
+			_systemFDSEntryserviceTrackerMap);
+
+		_creationMenuServiceTrackerMap =
+			ServiceTrackerMapFactory.openSingleValueMap(
+				_bundleContext, FDSCreationMenu.class, "frontend.data.set.name",
+				ServiceTrackerCustomizerFactory.<FDSCreationMenu>serviceWrapper(
+					_bundleContext));
+
+		ReflectionTestUtil.setFieldValue(
+			_fdsCreationMenuRegistryImpl, "_serviceTrackerMap",
+			_creationMenuServiceTrackerMap);
+
+		ReflectionTestUtil.setFieldValue(
+			_systemFDSCreationMenuSerializerImpl, "_fdsCreationMenuRegistry",
+			_fdsCreationMenuRegistryImpl);
+	}
+
+	@After
+	public void tearDown() {
+		_creationMenuServiceTrackerMap.close();
+		_systemFDSEntryserviceTrackerMap.close();
+	}
+
+	@Test
+	public void testFDSCreationMenuSerialization() throws Exception {
+		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration =
+			_registerSystemFDSEntry("fdsName", "/app", "/endpoint", "schema");
+
+		CreationMenu creationMenu = CreationMenuBuilder.addDropdownItem(
+			DropdownItemBuilder.setIcon(
+				"times"
+			).build()
+		).build();
+
+		ServiceRegistration<FDSCreationMenu> creationMenuServiceRegistration =
+			_registerCreationMenu("fdsName", creationMenu);
+
+		Assert.assertEquals(
+			creationMenu,
+			_systemFDSCreationMenuSerializerImpl.serialize(
+				"fdsName", _httpServletRequest));
+
+		creationMenuServiceRegistration.unregister();
+
+		systemFDSEntryServiceRegistration.unregister();
+	}
+
+	@Test
+	public void testFDSCreationMenuSerializationNoCreationMenu()
+		throws Exception {
+
+		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration =
+			_registerSystemFDSEntry("fdsName", "/app", "/endpoint", "schema");
+
+		Assert.assertTrue(
+			_systemFDSCreationMenuSerializerImpl.serialize(
+				"fdsName", _httpServletRequest
+			).isEmpty());
+
+		systemFDSEntryServiceRegistration.unregister();
+	}
+
+	@Test
+	public void testFDSCreationMenuSerializationSeparateCreationMenus()
+		throws Exception {
+
+		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration1 =
+			_registerSystemFDSEntry("fdsName1", "/app", "/endpoint", "schema");
+
+		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration2 =
+			_registerSystemFDSEntry("fdsName2", "/app", "/endpoint", "schema");
+
+		CreationMenu creationMenu1 = CreationMenuBuilder.addDropdownItem(
+			DropdownItemBuilder.setIcon(
+				"times"
+			).build()
+		).build();
+
+		ServiceRegistration<FDSCreationMenu> creationMenuServiceRegistration1 =
+			_registerCreationMenu("fdsName1", creationMenu1);
+
+		CreationMenu creationMenu2 = CreationMenuBuilder.addDropdownItem(
+			DropdownItemBuilder.setIcon(
+				"cog"
+			).build()
+		).build();
+
+		ServiceRegistration<FDSCreationMenu> creationMenuServiceRegistration2 =
+			_registerCreationMenu("fdsName2", creationMenu2);
+
+		Assert.assertNotEquals(
+			_systemFDSCreationMenuSerializerImpl.serialize(
+				"fdsName1", _httpServletRequest),
+			_systemFDSCreationMenuSerializerImpl.serialize(
+				"fdsName2", _httpServletRequest));
+
+		Assert.assertEquals(
+			creationMenu1,
+			_systemFDSCreationMenuSerializerImpl.serialize(
+				"fdsName1", _httpServletRequest));
+
+		Assert.assertEquals(
+			creationMenu2,
+			_systemFDSCreationMenuSerializerImpl.serialize(
+				"fdsName2", _httpServletRequest));
+
+		creationMenuServiceRegistration1.unregister();
+
+		creationMenuServiceRegistration2.unregister();
+
+		systemFDSEntryServiceRegistration1.unregister();
+
+		systemFDSEntryServiceRegistration2.unregister();
+	}
+
+	@Test
+	public void testFDSCreationMenuSerializationSharingCreationMenu()
+		throws Exception {
+
+		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration1 =
+			_registerSystemFDSEntry("fdsName1", "/app", "/endpoint", "schema");
+
+		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration2 =
+			_registerSystemFDSEntry("fdsName2", "/app", "/endpoint", "schema");
+
+		CreationMenu creationMenu = CreationMenuBuilder.addDropdownItem(
+			DropdownItemBuilder.setIcon(
+				"times"
+			).build()
+		).build();
+
+		ServiceRegistration<FDSCreationMenu> creationMenuServiceRegistration1 =
+			_registerCreationMenu("fdsName1", creationMenu);
+
+		ServiceRegistration<FDSCreationMenu> creationMenuServiceRegistration2 =
+			_registerCreationMenu("fdsName2", creationMenu);
+
+		Assert.assertEquals(
+			_systemFDSCreationMenuSerializerImpl.serialize(
+				"fdsName1", _httpServletRequest),
+			_systemFDSCreationMenuSerializerImpl.serialize(
+				"fdsName2", _httpServletRequest));
+
+		creationMenuServiceRegistration1.unregister();
+
+		creationMenuServiceRegistration2.unregister();
+
+		systemFDSEntryServiceRegistration1.unregister();
+
+		systemFDSEntryServiceRegistration2.unregister();
+	}
+
+	private ServiceRegistration<FDSCreationMenu> _registerCreationMenu(
+		String fdsName, CreationMenu creationMenu) {
+
+		return _bundleContext.registerService(
+			FDSCreationMenu.class,
+			new FDSCreationMenu() {
+
+				@Override
+				public CreationMenu getCreationMenu(
+					HttpServletRequest httpServletRequest) {
+
+					return creationMenu;
+				}
+
+			},
+			MapUtil.singletonDictionary("frontend.data.set.name", fdsName));
+	}
+
+	private ServiceRegistration<SystemFDSEntry> _registerSystemFDSEntry(
+		String fdsName, String restApplication, String restEndpoint,
+		String restSchema) {
+
+		return _registerSystemFDSEntry(
+			fdsName, restApplication, restEndpoint, restSchema, null);
+	}
+
+	private ServiceRegistration<SystemFDSEntry> _registerSystemFDSEntry(
+		String fdsName, String restApplication, String restEndpoint,
+		String restSchema, String additionalURLParameters) {
+
+		return _bundleContext.registerService(
+			SystemFDSEntry.class,
+			new SystemFDSEntry() {
+
+				@Override
+				public String getAdditionalAPIURLParameters() {
+					return additionalURLParameters;
+				}
+
+				@Override
+				public String getDescription() {
+					return "";
+				}
+
+				@Override
+				public String getName() {
+					return fdsName;
+				}
+
+				@Override
+				public String getRESTApplication() {
+					return restApplication;
+				}
+
+				@Override
+				public String getRESTEndpoint() {
+					return restEndpoint;
+				}
+
+				@Override
+				public String getRESTSchema() {
+					return restSchema;
+				}
+
+				@Override
+				public String getTitle() {
+					return "";
+				}
+
+			},
+			MapUtil.singletonDictionary("frontend.data.set.name", fdsName));
+	}
+
+	private static BundleContext _bundleContext;
+	private static ServiceTrackerMap
+		<String,
+		 ServiceTrackerCustomizerFactory.ServiceWrapper<FDSCreationMenu>>
+			_creationMenuServiceTrackerMap;
+	private static final FDSCreationMenuRegistryImpl
+		_fdsCreationMenuRegistryImpl = new FDSCreationMenuRegistryImpl();
+	private static final HttpServletRequest _httpServletRequest = Mockito.mock(
+		HttpServletRequest.class);
+	private static final SystemFDSCreationMenuSerializerImpl
+		_systemFDSCreationMenuSerializerImpl =
+			new SystemFDSCreationMenuSerializerImpl();
+	private static final SystemFDSEntryRegistryImpl
+		_systemFDSEntryRegistryImpl = new SystemFDSEntryRegistryImpl();
+	private static ServiceTrackerMap<String, SystemFDSEntry>
+		_systemFDSEntryserviceTrackerMap;
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/action/SystemFDSCreationMenuSerializerImplTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/action/SystemFDSCreationMenuSerializerImplTest.java
@@ -67,47 +67,9 @@ public class SystemFDSCreationMenuSerializerImplTest
 	}
 
 	@Test
-	public void testFDSCreationMenuSerialization() throws Exception {
-		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration =
-			registerSystemFDSEntry("fdsName", "/app", "/endpoint", "schema");
+	public void testSerialization() throws Exception {
 
-		CreationMenu creationMenu = CreationMenuBuilder.addDropdownItem(
-			DropdownItemBuilder.setIcon(
-				"times"
-			).build()
-		).build();
-
-		ServiceRegistration<FDSCreationMenu> creationMenuServiceRegistration =
-			_registerCreationMenu("fdsName", creationMenu);
-
-		Assert.assertEquals(
-			creationMenu,
-			_systemFDSCreationMenuSerializerImpl.serialize(
-				"fdsName", httpServletRequest));
-
-		creationMenuServiceRegistration.unregister();
-
-		systemFDSEntryServiceRegistration.unregister();
-	}
-
-	@Test
-	public void testFDSCreationMenuSerializationNoCreationMenu()
-		throws Exception {
-
-		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration =
-			registerSystemFDSEntry("fdsName", "/app", "/endpoint", "schema");
-
-		Assert.assertTrue(
-			_systemFDSCreationMenuSerializerImpl.serialize(
-				"fdsName", httpServletRequest
-			).isEmpty());
-
-		systemFDSEntryServiceRegistration.unregister();
-	}
-
-	@Test
-	public void testFDSCreationMenuSerializationSeparateCreationMenus()
-		throws Exception {
+		// different creation menus
 
 		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration1 =
 			registerSystemFDSEntry("fdsName1", "/app", "/endpoint", "schema");
@@ -122,7 +84,7 @@ public class SystemFDSCreationMenuSerializerImplTest
 		).build();
 
 		ServiceRegistration<FDSCreationMenu> creationMenuServiceRegistration1 =
-			_registerCreationMenu("fdsName1", creationMenu1);
+			_registerCreationMenu(creationMenu1, "fdsName1");
 
 		CreationMenu creationMenu2 = CreationMenuBuilder.addDropdownItem(
 			DropdownItemBuilder.setIcon(
@@ -131,7 +93,7 @@ public class SystemFDSCreationMenuSerializerImplTest
 		).build();
 
 		ServiceRegistration<FDSCreationMenu> creationMenuServiceRegistration2 =
-			_registerCreationMenu("fdsName2", creationMenu2);
+			_registerCreationMenu(creationMenu2, "fdsName2");
 
 		Assert.assertNotEquals(
 			_systemFDSCreationMenuSerializerImpl.serialize(
@@ -156,29 +118,38 @@ public class SystemFDSCreationMenuSerializerImplTest
 		systemFDSEntryServiceRegistration1.unregister();
 
 		systemFDSEntryServiceRegistration2.unregister();
-	}
 
-	@Test
-	public void testFDSCreationMenuSerializationSharingCreationMenu()
-		throws Exception {
+		// no creation menu
 
-		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration1 =
-			registerSystemFDSEntry("fdsName1", "/app", "/endpoint", "schema");
+		systemFDSEntryServiceRegistration1 = registerSystemFDSEntry(
+			"fdsName", "/app", "/endpoint", "schema");
 
-		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration2 =
-			registerSystemFDSEntry("fdsName2", "/app", "/endpoint", "schema");
+		Assert.assertTrue(
+			_systemFDSCreationMenuSerializerImpl.serialize(
+				"fdsName", httpServletRequest
+			).isEmpty());
 
-		CreationMenu creationMenu = CreationMenuBuilder.addDropdownItem(
+		systemFDSEntryServiceRegistration1.unregister();
+
+		// shared creation menu
+
+		systemFDSEntryServiceRegistration1 = registerSystemFDSEntry(
+			"fdsName1", "/app", "/endpoint", "schema");
+
+		systemFDSEntryServiceRegistration2 = registerSystemFDSEntry(
+			"fdsName2", "/app", "/endpoint", "schema");
+
+		creationMenu1 = CreationMenuBuilder.addDropdownItem(
 			DropdownItemBuilder.setIcon(
 				"times"
 			).build()
 		).build();
 
-		ServiceRegistration<FDSCreationMenu> creationMenuServiceRegistration1 =
-			_registerCreationMenu("fdsName1", creationMenu);
+		creationMenuServiceRegistration1 = _registerCreationMenu(
+			creationMenu1, "fdsName1");
 
-		ServiceRegistration<FDSCreationMenu> creationMenuServiceRegistration2 =
-			_registerCreationMenu("fdsName2", creationMenu);
+		creationMenuServiceRegistration2 = _registerCreationMenu(
+			creationMenu1, "fdsName2");
 
 		Assert.assertEquals(
 			_systemFDSCreationMenuSerializerImpl.serialize(
@@ -196,7 +167,7 @@ public class SystemFDSCreationMenuSerializerImplTest
 	}
 
 	private ServiceRegistration<FDSCreationMenu> _registerCreationMenu(
-		String fdsName, CreationMenu creationMenu) {
+		CreationMenu creationMenu, String fdsName) {
 
 		return bundleContext.registerService(
 			FDSCreationMenu.class,

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/action/SystemFDSItemActionListSerializerImplTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/action/SystemFDSItemActionListSerializerImplTest.java
@@ -1,0 +1,301 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.data.set.internal.action;
+
+import com.liferay.frontend.data.set.SystemFDSEntry;
+import com.liferay.frontend.data.set.action.FDSItemActionList;
+import com.liferay.frontend.data.set.internal.SystemFDSEntryRegistryImpl;
+import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerCustomizerFactory;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Daniel Sanz
+ */
+public class SystemFDSItemActionListSerializerImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		_bundleContext = SystemBundleUtil.getBundleContext();
+
+		_systemFDSEntryserviceTrackerMap =
+			ServiceTrackerMapFactory.openSingleValueMap(
+				_bundleContext, SystemFDSEntry.class, "frontend.data.set.name");
+
+		ReflectionTestUtil.setFieldValue(
+			_systemFDSEntryRegistryImpl, "_serviceTrackerMap",
+			_systemFDSEntryserviceTrackerMap);
+
+		_itemActionListServiceTrackerMap =
+			ServiceTrackerMapFactory.openSingleValueMap(
+				_bundleContext, FDSItemActionList.class,
+				"frontend.data.set.name",
+				ServiceTrackerCustomizerFactory.
+					<FDSItemActionList>serviceWrapper(_bundleContext));
+
+		ReflectionTestUtil.setFieldValue(
+			_fdsItemActionListRegistryImpl, "_serviceTrackerMap",
+			_itemActionListServiceTrackerMap);
+
+		ReflectionTestUtil.setFieldValue(
+			_systemFDSItemActionListSerializerImpl,
+			"_fdsItemActionListRegistry", _fdsItemActionListRegistryImpl);
+	}
+
+	@After
+	public void tearDown() {
+		_itemActionListServiceTrackerMap.close();
+		_systemFDSEntryserviceTrackerMap.close();
+	}
+
+	@Test
+	public void testFDSCreationMenuSerialization() throws Exception {
+		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration =
+			_registerSystemFDSEntry("fdsName", "/app", "/endpoint", "schema");
+
+		List<FDSActionDropdownItem> dropDownItemList = ListUtil.fromArray(
+			new FDSActionDropdownItem(
+				null, "trash", "delete", "delete", "delete", "delete",
+				"headless"));
+
+		ServiceRegistration<FDSItemActionList>
+			itemActionListServiceRegistration = _registerItemActionList(
+				"fdsName", dropDownItemList);
+
+		Assert.assertEquals(
+			dropDownItemList,
+			_systemFDSItemActionListSerializerImpl.serialize(
+				"fdsName", _httpServletRequest));
+
+		itemActionListServiceRegistration.unregister();
+
+		systemFDSEntryServiceRegistration.unregister();
+	}
+
+	@Test
+	public void testFDSCreationMenuSerializationNoCreationMenu()
+		throws Exception {
+
+		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration =
+			_registerSystemFDSEntry("fdsName", "/app", "/endpoint", "schema");
+
+		Assert.assertTrue(
+			_systemFDSItemActionListSerializerImpl.serialize(
+				"fdsName", _httpServletRequest
+			).isEmpty());
+
+		systemFDSEntryServiceRegistration.unregister();
+	}
+
+	@Test
+	public void testFDSCreationMenuSerializationSeparateCreationMenus()
+		throws Exception {
+
+		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration1 =
+			_registerSystemFDSEntry("fdsName1", "/app", "/endpoint", "schema");
+
+		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration2 =
+			_registerSystemFDSEntry("fdsName2", "/app", "/endpoint", "schema");
+
+		List<FDSActionDropdownItem> dropDownItemList1 = ListUtil.fromArray(
+			new FDSActionDropdownItem(
+				null, "trash", "delete", "delete", "delete", "delete",
+				"headless"));
+
+		ServiceRegistration<FDSItemActionList>
+			itemActionListServiceRegistration1 = _registerItemActionList(
+				"fdsName1", dropDownItemList1);
+
+		List<FDSActionDropdownItem> dropDownItemList2 = ListUtil.fromArray(
+			new FDSActionDropdownItem(
+				null, "cog", "permissions", "permissions", "get", "permissions",
+				"modal-permissions"));
+
+		ServiceRegistration<FDSItemActionList>
+			itemActionListServiceRegistration2 = _registerItemActionList(
+				"fdsName2", dropDownItemList2);
+
+		Assert.assertNotEquals(
+			_systemFDSItemActionListSerializerImpl.serialize(
+				"fdsName1", _httpServletRequest),
+			_systemFDSItemActionListSerializerImpl.serialize(
+				"fdsName2", _httpServletRequest));
+
+		Assert.assertEquals(
+			dropDownItemList1,
+			_systemFDSItemActionListSerializerImpl.serialize(
+				"fdsName1", _httpServletRequest));
+
+		Assert.assertEquals(
+			dropDownItemList2,
+			_systemFDSItemActionListSerializerImpl.serialize(
+				"fdsName2", _httpServletRequest));
+
+		itemActionListServiceRegistration1.unregister();
+
+		itemActionListServiceRegistration2.unregister();
+
+		systemFDSEntryServiceRegistration1.unregister();
+
+		systemFDSEntryServiceRegistration2.unregister();
+	}
+
+	@Test
+	public void testFDSCreationMenuSerializationSharingCreationMenu()
+		throws Exception {
+
+		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration1 =
+			_registerSystemFDSEntry("fdsName1", "/app", "/endpoint", "schema");
+
+		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration2 =
+			_registerSystemFDSEntry("fdsName2", "/app", "/endpoint", "schema");
+
+		List<FDSActionDropdownItem> dropDownItemList = ListUtil.fromArray(
+			new FDSActionDropdownItem(
+				null, "trash", "delete", "delete", "delete", "delete",
+				"headless"));
+
+		ServiceRegistration<FDSItemActionList>
+			itemActionListServiceRegistration1 = _registerItemActionList(
+				"fdsName1", dropDownItemList);
+
+		ServiceRegistration<FDSItemActionList>
+			itemActionListServiceRegistration2 = _registerItemActionList(
+				"fdsName2", dropDownItemList);
+
+		Assert.assertEquals(
+			_systemFDSItemActionListSerializerImpl.serialize(
+				"fdsName1", _httpServletRequest),
+			_systemFDSItemActionListSerializerImpl.serialize(
+				"fdsName2", _httpServletRequest));
+
+		itemActionListServiceRegistration1.unregister();
+
+		itemActionListServiceRegistration2.unregister();
+
+		systemFDSEntryServiceRegistration1.unregister();
+
+		systemFDSEntryServiceRegistration2.unregister();
+	}
+
+	private ServiceRegistration<FDSItemActionList> _registerItemActionList(
+		String fdsName, List<FDSActionDropdownItem> itemActions) {
+
+		return _bundleContext.registerService(
+			FDSItemActionList.class,
+			new FDSItemActionList() {
+
+				@Override
+				public List<FDSActionDropdownItem> getFDSActionDropdownItems(
+					HttpServletRequest httpServletRequest) {
+
+					return itemActions;
+				}
+
+			},
+			MapUtil.singletonDictionary("frontend.data.set.name", fdsName));
+	}
+
+	private ServiceRegistration<SystemFDSEntry> _registerSystemFDSEntry(
+		String fdsName, String restApplication, String restEndpoint,
+		String restSchema) {
+
+		return _registerSystemFDSEntry(
+			fdsName, restApplication, restEndpoint, restSchema, null);
+	}
+
+	private ServiceRegistration<SystemFDSEntry> _registerSystemFDSEntry(
+		String fdsName, String restApplication, String restEndpoint,
+		String restSchema, String additionalURLParameters) {
+
+		return _bundleContext.registerService(
+			SystemFDSEntry.class,
+			new SystemFDSEntry() {
+
+				@Override
+				public String getAdditionalAPIURLParameters() {
+					return additionalURLParameters;
+				}
+
+				@Override
+				public String getDescription() {
+					return "";
+				}
+
+				@Override
+				public String getName() {
+					return fdsName;
+				}
+
+				@Override
+				public String getRESTApplication() {
+					return restApplication;
+				}
+
+				@Override
+				public String getRESTEndpoint() {
+					return restEndpoint;
+				}
+
+				@Override
+				public String getRESTSchema() {
+					return restSchema;
+				}
+
+				@Override
+				public String getTitle() {
+					return "";
+				}
+
+			},
+			MapUtil.singletonDictionary("frontend.data.set.name", fdsName));
+	}
+
+	private static BundleContext _bundleContext;
+	private static final FDSItemActionListRegistryImpl
+		_fdsItemActionListRegistryImpl = new FDSItemActionListRegistryImpl();
+	private static final HttpServletRequest _httpServletRequest = Mockito.mock(
+		HttpServletRequest.class);
+	private static ServiceTrackerMap
+		<String,
+		 ServiceTrackerCustomizerFactory.ServiceWrapper<FDSItemActionList>>
+			_itemActionListServiceTrackerMap;
+	private static final SystemFDSEntryRegistryImpl
+		_systemFDSEntryRegistryImpl = new SystemFDSEntryRegistryImpl();
+	private static ServiceTrackerMap<String, SystemFDSEntry>
+		_systemFDSEntryserviceTrackerMap;
+	private static final SystemFDSItemActionListSerializerImpl
+		_systemFDSItemActionListSerializerImpl =
+			new SystemFDSItemActionListSerializerImpl();
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/action/SystemFDSItemActionListSerializerImplTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/action/SystemFDSItemActionListSerializerImplTest.java
@@ -7,12 +7,11 @@ package com.liferay.frontend.data.set.internal.action;
 
 import com.liferay.frontend.data.set.SystemFDSEntry;
 import com.liferay.frontend.data.set.action.FDSItemActionList;
-import com.liferay.frontend.data.set.internal.SystemFDSEntryRegistryImpl;
+import com.liferay.frontend.data.set.internal.BaseSystemFDSSerializerTestCase;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerCustomizerFactory;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
-import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -29,15 +28,13 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
-import org.mockito.Mockito;
-
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 
 /**
  * @author Daniel Sanz
  */
-public class SystemFDSItemActionListSerializerImplTest {
+public class SystemFDSItemActionListSerializerImplTest
+	extends BaseSystemFDSSerializerTestCase {
 
 	@ClassRule
 	@Rule
@@ -46,22 +43,14 @@ public class SystemFDSItemActionListSerializerImplTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_bundleContext = SystemBundleUtil.getBundleContext();
-
-		_systemFDSEntryserviceTrackerMap =
-			ServiceTrackerMapFactory.openSingleValueMap(
-				_bundleContext, SystemFDSEntry.class, "frontend.data.set.name");
-
-		ReflectionTestUtil.setFieldValue(
-			_systemFDSEntryRegistryImpl, "_serviceTrackerMap",
-			_systemFDSEntryserviceTrackerMap);
+		super.setUp();
 
 		_itemActionListServiceTrackerMap =
 			ServiceTrackerMapFactory.openSingleValueMap(
-				_bundleContext, FDSItemActionList.class,
+				bundleContext, FDSItemActionList.class,
 				"frontend.data.set.name",
 				ServiceTrackerCustomizerFactory.
-					<FDSItemActionList>serviceWrapper(_bundleContext));
+					<FDSItemActionList>serviceWrapper(bundleContext));
 
 		ReflectionTestUtil.setFieldValue(
 			_fdsItemActionListRegistryImpl, "_serviceTrackerMap",
@@ -74,14 +63,15 @@ public class SystemFDSItemActionListSerializerImplTest {
 
 	@After
 	public void tearDown() {
+		super.tearDown();
+
 		_itemActionListServiceTrackerMap.close();
-		_systemFDSEntryserviceTrackerMap.close();
 	}
 
 	@Test
-	public void testFDSCreationMenuSerialization() throws Exception {
+	public void testFDSItemActionListSerialization() throws Exception {
 		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration =
-			_registerSystemFDSEntry("fdsName", "/app", "/endpoint", "schema");
+			registerSystemFDSEntry("fdsName", "/app", "/endpoint", "schema");
 
 		List<FDSActionDropdownItem> dropDownItemList = ListUtil.fromArray(
 			new FDSActionDropdownItem(
@@ -95,7 +85,7 @@ public class SystemFDSItemActionListSerializerImplTest {
 		Assert.assertEquals(
 			dropDownItemList,
 			_systemFDSItemActionListSerializerImpl.serialize(
-				"fdsName", _httpServletRequest));
+				"fdsName", httpServletRequest));
 
 		itemActionListServiceRegistration.unregister();
 
@@ -103,29 +93,29 @@ public class SystemFDSItemActionListSerializerImplTest {
 	}
 
 	@Test
-	public void testFDSCreationMenuSerializationNoCreationMenu()
+	public void testFDSItemActionListSerializationNoItemActionList()
 		throws Exception {
 
 		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration =
-			_registerSystemFDSEntry("fdsName", "/app", "/endpoint", "schema");
+			registerSystemFDSEntry("fdsName", "/app", "/endpoint", "schema");
 
 		Assert.assertTrue(
 			_systemFDSItemActionListSerializerImpl.serialize(
-				"fdsName", _httpServletRequest
+				"fdsName", httpServletRequest
 			).isEmpty());
 
 		systemFDSEntryServiceRegistration.unregister();
 	}
 
 	@Test
-	public void testFDSCreationMenuSerializationSeparateCreationMenus()
+	public void testFDSItemActionListSerializationSeparateItemActionLists()
 		throws Exception {
 
 		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration1 =
-			_registerSystemFDSEntry("fdsName1", "/app", "/endpoint", "schema");
+			registerSystemFDSEntry("fdsName1", "/app", "/endpoint", "schema");
 
 		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration2 =
-			_registerSystemFDSEntry("fdsName2", "/app", "/endpoint", "schema");
+			registerSystemFDSEntry("fdsName2", "/app", "/endpoint", "schema");
 
 		List<FDSActionDropdownItem> dropDownItemList1 = ListUtil.fromArray(
 			new FDSActionDropdownItem(
@@ -147,19 +137,19 @@ public class SystemFDSItemActionListSerializerImplTest {
 
 		Assert.assertNotEquals(
 			_systemFDSItemActionListSerializerImpl.serialize(
-				"fdsName1", _httpServletRequest),
+				"fdsName1", httpServletRequest),
 			_systemFDSItemActionListSerializerImpl.serialize(
-				"fdsName2", _httpServletRequest));
+				"fdsName2", httpServletRequest));
 
 		Assert.assertEquals(
 			dropDownItemList1,
 			_systemFDSItemActionListSerializerImpl.serialize(
-				"fdsName1", _httpServletRequest));
+				"fdsName1", httpServletRequest));
 
 		Assert.assertEquals(
 			dropDownItemList2,
 			_systemFDSItemActionListSerializerImpl.serialize(
-				"fdsName2", _httpServletRequest));
+				"fdsName2", httpServletRequest));
 
 		itemActionListServiceRegistration1.unregister();
 
@@ -171,14 +161,14 @@ public class SystemFDSItemActionListSerializerImplTest {
 	}
 
 	@Test
-	public void testFDSCreationMenuSerializationSharingCreationMenu()
+	public void testFDSItemActionListSerializationSharingItemActionList()
 		throws Exception {
 
 		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration1 =
-			_registerSystemFDSEntry("fdsName1", "/app", "/endpoint", "schema");
+			registerSystemFDSEntry("fdsName1", "/app", "/endpoint", "schema");
 
 		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration2 =
-			_registerSystemFDSEntry("fdsName2", "/app", "/endpoint", "schema");
+			registerSystemFDSEntry("fdsName2", "/app", "/endpoint", "schema");
 
 		List<FDSActionDropdownItem> dropDownItemList = ListUtil.fromArray(
 			new FDSActionDropdownItem(
@@ -195,9 +185,9 @@ public class SystemFDSItemActionListSerializerImplTest {
 
 		Assert.assertEquals(
 			_systemFDSItemActionListSerializerImpl.serialize(
-				"fdsName1", _httpServletRequest),
+				"fdsName1", httpServletRequest),
 			_systemFDSItemActionListSerializerImpl.serialize(
-				"fdsName2", _httpServletRequest));
+				"fdsName2", httpServletRequest));
 
 		itemActionListServiceRegistration1.unregister();
 
@@ -211,7 +201,7 @@ public class SystemFDSItemActionListSerializerImplTest {
 	private ServiceRegistration<FDSItemActionList> _registerItemActionList(
 		String fdsName, List<FDSActionDropdownItem> itemActions) {
 
-		return _bundleContext.registerService(
+		return bundleContext.registerService(
 			FDSItemActionList.class,
 			new FDSItemActionList() {
 
@@ -226,74 +216,12 @@ public class SystemFDSItemActionListSerializerImplTest {
 			MapUtil.singletonDictionary("frontend.data.set.name", fdsName));
 	}
 
-	private ServiceRegistration<SystemFDSEntry> _registerSystemFDSEntry(
-		String fdsName, String restApplication, String restEndpoint,
-		String restSchema) {
-
-		return _registerSystemFDSEntry(
-			fdsName, restApplication, restEndpoint, restSchema, null);
-	}
-
-	private ServiceRegistration<SystemFDSEntry> _registerSystemFDSEntry(
-		String fdsName, String restApplication, String restEndpoint,
-		String restSchema, String additionalURLParameters) {
-
-		return _bundleContext.registerService(
-			SystemFDSEntry.class,
-			new SystemFDSEntry() {
-
-				@Override
-				public String getAdditionalAPIURLParameters() {
-					return additionalURLParameters;
-				}
-
-				@Override
-				public String getDescription() {
-					return "";
-				}
-
-				@Override
-				public String getName() {
-					return fdsName;
-				}
-
-				@Override
-				public String getRESTApplication() {
-					return restApplication;
-				}
-
-				@Override
-				public String getRESTEndpoint() {
-					return restEndpoint;
-				}
-
-				@Override
-				public String getRESTSchema() {
-					return restSchema;
-				}
-
-				@Override
-				public String getTitle() {
-					return "";
-				}
-
-			},
-			MapUtil.singletonDictionary("frontend.data.set.name", fdsName));
-	}
-
-	private static BundleContext _bundleContext;
 	private static final FDSItemActionListRegistryImpl
 		_fdsItemActionListRegistryImpl = new FDSItemActionListRegistryImpl();
-	private static final HttpServletRequest _httpServletRequest = Mockito.mock(
-		HttpServletRequest.class);
 	private static ServiceTrackerMap
 		<String,
 		 ServiceTrackerCustomizerFactory.ServiceWrapper<FDSItemActionList>>
 			_itemActionListServiceTrackerMap;
-	private static final SystemFDSEntryRegistryImpl
-		_systemFDSEntryRegistryImpl = new SystemFDSEntryRegistryImpl();
-	private static ServiceTrackerMap<String, SystemFDSEntry>
-		_systemFDSEntryserviceTrackerMap;
 	private static final SystemFDSItemActionListSerializerImpl
 		_systemFDSItemActionListSerializerImpl =
 			new SystemFDSItemActionListSerializerImpl();

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/action/SystemFDSItemActionListSerializerImplTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/action/SystemFDSItemActionListSerializerImplTest.java
@@ -69,47 +69,9 @@ public class SystemFDSItemActionListSerializerImplTest
 	}
 
 	@Test
-	public void testFDSItemActionListSerialization() throws Exception {
-		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration =
-			registerSystemFDSEntry("fdsName", "/app", "/endpoint", "schema");
+	public void testSerialization() throws Exception {
 
-		List<FDSActionDropdownItem> dropDownItemList = ListUtil.fromArray(
-			new FDSActionDropdownItem(
-				null, "trash", "delete", "delete", "delete", "delete",
-				"headless"));
-
-		ServiceRegistration<FDSItemActionList>
-			itemActionListServiceRegistration = _registerItemActionList(
-				"fdsName", dropDownItemList);
-
-		Assert.assertEquals(
-			dropDownItemList,
-			_systemFDSItemActionListSerializerImpl.serialize(
-				"fdsName", httpServletRequest));
-
-		itemActionListServiceRegistration.unregister();
-
-		systemFDSEntryServiceRegistration.unregister();
-	}
-
-	@Test
-	public void testFDSItemActionListSerializationNoItemActionList()
-		throws Exception {
-
-		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration =
-			registerSystemFDSEntry("fdsName", "/app", "/endpoint", "schema");
-
-		Assert.assertTrue(
-			_systemFDSItemActionListSerializerImpl.serialize(
-				"fdsName", httpServletRequest
-			).isEmpty());
-
-		systemFDSEntryServiceRegistration.unregister();
-	}
-
-	@Test
-	public void testFDSItemActionListSerializationSeparateItemActionLists()
-		throws Exception {
+		// different action lists
 
 		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration1 =
 			registerSystemFDSEntry("fdsName1", "/app", "/endpoint", "schema");
@@ -158,30 +120,37 @@ public class SystemFDSItemActionListSerializerImplTest
 		systemFDSEntryServiceRegistration1.unregister();
 
 		systemFDSEntryServiceRegistration2.unregister();
-	}
 
-	@Test
-	public void testFDSItemActionListSerializationSharingItemActionList()
-		throws Exception {
+		// no action list
 
-		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration1 =
-			registerSystemFDSEntry("fdsName1", "/app", "/endpoint", "schema");
+		systemFDSEntryServiceRegistration1 = registerSystemFDSEntry(
+			"fdsName", "/app", "/endpoint", "schema");
 
-		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration2 =
-			registerSystemFDSEntry("fdsName2", "/app", "/endpoint", "schema");
+		Assert.assertTrue(
+			_systemFDSItemActionListSerializerImpl.serialize(
+				"fdsName", httpServletRequest
+			).isEmpty());
 
-		List<FDSActionDropdownItem> dropDownItemList = ListUtil.fromArray(
+		systemFDSEntryServiceRegistration1.unregister();
+
+		// shared action list
+
+		systemFDSEntryServiceRegistration1 = registerSystemFDSEntry(
+			"fdsName1", "/app", "/endpoint", "schema");
+
+		systemFDSEntryServiceRegistration2 = registerSystemFDSEntry(
+			"fdsName2", "/app", "/endpoint", "schema");
+
+		dropDownItemList1 = ListUtil.fromArray(
 			new FDSActionDropdownItem(
 				null, "trash", "delete", "delete", "delete", "delete",
 				"headless"));
 
-		ServiceRegistration<FDSItemActionList>
-			itemActionListServiceRegistration1 = _registerItemActionList(
-				"fdsName1", dropDownItemList);
+		itemActionListServiceRegistration1 = _registerItemActionList(
+			"fdsName1", dropDownItemList1);
 
-		ServiceRegistration<FDSItemActionList>
-			itemActionListServiceRegistration2 = _registerItemActionList(
-				"fdsName2", dropDownItemList);
+		itemActionListServiceRegistration2 = _registerItemActionList(
+			"fdsName2", dropDownItemList1);
 
 		Assert.assertEquals(
 			_systemFDSItemActionListSerializerImpl.serialize(

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/url/SystemFDSAPIURLSerializerImplTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/url/SystemFDSAPIURLSerializerImplTest.java
@@ -6,7 +6,7 @@
 package com.liferay.frontend.data.set.internal.url;
 
 import com.liferay.frontend.data.set.SystemFDSEntry;
-import com.liferay.frontend.data.set.internal.SystemFDSEntryRegistryImpl;
+import com.liferay.frontend.data.set.internal.BaseSystemFDSSerializerTestCase;
 import com.liferay.frontend.data.set.url.FDSAPIURLResolver;
 import com.liferay.frontend.data.set.url.FDSAPIURLResolverRegistry;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerCustomizerFactory;
@@ -14,7 +14,6 @@ import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerCustomizer
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -33,13 +32,13 @@ import org.junit.Test;
 
 import org.mockito.Mockito;
 
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 
 /**
  * @author Daniel Sanz
  */
-public class SystemFDSAPIURLSerializerImplTest {
+public class SystemFDSAPIURLSerializerImplTest
+	extends BaseSystemFDSSerializerTestCase {
 
 	@ClassRule
 	@Rule
@@ -48,7 +47,7 @@ public class SystemFDSAPIURLSerializerImplTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_bundleContext = SystemBundleUtil.getBundleContext();
+		super.setUp();
 
 		ReflectionTestUtil.setFieldValue(
 			_fdsAPIURLBuilderFactoryImpl, "_fdsAPIURLResolverRegistry",
@@ -56,10 +55,10 @@ public class SystemFDSAPIURLSerializerImplTest {
 
 		_fdsAPIURLResolverServiceTrackerMap =
 			ServiceTrackerMapFactory.openSingleValueMap(
-				_bundleContext, FDSAPIURLResolver.class,
+				bundleContext, FDSAPIURLResolver.class,
 				"fds.rest.application.key",
 				ServiceTrackerCustomizerFactory.
-					<FDSAPIURLResolver>serviceWrapper(_bundleContext));
+					<FDSAPIURLResolver>serviceWrapper(bundleContext));
 
 		ReflectionTestUtil.setFieldValue(
 			_fdsAPIURLResolverRegistry, "_serviceTrackerMap",
@@ -68,7 +67,7 @@ public class SystemFDSAPIURLSerializerImplTest {
 		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
 
 		Mockito.when(
-			_httpServletRequest.getAttribute(WebKeys.THEME_DISPLAY)
+			httpServletRequest.getAttribute(WebKeys.THEME_DISPLAY)
 		).thenReturn(
 			themeDisplay
 		);
@@ -78,21 +77,14 @@ public class SystemFDSAPIURLSerializerImplTest {
 			_fdsAPIURLBuilderFactoryImpl);
 		ReflectionTestUtil.setFieldValue(
 			_systemFDSAPIURLSerializerImpl, "_systemFDSEntryRegistry",
-			_systemFDSEntryRegistryImpl);
-
-		_systemFDSEntryServiceTrackerMap =
-			ServiceTrackerMapFactory.openSingleValueMap(
-				_bundleContext, SystemFDSEntry.class, "frontend.data.set.name");
-
-		ReflectionTestUtil.setFieldValue(
-			_systemFDSEntryRegistryImpl, "_serviceTrackerMap",
-			_systemFDSEntryServiceTrackerMap);
+			systemFDSEntryRegistryImpl);
 	}
 
 	@After
 	public void tearDown() {
+		super.tearDown();
+
 		_fdsAPIURLResolverServiceTrackerMap.close();
-		_systemFDSEntryServiceTrackerMap.close();
 	}
 
 	@Test
@@ -105,20 +97,20 @@ public class SystemFDSAPIURLSerializerImplTest {
 				"/app1", "schema", new String[] {"{foo}"},
 				new String[] {"bar"});
 		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration1 =
-			_registerSystemFDSEntry(
+			registerSystemFDSEntry(
 				"fdsName1", "/app1", "/endpoint/{foo}", "schema");
 		ServiceRegistration<SystemFDSEntry> systemFDSEntryServiceRegistration2 =
-			_registerSystemFDSEntry(
+			registerSystemFDSEntry(
 				"fdsName2", "/app2", "/endpoint/{foo}", "schema");
 
 		Assert.assertEquals(
 			"/o/app1/endpoint/bar",
 			_systemFDSAPIURLSerializerImpl.serialize(
-				"fdsName1", _httpServletRequest));
+				"fdsName1", httpServletRequest));
 		Assert.assertEquals(
 			"/o/app2/endpoint/{foo}",
 			_systemFDSAPIURLSerializerImpl.serialize(
-				"fdsName2", _httpServletRequest));
+				"fdsName2", httpServletRequest));
 
 		fdsAPIURLServiceRegistration.unregister();
 		systemFDSEntryServiceRegistration1.unregister();
@@ -126,25 +118,25 @@ public class SystemFDSAPIURLSerializerImplTest {
 
 		// No resolver, URL
 
-		systemFDSEntryServiceRegistration1 = _registerSystemFDSEntry(
+		systemFDSEntryServiceRegistration1 = registerSystemFDSEntry(
 			"fdsName", "/app", "/endpoint", "schema");
 
 		Assert.assertEquals(
 			"/o/app/endpoint",
 			_systemFDSAPIURLSerializerImpl.serialize(
-				"fdsName", _httpServletRequest));
+				"fdsName", httpServletRequest));
 
 		systemFDSEntryServiceRegistration1.unregister();
 
 		// No resolver, URL with parameters
 
-		systemFDSEntryServiceRegistration1 = _registerSystemFDSEntry(
+		systemFDSEntryServiceRegistration1 = registerSystemFDSEntry(
 			"param=3", "fdsName", "/app", "/endpoint", "schema");
 
 		Assert.assertEquals(
 			"/o/app/endpoint?param=3",
 			_systemFDSAPIURLSerializerImpl.serialize(
-				"fdsName", _httpServletRequest));
+				"fdsName", httpServletRequest));
 
 		systemFDSEntryServiceRegistration1.unregister();
 
@@ -152,13 +144,13 @@ public class SystemFDSAPIURLSerializerImplTest {
 
 		fdsAPIURLServiceRegistration = _registerFDSAPIURLResolver(
 			"/app", "schema", new String[] {"{foo}"}, new String[] {"bar"});
-		systemFDSEntryServiceRegistration1 = _registerSystemFDSEntry(
+		systemFDSEntryServiceRegistration1 = registerSystemFDSEntry(
 			"{foo}=3", "fdsName", "/app", "/endpoint/{foo}", "schema");
 
 		Assert.assertEquals(
 			"/o/app/endpoint/bar?bar=3",
 			_systemFDSAPIURLSerializerImpl.serialize(
-				"fdsName", _httpServletRequest));
+				"fdsName", httpServletRequest));
 
 		fdsAPIURLServiceRegistration.unregister();
 		systemFDSEntryServiceRegistration1.unregister();
@@ -167,19 +159,19 @@ public class SystemFDSAPIURLSerializerImplTest {
 
 		fdsAPIURLServiceRegistration = _registerFDSAPIURLResolver(
 			"/app", "schema", new String[] {"{foo}"}, new String[] {"bar"});
-		systemFDSEntryServiceRegistration1 = _registerSystemFDSEntry(
+		systemFDSEntryServiceRegistration1 = registerSystemFDSEntry(
 			"fdsName1", "/app", "/endpoint/{foo}", "schema");
-		systemFDSEntryServiceRegistration2 = _registerSystemFDSEntry(
+		systemFDSEntryServiceRegistration2 = registerSystemFDSEntry(
 			"fdsName2", "/app", "/endpoint/{foo}", "schema");
 
 		Assert.assertEquals(
 			"/o/app/endpoint/bar",
 			_systemFDSAPIURLSerializerImpl.serialize(
-				"fdsName1", _httpServletRequest));
+				"fdsName1", httpServletRequest));
 		Assert.assertEquals(
 			"/o/app/endpoint/bar",
 			_systemFDSAPIURLSerializerImpl.serialize(
-				"fdsName2", _httpServletRequest));
+				"fdsName2", httpServletRequest));
 
 		fdsAPIURLServiceRegistration.unregister();
 		systemFDSEntryServiceRegistration1.unregister();
@@ -190,7 +182,7 @@ public class SystemFDSAPIURLSerializerImplTest {
 		String restApplication, String restSchema, String[] tokens,
 		String[] values) {
 
-		return _bundleContext.registerService(
+		return bundleContext.registerService(
 			FDSAPIURLResolver.class,
 			new FDSAPIURLResolver() {
 
@@ -213,75 +205,13 @@ public class SystemFDSAPIURLSerializerImplTest {
 				restApplication + "/" + restSchema));
 	}
 
-	private ServiceRegistration<SystemFDSEntry> _registerSystemFDSEntry(
-		String fdsName, String restApplication, String restEndpoint,
-		String restSchema) {
-
-		return _registerSystemFDSEntry(
-			null, fdsName, restApplication, restEndpoint, restSchema);
-	}
-
-	private ServiceRegistration<SystemFDSEntry> _registerSystemFDSEntry(
-		String additionalURLParameters, String fdsName, String restApplication,
-		String restEndpoint, String restSchema) {
-
-		return _bundleContext.registerService(
-			SystemFDSEntry.class,
-			new SystemFDSEntry() {
-
-				@Override
-				public String getAdditionalAPIURLParameters() {
-					return additionalURLParameters;
-				}
-
-				@Override
-				public String getDescription() {
-					return "";
-				}
-
-				@Override
-				public String getName() {
-					return fdsName;
-				}
-
-				@Override
-				public String getRESTApplication() {
-					return restApplication;
-				}
-
-				@Override
-				public String getRESTEndpoint() {
-					return restEndpoint;
-				}
-
-				@Override
-				public String getRESTSchema() {
-					return restSchema;
-				}
-
-				@Override
-				public String getTitle() {
-					return "";
-				}
-
-			},
-			MapUtil.singletonDictionary("frontend.data.set.name", fdsName));
-	}
-
-	private static BundleContext _bundleContext;
 	private static final FDSAPIURLBuilderFactoryImpl
 		_fdsAPIURLBuilderFactoryImpl = new FDSAPIURLBuilderFactoryImpl();
 	private static final FDSAPIURLResolverRegistry _fdsAPIURLResolverRegistry =
 		new FDSAPIURLResolverRegistryImpl();
 	private static ServiceTrackerMap<String, ServiceWrapper<FDSAPIURLResolver>>
 		_fdsAPIURLResolverServiceTrackerMap;
-	private static final HttpServletRequest _httpServletRequest = Mockito.mock(
-		HttpServletRequest.class);
 	private static final SystemFDSAPIURLSerializerImpl
 		_systemFDSAPIURLSerializerImpl = new SystemFDSAPIURLSerializerImpl();
-	private static final SystemFDSEntryRegistryImpl
-		_systemFDSEntryRegistryImpl = new SystemFDSEntryRegistryImpl();
-	private static ServiceTrackerMap<String, SystemFDSEntry>
-		_systemFDSEntryServiceTrackerMap;
 
 }


### PR DESCRIPTION
Second PR about system data sets, on top of your origin. 

I'm applying the same pattern we agreed today. 

Here I'm sending the serializers for the 3 types of actions FDS supports: item actions, bulk actions and the creation menu. They work pretty similar, with the only exception of the "custom" serializer for bulk actions which is still a dummy class because the DSM does not support bulk actions yet. 
