### PR TITLE
LPD-45896 Fixing export/import product menu

### DIFF
--- a/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/PanelAppRegistry.java
+++ b/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/PanelAppRegistry.java
@@ -207,7 +207,7 @@ public class PanelAppRegistry {
 					}
 
 					String featureFlagKey = String.valueOf(
-						serviceReference.getProperty("featureFlagKey"));
+						serviceReference.getProperty("feature.flag.key"));
 
 					if (Validator.isNotNull(featureFlagKey)) {
 						_featureFlagKeys.put(panelApp, featureFlagKey);

--- a/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/PanelAppRegistry.java
+++ b/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/PanelAppRegistry.java
@@ -12,6 +12,7 @@ import com.liferay.osgi.service.tracker.collections.map.PropertyServiceReference
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
@@ -22,9 +23,12 @@ import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
@@ -96,6 +100,16 @@ public class PanelAppRegistry {
 					(portletCompanyId != companyId)) {
 
 					return false;
+				}
+
+				if (_featureFlagKeys.containsKey(panelApp)) {
+					String featureFlagKey = _featureFlagKeys.get(panelApp);
+
+					if (!FeatureFlagManagerUtil.isEnabled(
+							companyId, featureFlagKey)) {
+
+						return false;
+					}
 				}
 
 				return true;
@@ -192,6 +206,13 @@ public class PanelAppRegistry {
 							_portletLocalService);
 					}
 
+					String featureFlagKey = String.valueOf(
+						serviceReference.getProperty("featureFlagKey"));
+
+					if (Validator.isNotNull(featureFlagKey)) {
+						_featureFlagKeys.put(panelApp, featureFlagKey);
+					}
+
 					return panelApp;
 				}
 
@@ -205,6 +226,8 @@ public class PanelAppRegistry {
 				public void removedService(
 					ServiceReference<PanelApp> serviceReference,
 					PanelApp panelApp) {
+
+					_featureFlagKeys.remove(panelApp);
 
 					bundleContext.ungetService(serviceReference);
 				}
@@ -222,6 +245,8 @@ public class PanelAppRegistry {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		PanelAppRegistry.class);
+
+	private final Map<PanelApp, String> _featureFlagKeys = new HashMap<>();
 
 	@Reference
 	private GroupProvider _groupProvider;

--- a/modules/apps/application-list/application-list-test/src/testIntegration/java/com/liferay/application/list/test/PanelAppRegistryTest.java
+++ b/modules/apps/application-list/application-list-test/src/testIntegration/java/com/liferay/application/list/test/PanelAppRegistryTest.java
@@ -1,0 +1,211 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.application.list.test;
+
+import com.liferay.application.list.GroupProvider;
+import com.liferay.application.list.PanelApp;
+import com.liferay.application.list.PanelAppRegistry;
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.test.AssertUtils;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.model.impl.PortletImpl;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.io.IOException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+import javax.portlet.PortletURL;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Carlos Correa
+ */
+@RunWith(Arquillian.class)
+public class PanelAppRegistryTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() {
+		Bundle bundle = FrameworkUtil.getBundle(PanelAppRegistryTest.class);
+
+		_bundleContext = bundle.getBundleContext();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_panelApp1 = _registerPanelApp(CompanyConstants.SYSTEM, null);
+		_panelApp2 = _registerPanelApp(CompanyConstants.SYSTEM, "LPD-TEST");
+		_panelApp3 = _registerPanelApp(TestPropsValues.getCompanyId(), null);
+		_panelApp4 = _registerPanelApp(
+			TestPropsValues.getCompanyId(), "LPD-TEST");
+
+		String randomFeatureFlag = StringUtil.toUpperCase(
+			RandomTestUtil.randomString());
+
+		_registerPanelApp(TestPropsValues.getCompanyId(), randomFeatureFlag);
+		_registerPanelApp(CompanyConstants.SYSTEM, randomFeatureFlag);
+
+		long randomCompanyId = RandomTestUtil.randomLong();
+
+		_registerPanelApp(randomCompanyId, null);
+		_registerPanelApp(randomCompanyId, "LPD-TEST");
+		_registerPanelApp(randomCompanyId, randomFeatureFlag);
+	}
+
+	@After
+	public void tearDown() {
+		_serviceRegistrations.forEach(ServiceRegistration::unregister);
+
+		_serviceRegistrations.clear();
+	}
+
+	@Test
+	public void testGetPanelApps() {
+		AssertUtils.assertEquals(
+			Arrays.asList(_panelApp1, _panelApp3),
+			_panelAppRegistry.getPanelApps(_PARENT_PANEL_CATEGORY_KEY));
+	}
+
+	@FeatureFlags("LPD-TEST")
+	@Test
+	public void testGetPanelAppsWithFeatureFlag() throws Exception {
+		AssertUtils.assertEquals(
+			Arrays.asList(_panelApp1, _panelApp2, _panelApp3, _panelApp4),
+			_panelAppRegistry.getPanelApps(_PARENT_PANEL_CATEGORY_KEY));
+	}
+
+	private PanelApp _registerPanelApp(long companyId, String featureFlagKey) {
+		PanelApp panelApp = new PanelAppImpl(companyId);
+
+		_serviceRegistrations.add(
+			_bundleContext.registerService(
+				PanelApp.class, panelApp,
+				HashMapDictionaryBuilder.put(
+					"featureFlagKey", () -> featureFlagKey
+				).put(
+					"panel.category.key", _PARENT_PANEL_CATEGORY_KEY
+				).build()));
+
+		return panelApp;
+	}
+
+	private static final String _PARENT_PANEL_CATEGORY_KEY =
+		RandomTestUtil.randomString();
+
+	private static BundleContext _bundleContext;
+
+	private PanelApp _panelApp1;
+	private PanelApp _panelApp2;
+	private PanelApp _panelApp3;
+	private PanelApp _panelApp4;
+
+	@Inject
+	private PanelAppRegistry _panelAppRegistry;
+
+	private final List<ServiceRegistration<PanelApp>> _serviceRegistrations =
+		new ArrayList<>();
+
+	private class PanelAppImpl implements PanelApp {
+
+		public PanelAppImpl(long companyId) {
+			_companyId = companyId;
+
+			_portletId = RandomTestUtil.randomString();
+		}
+
+		@Override
+		public String getKey() {
+			return RandomTestUtil.randomString();
+		}
+
+		@Override
+		public String getLabel(Locale locale) {
+			return RandomTestUtil.randomString();
+		}
+
+		@Override
+		public int getNotificationsCount(User user) {
+			return 0;
+		}
+
+		@Override
+		public Portlet getPortlet() {
+			return new PortletImpl(_companyId, _portletId);
+		}
+
+		@Override
+		public String getPortletId() {
+			return _portletId;
+		}
+
+		@Override
+		public PortletURL getPortletURL(HttpServletRequest httpServletRequest)
+			throws PortalException {
+
+			return null;
+		}
+
+		@Override
+		public boolean include(
+				HttpServletRequest httpServletRequest,
+				HttpServletResponse httpServletResponse)
+			throws IOException {
+
+			return true;
+		}
+
+		@Override
+		public boolean isShow(PermissionChecker permissionChecker, Group group)
+			throws PortalException {
+
+			return true;
+		}
+
+		@Override
+		public void setGroupProvider(GroupProvider groupProvider) {
+		}
+
+		private final long _companyId;
+		private final String _portletId;
+
+	}
+
+}

--- a/modules/apps/application-list/application-list-test/src/testIntegration/java/com/liferay/application/list/test/PanelAppRegistryTest.java
+++ b/modules/apps/application-list/application-list-test/src/testIntegration/java/com/liferay/application/list/test/PanelAppRegistryTest.java
@@ -77,17 +77,17 @@ public class PanelAppRegistryTest {
 		_panelApp4 = _registerPanelApp(
 			TestPropsValues.getCompanyId(), "LPD-TEST");
 
-		String randomFeatureFlag = StringUtil.toUpperCase(
+		String featureFlagKey = StringUtil.toUpperCase(
 			RandomTestUtil.randomString());
 
-		_registerPanelApp(TestPropsValues.getCompanyId(), randomFeatureFlag);
-		_registerPanelApp(CompanyConstants.SYSTEM, randomFeatureFlag);
+		_registerPanelApp(TestPropsValues.getCompanyId(), featureFlagKey);
+		_registerPanelApp(CompanyConstants.SYSTEM, featureFlagKey);
 
-		long randomCompanyId = RandomTestUtil.randomLong();
+		long companyId = RandomTestUtil.randomLong();
 
-		_registerPanelApp(randomCompanyId, null);
-		_registerPanelApp(randomCompanyId, "LPD-TEST");
-		_registerPanelApp(randomCompanyId, randomFeatureFlag);
+		_registerPanelApp(companyId, null);
+		_registerPanelApp(companyId, "LPD-TEST");
+		_registerPanelApp(companyId, featureFlagKey);
 	}
 
 	@After

--- a/modules/apps/application-list/application-list-test/src/testIntegration/java/com/liferay/application/list/test/PanelAppRegistryTest.java
+++ b/modules/apps/application-list/application-list-test/src/testIntegration/java/com/liferay/application/list/test/PanelAppRegistryTest.java
@@ -119,7 +119,7 @@ public class PanelAppRegistryTest {
 			_bundleContext.registerService(
 				PanelApp.class, panelApp,
 				HashMapDictionaryBuilder.put(
-					"featureFlagKey", () -> featureFlagKey
+					"feature.flag.key", () -> featureFlagKey
 				).put(
 					"panel.category.key", _PARENT_PANEL_CATEGORY_KEY
 				).build()));

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/application/list/CompanyExportPanelApp.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/application/list/CompanyExportPanelApp.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"panel.app.order:Integer=1300",
+		"featureFlagKey=LPD-35914", "panel.app.order:Integer=1300",
 		"panel.category.key=" + PanelCategoryKeys.APPLICATIONS_MENU_APPLICATIONS_BATCH_PLANNER
 	},
 	service = PanelApp.class

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/application/list/CompanyExportPanelApp.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/application/list/CompanyExportPanelApp.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"featureFlagKey=LPD-35914", "panel.app.order:Integer=1300",
+		"feature.flag.key=LPD-35914", "panel.app.order:Integer=1300",
 		"panel.category.key=" + PanelCategoryKeys.APPLICATIONS_MENU_APPLICATIONS_BATCH_PLANNER
 	},
 	service = PanelApp.class

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/application/list/CompanyImportPanelApp.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/application/list/CompanyImportPanelApp.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"panel.app.order:Integer=1400",
+		"featureFlagKey=LPD-35914", "panel.app.order:Integer=1400",
 		"panel.category.key=" + PanelCategoryKeys.APPLICATIONS_MENU_APPLICATIONS_BATCH_PLANNER
 	},
 	service = PanelApp.class

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/application/list/CompanyImportPanelApp.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/application/list/CompanyImportPanelApp.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"featureFlagKey=LPD-35914", "panel.app.order:Integer=1400",
+		"feature.flag.key=LPD-35914", "panel.app.order:Integer=1400",
 		"panel.category.key=" + PanelCategoryKeys.APPLICATIONS_MENU_APPLICATIONS_BATCH_PLANNER
 	},
 	service = PanelApp.class

--- a/portal-test/src/com/liferay/portal/test/rule/FeatureFlagTestRule.java
+++ b/portal-test/src/com/liferay/portal/test/rule/FeatureFlagTestRule.java
@@ -7,7 +7,6 @@ package com.liferay.portal.test.rule;
 
 import com.liferay.portal.kernel.test.rule.AbstractTestRule;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.util.PropsUtil;
 
 import java.util.Collections;
@@ -58,9 +57,23 @@ public class FeatureFlagTestRule
 	}
 
 	private void _restoreFeatureFlags(Map<String, String> previousValues) {
+		Map<String, String> values = new HashMap<>();
+
+		for (Map.Entry<String, String> entry : previousValues.entrySet()) {
+			String value = entry.getValue();
+
+			if (value == null) {
+				PropsUtil.set(entry.getKey(), value);
+
+				continue;
+			}
+
+			values.put(entry.getKey(), entry.getValue());
+		}
+
 		PropsUtil.addProperties(
 			UnicodePropertiesBuilder.create(
-				previousValues, true
+				values, true
 			).build());
 	}
 
@@ -77,11 +90,7 @@ public class FeatureFlagTestRule
 		for (String key : featureFlags.value()) {
 			String featureFlagKey = "feature.flag." + key;
 
-			String previousValue = PropsUtil.get(featureFlagKey);
-
-			if (Validator.isNotNull(previousValue)) {
-				previousValues.put(featureFlagKey, previousValue);
-			}
+			previousValues.put(featureFlagKey, PropsUtil.get(featureFlagKey));
 
 			PropsUtil.addProperties(
 				UnicodePropertiesBuilder.setProperty(


### PR DESCRIPTION
This PR contains the renaming of the `featureFlagKey` property to `feature.flag.key`

---

https://liferay.atlassian.net/browse/LPD-45896

See https://github.com/brianchandotcom/liferay-portal/pull/158242

---

The purpose of this ticket is to allow registering `PanelApp` based on the value of a Feature Flag. If the feature flag is not enabled, then, the `PanelApp` will not be returned by any of the `PanelAppRegistry` methods, ignoring them until the Feature flag is active

cc/ @4lejandrito 

---

![image](https://github.com/user-attachments/assets/83a6e664-755d-420d-a46e-c647eee46bd1)

**Before the PR with the FF disabled:**

![image](https://github.com/user-attachments/assets/6654d9df-194c-4394-b704-5feb394f315a)

**After the PR with the FF disabled:**

![image](https://github.com/user-attachments/assets/768e4dc1-ad98-4a04-ac3d-847175831420)


