### PR TITLE
LPD-47677 Tomcat 10 started to disable session persistence by default…

### DIFF
--- a/build-dist.xml
+++ b/build-dist.xml
@@ -1012,6 +1012,20 @@ tomcat.util.scan.StandardJarScanFilter.jarsToSkip=*
 tomcat.util.scan.StandardJarScanFilter.jarsToScan=]]>
 		</echo>
 
+		<fixcrlf eof="asis" eol="lf" file="${app.server.tomcat.dir}/conf/context.xml" />
+
+		<replace
+			file="${app.server.tomcat.dir}/conf/context.xml"
+		>
+			<replacetoken><![CDATA[    <!-- Uncomment this to enable session persistence across Tomcat restarts -->
+    <!--
+    <Manager pathname="SESSIONS.ser" />
+    -->]]></replacetoken>
+			<replacevalue><![CDATA[    <Manager pathname="SESSIONS.ser" />]]></replacevalue>
+		</replace>
+
+		<fixcrlf eof="asis" eol="crlf" file="${app.server.tomcat.dir}/conf/context.xml" />
+
 		<echo append="true" file="${app.server.tomcat.dir}/conf/logging.properties">
 			<![CDATA[
 org.apache.catalina.startup.Catalina.level=INFO


### PR DESCRIPTION
…, to keep the behavior same as tomcat 9, liferay turns it on.

@ling-alan-huang SF removes the leading spaces at https://github.com/brianchandotcom/liferay-portal/compare/master...shuyangzhou:liferay-portal:LPD-47677?expand=1#diff-e7e88e42c7fdbec91ff830650d809a4466cd4642ff0c8ab32c9aee6390752bc0R1022
Note this is inside CDATA block, SF should not touch anything in CDATA, this is search token once changed the search/replace logic will break. Please fix SF for this, thanks!