### PR TITLE
LPD-46477 - Remove moment.js

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/package.json
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/package.json
@@ -36,7 +36,6 @@
 		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"fuzzy": "0.1.3",
-		"moment": "2.29.4",
 		"prop-types": "15.7.2",
 		"react": "18.2.0"
 	},

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/preview_sidebar/ResultListItem.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/preview_sidebar/ResultListItem.js
@@ -8,7 +8,7 @@ import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import ClayList from '@clayui/list';
 import getCN from 'classnames';
-import moment from 'moment';
+import {dateUtils} from 'frontend-js-web';
 import React, {useContext, useState} from 'react';
 
 import {PreviewModalWithCopyDownload} from '../../shared/PreviewModal';
@@ -34,9 +34,10 @@ const sxpBlueprintFieldPrefixRegex = new RegExp(
 
 function localizeDate(property, value) {
 	if (DATE_KEYS.includes(property)) {
-		return moment(moment(value, 'YYYYMMDDHHmmss'))
-			.locale(Liferay.ThemeDisplay.getBCP47LanguageId() || 'en-US')
-			.format('lll');
+		return dateUtils.format(
+			dateUtils.parse(value, 'yyyyMMddhhmmss'),
+			'PP p'
+		);
 	}
 
 	return value;

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/sxp_element/get_ui_configuration_values.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/sxp_element/get_ui_configuration_values.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import moment from 'moment';
+import {dateUtils} from 'frontend-js-web';
 
 import toNumber from '../functions/to_number';
 import {INPUT_TYPES} from '../types/inputTypes';
@@ -90,8 +90,24 @@ export function getDefaultValue(item) {
 		case INPUT_TYPES.DATE:
 			return typeof itemValue === 'number'
 				? itemValue
-				: moment(itemValue, ['MM-DD-YYYY', 'YYYY-MM-DD']).isValid()
-					? moment(itemValue, ['MM-DD-YYYY', 'YYYY-MM-DD']).unix()
+				: dateUtils.isValid(
+							dateUtils.parse(
+								itemValue,
+								itemValue?.indexOf('-') === 2
+									? 'MM-dd-yyyy'
+									: 'yyyy-MM-dd'
+							)
+					  )
+					? Math.floor(
+							dateUtils
+								.parse(
+									itemValue,
+									itemValue?.indexOf('-') === 2
+										? 'MM-dd-yyyy'
+										: 'yyyy-MM-dd'
+								)
+								.getTime() / 1000
+						)
 					: '';
 		case INPUT_TYPES.FIELD_MAPPING:
 			return typeof itemValue === 'object' && itemValue.field

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/sxp_element/replace_template_variable.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/sxp_element/replace_template_variable.js
@@ -69,15 +69,22 @@ export default function replaceTemplateVariable({
 					);
 				}
 				else if (config.type === INPUT_TYPES.DATE) {
-					configValue = initialConfigValue
-						? JSON.parse(
-								dateUtils.format(
-									new Date(initialConfigValue * 1000),
-									config.typeOptions?.format ||
-										'yyyyMMddhhmmss'
-								)
-							)
-						: '';
+					if (!initialConfigValue) {
+						configValue = '';
+					}
+					else {
+						const formattedDate = dateUtils.format(
+							new Date(initialConfigValue * 1000),
+							config.typeOptions?.format || 'yyyyMMddhhmmss'
+						);
+
+						try {
+							configValue = JSON.parse(formattedDate);
+						}
+						catch {
+							configValue = '';
+						}
+					}
 				}
 				else if (config.type === INPUT_TYPES.ITEM_SELECTOR) {
 					configValue = JSON.stringify(

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/sxp_element/replace_template_variable.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/sxp_element/replace_template_variable.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import moment from 'moment';
+import {dateUtils} from 'frontend-js-web';
 
 import {CONFIG_PREFIX} from '../constants';
 import isEmpty from '../functions/is_empty';
@@ -71,12 +71,11 @@ export default function replaceTemplateVariable({
 				else if (config.type === INPUT_TYPES.DATE) {
 					configValue = initialConfigValue
 						? JSON.parse(
-								moment
-									.unix(initialConfigValue)
-									.format(
-										config.typeOptions?.format ||
-											'YYYYMMDDHHMMSS'
-									)
+								dateUtils.format(
+									new Date(initialConfigValue * 1000),
+									config.typeOptions?.format ||
+										'yyyyMMddhhmmss'
+								)
 							)
 						: '';
 				}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/sxp_element/replace_template_variable.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/utils/sxp_element/replace_template_variable.js
@@ -73,13 +73,14 @@ export default function replaceTemplateVariable({
 						configValue = '';
 					}
 					else {
-						const formattedDate = dateUtils.format(
-							new Date(initialConfigValue * 1000),
-							config.typeOptions?.format || 'yyyyMMddhhmmss'
-						);
-
 						try {
-							configValue = JSON.parse(formattedDate);
+							configValue = JSON.parse(
+								dateUtils.format(
+									new Date(initialConfigValue * 1000),
+									config.typeOptions?.format ||
+										'yyyyMMddhhmmss'
+								)
+							);
 						}
 						catch {
 							configValue = '';

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/utils/sxp_elements/replace_template_variable.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/utils/sxp_elements/replace_template_variable.js
@@ -23,7 +23,7 @@ describe('replaceTemplateVariable', () => {
 											name: 'start_date',
 											type: 'date',
 											typeOptions: {
-												format: 'YYYYMMDD',
+												format: 'yyyyMMdd',
 											},
 										},
 									],


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-46477

Includes https://github.com/liferay-search/liferay-portal/pull/1578 @bryceosterhaus

> Hey, we are in the process of removing moment.js and date-fns from all of liferay-portal and replacement with our internal utilities. This significantly reduces total bytes sent to the client.
> 
> Please review this PR and make sure we didn't miss anything.

Manually sent from https://github.com/liferay-search/liferay-portal/pull/1581 @thektan

> With dateUtils.format, if the element has customized the format of a field date and it's not one of the options available in the [FORMATTER_MAP](https://github.com/liferay-search/liferay-portal/blob/729163741639c6f6875c5ad7633a318a69a57f6e/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/utils/date_time/format.ts#L45), the default setting will be yyyy-MM-ddThh:mm:ssZ. This (or having any format that isn't a number) ends up erroring in search blueprints when doing JSON.parse on the formatted date.
> 
> Extra commit adds a try/catch to prevent the error and sets the configValue to an empty string if the format is not applicable.