### PR TITLE
LRCI-5292 Utilize file name

### DIFF
--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
@@ -436,7 +436,7 @@ public class MirrorsGetTask extends Task {
 		File mirrorsCacheTempFile = new File(
 			mirrorsCacheFile,
 			mirrorsCacheFile.getParentFile() + "/" +
-				System.currentTimeMillis() + mirrorsCacheFile);
+				System.currentTimeMillis() + mirrorsCacheFile.toString());
 
 		if (mirrorsCacheFile.exists() && !_force) {
 			if (_is7zFileName(_fileName)) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-5292
Hey Brian, we need the file string otherwise it creates issues with our validation logic. Example here:
https://liferay.slack.com/archives/CR6GDGESY/p1738687615588099?thread_ts=1738666945.300409&cid=CR6GDGESY