### PR TITLE
LPD-37787 Filtering using r_<relationshipName>_c_<objectName>ERC is not working properly

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/ReferenceStringEntityField.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/ReferenceStringEntityField.java
@@ -17,17 +17,17 @@ public class ReferenceStringEntityField extends StringEntityField {
 
 	public ReferenceStringEntityField(
 		String fieldName, Function<Locale, String> filterableFunction,
-		String referencedFieldName) {
+		String referenceFieldName) {
 
-		super(fieldName, locale -> referencedFieldName, filterableFunction);
+		super(fieldName, locale -> referenceFieldName, filterableFunction);
 
-		_referencedFieldName = referencedFieldName;
+		_referenceFieldName = referenceFieldName;
 	}
 
-	public String getReferencedFieldName() {
-		return _referencedFieldName;
+	public String getReferenceFieldName() {
+		return _referenceFieldName;
 	}
 
-	private final String _referencedFieldName;
+	private final String _referenceFieldName;
 
 }

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/ReferenceStringEntityField.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/ReferenceStringEntityField.java
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.rest.internal.odata.entity;
+
+import com.liferay.portal.odata.entity.StringEntityField;
+
+import java.util.Locale;
+import java.util.function.Function;
+
+/**
+ * @author Carlos Correa
+ */
+public class ReferenceStringEntityField extends StringEntityField {
+
+	public ReferenceStringEntityField(
+		String fieldName, Function<Locale, String> filterableFunction,
+		String referencedFieldName) {
+
+		super(fieldName, locale -> referencedFieldName, filterableFunction);
+
+		_referencedFieldName = referencedFieldName;
+	}
+
+	public String getReferencedFieldName() {
+		return _referencedFieldName;
+	}
+
+	private final String _referencedFieldName;
+
+}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
@@ -277,11 +277,15 @@ public class ObjectEntryEntityModel implements EntityModel {
 						NAME_OBJECT_RELATIONSHIP_ERC_OBJECT_FIELD_NAME,
 					objectField);
 
+			String relationshipName =
+				objectRelationshipERCObjectFieldName.split("_c_")[0].substring(
+					2);
+
 			entityFieldsMap.put(
 				objectRelationshipERCObjectFieldName,
 				new StringEntityField(
 					objectRelationshipERCObjectFieldName,
-					locale -> objectFieldName));
+					locale -> relationshipName + "/externalReferenceCode"));
 
 			String relationshipIdName = objectFieldName.substring(
 				objectFieldName.lastIndexOf(StringPool.UNDERLINE) + 1);

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
@@ -283,9 +283,11 @@ public class ObjectEntryEntityModel implements EntityModel {
 
 			entityFieldsMap.put(
 				objectRelationshipERCObjectFieldName,
-				new StringEntityField(
+				new EntityField(
 					objectRelationshipERCObjectFieldName,
-					locale -> relationshipName + "/externalReferenceCode"));
+					EntityField.Type.STRING, locale -> "externalReferenceCode",
+					locale -> relationshipName + "/externalReferenceCode",
+					String::valueOf));
 
 			String relationshipIdName = objectFieldName.substring(
 				objectFieldName.lastIndexOf(StringPool.UNDERLINE) + 1);

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
@@ -277,16 +277,14 @@ public class ObjectEntryEntityModel implements EntityModel {
 						NAME_OBJECT_RELATIONSHIP_ERC_OBJECT_FIELD_NAME,
 					objectField);
 
-			String relationshipName =
-				objectRelationshipERCObjectFieldName.split("_c_")[0].substring(
-					2);
-
 			entityFieldsMap.put(
 				objectRelationshipERCObjectFieldName,
 				new EntityField(
 					objectRelationshipERCObjectFieldName,
 					EntityField.Type.STRING, locale -> "externalReferenceCode",
-					locale -> relationshipName + "/externalReferenceCode",
+					locale ->
+						objectFieldName.split(StringPool.UNDERLINE)[1] +
+							"/externalReferenceCode",
 					String::valueOf));
 
 			String relationshipIdName = objectFieldName.substring(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
@@ -13,6 +13,7 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.relationship.util.ObjectRelationshipUtil;
+import com.liferay.object.rest.internal.odata.entity.ReferenceStringEntityField;
 import com.liferay.object.service.ObjectFieldLocalServiceUtil;
 import com.liferay.object.service.ObjectRelationshipLocalServiceUtil;
 import com.liferay.petra.string.StringPool;
@@ -33,9 +34,11 @@ import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 
 import javax.ws.rs.BadRequestException;
 
@@ -157,6 +160,10 @@ public class ObjectEntryEntityModel implements EntityModel {
 			"Unable to get entity field for object field " + objectField);
 	}
 
+	private Function<Locale, String> _getExternalReferenceCodeFunction() {
+		return locale -> "externalReferenceCode";
+	}
+
 	private Map<String, EntityField> _getObjectDefinitionEntityFieldsMap(
 		ObjectDefinition objectDefinition) {
 
@@ -211,7 +218,8 @@ public class ObjectEntryEntityModel implements EntityModel {
 			).put(
 				"externalReferenceCode",
 				() -> new StringEntityField(
-					"externalReferenceCode", locale -> "externalReferenceCode")
+					"externalReferenceCode",
+					_getExternalReferenceCodeFunction())
 			).put(
 				"id", new IdEntityField("id", locale -> "id", String::valueOf)
 			).put(
@@ -279,13 +287,11 @@ public class ObjectEntryEntityModel implements EntityModel {
 
 			entityFieldsMap.put(
 				objectRelationshipERCObjectFieldName,
-				new EntityField(
+				new ReferenceStringEntityField(
 					objectRelationshipERCObjectFieldName,
-					EntityField.Type.STRING, locale -> "externalReferenceCode",
-					locale ->
-						objectFieldName.split(StringPool.UNDERLINE)[1] +
-							"/externalReferenceCode",
-					String::valueOf));
+					_getExternalReferenceCodeFunction(),
+					objectFieldName.split(StringPool.UNDERLINE)[1] +
+						"/externalReferenceCode"));
 
 			String relationshipIdName = objectFieldName.substring(
 				objectFieldName.lastIndexOf(StringPool.UNDERLINE) + 1);

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -796,17 +796,17 @@ public class PredicateExpressionVisitorImpl
 			PrimitivePropertyExpression primitivePropertyExpression =
 				(PrimitivePropertyExpression)propertyExpression;
 
-			String relationshipsNamesValue = StringUtil.merge(
+			String relationshipsNamesString = StringUtil.merge(
 				relationshipsNames, StringPool.SLASH);
 
 			Object value = _visitPrimitivePropertyExpression(
 				_getEntityField(
-					relationshipsNamesValue + StringPool.SLASH +
+					relationshipsNamesString + StringPool.SLASH +
 						primitivePropertyExpression.getName(),
 					_objectDefinition),
 				primitivePropertyExpression);
 
-			return relationshipsNamesValue + StringPool.SLASH + value;
+			return relationshipsNamesString + StringPool.SLASH + value;
 		}
 
 		relationshipsNames.add(propertyExpression.toString());

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -891,7 +891,7 @@ public class PredicateExpressionVisitorImpl
 			ReferenceStringEntityField referenceStringEntityField =
 				(ReferenceStringEntityField)entityField;
 
-			return referenceStringEntityField.getReferencedFieldName();
+			return referenceStringEntityField.getReferenceFieldName();
 		}
 
 		return primitivePropertyExpression.getName();

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -161,6 +161,28 @@ public class PredicateExpressionVisitorImpl
 				});
 		}
 
+		EntityModel entityModel = _getObjectDefinitionEntityModel(
+			ObjectRelationshipUtil.getRelatedObjectDefinition(
+				_objectDefinition,
+				_fetchObjectRelationship(
+					_objectDefinition, complexPropertyExpression.getName())));
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		EntityField entityField = entityFieldsMap.get(
+			propertyExpression.getName());
+
+		if (entityField.getFilterableName(
+				null
+			).contains(
+				"/"
+			)) {
+
+			return complexPropertyExpression.getName() + "/" +
+				entityField.getFilterableName(null);
+		}
+
 		return complexPropertyExpression.toString();
 	}
 
@@ -317,6 +339,24 @@ public class PredicateExpressionVisitorImpl
 	@Override
 	public Object visitPrimitivePropertyExpression(
 		PrimitivePropertyExpression primitivePropertyExpression) {
+
+		EntityModel entityModel = _entityModels.get(
+			_objectDefinition.getObjectDefinitionId());
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		EntityField entityField = entityFieldsMap.get(
+			primitivePropertyExpression.getName());
+
+		if (entityField.getFilterableName(
+				null
+			).contains(
+				"/"
+			)) {
+
+			return entityField.getFilterableName(null);
+		}
 
 		return primitivePropertyExpression.getName();
 	}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -696,7 +696,7 @@ public class PredicateExpressionVisitorImpl
 
 		try {
 			ObjectField objectField = _objectFieldLocalService.getObjectField(
-				_objectDefinition.getObjectDefinitionId(),
+				objectDefinition.getObjectDefinitionId(),
 				entityFieldFilterableName);
 
 			ObjectFieldBusinessType objectFieldBusinessType =

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -450,16 +450,16 @@ public class PredicateExpressionVisitorImpl
 
 		int index = fieldName.indexOf(StringPool.SLASH);
 
-		if (index != -1) {
-			return _getEntityField(
-				fieldName.substring(index + 1),
-				ObjectRelationshipUtil.getRelatedObjectDefinition(
-					objectDefinition,
-					_fetchObjectRelationship(
-						objectDefinition, fieldName.substring(0, index))));
+		if (index == -1) {
+			return entityFieldsMap.get(fieldName);
 		}
 
-		return entityFieldsMap.get(fieldName);
+		return _getEntityField(
+			fieldName.substring(index + 1),
+			ObjectRelationshipUtil.getRelatedObjectDefinition(
+				objectDefinition,
+				_fetchObjectRelationship(
+					objectDefinition, fieldName.substring(0, index))));
 	}
 
 	private Map<String, EntityField> _getEntityFieldsMap(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -16,6 +16,7 @@ import com.liferay.object.odata.filter.expression.field.predicate.provider.Field
 import com.liferay.object.related.models.ObjectRelatedModelsPredicateProvider;
 import com.liferay.object.related.models.ObjectRelatedModelsPredicateProviderRegistry;
 import com.liferay.object.relationship.util.ObjectRelationshipUtil;
+import com.liferay.object.rest.internal.odata.entity.ReferenceStringEntityField;
 import com.liferay.object.rest.internal.util.BinaryExpressionConverterUtil;
 import com.liferay.object.rest.odata.entity.v1_0.provider.EntityModelProvider;
 import com.liferay.object.service.ObjectFieldLocalService;
@@ -161,27 +162,19 @@ public class PredicateExpressionVisitorImpl
 				});
 		}
 
-		EntityModel entityModel = _getObjectDefinitionEntityModel(
-			ObjectRelationshipUtil.getRelatedObjectDefinition(
-				_objectDefinition,
-				_fetchObjectRelationship(
-					_objectDefinition, complexPropertyExpression.getName())));
+		if (propertyExpression instanceof PrimitivePropertyExpression) {
+			PrimitivePropertyExpression primitivePropertyExpression =
+				(PrimitivePropertyExpression)propertyExpression;
 
-		Map<String, EntityField> entityFieldsMap =
-			entityModel.getEntityFieldsMap();
+			Object value = _visitPrimitivePropertyExpression(
+				_getEntityField(
+					complexPropertyExpression.getName() + StringPool.SLASH +
+						primitivePropertyExpression.getName(),
+					_objectDefinition),
+				primitivePropertyExpression);
 
-		EntityField entityField = entityFieldsMap.get(
-			propertyExpression.getName());
-
-		if (entityField.getFilterableName(
-				null
-			).contains(
-				StringPool.SLASH
-			)) {
-
-			return StringBundler.concat(
-				complexPropertyExpression.getName(), StringPool.SLASH,
-				entityField.getFilterableName(null));
+			return complexPropertyExpression.getName() + StringPool.SLASH +
+				value;
 		}
 
 		return complexPropertyExpression.toString();
@@ -341,25 +334,10 @@ public class PredicateExpressionVisitorImpl
 	public Object visitPrimitivePropertyExpression(
 		PrimitivePropertyExpression primitivePropertyExpression) {
 
-		EntityModel entityModel = _entityModels.get(
-			_objectDefinition.getObjectDefinitionId());
-
-		Map<String, EntityField> entityFieldsMap =
-			entityModel.getEntityFieldsMap();
-
-		EntityField entityField = entityFieldsMap.get(
-			primitivePropertyExpression.getName());
-
-		if (entityField.getFilterableName(
-				null
-			).contains(
-				StringPool.SLASH
-			)) {
-
-			return entityField.getFilterableName(null);
-		}
-
-		return primitivePropertyExpression.getName();
+		return _visitPrimitivePropertyExpression(
+			_getEntityField(
+				primitivePropertyExpression.getName(), _objectDefinition),
+			primitivePropertyExpression);
 	}
 
 	@Override
@@ -456,7 +434,8 @@ public class PredicateExpressionVisitorImpl
 	private Column<?, Object> _getColumn(
 		Object fieldName, ObjectDefinition objectDefinition) {
 
-		EntityField entityField = _getEntityField(fieldName, objectDefinition);
+		EntityField entityField = _getEntityField(
+			(String)fieldName, objectDefinition);
 
 		return (Column<?, Object>)_objectFieldLocalService.getColumn(
 			objectDefinition.getObjectDefinitionId(),
@@ -464,12 +443,23 @@ public class PredicateExpressionVisitorImpl
 	}
 
 	private EntityField _getEntityField(
-		Object fieldName, ObjectDefinition objectDefinition) {
+		String fieldName, ObjectDefinition objectDefinition) {
 
 		Map<String, EntityField> entityFieldsMap = _getEntityFieldsMap(
 			objectDefinition);
 
-		return entityFieldsMap.get(GetterUtil.getString(fieldName));
+		int index = fieldName.indexOf(StringPool.SLASH);
+
+		if (index != -1) {
+			return _getEntityField(
+				fieldName.substring(index + 1),
+				ObjectRelationshipUtil.getRelatedObjectDefinition(
+					objectDefinition,
+					_fetchObjectRelationship(
+						objectDefinition, fieldName.substring(0, index))));
+		}
+
+		return entityFieldsMap.get(fieldName);
 	}
 
 	private Map<String, EntityField> _getEntityFieldsMap(
@@ -686,7 +676,8 @@ public class PredicateExpressionVisitorImpl
 	private Object _getValue(
 		Object left, ObjectDefinition objectDefinition, Object right) {
 
-		EntityField entityField = _getEntityField(left, objectDefinition);
+		EntityField entityField = _getEntityField(
+			(String)left, objectDefinition);
 
 		EntityField.Type entityType = entityField.getType();
 
@@ -801,6 +792,22 @@ public class PredicateExpressionVisitorImpl
 				complexPropertyExpression.getPropertyExpression(),
 				relationshipsNames);
 		}
+		else if (propertyExpression instanceof PrimitivePropertyExpression) {
+			PrimitivePropertyExpression primitivePropertyExpression =
+				(PrimitivePropertyExpression)propertyExpression;
+
+			String relationshipsNamesValue = StringUtil.merge(
+				relationshipsNames, StringPool.SLASH);
+
+			Object value = _visitPrimitivePropertyExpression(
+				_getEntityField(
+					relationshipsNamesValue + StringPool.SLASH +
+						primitivePropertyExpression.getName(),
+					_objectDefinition),
+				primitivePropertyExpression);
+
+			return relationshipsNamesValue + StringPool.SLASH + value;
+		}
 
 		relationshipsNames.add(propertyExpression.toString());
 
@@ -874,6 +881,20 @@ public class PredicateExpressionVisitorImpl
 				_objectFieldLocalService,
 				_objectRelatedModelsPredicateProviderRegistry,
 				_serviceTrackerMap));
+	}
+
+	private Object _visitPrimitivePropertyExpression(
+		EntityField entityField,
+		PrimitivePropertyExpression primitivePropertyExpression) {
+
+		if (entityField instanceof ReferenceStringEntityField) {
+			ReferenceStringEntityField referenceStringEntityField =
+				(ReferenceStringEntityField)entityField;
+
+			return referenceStringEntityField.getReferencedFieldName();
+		}
+
+		return primitivePropertyExpression.getName();
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -176,11 +176,12 @@ public class PredicateExpressionVisitorImpl
 		if (entityField.getFilterableName(
 				null
 			).contains(
-				"/"
+				StringPool.SLASH
 			)) {
 
-			return complexPropertyExpression.getName() + "/" +
-				entityField.getFilterableName(null);
+			return StringBundler.concat(
+				complexPropertyExpression.getName(), StringPool.SLASH,
+				entityField.getFilterableName(null));
 		}
 
 		return complexPropertyExpression.toString();
@@ -352,7 +353,7 @@ public class PredicateExpressionVisitorImpl
 		if (entityField.getFilterableName(
 				null
 			).contains(
-				"/"
+				StringPool.SLASH
 			)) {
 
 			return entityField.getFilterableName(null);

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -2863,6 +2863,22 @@ public class DefaultObjectEntryManagerImplTest
 			HashMapBuilder.put(
 				"filter",
 				_buildContainsExpressionFilterString(
+					_objectRelationshipERCObjectFieldName,
+					parentObjectEntry1.getExternalReferenceCode())
+			).build(),
+			childObjectEntry1);
+		testGetObjectEntries(
+			HashMapBuilder.put(
+				"filter",
+				_buildContainsExpressionFilterString(
+					_objectRelationshipERCObjectFieldName,
+					parentObjectEntry2.getExternalReferenceCode())
+			).build(),
+			childObjectEntry2);
+		testGetObjectEntries(
+			HashMapBuilder.put(
+				"filter",
+				_buildContainsExpressionFilterString(
 					"id", RandomTestUtil.randomString())
 			).build());
 		testGetObjectEntries(
@@ -2917,22 +2933,6 @@ public class DefaultObjectEntryManagerImplTest
 			HashMapBuilder.put(
 				"filter",
 				_buildContainsExpressionFilterString("textObjectFieldName", "b")
-			).build(),
-			childObjectEntry2);
-		testGetObjectEntries(
-			HashMapBuilder.put(
-				"filter",
-				_buildContainsExpressionFilterString(
-					_objectRelationshipERCObjectFieldName,
-					parentObjectEntry1.getExternalReferenceCode())
-			).build(),
-			childObjectEntry1);
-		testGetObjectEntries(
-			HashMapBuilder.put(
-				"filter",
-				_buildContainsExpressionFilterString(
-					_objectRelationshipERCObjectFieldName,
-					parentObjectEntry2.getExternalReferenceCode())
 			).build(),
 			childObjectEntry2);
 
@@ -3390,6 +3390,22 @@ public class DefaultObjectEntryManagerImplTest
 			HashMapBuilder.put(
 				"filter",
 				_buildStartsWithExpressionFilterString(
+					_objectRelationshipERCObjectFieldName,
+					parentObjectEntry1.getExternalReferenceCode())
+			).build(),
+			childObjectEntry1);
+		testGetObjectEntries(
+			HashMapBuilder.put(
+				"filter",
+				_buildStartsWithExpressionFilterString(
+					_objectRelationshipERCObjectFieldName,
+					parentObjectEntry2.getExternalReferenceCode())
+			).build(),
+			childObjectEntry2);
+		testGetObjectEntries(
+			HashMapBuilder.put(
+				"filter",
+				_buildStartsWithExpressionFilterString(
 					"id", RandomTestUtil.randomString())
 			).build());
 		testGetObjectEntries(
@@ -3445,22 +3461,6 @@ public class DefaultObjectEntryManagerImplTest
 				_buildStartsWithExpressionFilterString(
 					"textObjectFieldName", "b")
 			).build());
-		testGetObjectEntries(
-			HashMapBuilder.put(
-				"filter",
-				_buildStartsWithExpressionFilterString(
-					_objectRelationshipERCObjectFieldName,
-					parentObjectEntry1.getExternalReferenceCode())
-			).build(),
-			childObjectEntry1);
-		testGetObjectEntries(
-			HashMapBuilder.put(
-				"filter",
-				_buildStartsWithExpressionFilterString(
-					_objectRelationshipERCObjectFieldName,
-					parentObjectEntry2.getExternalReferenceCode())
-			).build(),
-			childObjectEntry2);
 	}
 
 	@Test

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -2919,6 +2919,22 @@ public class DefaultObjectEntryManagerImplTest
 				_buildContainsExpressionFilterString("textObjectFieldName", "b")
 			).build(),
 			childObjectEntry2);
+		testGetObjectEntries(
+			HashMapBuilder.put(
+				"filter",
+				_buildContainsExpressionFilterString(
+					_objectRelationshipERCObjectFieldName,
+					parentObjectEntry1.getExternalReferenceCode())
+			).build(),
+			childObjectEntry1);
+		testGetObjectEntries(
+			HashMapBuilder.put(
+				"filter",
+				_buildContainsExpressionFilterString(
+					_objectRelationshipERCObjectFieldName,
+					parentObjectEntry2.getExternalReferenceCode())
+			).build(),
+			childObjectEntry2);
 
 		// Equals expression
 
@@ -3429,6 +3445,22 @@ public class DefaultObjectEntryManagerImplTest
 				_buildStartsWithExpressionFilterString(
 					"textObjectFieldName", "b")
 			).build());
+		testGetObjectEntries(
+			HashMapBuilder.put(
+				"filter",
+				_buildStartsWithExpressionFilterString(
+					_objectRelationshipERCObjectFieldName,
+					parentObjectEntry1.getExternalReferenceCode())
+			).build(),
+			childObjectEntry1);
+		testGetObjectEntries(
+			HashMapBuilder.put(
+				"filter",
+				_buildStartsWithExpressionFilterString(
+					_objectRelationshipERCObjectFieldName,
+					parentObjectEntry2.getExternalReferenceCode())
+			).build(),
+			childObjectEntry2);
 	}
 
 	@Test

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/odata/entity/v1_0/test/ObjectEntryEntityModelTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/odata/entity/v1_0/test/ObjectEntryEntityModelTest.java
@@ -109,11 +109,9 @@ public class ObjectEntryEntityModelTest {
 			_addObjectRelationship(
 				objectDefinition, relatedObjectDefinition,
 				ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
-
 		ObjectRelationship manyToOneObjectRelationship = _addObjectRelationship(
 			relatedObjectDefinition, objectDefinition,
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
 		ObjectRelationship oneToManyObjectRelationship = _addObjectRelationship(
 			objectDefinition, relatedObjectDefinition,
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
@@ -228,15 +226,15 @@ public class ObjectEntryEntityModelTest {
 	private Map<String, EntityField> _getExpectedObjectFieldsEntityFieldsMap(
 		List<ObjectField> customObjectFields) {
 
-		Map<String, EntityField> expectedEntityFieldsMap = new HashMap<>();
+		Map<String, EntityField> entityFieldsMap = new HashMap<>();
 
 		for (ObjectField customObjectField : customObjectFields) {
 			EntityField entityField = _toExpectedEntityField(customObjectField);
 
-			expectedEntityFieldsMap.put(entityField.getName(), entityField);
+			entityFieldsMap.put(entityField.getName(), entityField);
 		}
 
-		return expectedEntityFieldsMap;
+		return entityFieldsMap;
 	}
 
 	private Map<String, EntityField>
@@ -244,13 +242,13 @@ public class ObjectEntryEntityModelTest {
 			ObjectRelationship objectRelationship,
 			ObjectDefinition relatedObjectDefinition) {
 
-		Map<String, EntityField> expectedEntityFieldsMap = new HashMap<>();
+		Map<String, EntityField> entityFieldsMap = new HashMap<>();
 
 		if (StringUtil.equals(
 				objectRelationship.getType(),
 				ObjectRelationshipConstants.TYPE_MANY_TO_MANY)) {
 
-			expectedEntityFieldsMap.put(
+			entityFieldsMap.put(
 				objectRelationship.getName(),
 				new ComplexEntityField(
 					objectRelationship.getName(), Collections.emptyList()));
@@ -270,7 +268,7 @@ public class ObjectEntryEntityModelTest {
 				String expectedObjectFieldName =
 					relationshipEntityFieldPrefix + pkObjectFieldName;
 
-				expectedEntityFieldsMap.put(
+				entityFieldsMap.put(
 					expectedObjectFieldName,
 					new IdEntityField(
 						expectedObjectFieldName,
@@ -280,7 +278,7 @@ public class ObjectEntryEntityModelTest {
 					relationshipEntityFieldPrefix +
 						StringUtil.replaceLast(pkObjectFieldName, "Id", "ERC");
 
-				expectedEntityFieldsMap.put(
+				entityFieldsMap.put(
 					expectedObjectRelationshipERCObjectFieldName,
 					new StringEntityField(
 						expectedObjectRelationshipERCObjectFieldName,
@@ -289,19 +287,19 @@ public class ObjectEntryEntityModelTest {
 				String expectedRelatedObjectDefinitionIdObjectFieldName =
 					pkObjectFieldName.replaceFirst("c_", "");
 
-				expectedEntityFieldsMap.put(
+				entityFieldsMap.put(
 					expectedRelatedObjectDefinitionIdObjectFieldName,
 					new IdEntityField(
 						expectedRelatedObjectDefinitionIdObjectFieldName,
 						locale -> expectedObjectFieldName, String::valueOf));
 
-				expectedEntityFieldsMap.put(
+				entityFieldsMap.put(
 					objectRelationship.getName(),
 					new ComplexEntityField(
 						objectRelationship.getName(), Collections.emptyList()));
 			}
 			else {
-				expectedEntityFieldsMap.put(
+				entityFieldsMap.put(
 					objectRelationship.getName(),
 					new ComplexEntityField(
 						objectRelationship.getName(), Collections.emptyList()));
@@ -311,14 +309,14 @@ public class ObjectEntryEntityModelTest {
 			throw new IllegalStateException();
 		}
 
-		return expectedEntityFieldsMap;
+		return entityFieldsMap;
 	}
 
 	private Map<String, EntityField> _getObjectDefinitionEntityFieldsMap(
 			ObjectDefinition objectDefinition)
 		throws Exception {
 
-		Map<String, EntityField> objectEntityFieldsMap = null;
+		Map<String, EntityField> entityFieldsMap = null;
 
 		Bundle bundle = FrameworkUtil.getBundle(
 			ObjectEntryEntityModelTest.class);
@@ -345,10 +343,10 @@ public class ObjectEntryEntityModelTest {
 
 			EntityModel entityModel = entityModelResource.getEntityModel(null);
 
-			objectEntityFieldsMap = entityModel.getEntityFieldsMap();
+			entityFieldsMap = entityModel.getEntityFieldsMap();
 		}
 
-		return objectEntityFieldsMap;
+		return entityFieldsMap;
 	}
 
 	private ObjectDefinition _publishObjectDefinition(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/odata/entity/v1_0/test/ObjectEntryEntityModelTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/odata/entity/v1_0/test/ObjectEntryEntityModelTest.java
@@ -105,8 +105,18 @@ public class ObjectEntryEntityModelTest {
 		ObjectDefinition relatedObjectDefinition = _publishObjectDefinition(
 			ObjectDefinitionTestUtil.getRandomName(), customObjectFields);
 
-		ObjectRelationship objectRelationship = _addObjectRelationship(
-			objectDefinition, relatedObjectDefinition);
+		ObjectRelationship manyToManyObjectRelationship =
+			_addObjectRelationship(
+				objectDefinition, relatedObjectDefinition,
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		ObjectRelationship manyToOneObjectRelationship = _addObjectRelationship(
+			relatedObjectDefinition, objectDefinition,
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		ObjectRelationship oneToManyObjectRelationship = _addObjectRelationship(
+			objectDefinition, relatedObjectDefinition,
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_assertEquals(
 			HashMapBuilder.<String, EntityField>put(
@@ -147,16 +157,23 @@ public class ObjectEntryEntityModelTest {
 				"userId",
 				new IntegerEntityField("userId", locale -> Field.USER_ID)
 			).putAll(
-				_getExpectedEntityFieldsMap(
-					customObjectFields, objectRelationship,
-					relatedObjectDefinition)
+				_getExpectedObjectFieldsEntityFieldsMap(customObjectFields)
+			).putAll(
+				_getExpectedRelationshipFieldsEntityFieldsMap(
+					manyToManyObjectRelationship, relatedObjectDefinition)
+			).putAll(
+				_getExpectedRelationshipFieldsEntityFieldsMap(
+					manyToOneObjectRelationship, relatedObjectDefinition)
+			).putAll(
+				_getExpectedRelationshipFieldsEntityFieldsMap(
+					oneToManyObjectRelationship, relatedObjectDefinition)
 			).build(),
 			_getObjectDefinitionEntityFieldsMap(objectDefinition));
 	}
 
 	private ObjectRelationship _addObjectRelationship(
 			ObjectDefinition objectDefinition,
-			ObjectDefinition relatedObjectDefinition)
+			ObjectDefinition relatedObjectDefinition, String type)
 		throws Exception {
 
 		ObjectRelationship objectRelationship =
@@ -166,8 +183,7 @@ public class ObjectEntryEntityModelTest {
 				objectDefinition.getObjectDefinitionId(), 0,
 				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				StringUtil.randomId(), false,
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+				StringUtil.randomId(), false, type, null);
 
 		_objectRelationships.add(objectRelationship);
 
@@ -209,10 +225,8 @@ public class ObjectEntryEntityModelTest {
 		).build();
 	}
 
-	private Map<String, EntityField> _getExpectedEntityFieldsMap(
-		List<ObjectField> customObjectFields,
-		ObjectRelationship objectRelationship,
-		ObjectDefinition relatedObjectDefinition) {
+	private Map<String, EntityField> _getExpectedObjectFieldsEntityFieldsMap(
+		List<ObjectField> customObjectFields) {
 
 		Map<String, EntityField> expectedEntityFieldsMap = new HashMap<>();
 
@@ -222,43 +236,80 @@ public class ObjectEntryEntityModelTest {
 			expectedEntityFieldsMap.put(entityField.getName(), entityField);
 		}
 
-		String pkObjectFieldName =
-			relatedObjectDefinition.getPKObjectFieldName();
-		String relationshipEntityFieldPrefix = StringBundler.concat(
-			"r_", objectRelationship.getName(), "_");
+		return expectedEntityFieldsMap;
+	}
 
-		String expectedObjectFieldName =
-			relationshipEntityFieldPrefix + pkObjectFieldName;
+	private Map<String, EntityField>
+		_getExpectedRelationshipFieldsEntityFieldsMap(
+			ObjectRelationship objectRelationship,
+			ObjectDefinition relatedObjectDefinition) {
 
-		expectedEntityFieldsMap.put(
-			expectedObjectFieldName,
-			new IdEntityField(
-				expectedObjectFieldName, locale -> expectedObjectFieldName,
-				String::valueOf));
+		Map<String, EntityField> expectedEntityFieldsMap = new HashMap<>();
 
-		String expectedObjectRelationshipERCObjectFieldName =
-			relationshipEntityFieldPrefix +
-				StringUtil.replaceLast(pkObjectFieldName, "Id", "ERC");
+		if (StringUtil.equals(
+				objectRelationship.getType(),
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY)) {
 
-		expectedEntityFieldsMap.put(
-			expectedObjectRelationshipERCObjectFieldName,
-			new StringEntityField(
-				expectedObjectRelationshipERCObjectFieldName,
-				locale -> expectedObjectFieldName));
+			expectedEntityFieldsMap.put(
+				objectRelationship.getName(),
+				new ComplexEntityField(
+					objectRelationship.getName(), Collections.emptyList()));
+		}
+		else if (StringUtil.equals(
+					objectRelationship.getType(),
+					ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
 
-		String expectedRelatedObjectDefinitionIdObjectFieldName =
-			pkObjectFieldName.replaceFirst("c_", "");
+			if (objectRelationship.getObjectDefinitionId1() ==
+					relatedObjectDefinition.getObjectDefinitionId()) {
 
-		expectedEntityFieldsMap.put(
-			expectedRelatedObjectDefinitionIdObjectFieldName,
-			new IdEntityField(
-				expectedRelatedObjectDefinitionIdObjectFieldName,
-				locale -> expectedObjectFieldName, String::valueOf));
+				String pkObjectFieldName =
+					relatedObjectDefinition.getPKObjectFieldName();
+				String relationshipEntityFieldPrefix = StringBundler.concat(
+					"r_", objectRelationship.getName(), "_");
 
-		expectedEntityFieldsMap.put(
-			objectRelationship.getName(),
-			new ComplexEntityField(
-				objectRelationship.getName(), Collections.emptyList()));
+				String expectedObjectFieldName =
+					relationshipEntityFieldPrefix + pkObjectFieldName;
+
+				expectedEntityFieldsMap.put(
+					expectedObjectFieldName,
+					new IdEntityField(
+						expectedObjectFieldName,
+						locale -> expectedObjectFieldName, String::valueOf));
+
+				String expectedObjectRelationshipERCObjectFieldName =
+					relationshipEntityFieldPrefix +
+						StringUtil.replaceLast(pkObjectFieldName, "Id", "ERC");
+
+				expectedEntityFieldsMap.put(
+					expectedObjectRelationshipERCObjectFieldName,
+					new StringEntityField(
+						expectedObjectRelationshipERCObjectFieldName,
+						locale -> expectedObjectFieldName));
+
+				String expectedRelatedObjectDefinitionIdObjectFieldName =
+					pkObjectFieldName.replaceFirst("c_", "");
+
+				expectedEntityFieldsMap.put(
+					expectedRelatedObjectDefinitionIdObjectFieldName,
+					new IdEntityField(
+						expectedRelatedObjectDefinitionIdObjectFieldName,
+						locale -> expectedObjectFieldName, String::valueOf));
+
+				expectedEntityFieldsMap.put(
+					objectRelationship.getName(),
+					new ComplexEntityField(
+						objectRelationship.getName(), Collections.emptyList()));
+			}
+			else {
+				expectedEntityFieldsMap.put(
+					objectRelationship.getName(),
+					new ComplexEntityField(
+						objectRelationship.getName(), Collections.emptyList()));
+			}
+		}
+		else {
+			throw new IllegalStateException();
+		}
 
 		return expectedEntityFieldsMap;
 	}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/odata/entity/v1_0/test/ObjectEntryEntityModelTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/odata/entity/v1_0/test/ObjectEntryEntityModelTest.java
@@ -262,11 +262,10 @@ public class ObjectEntryEntityModelTest {
 
 				String pkObjectFieldName =
 					relatedObjectDefinition.getPKObjectFieldName();
-				String relationshipEntityFieldPrefix = StringBundler.concat(
+				String prefix = StringBundler.concat(
 					"r_", objectRelationship.getName(), "_");
 
-				String expectedObjectFieldName =
-					relationshipEntityFieldPrefix + pkObjectFieldName;
+				String expectedObjectFieldName = prefix + pkObjectFieldName;
 
 				entityFieldsMap.put(
 					expectedObjectFieldName,
@@ -275,7 +274,7 @@ public class ObjectEntryEntityModelTest {
 						locale -> expectedObjectFieldName, String::valueOf));
 
 				String expectedObjectRelationshipERCObjectFieldName =
-					relationshipEntityFieldPrefix +
+					prefix +
 						StringUtil.replaceLast(pkObjectFieldName, "Id", "ERC");
 
 				entityFieldsMap.put(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -10005,6 +10005,7 @@ public class ObjectEntryResourceTest {
 			ObjectFieldValidationConstants.BUSINESS_TYPE_LONG_VALUE_MAX);
 		String randomString1 = RandomTestUtil.randomString();
 		String randomString2 = RandomTestUtil.randomString();
+		String randomString3 = RandomTestUtil.randomString();
 
 		JSONObject jsonObject1 = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
@@ -10032,6 +10033,8 @@ public class ObjectEntryResourceTest {
 			).put(
 				_OBJECT_FIELD_NAME_TEXT, "a" + randomString2
 			).put(
+				"externalReferenceCode", _ERC_VALUE_2
+			).put(
 				objectField.getName(),
 				() -> {
 					ObjectEntry relatedObjectEntry =
@@ -10040,7 +10043,7 @@ public class ObjectEntryResourceTest {
 							HashMapBuilder.<String, Serializable>put(
 								_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2
 							).put(
-								"externalReferenceCode", _ERC_VALUE_1
+								"externalReferenceCode", "a" + randomString3
 							).build());
 
 					return relatedObjectEntry.getObjectEntryId();
@@ -10080,6 +10083,8 @@ public class ObjectEntryResourceTest {
 			).put(
 				_OBJECT_FIELD_NAME_TEXT, "b" + randomString2
 			).put(
+				"externalReferenceCode", _ERC_VALUE_1
+			).put(
 				objectField.getName(),
 				() -> {
 					ObjectEntry relatedObjectEntry =
@@ -10088,7 +10093,7 @@ public class ObjectEntryResourceTest {
 							HashMapBuilder.<String, Serializable>put(
 								_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2
 							).put(
-								"externalReferenceCode", _ERC_VALUE_2
+								"externalReferenceCode", "b" + randomString3
 							).build());
 
 					return relatedObjectEntry.getObjectEntryId();
@@ -16221,13 +16226,14 @@ public class ObjectEntryResourceTest {
 		return JSONFactoryUtil.createJSONObject(fileEntry.toString());
 	}
 
-	private static final String _ERC_VALUE_1 = RandomTestUtil.randomString();
+	private static final String _ERC_VALUE_1 =
+		"a" + RandomTestUtil.randomString();
 
 	private static final String _ERC_VALUE_2 =
-		_ERC_VALUE_1 + RandomTestUtil.randomString();
+		"b" + RandomTestUtil.randomString();
 
 	private static final String _ERC_VALUE_3 =
-		_ERC_VALUE_2 + RandomTestUtil.randomString();
+		"c" + RandomTestUtil.randomString();
 
 	private static final String _LIST_TYPE_ENTRY_KEY_1 =
 		"a" + RandomTestUtil.randomString();

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -4174,12 +4174,19 @@ public class ObjectEntryResourceTest {
 		_objectRelationship1 = _addObjectRelationshipAndRelateObjectEntries(
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		String relationshipERCFieldName = String.format(
-			"r_%s_%s", _objectRelationship1.getName(),
-			_objectDefinition1.getPKObjectFieldName()
-		).replace(
-			"Id", "ERC"
-		);
+		String objectRelationshipERCObjectFieldName =
+			ObjectFieldSettingUtil.getValue(
+				ObjectFieldSettingConstants.
+					NAME_OBJECT_RELATIONSHIP_ERC_OBJECT_FIELD_NAME,
+				_objectFieldLocalService.getObjectField(
+					_objectRelationship1.getObjectFieldId2()));
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"r_", _objectRelationship1.getName(), "_",
+				StringUtil.replaceLast(
+					_objectDefinition1.getPKObjectFieldName(), "Id", "ERC")),
+			objectRelationshipERCObjectFieldName);
 
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
 			null, _objectDefinition2.getRESTContextPath(), Http.Method.GET);
@@ -4191,7 +4198,7 @@ public class ObjectEntryResourceTest {
 		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
 
 		Assert.assertEquals(
-			itemJSONObject.getString(relationshipERCFieldName),
+			itemJSONObject.getString(objectRelationshipERCObjectFieldName),
 			_objectEntry1.getExternalReferenceCode());
 
 		// Comparison operators
@@ -4206,7 +4213,7 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/%s eq '%s'", _objectRelationship1.getName(),
-					relationshipERCFieldName,
+					objectRelationshipERCObjectFieldName,
 					_objectEntry1.getExternalReferenceCode())),
 			_objectDefinition1);
 
@@ -4215,7 +4222,7 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/%s ge '%s'", _objectRelationship1.getName(),
-					relationshipERCFieldName,
+					objectRelationshipERCObjectFieldName,
 					_objectEntry1.getExternalReferenceCode())),
 			_objectDefinition1);
 
@@ -4224,7 +4231,7 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/%s gt '%s'", _objectRelationship1.getName(),
-					relationshipERCFieldName, substring + "0000")),
+					objectRelationshipERCObjectFieldName, substring + "0000")),
 			_objectDefinition1);
 
 		_assertFilterString(
@@ -4232,7 +4239,7 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/%s le '%s'", _objectRelationship1.getName(),
-					relationshipERCFieldName,
+					objectRelationshipERCObjectFieldName,
 					_objectEntry1.getExternalReferenceCode())),
 			_objectDefinition1);
 
@@ -4241,7 +4248,7 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/%s lt '%s'", _objectRelationship1.getName(),
-					relationshipERCFieldName, substring + "ZZZZ")),
+					objectRelationshipERCObjectFieldName, substring + "ZZZZ")),
 			_objectDefinition1);
 
 		_assertFilterString(
@@ -4249,7 +4256,8 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/%s ne '%s'", _objectRelationship1.getName(),
-					relationshipERCFieldName, RandomTestUtil.randomInt())),
+					objectRelationshipERCObjectFieldName,
+					RandomTestUtil.randomInt())),
 			_objectDefinition1);
 
 		// List operators
@@ -4259,7 +4267,7 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/%s in ('%s', '%s')", _objectRelationship1.getName(),
-					relationshipERCFieldName,
+					objectRelationshipERCObjectFieldName,
 					_objectEntry1.getExternalReferenceCode(),
 					RandomTestUtil.randomInt())),
 			_objectDefinition1);
@@ -4270,14 +4278,14 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			String.format(
 				"contains(%s/%s,'%s')", _objectRelationship1.getName(),
-				relationshipERCFieldName, substring),
+				objectRelationshipERCObjectFieldName, substring),
 			_objectDefinition1);
 
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			String.format(
 				"startswith(%s/%s,'%s')", _objectRelationship1.getName(),
-				relationshipERCFieldName, substring),
+				objectRelationshipERCObjectFieldName, substring),
 			_objectDefinition1);
 	}
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -4196,11 +4196,10 @@ public class ObjectEntryResourceTest {
 
 		// Comparison operators
 
-		String relationshipERCSubstring =
-			_objectEntry1.getExternalReferenceCode(
-			).substring(
-				0, 3
-			);
+		String substring = _objectEntry1.getExternalReferenceCode(
+		).substring(
+			0, 3
+		);
 
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
@@ -4225,8 +4224,7 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/%s gt '%s'", _objectRelationship1.getName(),
-					relationshipERCFieldName,
-					relationshipERCSubstring + "0000")),
+					relationshipERCFieldName, substring + "0000")),
 			_objectDefinition1);
 
 		_assertFilterString(
@@ -4243,8 +4241,7 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/%s lt '%s'", _objectRelationship1.getName(),
-					relationshipERCFieldName,
-					relationshipERCSubstring + "ZZZZ")),
+					relationshipERCFieldName, substring + "ZZZZ")),
 			_objectDefinition1);
 
 		_assertFilterString(
@@ -4273,22 +4270,14 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			String.format(
 				"contains(%s/%s,'%s')", _objectRelationship1.getName(),
-				relationshipERCFieldName,
-				_objectEntry1.getExternalReferenceCode(
-				).substring(
-					0, 2
-				)),
+				relationshipERCFieldName, substring),
 			_objectDefinition1);
 
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			String.format(
 				"startswith(%s/%s,'%s')", _objectRelationship1.getName(),
-				relationshipERCFieldName,
-				_objectEntry1.getExternalReferenceCode(
-				).substring(
-					0, 2
-				)),
+				relationshipERCFieldName, substring),
 			_objectDefinition1);
 	}
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -10036,8 +10036,12 @@ public class ObjectEntryResourceTest {
 				() -> {
 					ObjectEntry relatedObjectEntry =
 						ObjectEntryTestUtil.addObjectEntry(
-							_objectDefinition2, _OBJECT_FIELD_NAME_2,
-							_OBJECT_FIELD_VALUE_2);
+							_objectDefinition2,
+							HashMapBuilder.<String, Serializable>put(
+								_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2
+							).put(
+								"externalReferenceCode", _ERC_VALUE_1
+							).build());
 
 					return relatedObjectEntry.getObjectEntryId();
 				}
@@ -10080,8 +10084,12 @@ public class ObjectEntryResourceTest {
 				() -> {
 					ObjectEntry relatedObjectEntry =
 						ObjectEntryTestUtil.addObjectEntry(
-							_objectDefinition2, _OBJECT_FIELD_NAME_2,
-							_OBJECT_FIELD_VALUE_2);
+							_objectDefinition2,
+							HashMapBuilder.<String, Serializable>put(
+								_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2
+							).put(
+								"externalReferenceCode", _ERC_VALUE_2
+							).build());
 
 					return relatedObjectEntry.getObjectEntryId();
 				}
@@ -16215,9 +16223,11 @@ public class ObjectEntryResourceTest {
 
 	private static final String _ERC_VALUE_1 = RandomTestUtil.randomString();
 
-	private static final String _ERC_VALUE_2 = RandomTestUtil.randomString();
+	private static final String _ERC_VALUE_2 =
+		_ERC_VALUE_1 + RandomTestUtil.randomString();
 
-	private static final String _ERC_VALUE_3 = RandomTestUtil.randomString();
+	private static final String _ERC_VALUE_3 =
+		_ERC_VALUE_2 + RandomTestUtil.randomString();
 
 	private static final String _LIST_TYPE_ENTRY_KEY_1 =
 		"a" + RandomTestUtil.randomString();

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -4162,6 +4162,137 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testFilterByRelationshipERCFieldNameInOneToManyRelationship()
+		throws Exception {
+
+		_objectEntry1 = ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition1, _OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1);
+
+		_objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition2, _OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
+
+		_objectRelationship1 = _addObjectRelationshipAndRelateObjectEntries(
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		String relationshipERCFieldName = String.format(
+			"r_%s_%s", _objectRelationship1.getName(),
+			_objectDefinition1.getPKObjectFieldName()
+		).replace(
+			"Id", "ERC"
+		);
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null, _objectDefinition2.getRESTContextPath(), Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(1, itemsJSONArray.length());
+
+		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
+
+		Assert.assertEquals(
+			itemJSONObject.getString(relationshipERCFieldName),
+			_objectEntry1.getExternalReferenceCode());
+
+		// Comparison operators
+
+		String relationshipERCSubstring =
+			_objectEntry1.getExternalReferenceCode(
+			).substring(
+				0, 3
+			);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s eq '%s'", _objectRelationship1.getName(),
+					relationshipERCFieldName,
+					_objectEntry1.getExternalReferenceCode())),
+			_objectDefinition1);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s ge '%s'", _objectRelationship1.getName(),
+					relationshipERCFieldName,
+					_objectEntry1.getExternalReferenceCode())),
+			_objectDefinition1);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s gt '%s'", _objectRelationship1.getName(),
+					relationshipERCFieldName,
+					relationshipERCSubstring + "0000")),
+			_objectDefinition1);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s le '%s'", _objectRelationship1.getName(),
+					relationshipERCFieldName,
+					_objectEntry1.getExternalReferenceCode())),
+			_objectDefinition1);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s lt '%s'", _objectRelationship1.getName(),
+					relationshipERCFieldName,
+					relationshipERCSubstring + "ZZZZ")),
+			_objectDefinition1);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s ne '%s'", _objectRelationship1.getName(),
+					relationshipERCFieldName, RandomTestUtil.randomInt())),
+			_objectDefinition1);
+
+		// List operators
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s in ('%s', '%s')", _objectRelationship1.getName(),
+					relationshipERCFieldName,
+					_objectEntry1.getExternalReferenceCode(),
+					RandomTestUtil.randomInt())),
+			_objectDefinition1);
+
+		// String operators
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			String.format(
+				"contains(%s/%s,'%s')", _objectRelationship1.getName(),
+				relationshipERCFieldName,
+				_objectEntry1.getExternalReferenceCode(
+				).substring(
+					0, 2
+				)),
+			_objectDefinition1);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			String.format(
+				"startswith(%s/%s,'%s')", _objectRelationship1.getName(),
+				relationshipERCFieldName,
+				_objectEntry1.getExternalReferenceCode(
+				).substring(
+					0, 2
+				)),
+			_objectDefinition1);
+	}
+
+	@Test
 	public void testFilterByStringOperatorsObjectEntriesByRelatedObjectEntriesFields()
 		throws Exception {
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -4162,7 +4162,7 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testFilterByRelationshipERCFieldNameInOneToManyRelationship()
+	public void testFilterByObjectRelationshipERCObjectFieldNameInOneToManyRelationship()
 		throws Exception {
 
 		_objectEntry1 = ObjectEntryTestUtil.addObjectEntry(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/ObjectEntryFieldSortDSLQueryVisitor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/ObjectEntryFieldSortDSLQueryVisitor.java
@@ -47,8 +47,10 @@ public class ObjectEntryFieldSortDSLQueryVisitor
 	public DSLQuery visit(DSLQuery dslQuery, Sort sort) throws PortalException {
 		ObjectDefinition objectDefinition = sort.getObjectDefinition();
 
+		String fieldName = _getSortFieldName(sort);
+
 		ObjectField objectField = objectFieldLocalService.fetchObjectField(
-			objectDefinition.getObjectDefinitionId(), sort.getFieldName());
+			objectDefinition.getObjectDefinitionId(), fieldName);
 
 		Expression<?> columnExpression = null;
 		Table fieldTable = null;
@@ -57,12 +59,11 @@ public class ObjectEntryFieldSortDSLQueryVisitor
 		if (objectField == null) {
 			Column<?, Object> column =
 				(Column<?, Object>)objectFieldLocalService.getColumn(
-					objectDefinition.getObjectDefinitionId(),
-					sort.getFieldName());
+					objectDefinition.getObjectDefinitionId(), fieldName);
 
 			fieldTable = getAliasedTable(_getSuffix(sort), column.getTable());
 
-			columnExpression = fieldTable.getColumn(sort.getFieldName());
+			columnExpression = fieldTable.getColumn(fieldName);
 		}
 		else {
 			fieldTable = getAliasedTable(
@@ -152,6 +153,16 @@ public class ObjectEntryFieldSortDSLQueryVisitor
 		return expression.ascending();
 	}
 
+	private String _getSortFieldName(Sort sort) {
+		String fieldName = sort.getFieldName();
+
+		if (!fieldName.contains(StringPool.SLASH)) {
+			return fieldName;
+		}
+
+		return StringUtil.extractLast(fieldName, StringPool.SLASH);
+	}
+
 	private String _getSuffix(Sort sort) {
 		if (!_isParentComplexField(sort)) {
 			return null;
@@ -160,12 +171,12 @@ public class ObjectEntryFieldSortDSLQueryVisitor
 		return StringUtil.replace(
 			StringUtil.removeLast(
 				sort.getFieldPath(),
-				CharPool.FORWARD_SLASH + sort.getFieldName()),
+				CharPool.FORWARD_SLASH + _getSortFieldName(sort)),
 			CharPool.FORWARD_SLASH, CharPool.UNDERLINE);
 	}
 
 	private boolean _isParentComplexField(Sort sort) {
-		return !StringUtil.equals(sort.getFieldName(), sort.getFieldPath());
+		return !StringUtil.equals(_getSortFieldName(sort), sort.getFieldPath());
 	}
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/ObjectEntryFieldSortDSLQueryVisitor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/ObjectEntryFieldSortDSLQueryVisitor.java
@@ -46,7 +46,6 @@ public class ObjectEntryFieldSortDSLQueryVisitor
 	@Override
 	public DSLQuery visit(DSLQuery dslQuery, Sort sort) throws PortalException {
 		ObjectDefinition objectDefinition = sort.getObjectDefinition();
-
 		String fieldName = _getSortFieldName(sort);
 
 		ObjectField objectField = objectFieldLocalService.fetchObjectField(

--- a/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/sort/SortField.java
+++ b/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/sort/SortField.java
@@ -82,6 +82,10 @@ public class SortField implements Serializable {
 	public String getSortableFieldPath(Locale locale) {
 		String sortableFieldName = getSortableFieldName(locale);
 
+		if (sortableFieldName.equals("externalReferenceCode")) {
+			sortableFieldName = _entityField.getFilterableName(locale);
+		}
+
 		if (ListUtil.isEmpty(_parentEntityFields)) {
 			return sortableFieldName;
 		}

--- a/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/sort/SortField.java
+++ b/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/sort/SortField.java
@@ -82,10 +82,6 @@ public class SortField implements Serializable {
 	public String getSortableFieldPath(Locale locale) {
 		String sortableFieldName = getSortableFieldName(locale);
 
-		if (sortableFieldName.equals("externalReferenceCode")) {
-			sortableFieldName = _entityField.getFilterableName(locale);
-		}
-
 		if (ListUtil.isEmpty(_parentEntityFields)) {
 			return sortableFieldName;
 		}


### PR DESCRIPTION
See: https://github.com/brianchandotcom/liferay-portal/pull/158791

@dannielraposo
@liferay-headless

Original pull request comment:
**Initial Approach https://github.com/liferay-headless/liferay-portal/pull/2460**
The first attempt to fix this involved modifying the query by adding a new inner join for this case. While technically feasible, this approach was quite complex.

**Solution in this PR**
The new solution leverages the fact that for a many-to-one relationship, the field r_cERC is always equivalent to /externalReferenceCode, which is already implemented and functional.

By modifying the filterableAndSortableFieldNameFunction of the entity field to utilize this existing workaround, the filter now works as intended without the need for additional joins or complex query adjustments.

See the following Jira Ticket: [LPD-37787](https://liferay.atlassian.net/browse/LPD-37787)