### PR TITLE
LPD-46389 Add default constructors to registry implementations

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/SystemFDSEntryRegistryImpl.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/SystemFDSEntryRegistryImpl.java
@@ -24,6 +24,9 @@ import org.osgi.service.component.annotations.Deactivate;
 @Component(service = SystemFDSEntryRegistry.class)
 public class SystemFDSEntryRegistryImpl implements SystemFDSEntryRegistry {
 
+	public SystemFDSEntryRegistryImpl() {
+	}
+
 	public SystemFDSEntryRegistryImpl(
 		ServiceTrackerMap<String, SystemFDSEntry> serviceTrackerMap) {
 

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/action/FDSBulkActionsRegistryImpl.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/action/FDSBulkActionsRegistryImpl.java
@@ -24,6 +24,9 @@ import org.osgi.service.component.annotations.Deactivate;
 @Component(service = FDSBulkActionsRegistry.class)
 public class FDSBulkActionsRegistryImpl implements FDSBulkActionsRegistry {
 
+	public FDSBulkActionsRegistryImpl() {
+	}
+
 	public FDSBulkActionsRegistryImpl(
 		ServiceTrackerMap
 			<String,

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/action/FDSCreationMenuRegistryImpl.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/action/FDSCreationMenuRegistryImpl.java
@@ -24,6 +24,9 @@ import org.osgi.service.component.annotations.Deactivate;
 @Component(service = FDSCreationMenuRegistry.class)
 public class FDSCreationMenuRegistryImpl implements FDSCreationMenuRegistry {
 
+	public FDSCreationMenuRegistryImpl() {
+	}
+
 	public FDSCreationMenuRegistryImpl(
 		ServiceTrackerMap
 			<String,

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/action/FDSItemsActionsRegistryImpl.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/action/FDSItemsActionsRegistryImpl.java
@@ -24,6 +24,9 @@ import org.osgi.service.component.annotations.Deactivate;
 @Component(service = FDSItemsActionsRegistry.class)
 public class FDSItemsActionsRegistryImpl implements FDSItemsActionsRegistry {
 
+	public FDSItemsActionsRegistryImpl() {
+	}
+
 	public FDSItemsActionsRegistryImpl(
 		ServiceTrackerMap
 			<String,

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/filter/FDSFilterContextContributorRegistryImpl.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/filter/FDSFilterContextContributorRegistryImpl.java
@@ -30,6 +30,9 @@ import org.osgi.service.component.annotations.Deactivate;
 public class FDSFilterContextContributorRegistryImpl
 	implements FDSFilterContextContributorRegistry {
 
+	public FDSFilterContextContributorRegistryImpl() {
+	}
+
 	public FDSFilterContextContributorRegistryImpl(
 		ServiceTrackerMap
 			<String, List<ServiceWrapper<FDSFilterContextContributor>>>

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/filter/FDSFilterRegistryImpl.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/filter/FDSFilterRegistryImpl.java
@@ -29,6 +29,9 @@ import org.osgi.service.component.annotations.Deactivate;
 @Component(service = FDSFilterRegistry.class)
 public class FDSFilterRegistryImpl implements FDSFilterRegistry {
 
+	public FDSFilterRegistryImpl() {
+	}
+
 	public FDSFilterRegistryImpl(
 		ServiceTrackerMap<String, List<ServiceWrapper<FDSFilter>>>
 			serviceTrackerMap) {

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/url/FDSAPIURLResolverRegistryImpl.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/url/FDSAPIURLResolverRegistryImpl.java
@@ -31,6 +31,9 @@ import org.osgi.service.component.annotations.Deactivate;
 public class FDSAPIURLResolverRegistryImpl
 	implements FDSAPIURLResolverRegistry {
 
+	public FDSAPIURLResolverRegistryImpl() {
+	}
+
 	public FDSAPIURLResolverRegistryImpl(
 		ServiceTrackerMap<String, ServiceWrapper<FDSAPIURLResolver>>
 			serviceTrackerMap) {


### PR DESCRIPTION
Because of the addition of [these constructors](https://github.com/liferay/liferay-portal/commit/a6cb0feb2adae289416babb27a9083321f0dce56#diff-7df91b165885feb20ca3df589a64914d3fdf8e626f07e1165298d4470cc59cd8R27), the OSGi is no longer able to instantiate the services. As a result, most of them don't start and the FDS taglibs render nothing.

Please make sure this reaches your origin before master is synced.

Thank you