### PR TITLE
LPD-41336 disable deprecation feature flags for the system when initializing Liferay for the first time

### DIFF
--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/unit/BatchEngineUnitMetaInfo.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/unit/BatchEngineUnitMetaInfo.java
@@ -16,7 +16,7 @@ public class BatchEngineUnitMetaInfo {
 	public static BatchEngineUnitMetaInfo readFrom(Deserializer deserializer) {
 		boolean advanced = deserializer.readBoolean();
 		long companyId = deserializer.readLong();
-		String featureFlag = deserializer.readString();
+		String featureFlagKey = deserializer.readString();
 		boolean multiCompany = deserializer.readBoolean();
 
 		int pathCount = deserializer.readInt();
@@ -28,16 +28,16 @@ public class BatchEngineUnitMetaInfo {
 		}
 
 		return new BatchEngineUnitMetaInfo(
-			advanced, companyId, featureFlag, multiCompany, paths);
+			advanced, companyId, featureFlagKey, multiCompany, paths);
 	}
 
 	public BatchEngineUnitMetaInfo(
-		boolean advanced, long companyId, String featureFlag,
+		boolean advanced, long companyId, String featureFlagKey,
 		boolean multiCompany, String[] paths) {
 
 		_advanced = advanced;
 		_companyId = companyId;
-		_featureFlag = featureFlag;
+		_featureFlagKey = featureFlagKey;
 		_multiCompany = multiCompany;
 		_paths = paths;
 	}
@@ -46,8 +46,8 @@ public class BatchEngineUnitMetaInfo {
 		return _companyId;
 	}
 
-	public String getFeatureFlag() {
-		return _featureFlag;
+	public String getFeatureFlagKey() {
+		return _featureFlagKey;
 	}
 
 	public String[] getPaths() {
@@ -65,7 +65,7 @@ public class BatchEngineUnitMetaInfo {
 	public void writeTo(Serializer serializer) {
 		serializer.writeBoolean(_advanced);
 		serializer.writeLong(_companyId);
-		serializer.writeString(_featureFlag);
+		serializer.writeString(_featureFlagKey);
 		serializer.writeBoolean(_multiCompany);
 
 		serializer.writeInt(_paths.length);
@@ -77,7 +77,7 @@ public class BatchEngineUnitMetaInfo {
 
 	private final boolean _advanced;
 	private final long _companyId;
-	private final String _featureFlag;
+	private final String _featureFlagKey;
 	private final boolean _multiCompany;
 	private final String[] _paths;
 

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/bundle/CompanyBatchEngineUnitWrapper.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/bundle/CompanyBatchEngineUnitWrapper.java
@@ -61,7 +61,7 @@ public class CompanyBatchEngineUnitWrapper implements BundleBatchEngineUnit {
 
 		return new BatchEngineUnitMetaInfo(
 			batchEngineUnitMetaInfo.isAdvanced(), _company.getCompanyId(),
-			batchEngineUnitMetaInfo.getFeatureFlag(),
+			batchEngineUnitMetaInfo.getFeatureFlagKey(),
 			batchEngineUnitMetaInfo.isMultiCompany(),
 			batchEngineUnitMetaInfo.getPaths());
 	}

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/BatchEngineUnitProcessorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/BatchEngineUnitProcessorImpl.java
@@ -80,12 +80,14 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 				BatchEngineUnitMetaInfo batchEngineUnitMetaInfo =
 					batchEngineUnit.getBatchEngineUnitMetaInfo();
 
-				String featureFlag = batchEngineUnitMetaInfo.getFeatureFlag();
+				String featureFlagKey =
+					batchEngineUnitMetaInfo.getFeatureFlagKey();
 
-				if (_isFeatureFlagDisabled(featureFlag)) {
+				if (_isFeatureFlagDisabled(featureFlagKey)) {
 					_featureFlagBatchEngineUnitProcessor.
 						registerBatchEngineUnit(
-							batchEngineUnitMetaInfo.getCompanyId(), featureFlag,
+							batchEngineUnitMetaInfo.getCompanyId(),
+							featureFlagKey,
 							() -> {
 								CompletableFuture<Void> localCompletableFuture =
 									new CompletableFuture<>();

--- a/modules/apps/feature-flag/feature-flag-web-test/src/testIntegration/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_1/test/FeatureFlagUpgradeProcessTest.java
+++ b/modules/apps/feature-flag/feature-flag-web-test/src/testIntegration/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_1/test/FeatureFlagUpgradeProcessTest.java
@@ -1,0 +1,96 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.feature.flag.web.internal.upgrade.v1_0_1.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.feature.flag.constants.FeatureFlagConstants;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.portlet.PortalPreferences;
+import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+import com.liferay.portlet.PortalPreferencesWrapper;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Thiago Buarque
+ */
+@RunWith(Arquillian.class)
+public class FeatureFlagUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testDoUpgrade() throws Exception {
+		PortalPreferences portalPreferences = _getPortalPreferences();
+
+		portalPreferences.setValue(
+			_OLD_NAMESPACE,
+			FeatureFlagConstants.PREFERENCE_KEY_DEPRECATION_PROCESSED, "false");
+
+		_portalPreferencesLocalService.updatePreferences(
+			CompanyConstants.SYSTEM, PortletKeys.PREFS_OWNER_TYPE_COMPANY,
+			portalPreferences);
+
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator, _CLASS_NAME);
+
+		upgradeProcess.upgrade();
+
+		portalPreferences = _getPortalPreferences();
+
+		Assert.assertNull(
+			portalPreferences.getValue(
+				_OLD_NAMESPACE,
+				FeatureFlagConstants.PREFERENCE_KEY_DEPRECATION_PROCESSED));
+		Assert.assertTrue(
+			GetterUtil.getBoolean(
+				portalPreferences.getValue(
+					FeatureFlagConstants.PREFERENCE_NAMESPACE,
+					FeatureFlagConstants.
+						PREFERENCE_KEY_DEPRECATION_PROCESSED)));
+	}
+
+	private PortalPreferences _getPortalPreferences() {
+		PortalPreferencesWrapper portalPreferencesWrapper =
+			(PortalPreferencesWrapper)
+				_portalPreferencesLocalService.getPreferences(
+					CompanyConstants.SYSTEM,
+					PortletKeys.PREFS_OWNER_TYPE_COMPANY);
+
+		return portalPreferencesWrapper.getPortalPreferencesImpl();
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.feature.flag.web.internal.upgrade.v1_0_1." +
+			"FeatureFlagUpgradeProcess";
+
+	private static final String _OLD_NAMESPACE =
+		FeatureFlagConstants.PORTAL_PROPERTY_KEY_FEATURE_FLAG;
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.feature.flag.web.internal.upgrade.registry.FeatureFlagUpgradeStepRegistrator))"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@Inject
+	private PortalPreferencesLocalService _portalPreferencesLocalService;
+
+}

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/model/listener/CompanyModelListener.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagType;
 import com.liferay.portal.kernel.feature.flag.constants.FeatureFlagConstants;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -49,6 +50,8 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 	protected void activate() {
 		_companyLocalService.forEachCompanyId(
 			this::_processDeprecationFeatureFlags);
+
+		_processDeprecationFeatureFlags(CompanyConstants.SYSTEM);
 	}
 
 	private PortalPreferences _getPortalPreferences(long companyId) {

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/upgrade/registry/FeatureFlagUpgradeStepRegistrator.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/upgrade/registry/FeatureFlagUpgradeStepRegistrator.java
@@ -5,7 +5,6 @@
 
 package com.liferay.feature.flag.web.internal.upgrade.registry;
 
-import com.liferay.feature.flag.web.internal.upgrade.v1_0_0.FeatureFlagUpgradeProcess;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
@@ -26,8 +25,14 @@ public class FeatureFlagUpgradeStepRegistrator
 
 		registry.register(
 			"0.0.1", "1.0.0",
-			new FeatureFlagUpgradeProcess(
-				_companyLocalService, _portalPreferencesLocalService));
+			new com.liferay.feature.flag.web.internal.upgrade.v1_0_0.
+				FeatureFlagUpgradeProcess(
+					_companyLocalService, _portalPreferencesLocalService));
+
+		registry.register(
+			"1.0.0", "1.0.1",
+			new com.liferay.feature.flag.web.internal.upgrade.v1_0_1.
+				FeatureFlagUpgradeProcess(_portalPreferencesLocalService));
 	}
 
 	@Reference

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_0/FeatureFlagUpgradeProcess.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_0/FeatureFlagUpgradeProcess.java
@@ -44,16 +44,17 @@ public class FeatureFlagUpgradeProcess extends UpgradeProcess {
 					portalPreferencesImpl.getNames(_OLD_NAMESPACE);
 
 				while (enumeration.hasMoreElements()) {
-					String featureFlag = enumeration.nextElement();
+					String portalPreferenceKey = enumeration.nextElement();
 
 					String value = portalPreferencesImpl.getValue(
-						_OLD_NAMESPACE, featureFlag);
+						_OLD_NAMESPACE, portalPreferenceKey);
 
-					portalPreferencesImpl.reset(_OLD_NAMESPACE, featureFlag);
+					portalPreferencesImpl.reset(
+						_OLD_NAMESPACE, portalPreferenceKey);
 
 					portalPreferencesImpl.setValue(
-						FeatureFlagConstants.PREFERENCE_NAMESPACE, featureFlag,
-						value);
+						FeatureFlagConstants.PREFERENCE_NAMESPACE,
+						portalPreferenceKey, value);
 				}
 
 				portalPreferencesImpl.setValue(

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_1/FeatureFlagUpgradeProcess.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_1/FeatureFlagUpgradeProcess.java
@@ -1,0 +1,69 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.feature.flag.web.internal.upgrade.v1_0_1;
+
+import com.liferay.portal.kernel.feature.flag.constants.FeatureFlagConstants;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portlet.PortalPreferencesImpl;
+import com.liferay.portlet.PortalPreferencesWrapper;
+
+import java.util.Enumeration;
+
+/**
+ * @author Thiago Buarque
+ */
+public class FeatureFlagUpgradeProcess extends UpgradeProcess {
+
+	public FeatureFlagUpgradeProcess(
+		PortalPreferencesLocalService portalPreferencesLocalService) {
+
+		_portalPreferencesLocalService = portalPreferencesLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() {
+		PortalPreferencesWrapper portalPreferencesWrapper =
+			(PortalPreferencesWrapper)
+				_portalPreferencesLocalService.getPreferences(
+					CompanyConstants.SYSTEM,
+					PortletKeys.PREFS_OWNER_TYPE_COMPANY);
+
+		PortalPreferencesImpl portalPreferencesImpl =
+			portalPreferencesWrapper.getPortalPreferencesImpl();
+
+		Enumeration<String> enumeration = portalPreferencesImpl.getNames(
+			_OLD_NAMESPACE);
+
+		while (enumeration.hasMoreElements()) {
+			String featureFlag = enumeration.nextElement();
+
+			String value = portalPreferencesImpl.getValue(
+				_OLD_NAMESPACE, featureFlag);
+
+			portalPreferencesImpl.reset(_OLD_NAMESPACE, featureFlag);
+
+			portalPreferencesImpl.setValue(
+				FeatureFlagConstants.PREFERENCE_NAMESPACE, featureFlag, value);
+		}
+
+		portalPreferencesImpl.setValue(
+			FeatureFlagConstants.PREFERENCE_NAMESPACE,
+			FeatureFlagConstants.PREFERENCE_KEY_DEPRECATION_PROCESSED, "true");
+
+		_portalPreferencesLocalService.updatePreferences(
+			CompanyConstants.SYSTEM, PortletKeys.PREFS_OWNER_TYPE_COMPANY,
+			portalPreferencesImpl);
+	}
+
+	private static final String _OLD_NAMESPACE =
+		FeatureFlagConstants.PORTAL_PROPERTY_KEY_FEATURE_FLAG;
+
+	private final PortalPreferencesLocalService _portalPreferencesLocalService;
+
+}

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_1/FeatureFlagUpgradeProcess.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_1/FeatureFlagUpgradeProcess.java
@@ -41,15 +41,16 @@ public class FeatureFlagUpgradeProcess extends UpgradeProcess {
 			_OLD_NAMESPACE);
 
 		while (enumeration.hasMoreElements()) {
-			String featureFlag = enumeration.nextElement();
+			String portalPreferenceKey = enumeration.nextElement();
 
 			String value = portalPreferencesImpl.getValue(
-				_OLD_NAMESPACE, featureFlag);
+				_OLD_NAMESPACE, portalPreferenceKey);
 
-			portalPreferencesImpl.reset(_OLD_NAMESPACE, featureFlag);
+			portalPreferencesImpl.reset(_OLD_NAMESPACE, portalPreferenceKey);
 
 			portalPreferencesImpl.setValue(
-				FeatureFlagConstants.PREFERENCE_NAMESPACE, featureFlag, value);
+				FeatureFlagConstants.PREFERENCE_NAMESPACE, portalPreferenceKey,
+				value);
 		}
 
 		portalPreferencesImpl.setValue(


### PR DESCRIPTION
Adding SF requested in https://github.com/brianchandotcom/liferay-portal/pull/158796

https://liferay.atlassian.net/browse/LPD-41336

Context
Currently only new company’s deprecation feature flags are disabled automatically.

For System, if Liferay is being set up for the first time, the deprecation feature flags remain enabled.

Approach
Call the method that disables the deprecation feature flags for other companies passing 0 as the companyId (which represents the system).
Upgrade existing system feature flag preferences to use the new namespace