### PR TITLE
master lpd 47148

### DIFF
--- a/modules/sdk/bnd-invoker/build.gradle
+++ b/modules/sdk/bnd-invoker/build.gradle
@@ -2,7 +2,7 @@ sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
 dependencies {
-	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "3.5.0"
+	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "6.4.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "org.apache.ant", name: "ant", transitive: false, version: "1.10.14"
 }

--- a/modules/sdk/project-templates/project-templates-war-core-ext/build.gradle
+++ b/modules/sdk/project-templates/project-templates-war-core-ext/build.gradle
@@ -3,7 +3,7 @@ dependencies {
 	compileOnly group: "com.liferay", name: "com.liferay.project.templates.extensions", version: "1.0.140"
 	compileOnly group: "org.apache.maven.archetype", name: "archetype-common", version: "2.4"
 	testImplementation gradleTestKit()
-	testImplementation group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "3.5.0"
+	testImplementation group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "6.4.0"
 	testImplementation group: "com.googlecode.java-diff-utils", name: "diffutils", version: "1.3.0"
 	testImplementation group: "com.liferay", name: "com.liferay.maven.executor", version: "1.0.2"
 	testImplementation group: "junit", name: "junit", version: "4.13.1"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-47148
Forwarded from: https://github.com/liferay-devtools/liferay-portal/pull/363 Passed PR Review, ci:test:relevant, ci:test:sf

Note: @brianchandotcom Upgrading biz.aQute.bnd to 6.4.0 breaks compile in 7.3.x and older versions, therefore if we want to be able to backport bnd-invoker jar to older versions still we will either need to fork the master code or do some other workaround if we need to enable jarkata support. cc: @drewbrokke
