### PR TITLE
LPD-45276 Journal Articles Folders

### DIFF
--- a/modules/apps/site-initializer/site-initializer-teaser-showcase/src/main/resources/site-initializer/journal-articles/announcements.metadata.json
+++ b/modules/apps/site-initializer/site-initializer-teaser-showcase/src/main/resources/site-initializer/journal-articles/announcements.metadata.json
@@ -1,0 +1,6 @@
+{
+	"description": "This folder contains all announcements",
+	"externalReferenceCode": "ANNOUNCEMENTS-FOLDER",
+	"name": "Announcements",
+	"viewableBy": "Anyone"
+}

--- a/modules/apps/site-initializer/site-initializer-teaser-showcase/src/main/resources/site-initializer/journal-articles/articles.metadata.json
+++ b/modules/apps/site-initializer/site-initializer-teaser-showcase/src/main/resources/site-initializer/journal-articles/articles.metadata.json
@@ -1,0 +1,6 @@
+{
+	"description": "This folder contains all articles",
+	"externalReferenceCode": "ARTICLES-FOLDER",
+	"name": "Articles",
+	"viewableBy": "Anyone"
+}

--- a/modules/apps/site-initializer/site-initializer-teaser-showcase/src/main/resources/site-initializer/journal-articles/faq.metadata.json
+++ b/modules/apps/site-initializer/site-initializer-teaser-showcase/src/main/resources/site-initializer/journal-articles/faq.metadata.json
@@ -1,0 +1,6 @@
+{
+	"description": "This folder contains all the FAQs.",
+	"externalReferenceCode": "FAQ-FOLDER",
+	"name": "FAQ",
+	"viewableBy": "Anyone"
+}

--- a/modules/apps/site-initializer/site-initializer-teaser-showcase/src/main/resources/site-initializer/journal-articles/general.metadata.json
+++ b/modules/apps/site-initializer/site-initializer-teaser-showcase/src/main/resources/site-initializer/journal-articles/general.metadata.json
@@ -1,0 +1,6 @@
+{
+	"description": "This folder contains general information about Clarity.",
+	"externalReferenceCode": "GENERAL-FOLDER",
+	"name": "General",
+	"viewableBy": "Anyone"
+}

--- a/modules/apps/site-initializer/site-initializer-teaser-showcase/src/main/resources/site-initializer/journal-articles/job-listing.metadata.json
+++ b/modules/apps/site-initializer/site-initializer-teaser-showcase/src/main/resources/site-initializer/journal-articles/job-listing.metadata.json
@@ -1,0 +1,6 @@
+{
+	"description": "This folder contains all job listings.",
+	"externalReferenceCode": "JOB-LISTINGS-FOLDER",
+	"name": "Job Listings",
+	"viewableBy": "Anyone"
+}

--- a/modules/apps/site-initializer/site-initializer-teaser-showcase/src/main/resources/site-initializer/journal-articles/leadership.metadata.json
+++ b/modules/apps/site-initializer/site-initializer-teaser-showcase/src/main/resources/site-initializer/journal-articles/leadership.metadata.json
@@ -1,0 +1,6 @@
+{
+	"description": "This folder contains information about the leadership of the company.",
+	"externalReferenceCode": "LEADERSHIP-FOLDER",
+	"name": "Leadership",
+	"viewableBy": "Anyone"
+}

--- a/modules/apps/site-initializer/site-initializer-teaser-showcase/src/main/resources/site-initializer/journal-articles/legal.metadata.json
+++ b/modules/apps/site-initializer/site-initializer-teaser-showcase/src/main/resources/site-initializer/journal-articles/legal.metadata.json
@@ -1,0 +1,6 @@
+{
+	"description": "This folder contains legal information about the company.",
+	"externalReferenceCode": "LEGAL-FOLDER",
+	"name": "Legal",
+	"viewableBy": "Anyone"
+}


### PR DESCRIPTION
Hey @brianchandotcom ,
I noticed that external reference codes for journal articles folders are not meaningful in other site initializers, so I tried to give them better ones.

Other site initializers:

1. JOURNALFOLDER001
2. JOURNALFOLDER002
3. JOURNALFOLDER003
4. JOURNALFOLDER004

Mine are:

1. LEGAL-FOLDER
2. LEADERSHIP-FOLDER
3. etc.

I also added a dash between the words following the external reference codes we have in other parts of the SI. (DDM templates for example)