### PR TITLE
LPD-47351 Technical Task | Folder permissions

### DIFF
--- a/modules/apps/portal-search/portal-search-rest-api/src/main/java/com/liferay/portal/search/rest/dto/v1_0/SearchResult.java
+++ b/modules/apps/portal-search/portal-search-rest-api/src/main/java/com/liferay/portal/search/rest/dto/v1_0/SearchResult.java
@@ -263,6 +263,47 @@ public class SearchResult implements Serializable {
 	@JsonIgnore
 	private Supplier<Object> _embeddedSupplier;
 
+	@Schema(description = "The object entry class name.")
+	public String getEntryClassName() {
+		if (_entryClassNameSupplier != null) {
+			entryClassName = _entryClassNameSupplier.get();
+
+			_entryClassNameSupplier = null;
+		}
+
+		return entryClassName;
+	}
+
+	public void setEntryClassName(String entryClassName) {
+		this.entryClassName = entryClassName;
+
+		_entryClassNameSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setEntryClassName(
+		UnsafeSupplier<String, Exception> entryClassNameUnsafeSupplier) {
+
+		_entryClassNameSupplier = () -> {
+			try {
+				return entryClassNameUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The object entry class name.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String entryClassName;
+
+	@JsonIgnore
+	private Supplier<String> _entryClassNameSupplier;
+
 	@Schema(description = "The link to the embedded item.")
 	public String getItemURL() {
 		if (_itemURLSupplier != null) {
@@ -496,6 +537,22 @@ public class SearchResult implements Serializable {
 			else {
 				sb.append(embedded);
 			}
+		}
+
+		String entryClassName = getEntryClassName();
+
+		if (entryClassName != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"entryClassName\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(entryClassName));
+
+			sb.append("\"");
 		}
 
 		String itemURL = getItemURL();

--- a/modules/apps/portal-search/portal-search-rest-client/src/main/java/com/liferay/portal/search/rest/client/dto/v1_0/SearchResult.java
+++ b/modules/apps/portal-search/portal-search-rest-client/src/main/java/com/liferay/portal/search/rest/client/dto/v1_0/SearchResult.java
@@ -133,6 +133,27 @@ public class SearchResult implements Cloneable, Serializable {
 
 	protected Object embedded;
 
+	public String getEntryClassName() {
+		return entryClassName;
+	}
+
+	public void setEntryClassName(String entryClassName) {
+		this.entryClassName = entryClassName;
+	}
+
+	public void setEntryClassName(
+		UnsafeSupplier<String, Exception> entryClassNameUnsafeSupplier) {
+
+		try {
+			entryClassName = entryClassNameUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String entryClassName;
+
 	public String getItemURL() {
 		return itemURL;
 	}

--- a/modules/apps/portal-search/portal-search-rest-client/src/main/java/com/liferay/portal/search/rest/client/serdes/v1_0/SearchResultSerDes.java
+++ b/modules/apps/portal-search/portal-search-rest-client/src/main/java/com/liferay/portal/search/rest/client/serdes/v1_0/SearchResultSerDes.java
@@ -123,6 +123,20 @@ public class SearchResultSerDes {
 			}
 		}
 
+		if (searchResult.getEntryClassName() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"entryClassName\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(searchResult.getEntryClassName()));
+
+			sb.append("\"");
+		}
+
 		if (searchResult.getItemURL() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -223,6 +237,15 @@ public class SearchResultSerDes {
 			map.put("embedded", String.valueOf(searchResult.getEmbedded()));
 		}
 
+		if (searchResult.getEntryClassName() == null) {
+			map.put("entryClassName", null);
+		}
+		else {
+			map.put(
+				"entryClassName",
+				String.valueOf(searchResult.getEntryClassName()));
+		}
+
 		if (searchResult.getItemURL() == null) {
 			map.put("itemURL", null);
 		}
@@ -277,6 +300,9 @@ public class SearchResultSerDes {
 			else if (Objects.equals(jsonParserFieldName, "embedded")) {
 				return false;
 			}
+			else if (Objects.equals(jsonParserFieldName, "entryClassName")) {
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "itemURL")) {
 				return false;
 			}
@@ -321,6 +347,12 @@ public class SearchResultSerDes {
 			else if (Objects.equals(jsonParserFieldName, "embedded")) {
 				if (jsonParserFieldValue != null) {
 					searchResult.setEmbedded((Object)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "entryClassName")) {
+				if (jsonParserFieldValue != null) {
+					searchResult.setEntryClassName(
+						(String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "itemURL")) {

--- a/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
+++ b/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
@@ -94,6 +94,10 @@ components:
                     type: string
                 embedded:
                     type: object
+                entryClassName:
+                    description:
+                        The object entry class name.
+                    type: string
                 itemURL:
                     description:
                         The link to the embedded item.

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SearchResultResourceImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SearchResultResourceImpl.java
@@ -622,6 +622,8 @@ public class SearchResultResourceImpl extends BaseSearchResultResourceImpl {
 				_setTitle(assetRenderer, fields, searchResult, summary);
 			}
 
+			searchResult.setEntryClassName(() -> entryClassName);
+
 			_setDTOFields(
 				embedded, entryClassName, entryClassPK, fields, searchResult);
 			_setDateCreated(document, fields, searchResult);

--- a/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/BaseSearchResultResourceTestCase.java
+++ b/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/BaseSearchResultResourceTestCase.java
@@ -171,6 +171,7 @@ public abstract class BaseSearchResultResourceTestCase {
 		SearchResult searchResult = randomSearchResult();
 
 		searchResult.setDescription(regex);
+		searchResult.setEntryClassName(regex);
 		searchResult.setItemURL(regex);
 		searchResult.setTitle(regex);
 
@@ -181,6 +182,7 @@ public abstract class BaseSearchResultResourceTestCase {
 		searchResult = SearchResultSerDes.toDTO(json);
 
 		Assert.assertEquals(regex, searchResult.getDescription());
+		Assert.assertEquals(regex, searchResult.getEntryClassName());
 		Assert.assertEquals(regex, searchResult.getItemURL());
 		Assert.assertEquals(regex, searchResult.getTitle());
 	}
@@ -637,6 +639,14 @@ public abstract class BaseSearchResultResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("entryClassName", additionalAssertFieldName)) {
+				if (searchResult.getEntryClassName() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("itemURL", additionalAssertFieldName)) {
 				if (searchResult.getItemURL() == null) {
 					valid = false;
@@ -828,6 +838,17 @@ public abstract class BaseSearchResultResourceTestCase {
 				if (!Objects.deepEquals(
 						searchResult1.getEmbedded(),
 						searchResult2.getEmbedded())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("entryClassName", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						searchResult1.getEntryClassName(),
+						searchResult2.getEntryClassName())) {
 
 					return false;
 				}
@@ -1091,6 +1112,52 @@ public abstract class BaseSearchResultResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
+		if (entityFieldName.equals("entryClassName")) {
+			Object object = searchResult.getEntryClassName();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("itemURL")) {
 			Object object = searchResult.getItemURL();
 
@@ -1236,6 +1303,8 @@ public abstract class BaseSearchResultResourceTestCase {
 				dateCreated = RandomTestUtil.nextDate();
 				dateModified = RandomTestUtil.nextDate();
 				description = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				entryClassName = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				itemURL = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				title = StringUtil.toLowerCase(RandomTestUtil.randomString());

--- a/modules/apps/site/site-cms-site-initializer-test/build.gradle
+++ b/modules/apps/site/site-cms-site-initializer-test/build.gradle
@@ -1,5 +1,8 @@
 dependencies {
 	testIntegrationImplementation project(":apps:depot:depot-api")
+	testIntegrationImplementation project(":apps:fragment:fragment-api")
+	testIntegrationImplementation project(":apps:frontend-data-set:frontend-data-set-api")
+	testIntegrationImplementation project(":apps:frontend-taglib:frontend-taglib-clay")
 	testIntegrationImplementation project(":apps:object:object-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ContentsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ContentsSectionDisplayContextTest.java
@@ -1,0 +1,147 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.display.context.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.fragment.renderer.FragmentRenderer;
+import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.Sync;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Mikel Lorza
+ */
+@RunWith(Arquillian.class)
+@Sync
+public class ContentsSectionDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testGetFDSActionDropdownItems() throws Exception {
+		List<FDSActionDropdownItem> fdsActionDropdownItems =
+			_getFDSActionDropdownItems();
+
+		Assert.assertEquals(
+			fdsActionDropdownItems.toString(), 1,
+			fdsActionDropdownItems.size());
+
+		FDSActionDropdownItem fdsActionDropdownItem =
+			fdsActionDropdownItems.get(0);
+
+		Assert.assertNotNull(fdsActionDropdownItem);
+
+		Map<String, String> data =
+			(Map<String, String>)fdsActionDropdownItem.get("data");
+
+		Assert.assertNotNull("permissions", data.get("id"));
+		Assert.assertNotNull("get", data.get("method"));
+
+		Assert.assertNotNull(fdsActionDropdownItem.get("href"));
+		Assert.assertEquals(
+			"password-policies", fdsActionDropdownItem.get("icon"));
+		Assert.assertEquals("permissions", fdsActionDropdownItem.get("label"));
+		Assert.assertEquals(
+			"modal-permissions", fdsActionDropdownItem.get("target"));
+		Assert.assertEquals("item", fdsActionDropdownItem.get("type"));
+	}
+
+	private List<FDSActionDropdownItem> _getFDSActionDropdownItems()
+		throws Exception {
+
+		HttpServletRequest httpServletRequest = _getMockHttpServletRequest();
+
+		_fragmentRenderer.render(
+			null, httpServletRequest, new MockHttpServletResponse());
+
+		Object contentsSectionDisplayContext = httpServletRequest.getAttribute(
+			"com.liferay.site.cms.site.initializer.internal.display.context." +
+				"ContentsSectionDisplayContext");
+
+		Assert.assertNotNull(contentsSectionDisplayContext);
+
+		return ReflectionTestUtil.invoke(
+			contentsSectionDisplayContext, "getFDSActionDropdownItems",
+			new Class<?>[0]);
+	}
+
+	private HttpServletRequest _getMockHttpServletRequest() throws Exception {
+		HttpServletRequest httpServletRequest = new MockHttpServletRequest();
+
+		httpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay(httpServletRequest));
+
+		return httpServletRequest;
+	}
+
+	private ThemeDisplay _getThemeDisplay(HttpServletRequest httpServletRequest)
+		throws Exception {
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(TestPropsValues.getCompanyId()));
+		themeDisplay.setPermissionChecker(
+			PermissionThreadLocal.getPermissionChecker());
+		themeDisplay.setRealUser(TestPropsValues.getUser());
+		themeDisplay.setRequest(httpServletRequest);
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+		themeDisplay.setSiteGroupId(_group.getGroupId());
+		themeDisplay.setURLCurrent("http://localhost:8080/currentURL");
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		return themeDisplay;
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject(
+		filter = "component.name=com.liferay.site.cms.site.initializer.internal.fragment.renderer.ContentsSectionFragmentRenderer"
+	)
+	private FragmentRenderer _fragmentRenderer;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/configuration/CMSSiteInitializerConfiguration.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/configuration/CMSSiteInitializerConfiguration.java
@@ -27,7 +27,7 @@ public interface CMSSiteInitializerConfiguration {
 	public String[] categorizationClassNames();
 
 	@Meta.AD(
-		deflt = "com.liferay.blogs.model.BlogsEntry|com.liferay.bookmarks.model.BookmarksEntry|com.liferay.bookmarks.model.BookmarksFolder|com.liferay.document.library.kernel.model.DLFileShortcut|com.liferay.document.library.kernel.model.DLFolder|com.liferay.dynamic.data.mapping.model.DDMFormInstance|com.liferay.journal.model.JournalArticle|com.liferay.journal.model.JournalFolder|com.liferay.knowledge.base.model.KBArticle|com.liferay.knowledge.base.model.KBFolder|com.liferay.message.boards.model.MBCategory|com.liferay.message.boards.model.MBThread",
+		deflt = "com.liferay.blogs.model.BlogsEntry|com.liferay.bookmarks.model.BookmarksEntry|com.liferay.bookmarks.model.BookmarksFolder|com.liferay.document.library.kernel.model.DLFileShortcut|com.liferay.document.library.kernel.model.DLFolder|com.liferay.dynamic.data.mapping.model.DDMFormInstance|com.liferay.journal.model.JournalArticle|com.liferay.journal.model.JournalFolder|com.liferay.knowledge.base.model.KBArticle|com.liferay.knowledge.base.model.KBFolder|com.liferay.message.boards.model.MBCategory|com.liferay.message.boards.model.MBThread|com.liferay.object.model.ObjectEntryFolder",
 		name = "contents-class-names", required = false
 	)
 	public String[] contentsClassNames();

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ContentsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ContentsSectionDisplayContext.java
@@ -8,7 +8,6 @@ package com.liferay.site.cms.site.initializer.internal.display.context;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenuBuilder;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
@@ -105,7 +104,7 @@ public class ContentsSectionDisplayContext extends BaseSectionDisplayContext {
 				).setRedirect(
 					_themeDisplay.getURLCurrent()
 				).setParameter(
-					"modelResource", ObjectEntryFolder.class.getName()
+					"modelResource", "{entryClassName}"
 				).setParameter(
 					"modelResourceDescription", "{embedded.name}"
 				).setParameter(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ContentsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ContentsSectionDisplayContext.java
@@ -5,13 +5,24 @@
 
 package com.liferay.site.cms.site.initializer.internal.display.context;
 
+import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenuBuilder;
-import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.portlet.LiferayWindowState;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.site.cms.site.initializer.internal.configuration.CMSSiteInitializerConfiguration;
 
+import java.util.List;
 import java.util.Map;
+
+import javax.portlet.ActionRequest;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -22,9 +33,14 @@ public class ContentsSectionDisplayContext extends BaseSectionDisplayContext {
 
 	public ContentsSectionDisplayContext(
 		CMSSiteInitializerConfiguration cmsSiteInitializerConfiguration,
-		HttpServletRequest httpServletRequest) {
+		HttpServletRequest httpServletRequest, Language language) {
 
 		super(cmsSiteInitializerConfiguration, httpServletRequest);
+
+		_language = language;
+
+		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
 	}
 
 	@Override
@@ -33,25 +49,25 @@ public class ContentsSectionDisplayContext extends BaseSectionDisplayContext {
 			dropdownItem -> {
 				dropdownItem.setIcon("forms");
 				dropdownItem.setLabel(
-					LanguageUtil.get(httpServletRequest, "basic-content"));
+					_language.get(httpServletRequest, "basic-content"));
 			}
 		).addPrimaryDropdownItem(
 			dropdownItem -> {
 				dropdownItem.setIcon("blogs");
 				dropdownItem.setLabel(
-					LanguageUtil.get(httpServletRequest, "blog"));
+					_language.get(httpServletRequest, "blog"));
 			}
 		).addPrimaryDropdownItem(
 			dropdownItem -> {
 				dropdownItem.setIcon("wiki");
 				dropdownItem.setLabel(
-					LanguageUtil.get(httpServletRequest, "knowledge-base"));
+					_language.get(httpServletRequest, "knowledge-base"));
 			}
 		).addPrimaryDropdownItem(
 			dropdownItem -> {
 				dropdownItem.setIcon("folder");
 				dropdownItem.setLabel(
-					LanguageUtil.get(httpServletRequest, "folder"));
+					_language.get(httpServletRequest, "folder"));
 			}
 		).build();
 	}
@@ -60,13 +76,13 @@ public class ContentsSectionDisplayContext extends BaseSectionDisplayContext {
 	public Map<String, Object> getEmptyState() {
 		return HashMapBuilder.<String, Object>put(
 			"description",
-			LanguageUtil.get(
+			_language.get(
 				httpServletRequest,
 				"click-new-to-create-your-first-piece-of-content")
 		).put(
 			"image", "/states/cms_empty_state_content.svg"
 		).put(
-			"title", LanguageUtil.get(httpServletRequest, "no-content-yet")
+			"title", _language.get(httpServletRequest, "no-content-yet")
 		).build();
 	}
 
@@ -74,5 +90,35 @@ public class ContentsSectionDisplayContext extends BaseSectionDisplayContext {
 	public String[] getEntryClassNames() {
 		return cmsSiteInitializerConfiguration.contentsClassNames();
 	}
+
+	public List<FDSActionDropdownItem> getFDSActionDropdownItems() {
+		return ListUtil.fromArray(
+			new FDSActionDropdownItem(
+				PortletURLBuilder.create(
+					PortalUtil.getControlPanelPortletURL(
+						httpServletRequest,
+						"com_liferay_portlet_configuration_web_portlet_" +
+							"PortletConfigurationPortlet",
+						ActionRequest.RENDER_PHASE)
+				).setMVCPath(
+					"/edit_permissions.jsp"
+				).setRedirect(
+					_themeDisplay.getURLCurrent()
+				).setParameter(
+					"modelResource", ObjectEntryFolder.class.getName()
+				).setParameter(
+					"modelResourceDescription", "{embedded.name}"
+				).setParameter(
+					"resourcePrimKey", "{embedded.id}"
+				).setWindowState(
+					LiferayWindowState.POP_UP
+				).buildString(),
+				"password-policies", "permissions",
+				_language.get(httpServletRequest, "permissions"), "get", null,
+				"modal-permissions"));
+	}
+
+	private final Language _language;
+	private final ThemeDisplay _themeDisplay;
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ContentsSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ContentsSectionFragmentRenderer.java
@@ -91,7 +91,8 @@ public class ContentsSectionFragmentRenderer implements FragmentRenderer {
 			httpServletRequest.setAttribute(
 				ContentsSectionDisplayContext.class.getName(),
 				new ContentsSectionDisplayContext(
-					_cmsSiteInitializerConfiguration, httpServletRequest));
+					_cmsSiteInitializerConfiguration, httpServletRequest,
+					_language));
 
 			requestDispatcher.include(httpServletRequest, httpServletResponse);
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-47351

# What is this trying to solve?

Show permissions action for folders.

# How am I fixing it?

As I need files section and a file fragment renderer to render folder and so on, I contribute it on this PR but it is probably something conflict with changes of Marco PR: https://github.com/liferay-content-management/liferay-portal/pull/6376. 

So, on this PR there are also commits from LPD-48254 and LPD-43166.

I need LPD-48254 and LPD-43166 PR's to have an ObjectEntryFolderDTO and the ObjectEntryFolderDTOConverter to have some fields from ObjectEntryFolder in order to use them to build the permissions url for each item from the FDS. So, if we have issues with LPD-48254,LPD-43166 to contribute them to master, also I can made the minimal changes in this files to have  the minimal information to contribute this PR to master.

If you need the object entry folders listed on files section, you have to deploy all modules from the following PR : https://github.com/liferay-content-management/liferay-portal/pull/6371.
 

# How can you verify that it works?

Run the included tests.
