### PR TITLE
LPD 48305 | TypeScriptClientGenerator. Make it compatible with referenced schemas

### DIFF
--- a/modules/apps/object/object-admin-rest-client-js/src/node/model/creator.ts
+++ b/modules/apps/object/object-admin-rest-client-js/src/node/model/creator.ts
@@ -1,0 +1,90 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+			import {UserGroupBrief} from './userGroupBrief';
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+
+	/**
+	* Represents the user account of the content's creator/author. Properties follow the [creator](https://schema.org/creator) specification.
+	*/
+	export class Creator {
+			'additionalName'?: string;
+			'contentType'?: string;
+			'externalReferenceCode'?: string;
+			'familyName'?: string;
+			'givenName'?: string;
+			'id'?: number;
+			'image'?: string;
+			'name'?: string;
+			'profileURL'?: string;
+			'userGroupBriefs'?: Array<UserGroupBrief>;
+
+		static 'discriminator': string | undefined = undefined;
+
+	static 'attributeTypeMap': Array<{
+		baseName: string;
+		name: string;
+		type: string;
+	}> = [
+		{
+			baseName: "additionalName",
+			name: "additionalName",
+			type: "string",
+		},
+		{
+			baseName: "contentType",
+			name: "contentType",
+			type: "string",
+		},
+		{
+			baseName: "externalReferenceCode",
+			name: "externalReferenceCode",
+			type: "string",
+		},
+		{
+			baseName: "familyName",
+			name: "familyName",
+			type: "string",
+		},
+		{
+			baseName: "givenName",
+			name: "givenName",
+			type: "string",
+		},
+		{
+			baseName: "id",
+			name: "id",
+			type: "number",
+		},
+		{
+			baseName: "image",
+			name: "image",
+			type: "string",
+		},
+		{
+			baseName: "name",
+			name: "name",
+			type: "string",
+		},
+		{
+			baseName: "profileURL",
+			name: "profileURL",
+			type: "string",
+		},
+		{
+			baseName: "userGroupBriefs",
+			name: "userGroupBriefs",
+			type: "Array<UserGroupBrief>",
+		},
+		];
+
+		static getAttributeTypeMap() {
+				return Creator.attributeTypeMap;
+		}
+	}

--- a/modules/apps/object/object-admin-rest-client-js/src/node/model/objectDefinition.ts
+++ b/modules/apps/object/object-admin-rest-client-js/src/node/model/objectDefinition.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+			import {Creator} from './creator';
 			import {ObjectAction} from './objectAction';
 			import {ObjectDefinitionSetting} from './objectDefinitionSetting';
 			import {ObjectField} from './objectField';
@@ -10,7 +11,6 @@
 			import {ObjectRelationship} from './objectRelationship';
 			import {ObjectValidationRule} from './objectValidationRule';
 			import {ObjectView} from './objectView';
-			import {rest-openapi.yaml#Creator} from './rest-openapi.yaml#Creator';
 			import {Status} from './status';
 
 /**
@@ -24,7 +24,7 @@
 			'actions'?: {[key: string]: {[key: string]: string;};};
 			'active'?: boolean;
 			'className'?: string;
-			'creator'?: rest-openapi.yaml#Creator;
+			'creator'?: Creator;
 			'dateCreated'?: Date;
 			'dateModified'?: Date;
 			'defaultLanguageId'?: string;
@@ -96,7 +96,7 @@
 		{
 			baseName: "creator",
 			name: "creator",
-			type: "rest-openapi.yaml#Creator",
+			type: "Creator",
 		},
 		{
 			baseName: "dateCreated",

--- a/modules/apps/object/object-admin-rest-client-js/src/node/model/userGroupBrief.ts
+++ b/modules/apps/object/object-admin-rest-client-js/src/node/model/userGroupBrief.ts
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+
+	/**
+	* The author's user groups information.
+	*/
+	export class UserGroupBrief {
+			'id'?: number;
+			'name'?: string;
+
+		static 'discriminator': string | undefined = undefined;
+
+	static 'attributeTypeMap': Array<{
+		baseName: string;
+		name: string;
+		type: string;
+	}> = [
+		{
+			baseName: "id",
+			name: "id",
+			type: "number",
+		},
+		{
+			baseName: "name",
+			name: "name",
+			type: "string",
+		},
+		];
+
+		static getAttributeTypeMap() {
+				return UserGroupBrief.attributeTypeMap;
+		}
+	}

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/typescript/TypeScriptClientUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/typescript/TypeScriptClientUtil.java
@@ -96,7 +96,12 @@ public class TypeScriptClientUtil {
 		Map<String, Schema> schemas = components.getSchemas();
 
 		if (schemas != null) {
+			Set<String> processedRelatedSchemaModels = new HashSet<>();
+
 			for (Map.Entry<String, Schema> entry : schemas.entrySet()) {
+				_createRelatedSchemaModels(
+					baseClientDir, configYAML, copyrightFile, files, "",
+					processedRelatedSchemaModels, entry.getValue());
 				_createFile(
 					_buildModelContext(entry.getKey(), entry.getValue()),
 					configYAML, copyrightFile, files, "typescript/model",
@@ -501,6 +506,101 @@ public class TypeScriptClientUtil {
 				).build()));
 	}
 
+	private static void _createRelatedSchemaModels(
+			File baseClientDir, ConfigYAML configYAML, File copyrightFile,
+			List<File> files, String parentYAMLPath,
+			Set<String> processedReferences, Schema schema)
+		throws Exception {
+
+		Map<String, Schema> propertySchemas = schema.getPropertySchemas();
+
+		if (propertySchemas == null) {
+			return;
+		}
+
+		for (Schema propertySchema : propertySchemas.values()) {
+			List<String> references = new ArrayList<>();
+
+			String propertySchemaReference = propertySchema.getReference();
+
+			if (propertySchemaReference != null) {
+				references.add(propertySchemaReference);
+			}
+
+			Items items = propertySchema.getItems();
+
+			if (items != null) {
+				String propertySchemaItemsReference = items.toSchema(
+				).getReference();
+
+				if (propertySchemaItemsReference != null) {
+					references.add(propertySchemaItemsReference);
+				}
+			}
+
+			for (String reference : references) {
+				boolean localReference = reference.startsWith("#");
+
+				if ((localReference && Validator.isNull(parentYAMLPath)) ||
+					!processedReferences.add(reference)) {
+
+					continue;
+				}
+
+				File referencedYamlFile;
+
+				if (localReference) {
+					referencedYamlFile = new File(parentYAMLPath);
+				}
+				else {
+					String parentYamlDirPath = parentYAMLPath.substring(
+						0, parentYAMLPath.lastIndexOf("/") + 1);
+
+					referencedYamlFile = new File(
+						parentYamlDirPath + reference.split("#")[0]);
+				}
+
+				files.add(referencedYamlFile);
+
+				OpenAPIYAML referencedOpenAPIYAML =
+					OpenAPIParserUtil.loadOpenAPIYAML(
+						FileUtil.read(referencedYamlFile));
+
+				String referencedSchemaName;
+
+				if (localReference) {
+					referencedSchemaName = reference.substring(
+						reference.lastIndexOf("/") + 1);
+				}
+				else {
+					String splitReference = reference.split("#")[1];
+
+					referencedSchemaName = splitReference.substring(
+						splitReference.lastIndexOf("/") + 1);
+				}
+
+				Schema referencedSchema = referencedOpenAPIYAML.getComponents(
+				).getSchemas(
+				).get(
+					referencedSchemaName
+				);
+
+				_createFile(
+					_buildModelContext(referencedSchemaName, referencedSchema),
+					configYAML, copyrightFile, files, "typescript/model",
+					StringBundler.concat(
+						baseClientDir.getPath(), "/src/node/model/",
+						StringUtil.lowerCaseFirstLetter(referencedSchemaName),
+						".ts"));
+
+				_createRelatedSchemaModels(
+					baseClientDir, configYAML, copyrightFile, files,
+					referencedYamlFile.getAbsolutePath(), processedReferences,
+					referencedSchema);
+			}
+		}
+	}
+
 	private static String _getDataType(
 		Set<String> importClasses, Schema schema) {
 
@@ -509,10 +609,17 @@ public class TypeScriptClientUtil {
 		}
 
 		if (schema.getReference() != null) {
+			String dataType;
 			String schemaReference = schema.getReference();
 
-			String dataType = schemaReference.substring(
-				schemaReference.lastIndexOf('/') + 1);
+			if (schemaReference.startsWith("#")) {
+				dataType = schemaReference.substring(
+					schemaReference.lastIndexOf('/') + 1);
+			}
+			else {
+				dataType = schemaReference.substring(
+					schemaReference.lastIndexOf('#') + 1);
+			}
 
 			importClasses.add(dataType);
 


### PR DESCRIPTION
The generator was only compatible with referenced schemas but from the same openapi.yaml.
With this PR, references from other modules are compatible. 
This was noticed because of https://github.com/brianchandotcom/liferay-portal/commit/1a94d92a495f1a61a59f769e234f774188e2f9e1 and https://github.com/brianchandotcom/liferay-portal/commit/529b5726f58304145e1eabe823db87e3fbf31928