### PR TITLE
Lpd 50740

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -95,6 +95,7 @@
 	<classpathentry kind="lib" path="lib/development/osgi-service-component.jar"/>
 	<classpathentry kind="lib" path="lib/development/osgi-service-log.jar"/>
 	<classpathentry kind="lib" path="lib/development/p6spy.jar"/>
+	<classpathentry kind="lib" path="lib/development/portlet.jar"/>
 	<classpathentry kind="lib" path="lib/development/portletmvc4spring-test.jar"/>
 	<classpathentry kind="lib" path="lib/development/postgresql.jar"/>
 	<classpathentry kind="lib" path="lib/development/qdox.jar"/>
@@ -145,7 +146,6 @@
 	<classpathentry kind="lib" path="lib/portal/log4j-api.jar"/>
 	<classpathentry kind="lib" path="lib/portal/log4j-core.jar"/>
 	<classpathentry kind="lib" path="lib/portal/persistence.jar"/>
-	<classpathentry kind="lib" path="lib/portal/portlet.jar"/>
 	<classpathentry kind="lib" path="lib/portal/slf4j-api.jar"/>
 	<classpathentry kind="lib" path="lib/portal/soap-api.jar"/>
 	<classpathentry kind="lib" path="lib/portal/spring-aop.jar"/>

--- a/build-common.xml
+++ b/build-common.xml
@@ -82,11 +82,7 @@
 		<pathelement path="${classpath.full}" />
 		<fileset
 			dir="${project.dir}/lib/development"
-			includes="osgi-annotation-versioning.jar,osgi-core.jar,tomcat-jsp-api.jar,mail.jar,tomcat-servlet-api.jar"
-		/>
-		<fileset
-			dir="${project.dir}/lib/portal"
-			includes="portlet.jar"
+			includes="osgi-annotation-versioning.jar,osgi-core.jar,portlet.jar,tomcat-jsp-api.jar,mail.jar,tomcat-servlet-api.jar"
 		/>
 		<path refid="lib.pre.classpath" />
 		<path refid="web-lib.classpath" />

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -64,6 +64,7 @@
 /development/osgi-service-component.jar
 /development/osgi-service-log.jar
 /development/p6spy.jar
+/development/portlet.jar
 /development/portletmvc4spring-test.jar
 /development/postgresql.jar
 /development/qdox.jar
@@ -116,7 +117,6 @@
 /portal/log4j-api.jar
 /portal/log4j-core.jar
 /portal/persistence.jar
-/portal/portlet.jar
 /portal/simplecaptcha.jar
 /portal/slf4j-api.jar
 /portal/soap-api.jar

--- a/lib/development/dependencies.properties
+++ b/lib/development/dependencies.properties
@@ -59,6 +59,7 @@ osgi-service-cm=org.osgi:org.osgi.service.cm:1.6.0
 osgi-service-component=org.osgi:org.osgi.service.component:1.4.0
 osgi-service-log=org.osgi:org.osgi.service.log:1.4.0
 p6spy=p6spy:p6spy:1.3
+portlet=javax.portlet:portlet-api:3.0.1
 portletmvc4spring-test=com.liferay.portletmvc4spring:com.liferay.portletmvc4spring.test:5.2.1
 postgresql=org.postgresql:postgresql:42.4.4
 qdox=com.thoughtworks.qdox:qdox:1.12.1

--- a/lib/portal/dependencies.properties
+++ b/lib/portal/dependencies.properties
@@ -18,7 +18,6 @@ jws-api=javax.jws:javax.jws-api:1.1
 log4j-api=com.liferay:org.apache.logging.log4j:2.17.1.LIFERAY-PATCHED-1
 log4j-core=com.liferay:org.apache.logging.log4j.core:2.17.1.LIFERAY-PATCHED-1
 persistence=org.eclipse.persistence:javax.persistence:2.2.1
-portlet=javax.portlet:portlet-api:3.0.1
 slf4j-api=org.slf4j:slf4j-api:1.7.26
 soap-api=javax.xml.soap:javax.xml.soap-api:1.4.0
 spring-aop=org.springframework:spring-aop:5.3.39

--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -6938,6 +6938,18 @@
 				</licenses>
 			</library>
 			<library>
+				<file-name>lib/development/portlet.jar</file-name>
+				<version>3.0.1</version>
+				<project-name>JSR 362 Portlet Specification 3.0</project-name>
+				<project-url>https://jcp.org/en/jsr/detail?id=362</project-url>
+				<licenses>
+					<license>
+						<license-name>Apache License 2.0</license-name>
+						<license-url>http://www.apache.org/licenses/LICENSE-2.0</license-url>
+					</license>
+				</licenses>
+			</library>
+			<library>
 				<file-name>lib/development/portletmvc4spring-test.jar</file-name>
 				<version>5.2.1</version>
 				<project-name>PortletMVC4Spring</project-name>
@@ -7547,18 +7559,6 @@
 					<license>
 						<license-name>Common Development and Distribution License 1.0</license-name>
 						<license-url>https://opensource.org/licenses/CDDL-1.0</license-url>
-					</license>
-				</licenses>
-			</library>
-			<library>
-				<file-name>lib/portal/portlet.jar</file-name>
-				<version>3.0.1</version>
-				<project-name>JSR 362 Portlet Specification 3.0</project-name>
-				<project-url>https://jcp.org/en/jsr/detail?id=362</project-url>
-				<licenses>
-					<license>
-						<license-name>Apache License 2.0</license-name>
-						<license-url>http://www.apache.org/licenses/LICENSE-2.0</license-url>
 					</license>
 				</licenses>
 			</library>

--- a/lib/versions-ext.xml
+++ b/lib/versions-ext.xml
@@ -651,6 +651,18 @@
 				</licenses>
 			</library>
 			<library>
+				<file-name>lib/development/portlet.jar</file-name>
+				<version>3.0.1</version>
+				<project-name>JSR 362 Portlet Specification 3.0</project-name>
+				<project-url>https://jcp.org/en/jsr/detail?id=362</project-url>
+				<licenses>
+					<license>
+						<license-name>Apache License 2.0</license-name>
+						<license-url>http://www.apache.org/licenses/LICENSE-2.0</license-url>
+					</license>
+				</licenses>
+			</library>
+			<library>
 				<file-name>lib/development/portletmvc4spring-test.jar</file-name>
 				<version>5.2.1</version>
 				<project-name>PortletMVC4Spring</project-name>
@@ -1319,18 +1331,6 @@
 					<license>
 						<license-name>Common Development and Distribution License 1.0</license-name>
 						<license-url>https://opensource.org/licenses/CDDL-1.0</license-url>
-					</license>
-				</licenses>
-			</library>
-			<library>
-				<file-name>lib/portal/portlet.jar</file-name>
-				<version>3.0.1</version>
-				<project-name>JSR 362 Portlet Specification 3.0</project-name>
-				<project-url>https://jcp.org/en/jsr/detail?id=362</project-url>
-				<licenses>
-					<license>
-						<license-name>Apache License 2.0</license-name>
-						<license-url>http://www.apache.org/licenses/LICENSE-2.0</license-url>
 					</license>
 				</licenses>
 			</library>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -3581,6 +3581,12 @@
                 </tr>
                 			
                 <tr>
+                    <td nowrap="nowrap">lib/development/portlet.jar</td><td nowrap="nowrap">3.0.1</td><td nowrap="nowrap"><a href="https://jcp.org/en/jsr/detail?id=362">JSR 362 Portlet Specification 3.0</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
+                        <br>
+                    </td><td></td>
+                </tr>
+                			
+                <tr>
                     <td nowrap="nowrap">lib/development/portletmvc4spring-test.jar</td><td nowrap="nowrap">5.2.1</td><td nowrap="nowrap"><a href="https://github.com/liferay/portletmvc4spring">PortletMVC4Spring</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
                         <br>
                     </td><td></td>
@@ -3888,12 +3894,6 @@
                 			
                 <tr>
                     <td nowrap="nowrap">lib/portal/persistence.jar</td><td nowrap="nowrap">2.2.1</td><td nowrap="nowrap"><a href="http://java.sun.com/javaee/overview/faq/persistence.jsp">Java Persistence</a></td><td nowrap><a href="https://opensource.org/licenses/CDDL-1.0">Common Development and Distribution License 1.0</a>
-                        <br>
-                    </td><td></td>
-                </tr>
-                			
-                <tr>
-                    <td nowrap="nowrap">lib/portal/portlet.jar</td><td nowrap="nowrap">3.0.1</td><td nowrap="nowrap"><a href="https://jcp.org/en/jsr/detail?id=362">JSR 362 Portlet Specification 3.0</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
                         <br>
                     </td><td></td>
                 </tr>

--- a/modules/core/portal-bootstrap/build.gradle
+++ b/modules/core/portal-bootstrap/build.gradle
@@ -117,6 +117,13 @@ dependencies {
 	compileOnly project(":core:petra:petra-string")
 	compileOnly project(":core:petra:petra-url-pattern-mapper")
 	compileOnly project(":core:portal-app-license-api")
+
+	if (jakartaAppServer) {
+		compileOnly group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"
+	}
+	else {
+		compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	}
 }
 
 deployDependencies {
@@ -135,5 +142,12 @@ deployDependencies {
 			include "jakarta.mail-api-*.jar"
 		}
 
+	}
+
+	if (jakartaAppServer) {
+		include "com.liferay.jakarta.portlet-api-*.jar"
+	}
+	else {
+		include "portlet-api-*.jar"
 	}
 }

--- a/modules/core/portal-bootstrap/system.packages.extra.bnd
+++ b/modules/core/portal-bootstrap/system.packages.extra.bnd
@@ -309,6 +309,7 @@ Provide-Capability:\
 	@../../../lib/development/jstl-api.jar,\
 	@../../../lib/development/jstl-impl.jar,\
 	@../../../lib/development/mail.jar,\
+	@../../../lib/development/portlet.jar,\
 	@../../../lib/development/tomcat-api.jar,\
 	@../../../lib/development/tomcat-el-api.jar,\
 	@../../../lib/development/tomcat-jasper.jar,\
@@ -329,7 +330,6 @@ Provide-Capability:\
 	@../../../lib/portal/log4j-api.jar,\
 	@../../../lib/portal/log4j-core.jar,\
 	@../../../lib/portal/persistence.jar,\
-	@../../../lib/portal/portlet.jar,\
 	@../../../lib/portal/slf4j-api.jar,\
 	@../../../lib/portal/spring-aop.jar,\
 	@../../../lib/portal/spring-beans.jar,\

--- a/modules/core/source-formatter-suppressions.xml
+++ b/modules/core/source-formatter-suppressions.xml
@@ -6,6 +6,7 @@
 	</checkstyle>
 	<source-check>
 		<suppress checks="BNDDefinitionKeysCheck" files="portal-bootstrap/system.packages.extra.bnd" />
+		<suppress checks="GradleDependencyArtifactsCheck" files="portal-bootstrap/build\.gradle" />
 		<suppress checks="JavaDeserializationSecurityCheck" files="shielded-container-impl/src/main/java/com/liferay/shielded/container/internal/session/SerializationUtil\.java" />
 		<suppress checks="JavaXMLSecurityCheck" files="portal-jsp-engine/src/main/java/com/liferay/portal/jsp/engine/internal/delegate/JspConfigDescriptorServletContextDelegate\.java" />
 		<suppress checks="JavaXMLSecurityCheck" files="portal-web/src/main/java/com/liferay/portal/web/internal/PortalWebShieldedContainerInitializer\.java" />

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -63,6 +63,7 @@ javac.classpath=\
     lib/development/osgi-service-cm.jar:\
     lib/development/osgi-service-component.jar:\
     lib/development/osgi-service-log.jar:\
+    lib/development/portlet.jar:\
     lib/development/portletmvc4spring-test.jar:\
     lib/development/p6spy.jar:\
     lib/development/postgresql.jar:\
@@ -114,7 +115,6 @@ javac.classpath=\
     lib/portal/log4j-api.jar:\
     lib/portal/log4j-core.jar:\
     lib/portal/persistence.jar:\
-    lib/portal/portlet.jar:\
     lib/portal/slf4j-api.jar:\
     lib/portal/soap-api.jar:\
     lib/portal/spring-aop.jar:\

--- a/portal-web/build.xml
+++ b/portal-web/build.xml
@@ -19,6 +19,7 @@
 		<pathelement location="${project.dir}/lib/development/jstl-api.jar" />
 		<pathelement location="${project.dir}/lib/development/jstl-impl.jar" />
 		<pathelement location="${project.dir}/lib/development/mail.jar" />
+		<pathelement location="${project.dir}/lib/development/portlet.jar" />
 		<pathelement location="${project.dir}/lib/development/velocity.jar" />
 		<pathelement location="${project.dir}/lib/portal/commons-lang.jar" />
 		<pathelement location="${project.dir}/lib/portal/commons-logging.jar" />
@@ -27,7 +28,6 @@
 		<pathelement location="${project.dir}/lib/portal/log4j-api.jar" />
 		<pathelement location="${project.dir}/lib/portal/log4j-core.jar" />
 		<pathelement location="${project.dir}/lib/portal/openid4java.jar" />
-		<pathelement location="${project.dir}/lib/portal/portlet.jar" />
 	</path>
 
 	<target depends="build-common-web.clean,clean-tlds" name="clean">


### PR DESCRIPTION
@ling-alan-huang please see the SF exclude commit https://github.com/brianchandotcom/liferay-portal/commit/e39bb934791e2da2dcddf63b7e69ee9363b01887

Without it SF generates this:
```format-source-files:
     [java] Loading file:/home/trunks/git/liferay-portal/portal-impl/classes/system.properties
     [java] Loading file:/home/trunks/git/liferay-portal/portal-impl/classes/system-ext.properties
     [java] Incorrect dependency "com.liferay.jakarta.portlet-api", see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/check/gradle_dependency_artifacts_check.markdown: ./modules/core/portal-bootstrap/build.gradle 122 (SourceCheck:GradleDependencyArtifactsCheck)
     [java] java.lang.Exception: Found 1 formatting issues:
     [java] 1: Incorrect dependency "com.liferay.jakarta.portlet-api", see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/check/gradle_dependency_artifacts_check.markdown: ./modules/core/portal-bootstrap/build.gradle 122 (SourceCheck:GradleDependencyArtifactsCheck)
     [java]
     [java] 	at com.liferay.source.formatter.SourceFormatter.format(SourceFormatter.java:472)
     [java] 	at com.liferay.source.formatter.SourceFormatter.main(SourceFormatter.java:301)

BUILD FAILED
/home/trunks/git/liferay-portal/portal-impl/build.xml:498: The following error occurred while executing this line:
/home/trunks/git/liferay-portal/portal-impl/build.xml:651: Java returned: 1
```
The doc https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/check/gradle_dependency_artifacts_check.markdown is asking to use version rather than default, which is what this pull is doing. This seems like a SF bug.