### PR TITLE
LPD-49283 Fix MultiselectPicklist field type definition for GraphQL

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
@@ -130,6 +130,15 @@ public class ObjectDefinitionGraphQLDTOContributor
 					GraphQLDTOProperty.of(
 						objectField.getName(), FileEntry.class));
 			}
+			else if (Objects.equals(
+						objectField.getBusinessType(),
+						ObjectFieldConstants.
+							BUSINESS_TYPE_MULTISELECT_PICKLIST)) {
+
+				graphQLDTOProperties.add(
+					GraphQLDTOProperty.of(
+						objectField.getName(), ListEntry[].class));
+			}
 			else if (objectField.getListTypeDefinitionId() != 0) {
 				graphQLDTOProperties.add(
 					GraphQLDTOProperty.of(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/graphql/v1_0/test/ObjectDefinitionGraphQLTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/graphql/v1_0/test/ObjectDefinitionGraphQLTest.java
@@ -14,6 +14,7 @@ import com.liferay.object.admin.rest.resource.v1_0.ObjectFieldResource;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.field.builder.LongTextObjectFieldBuilder;
+import com.liferay.object.field.builder.MultiselectPicklistObjectFieldBuilder;
 import com.liferay.object.field.builder.PicklistObjectFieldBuilder;
 import com.liferay.object.field.builder.RichTextObjectFieldBuilder;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
@@ -30,6 +31,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
@@ -204,6 +206,101 @@ public class ObjectDefinitionGraphQLTest {
 	public void tearDown() throws PortalException {
 		ObjectEntryLocalServiceUtil.deleteObjectEntry(_childObjectEntry);
 		ObjectEntryLocalServiceUtil.deleteObjectEntry(_parentObjectEntry);
+	}
+
+	@Test
+	@TestInfo("LPD-49283")
+	public void testAddAndGetObjectEntryWithMultiselectPicklistField()
+		throws Exception {
+
+		ListTypeDefinition listTypeDefinition =
+			ListTypeDefinitionLocalServiceUtil.addListTypeDefinition(
+				null, TestPropsValues.getUserId(),
+				LocalizedMapUtil.getLocalizedMap(StringUtil.randomId()), false,
+				Collections.emptyList());
+
+		String listFieldValueKey1 = StringUtil.randomId();
+		String listFieldValueKey2 = StringUtil.randomId();
+		String listFieldValueKey3 = StringUtil.randomId();
+
+		_addListTypeEntry(listTypeDefinition, listFieldValueKey1);
+		_addListTypeEntry(listTypeDefinition, listFieldValueKey2);
+		_addListTypeEntry(listTypeDefinition, listFieldValueKey3);
+
+		String picklistFieldName = StringUtil.randomId();
+		String multiselectPicklistFieldName = StringUtil.randomId();
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				true, ObjectDefinitionTestUtil.getRandomName(),
+				Arrays.asList(
+					new PicklistObjectFieldBuilder(
+					).userId(
+						TestPropsValues.getUserId()
+					).listTypeDefinitionId(
+						listTypeDefinition.getListTypeDefinitionId()
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).indexedAsKeyword(
+						true
+					).name(
+						picklistFieldName
+					).required(
+						true
+					).build(),
+					new MultiselectPicklistObjectFieldBuilder(
+					).userId(
+						TestPropsValues.getUserId()
+					).listTypeDefinitionId(
+						listTypeDefinition.getListTypeDefinitionId()
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).indexedAsKeyword(
+						true
+					).name(
+						multiselectPicklistFieldName
+					).required(
+						true
+					).build()),
+				ObjectDefinitionConstants.SCOPE_COMPANY,
+				TestPropsValues.getUserId());
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				multiselectPicklistFieldName,
+				JSONUtil.putAll(
+					JSONUtil.put("key", listFieldValueKey2),
+					JSONUtil.put("key", listFieldValueKey3))
+			).put(
+				picklistFieldName, JSONUtil.put("key", listFieldValueKey1)
+			).toString(),
+			JSONUtil.getValueAsString(
+				_invoke(
+					new GraphQLField(
+						"mutation",
+						new GraphQLField(
+							"c",
+							new GraphQLField(
+								"create" + objectDefinition.getShortName(),
+								HashMapBuilder.<String, Object>put(
+									objectDefinition.getShortName(),
+									StringBundler.concat(
+										"{", picklistFieldName, ": {key: \"",
+										listFieldValueKey1, "\"}, ",
+										multiselectPicklistFieldName,
+										": [{key: \"", listFieldValueKey2,
+										"\"}, {key: \"", listFieldValueKey3,
+										"\"}]}")
+								).build(),
+								new GraphQLField(picklistFieldName + " {key}"),
+								new GraphQLField(
+									multiselectPicklistFieldName +
+										" {key}"))))),
+				"JSONObject/data", "JSONObject/c",
+				"JSONObject/create" + objectDefinition.getShortName()),
+			JSONCompareMode.STRICT);
 	}
 
 	@Test

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/graphql/v1_0/test/ObjectDefinitionGraphQLTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/graphql/v1_0/test/ObjectDefinitionGraphQLTest.java
@@ -232,7 +232,7 @@ public class ObjectDefinitionGraphQLTest {
 
 		ObjectDefinition objectDefinition =
 			ObjectDefinitionTestUtil.publishObjectDefinition(
-				true, ObjectDefinitionTestUtil.getRandomName(),
+				false, ObjectDefinitionTestUtil.getRandomName(),
 				Arrays.asList(
 					new PicklistObjectFieldBuilder(
 					).userId(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/graphql/v1_0/test/ObjectDefinitionGraphQLTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/graphql/v1_0/test/ObjectDefinitionGraphQLTest.java
@@ -333,7 +333,7 @@ public class ObjectDefinitionGraphQLTest {
 
 	@Test
 	@TestInfo("LPD-49283")
-	public void testAddObjectEntryWithMultiselectPicklistField()
+	public void testAddObjectEntryWithMultiselectPicklistObjectField()
 		throws Exception {
 
 		ListTypeDefinition listTypeDefinition =
@@ -342,16 +342,16 @@ public class ObjectDefinitionGraphQLTest {
 				LocalizedMapUtil.getLocalizedMap(StringUtil.randomId()), false,
 				Collections.emptyList());
 
-		String listFieldValueKey1 = StringUtil.randomId();
-		String listFieldValueKey2 = StringUtil.randomId();
-		String listFieldValueKey3 = StringUtil.randomId();
+		String listTypeEntryKey1 = StringUtil.randomId();
+		String listTypeEntryKey2 = StringUtil.randomId();
+		String listTypeEntryKey3 = StringUtil.randomId();
 
-		_addListTypeEntry(listTypeDefinition, listFieldValueKey1);
-		_addListTypeEntry(listTypeDefinition, listFieldValueKey2);
-		_addListTypeEntry(listTypeDefinition, listFieldValueKey3);
+		_addListTypeEntry(listTypeDefinition, listTypeEntryKey1);
+		_addListTypeEntry(listTypeDefinition, listTypeEntryKey2);
+		_addListTypeEntry(listTypeDefinition, listTypeEntryKey3);
 
-		String multiselectPicklistFieldName = StringUtil.randomId();
-		String picklistFieldName = StringUtil.randomId();
+		String multiselectPicklistObjectFieldName = StringUtil.randomId();
+		String picklistObjectFieldName = StringUtil.randomId();
 
 		ObjectDefinition objectDefinition =
 			ObjectDefinitionTestUtil.publishObjectDefinition(
@@ -368,7 +368,7 @@ public class ObjectDefinitionGraphQLTest {
 					).indexedAsKeyword(
 						true
 					).name(
-						multiselectPicklistFieldName
+						multiselectPicklistObjectFieldName
 					).required(
 						true
 					).build(),
@@ -383,7 +383,7 @@ public class ObjectDefinitionGraphQLTest {
 					).indexedAsKeyword(
 						true
 					).name(
-						picklistFieldName
+						picklistObjectFieldName
 					).required(
 						true
 					).build()),
@@ -392,12 +392,12 @@ public class ObjectDefinitionGraphQLTest {
 
 		JSONAssert.assertEquals(
 			JSONUtil.put(
-				multiselectPicklistFieldName,
+				multiselectPicklistObjectFieldName,
 				JSONUtil.putAll(
-					JSONUtil.put("key", listFieldValueKey1),
-					JSONUtil.put("key", listFieldValueKey2))
+					JSONUtil.put("key", listTypeEntryKey1),
+					JSONUtil.put("key", listTypeEntryKey2))
 			).put(
-				picklistFieldName, JSONUtil.put("key", listFieldValueKey3)
+				picklistObjectFieldName, JSONUtil.put("key", listTypeEntryKey3)
 			).toString(),
 			JSONUtil.getValueAsString(
 				_invoke(
@@ -410,17 +410,17 @@ public class ObjectDefinitionGraphQLTest {
 								HashMapBuilder.<String, Object>put(
 									objectDefinition.getShortName(),
 									StringBundler.concat(
-										"{", multiselectPicklistFieldName,
-										": [{key: \"", listFieldValueKey1,
-										"\"}, {key: \"", listFieldValueKey2,
-										"\"}], ", picklistFieldName,
-										": {key: \"", listFieldValueKey3,
-										"\"}}")
+										"{", multiselectPicklistObjectFieldName,
+										": [{key: \"", listTypeEntryKey1,
+										"\"}, {key: \"", listTypeEntryKey2,
+										"\"}], ", picklistObjectFieldName,
+										": {key: \"", listTypeEntryKey3, "\"}}")
 								).build(),
 								new GraphQLField(
-									multiselectPicklistFieldName + " {key}"),
+									multiselectPicklistObjectFieldName +
+										" {key}"),
 								new GraphQLField(
-									picklistFieldName + " {key}"))))),
+									picklistObjectFieldName + " {key}"))))),
 				"JSONObject/data", "JSONObject/c",
 				"JSONObject/create" + objectDefinition.getShortName()),
 			JSONCompareMode.STRICT);

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/graphql/v1_0/test/ObjectDefinitionGraphQLTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/graphql/v1_0/test/ObjectDefinitionGraphQLTest.java
@@ -209,101 +209,6 @@ public class ObjectDefinitionGraphQLTest {
 	}
 
 	@Test
-	@TestInfo("LPD-49283")
-	public void testAddAndGetObjectEntryWithMultiselectPicklistField()
-		throws Exception {
-
-		ListTypeDefinition listTypeDefinition =
-			ListTypeDefinitionLocalServiceUtil.addListTypeDefinition(
-				null, TestPropsValues.getUserId(),
-				LocalizedMapUtil.getLocalizedMap(StringUtil.randomId()), false,
-				Collections.emptyList());
-
-		String listFieldValueKey1 = StringUtil.randomId();
-		String listFieldValueKey2 = StringUtil.randomId();
-		String listFieldValueKey3 = StringUtil.randomId();
-
-		_addListTypeEntry(listTypeDefinition, listFieldValueKey1);
-		_addListTypeEntry(listTypeDefinition, listFieldValueKey2);
-		_addListTypeEntry(listTypeDefinition, listFieldValueKey3);
-
-		String picklistFieldName = StringUtil.randomId();
-		String multiselectPicklistFieldName = StringUtil.randomId();
-
-		ObjectDefinition objectDefinition =
-			ObjectDefinitionTestUtil.publishObjectDefinition(
-				false, ObjectDefinitionTestUtil.getRandomName(),
-				Arrays.asList(
-					new PicklistObjectFieldBuilder(
-					).userId(
-						TestPropsValues.getUserId()
-					).listTypeDefinitionId(
-						listTypeDefinition.getListTypeDefinitionId()
-					).labelMap(
-						LocalizedMapUtil.getLocalizedMap(
-							RandomTestUtil.randomString())
-					).indexedAsKeyword(
-						true
-					).name(
-						picklistFieldName
-					).required(
-						true
-					).build(),
-					new MultiselectPicklistObjectFieldBuilder(
-					).userId(
-						TestPropsValues.getUserId()
-					).listTypeDefinitionId(
-						listTypeDefinition.getListTypeDefinitionId()
-					).labelMap(
-						LocalizedMapUtil.getLocalizedMap(
-							RandomTestUtil.randomString())
-					).indexedAsKeyword(
-						true
-					).name(
-						multiselectPicklistFieldName
-					).required(
-						true
-					).build()),
-				ObjectDefinitionConstants.SCOPE_COMPANY,
-				TestPropsValues.getUserId());
-
-		JSONAssert.assertEquals(
-			JSONUtil.put(
-				multiselectPicklistFieldName,
-				JSONUtil.putAll(
-					JSONUtil.put("key", listFieldValueKey2),
-					JSONUtil.put("key", listFieldValueKey3))
-			).put(
-				picklistFieldName, JSONUtil.put("key", listFieldValueKey1)
-			).toString(),
-			JSONUtil.getValueAsString(
-				_invoke(
-					new GraphQLField(
-						"mutation",
-						new GraphQLField(
-							"c",
-							new GraphQLField(
-								"create" + objectDefinition.getShortName(),
-								HashMapBuilder.<String, Object>put(
-									objectDefinition.getShortName(),
-									StringBundler.concat(
-										"{", picklistFieldName, ": {key: \"",
-										listFieldValueKey1, "\"}, ",
-										multiselectPicklistFieldName,
-										": [{key: \"", listFieldValueKey2,
-										"\"}, {key: \"", listFieldValueKey3,
-										"\"}]}")
-								).build(),
-								new GraphQLField(picklistFieldName + " {key}"),
-								new GraphQLField(
-									multiselectPicklistFieldName +
-										" {key}"))))),
-				"JSONObject/data", "JSONObject/c",
-				"JSONObject/create" + objectDefinition.getShortName()),
-			JSONCompareMode.STRICT);
-	}
-
-	@Test
 	public void testAddObjectEntry() throws Exception {
 		String value = RandomTestUtil.randomString();
 
@@ -423,6 +328,101 @@ public class ObjectDefinitionGraphQLTest {
 								new GraphQLField("statusCode"))))),
 				"JSONObject/data", "JSONObject/c",
 				"JSONObject/create" + _draftAllowedObjectDefinitionName),
+			JSONCompareMode.STRICT);
+	}
+
+	@Test
+	@TestInfo("LPD-49283")
+	public void testAddObjectEntryWithMultiselectPicklistField()
+		throws Exception {
+
+		ListTypeDefinition listTypeDefinition =
+			ListTypeDefinitionLocalServiceUtil.addListTypeDefinition(
+				null, TestPropsValues.getUserId(),
+				LocalizedMapUtil.getLocalizedMap(StringUtil.randomId()), false,
+				Collections.emptyList());
+
+		String listFieldValueKey1 = StringUtil.randomId();
+		String listFieldValueKey2 = StringUtil.randomId();
+		String listFieldValueKey3 = StringUtil.randomId();
+
+		_addListTypeEntry(listTypeDefinition, listFieldValueKey1);
+		_addListTypeEntry(listTypeDefinition, listFieldValueKey2);
+		_addListTypeEntry(listTypeDefinition, listFieldValueKey3);
+
+		String picklistFieldName = StringUtil.randomId();
+		String multiselectPicklistFieldName = StringUtil.randomId();
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				false, ObjectDefinitionTestUtil.getRandomName(),
+				Arrays.asList(
+					new PicklistObjectFieldBuilder(
+					).userId(
+						TestPropsValues.getUserId()
+					).listTypeDefinitionId(
+						listTypeDefinition.getListTypeDefinitionId()
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).indexedAsKeyword(
+						true
+					).name(
+						picklistFieldName
+					).required(
+						true
+					).build(),
+					new MultiselectPicklistObjectFieldBuilder(
+					).userId(
+						TestPropsValues.getUserId()
+					).listTypeDefinitionId(
+						listTypeDefinition.getListTypeDefinitionId()
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).indexedAsKeyword(
+						true
+					).name(
+						multiselectPicklistFieldName
+					).required(
+						true
+					).build()),
+				ObjectDefinitionConstants.SCOPE_COMPANY,
+				TestPropsValues.getUserId());
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				multiselectPicklistFieldName,
+				JSONUtil.putAll(
+					JSONUtil.put("key", listFieldValueKey2),
+					JSONUtil.put("key", listFieldValueKey3))
+			).put(
+				picklistFieldName, JSONUtil.put("key", listFieldValueKey1)
+			).toString(),
+			JSONUtil.getValueAsString(
+				_invoke(
+					new GraphQLField(
+						"mutation",
+						new GraphQLField(
+							"c",
+							new GraphQLField(
+								"create" + objectDefinition.getShortName(),
+								HashMapBuilder.<String, Object>put(
+									objectDefinition.getShortName(),
+									StringBundler.concat(
+										"{", picklistFieldName, ": {key: \"",
+										listFieldValueKey1, "\"}, ",
+										multiselectPicklistFieldName,
+										": [{key: \"", listFieldValueKey2,
+										"\"}, {key: \"", listFieldValueKey3,
+										"\"}]}")
+								).build(),
+								new GraphQLField(picklistFieldName + " {key}"),
+								new GraphQLField(
+									multiselectPicklistFieldName +
+										" {key}"))))),
+				"JSONObject/data", "JSONObject/c",
+				"JSONObject/create" + objectDefinition.getShortName()),
 			JSONCompareMode.STRICT);
 	}
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/graphql/v1_0/test/ObjectDefinitionGraphQLTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/graphql/v1_0/test/ObjectDefinitionGraphQLTest.java
@@ -350,28 +350,13 @@ public class ObjectDefinitionGraphQLTest {
 		_addListTypeEntry(listTypeDefinition, listFieldValueKey2);
 		_addListTypeEntry(listTypeDefinition, listFieldValueKey3);
 
-		String picklistFieldName = StringUtil.randomId();
 		String multiselectPicklistFieldName = StringUtil.randomId();
+		String picklistFieldName = StringUtil.randomId();
 
 		ObjectDefinition objectDefinition =
 			ObjectDefinitionTestUtil.publishObjectDefinition(
 				false, ObjectDefinitionTestUtil.getRandomName(),
 				Arrays.asList(
-					new PicklistObjectFieldBuilder(
-					).userId(
-						TestPropsValues.getUserId()
-					).listTypeDefinitionId(
-						listTypeDefinition.getListTypeDefinitionId()
-					).labelMap(
-						LocalizedMapUtil.getLocalizedMap(
-							RandomTestUtil.randomString())
-					).indexedAsKeyword(
-						true
-					).name(
-						picklistFieldName
-					).required(
-						true
-					).build(),
 					new MultiselectPicklistObjectFieldBuilder(
 					).userId(
 						TestPropsValues.getUserId()
@@ -386,6 +371,21 @@ public class ObjectDefinitionGraphQLTest {
 						multiselectPicklistFieldName
 					).required(
 						true
+					).build(),
+					new PicklistObjectFieldBuilder(
+					).userId(
+						TestPropsValues.getUserId()
+					).listTypeDefinitionId(
+						listTypeDefinition.getListTypeDefinitionId()
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).indexedAsKeyword(
+						true
+					).name(
+						picklistFieldName
+					).required(
+						true
 					).build()),
 				ObjectDefinitionConstants.SCOPE_COMPANY,
 				TestPropsValues.getUserId());
@@ -394,10 +394,10 @@ public class ObjectDefinitionGraphQLTest {
 			JSONUtil.put(
 				multiselectPicklistFieldName,
 				JSONUtil.putAll(
-					JSONUtil.put("key", listFieldValueKey2),
-					JSONUtil.put("key", listFieldValueKey3))
+					JSONUtil.put("key", listFieldValueKey1),
+					JSONUtil.put("key", listFieldValueKey2))
 			).put(
-				picklistFieldName, JSONUtil.put("key", listFieldValueKey1)
+				picklistFieldName, JSONUtil.put("key", listFieldValueKey3)
 			).toString(),
 			JSONUtil.getValueAsString(
 				_invoke(
@@ -410,17 +410,17 @@ public class ObjectDefinitionGraphQLTest {
 								HashMapBuilder.<String, Object>put(
 									objectDefinition.getShortName(),
 									StringBundler.concat(
-										"{", picklistFieldName, ": {key: \"",
-										listFieldValueKey1, "\"}, ",
-										multiselectPicklistFieldName,
-										": [{key: \"", listFieldValueKey2,
-										"\"}, {key: \"", listFieldValueKey3,
-										"\"}]}")
+										"{", multiselectPicklistFieldName,
+										": [{key: \"", listFieldValueKey1,
+										"\"}, {key: \"", listFieldValueKey2,
+										"\"}], ", picklistFieldName,
+										": {key: \"", listFieldValueKey3,
+										"\"}}")
 								).build(),
-								new GraphQLField(picklistFieldName + " {key}"),
 								new GraphQLField(
-									multiselectPicklistFieldName +
-										" {key}"))))),
+									multiselectPicklistFieldName + " {key}"),
+								new GraphQLField(
+									picklistFieldName + " {key}"))))),
 				"JSONObject/data", "JSONObject/c",
 				"JSONObject/create" + objectDefinition.getShortName()),
 			JSONCompareMode.STRICT);

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -1244,6 +1244,26 @@ public class GraphQLServletExtender {
 		return graphQLObjectTypeBuilder.build();
 	}
 
+	private GraphQLType _getGraphQLType(
+		Class<?> clazz, Map<String, GraphQLType> graphQLTypes, boolean input) {
+
+		String prefix = input ? "Input" : "";
+
+		String key = prefix + clazz.getSimpleName();
+
+		if (graphQLTypes.containsKey(key)) {
+			return graphQLTypes.get(key);
+		}
+
+		key = prefix + StringUtil.replace(clazz.getName(), '.', '_');
+
+		if (graphQLTypes.containsKey(key)) {
+			return graphQLTypes.get(key);
+		}
+
+		return _mapGraphQLScalarType;
+	}
+
 	private GraphQLObjectType _getPageGraphQLObjectType(
 		GraphQLType facetGraphQLType, GraphQLType objectGraphQLType,
 		String name) {
@@ -1895,40 +1915,11 @@ public class GraphQLServletExtender {
 			return Scalars.GraphQLString;
 		}
 		else if (clazz.isArray()) {
-			Class<?> realClazz = clazz.getComponentType();
-
-			String key = (input ? "Input" : "") + realClazz.getSimpleName();
-
-			if (graphQLTypes.containsKey(key)) {
-				return new GraphQLList(graphQLTypes.get(key));
-			}
-
-			key =
-				(input ? "Input" : "") +
-					StringUtil.replace(clazz.getName(), '.', '_');
-
-			if (graphQLTypes.containsKey(key)) {
-				return new GraphQLList(graphQLTypes.get(key));
-			}
-
-			return new GraphQLList(_mapGraphQLScalarType);
+			return new GraphQLList(
+				_getGraphQLType(clazz.getComponentType(), graphQLTypes, input));
 		}
 
-		String key = (input ? "Input" : "") + clazz.getSimpleName();
-
-		if (graphQLTypes.containsKey(key)) {
-			return graphQLTypes.get(key);
-		}
-
-		key =
-			(input ? "Input" : "") +
-				StringUtil.replace(clazz.getName(), '.', '_');
-
-		if (graphQLTypes.containsKey(key)) {
-			return graphQLTypes.get(key);
-		}
-
-		return _mapGraphQLScalarType;
+		return _getGraphQLType(clazz, graphQLTypes, input);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -1244,26 +1244,6 @@ public class GraphQLServletExtender {
 		return graphQLObjectTypeBuilder.build();
 	}
 
-	private GraphQLType _getGraphQLType(
-		Class<?> clazz, Map<String, GraphQLType> graphQLTypes, boolean input) {
-
-		String prefix = input ? "Input" : "";
-
-		String key = prefix + clazz.getSimpleName();
-
-		if (graphQLTypes.containsKey(key)) {
-			return graphQLTypes.get(key);
-		}
-
-		key = prefix + StringUtil.replace(clazz.getName(), '.', '_');
-
-		if (graphQLTypes.containsKey(key)) {
-			return graphQLTypes.get(key);
-		}
-
-		return _mapGraphQLScalarType;
-	}
-
 	private GraphQLObjectType _getPageGraphQLObjectType(
 		GraphQLType facetGraphQLType, GraphQLType objectGraphQLType,
 		String name) {
@@ -1916,10 +1896,24 @@ public class GraphQLServletExtender {
 		}
 		else if (clazz.isArray()) {
 			return new GraphQLList(
-				_getGraphQLType(clazz.getComponentType(), graphQLTypes, input));
+				_toGraphQLType(clazz.getComponentType(), graphQLTypes, input));
 		}
 
-		return _getGraphQLType(clazz, graphQLTypes, input);
+		String key = (input ? "Input" : "") + clazz.getSimpleName();
+
+		if (graphQLTypes.containsKey(key)) {
+			return graphQLTypes.get(key);
+		}
+
+		key =
+			(input ? "Input" : "") +
+				StringUtil.replace(clazz.getName(), '.', '_');
+
+		if (graphQLTypes.containsKey(key)) {
+			return graphQLTypes.get(key);
+		}
+
+		return _mapGraphQLScalarType;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -1894,6 +1894,25 @@ public class GraphQLServletExtender {
 		else if (String.class.equals(clazz)) {
 			return Scalars.GraphQLString;
 		}
+		else if (clazz.isArray()) {
+			Class<?> realClazz = clazz.getComponentType();
+
+			String key = (input ? "Input" : "") + realClazz.getSimpleName();
+
+			if (graphQLTypes.containsKey(key)) {
+				return new GraphQLList(graphQLTypes.get(key));
+			}
+
+			key =
+				(input ? "Input" : "") +
+					StringUtil.replace(clazz.getName(), '.', '_');
+
+			if (graphQLTypes.containsKey(key)) {
+				return new GraphQLList(graphQLTypes.get(key));
+			}
+
+			return new GraphQLList(_mapGraphQLScalarType);
+		}
 
 		String key = (input ? "Input" : "") + clazz.getSimpleName();
 


### PR DESCRIPTION
What's changed?:
- Before this PR, the Multiselect Picklist fields of ObjectEntries were treated exactly the same as the Picklists which mean that the schema used was a single object with Key Value (the ListTypeEntry Schema). Now, with this changes, this follows the proper structure which is  List of different ListTypeEntry objects, making the query and creation of the objects work as expected.

What's new?:
- New test has been added that test that an ObjectEntry with a MultiSelect Picklist field can be created and queried with the proper schema.

See the following Jira Tickets: [LPD-49283](https://liferay.atlassian.net/browse/LPD-49283), [ LPP-57814 ](https://liferay.atlassian.net/browse/LPP-57814)
