### PR TITLE
LPD-50800 Jakarta transform DDMTemplate script. We have use cases whe…

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/model/listener/DDMTemplateModelListener.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/model/listener/DDMTemplateModelListener.java
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dynamic.data.mapping.internal.model.listener;
+
+import com.liferay.dynamic.data.mapping.model.DDMTemplate;
+import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.model.BaseModelListener;
+
+import java.util.function.BiFunction;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class DDMTemplateModelListener extends BaseModelListener<DDMTemplate> {
+
+	public DDMTemplateModelListener(
+		BiFunction<String, String, String> textReplacerBiFunction) {
+
+		_textReplacerBiFunction = textReplacerBiFunction;
+	}
+
+	@Override
+	public void onBeforeCreate(DDMTemplate ddmTemplate)
+		throws ModelListenerException {
+
+		_jakartaTransformScript(ddmTemplate);
+	}
+
+	@Override
+	public void onBeforeUpdate(
+			DDMTemplate originalDDMTemplate, DDMTemplate ddmTemplate)
+		throws ModelListenerException {
+
+		_jakartaTransformScript(ddmTemplate);
+	}
+
+	private void _jakartaTransformScript(DDMTemplate ddmTemplate) {
+		ddmTemplate.setScript(
+			_textReplacerBiFunction.apply(
+				"DDMTemplate#Script#" + ddmTemplate.getTemplateId(),
+				ddmTemplate.getScript()));
+	}
+
+	private final BiFunction<String, String, String> _textReplacerBiFunction;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMTemplateLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMTemplateLocalServiceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.dynamic.data.mapping.exception.TemplateScriptException;
 import com.liferay.dynamic.data.mapping.exception.TemplateSmallImageContentException;
 import com.liferay.dynamic.data.mapping.exception.TemplateSmallImageNameException;
 import com.liferay.dynamic.data.mapping.exception.TemplateSmallImageSizeException;
+import com.liferay.dynamic.data.mapping.internal.model.listener.DDMTemplateModelListener;
 import com.liferay.dynamic.data.mapping.internal.search.util.DDMSearchUtil;
 import com.liferay.dynamic.data.mapping.model.DDMTemplate;
 import com.liferay.dynamic.data.mapping.model.DDMTemplateVersion;
@@ -38,6 +39,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Image;
+import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
@@ -74,9 +76,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.BiFunction;
 
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
@@ -1606,8 +1612,27 @@ public class DDMTemplateLocalServiceImpl
 	}
 
 	@Activate
+	protected void activate(
+		BundleContext bundleContext, Map<String, Object> properties) {
+
+		if (_textReplacerBiFunction != null) {
+			_serviceRegistration = bundleContext.registerService(
+				ModelListener.class,
+				new DDMTemplateModelListener(_textReplacerBiFunction), null);
+		}
+
+		modified(properties);
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		if (_serviceRegistration != null) {
+			_serviceRegistration.unregister();
+		}
+	}
+
 	@Modified
-	protected void activate(Map<String, Object> properties) {
+	protected void modified(Map<String, Object> properties) {
 		ddmWebConfiguration = ConfigurableUtil.createConfigurable(
 			DDMWebConfiguration.class, properties);
 	}
@@ -1958,6 +1983,32 @@ public class DDMTemplateLocalServiceImpl
 		_siteConnectedGroupGroupProviderSnapshot = new Snapshot<>(
 			DDMTemplateLocalServiceImpl.class,
 			SiteConnectedGroupGroupProvider.class, null, true);
+	private static final BiFunction<String, String, String>
+		_textReplacerBiFunction;
+
+	static {
+		ClassLoader classLoader = ClassLoader.getSystemClassLoader();
+
+		Object instance = null;
+
+		try {
+			Class<?> clazz = classLoader.loadClass(
+				"com.liferay.portal.tools.jakarta.ee.transformer.function." +
+					"TextReplacerBiFunction");
+
+			instance = clazz.newInstance();
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			if (!(reflectiveOperationException instanceof
+					ClassNotFoundException)) {
+
+				throw new ExceptionInInitializerError(
+					reflectiveOperationException);
+			}
+		}
+
+		_textReplacerBiFunction = (BiFunction<String, String, String>)instance;
+	}
 
 	@Reference
 	private ConfigurationProvider _configurationProvider;
@@ -1982,6 +2033,8 @@ public class DDMTemplateLocalServiceImpl
 
 	@Reference
 	private ResourceLocalService _resourceLocalService;
+
+	private ServiceRegistration<?> _serviceRegistration;
 
 	@Reference
 	private UserLocalService _userLocalService;


### PR DESCRIPTION
…re javax.portlet literals are referenced from script, for example portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/template/WebContentTemplates.testcase 's MapTemplateWithPortletRequestModelToFragment

@achaparro please link the upgrade ticket to LPD-50800 once you have it. This is specifically for DDMTemplate table's script column. But consider the widely used nature of "javax.portlet" literals, it could happen to any DB columns that is containing user supplied strings.