### PR TITLE
LPD-50846 Restrict to limited basenames. Some third party (for exampl…

### DIFF
--- a/modules/util/portal-tools-jakarta-ee-transformer/src/main/java/com/liferay/portal/tools/jakarta/ee/transformer/language/TransformerResourceBundleControlProvider.java
+++ b/modules/util/portal-tools-jakarta-ee-transformer/src/main/java/com/liferay/portal/tools/jakarta/ee/transformer/language/TransformerResourceBundleControlProvider.java
@@ -28,8 +28,24 @@ public class TransformerResourceBundleControlProvider
 
 	@Override
 	public ResourceBundle.Control getControl(String baseName) {
-		return TransformerResourceBundleControl._INSTANCE;
+		if (_shouldTransform(baseName)) {
+			return TransformerResourceBundleControl._INSTANCE;
+		}
+
+		return null;
 	}
+
+	private boolean _shouldTransform(String baseName) {
+		for (String baseNamePrefix : _BASE_NAME_PREFIXES) {
+			if (baseName.startsWith(baseNamePrefix)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static final String[] _BASE_NAME_PREFIXES = {"javax.portlet.tck."};
 
 	private static class TransformerResourceBundleControl
 		extends ResourceBundle.Control {


### PR DESCRIPTION
…e jfreechart) libs have unconventional resource bundle naming, this ResourceBundleControlProvider should back off upon unknown baseNames.