### PR TITLE
LCD 45164

### DIFF
--- a/modules/apps/portal-store/portal-store-s3/build.gradle
+++ b/modules/apps/portal-store/portal-store-s3/build.gradle
@@ -58,6 +58,7 @@ dependencies {
 	compileInclude group: "com.amazonaws", name: "aws-java-sdk-core", version: "1.12.719"
 	compileInclude group: "com.amazonaws", name: "aws-java-sdk-kms", version: "1.12.719"
 	compileInclude group: "com.amazonaws", name: "aws-java-sdk-s3", version: "1.12.719"
+	compileInclude group: "com.amazonaws", name: "aws-java-sdk-sts", version: "1.12.719"
 	compileInclude group: "com.ibm.cos", name: "ibm-cos-java-sdk-core", version: "2.9.0"
 	compileInclude group: "com.ibm.cos", name: "ibm-cos-java-sdk-kms", version: "2.9.0"
 	compileInclude group: "com.ibm.cos", name: "ibm-cos-java-sdk-s3", version: "2.9.0"

--- a/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/IBMS3Store.java
+++ b/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/IBMS3Store.java
@@ -79,6 +79,7 @@ import org.osgi.service.component.annotations.Deactivate;
 @Component(
 	configurationPid = "com.liferay.portal.store.s3.configuration.S3StoreConfiguration",
 	configurationPolicy = ConfigurationPolicy.REQUIRE,
+	enabled = false,
 	property = "store.type=com.liferay.portal.store.s3.IBMS3Store",
 	service = Store.class
 )

--- a/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java
+++ b/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java
@@ -77,6 +77,7 @@ import org.osgi.service.component.annotations.Deactivate;
 @Component(
 	configurationPid = "com.liferay.portal.store.s3.configuration.S3StoreConfiguration",
 	configurationPolicy = ConfigurationPolicy.REQUIRE,
+	enabled = false,
 	property = "store.type=com.liferay.portal.store.s3.S3Store",
 	service = Store.class
 )

--- a/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/component/enabler/ComponentEnabler.java
+++ b/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/component/enabler/ComponentEnabler.java
@@ -7,6 +7,7 @@ package com.liferay.portal.store.s3.component.enabler;
 
 import com.liferay.document.library.kernel.store.Store;
 import com.liferay.osgi.util.ComponentUtil;
+import com.liferay.portal.store.s3.IBMS3Store;
 import com.liferay.portal.store.s3.S3Store;
 import com.liferay.portal.store.s3.scheduler.AbortedMultipartUploadCleanerSchedulerJobConfiguration;
 import com.liferay.portal.util.PropsValues;
@@ -28,10 +29,17 @@ public class ComponentEnabler {
 		if (Objects.equals(
 				PropsValues.DL_STORE_IMPL, S3Store.class.getName())) {
 
+			componentContext.enableComponent(S3Store.class.getName());
+
 			ComponentUtil.enableComponents(
 				Store.class, "(store.type=" + PropsValues.DL_STORE_IMPL + ")",
 				componentContext,
 				AbortedMultipartUploadCleanerSchedulerJobConfiguration.class);
+		}
+		else if (Objects.equals(
+				PropsValues.DL_STORE_IMPL, IBMS3Store.class.getName())) {
+
+			componentContext.enableComponent(IBMS3Store.class.getName());
 		}
 	}
 


### PR DESCRIPTION
- **LCD-45164 the STS library is required by the SDK in AWS marketplace apps because this is how credentials are obtained**
- **LCD-45164 only enable the component when appropriate in order to avoid errors in the logs**
