### PR TITLE
LPD-51094 Support sharing for user groups

### DIFF
--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/exception/InvalidSharingEntryUserAndUserGroupException.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/exception/InvalidSharingEntryUserAndUserGroupException.java
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.sharing.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class InvalidSharingEntryUserAndUserGroupException
+	extends PortalException {
+
+	public InvalidSharingEntryUserAndUserGroupException() {
+	}
+
+	public InvalidSharingEntryUserAndUserGroupException(String msg) {
+		super(msg);
+	}
+
+	public InvalidSharingEntryUserAndUserGroupException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public InvalidSharingEntryUserAndUserGroupException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/model/SharingEntryModel.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/model/SharingEntryModel.java
@@ -215,6 +215,20 @@ public interface SharingEntryModel
 	public void setModifiedDate(Date modifiedDate);
 
 	/**
+	 * Returns the to user group ID of this sharing entry.
+	 *
+	 * @return the to user group ID of this sharing entry
+	 */
+	public long getToUserGroupId();
+
+	/**
+	 * Sets the to user group ID of this sharing entry.
+	 *
+	 * @param toUserGroupId the to user group ID of this sharing entry
+	 */
+	public void setToUserGroupId(long toUserGroupId);
+
+	/**
 	 * Returns the to user ID of this sharing entry.
 	 *
 	 * @return the to user ID of this sharing entry

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/model/SharingEntryTable.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/model/SharingEntryTable.java
@@ -43,6 +43,8 @@ public class SharingEntryTable extends BaseTable<SharingEntryTable> {
 		"createDate", Date.class, Types.TIMESTAMP, Column.FLAG_DEFAULT);
 	public final Column<SharingEntryTable, Date> modifiedDate = createColumn(
 		"modifiedDate", Date.class, Types.TIMESTAMP, Column.FLAG_DEFAULT);
+	public final Column<SharingEntryTable, Long> toUserGroupId = createColumn(
+		"toUserGroupId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
 	public final Column<SharingEntryTable, Long> toUserId = createColumn(
 		"toUserId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
 	public final Column<SharingEntryTable, Long> classNameId = createColumn(

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/model/SharingEntryWrapper.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/model/SharingEntryWrapper.java
@@ -43,6 +43,7 @@ public class SharingEntryWrapper
 		attributes.put("userName", getUserName());
 		attributes.put("createDate", getCreateDate());
 		attributes.put("modifiedDate", getModifiedDate());
+		attributes.put("toUserGroupId", getToUserGroupId());
 		attributes.put("toUserId", getToUserId());
 		attributes.put("classNameId", getClassNameId());
 		attributes.put("classPK", getClassPK());
@@ -108,6 +109,12 @@ public class SharingEntryWrapper
 
 		if (modifiedDate != null) {
 			setModifiedDate(modifiedDate);
+		}
+
+		Long toUserGroupId = (Long)attributes.get("toUserGroupId");
+
+		if (toUserGroupId != null) {
+			setToUserGroupId(toUserGroupId);
 		}
 
 		Long toUserId = (Long)attributes.get("toUserId");
@@ -280,6 +287,16 @@ public class SharingEntryWrapper
 	@Override
 	public long getSharingEntryId() {
 		return model.getSharingEntryId();
+	}
+
+	/**
+	 * Returns the to user group ID of this sharing entry.
+	 *
+	 * @return the to user group ID of this sharing entry
+	 */
+	@Override
+	public long getToUserGroupId() {
+		return model.getToUserGroupId();
 	}
 
 	/**
@@ -496,6 +513,16 @@ public class SharingEntryWrapper
 	@Override
 	public void setSharingEntryId(long sharingEntryId) {
 		model.setSharingEntryId(sharingEntryId);
+	}
+
+	/**
+	 * Sets the to user group ID of this sharing entry.
+	 *
+	 * @param toUserGroupId the to user group ID of this sharing entry
+	 */
+	@Override
+	public void setToUserGroupId(long toUserGroupId) {
+		model.setToUserGroupId(toUserGroupId);
 	}
 
 	/**

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalService.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalService.java
@@ -82,8 +82,9 @@ public interface SharingEntryLocalService
 	 * @review
 	 */
 	public SharingEntry addOrUpdateSharingEntry(
-			String externalReferenceCode, long userId, long toUserId,
-			long classNameId, long classPK, long groupId, boolean shareable,
+			String externalReferenceCode, long userId, long toUserGroupId,
+			long toUserId, long classNameId, long classPK, long groupId,
+			boolean shareable,
 			Collection<SharingEntryAction> sharingEntryActions,
 			Date expirationDate, ServiceContext serviceContext)
 		throws PortalException;
@@ -123,8 +124,9 @@ public interface SharingEntryLocalService
 	 * @review
 	 */
 	public SharingEntry addSharingEntry(
-			String externalReferenceCode, long userId, long toUserId,
-			long classNameId, long classPK, long groupId, boolean shareable,
+			String externalReferenceCode, long userId, long toUserGroupId,
+			long toUserId, long classNameId, long classPK, long groupId,
+			boolean shareable,
 			Collection<SharingEntryAction> sharingEntryActions,
 			Date expirationDate, ServiceContext serviceContext)
 		throws PortalException;

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalServiceUtil.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalServiceUtil.java
@@ -58,8 +58,9 @@ public class SharingEntryLocalServiceUtil {
 	 * @review
 	 */
 	public static SharingEntry addOrUpdateSharingEntry(
-			String externalReferenceCode, long userId, long toUserId,
-			long classNameId, long classPK, long groupId, boolean shareable,
+			String externalReferenceCode, long userId, long toUserGroupId,
+			long toUserId, long classNameId, long classPK, long groupId,
+			boolean shareable,
 			java.util.Collection
 				<com.liferay.sharing.security.permission.SharingEntryAction>
 					sharingEntryActions,
@@ -68,8 +69,8 @@ public class SharingEntryLocalServiceUtil {
 		throws PortalException {
 
 		return getService().addOrUpdateSharingEntry(
-			externalReferenceCode, userId, toUserId, classNameId, classPK,
-			groupId, shareable, sharingEntryActions, expirationDate,
+			externalReferenceCode, userId, toUserGroupId, toUserId, classNameId,
+			classPK, groupId, shareable, sharingEntryActions, expirationDate,
 			serviceContext);
 	}
 
@@ -109,8 +110,9 @@ public class SharingEntryLocalServiceUtil {
 	 * @review
 	 */
 	public static SharingEntry addSharingEntry(
-			String externalReferenceCode, long userId, long toUserId,
-			long classNameId, long classPK, long groupId, boolean shareable,
+			String externalReferenceCode, long userId, long toUserGroupId,
+			long toUserId, long classNameId, long classPK, long groupId,
+			boolean shareable,
 			java.util.Collection
 				<com.liferay.sharing.security.permission.SharingEntryAction>
 					sharingEntryActions,
@@ -119,8 +121,8 @@ public class SharingEntryLocalServiceUtil {
 		throws PortalException {
 
 		return getService().addSharingEntry(
-			externalReferenceCode, userId, toUserId, classNameId, classPK,
-			groupId, shareable, sharingEntryActions, expirationDate,
+			externalReferenceCode, userId, toUserGroupId, toUserId, classNameId,
+			classPK, groupId, shareable, sharingEntryActions, expirationDate,
 			serviceContext);
 	}
 

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalServiceWrapper.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryLocalServiceWrapper.java
@@ -51,8 +51,9 @@ public class SharingEntryLocalServiceWrapper
 	 */
 	@Override
 	public com.liferay.sharing.model.SharingEntry addOrUpdateSharingEntry(
-			String externalReferenceCode, long userId, long toUserId,
-			long classNameId, long classPK, long groupId, boolean shareable,
+			String externalReferenceCode, long userId, long toUserGroupId,
+			long toUserId, long classNameId, long classPK, long groupId,
+			boolean shareable,
 			java.util.Collection
 				<com.liferay.sharing.security.permission.SharingEntryAction>
 					sharingEntryActions,
@@ -61,8 +62,8 @@ public class SharingEntryLocalServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _sharingEntryLocalService.addOrUpdateSharingEntry(
-			externalReferenceCode, userId, toUserId, classNameId, classPK,
-			groupId, shareable, sharingEntryActions, expirationDate,
+			externalReferenceCode, userId, toUserGroupId, toUserId, classNameId,
+			classPK, groupId, shareable, sharingEntryActions, expirationDate,
 			serviceContext);
 	}
 
@@ -106,8 +107,9 @@ public class SharingEntryLocalServiceWrapper
 	 */
 	@Override
 	public com.liferay.sharing.model.SharingEntry addSharingEntry(
-			String externalReferenceCode, long userId, long toUserId,
-			long classNameId, long classPK, long groupId, boolean shareable,
+			String externalReferenceCode, long userId, long toUserGroupId,
+			long toUserId, long classNameId, long classPK, long groupId,
+			boolean shareable,
 			java.util.Collection
 				<com.liferay.sharing.security.permission.SharingEntryAction>
 					sharingEntryActions,
@@ -116,8 +118,8 @@ public class SharingEntryLocalServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _sharingEntryLocalService.addSharingEntry(
-			externalReferenceCode, userId, toUserId, classNameId, classPK,
-			groupId, shareable, sharingEntryActions, expirationDate,
+			externalReferenceCode, userId, toUserGroupId, toUserId, classNameId,
+			classPK, groupId, shareable, sharingEntryActions, expirationDate,
 			serviceContext);
 	}
 

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryService.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryService.java
@@ -66,8 +66,8 @@ public interface SharingEntryService extends BaseService {
 	 the expiration date is a past value
 	 */
 	public SharingEntry addOrUpdateSharingEntry(
-			String externalReferenceCode, long toUserId, long classNameId,
-			long classPK, long groupId, boolean shareable,
+			String externalReferenceCode, long toUserGroupId, long toUserId,
+			long classNameId, long classPK, long groupId, boolean shareable,
 			Collection<SharingEntryAction> sharingEntryActions,
 			Date expirationDate, ServiceContext serviceContext)
 		throws PortalException;
@@ -93,8 +93,8 @@ public interface SharingEntryService extends BaseService {
 	 expiration date is a past value
 	 */
 	public SharingEntry addSharingEntry(
-			String externalReferenceCode, long toUserId, long classNameId,
-			long classPK, long groupId, boolean shareable,
+			String externalReferenceCode, long toUserGroupId, long toUserId,
+			long classNameId, long classPK, long groupId, boolean shareable,
 			Collection<SharingEntryAction> sharingEntryActions,
 			Date expirationDate, ServiceContext serviceContext)
 		throws PortalException;

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryServiceUtil.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryServiceUtil.java
@@ -49,8 +49,8 @@ public class SharingEntryServiceUtil {
 	 the expiration date is a past value
 	 */
 	public static SharingEntry addOrUpdateSharingEntry(
-			String externalReferenceCode, long toUserId, long classNameId,
-			long classPK, long groupId, boolean shareable,
+			String externalReferenceCode, long toUserGroupId, long toUserId,
+			long classNameId, long classPK, long groupId, boolean shareable,
 			java.util.Collection
 				<com.liferay.sharing.security.permission.SharingEntryAction>
 					sharingEntryActions,
@@ -59,8 +59,9 @@ public class SharingEntryServiceUtil {
 		throws PortalException {
 
 		return getService().addOrUpdateSharingEntry(
-			externalReferenceCode, toUserId, classNameId, classPK, groupId,
-			shareable, sharingEntryActions, expirationDate, serviceContext);
+			externalReferenceCode, toUserGroupId, toUserId, classNameId,
+			classPK, groupId, shareable, sharingEntryActions, expirationDate,
+			serviceContext);
 	}
 
 	/**
@@ -84,8 +85,8 @@ public class SharingEntryServiceUtil {
 	 expiration date is a past value
 	 */
 	public static SharingEntry addSharingEntry(
-			String externalReferenceCode, long toUserId, long classNameId,
-			long classPK, long groupId, boolean shareable,
+			String externalReferenceCode, long toUserGroupId, long toUserId,
+			long classNameId, long classPK, long groupId, boolean shareable,
 			java.util.Collection
 				<com.liferay.sharing.security.permission.SharingEntryAction>
 					sharingEntryActions,
@@ -94,8 +95,9 @@ public class SharingEntryServiceUtil {
 		throws PortalException {
 
 		return getService().addSharingEntry(
-			externalReferenceCode, toUserId, classNameId, classPK, groupId,
-			shareable, sharingEntryActions, expirationDate, serviceContext);
+			externalReferenceCode, toUserGroupId, toUserId, classNameId,
+			classPK, groupId, shareable, sharingEntryActions, expirationDate,
+			serviceContext);
 	}
 
 	public static SharingEntry deleteSharingEntry(

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryServiceWrapper.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryServiceWrapper.java
@@ -46,8 +46,8 @@ public class SharingEntryServiceWrapper
 	 */
 	@Override
 	public com.liferay.sharing.model.SharingEntry addOrUpdateSharingEntry(
-			String externalReferenceCode, long toUserId, long classNameId,
-			long classPK, long groupId, boolean shareable,
+			String externalReferenceCode, long toUserGroupId, long toUserId,
+			long classNameId, long classPK, long groupId, boolean shareable,
 			java.util.Collection
 				<com.liferay.sharing.security.permission.SharingEntryAction>
 					sharingEntryActions,
@@ -56,8 +56,9 @@ public class SharingEntryServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _sharingEntryService.addOrUpdateSharingEntry(
-			externalReferenceCode, toUserId, classNameId, classPK, groupId,
-			shareable, sharingEntryActions, expirationDate, serviceContext);
+			externalReferenceCode, toUserGroupId, toUserId, classNameId,
+			classPK, groupId, shareable, sharingEntryActions, expirationDate,
+			serviceContext);
 	}
 
 	/**
@@ -82,8 +83,8 @@ public class SharingEntryServiceWrapper
 	 */
 	@Override
 	public com.liferay.sharing.model.SharingEntry addSharingEntry(
-			String externalReferenceCode, long toUserId, long classNameId,
-			long classPK, long groupId, boolean shareable,
+			String externalReferenceCode, long toUserGroupId, long toUserId,
+			long classNameId, long classPK, long groupId, boolean shareable,
 			java.util.Collection
 				<com.liferay.sharing.security.permission.SharingEntryAction>
 					sharingEntryActions,
@@ -92,8 +93,9 @@ public class SharingEntryServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _sharingEntryService.addSharingEntry(
-			externalReferenceCode, toUserId, classNameId, classPK, groupId,
-			shareable, sharingEntryActions, expirationDate, serviceContext);
+			externalReferenceCode, toUserGroupId, toUserId, classNameId,
+			classPK, groupId, shareable, sharingEntryActions, expirationDate,
+			serviceContext);
 	}
 
 	@Override

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/persistence/SharingEntryPersistence.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/persistence/SharingEntryPersistence.java
@@ -1420,62 +1420,69 @@ public interface SharingEntryPersistence extends BasePersistence<SharingEntry> {
 	public int countByC_C(long classNameId, long classPK);
 
 	/**
-	 * Returns the sharing entry where toUserId = &#63; and classNameId = &#63; and classPK = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
+	 * Returns the sharing entry where toUserGroupId = &#63; and toUserId = &#63; and classNameId = &#63; and classPK = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
 	 *
+	 * @param toUserGroupId the to user group ID
 	 * @param toUserId the to user ID
 	 * @param classNameId the class name ID
 	 * @param classPK the class pk
 	 * @return the matching sharing entry
 	 * @throws NoSuchEntryException if a matching sharing entry could not be found
 	 */
-	public SharingEntry findByTU_C_C(
-			long toUserId, long classNameId, long classPK)
+	public SharingEntry findByTUG_TU_C_C(
+			long toUserGroupId, long toUserId, long classNameId, long classPK)
 		throws NoSuchEntryException;
 
 	/**
-	 * Returns the sharing entry where toUserId = &#63; and classNameId = &#63; and classPK = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the sharing entry where toUserGroupId = &#63; and toUserId = &#63; and classNameId = &#63; and classPK = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
+	 * @param toUserGroupId the to user group ID
 	 * @param toUserId the to user ID
 	 * @param classNameId the class name ID
 	 * @param classPK the class pk
 	 * @return the matching sharing entry, or <code>null</code> if a matching sharing entry could not be found
 	 */
-	public SharingEntry fetchByTU_C_C(
-		long toUserId, long classNameId, long classPK);
+	public SharingEntry fetchByTUG_TU_C_C(
+		long toUserGroupId, long toUserId, long classNameId, long classPK);
 
 	/**
-	 * Returns the sharing entry where toUserId = &#63; and classNameId = &#63; and classPK = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the sharing entry where toUserGroupId = &#63; and toUserId = &#63; and classNameId = &#63; and classPK = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
+	 * @param toUserGroupId the to user group ID
 	 * @param toUserId the to user ID
 	 * @param classNameId the class name ID
 	 * @param classPK the class pk
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching sharing entry, or <code>null</code> if a matching sharing entry could not be found
 	 */
-	public SharingEntry fetchByTU_C_C(
-		long toUserId, long classNameId, long classPK, boolean useFinderCache);
+	public SharingEntry fetchByTUG_TU_C_C(
+		long toUserGroupId, long toUserId, long classNameId, long classPK,
+		boolean useFinderCache);
 
 	/**
-	 * Removes the sharing entry where toUserId = &#63; and classNameId = &#63; and classPK = &#63; from the database.
+	 * Removes the sharing entry where toUserGroupId = &#63; and toUserId = &#63; and classNameId = &#63; and classPK = &#63; from the database.
 	 *
+	 * @param toUserGroupId the to user group ID
 	 * @param toUserId the to user ID
 	 * @param classNameId the class name ID
 	 * @param classPK the class pk
 	 * @return the sharing entry that was removed
 	 */
-	public SharingEntry removeByTU_C_C(
-			long toUserId, long classNameId, long classPK)
+	public SharingEntry removeByTUG_TU_C_C(
+			long toUserGroupId, long toUserId, long classNameId, long classPK)
 		throws NoSuchEntryException;
 
 	/**
-	 * Returns the number of sharing entries where toUserId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 * Returns the number of sharing entries where toUserGroupId = &#63; and toUserId = &#63; and classNameId = &#63; and classPK = &#63;.
 	 *
+	 * @param toUserGroupId the to user group ID
 	 * @param toUserId the to user ID
 	 * @param classNameId the class name ID
 	 * @param classPK the class pk
 	 * @return the number of matching sharing entries
 	 */
-	public int countByTU_C_C(long toUserId, long classNameId, long classPK);
+	public int countByTUG_TU_C_C(
+		long toUserGroupId, long toUserId, long classNameId, long classPK);
 
 	/**
 	 * Returns the sharing entry where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/persistence/SharingEntryPersistence.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/persistence/SharingEntryPersistence.java
@@ -1420,6 +1420,263 @@ public interface SharingEntryPersistence extends BasePersistence<SharingEntry> {
 	public int countByC_C(long classNameId, long classPK);
 
 	/**
+	 * Returns all the sharing entries where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @return the matching sharing entries
+	 */
+	public java.util.List<SharingEntry> findByTUG_C_C(
+		long toUserGroupId, long classNameId, long classPK);
+
+	/**
+	 * Returns a range of all the sharing entries where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @return the range of matching sharing entries
+	 */
+	public java.util.List<SharingEntry> findByTUG_C_C(
+		long toUserGroupId, long classNameId, long classPK, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching sharing entries
+	 */
+	public java.util.List<SharingEntry> findByTUG_C_C(
+		long toUserGroupId, long classNameId, long classPK, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<SharingEntry>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching sharing entries
+	 */
+	public java.util.List<SharingEntry> findByTUG_C_C(
+		long toUserGroupId, long classNameId, long classPK, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<SharingEntry>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first sharing entry in the ordered set where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching sharing entry
+	 * @throws NoSuchEntryException if a matching sharing entry could not be found
+	 */
+	public SharingEntry findByTUG_C_C_First(
+			long toUserGroupId, long classNameId, long classPK,
+			com.liferay.portal.kernel.util.OrderByComparator<SharingEntry>
+				orderByComparator)
+		throws NoSuchEntryException;
+
+	/**
+	 * Returns the first sharing entry in the ordered set where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching sharing entry, or <code>null</code> if a matching sharing entry could not be found
+	 */
+	public SharingEntry fetchByTUG_C_C_First(
+		long toUserGroupId, long classNameId, long classPK,
+		com.liferay.portal.kernel.util.OrderByComparator<SharingEntry>
+			orderByComparator);
+
+	/**
+	 * Returns the last sharing entry in the ordered set where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching sharing entry
+	 * @throws NoSuchEntryException if a matching sharing entry could not be found
+	 */
+	public SharingEntry findByTUG_C_C_Last(
+			long toUserGroupId, long classNameId, long classPK,
+			com.liferay.portal.kernel.util.OrderByComparator<SharingEntry>
+				orderByComparator)
+		throws NoSuchEntryException;
+
+	/**
+	 * Returns the last sharing entry in the ordered set where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching sharing entry, or <code>null</code> if a matching sharing entry could not be found
+	 */
+	public SharingEntry fetchByTUG_C_C_Last(
+		long toUserGroupId, long classNameId, long classPK,
+		com.liferay.portal.kernel.util.OrderByComparator<SharingEntry>
+			orderByComparator);
+
+	/**
+	 * Returns the sharing entries before and after the current sharing entry in the ordered set where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * @param sharingEntryId the primary key of the current sharing entry
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next sharing entry
+	 * @throws NoSuchEntryException if a sharing entry with the primary key could not be found
+	 */
+	public SharingEntry[] findByTUG_C_C_PrevAndNext(
+			long sharingEntryId, long toUserGroupId, long classNameId,
+			long classPK,
+			com.liferay.portal.kernel.util.OrderByComparator<SharingEntry>
+				orderByComparator)
+		throws NoSuchEntryException;
+
+	/**
+	 * Returns all the sharing entries where toUserGroupId = any &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupIds the to user group IDs
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @return the matching sharing entries
+	 */
+	public java.util.List<SharingEntry> findByTUG_C_C(
+		long[] toUserGroupIds, long classNameId, long classPK);
+
+	/**
+	 * Returns a range of all the sharing entries where toUserGroupId = any &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupIds the to user group IDs
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @return the range of matching sharing entries
+	 */
+	public java.util.List<SharingEntry> findByTUG_C_C(
+		long[] toUserGroupIds, long classNameId, long classPK, int start,
+		int end);
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toUserGroupId = any &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupIds the to user group IDs
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching sharing entries
+	 */
+	public java.util.List<SharingEntry> findByTUG_C_C(
+		long[] toUserGroupIds, long classNameId, long classPK, int start,
+		int end,
+		com.liferay.portal.kernel.util.OrderByComparator<SharingEntry>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupIds the to user group IDs
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching sharing entries
+	 */
+	public java.util.List<SharingEntry> findByTUG_C_C(
+		long[] toUserGroupIds, long classNameId, long classPK, int start,
+		int end,
+		com.liferay.portal.kernel.util.OrderByComparator<SharingEntry>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Removes all the sharing entries where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63; from the database.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 */
+	public void removeByTUG_C_C(
+		long toUserGroupId, long classNameId, long classPK);
+
+	/**
+	 * Returns the number of sharing entries where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @return the number of matching sharing entries
+	 */
+	public int countByTUG_C_C(
+		long toUserGroupId, long classNameId, long classPK);
+
+	/**
+	 * Returns the number of sharing entries where toUserGroupId = any &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * @param toUserGroupIds the to user group IDs
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @return the number of matching sharing entries
+	 */
+	public int countByTUG_C_C(
+		long[] toUserGroupIds, long classNameId, long classPK);
+
+	/**
 	 * Returns the sharing entry where toUserGroupId = &#63; and toUserId = &#63; and classNameId = &#63; and classPK = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
 	 *
 	 * @param toUserGroupId the to user group ID

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/persistence/SharingEntryUtil.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/persistence/SharingEntryUtil.java
@@ -1755,78 +1755,88 @@ public class SharingEntryUtil {
 	}
 
 	/**
-	 * Returns the sharing entry where toUserId = &#63; and classNameId = &#63; and classPK = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
+	 * Returns the sharing entry where toUserGroupId = &#63; and toUserId = &#63; and classNameId = &#63; and classPK = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
 	 *
+	 * @param toUserGroupId the to user group ID
 	 * @param toUserId the to user ID
 	 * @param classNameId the class name ID
 	 * @param classPK the class pk
 	 * @return the matching sharing entry
 	 * @throws NoSuchEntryException if a matching sharing entry could not be found
 	 */
-	public static SharingEntry findByTU_C_C(
-			long toUserId, long classNameId, long classPK)
+	public static SharingEntry findByTUG_TU_C_C(
+			long toUserGroupId, long toUserId, long classNameId, long classPK)
 		throws com.liferay.sharing.exception.NoSuchEntryException {
 
-		return getPersistence().findByTU_C_C(toUserId, classNameId, classPK);
+		return getPersistence().findByTUG_TU_C_C(
+			toUserGroupId, toUserId, classNameId, classPK);
 	}
 
 	/**
-	 * Returns the sharing entry where toUserId = &#63; and classNameId = &#63; and classPK = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the sharing entry where toUserGroupId = &#63; and toUserId = &#63; and classNameId = &#63; and classPK = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
+	 * @param toUserGroupId the to user group ID
 	 * @param toUserId the to user ID
 	 * @param classNameId the class name ID
 	 * @param classPK the class pk
 	 * @return the matching sharing entry, or <code>null</code> if a matching sharing entry could not be found
 	 */
-	public static SharingEntry fetchByTU_C_C(
-		long toUserId, long classNameId, long classPK) {
+	public static SharingEntry fetchByTUG_TU_C_C(
+		long toUserGroupId, long toUserId, long classNameId, long classPK) {
 
-		return getPersistence().fetchByTU_C_C(toUserId, classNameId, classPK);
+		return getPersistence().fetchByTUG_TU_C_C(
+			toUserGroupId, toUserId, classNameId, classPK);
 	}
 
 	/**
-	 * Returns the sharing entry where toUserId = &#63; and classNameId = &#63; and classPK = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the sharing entry where toUserGroupId = &#63; and toUserId = &#63; and classNameId = &#63; and classPK = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
+	 * @param toUserGroupId the to user group ID
 	 * @param toUserId the to user ID
 	 * @param classNameId the class name ID
 	 * @param classPK the class pk
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the matching sharing entry, or <code>null</code> if a matching sharing entry could not be found
 	 */
-	public static SharingEntry fetchByTU_C_C(
-		long toUserId, long classNameId, long classPK, boolean useFinderCache) {
+	public static SharingEntry fetchByTUG_TU_C_C(
+		long toUserGroupId, long toUserId, long classNameId, long classPK,
+		boolean useFinderCache) {
 
-		return getPersistence().fetchByTU_C_C(
-			toUserId, classNameId, classPK, useFinderCache);
+		return getPersistence().fetchByTUG_TU_C_C(
+			toUserGroupId, toUserId, classNameId, classPK, useFinderCache);
 	}
 
 	/**
-	 * Removes the sharing entry where toUserId = &#63; and classNameId = &#63; and classPK = &#63; from the database.
+	 * Removes the sharing entry where toUserGroupId = &#63; and toUserId = &#63; and classNameId = &#63; and classPK = &#63; from the database.
 	 *
+	 * @param toUserGroupId the to user group ID
 	 * @param toUserId the to user ID
 	 * @param classNameId the class name ID
 	 * @param classPK the class pk
 	 * @return the sharing entry that was removed
 	 */
-	public static SharingEntry removeByTU_C_C(
-			long toUserId, long classNameId, long classPK)
+	public static SharingEntry removeByTUG_TU_C_C(
+			long toUserGroupId, long toUserId, long classNameId, long classPK)
 		throws com.liferay.sharing.exception.NoSuchEntryException {
 
-		return getPersistence().removeByTU_C_C(toUserId, classNameId, classPK);
+		return getPersistence().removeByTUG_TU_C_C(
+			toUserGroupId, toUserId, classNameId, classPK);
 	}
 
 	/**
-	 * Returns the number of sharing entries where toUserId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 * Returns the number of sharing entries where toUserGroupId = &#63; and toUserId = &#63; and classNameId = &#63; and classPK = &#63;.
 	 *
+	 * @param toUserGroupId the to user group ID
 	 * @param toUserId the to user ID
 	 * @param classNameId the class name ID
 	 * @param classPK the class pk
 	 * @return the number of matching sharing entries
 	 */
-	public static int countByTU_C_C(
-		long toUserId, long classNameId, long classPK) {
+	public static int countByTUG_TU_C_C(
+		long toUserGroupId, long toUserId, long classNameId, long classPK) {
 
-		return getPersistence().countByTU_C_C(toUserId, classNameId, classPK);
+		return getPersistence().countByTUG_TU_C_C(
+			toUserGroupId, toUserId, classNameId, classPK);
 	}
 
 	/**

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/persistence/SharingEntryUtil.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/persistence/SharingEntryUtil.java
@@ -1755,6 +1755,319 @@ public class SharingEntryUtil {
 	}
 
 	/**
+	 * Returns all the sharing entries where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @return the matching sharing entries
+	 */
+	public static List<SharingEntry> findByTUG_C_C(
+		long toUserGroupId, long classNameId, long classPK) {
+
+		return getPersistence().findByTUG_C_C(
+			toUserGroupId, classNameId, classPK);
+	}
+
+	/**
+	 * Returns a range of all the sharing entries where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @return the range of matching sharing entries
+	 */
+	public static List<SharingEntry> findByTUG_C_C(
+		long toUserGroupId, long classNameId, long classPK, int start,
+		int end) {
+
+		return getPersistence().findByTUG_C_C(
+			toUserGroupId, classNameId, classPK, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching sharing entries
+	 */
+	public static List<SharingEntry> findByTUG_C_C(
+		long toUserGroupId, long classNameId, long classPK, int start, int end,
+		OrderByComparator<SharingEntry> orderByComparator) {
+
+		return getPersistence().findByTUG_C_C(
+			toUserGroupId, classNameId, classPK, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching sharing entries
+	 */
+	public static List<SharingEntry> findByTUG_C_C(
+		long toUserGroupId, long classNameId, long classPK, int start, int end,
+		OrderByComparator<SharingEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByTUG_C_C(
+			toUserGroupId, classNameId, classPK, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first sharing entry in the ordered set where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching sharing entry
+	 * @throws NoSuchEntryException if a matching sharing entry could not be found
+	 */
+	public static SharingEntry findByTUG_C_C_First(
+			long toUserGroupId, long classNameId, long classPK,
+			OrderByComparator<SharingEntry> orderByComparator)
+		throws com.liferay.sharing.exception.NoSuchEntryException {
+
+		return getPersistence().findByTUG_C_C_First(
+			toUserGroupId, classNameId, classPK, orderByComparator);
+	}
+
+	/**
+	 * Returns the first sharing entry in the ordered set where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching sharing entry, or <code>null</code> if a matching sharing entry could not be found
+	 */
+	public static SharingEntry fetchByTUG_C_C_First(
+		long toUserGroupId, long classNameId, long classPK,
+		OrderByComparator<SharingEntry> orderByComparator) {
+
+		return getPersistence().fetchByTUG_C_C_First(
+			toUserGroupId, classNameId, classPK, orderByComparator);
+	}
+
+	/**
+	 * Returns the last sharing entry in the ordered set where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching sharing entry
+	 * @throws NoSuchEntryException if a matching sharing entry could not be found
+	 */
+	public static SharingEntry findByTUG_C_C_Last(
+			long toUserGroupId, long classNameId, long classPK,
+			OrderByComparator<SharingEntry> orderByComparator)
+		throws com.liferay.sharing.exception.NoSuchEntryException {
+
+		return getPersistence().findByTUG_C_C_Last(
+			toUserGroupId, classNameId, classPK, orderByComparator);
+	}
+
+	/**
+	 * Returns the last sharing entry in the ordered set where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching sharing entry, or <code>null</code> if a matching sharing entry could not be found
+	 */
+	public static SharingEntry fetchByTUG_C_C_Last(
+		long toUserGroupId, long classNameId, long classPK,
+		OrderByComparator<SharingEntry> orderByComparator) {
+
+		return getPersistence().fetchByTUG_C_C_Last(
+			toUserGroupId, classNameId, classPK, orderByComparator);
+	}
+
+	/**
+	 * Returns the sharing entries before and after the current sharing entry in the ordered set where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * @param sharingEntryId the primary key of the current sharing entry
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next sharing entry
+	 * @throws NoSuchEntryException if a sharing entry with the primary key could not be found
+	 */
+	public static SharingEntry[] findByTUG_C_C_PrevAndNext(
+			long sharingEntryId, long toUserGroupId, long classNameId,
+			long classPK, OrderByComparator<SharingEntry> orderByComparator)
+		throws com.liferay.sharing.exception.NoSuchEntryException {
+
+		return getPersistence().findByTUG_C_C_PrevAndNext(
+			sharingEntryId, toUserGroupId, classNameId, classPK,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns all the sharing entries where toUserGroupId = any &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupIds the to user group IDs
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @return the matching sharing entries
+	 */
+	public static List<SharingEntry> findByTUG_C_C(
+		long[] toUserGroupIds, long classNameId, long classPK) {
+
+		return getPersistence().findByTUG_C_C(
+			toUserGroupIds, classNameId, classPK);
+	}
+
+	/**
+	 * Returns a range of all the sharing entries where toUserGroupId = any &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupIds the to user group IDs
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @return the range of matching sharing entries
+	 */
+	public static List<SharingEntry> findByTUG_C_C(
+		long[] toUserGroupIds, long classNameId, long classPK, int start,
+		int end) {
+
+		return getPersistence().findByTUG_C_C(
+			toUserGroupIds, classNameId, classPK, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toUserGroupId = any &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupIds the to user group IDs
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching sharing entries
+	 */
+	public static List<SharingEntry> findByTUG_C_C(
+		long[] toUserGroupIds, long classNameId, long classPK, int start,
+		int end, OrderByComparator<SharingEntry> orderByComparator) {
+
+		return getPersistence().findByTUG_C_C(
+			toUserGroupIds, classNameId, classPK, start, end,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupIds the to user group IDs
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching sharing entries
+	 */
+	public static List<SharingEntry> findByTUG_C_C(
+		long[] toUserGroupIds, long classNameId, long classPK, int start,
+		int end, OrderByComparator<SharingEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByTUG_C_C(
+			toUserGroupIds, classNameId, classPK, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Removes all the sharing entries where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63; from the database.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 */
+	public static void removeByTUG_C_C(
+		long toUserGroupId, long classNameId, long classPK) {
+
+		getPersistence().removeByTUG_C_C(toUserGroupId, classNameId, classPK);
+	}
+
+	/**
+	 * Returns the number of sharing entries where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @return the number of matching sharing entries
+	 */
+	public static int countByTUG_C_C(
+		long toUserGroupId, long classNameId, long classPK) {
+
+		return getPersistence().countByTUG_C_C(
+			toUserGroupId, classNameId, classPK);
+	}
+
+	/**
+	 * Returns the number of sharing entries where toUserGroupId = any &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * @param toUserGroupIds the to user group IDs
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @return the number of matching sharing entries
+	 */
+	public static int countByTUG_C_C(
+		long[] toUserGroupIds, long classNameId, long classPK) {
+
+		return getPersistence().countByTUG_C_C(
+			toUserGroupIds, classNameId, classPK);
+	}
+
+	/**
 	 * Returns the sharing entry where toUserGroupId = &#63; and toUserId = &#63; and classNameId = &#63; and classPK = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
 	 *
 	 * @param toUserGroupId the to user group ID

--- a/modules/apps/sharing/sharing-api/src/main/resources/com/liferay/sharing/service/persistence/packageinfo
+++ b/modules/apps/sharing/sharing-api/src/main/resources/com/liferay/sharing/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 2.2.0
+version 3.0.0

--- a/modules/apps/sharing/sharing-demo/src/main/java/com/liferay/sharing/demo/internal/SharingDemo.java
+++ b/modules/apps/sharing/sharing-demo/src/main/java/com/liferay/sharing/demo/internal/SharingDemo.java
@@ -66,7 +66,7 @@ public class SharingDemo extends BasePortalInstanceLifecycleListener {
 				company.getCompanyId());
 
 			_sharingEntryLocalService.addSharingEntry(
-				null, sharerUser.getUserId(), user.getUserId(),
+				null, sharerUser.getUserId(), 0, user.getUserId(),
 				_portal.getClassNameId(DLFileEntry.class),
 				fileEntry.getFileEntryId(), group.getGroupId(), (i % 3) == 0,
 				Arrays.asList(SharingEntryAction.VIEW),
@@ -79,7 +79,7 @@ public class SharingDemo extends BasePortalInstanceLifecycleListener {
 
 		if (testUser != null) {
 			_sharingEntryLocalService.addSharingEntry(
-				null, sharerUser.getUserId(), testUser.getUserId(),
+				null, sharerUser.getUserId(), 0, testUser.getUserId(),
 				_portal.getClassNameId(DLFileEntry.class),
 				fileEntry.getFileEntryId(), group.getGroupId(), true,
 				Arrays.asList(

--- a/modules/apps/sharing/sharing-document-library-test/src/testIntegration/java/com/liferay/sharing/document/library/internal/service/test/DLFileEntrySharingEntryServiceTest.java
+++ b/modules/apps/sharing/sharing-document-library-test/src/testIntegration/java/com/liferay/sharing/document/library/internal/service/test/DLFileEntrySharingEntryServiceTest.java
@@ -141,7 +141,7 @@ public class DLFileEntrySharingEntryServiceTest {
 		throws Exception {
 
 		return _sharingEntryService.addSharingEntry(
-			null, _toUser.getUserId(), classNameId, classPK,
+			null, 0, _toUser.getUserId(), classNameId, classPK,
 			_group.getGroupId(), true,
 			Collections.singletonList(SharingEntryAction.VIEW), expirationDate,
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));

--- a/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/service/DLFileEntrySharingEntryServiceWrapper.java
+++ b/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/service/DLFileEntrySharingEntryServiceWrapper.java
@@ -32,30 +32,30 @@ public class DLFileEntrySharingEntryServiceWrapper
 
 	@Override
 	public SharingEntry addOrUpdateSharingEntry(
-			String externalReferenceCode, long toUserId, long classNameId,
-			long classPK, long groupId, boolean shareable,
+			String externalReferenceCode, long toUserGroupId, long toUserId,
+			long classNameId, long classPK, long groupId, boolean shareable,
 			Collection<SharingEntryAction> sharingEntryActions,
 			Date expirationDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		return super.addOrUpdateSharingEntry(
-			externalReferenceCode, toUserId, classNameId, classPK, groupId,
-			shareable,
+			externalReferenceCode, toUserGroupId, toUserId, classNameId,
+			classPK, groupId, shareable,
 			_processSharingEntryActions(classNameId, sharingEntryActions),
 			expirationDate, serviceContext);
 	}
 
 	@Override
 	public SharingEntry addSharingEntry(
-			String externalReferenceCode, long toUserId, long classNameId,
-			long classPK, long groupId, boolean shareable,
+			String externalReferenceCode, long toUserGroupId, long toUserId,
+			long classNameId, long classPK, long groupId, boolean shareable,
 			Collection<SharingEntryAction> sharingEntryActions,
 			Date expirationDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		return super.addSharingEntry(
-			externalReferenceCode, toUserId, classNameId, classPK, groupId,
-			shareable,
+			externalReferenceCode, toUserGroupId, toUserId, classNameId,
+			classPK, groupId, shareable,
 			_processSharingEntryActions(classNameId, sharingEntryActions),
 			expirationDate, serviceContext);
 	}

--- a/modules/apps/sharing/sharing-notifications/src/main/java/com/liferay/sharing/notifications/internal/service/NotificationsSharingEntryLocalServiceWrapper.java
+++ b/modules/apps/sharing/sharing-notifications/src/main/java/com/liferay/sharing/notifications/internal/service/NotificationsSharingEntryLocalServiceWrapper.java
@@ -303,11 +303,9 @@ public class NotificationsSharingEntryLocalServiceWrapper
 
 		try {
 			if (sharingEntry.getToUserId() > 0) {
-				User user = _userLocalService.getUser(
-					sharingEntry.getToUserId());
-
 				_sendNotificationEvent(
-					sharingEntry, notificationType, serviceContext, user);
+					sharingEntry, notificationType, serviceContext,
+					_userLocalService.getUser(sharingEntry.getToUserId()));
 
 				return;
 			}

--- a/modules/apps/sharing/sharing-notifications/src/main/java/com/liferay/sharing/notifications/internal/service/NotificationsSharingEntryLocalServiceWrapper.java
+++ b/modules/apps/sharing/sharing-notifications/src/main/java/com/liferay/sharing/notifications/internal/service/NotificationsSharingEntryLocalServiceWrapper.java
@@ -58,16 +58,17 @@ public class NotificationsSharingEntryLocalServiceWrapper
 
 	@Override
 	public SharingEntry addSharingEntry(
-			String externalReferenceCode, long fromUserId, long toUserId,
-			long classNameId, long classPK, long groupId, boolean shareable,
+			String externalReferenceCode, long fromUserId, long userGroupId,
+			long toUserId, long classNameId, long classPK, long groupId,
+			boolean shareable,
 			Collection<SharingEntryAction> sharingEntryActions,
 			Date expirationDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		SharingEntry sharingEntry = super.addSharingEntry(
-			externalReferenceCode, fromUserId, toUserId, classNameId, classPK,
-			groupId, shareable, sharingEntryActions, expirationDate,
-			serviceContext);
+			externalReferenceCode, fromUserId, userGroupId, toUserId,
+			classNameId, classPK, groupId, shareable, sharingEntryActions,
+			expirationDate, serviceContext);
 
 		_sendNotificationEvent(
 			sharingEntry,

--- a/modules/apps/sharing/sharing-notifications/src/main/java/com/liferay/sharing/notifications/internal/service/NotificationsSharingEntryLocalServiceWrapper.java
+++ b/modules/apps/sharing/sharing-notifications/src/main/java/com/liferay/sharing/notifications/internal/service/NotificationsSharingEntryLocalServiceWrapper.java
@@ -41,6 +41,7 @@ import java.text.Format;
 
 import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
@@ -202,7 +203,7 @@ public class NotificationsSharingEntryLocalServiceWrapper
 	private String _getNotificationMessage(
 			SharingEntry sharingEntry, Locale locale,
 			PortletRequest portletRequest)
-		throws PortalException {
+		throws Exception {
 
 		String languageKey = "x-has-shared-x-with-you-for-x";
 
@@ -243,7 +244,7 @@ public class NotificationsSharingEntryLocalServiceWrapper
 
 	private String _getNotificationURL(
 			SharingEntry sharingEntry, PortletRequest portletRequest)
-		throws PortalException {
+		throws Exception {
 
 		if (portletRequest != null) {
 			return PortletURLBuilder.create(
@@ -272,7 +273,7 @@ public class NotificationsSharingEntryLocalServiceWrapper
 	private String _getSharingEntryObjectTitle(
 			SharingEntry sharingEntry, ResourceBundle resourceBundle,
 			PortletRequest portletRequest)
-		throws PortalException {
+		throws Exception {
 
 		SharingEntryInterpreter sharingEntryInterpreter =
 			_getSharingEntryInterpreter(sharingEntry);
@@ -301,53 +302,23 @@ public class NotificationsSharingEntryLocalServiceWrapper
 		ServiceContext serviceContext) {
 
 		try {
-			User user = _userLocalService.getUser(sharingEntry.getToUserId());
+			if (sharingEntry.getToUserId() > 0) {
+				User user = _userLocalService.getUser(
+					sharingEntry.getToUserId());
 
-			SharingNotificationSubcriptionSender
-				sharingNotificationSubcriptionSender =
-					new SharingNotificationSubcriptionSender();
+				_sendNotificationEvent(
+					sharingEntry, notificationType, serviceContext, user);
 
-			sharingNotificationSubcriptionSender.setSubject(
-				_getNotificationMessage(sharingEntry, user.getLocale(), null));
+				return;
+			}
 
-			String entryURL = _getNotificationURL(
-				sharingEntry, serviceContext.getLiferayPortletRequest());
+			List<User> userGroupUsers = _userLocalService.getUserGroupUsers(
+				sharingEntry.getToUserGroupId());
 
-			sharingNotificationSubcriptionSender.setBody(
-				_getNotificationEmailBody(
-					sharingEntry, serviceContext.getLiferayPortletRequest()));
-
-			sharingNotificationSubcriptionSender.setClassName(
-				sharingEntry.getModelClassName());
-			sharingNotificationSubcriptionSender.setClassPK(
-				sharingEntry.getSharingEntryId());
-			sharingNotificationSubcriptionSender.setCurrentUserId(
-				serviceContext.getUserId());
-			sharingNotificationSubcriptionSender.setEntryURL(entryURL);
-
-			String fromName = PrefsPropsUtil.getString(
-				user.getCompanyId(), PropsKeys.ADMIN_EMAIL_FROM_NAME);
-			String fromAddress = PrefsPropsUtil.getString(
-				user.getCompanyId(), PropsKeys.ADMIN_EMAIL_FROM_ADDRESS);
-
-			sharingNotificationSubcriptionSender.setFrom(fromAddress, fromName);
-
-			sharingNotificationSubcriptionSender.setHtmlFormat(true);
-			sharingNotificationSubcriptionSender.setMailId(
-				"sharing_entry", sharingEntry.getSharingEntryId());
-			sharingNotificationSubcriptionSender.setNotificationType(
-				notificationType);
-			sharingNotificationSubcriptionSender.setPortletId(
-				SharingPortletKeys.SHARING);
-			sharingNotificationSubcriptionSender.setScopeGroupId(
-				sharingEntry.getGroupId());
-			sharingNotificationSubcriptionSender.setServiceContext(
-				serviceContext);
-
-			sharingNotificationSubcriptionSender.addRuntimeSubscribers(
-				user.getEmailAddress(), user.getFullName());
-
-			sharingNotificationSubcriptionSender.flushNotificationsAsync();
+			for (User user : userGroupUsers) {
+				_sendNotificationEvent(
+					sharingEntry, notificationType, serviceContext, user);
+			}
 		}
 		catch (Exception exception) {
 			_log.error(
@@ -355,6 +326,57 @@ public class NotificationsSharingEntryLocalServiceWrapper
 					sharingEntry.getSharingEntryId(),
 				exception);
 		}
+	}
+
+	private void _sendNotificationEvent(
+			SharingEntry sharingEntry, int notificationType,
+			ServiceContext serviceContext, User user)
+		throws Exception {
+
+		SharingNotificationSubcriptionSender
+			sharingNotificationSubcriptionSender =
+				new SharingNotificationSubcriptionSender();
+
+		sharingNotificationSubcriptionSender.setSubject(
+			_getNotificationMessage(sharingEntry, user.getLocale(), null));
+
+		String entryURL = _getNotificationURL(
+			sharingEntry, serviceContext.getLiferayPortletRequest());
+
+		sharingNotificationSubcriptionSender.setBody(
+			_getNotificationEmailBody(
+				sharingEntry, serviceContext.getLiferayPortletRequest()));
+
+		sharingNotificationSubcriptionSender.setClassName(
+			sharingEntry.getModelClassName());
+		sharingNotificationSubcriptionSender.setClassPK(
+			sharingEntry.getSharingEntryId());
+		sharingNotificationSubcriptionSender.setCurrentUserId(
+			serviceContext.getUserId());
+		sharingNotificationSubcriptionSender.setEntryURL(entryURL);
+
+		String fromName = PrefsPropsUtil.getString(
+			user.getCompanyId(), PropsKeys.ADMIN_EMAIL_FROM_NAME);
+		String fromAddress = PrefsPropsUtil.getString(
+			user.getCompanyId(), PropsKeys.ADMIN_EMAIL_FROM_ADDRESS);
+
+		sharingNotificationSubcriptionSender.setFrom(fromAddress, fromName);
+
+		sharingNotificationSubcriptionSender.setHtmlFormat(true);
+		sharingNotificationSubcriptionSender.setMailId(
+			"sharing_entry", sharingEntry.getSharingEntryId());
+		sharingNotificationSubcriptionSender.setNotificationType(
+			notificationType);
+		sharingNotificationSubcriptionSender.setPortletId(
+			SharingPortletKeys.SHARING);
+		sharingNotificationSubcriptionSender.setScopeGroupId(
+			sharingEntry.getGroupId());
+		sharingNotificationSubcriptionSender.setServiceContext(serviceContext);
+
+		sharingNotificationSubcriptionSender.addRuntimeSubscribers(
+			user.getEmailAddress(), user.getFullName());
+
+		sharingNotificationSubcriptionSender.flushNotificationsAsync();
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/sharing/sharing-search-test/src/testIntegration/java/com/liferay/sharing/search/internal/test/SharingEntrySearchDLTest.java
+++ b/modules/apps/sharing/sharing-search-test/src/testIntegration/java/com/liferay/sharing/search/internal/test/SharingEntrySearchDLTest.java
@@ -14,6 +14,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.search.Hits;
@@ -24,12 +25,14 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.test.context.ContextUserReplace;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -145,6 +148,55 @@ public class SharingEntrySearchDLTest {
 		}
 	}
 
+	@Test
+	public void testUserCanSearchSharedPrivateDocumentSharedToUserGroup()
+		throws Exception {
+
+		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
+
+		try {
+			_userGroupLocalService.addUserUserGroup(
+				_groupUser.getUserId(), userGroup);
+
+			_sharingEntryLocalService.addSharingEntry(
+				null, TestPropsValues.getUserId(), userGroup.getUserGroupId(),
+				0, _classNameId, _fileEntry.getFileEntryId(),
+				_group.getGroupId(), true,
+				Arrays.asList(SharingEntryAction.VIEW), null,
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId()));
+
+			Indexer<DLFileEntry> indexer = IndexerRegistryUtil.getIndexer(
+				DLFileEntryConstants.getClassName());
+
+			PermissionChecker permissionChecker =
+				PermissionCheckerFactoryUtil.create(_groupUser);
+
+			try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+					_groupUser, permissionChecker)) {
+
+				SearchContext searchContext = new SearchContext();
+
+				searchContext.setCompanyId(_fileEntry.getCompanyId());
+				searchContext.setGroupIds(
+					new long[] {_fileEntry.getRepositoryId()});
+				searchContext.setKeywords(_title);
+				searchContext.setUserId(_groupUser.getUserId());
+
+				Hits hits = indexer.search(searchContext);
+
+				Assert.assertEquals(hits.toString(), 1, hits.getLength());
+			}
+		}
+		finally {
+			if (userGroup != null) {
+				_userGroupLocalService.deleteUserUserGroup(
+					_groupUser.getUserId(), userGroup);
+				_userGroupLocalService.deleteUserGroup(userGroup);
+			}
+		}
+	}
+
 	private long _classNameId;
 
 	@Inject
@@ -165,5 +217,8 @@ public class SharingEntrySearchDLTest {
 	private SharingEntryLocalService _sharingEntryLocalService;
 
 	private String _title;
+
+	@Inject
+	private UserGroupLocalService _userGroupLocalService;
 
 }

--- a/modules/apps/sharing/sharing-search-test/src/testIntegration/java/com/liferay/sharing/search/internal/test/SharingEntrySearchDLTest.java
+++ b/modules/apps/sharing/sharing-search-test/src/testIntegration/java/com/liferay/sharing/search/internal/test/SharingEntrySearchDLTest.java
@@ -116,7 +116,7 @@ public class SharingEntrySearchDLTest {
 	@Test
 	public void testUserCanSearchSharedPrivateDocument() throws Exception {
 		_sharingEntryLocalService.addSharingEntry(
-			null, TestPropsValues.getUserId(), _groupUser.getUserId(),
+			null, TestPropsValues.getUserId(), 0, _groupUser.getUserId(),
 			_classNameId, _fileEntry.getFileEntryId(), _group.getGroupId(),
 			true, Arrays.asList(SharingEntryAction.VIEW), null,
 			ServiceContextTestUtil.getServiceContext(

--- a/modules/apps/sharing/sharing-search-test/src/testIntegration/java/com/liferay/sharing/search/internal/test/SharingEntrySearchDLTest.java
+++ b/modules/apps/sharing/sharing-search-test/src/testIntegration/java/com/liferay/sharing/search/internal/test/SharingEntrySearchDLTest.java
@@ -189,12 +189,10 @@ public class SharingEntrySearchDLTest {
 			}
 		}
 		finally {
-			if (userGroup != null) {
-				_userGroupLocalService.deleteUserUserGroup(
-					_groupUser.getUserId(), userGroup);
+			_userGroupLocalService.deleteUserUserGroup(
+				_groupUser.getUserId(), userGroup);
 
-				_userGroupLocalService.deleteUserGroup(userGroup);
-			}
+			_userGroupLocalService.deleteUserGroup(userGroup);
 		}
 	}
 

--- a/modules/apps/sharing/sharing-search-test/src/testIntegration/java/com/liferay/sharing/search/internal/test/SharingEntrySearchDLTest.java
+++ b/modules/apps/sharing/sharing-search-test/src/testIntegration/java/com/liferay/sharing/search/internal/test/SharingEntrySearchDLTest.java
@@ -192,6 +192,7 @@ public class SharingEntrySearchDLTest {
 			if (userGroup != null) {
 				_userGroupLocalService.deleteUserUserGroup(
 					_groupUser.getUserId(), userGroup);
+
 				_userGroupLocalService.deleteUserGroup(userGroup);
 			}
 		}

--- a/modules/apps/sharing/sharing-search/build.gradle
+++ b/modules/apps/sharing/sharing-search/build.gradle
@@ -3,4 +3,5 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly project(":apps:portal-search:portal-search-spi")
 	compileOnly project(":apps:sharing:sharing-api")
+	compileOnly project(":core:petra:petra-function")
 }

--- a/modules/apps/sharing/sharing-search/src/main/java/com/liferay/sharing/search/internal/permission/SharingEntrySearchPermissionDocumentContributor.java
+++ b/modules/apps/sharing/sharing-search/src/main/java/com/liferay/sharing/search/internal/permission/SharingEntrySearchPermissionDocumentContributor.java
@@ -5,6 +5,7 @@
 
 package com.liferay.sharing.search.internal.permission;
 
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
@@ -53,15 +54,29 @@ public class SharingEntrySearchPermissionDocumentContributor
 			return;
 		}
 
-		long[] userIds = new long[sharingEntries.size()];
+		document.addKeyword(
+			"sharedToUserId",
+			TransformUtil.transformToLongArray(
+				sharingEntries,
+				sharingEntry -> {
+					if (sharingEntry.getToUserId() == 0) {
+						return null;
+					}
 
-		for (int i = 0; i < userIds.length; i++) {
-			SharingEntry sharingEntry = sharingEntries.get(i);
+					return sharingEntry.getToUserId();
+				}));
 
-			userIds[i] = sharingEntry.getToUserId();
-		}
+		document.addKeyword(
+			"sharedToUserGroupId",
+			TransformUtil.transformToLongArray(
+				sharingEntries,
+				sharingEntry -> {
+					if (sharingEntry.getToUserGroupId() == 0) {
+						return null;
+					}
 
-		document.addKeyword("sharedToUserId", userIds);
+					return sharingEntry.getToUserGroupId();
+				}));
 	}
 
 	@Reference

--- a/modules/apps/sharing/sharing-search/src/main/java/com/liferay/sharing/search/internal/permission/SharingEntrySearchPermissionDocumentContributor.java
+++ b/modules/apps/sharing/sharing-search/src/main/java/com/liferay/sharing/search/internal/permission/SharingEntrySearchPermissionDocumentContributor.java
@@ -55,18 +55,6 @@ public class SharingEntrySearchPermissionDocumentContributor
 		}
 
 		document.addKeyword(
-			"sharedToUserId",
-			TransformUtil.transformToLongArray(
-				sharingEntries,
-				sharingEntry -> {
-					if (sharingEntry.getToUserId() == 0) {
-						return null;
-					}
-
-					return sharingEntry.getToUserId();
-				}));
-
-		document.addKeyword(
 			"sharedToUserGroupId",
 			TransformUtil.transformToLongArray(
 				sharingEntries,
@@ -76,6 +64,17 @@ public class SharingEntrySearchPermissionDocumentContributor
 					}
 
 					return sharingEntry.getToUserGroupId();
+				}));
+		document.addKeyword(
+			"sharedToUserId",
+			TransformUtil.transformToLongArray(
+				sharingEntries,
+				sharingEntry -> {
+					if (sharingEntry.getToUserId() == 0) {
+						return null;
+					}
+
+					return sharingEntry.getToUserId();
 				}));
 	}
 

--- a/modules/apps/sharing/sharing-search/src/main/java/com/liferay/sharing/search/internal/permission/SharingEntrySearchPermissionFilterContributor.java
+++ b/modules/apps/sharing/sharing-search/src/main/java/com/liferay/sharing/search/internal/permission/SharingEntrySearchPermissionFilterContributor.java
@@ -5,13 +5,16 @@
 
 package com.liferay.sharing.search.internal.permission;
 
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.TermsFilter;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.search.spi.model.permission.contributor.SearchPermissionFilterContributor;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * Adds a new permission filter so the search returns shared documents based on
@@ -33,11 +36,27 @@ public class SharingEntrySearchPermissionFilterContributor
 			return;
 		}
 
-		TermsFilter termsFilter = new TermsFilter("sharedToUserId");
+		TermsFilter termsFilterSharedToUserId = new TermsFilter(
+			"sharedToUserId");
 
-		termsFilter.addValue(String.valueOf(userId));
+		termsFilterSharedToUserId.addValue(String.valueOf(userId));
 
-		booleanFilter.add(termsFilter, BooleanClauseOccur.SHOULD);
+		booleanFilter.add(termsFilterSharedToUserId, BooleanClauseOccur.SHOULD);
+
+		TermsFilter termsFilterSharedToUserGroupId = new TermsFilter(
+			"sharedToUserGroupId");
+
+		termsFilterSharedToUserGroupId.addValues(
+			TransformUtil.transformToArray(
+				_userGroupLocalService.getUserUserGroups(userId),
+				userGroup -> String.valueOf(userGroup.getUserGroupId()),
+				String.class));
+
+		booleanFilter.add(
+			termsFilterSharedToUserGroupId, BooleanClauseOccur.SHOULD);
 	}
+
+	@Reference
+	private UserGroupLocalService _userGroupLocalService;
 
 }

--- a/modules/apps/sharing/sharing-search/src/main/java/com/liferay/sharing/search/internal/permission/SharingEntrySearchPermissionFilterContributor.java
+++ b/modules/apps/sharing/sharing-search/src/main/java/com/liferay/sharing/search/internal/permission/SharingEntrySearchPermissionFilterContributor.java
@@ -36,13 +36,6 @@ public class SharingEntrySearchPermissionFilterContributor
 			return;
 		}
 
-		TermsFilter sharedToUserIdTermsFilter = new TermsFilter(
-			"sharedToUserId");
-
-		sharedToUserIdTermsFilter.addValue(String.valueOf(userId));
-
-		booleanFilter.add(sharedToUserIdTermsFilter, BooleanClauseOccur.SHOULD);
-
 		TermsFilter sharedToUserGroupIdTermsFilter = new TermsFilter(
 			"sharedToUserGroupId");
 
@@ -54,6 +47,13 @@ public class SharingEntrySearchPermissionFilterContributor
 
 		booleanFilter.add(
 			sharedToUserGroupIdTermsFilter, BooleanClauseOccur.SHOULD);
+
+		TermsFilter sharedToUserIdTermsFilter = new TermsFilter(
+			"sharedToUserId");
+
+		sharedToUserIdTermsFilter.addValue(String.valueOf(userId));
+
+		booleanFilter.add(sharedToUserIdTermsFilter, BooleanClauseOccur.SHOULD);
 	}
 
 	@Reference

--- a/modules/apps/sharing/sharing-search/src/main/java/com/liferay/sharing/search/internal/permission/SharingEntrySearchPermissionFilterContributor.java
+++ b/modules/apps/sharing/sharing-search/src/main/java/com/liferay/sharing/search/internal/permission/SharingEntrySearchPermissionFilterContributor.java
@@ -36,24 +36,24 @@ public class SharingEntrySearchPermissionFilterContributor
 			return;
 		}
 
-		TermsFilter termsFilterSharedToUserId = new TermsFilter(
+		TermsFilter sharedToUserIdTermsFilter = new TermsFilter(
 			"sharedToUserId");
 
-		termsFilterSharedToUserId.addValue(String.valueOf(userId));
+		sharedToUserIdTermsFilter.addValue(String.valueOf(userId));
 
-		booleanFilter.add(termsFilterSharedToUserId, BooleanClauseOccur.SHOULD);
+		booleanFilter.add(sharedToUserIdTermsFilter, BooleanClauseOccur.SHOULD);
 
-		TermsFilter termsFilterSharedToUserGroupId = new TermsFilter(
+		TermsFilter sharedToUserGroupIdTermsFilter = new TermsFilter(
 			"sharedToUserGroupId");
 
-		termsFilterSharedToUserGroupId.addValues(
+		sharedToUserGroupIdTermsFilter.addValues(
 			TransformUtil.transformToArray(
 				_userGroupLocalService.getUserUserGroups(userId),
 				userGroup -> String.valueOf(userGroup.getUserGroupId()),
 				String.class));
 
 		booleanFilter.add(
-			termsFilterSharedToUserGroupId, BooleanClauseOccur.SHOULD);
+			sharedToUserGroupIdTermsFilter, BooleanClauseOccur.SHOULD);
 	}
 
 	@Reference

--- a/modules/apps/sharing/sharing-service/bnd.bnd
+++ b/modules/apps/sharing/sharing-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Sharing Service
 Bundle-SymbolicName: com.liferay.sharing.service
 Bundle-Version: 3.0.53
-Liferay-Require-SchemaVersion: 1.1.0
+Liferay-Require-SchemaVersion: 1.2.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/sharing/sharing-service/service.xml
+++ b/modules/apps/sharing/sharing-service/service.xml
@@ -57,6 +57,11 @@
 			<finder-column name="classNameId" />
 			<finder-column name="classPK" />
 		</finder>
+		<finder name="TUG_C_C" return-type="Collection">
+			<finder-column arrayable-operator="OR" name="toUserGroupId" />
+			<finder-column name="classNameId" />
+			<finder-column name="classPK" />
+		</finder>
 		<finder name="TUG_TU_C_C" return-type="SharingEntry" unique="true">
 			<finder-column name="toUserGroupId" />
 			<finder-column name="toUserId" />

--- a/modules/apps/sharing/sharing-service/service.xml
+++ b/modules/apps/sharing/sharing-service/service.xml
@@ -68,5 +68,6 @@
 		<exception>InvalidSharingEntryAction</exception>
 		<exception>InvalidSharingEntryExpirationDate</exception>
 		<exception>InvalidSharingEntryUser</exception>
+		<exception>InvalidSharingEntryUserAndUserGroup</exception>
 	</exceptions>
 </service-builder>

--- a/modules/apps/sharing/sharing-service/service.xml
+++ b/modules/apps/sharing/sharing-service/service.xml
@@ -23,6 +23,7 @@
 
 		<!-- Other fields -->
 
+		<column name="toUserGroupId" type="long" />
 		<column name="toUserId" type="long" />
 		<column name="classNameId" type="long" />
 		<column name="classPK" type="long" />

--- a/modules/apps/sharing/sharing-service/service.xml
+++ b/modules/apps/sharing/sharing-service/service.xml
@@ -57,7 +57,8 @@
 			<finder-column name="classNameId" />
 			<finder-column name="classPK" />
 		</finder>
-		<finder name="TU_C_C" return-type="SharingEntry" unique="true">
+		<finder name="TUG_TU_C_C" return-type="SharingEntry" unique="true">
+			<finder-column name="toUserGroupId" />
 			<finder-column name="toUserId" />
 			<finder-column name="classNameId" />
 			<finder-column name="classPK" />

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/security/permission/contributor/SharingPermissionSQLContributor.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/security/permission/contributor/SharingPermissionSQLContributor.java
@@ -144,7 +144,7 @@ public class SharingPermissionSQLContributor
 				StringUtil.merge(
 					TransformUtil.transformToLongArray(
 						userGroups, UserGroup::getUserGroupId),
-					","));
+					StringPool.COMMA));
 			sb.append(")");
 		}
 

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/security/permission/contributor/SharingPermissionSQLContributor.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/security/permission/contributor/SharingPermissionSQLContributor.java
@@ -132,21 +132,23 @@ public class SharingPermissionSQLContributor
 
 		_addDisabledGroupsSQL(sb, groupIds);
 
-		sb.append("((SharingEntry.toUserId = ");
-		sb.append(permissionChecker.getUserId());
-
 		List<UserGroup> userGroups = _userGroupLocalService.getUserUserGroups(
 			permissionChecker.getUserId());
 
+		sb.append("(");
+
 		if (!userGroups.isEmpty()) {
-			sb.append(") OR (SharingEntry.toUserGroupId IN ( ");
+			sb.append("(SharingEntry.toUserGroupId IN ( ");
 			sb.append(
 				StringUtil.merge(
 					TransformUtil.transformToLongArray(
 						userGroups, UserGroup::getUserGroupId),
 					StringPool.COMMA));
-			sb.append(")");
+			sb.append(")) OR ");
 		}
+
+		sb.append("(SharingEntry.toUserId = ");
+		sb.append(permissionChecker.getUserId());
 
 		sb.append(")) AND (SharingEntry.classNameId = ");
 		sb.append(_classNameLocalService.getClassNameId(className));

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/security/permission/contributor/SharingPermissionSQLContributor.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/security/permission/contributor/SharingPermissionSQLContributor.java
@@ -5,18 +5,22 @@
 
 package com.liferay.sharing.internal.security.permission.contributor;
 
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.security.permission.contributor.PermissionSQLContributor;
 import com.liferay.sharing.configuration.SharingConfiguration;
@@ -39,11 +43,13 @@ public class SharingPermissionSQLContributor
 	public SharingPermissionSQLContributor(
 		ClassNameLocalService classNameLocalService,
 		GroupLocalService groupLocalService,
-		SharingConfigurationFactory sharingConfigurationFactory) {
+		SharingConfigurationFactory sharingConfigurationFactory,
+		UserGroupLocalService userGroupLocalService) {
 
 		_classNameLocalService = classNameLocalService;
 		_groupLocalService = groupLocalService;
 		_sharingConfigurationFactory = sharingConfigurationFactory;
+		_userGroupLocalService = userGroupLocalService;
 	}
 
 	@Override
@@ -86,14 +92,12 @@ public class SharingPermissionSQLContributor
 				SharingEntryTable.INSTANCE
 			).where(
 				() -> {
-					Predicate predicate =
-						SharingEntryTable.INSTANCE.toUserId.eq(
-							permissionChecker.getUserId()
-						).and(
-							SharingEntryTable.INSTANCE.classNameId.eq(
-								_classNameLocalService.getClassNameId(
-									className))
-						);
+					Predicate predicate = _getUserAndUserGroupPredicate(
+						permissionChecker
+					).and(
+						SharingEntryTable.INSTANCE.classNameId.eq(
+							_classNameLocalService.getClassNameId(className))
+					);
 
 					if (disableGroupIds.isEmpty()) {
 						return predicate;
@@ -128,9 +132,23 @@ public class SharingPermissionSQLContributor
 
 		_addDisabledGroupsSQL(sb, groupIds);
 
-		sb.append("(SharingEntry.toUserId = ");
+		sb.append("((SharingEntry.toUserId = ");
 		sb.append(permissionChecker.getUserId());
-		sb.append(") AND (SharingEntry.classNameId = ");
+
+		List<UserGroup> userGroups = _userGroupLocalService.getUserUserGroups(
+			permissionChecker.getUserId());
+
+		if (!userGroups.isEmpty()) {
+			sb.append(") OR (SharingEntry.toUserGroupId IN ( ");
+			sb.append(
+				StringUtil.merge(
+					TransformUtil.transformToLongArray(
+						userGroups, UserGroup::getUserGroupId),
+					","));
+			sb.append(")");
+		}
+
+		sb.append(")) AND (SharingEntry.classNameId = ");
 		sb.append(_classNameLocalService.getClassNameId(className));
 		sb.append("))");
 
@@ -181,8 +199,31 @@ public class SharingPermissionSQLContributor
 		}
 	}
 
+	private Predicate _getUserAndUserGroupPredicate(
+		PermissionChecker permissionChecker) {
+
+		return SharingEntryTable.INSTANCE.toUserId.eq(
+			permissionChecker.getUserId()
+		).or(
+			() -> {
+				List<UserGroup> userGroups =
+					_userGroupLocalService.getUserUserGroups(
+						permissionChecker.getUserId());
+
+				if (userGroups.isEmpty()) {
+					return null;
+				}
+
+				return SharingEntryTable.INSTANCE.toUserGroupId.in(
+					TransformUtil.transformToArray(
+						userGroups, UserGroup::getUserGroupId, Long.class));
+			}
+		);
+	}
+
 	private final ClassNameLocalService _classNameLocalService;
 	private final GroupLocalService _groupLocalService;
 	private final SharingConfigurationFactory _sharingConfigurationFactory;
+	private final UserGroupLocalService _userGroupLocalService;
 
 }

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/security/permission/resource/SharingModelResourcePermissionConfiguratorImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/security/permission/resource/SharingModelResourcePermissionConfiguratorImpl.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionLogic;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.security.permission.contributor.PermissionSQLContributor;
@@ -81,7 +82,7 @@ public class SharingModelResourcePermissionConfiguratorImpl
 				PermissionSQLContributor.class,
 				new SharingPermissionSQLContributor(
 					_classNameLocalService, _groupLocalService,
-					_sharingConfigurationFactory),
+					_sharingConfigurationFactory, _userGroupLocalService),
 				new HashMapDictionary<>());
 	}
 
@@ -123,6 +124,9 @@ public class SharingModelResourcePermissionConfiguratorImpl
 	private ServiceRegistration<PermissionSQLContributor>
 		_sharingPermissionSQLContributorServiceRegistration;
 	private SharingSystemConfiguration _sharingSystemConfiguration;
+
+	@Reference
+	private UserGroupLocalService _userGroupLocalService;
 
 	private class SharingModelResourcePermissionLogic<T extends GroupedModel>
 		implements ModelResourcePermissionLogic<T> {

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/upgrade/registry/SharingServiceUpgradeStepRegistrator.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/upgrade/registry/SharingServiceUpgradeStepRegistrator.java
@@ -29,6 +29,11 @@ public class SharingServiceUpgradeStepRegistrator
 				}
 
 			});
+
+		registry.register(
+			"1.1.0", "1.2.0",
+			new com.liferay.sharing.internal.upgrade.v1_2_0.
+				SharingEntryUpgradeProcess());
 	}
 
 }

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/upgrade/v1_2_0/SharingEntryUpgradeProcess.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/upgrade/v1_2_0/SharingEntryUpgradeProcess.java
@@ -1,0 +1,30 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.sharing.internal.upgrade.v1_2_0;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
+import com.liferay.portal.kernel.upgrade.UpgradeStep;
+
+/**
+ * @author Mikel Lorza
+ */
+public class SharingEntryUpgradeProcess extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		runSQL("update SharingEntry set toUserGroupId = 0");
+	}
+
+	@Override
+	protected UpgradeStep[] getPreUpgradeSteps() {
+		return new UpgradeStep[] {
+			UpgradeProcessFactory.addColumns(
+				"SharingEntry", "toUserGroupId LONG")
+		};
+	}
+
+}

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/model/impl/SharingEntryCacheModel.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/model/impl/SharingEntryCacheModel.java
@@ -53,7 +53,7 @@ public class SharingEntryCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(31);
+		StringBundler sb = new StringBundler(33);
 
 		sb.append("{uuid=");
 		sb.append(uuid);
@@ -73,6 +73,8 @@ public class SharingEntryCacheModel
 		sb.append(createDate);
 		sb.append(", modifiedDate=");
 		sb.append(modifiedDate);
+		sb.append(", toUserGroupId=");
+		sb.append(toUserGroupId);
 		sb.append(", toUserId=");
 		sb.append(toUserId);
 		sb.append(", classNameId=");
@@ -134,6 +136,7 @@ public class SharingEntryCacheModel
 			sharingEntryImpl.setModifiedDate(new Date(modifiedDate));
 		}
 
+		sharingEntryImpl.setToUserGroupId(toUserGroupId);
 		sharingEntryImpl.setToUserId(toUserId);
 		sharingEntryImpl.setClassNameId(classNameId);
 		sharingEntryImpl.setClassPK(classPK);
@@ -167,6 +170,8 @@ public class SharingEntryCacheModel
 		userName = objectInput.readUTF();
 		createDate = objectInput.readLong();
 		modifiedDate = objectInput.readLong();
+
+		toUserGroupId = objectInput.readLong();
 
 		toUserId = objectInput.readLong();
 
@@ -214,6 +219,8 @@ public class SharingEntryCacheModel
 		objectOutput.writeLong(createDate);
 		objectOutput.writeLong(modifiedDate);
 
+		objectOutput.writeLong(toUserGroupId);
+
 		objectOutput.writeLong(toUserId);
 
 		objectOutput.writeLong(classNameId);
@@ -235,6 +242,7 @@ public class SharingEntryCacheModel
 	public String userName;
 	public long createDate;
 	public long modifiedDate;
+	public long toUserGroupId;
 	public long toUserId;
 	public long classNameId;
 	public long classPK;

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/model/impl/SharingEntryModelImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/model/impl/SharingEntryModelImpl.java
@@ -69,10 +69,10 @@ public class SharingEntryModelImpl
 		{"sharingEntryId", Types.BIGINT}, {"groupId", Types.BIGINT},
 		{"companyId", Types.BIGINT}, {"userId", Types.BIGINT},
 		{"userName", Types.VARCHAR}, {"createDate", Types.TIMESTAMP},
-		{"modifiedDate", Types.TIMESTAMP}, {"toUserId", Types.BIGINT},
-		{"classNameId", Types.BIGINT}, {"classPK", Types.BIGINT},
-		{"shareable", Types.BOOLEAN}, {"actionIds", Types.BIGINT},
-		{"expirationDate", Types.TIMESTAMP}
+		{"modifiedDate", Types.TIMESTAMP}, {"toUserGroupId", Types.BIGINT},
+		{"toUserId", Types.BIGINT}, {"classNameId", Types.BIGINT},
+		{"classPK", Types.BIGINT}, {"shareable", Types.BOOLEAN},
+		{"actionIds", Types.BIGINT}, {"expirationDate", Types.TIMESTAMP}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -88,6 +88,7 @@ public class SharingEntryModelImpl
 		TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
 		TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+		TABLE_COLUMNS_MAP.put("toUserGroupId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("toUserId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("classNameId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("classPK", Types.BIGINT);
@@ -97,7 +98,7 @@ public class SharingEntryModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table SharingEntry (uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,sharingEntryId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,toUserId LONG,classNameId LONG,classPK LONG,shareable BOOLEAN,actionIds LONG,expirationDate DATE null)";
+		"create table SharingEntry (uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,sharingEntryId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,toUserGroupId LONG,toUserId LONG,classNameId LONG,classPK LONG,shareable BOOLEAN,actionIds LONG,expirationDate DATE null)";
 
 	public static final String TABLE_SQL_DROP = "drop table SharingEntry";
 
@@ -298,6 +299,8 @@ public class SharingEntryModelImpl
 				"createDate", SharingEntry::getCreateDate);
 			attributeGetterFunctions.put(
 				"modifiedDate", SharingEntry::getModifiedDate);
+			attributeGetterFunctions.put(
+				"toUserGroupId", SharingEntry::getToUserGroupId);
 			attributeGetterFunctions.put("toUserId", SharingEntry::getToUserId);
 			attributeGetterFunctions.put(
 				"classNameId", SharingEntry::getClassNameId);
@@ -354,6 +357,9 @@ public class SharingEntryModelImpl
 			attributeSetterBiConsumers.put(
 				"modifiedDate",
 				(BiConsumer<SharingEntry, Date>)SharingEntry::setModifiedDate);
+			attributeSetterBiConsumers.put(
+				"toUserGroupId",
+				(BiConsumer<SharingEntry, Long>)SharingEntry::setToUserGroupId);
 			attributeSetterBiConsumers.put(
 				"toUserId",
 				(BiConsumer<SharingEntry, Long>)SharingEntry::setToUserId);
@@ -600,6 +606,21 @@ public class SharingEntryModelImpl
 
 	@JSON
 	@Override
+	public long getToUserGroupId() {
+		return _toUserGroupId;
+	}
+
+	@Override
+	public void setToUserGroupId(long toUserGroupId) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_toUserGroupId = toUserGroupId;
+	}
+
+	@JSON
+	@Override
 	public long getToUserId() {
 		return _toUserId;
 	}
@@ -840,6 +861,7 @@ public class SharingEntryModelImpl
 		sharingEntryImpl.setUserName(getUserName());
 		sharingEntryImpl.setCreateDate(getCreateDate());
 		sharingEntryImpl.setModifiedDate(getModifiedDate());
+		sharingEntryImpl.setToUserGroupId(getToUserGroupId());
 		sharingEntryImpl.setToUserId(getToUserId());
 		sharingEntryImpl.setClassNameId(getClassNameId());
 		sharingEntryImpl.setClassPK(getClassPK());
@@ -872,6 +894,8 @@ public class SharingEntryModelImpl
 			this.<Date>getColumnOriginalValue("createDate"));
 		sharingEntryImpl.setModifiedDate(
 			this.<Date>getColumnOriginalValue("modifiedDate"));
+		sharingEntryImpl.setToUserGroupId(
+			this.<Long>getColumnOriginalValue("toUserGroupId"));
 		sharingEntryImpl.setToUserId(
 			this.<Long>getColumnOriginalValue("toUserId"));
 		sharingEntryImpl.setClassNameId(
@@ -1016,6 +1040,8 @@ public class SharingEntryModelImpl
 			sharingEntryCacheModel.modifiedDate = Long.MIN_VALUE;
 		}
 
+		sharingEntryCacheModel.toUserGroupId = getToUserGroupId();
+
 		sharingEntryCacheModel.toUserId = getToUserId();
 
 		sharingEntryCacheModel.classNameId = getClassNameId();
@@ -1106,6 +1132,7 @@ public class SharingEntryModelImpl
 	private Date _createDate;
 	private Date _modifiedDate;
 	private boolean _setModifiedDate;
+	private long _toUserGroupId;
 	private long _toUserId;
 	private long _classNameId;
 	private long _classPK;
@@ -1153,6 +1180,7 @@ public class SharingEntryModelImpl
 		_columnOriginalValues.put("userName", _userName);
 		_columnOriginalValues.put("createDate", _createDate);
 		_columnOriginalValues.put("modifiedDate", _modifiedDate);
+		_columnOriginalValues.put("toUserGroupId", _toUserGroupId);
 		_columnOriginalValues.put("toUserId", _toUserId);
 		_columnOriginalValues.put("classNameId", _classNameId);
 		_columnOriginalValues.put("classPK", _classPK);
@@ -1200,17 +1228,19 @@ public class SharingEntryModelImpl
 
 		columnBitmasks.put("modifiedDate", 256L);
 
-		columnBitmasks.put("toUserId", 512L);
+		columnBitmasks.put("toUserGroupId", 512L);
 
-		columnBitmasks.put("classNameId", 1024L);
+		columnBitmasks.put("toUserId", 1024L);
 
-		columnBitmasks.put("classPK", 2048L);
+		columnBitmasks.put("classNameId", 2048L);
 
-		columnBitmasks.put("shareable", 4096L);
+		columnBitmasks.put("classPK", 4096L);
 
-		columnBitmasks.put("actionIds", 8192L);
+		columnBitmasks.put("shareable", 8192L);
 
-		columnBitmasks.put("expirationDate", 16384L);
+		columnBitmasks.put("actionIds", 16384L);
+
+		columnBitmasks.put("expirationDate", 32768L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/model/impl/SharingEntryModelImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/model/impl/SharingEntryModelImpl.java
@@ -154,26 +154,32 @@ public class SharingEntryModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long TOUSERID_COLUMN_BITMASK = 64L;
+	public static final long TOUSERGROUPID_COLUMN_BITMASK = 64L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long USERID_COLUMN_BITMASK = 128L;
+	public static final long TOUSERID_COLUMN_BITMASK = 128L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 256L;
+	public static final long USERID_COLUMN_BITMASK = 256L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long UUID_COLUMN_BITMASK = 512L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *		#getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long SHARINGENTRYID_COLUMN_BITMASK = 512L;
+	public static final long SHARINGENTRYID_COLUMN_BITMASK = 1024L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
@@ -617,6 +623,16 @@ public class SharingEntryModelImpl
 		}
 
 		_toUserGroupId = toUserGroupId;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public long getOriginalToUserGroupId() {
+		return GetterUtil.getLong(
+			this.<Long>getColumnOriginalValue("toUserGroupId"));
 	}
 
 	@JSON

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/http/SharingEntryServiceHttp.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/http/SharingEntryServiceHttp.java
@@ -44,8 +44,8 @@ public class SharingEntryServiceHttp {
 	public static com.liferay.sharing.model.SharingEntry
 			addOrUpdateSharingEntry(
 				HttpPrincipal httpPrincipal, String externalReferenceCode,
-				long toUserId, long classNameId, long classPK, long groupId,
-				boolean shareable,
+				long toUserGroupId, long toUserId, long classNameId,
+				long classPK, long groupId, boolean shareable,
 				java.util.Collection
 					<com.liferay.sharing.security.permission.SharingEntryAction>
 						sharingEntryActions,
@@ -59,8 +59,8 @@ public class SharingEntryServiceHttp {
 				_addOrUpdateSharingEntryParameterTypes0);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, externalReferenceCode, toUserId, classNameId,
-				classPK, groupId, shareable, sharingEntryActions,
+				methodKey, externalReferenceCode, toUserGroupId, toUserId,
+				classNameId, classPK, groupId, shareable, sharingEntryActions,
 				expirationDate, serviceContext);
 
 			Object returnObj = null;
@@ -93,8 +93,8 @@ public class SharingEntryServiceHttp {
 
 	public static com.liferay.sharing.model.SharingEntry addSharingEntry(
 			HttpPrincipal httpPrincipal, String externalReferenceCode,
-			long toUserId, long classNameId, long classPK, long groupId,
-			boolean shareable,
+			long toUserGroupId, long toUserId, long classNameId, long classPK,
+			long groupId, boolean shareable,
 			java.util.Collection
 				<com.liferay.sharing.security.permission.SharingEntryAction>
 					sharingEntryActions,
@@ -108,8 +108,8 @@ public class SharingEntryServiceHttp {
 				_addSharingEntryParameterTypes1);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, externalReferenceCode, toUserId, classNameId,
-				classPK, groupId, shareable, sharingEntryActions,
+				methodKey, externalReferenceCode, toUserGroupId, toUserId,
+				classNameId, classPK, groupId, shareable, sharingEntryActions,
 				expirationDate, serviceContext);
 
 			Object returnObj = null;
@@ -362,13 +362,15 @@ public class SharingEntryServiceHttp {
 	private static final Class<?>[] _addOrUpdateSharingEntryParameterTypes0 =
 		new Class[] {
 			String.class, long.class, long.class, long.class, long.class,
-			boolean.class, java.util.Collection.class, java.util.Date.class,
+			long.class, boolean.class, java.util.Collection.class,
+			java.util.Date.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _addSharingEntryParameterTypes1 =
 		new Class[] {
 			String.class, long.class, long.class, long.class, long.class,
-			boolean.class, java.util.Collection.class, java.util.Date.class,
+			long.class, boolean.class, java.util.Collection.class,
+			java.util.Date.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _deleteSharingEntryParameterTypes2 =

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
@@ -638,19 +638,13 @@ public class SharingEntryLocalServiceImpl
 		long toUserId, long classNameId, long classPK,
 		SharingEntryAction sharingEntryAction) {
 
-		List<SharingEntry> sharingEntries = sharingEntryPersistence.findByTU_C(
-			toUserId, classNameId);
+		SharingEntry sharingEntry = sharingEntryPersistence.fetchByTUG_TU_C_C(
+			0, toUserId, classNameId, classPK);
 
-		if (!sharingEntries.isEmpty()) {
-			for (SharingEntry sharingEntry : sharingEntries) {
-				if (classPK == sharingEntry.getClassPK()) {
-					if (sharingEntry.hasSharingPermission(sharingEntryAction)) {
-						return true;
-					}
+		if ((sharingEntry != null) &&
+			sharingEntry.hasSharingPermission(sharingEntryAction)) {
 
-					break;
-				}
-			}
+			return true;
 		}
 
 		List<UserGroup> userGroups = _userGroupLocalService.getUserUserGroups(
@@ -660,13 +654,13 @@ public class SharingEntryLocalServiceImpl
 			return false;
 		}
 
-		for (SharingEntry sharingEntry :
+		for (SharingEntry curSharingEntry :
 				sharingEntryPersistence.findByTUG_C_C(
 					TransformUtil.transformToLongArray(
 						userGroups, UserGroup::getUserGroupId),
 					classNameId, classPK)) {
 
-			if (sharingEntry.hasSharingPermission(sharingEntryAction)) {
+			if (curSharingEntry.hasSharingPermission(sharingEntryAction)) {
 				return true;
 			}
 		}

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
@@ -94,9 +94,9 @@ public class SharingEntryLocalServiceImpl
 
 		if (sharingEntry == null) {
 			return sharingEntryLocalService.addSharingEntry(
-				externalReferenceCode, userId, toUserId, classNameId, classPK,
-				groupId, shareable, sharingEntryActions, expirationDate,
-				serviceContext);
+				externalReferenceCode, userId, toUserGroupId, toUserId,
+				classNameId, classPK, groupId, shareable, sharingEntryActions,
+				expirationDate, serviceContext);
 		}
 
 		return sharingEntryLocalService.updateSharingEntry(

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
@@ -796,8 +796,8 @@ public class SharingEntryLocalServiceImpl
 
 		if ((toUserGroupId > 0) && (toUserId > 0)) {
 			throw new InvalidSharingEntryUserAndUserGroupException(
-				"Creating a sharing entry for a user and a user group at the " +
-					"same time is not allowed");
+				"A sharing entry cannot be associated with a user and a user " +
+					"group at the same time");
 		}
 
 		if ((toUserId > 0) && (fromUserId == toUserId)) {

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
@@ -91,8 +91,8 @@ public class SharingEntryLocalServiceImpl
 			Date expirationDate, ServiceContext serviceContext)
 		throws PortalException {
 
-		SharingEntry sharingEntry = sharingEntryPersistence.fetchByTU_C_C(
-			toUserId, classNameId, classPK);
+		SharingEntry sharingEntry = sharingEntryPersistence.fetchByTUG_TU_C_C(
+			toUserGroupId, toUserId, classNameId, classPK);
 
 		if (sharingEntry == null) {
 			return sharingEntryLocalService.addSharingEntry(
@@ -143,8 +143,8 @@ public class SharingEntryLocalServiceImpl
 		_validateExpirationDate(expirationDate);
 
 		SharingEntry existingSharingEntry =
-			sharingEntryPersistence.fetchByTU_C_C(
-				toUserId, classNameId, classPK);
+			sharingEntryPersistence.fetchByTUG_TU_C_C(
+				toUserGroupId, toUserId, classNameId, classPK);
 
 		if (existingSharingEntry != null) {
 			throw new DuplicateSharingEntryException(
@@ -260,8 +260,8 @@ public class SharingEntryLocalServiceImpl
 			long toUserId, long classNameId, long classPK)
 		throws PortalException {
 
-		SharingEntry sharingEntry = sharingEntryPersistence.findByTU_C_C(
-			toUserId, classNameId, classPK);
+		SharingEntry sharingEntry = sharingEntryPersistence.findByTUG_TU_C_C(
+			0, toUserId, classNameId, classPK);
 
 		return deleteSharingEntry(sharingEntry);
 	}
@@ -341,8 +341,8 @@ public class SharingEntryLocalServiceImpl
 	public SharingEntry fetchSharingEntry(
 		long toUserId, long classNameId, long classPK) {
 
-		return sharingEntryPersistence.fetchByTU_C_C(
-			toUserId, classNameId, classPK);
+		return sharingEntryPersistence.fetchByTUG_TU_C_C(
+			0, toUserId, classNameId, classPK);
 	}
 
 	/**
@@ -468,8 +468,8 @@ public class SharingEntryLocalServiceImpl
 			long toUserId, long classNameId, long classPK)
 		throws PortalException {
 
-		return sharingEntryPersistence.findByTU_C_C(
-			toUserId, classNameId, classPK);
+		return sharingEntryPersistence.findByTUG_TU_C_C(
+			0, toUserId, classNameId, classPK);
 	}
 
 	/**
@@ -587,8 +587,8 @@ public class SharingEntryLocalServiceImpl
 		long toUserId, long classNameId, long classPK,
 		SharingEntryAction sharingEntryAction) {
 
-		SharingEntry sharingEntry = sharingEntryPersistence.fetchByTU_C_C(
-			toUserId, classNameId, classPK);
+		SharingEntry sharingEntry = sharingEntryPersistence.fetchByTUG_TU_C_C(
+			0, toUserId, classNameId, classPK);
 
 		if ((sharingEntry != null) && sharingEntry.isShareable() &&
 			sharingEntry.hasSharingPermission(sharingEntryAction)) {

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.DateUtil;
@@ -24,6 +25,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.sharing.exception.DuplicateSharingEntryException;
 import com.liferay.sharing.exception.InvalidSharingEntryActionException;
 import com.liferay.sharing.exception.InvalidSharingEntryExpirationDateException;
+import com.liferay.sharing.exception.InvalidSharingEntryUserAndUserGroupException;
 import com.liferay.sharing.exception.InvalidSharingEntryUserException;
 import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.security.permission.SharingEntryAction;
@@ -136,7 +138,7 @@ public class SharingEntryLocalServiceImpl
 
 		_validateSharingEntryActions(sharingEntryActions);
 
-		_validateUsers(userId, toUserId);
+		_validateUsersAndUserGroup(userId, toUserGroupId, toUserId);
 
 		_validateExpirationDate(expirationDate);
 
@@ -167,6 +169,7 @@ public class SharingEntryLocalServiceImpl
 		sharingEntry.setUserId(user.getUserId());
 		sharingEntry.setUserName(user.getFullName());
 
+		sharingEntry.setToUserGroupId(toUserGroupId);
 		sharingEntry.setToUserId(toUserId);
 		sharingEntry.setClassNameId(classNameId);
 		sharingEntry.setClassPK(classPK);
@@ -751,10 +754,21 @@ public class SharingEntryLocalServiceImpl
 		}
 	}
 
-	private void _validateUsers(long fromUserId, long toUserId)
-		throws InvalidSharingEntryUserException {
+	private void _validateUsersAndUserGroup(
+			long fromUserId, long toUserGroupId, long toUserId)
+		throws PortalException {
 
-		if (fromUserId == toUserId) {
+		if (toUserGroupId > 0) {
+			_userGroupLocalService.getUserGroup(toUserGroupId);
+		}
+
+		if ((toUserGroupId > 0) && (toUserId > 0)) {
+			throw new InvalidSharingEntryUserAndUserGroupException(
+				"Creating a sharing entry for a user and a user group at the " +
+					"same time is not allowed");
+		}
+
+		if ((toUserId > 0) && (fromUserId == toUserId)) {
 			throw new InvalidSharingEntryUserException(
 				"From user cannot be the same as to user");
 		}
@@ -768,6 +782,9 @@ public class SharingEntryLocalServiceImpl
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private UserGroupLocalService _userGroupLocalService;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.sharing.service.impl;
 
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -12,6 +13,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.SearchException;
@@ -596,6 +598,26 @@ public class SharingEntryLocalServiceImpl
 			return true;
 		}
 
+		List<UserGroup> userGroups = _userGroupLocalService.getUserUserGroups(
+			toUserId);
+
+		if (userGroups.isEmpty()) {
+			return false;
+		}
+
+		for (SharingEntry curSharingEntry :
+				sharingEntryPersistence.findByTUG_C_C(
+					TransformUtil.transformToLongArray(
+						userGroups, UserGroup::getUserGroupId),
+					classNameId, classPK)) {
+
+			if (curSharingEntry.isShareable() &&
+				curSharingEntry.hasSharingPermission(sharingEntryAction)) {
+
+				return true;
+			}
+		}
+
 		return false;
 	}
 
@@ -619,17 +641,33 @@ public class SharingEntryLocalServiceImpl
 		List<SharingEntry> sharingEntries = sharingEntryPersistence.findByTU_C(
 			toUserId, classNameId);
 
-		if (sharingEntries.isEmpty()) {
+		if (!sharingEntries.isEmpty()) {
+			for (SharingEntry sharingEntry : sharingEntries) {
+				if (classPK == sharingEntry.getClassPK()) {
+					if (sharingEntry.hasSharingPermission(sharingEntryAction)) {
+						return true;
+					}
+
+					break;
+				}
+			}
+		}
+
+		List<UserGroup> userGroups = _userGroupLocalService.getUserUserGroups(
+			toUserId);
+
+		if (userGroups.isEmpty()) {
 			return false;
 		}
 
-		for (SharingEntry sharingEntry : sharingEntries) {
-			if (classPK == sharingEntry.getClassPK()) {
-				if (sharingEntry.hasSharingPermission(sharingEntryAction)) {
-					return true;
-				}
+		for (SharingEntry sharingEntry :
+				sharingEntryPersistence.findByTUG_C_C(
+					TransformUtil.transformToLongArray(
+						userGroups, UserGroup::getUserGroupId),
+					classNameId, classPK)) {
 
-				return false;
+			if (sharingEntry.hasSharingPermission(sharingEntryAction)) {
+				return true;
 			}
 		}
 

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
@@ -82,8 +82,9 @@ public class SharingEntryLocalServiceImpl
 	 */
 	@Override
 	public SharingEntry addOrUpdateSharingEntry(
-			String externalReferenceCode, long userId, long toUserId,
-			long classNameId, long classPK, long groupId, boolean shareable,
+			String externalReferenceCode, long userId, long toUserGroupId,
+			long toUserId, long classNameId, long classPK, long groupId,
+			boolean shareable,
 			Collection<SharingEntryAction> sharingEntryActions,
 			Date expirationDate, ServiceContext serviceContext)
 		throws PortalException {
@@ -126,8 +127,9 @@ public class SharingEntryLocalServiceImpl
 	 */
 	@Override
 	public SharingEntry addSharingEntry(
-			String externalReferenceCode, long userId, long toUserId,
-			long classNameId, long classPK, long groupId, boolean shareable,
+			String externalReferenceCode, long userId, long toUserGroupId,
+			long toUserId, long classNameId, long classPK, long groupId,
+			boolean shareable,
 			Collection<SharingEntryAction> sharingEntryActions,
 			Date expirationDate, ServiceContext serviceContext)
 		throws PortalException {

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryServiceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryServiceImpl.java
@@ -71,8 +71,9 @@ public class SharingEntryServiceImpl extends SharingEntryServiceBaseImpl {
 
 		if (sharingEntry == null) {
 			return sharingEntryService.addSharingEntry(
-				externalReferenceCode, toUserId, classNameId, classPK, groupId,
-				shareable, sharingEntryActions, expirationDate, serviceContext);
+				externalReferenceCode, toUserGroupId, toUserId, classNameId,
+				classPK, groupId, shareable, sharingEntryActions,
+				expirationDate, serviceContext);
 		}
 
 		return sharingEntryService.updateSharingEntry(
@@ -113,9 +114,9 @@ public class SharingEntryServiceImpl extends SharingEntryServiceBaseImpl {
 			sharingEntryActions);
 
 		return sharingEntryLocalService.addSharingEntry(
-			externalReferenceCode, getUserId(), toUserId, classNameId, classPK,
-			groupId, shareable, sharingEntryActions, expirationDate,
-			serviceContext);
+			externalReferenceCode, getUserId(), toUserGroupId, toUserId,
+			classNameId, classPK, groupId, shareable, sharingEntryActions,
+			expirationDate, serviceContext);
 	}
 
 	@Override

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryServiceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryServiceImpl.java
@@ -66,8 +66,8 @@ public class SharingEntryServiceImpl extends SharingEntryServiceBaseImpl {
 			Date expirationDate, ServiceContext serviceContext)
 		throws PortalException {
 
-		SharingEntry sharingEntry = sharingEntryPersistence.fetchByTU_C_C(
-			toUserId, classNameId, classPK);
+		SharingEntry sharingEntry = sharingEntryPersistence.fetchByTUG_TU_C_C(
+			0, toUserId, classNameId, classPK);
 
 		if (sharingEntry == null) {
 			return sharingEntryService.addSharingEntry(

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryServiceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryServiceImpl.java
@@ -60,8 +60,8 @@ public class SharingEntryServiceImpl extends SharingEntryServiceBaseImpl {
 	 */
 	@Override
 	public SharingEntry addOrUpdateSharingEntry(
-			String externalReferenceCode, long toUserId, long classNameId,
-			long classPK, long groupId, boolean shareable,
+			String externalReferenceCode, long toUserGroupId, long toUserId,
+			long classNameId, long classPK, long groupId, boolean shareable,
 			Collection<SharingEntryAction> sharingEntryActions,
 			Date expirationDate, ServiceContext serviceContext)
 		throws PortalException {
@@ -102,8 +102,8 @@ public class SharingEntryServiceImpl extends SharingEntryServiceBaseImpl {
 	 */
 	@Override
 	public SharingEntry addSharingEntry(
-			String externalReferenceCode, long toUserId, long classNameId,
-			long classPK, long groupId, boolean shareable,
+			String externalReferenceCode, long toUserGroupId, long toUserId,
+			long classNameId, long classPK, long groupId, boolean shareable,
 			Collection<SharingEntryAction> sharingEntryActions,
 			Date expirationDate, ServiceContext serviceContext)
 		throws PortalException {

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/persistence/impl/SharingEntryPersistenceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/persistence/impl/SharingEntryPersistenceImpl.java
@@ -5031,11 +5031,12 @@ public class SharingEntryPersistenceImpl
 	private static final String _FINDER_COLUMN_C_C_CLASSPK_2 =
 		"sharingEntry.classPK = ?";
 
-	private FinderPath _finderPathFetchByTU_C_C;
+	private FinderPath _finderPathFetchByTUG_TU_C_C;
 
 	/**
-	 * Returns the sharing entry where toUserId = &#63; and classNameId = &#63; and classPK = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
+	 * Returns the sharing entry where toUserGroupId = &#63; and toUserId = &#63; and classNameId = &#63; and classPK = &#63; or throws a <code>NoSuchEntryException</code> if it could not be found.
 	 *
+	 * @param toUserGroupId the to user group ID
 	 * @param toUserId the to user ID
 	 * @param classNameId the class name ID
 	 * @param classPK the class pk
@@ -5043,19 +5044,22 @@ public class SharingEntryPersistenceImpl
 	 * @throws NoSuchEntryException if a matching sharing entry could not be found
 	 */
 	@Override
-	public SharingEntry findByTU_C_C(
-			long toUserId, long classNameId, long classPK)
+	public SharingEntry findByTUG_TU_C_C(
+			long toUserGroupId, long toUserId, long classNameId, long classPK)
 		throws NoSuchEntryException {
 
-		SharingEntry sharingEntry = fetchByTU_C_C(
-			toUserId, classNameId, classPK);
+		SharingEntry sharingEntry = fetchByTUG_TU_C_C(
+			toUserGroupId, toUserId, classNameId, classPK);
 
 		if (sharingEntry == null) {
-			StringBundler sb = new StringBundler(8);
+			StringBundler sb = new StringBundler(10);
 
 			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-			sb.append("toUserId=");
+			sb.append("toUserGroupId=");
+			sb.append(toUserGroupId);
+
+			sb.append(", toUserId=");
 			sb.append(toUserId);
 
 			sb.append(", classNameId=");
@@ -5077,23 +5081,26 @@ public class SharingEntryPersistenceImpl
 	}
 
 	/**
-	 * Returns the sharing entry where toUserId = &#63; and classNameId = &#63; and classPK = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns the sharing entry where toUserGroupId = &#63; and toUserId = &#63; and classNameId = &#63; and classPK = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
 	 *
+	 * @param toUserGroupId the to user group ID
 	 * @param toUserId the to user ID
 	 * @param classNameId the class name ID
 	 * @param classPK the class pk
 	 * @return the matching sharing entry, or <code>null</code> if a matching sharing entry could not be found
 	 */
 	@Override
-	public SharingEntry fetchByTU_C_C(
-		long toUserId, long classNameId, long classPK) {
+	public SharingEntry fetchByTUG_TU_C_C(
+		long toUserGroupId, long toUserId, long classNameId, long classPK) {
 
-		return fetchByTU_C_C(toUserId, classNameId, classPK, true);
+		return fetchByTUG_TU_C_C(
+			toUserGroupId, toUserId, classNameId, classPK, true);
 	}
 
 	/**
-	 * Returns the sharing entry where toUserId = &#63; and classNameId = &#63; and classPK = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns the sharing entry where toUserGroupId = &#63; and toUserId = &#63; and classNameId = &#63; and classPK = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
 	 *
+	 * @param toUserGroupId the to user group ID
 	 * @param toUserId the to user ID
 	 * @param classNameId the class name ID
 	 * @param classPK the class pk
@@ -5101,26 +5108,30 @@ public class SharingEntryPersistenceImpl
 	 * @return the matching sharing entry, or <code>null</code> if a matching sharing entry could not be found
 	 */
 	@Override
-	public SharingEntry fetchByTU_C_C(
-		long toUserId, long classNameId, long classPK, boolean useFinderCache) {
+	public SharingEntry fetchByTUG_TU_C_C(
+		long toUserGroupId, long toUserId, long classNameId, long classPK,
+		boolean useFinderCache) {
 
 		Object[] finderArgs = null;
 
 		if (useFinderCache) {
-			finderArgs = new Object[] {toUserId, classNameId, classPK};
+			finderArgs = new Object[] {
+				toUserGroupId, toUserId, classNameId, classPK
+			};
 		}
 
 		Object result = null;
 
 		if (useFinderCache) {
 			result = finderCache.getResult(
-				_finderPathFetchByTU_C_C, finderArgs, this);
+				_finderPathFetchByTUG_TU_C_C, finderArgs, this);
 		}
 
 		if (result instanceof SharingEntry) {
 			SharingEntry sharingEntry = (SharingEntry)result;
 
-			if ((toUserId != sharingEntry.getToUserId()) ||
+			if ((toUserGroupId != sharingEntry.getToUserGroupId()) ||
+				(toUserId != sharingEntry.getToUserId()) ||
 				(classNameId != sharingEntry.getClassNameId()) ||
 				(classPK != sharingEntry.getClassPK())) {
 
@@ -5129,15 +5140,17 @@ public class SharingEntryPersistenceImpl
 		}
 
 		if (result == null) {
-			StringBundler sb = new StringBundler(5);
+			StringBundler sb = new StringBundler(6);
 
 			sb.append(_SQL_SELECT_SHARINGENTRY_WHERE);
 
-			sb.append(_FINDER_COLUMN_TU_C_C_TOUSERID_2);
+			sb.append(_FINDER_COLUMN_TUG_TU_C_C_TOUSERGROUPID_2);
 
-			sb.append(_FINDER_COLUMN_TU_C_C_CLASSNAMEID_2);
+			sb.append(_FINDER_COLUMN_TUG_TU_C_C_TOUSERID_2);
 
-			sb.append(_FINDER_COLUMN_TU_C_C_CLASSPK_2);
+			sb.append(_FINDER_COLUMN_TUG_TU_C_C_CLASSNAMEID_2);
+
+			sb.append(_FINDER_COLUMN_TUG_TU_C_C_CLASSPK_2);
 
 			String sql = sb.toString();
 
@@ -5150,6 +5163,8 @@ public class SharingEntryPersistenceImpl
 
 				QueryPos queryPos = QueryPos.getInstance(query);
 
+				queryPos.add(toUserGroupId);
+
 				queryPos.add(toUserId);
 
 				queryPos.add(classNameId);
@@ -5161,7 +5176,7 @@ public class SharingEntryPersistenceImpl
 				if (list.isEmpty()) {
 					if (useFinderCache) {
 						finderCache.putResult(
-							_finderPathFetchByTU_C_C, finderArgs, list);
+							_finderPathFetchByTUG_TU_C_C, finderArgs, list);
 					}
 				}
 				else {
@@ -5189,36 +5204,40 @@ public class SharingEntryPersistenceImpl
 	}
 
 	/**
-	 * Removes the sharing entry where toUserId = &#63; and classNameId = &#63; and classPK = &#63; from the database.
+	 * Removes the sharing entry where toUserGroupId = &#63; and toUserId = &#63; and classNameId = &#63; and classPK = &#63; from the database.
 	 *
+	 * @param toUserGroupId the to user group ID
 	 * @param toUserId the to user ID
 	 * @param classNameId the class name ID
 	 * @param classPK the class pk
 	 * @return the sharing entry that was removed
 	 */
 	@Override
-	public SharingEntry removeByTU_C_C(
-			long toUserId, long classNameId, long classPK)
+	public SharingEntry removeByTUG_TU_C_C(
+			long toUserGroupId, long toUserId, long classNameId, long classPK)
 		throws NoSuchEntryException {
 
-		SharingEntry sharingEntry = findByTU_C_C(
-			toUserId, classNameId, classPK);
+		SharingEntry sharingEntry = findByTUG_TU_C_C(
+			toUserGroupId, toUserId, classNameId, classPK);
 
 		return remove(sharingEntry);
 	}
 
 	/**
-	 * Returns the number of sharing entries where toUserId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 * Returns the number of sharing entries where toUserGroupId = &#63; and toUserId = &#63; and classNameId = &#63; and classPK = &#63;.
 	 *
+	 * @param toUserGroupId the to user group ID
 	 * @param toUserId the to user ID
 	 * @param classNameId the class name ID
 	 * @param classPK the class pk
 	 * @return the number of matching sharing entries
 	 */
 	@Override
-	public int countByTU_C_C(long toUserId, long classNameId, long classPK) {
-		SharingEntry sharingEntry = fetchByTU_C_C(
-			toUserId, classNameId, classPK);
+	public int countByTUG_TU_C_C(
+		long toUserGroupId, long toUserId, long classNameId, long classPK) {
+
+		SharingEntry sharingEntry = fetchByTUG_TU_C_C(
+			toUserGroupId, toUserId, classNameId, classPK);
 
 		if (sharingEntry == null) {
 			return 0;
@@ -5227,13 +5246,16 @@ public class SharingEntryPersistenceImpl
 		return 1;
 	}
 
-	private static final String _FINDER_COLUMN_TU_C_C_TOUSERID_2 =
+	private static final String _FINDER_COLUMN_TUG_TU_C_C_TOUSERGROUPID_2 =
+		"sharingEntry.toUserGroupId = ? AND ";
+
+	private static final String _FINDER_COLUMN_TUG_TU_C_C_TOUSERID_2 =
 		"sharingEntry.toUserId = ? AND ";
 
-	private static final String _FINDER_COLUMN_TU_C_C_CLASSNAMEID_2 =
+	private static final String _FINDER_COLUMN_TUG_TU_C_C_CLASSNAMEID_2 =
 		"sharingEntry.classNameId = ? AND ";
 
-	private static final String _FINDER_COLUMN_TU_C_C_CLASSPK_2 =
+	private static final String _FINDER_COLUMN_TUG_TU_C_C_CLASSPK_2 =
 		"sharingEntry.classPK = ?";
 
 	private FinderPath _finderPathFetchByERC_G;
@@ -5472,10 +5494,10 @@ public class SharingEntryPersistenceImpl
 			sharingEntry);
 
 		finderCache.putResult(
-			_finderPathFetchByTU_C_C,
+			_finderPathFetchByTUG_TU_C_C,
 			new Object[] {
-				sharingEntry.getToUserId(), sharingEntry.getClassNameId(),
-				sharingEntry.getClassPK()
+				sharingEntry.getToUserGroupId(), sharingEntry.getToUserId(),
+				sharingEntry.getClassNameId(), sharingEntry.getClassPK()
 			},
 			sharingEntry);
 
@@ -5567,13 +5589,14 @@ public class SharingEntryPersistenceImpl
 			_finderPathFetchByUUID_G, args, sharingEntryModelImpl);
 
 		args = new Object[] {
+			sharingEntryModelImpl.getToUserGroupId(),
 			sharingEntryModelImpl.getToUserId(),
 			sharingEntryModelImpl.getClassNameId(),
 			sharingEntryModelImpl.getClassPK()
 		};
 
 		finderCache.putResult(
-			_finderPathFetchByTU_C_C, args, sharingEntryModelImpl);
+			_finderPathFetchByTUG_TU_C_C, args, sharingEntryModelImpl);
 
 		args = new Object[] {
 			sharingEntryModelImpl.getExternalReferenceCode(),
@@ -6279,12 +6302,16 @@ public class SharingEntryPersistenceImpl
 			new String[] {Long.class.getName(), Long.class.getName()},
 			new String[] {"classNameId", "classPK"}, false);
 
-		_finderPathFetchByTU_C_C = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByTU_C_C",
+		_finderPathFetchByTUG_TU_C_C = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByTUG_TU_C_C",
 			new String[] {
-				Long.class.getName(), Long.class.getName(), Long.class.getName()
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Long.class.getName()
 			},
-			new String[] {"toUserId", "classNameId", "classPK"}, true);
+			new String[] {
+				"toUserGroupId", "toUserId", "classNameId", "classPK"
+			},
+			true);
 
 		_finderPathFetchByERC_G = new FinderPath(
 			FINDER_CLASS_NAME_ENTITY, "fetchByERC_G",

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/persistence/impl/SharingEntryPersistenceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/persistence/impl/SharingEntryPersistenceImpl.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.persistence.impl.BasePersistenceImpl;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -33,6 +34,7 @@ import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import com.liferay.sharing.exception.DuplicateSharingEntryExternalReferenceCodeException;
@@ -5031,6 +5033,893 @@ public class SharingEntryPersistenceImpl
 	private static final String _FINDER_COLUMN_C_C_CLASSPK_2 =
 		"sharingEntry.classPK = ?";
 
+	private FinderPath _finderPathWithPaginationFindByTUG_C_C;
+	private FinderPath _finderPathWithoutPaginationFindByTUG_C_C;
+	private FinderPath _finderPathCountByTUG_C_C;
+	private FinderPath _finderPathWithPaginationCountByTUG_C_C;
+
+	/**
+	 * Returns all the sharing entries where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @return the matching sharing entries
+	 */
+	@Override
+	public List<SharingEntry> findByTUG_C_C(
+		long toUserGroupId, long classNameId, long classPK) {
+
+		return findByTUG_C_C(
+			toUserGroupId, classNameId, classPK, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the sharing entries where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @return the range of matching sharing entries
+	 */
+	@Override
+	public List<SharingEntry> findByTUG_C_C(
+		long toUserGroupId, long classNameId, long classPK, int start,
+		int end) {
+
+		return findByTUG_C_C(
+			toUserGroupId, classNameId, classPK, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching sharing entries
+	 */
+	@Override
+	public List<SharingEntry> findByTUG_C_C(
+		long toUserGroupId, long classNameId, long classPK, int start, int end,
+		OrderByComparator<SharingEntry> orderByComparator) {
+
+		return findByTUG_C_C(
+			toUserGroupId, classNameId, classPK, start, end, orderByComparator,
+			true);
+	}
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching sharing entries
+	 */
+	@Override
+	public List<SharingEntry> findByTUG_C_C(
+		long toUserGroupId, long classNameId, long classPK, int start, int end,
+		OrderByComparator<SharingEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			if (useFinderCache) {
+				finderPath = _finderPathWithoutPaginationFindByTUG_C_C;
+				finderArgs = new Object[] {toUserGroupId, classNameId, classPK};
+			}
+		}
+		else if (useFinderCache) {
+			finderPath = _finderPathWithPaginationFindByTUG_C_C;
+			finderArgs = new Object[] {
+				toUserGroupId, classNameId, classPK, start, end,
+				orderByComparator
+			};
+		}
+
+		List<SharingEntry> list = null;
+
+		if (useFinderCache) {
+			list = (List<SharingEntry>)finderCache.getResult(
+				finderPath, finderArgs, this);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (SharingEntry sharingEntry : list) {
+					if ((toUserGroupId != sharingEntry.getToUserGroupId()) ||
+						(classNameId != sharingEntry.getClassNameId()) ||
+						(classPK != sharingEntry.getClassPK())) {
+
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler sb = null;
+
+			if (orderByComparator != null) {
+				sb = new StringBundler(
+					5 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				sb = new StringBundler(5);
+			}
+
+			sb.append(_SQL_SELECT_SHARINGENTRY_WHERE);
+
+			sb.append(_FINDER_COLUMN_TUG_C_C_TOUSERGROUPID_2);
+
+			sb.append(_FINDER_COLUMN_TUG_C_C_CLASSNAMEID_2);
+
+			sb.append(_FINDER_COLUMN_TUG_C_C_CLASSPK_2);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else {
+				sb.append(SharingEntryModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(toUserGroupId);
+
+				queryPos.add(classNameId);
+
+				queryPos.add(classPK);
+
+				list = (List<SharingEntry>)QueryUtil.list(
+					query, getDialect(), start, end);
+
+				cacheResult(list);
+
+				if (useFinderCache) {
+					finderCache.putResult(finderPath, finderArgs, list);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first sharing entry in the ordered set where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching sharing entry
+	 * @throws NoSuchEntryException if a matching sharing entry could not be found
+	 */
+	@Override
+	public SharingEntry findByTUG_C_C_First(
+			long toUserGroupId, long classNameId, long classPK,
+			OrderByComparator<SharingEntry> orderByComparator)
+		throws NoSuchEntryException {
+
+		SharingEntry sharingEntry = fetchByTUG_C_C_First(
+			toUserGroupId, classNameId, classPK, orderByComparator);
+
+		if (sharingEntry != null) {
+			return sharingEntry;
+		}
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("toUserGroupId=");
+		sb.append(toUserGroupId);
+
+		sb.append(", classNameId=");
+		sb.append(classNameId);
+
+		sb.append(", classPK=");
+		sb.append(classPK);
+
+		sb.append("}");
+
+		throw new NoSuchEntryException(sb.toString());
+	}
+
+	/**
+	 * Returns the first sharing entry in the ordered set where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching sharing entry, or <code>null</code> if a matching sharing entry could not be found
+	 */
+	@Override
+	public SharingEntry fetchByTUG_C_C_First(
+		long toUserGroupId, long classNameId, long classPK,
+		OrderByComparator<SharingEntry> orderByComparator) {
+
+		List<SharingEntry> list = findByTUG_C_C(
+			toUserGroupId, classNameId, classPK, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last sharing entry in the ordered set where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching sharing entry
+	 * @throws NoSuchEntryException if a matching sharing entry could not be found
+	 */
+	@Override
+	public SharingEntry findByTUG_C_C_Last(
+			long toUserGroupId, long classNameId, long classPK,
+			OrderByComparator<SharingEntry> orderByComparator)
+		throws NoSuchEntryException {
+
+		SharingEntry sharingEntry = fetchByTUG_C_C_Last(
+			toUserGroupId, classNameId, classPK, orderByComparator);
+
+		if (sharingEntry != null) {
+			return sharingEntry;
+		}
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("toUserGroupId=");
+		sb.append(toUserGroupId);
+
+		sb.append(", classNameId=");
+		sb.append(classNameId);
+
+		sb.append(", classPK=");
+		sb.append(classPK);
+
+		sb.append("}");
+
+		throw new NoSuchEntryException(sb.toString());
+	}
+
+	/**
+	 * Returns the last sharing entry in the ordered set where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching sharing entry, or <code>null</code> if a matching sharing entry could not be found
+	 */
+	@Override
+	public SharingEntry fetchByTUG_C_C_Last(
+		long toUserGroupId, long classNameId, long classPK,
+		OrderByComparator<SharingEntry> orderByComparator) {
+
+		int count = countByTUG_C_C(toUserGroupId, classNameId, classPK);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<SharingEntry> list = findByTUG_C_C(
+			toUserGroupId, classNameId, classPK, count - 1, count,
+			orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the sharing entries before and after the current sharing entry in the ordered set where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * @param sharingEntryId the primary key of the current sharing entry
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next sharing entry
+	 * @throws NoSuchEntryException if a sharing entry with the primary key could not be found
+	 */
+	@Override
+	public SharingEntry[] findByTUG_C_C_PrevAndNext(
+			long sharingEntryId, long toUserGroupId, long classNameId,
+			long classPK, OrderByComparator<SharingEntry> orderByComparator)
+		throws NoSuchEntryException {
+
+		SharingEntry sharingEntry = findByPrimaryKey(sharingEntryId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SharingEntry[] array = new SharingEntryImpl[3];
+
+			array[0] = getByTUG_C_C_PrevAndNext(
+				session, sharingEntry, toUserGroupId, classNameId, classPK,
+				orderByComparator, true);
+
+			array[1] = sharingEntry;
+
+			array[2] = getByTUG_C_C_PrevAndNext(
+				session, sharingEntry, toUserGroupId, classNameId, classPK,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected SharingEntry getByTUG_C_C_PrevAndNext(
+		Session session, SharingEntry sharingEntry, long toUserGroupId,
+		long classNameId, long classPK,
+		OrderByComparator<SharingEntry> orderByComparator, boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				6 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(5);
+		}
+
+		sb.append(_SQL_SELECT_SHARINGENTRY_WHERE);
+
+		sb.append(_FINDER_COLUMN_TUG_C_C_TOUSERGROUPID_2);
+
+		sb.append(_FINDER_COLUMN_TUG_C_C_CLASSNAMEID_2);
+
+		sb.append(_FINDER_COLUMN_TUG_C_C_CLASSPK_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(SharingEntryModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(toUserGroupId);
+
+		queryPos.add(classNameId);
+
+		queryPos.add(classPK);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(sharingEntry)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<SharingEntry> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Returns all the sharing entries where toUserGroupId = any &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupIds the to user group IDs
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @return the matching sharing entries
+	 */
+	@Override
+	public List<SharingEntry> findByTUG_C_C(
+		long[] toUserGroupIds, long classNameId, long classPK) {
+
+		return findByTUG_C_C(
+			toUserGroupIds, classNameId, classPK, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the sharing entries where toUserGroupId = any &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupIds the to user group IDs
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @return the range of matching sharing entries
+	 */
+	@Override
+	public List<SharingEntry> findByTUG_C_C(
+		long[] toUserGroupIds, long classNameId, long classPK, int start,
+		int end) {
+
+		return findByTUG_C_C(
+			toUserGroupIds, classNameId, classPK, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toUserGroupId = any &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupIds the to user group IDs
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching sharing entries
+	 */
+	@Override
+	public List<SharingEntry> findByTUG_C_C(
+		long[] toUserGroupIds, long classNameId, long classPK, int start,
+		int end, OrderByComparator<SharingEntry> orderByComparator) {
+
+		return findByTUG_C_C(
+			toUserGroupIds, classNameId, classPK, start, end, orderByComparator,
+			true);
+	}
+
+	/**
+	 * Returns an ordered range of all the sharing entries where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SharingEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toUserGroupIds the to user group IDs
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @param start the lower bound of the range of sharing entries
+	 * @param end the upper bound of the range of sharing entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching sharing entries
+	 */
+	@Override
+	public List<SharingEntry> findByTUG_C_C(
+		long[] toUserGroupIds, long classNameId, long classPK, int start,
+		int end, OrderByComparator<SharingEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		if (toUserGroupIds == null) {
+			toUserGroupIds = new long[0];
+		}
+		else if (toUserGroupIds.length > 1) {
+			toUserGroupIds = ArrayUtil.sortedUnique(toUserGroupIds);
+		}
+
+		if (toUserGroupIds.length == 1) {
+			return findByTUG_C_C(
+				toUserGroupIds[0], classNameId, classPK, start, end,
+				orderByComparator);
+		}
+
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			if (useFinderCache) {
+				finderArgs = new Object[] {
+					StringUtil.merge(toUserGroupIds), classNameId, classPK
+				};
+			}
+		}
+		else if (useFinderCache) {
+			finderArgs = new Object[] {
+				StringUtil.merge(toUserGroupIds), classNameId, classPK, start,
+				end, orderByComparator
+			};
+		}
+
+		List<SharingEntry> list = null;
+
+		if (useFinderCache) {
+			list = (List<SharingEntry>)finderCache.getResult(
+				_finderPathWithPaginationFindByTUG_C_C, finderArgs, this);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (SharingEntry sharingEntry : list) {
+					if (!ArrayUtil.contains(
+							toUserGroupIds, sharingEntry.getToUserGroupId()) ||
+						(classNameId != sharingEntry.getClassNameId()) ||
+						(classPK != sharingEntry.getClassPK())) {
+
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler sb = new StringBundler();
+
+			sb.append(_SQL_SELECT_SHARINGENTRY_WHERE);
+
+			if (toUserGroupIds.length > 0) {
+				sb.append("(");
+
+				sb.append(_FINDER_COLUMN_TUG_C_C_TOUSERGROUPID_7);
+
+				sb.append(StringUtil.merge(toUserGroupIds));
+
+				sb.append(")");
+
+				sb.append(")");
+
+				sb.append(WHERE_AND);
+			}
+
+			sb.append(_FINDER_COLUMN_TUG_C_C_CLASSNAMEID_2);
+
+			sb.append(_FINDER_COLUMN_TUG_C_C_CLASSPK_2);
+
+			sb.setStringAt(
+				removeConjunction(sb.stringAt(sb.index() - 1)), sb.index() - 1);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else {
+				sb.append(SharingEntryModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(classNameId);
+
+				queryPos.add(classPK);
+
+				list = (List<SharingEntry>)QueryUtil.list(
+					query, getDialect(), start, end);
+
+				cacheResult(list);
+
+				if (useFinderCache) {
+					finderCache.putResult(
+						_finderPathWithPaginationFindByTUG_C_C, finderArgs,
+						list);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Removes all the sharing entries where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63; from the database.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 */
+	@Override
+	public void removeByTUG_C_C(
+		long toUserGroupId, long classNameId, long classPK) {
+
+		for (SharingEntry sharingEntry :
+				findByTUG_C_C(
+					toUserGroupId, classNameId, classPK, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null)) {
+
+			remove(sharingEntry);
+		}
+	}
+
+	/**
+	 * Returns the number of sharing entries where toUserGroupId = &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * @param toUserGroupId the to user group ID
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @return the number of matching sharing entries
+	 */
+	@Override
+	public int countByTUG_C_C(
+		long toUserGroupId, long classNameId, long classPK) {
+
+		FinderPath finderPath = _finderPathCountByTUG_C_C;
+
+		Object[] finderArgs = new Object[] {
+			toUserGroupId, classNameId, classPK
+		};
+
+		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
+
+		if (count == null) {
+			StringBundler sb = new StringBundler(4);
+
+			sb.append(_SQL_COUNT_SHARINGENTRY_WHERE);
+
+			sb.append(_FINDER_COLUMN_TUG_C_C_TOUSERGROUPID_2);
+
+			sb.append(_FINDER_COLUMN_TUG_C_C_CLASSNAMEID_2);
+
+			sb.append(_FINDER_COLUMN_TUG_C_C_CLASSPK_2);
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(toUserGroupId);
+
+				queryPos.add(classNameId);
+
+				queryPos.add(classPK);
+
+				count = (Long)query.uniqueResult();
+
+				finderCache.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	/**
+	 * Returns the number of sharing entries where toUserGroupId = any &#63; and classNameId = &#63; and classPK = &#63;.
+	 *
+	 * @param toUserGroupIds the to user group IDs
+	 * @param classNameId the class name ID
+	 * @param classPK the class pk
+	 * @return the number of matching sharing entries
+	 */
+	@Override
+	public int countByTUG_C_C(
+		long[] toUserGroupIds, long classNameId, long classPK) {
+
+		if (toUserGroupIds == null) {
+			toUserGroupIds = new long[0];
+		}
+		else if (toUserGroupIds.length > 1) {
+			toUserGroupIds = ArrayUtil.sortedUnique(toUserGroupIds);
+		}
+
+		Object[] finderArgs = new Object[] {
+			StringUtil.merge(toUserGroupIds), classNameId, classPK
+		};
+
+		Long count = (Long)finderCache.getResult(
+			_finderPathWithPaginationCountByTUG_C_C, finderArgs, this);
+
+		if (count == null) {
+			StringBundler sb = new StringBundler();
+
+			sb.append(_SQL_COUNT_SHARINGENTRY_WHERE);
+
+			if (toUserGroupIds.length > 0) {
+				sb.append("(");
+
+				sb.append(_FINDER_COLUMN_TUG_C_C_TOUSERGROUPID_7);
+
+				sb.append(StringUtil.merge(toUserGroupIds));
+
+				sb.append(")");
+
+				sb.append(")");
+
+				sb.append(WHERE_AND);
+			}
+
+			sb.append(_FINDER_COLUMN_TUG_C_C_CLASSNAMEID_2);
+
+			sb.append(_FINDER_COLUMN_TUG_C_C_CLASSPK_2);
+
+			sb.setStringAt(
+				removeConjunction(sb.stringAt(sb.index() - 1)), sb.index() - 1);
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(classNameId);
+
+				queryPos.add(classPK);
+
+				count = (Long)query.uniqueResult();
+
+				finderCache.putResult(
+					_finderPathWithPaginationCountByTUG_C_C, finderArgs, count);
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_TUG_C_C_TOUSERGROUPID_2 =
+		"sharingEntry.toUserGroupId = ? AND ";
+
+	private static final String _FINDER_COLUMN_TUG_C_C_TOUSERGROUPID_7 =
+		"sharingEntry.toUserGroupId IN (";
+
+	private static final String _FINDER_COLUMN_TUG_C_C_CLASSNAMEID_2 =
+		"sharingEntry.classNameId = ? AND ";
+
+	private static final String _FINDER_COLUMN_TUG_C_C_CLASSPK_2 =
+		"sharingEntry.classPK = ?";
+
 	private FinderPath _finderPathFetchByTUG_TU_C_C;
 
 	/**
@@ -6301,6 +7190,36 @@ public class SharingEntryPersistenceImpl
 			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_C",
 			new String[] {Long.class.getName(), Long.class.getName()},
 			new String[] {"classNameId", "classPK"}, false);
+
+		_finderPathWithPaginationFindByTUG_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByTUG_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"toUserGroupId", "classNameId", "classPK"}, true);
+
+		_finderPathWithoutPaginationFindByTUG_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByTUG_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"toUserGroupId", "classNameId", "classPK"}, true);
+
+		_finderPathCountByTUG_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByTUG_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"toUserGroupId", "classNameId", "classPK"}, false);
+
+		_finderPathWithPaginationCountByTUG_C_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByTUG_C_C",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName()
+			},
+			new String[] {"toUserGroupId", "classNameId", "classPK"}, false);
 
 		_finderPathFetchByTUG_TU_C_C = new FinderPath(
 			FINDER_CLASS_NAME_ENTITY, "fetchByTUG_TU_C_C",

--- a/modules/apps/sharing/sharing-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/sharing/sharing-service/src/main/resources/META-INF/module-hbm.xml
@@ -15,6 +15,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="userName" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="createDate" type="org.hibernate.type.TimestampType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="modifiedDate" type="org.hibernate.type.TimestampType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="toUserGroupId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="toUserId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="classNameId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="classPK" type="com.liferay.portal.dao.orm.hibernate.LongType" />

--- a/modules/apps/sharing/sharing-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/sharing/sharing-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -11,6 +11,7 @@
 		<field name="userName" type="String" />
 		<field name="createDate" type="Date" />
 		<field name="modifiedDate" type="Date" />
+		<field name="toUserGroupId" type="long" />
 		<field name="toUserId" type="long" />
 		<field name="classNameId" type="long" />
 		<field name="classPK" type="long" />

--- a/modules/apps/sharing/sharing-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/sharing/sharing-service/src/main/resources/META-INF/sql/indexes.sql
@@ -1,5 +1,5 @@
 create index IX_1ED300B1 on SharingEntry (classNameId, classPK);
-create unique index IX_E0D3AF7C on SharingEntry (classNameId, toUserId, classPK);
+create unique index IX_129770E8 on SharingEntry (classNameId, toUserId, classPK, toUserGroupId);
 create index IX_8E0359AC on SharingEntry (classNameId, userId);
 create index IX_1E35B88D on SharingEntry (expirationDate);
 create unique index IX_FA5E24AF on SharingEntry (groupId, externalReferenceCode[$COLUMN_LENGTH:75$]);

--- a/modules/apps/sharing/sharing-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/sharing/sharing-service/src/main/resources/META-INF/sql/indexes.sql
@@ -1,4 +1,4 @@
-create index IX_1ED300B1 on SharingEntry (classNameId, classPK);
+create index IX_111EEF13 on SharingEntry (classNameId, classPK, toUserGroupId);
 create unique index IX_129770E8 on SharingEntry (classNameId, toUserId, classPK, toUserGroupId);
 create index IX_8E0359AC on SharingEntry (classNameId, userId);
 create index IX_1E35B88D on SharingEntry (expirationDate);

--- a/modules/apps/sharing/sharing-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/sharing/sharing-service/src/main/resources/META-INF/sql/tables.sql
@@ -8,6 +8,7 @@ create table SharingEntry (
 	userName VARCHAR(75) null,
 	createDate DATE null,
 	modifiedDate DATE null,
+	toUserGroupId LONG,
 	toUserId LONG,
 	classNameId LONG,
 	classPK LONG,

--- a/modules/apps/sharing/sharing-test-util/bnd.bnd
+++ b/modules/apps/sharing/sharing-test-util/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Sharing Test Utilities
 Bundle-SymbolicName: com.liferay.sharing.test.util
-Bundle-Version: 3.0.11
+Bundle-Version: 3.1.0
 Export-Package: com.liferay.sharing.test.util

--- a/modules/apps/sharing/sharing-test-util/src/main/java/com/liferay/sharing/test/util/BaseSharingTestCase.java
+++ b/modules/apps/sharing/sharing-test-util/src/main/java/com/liferay/sharing/test/util/BaseSharingTestCase.java
@@ -274,12 +274,11 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 
 	@Test
 	public void testModelClassNameReturnsPermissionSQL() throws Exception {
+		UserGroup userGroup1 = UserGroupTestUtil.addUserGroup();
+		UserGroup userGroup2 = UserGroupTestUtil.addUserGroup();
+
 		PermissionChecker permissionChecker =
 			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser());
-
-		UserGroup userGroup1 = UserGroupTestUtil.addUserGroup();
-
-		UserGroup userGroup2 = UserGroupTestUtil.addUserGroup();
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				TestPropsValues.getUser(), permissionChecker)) {
@@ -317,12 +316,14 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 			if (userGroup1 != null) {
 				_userGroupLocalService.deleteUserUserGroup(
 					TestPropsValues.getUserId(), userGroup1);
+
 				_userGroupLocalService.deleteUserGroup(userGroup1);
 			}
 
 			if (userGroup2 != null) {
 				_userGroupLocalService.deleteUserUserGroup(
 					TestPropsValues.getUserId(), userGroup2);
+
 				_userGroupLocalService.deleteUserGroup(userGroup2);
 			}
 		}

--- a/modules/apps/sharing/sharing-test-util/src/main/java/com/liferay/sharing/test/util/BaseSharingTestCase.java
+++ b/modules/apps/sharing/sharing-test-util/src/main/java/com/liferay/sharing/test/util/BaseSharingTestCase.java
@@ -266,6 +266,7 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 			if (userGroup != null) {
 				_userGroupLocalService.deleteUserUserGroup(
 					_groupUser.getUserId(), userGroup);
+
 				_userGroupLocalService.deleteUserGroup(userGroup);
 			}
 		}

--- a/modules/apps/sharing/sharing-test-util/src/main/java/com/liferay/sharing/test/util/BaseSharingTestCase.java
+++ b/modules/apps/sharing/sharing-test-util/src/main/java/com/liferay/sharing/test/util/BaseSharingTestCase.java
@@ -129,7 +129,7 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 		long classPK = (Long)model.getPrimaryKeyObj();
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, TestPropsValues.getUserId(), _groupUser.getUserId(),
+			null, TestPropsValues.getUserId(), 0, _groupUser.getUserId(),
 			_classNameLocalService.getClassNameId(model.getModelClassName()),
 			classPK, _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
@@ -167,7 +167,7 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 		long classPK1 = (Long)model1.getPrimaryKeyObj();
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, TestPropsValues.getUserId(), _groupUser.getUserId(),
+			null, TestPropsValues.getUserId(), 0, _groupUser.getUserId(),
 			classNameId1, classPK1, _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
 			null, serviceContext);
@@ -179,7 +179,7 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 		long classPK2 = (Long)model2.getPrimaryKeyObj();
 
 		SharingEntry sharingEntry = _sharingEntryLocalService.addSharingEntry(
-			null, TestPropsValues.getUserId(), _groupUser.getUserId(),
+			null, TestPropsValues.getUserId(), 0, _groupUser.getUserId(),
 			classNameId2, classPK2, _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
 			null, serviceContext);
@@ -217,7 +217,7 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 			long classPK = (long)model.getPrimaryKeyObj();
 
 			_sharingEntryLocalService.addSharingEntry(
-				null, TestPropsValues.getUserId(), _groupUser.getUserId(),
+				null, TestPropsValues.getUserId(), 0, _groupUser.getUserId(),
 				_classNameLocalService.getClassNameId(
 					model.getModelClassName()),
 				classPK, _group.getGroupId(), true,
@@ -268,7 +268,7 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 		long classPK = (Long)model.getPrimaryKeyObj();
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, TestPropsValues.getUserId(), _groupUser.getUserId(),
+			null, TestPropsValues.getUserId(), 0, _groupUser.getUserId(),
 			_classNameLocalService.getClassNameId(model.getModelClassName()),
 			classPK, _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
@@ -304,7 +304,7 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 		long classPK = (Long)model.getPrimaryKeyObj();
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, TestPropsValues.getUserId(), _groupUser.getUserId(),
+			null, TestPropsValues.getUserId(), 0, _groupUser.getUserId(),
 			_classNameLocalService.getClassNameId(model.getModelClassName()),
 			classPK, _group.getGroupId(), true,
 			Arrays.asList(
@@ -335,7 +335,7 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 		long classPK = (Long)model.getPrimaryKeyObj();
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, TestPropsValues.getUserId(), _groupUser.getUserId(),
+			null, TestPropsValues.getUserId(), 0, _groupUser.getUserId(),
 			_classNameLocalService.getClassNameId(model.getModelClassName()),
 			classPK, _group.getGroupId(), true,
 			Arrays.asList(
@@ -535,7 +535,7 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 		long classPK = (Long)model.getPrimaryKeyObj();
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, TestPropsValues.getUserId(), _groupUser.getUserId(),
+			null, TestPropsValues.getUserId(), 0, _groupUser.getUserId(),
 			_classNameLocalService.getClassNameId(model.getModelClassName()),
 			classPK, _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
@@ -565,7 +565,7 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 		long classPK = (Long)model.getPrimaryKeyObj();
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, TestPropsValues.getUserId(), _groupUser.getUserId(),
+			null, TestPropsValues.getUserId(), 0, _groupUser.getUserId(),
 			_classNameLocalService.getClassNameId(model.getModelClassName()),
 			classPK, _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
@@ -704,7 +704,7 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 		long classPK = (Long)model.getPrimaryKeyObj();
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, TestPropsValues.getUserId(), _groupUser.getUserId(),
+			null, TestPropsValues.getUserId(), 0, _groupUser.getUserId(),
 			_classNameLocalService.getClassNameId(model.getModelClassName()),
 			classPK, _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null, serviceContext);
@@ -733,7 +733,7 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 		long classPK = (Long)model.getPrimaryKeyObj();
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, TestPropsValues.getUserId(), _groupUser.getUserId(),
+			null, TestPropsValues.getUserId(), 0, _groupUser.getUserId(),
 			_classNameLocalService.getClassNameId(model.getModelClassName()),
 			classPK, _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null, serviceContext);

--- a/modules/apps/sharing/sharing-test-util/src/main/java/com/liferay/sharing/test/util/BaseSharingTestCase.java
+++ b/modules/apps/sharing/sharing-test-util/src/main/java/com/liferay/sharing/test/util/BaseSharingTestCase.java
@@ -234,10 +234,10 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 
 	@Test
 	public void testInlinePermissionsToUserGroup() throws Exception {
+		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
+
 		PermissionChecker permissionChecker =
 			PermissionCheckerFactoryUtil.create(_groupUser);
-
-		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
@@ -263,12 +263,10 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 			Assert.assertEquals(1, getModelCount(_group));
 		}
 		finally {
-			if (userGroup != null) {
-				_userGroupLocalService.deleteUserUserGroup(
-					_groupUser.getUserId(), userGroup);
+			_userGroupLocalService.deleteUserUserGroup(
+				_groupUser.getUserId(), userGroup);
 
-				_userGroupLocalService.deleteUserGroup(userGroup);
-			}
+			_userGroupLocalService.deleteUserGroup(userGroup);
 		}
 	}
 
@@ -313,19 +311,15 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 					model.getModelClassName(), "1234", null, null, null));
 		}
 		finally {
-			if (userGroup1 != null) {
-				_userGroupLocalService.deleteUserUserGroup(
-					TestPropsValues.getUserId(), userGroup1);
+			_userGroupLocalService.deleteUserUserGroup(
+				TestPropsValues.getUserId(), userGroup1);
 
-				_userGroupLocalService.deleteUserGroup(userGroup1);
-			}
+			_userGroupLocalService.deleteUserGroup(userGroup1);
 
-			if (userGroup2 != null) {
-				_userGroupLocalService.deleteUserUserGroup(
-					TestPropsValues.getUserId(), userGroup2);
+			_userGroupLocalService.deleteUserUserGroup(
+				TestPropsValues.getUserId(), userGroup2);
 
-				_userGroupLocalService.deleteUserGroup(userGroup2);
-			}
+			_userGroupLocalService.deleteUserGroup(userGroup2);
 		}
 	}
 

--- a/modules/apps/sharing/sharing-test-util/src/main/java/com/liferay/sharing/test/util/BaseSharingTestCase.java
+++ b/modules/apps/sharing/sharing-test-util/src/main/java/com/liferay/sharing/test/util/BaseSharingTestCase.java
@@ -294,16 +294,16 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 			Assert.assertEquals(
 				StringBundler.concat(
 					"1234 IN (SELECT SharingEntry.classPK FROM SharingEntry ",
-					"WHERE ((SharingEntry.toUserId = ",
-					TestPropsValues.getUserId(),
-					") OR (SharingEntry.toUserGroupId IN ( ",
+					"WHERE ((SharingEntry.toUserGroupId IN ( ",
 					StringUtil.merge(
 						new long[] {
 							userGroup1.getUserGroupId(),
 							userGroup2.getUserGroupId()
 						},
 						","),
-					"))) AND (SharingEntry.classNameId = ",
+					")) OR (SharingEntry.toUserId = ",
+					TestPropsValues.getUserId(),
+					")) AND (SharingEntry.classNameId = ",
 					_classNameLocalService.getClassNameId(
 						model.getModelClassName()),
 					"))"),

--- a/modules/apps/sharing/sharing-test-util/src/main/java/com/liferay/sharing/test/util/BaseSharingTestCase.java
+++ b/modules/apps/sharing/sharing-test-util/src/main/java/com/liferay/sharing/test/util/BaseSharingTestCase.java
@@ -6,6 +6,7 @@
 package com.liferay.sharing.test.util;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -15,6 +16,7 @@ import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
@@ -24,12 +26,14 @@ import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.test.context.ContextUserReplace;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.security.permission.contributor.PermissionSQLContributor;
 import com.liferay.portal.test.rule.Inject;
@@ -229,9 +233,52 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 	}
 
 	@Test
+	public void testInlinePermissionsToUserGroup() throws Exception {
+		PermissionChecker permissionChecker =
+			PermissionCheckerFactoryUtil.create(_groupUser);
+
+		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_groupUser, permissionChecker)) {
+
+			Assert.assertEquals(0, getModelCount(_group));
+
+			T model = getModel(TestPropsValues.getUser(), _group);
+
+			long classPK = (long)model.getPrimaryKeyObj();
+
+			_userGroupLocalService.addUserUserGroup(
+				_groupUser.getUserId(), userGroup);
+
+			_sharingEntryLocalService.addSharingEntry(
+				null, TestPropsValues.getUserId(), userGroup.getUserGroupId(),
+				0,
+				_classNameLocalService.getClassNameId(
+					model.getModelClassName()),
+				classPK, _group.getGroupId(), true,
+				Collections.singletonList(SharingEntryAction.VIEW), null,
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+			Assert.assertEquals(1, getModelCount(_group));
+		}
+		finally {
+			if (userGroup != null) {
+				_userGroupLocalService.deleteUserUserGroup(
+					_groupUser.getUserId(), userGroup);
+				_userGroupLocalService.deleteUserGroup(userGroup);
+			}
+		}
+	}
+
+	@Test
 	public void testModelClassNameReturnsPermissionSQL() throws Exception {
 		PermissionChecker permissionChecker =
 			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser());
+
+		UserGroup userGroup1 = UserGroupTestUtil.addUserGroup();
+
+		UserGroup userGroup2 = UserGroupTestUtil.addUserGroup();
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				TestPropsValues.getUser(), permissionChecker)) {
@@ -241,17 +288,42 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 			PermissionSQLContributor permissionSQLContributor =
 				getPermissionSQLContributor();
 
+			_userGroupLocalService.addUserUserGroup(
+				TestPropsValues.getUserId(), userGroup1);
+			_userGroupLocalService.addUserUserGroup(
+				TestPropsValues.getUserId(), userGroup2);
+
 			Assert.assertEquals(
 				StringBundler.concat(
 					"1234 IN (SELECT SharingEntry.classPK FROM SharingEntry ",
-					"WHERE (SharingEntry.toUserId = ",
+					"WHERE ((SharingEntry.toUserId = ",
 					TestPropsValues.getUserId(),
-					") AND (SharingEntry.classNameId = ",
+					") OR (SharingEntry.toUserGroupId IN ( ",
+					StringUtil.merge(
+						new long[] {
+							userGroup1.getUserGroupId(),
+							userGroup2.getUserGroupId()
+						},
+						","),
+					"))) AND (SharingEntry.classNameId = ",
 					_classNameLocalService.getClassNameId(
 						model.getModelClassName()),
 					"))"),
 				permissionSQLContributor.getPermissionSQL(
 					model.getModelClassName(), "1234", null, null, null));
+		}
+		finally {
+			if (userGroup1 != null) {
+				_userGroupLocalService.deleteUserUserGroup(
+					TestPropsValues.getUserId(), userGroup1);
+				_userGroupLocalService.deleteUserGroup(userGroup1);
+			}
+
+			if (userGroup2 != null) {
+				_userGroupLocalService.deleteUserUserGroup(
+					TestPropsValues.getUserId(), userGroup2);
+				_userGroupLocalService.deleteUserGroup(userGroup2);
+			}
 		}
 	}
 
@@ -843,6 +915,9 @@ public abstract class BaseSharingTestCase<T extends ClassedModel> {
 
 	@Inject
 	private SharingEntryLocalService _sharingEntryLocalService;
+
+	@Inject
+	private UserGroupLocalService _userGroupLocalService;
 
 	private class AddModelResourcePermission implements AutoCloseable {
 

--- a/modules/apps/sharing/sharing-test-util/src/main/resources/com/liferay/sharing/test/util/packageinfo
+++ b/modules/apps/sharing/sharing-test-util/src/main/resources/com/liferay/sharing/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/sharing/sharing-test/build.gradle
+++ b/modules/apps/sharing/sharing-test/build.gradle
@@ -1,5 +1,7 @@
 dependencies {
 	testIntegrationImplementation project(":apps:portal:portal-notifications-test-util")
+	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:sharing:sharing-api")
+	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/GroupModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/GroupModelListenerTest.java
@@ -63,7 +63,7 @@ public class GroupModelListenerTest {
 		long classPK = _group.getGroupId();
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, TestPropsValues.getUserId(), _groupUser.getUserId(),
+			null, TestPropsValues.getUserId(), 0, _groupUser.getUserId(),
 			_classNameLocalService.getClassNameId(Group.class.getName()),
 			classPK, _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null,
@@ -101,12 +101,12 @@ public class GroupModelListenerTest {
 					_group.getGroupId(), TestPropsValues.getUserId());
 
 			_sharingEntryLocalService.addSharingEntry(
-				null, TestPropsValues.getUserId(), _groupUser.getUserId(),
+				null, TestPropsValues.getUserId(), 0, _groupUser.getUserId(),
 				classNameId, _group.getGroupId(), _group.getGroupId(), true,
 				Arrays.asList(SharingEntryAction.VIEW), null, serviceContext);
 
 			_sharingEntryLocalService.addSharingEntry(
-				null, TestPropsValues.getUserId(), _groupUser.getUserId(),
+				null, TestPropsValues.getUserId(), 0, _groupUser.getUserId(),
 				classNameId, group2.getGroupId(), group2.getGroupId(), true,
 				Arrays.asList(SharingEntryAction.VIEW), null, serviceContext);
 

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/GroupModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/GroupModelListenerTest.java
@@ -8,15 +8,18 @@ package com.liferay.sharing.internal.model.listener.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -62,28 +65,46 @@ public class GroupModelListenerTest {
 	public void testDeletingGroupDeletesSharingEntries() throws Exception {
 		long classPK = _group.getGroupId();
 
-		_sharingEntryLocalService.addSharingEntry(
-			null, TestPropsValues.getUserId(), 0, _groupUser.getUserId(),
-			_classNameLocalService.getClassNameId(Group.class.getName()),
-			classPK, _group.getGroupId(), true,
-			Arrays.asList(SharingEntryAction.VIEW), null,
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
+		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
 
-		List<SharingEntry> groupSharingEntries =
-			_sharingEntryLocalService.getGroupSharingEntries(
-				_group.getGroupId());
+		try {
+			_sharingEntryLocalService.addSharingEntry(
+				null, TestPropsValues.getUserId(), 0, _groupUser.getUserId(),
+				_classNameLocalService.getClassNameId(Group.class.getName()),
+				classPK, _group.getGroupId(), true,
+				Arrays.asList(SharingEntryAction.VIEW), null,
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId()));
 
-		Assert.assertEquals(
-			groupSharingEntries.toString(), 1, groupSharingEntries.size());
+			_sharingEntryLocalService.addSharingEntry(
+				null, TestPropsValues.getUserId(), userGroup.getUserGroupId(),
+				0, _classNameLocalService.getClassNameId(Group.class.getName()),
+				classPK, _group.getGroupId(), true,
+				Arrays.asList(SharingEntryAction.VIEW), null,
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId()));
 
-		_groupLocalService.deleteGroup(_group.getGroupId());
+			List<SharingEntry> groupSharingEntries =
+				_sharingEntryLocalService.getGroupSharingEntries(
+					_group.getGroupId());
 
-		groupSharingEntries = _sharingEntryLocalService.getGroupSharingEntries(
-			_group.getGroupId());
+			Assert.assertEquals(
+				groupSharingEntries.toString(), 2, groupSharingEntries.size());
 
-		Assert.assertEquals(
-			groupSharingEntries.toString(), 0, groupSharingEntries.size());
+			_groupLocalService.deleteGroup(_group.getGroupId());
+
+			groupSharingEntries =
+				_sharingEntryLocalService.getGroupSharingEntries(
+					_group.getGroupId());
+
+			Assert.assertEquals(
+				groupSharingEntries.toString(), 0, groupSharingEntries.size());
+		}
+		finally {
+			if (userGroup != null) {
+				_userGroupLocalService.deleteUserGroup(userGroup);
+			}
+		}
 	}
 
 	@Test
@@ -162,5 +183,8 @@ public class GroupModelListenerTest {
 
 	@Inject
 	private SharingEntryLocalService _sharingEntryLocalService;
+
+	@Inject
+	private UserGroupLocalService _userGroupLocalService;
 
 }

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/GroupModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/GroupModelListenerTest.java
@@ -64,7 +64,6 @@ public class GroupModelListenerTest {
 	@Test
 	public void testDeletingGroupDeletesSharingEntries() throws Exception {
 		long classPK = _group.getGroupId();
-
 		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
 
 		try {
@@ -101,9 +100,7 @@ public class GroupModelListenerTest {
 				groupSharingEntries.toString(), 0, groupSharingEntries.size());
 		}
 		finally {
-			if (userGroup != null) {
-				_userGroupLocalService.deleteUserGroup(userGroup);
-			}
+			_userGroupLocalService.deleteUserGroup(userGroup);
 		}
 	}
 

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
@@ -64,7 +64,7 @@ public class UserModelListenerTest {
 		long classPK = _group.getGroupId();
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, TestPropsValues.getUserId(), _groupUser1.getUserId(),
+			null, TestPropsValues.getUserId(), 0, _groupUser1.getUserId(),
 			_classNameLocalService.getClassNameId(Group.class.getName()),
 			classPK, _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null,
@@ -95,7 +95,7 @@ public class UserModelListenerTest {
 		long classPK = _group.getGroupId();
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, TestPropsValues.getUserId(), _groupUser1.getUserId(),
+			null, TestPropsValues.getUserId(), 0, _groupUser1.getUserId(),
 			_classNameLocalService.getClassNameId(Group.class.getName()),
 			classPK, _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null,

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/upgrade/v1_2_0/test/SharingEntryUpgradeProcessTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/upgrade/v1_2_0/test/SharingEntryUpgradeProcessTest.java
@@ -1,0 +1,94 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.sharing.internal.upgrade.v1_2_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+import com.liferay.sharing.security.permission.SharingEntryAction;
+import com.liferay.sharing.service.SharingEntryLocalService;
+
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Mikel Lorza
+ */
+@RunWith(Arquillian.class)
+public class SharingEntryUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		UserTestUtil.setUser(TestPropsValues.getUser());
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		User toUser = UserTestUtil.addUser();
+
+		_sharingEntryLocalService.addSharingEntry(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(), 0,
+			toUser.getUserId(),
+			_classNameLocalService.getClassNameId(Group.class.getName()),
+			_group.getGroupId(), _group.getGroupId(), true,
+			Arrays.asList(SharingEntryAction.VIEW), null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator,
+			"com.liferay.sharing.internal.upgrade.v1_2_0." +
+				"SharingEntryUpgradeProcess");
+
+		upgradeProcess.upgrade();
+	}
+
+	@Inject(
+		filter = "component.name=com.liferay.sharing.internal.upgrade.registry.SharingServiceUpgradeStepRegistrator"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private SharingEntryLocalService _sharingEntryLocalService;
+
+	@Inject
+	private UserGroupLocalService _userGroupLocalService;
+
+}

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/notifications/test/AddOrUpdateSharingUserNotificationTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/notifications/test/AddOrUpdateSharingUserNotificationTest.java
@@ -59,7 +59,7 @@ public class AddOrUpdateSharingUserNotificationTest
 		long classPK = group.getGroupId();
 
 		return _sharingEntryLocalService.addOrUpdateSharingEntry(
-			null, _fromUser.getUserId(), user.getUserId(),
+			null, _fromUser.getUserId(), 0, user.getUserId(),
 			_classNameLocalService.getClassNameId(Group.class.getName()),
 			classPK, group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null,
@@ -87,7 +87,7 @@ public class AddOrUpdateSharingUserNotificationTest
 		SharingEntry sharingEntry = (SharingEntry)baseModel;
 
 		return _sharingEntryLocalService.addOrUpdateSharingEntry(
-			null, sharingEntry.getUserId(), sharingEntry.getToUserId(),
+			null, sharingEntry.getUserId(), 0, sharingEntry.getToUserId(),
 			sharingEntry.getClassNameId(), sharingEntry.getClassPK(),
 			sharingEntry.getGroupId(), sharingEntry.isShareable(),
 			Arrays.asList(SharingEntryAction.VIEW, SharingEntryAction.UPDATE),

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/notifications/test/SharingUserNotificationTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/notifications/test/SharingUserNotificationTest.java
@@ -141,7 +141,7 @@ public class SharingUserNotificationTest extends BaseUserNotificationTestCase {
 		long classPK = (Long)model.getPrimaryKeyObj();
 
 		return _sharingEntryLocalService.addOrUpdateSharingEntry(
-			null, fromUser.getUserId(), toUser.getUserId(),
+			null, fromUser.getUserId(), 0, toUser.getUserId(),
 			_classNameLocalService.getClassNameId(model.getModelClassName()),
 			classPK, group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null,

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/persistence/test/SharingEntryPersistenceTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/persistence/test/SharingEntryPersistenceTest.java
@@ -294,12 +294,12 @@ public class SharingEntryPersistenceTest {
 	}
 
 	@Test
-	public void testCountByTU_C_C() throws Exception {
-		_persistence.countByTU_C_C(
+	public void testCountByTUG_TU_C_C() throws Exception {
+		_persistence.countByTUG_TU_C_C(
 			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(),
-			RandomTestUtil.nextLong());
+			RandomTestUtil.nextLong(), RandomTestUtil.nextLong());
 
-		_persistence.countByTU_C_C(0L, 0L, 0L);
+		_persistence.countByTUG_TU_C_C(0L, 0L, 0L, 0L);
 	}
 
 	@Test
@@ -619,6 +619,11 @@ public class SharingEntryPersistenceTest {
 				sharingEntry, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "groupId"));
 
+		Assert.assertEquals(
+			Long.valueOf(sharingEntry.getToUserGroupId()),
+			ReflectionTestUtil.<Long>invoke(
+				sharingEntry, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "toUserGroupId"));
 		Assert.assertEquals(
 			Long.valueOf(sharingEntry.getToUserId()),
 			ReflectionTestUtil.<Long>invoke(

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/persistence/test/SharingEntryPersistenceTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/persistence/test/SharingEntryPersistenceTest.java
@@ -132,6 +132,8 @@ public class SharingEntryPersistenceTest {
 
 		newSharingEntry.setModifiedDate(RandomTestUtil.nextDate());
 
+		newSharingEntry.setToUserGroupId(RandomTestUtil.nextLong());
+
 		newSharingEntry.setToUserId(RandomTestUtil.nextLong());
 
 		newSharingEntry.setClassNameId(RandomTestUtil.nextLong());
@@ -172,6 +174,9 @@ public class SharingEntryPersistenceTest {
 		Assert.assertEquals(
 			Time.getShortTimestamp(existingSharingEntry.getModifiedDate()),
 			Time.getShortTimestamp(newSharingEntry.getModifiedDate()));
+		Assert.assertEquals(
+			existingSharingEntry.getToUserGroupId(),
+			newSharingEntry.getToUserGroupId());
 		Assert.assertEquals(
 			existingSharingEntry.getToUserId(), newSharingEntry.getToUserId());
 		Assert.assertEquals(
@@ -334,9 +339,9 @@ public class SharingEntryPersistenceTest {
 			"SharingEntry", "uuid", true, "externalReferenceCode", true,
 			"sharingEntryId", true, "groupId", true, "companyId", true,
 			"userId", true, "userName", true, "createDate", true,
-			"modifiedDate", true, "toUserId", true, "classNameId", true,
-			"classPK", true, "shareable", true, "actionIds", true,
-			"expirationDate", true);
+			"modifiedDate", true, "toUserGroupId", true, "toUserId", true,
+			"classNameId", true, "classPK", true, "shareable", true,
+			"actionIds", true, "expirationDate", true);
 	}
 
 	@Test
@@ -662,6 +667,8 @@ public class SharingEntryPersistenceTest {
 		sharingEntry.setCreateDate(RandomTestUtil.nextDate());
 
 		sharingEntry.setModifiedDate(RandomTestUtil.nextDate());
+
+		sharingEntry.setToUserGroupId(RandomTestUtil.nextLong());
 
 		sharingEntry.setToUserId(RandomTestUtil.nextLong());
 

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/persistence/test/SharingEntryPersistenceTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/persistence/test/SharingEntryPersistenceTest.java
@@ -294,6 +294,22 @@ public class SharingEntryPersistenceTest {
 	}
 
 	@Test
+	public void testCountByTUG_C_C() throws Exception {
+		_persistence.countByTUG_C_C(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(),
+			RandomTestUtil.nextLong());
+
+		_persistence.countByTUG_C_C(0L, 0L, 0L);
+	}
+
+	@Test
+	public void testCountByTUG_C_CArrayable() throws Exception {
+		_persistence.countByTUG_C_C(
+			new long[] {RandomTestUtil.nextLong(), 0L},
+			RandomTestUtil.nextLong(), RandomTestUtil.nextLong());
+	}
+
+	@Test
 	public void testCountByTUG_TU_C_C() throws Exception {
 		_persistence.countByTUG_TU_C_C(
 			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(),

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/test/SharingEntryLocalServiceTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/test/SharingEntryLocalServiceTest.java
@@ -794,11 +794,10 @@ public class SharingEntryLocalServiceTest {
 					SharingEntryAction.UPDATE));
 		}
 		finally {
-			if (userGroup != null) {
-				_userGroupLocalService.deleteUserUserGroup(
-					_toUser.getUserId(), userGroup);
-				_userGroupLocalService.deleteUserGroup(userGroup);
-			}
+			_userGroupLocalService.deleteUserUserGroup(
+				_toUser.getUserId(), userGroup);
+
+			_userGroupLocalService.deleteUserGroup(userGroup);
 		}
 	}
 
@@ -888,11 +887,10 @@ public class SharingEntryLocalServiceTest {
 					SharingEntryAction.VIEW));
 		}
 		finally {
-			if (userGroup != null) {
-				_userGroupLocalService.deleteUserUserGroup(
-					_toUser.getUserId(), userGroup);
-				_userGroupLocalService.deleteUserGroup(userGroup);
-			}
+			_userGroupLocalService.deleteUserUserGroup(
+				_toUser.getUserId(), userGroup);
+
+			_userGroupLocalService.deleteUserGroup(userGroup);
 		}
 	}
 

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/test/SharingEntryLocalServiceTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/test/SharingEntryLocalServiceTest.java
@@ -758,6 +758,59 @@ public class SharingEntryLocalServiceTest {
 	}
 
 	@Test
+	public void testHasShareableSharingPermissionToUserGroup()
+		throws Exception {
+
+		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
+
+		try {
+			_userGroupLocalService.addUserUserGroup(
+				_toUser.getUserId(), userGroup);
+
+			SharingEntry sharingEntry =
+				_sharingEntryLocalService.addSharingEntry(
+					null, _fromUser.getUserId(), userGroup.getUserGroupId(), 0,
+					_classNameId, _group.getGroupId(), _group.getGroupId(),
+					true,
+					Arrays.asList(
+						SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
+					null, _serviceContext);
+
+			Assert.assertTrue(
+				_sharingEntryLocalService.hasShareableSharingPermission(
+					_toUser.getUserId(), _classNameId, _group.getGroupId(),
+					SharingEntryAction.UPDATE));
+
+			_sharingEntryLocalService.updateSharingEntry(
+				_fromUser.getUserId(), sharingEntry.getSharingEntryId(),
+				Arrays.asList(SharingEntryAction.VIEW), true, null,
+				_serviceContext);
+
+			Assert.assertFalse(
+				_sharingEntryLocalService.hasShareableSharingPermission(
+					_toUser.getUserId(), _classNameId, _group.getGroupId(),
+					SharingEntryAction.UPDATE));
+
+			_sharingEntryLocalService.updateSharingEntry(
+				_fromUser.getUserId(), sharingEntry.getSharingEntryId(),
+				Arrays.asList(SharingEntryAction.VIEW), false, null,
+				_serviceContext);
+
+			Assert.assertFalse(
+				_sharingEntryLocalService.hasShareableSharingPermission(
+					_toUser.getUserId(), _classNameId, _group.getGroupId(),
+					SharingEntryAction.UPDATE));
+		}
+		finally {
+			if (userGroup != null) {
+				_userGroupLocalService.deleteUserUserGroup(
+					_toUser.getUserId(), userGroup);
+				_userGroupLocalService.deleteUserGroup(userGroup);
+			}
+		}
+	}
+
+	@Test
 	public void testHasShareableSharingPermissionWithShareableAddDiscussionAndViewSharingEntryAction()
 		throws Exception {
 
@@ -805,6 +858,50 @@ public class SharingEntryLocalServiceTest {
 			_sharingEntryLocalService.hasShareableSharingPermission(
 				_toUser.getUserId(), _classNameId, _group.getGroupId(),
 				SharingEntryAction.VIEW));
+	}
+
+	@Test
+	public void testHasSharingPermissionToUserGroup() throws Exception {
+		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
+
+		try {
+			_userGroupLocalService.addUserUserGroup(
+				_toUser.getUserId(), userGroup);
+
+			_sharingEntryLocalService.addSharingEntry(
+				null, _fromUser.getUserId(), userGroup.getUserGroupId(), 0,
+				_classNameId, _group.getGroupId(), _group.getGroupId(), true,
+				Arrays.asList(
+					SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
+				null, _serviceContext);
+
+			Assert.assertTrue(
+				_sharingEntryLocalService.hasSharingPermission(
+					_toUser.getUserId(), _classNameId, _group.getGroupId(),
+					SharingEntryAction.UPDATE));
+			Assert.assertTrue(
+				_sharingEntryLocalService.hasSharingPermission(
+					_toUser.getUserId(), _classNameId, _group.getGroupId(),
+					SharingEntryAction.VIEW));
+
+			User user = UserTestUtil.addUser();
+
+			Assert.assertFalse(
+				_sharingEntryLocalService.hasSharingPermission(
+					user.getUserId(), _classNameId, _group.getGroupId(),
+					SharingEntryAction.UPDATE));
+			Assert.assertFalse(
+				_sharingEntryLocalService.hasSharingPermission(
+					user.getUserId(), _classNameId, _group.getGroupId(),
+					SharingEntryAction.VIEW));
+		}
+		finally {
+			if (userGroup != null) {
+				_userGroupLocalService.deleteUserUserGroup(
+					_toUser.getUserId(), userGroup);
+				_userGroupLocalService.deleteUserGroup(userGroup);
+			}
+		}
 	}
 
 	@Test

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/test/SharingEntryLocalServiceTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/test/SharingEntryLocalServiceTest.java
@@ -87,7 +87,7 @@ public class SharingEntryLocalServiceTest {
 		Instant instant = Instant.now();
 
 		_sharingEntryLocalService.addOrUpdateSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW),
 			Date.from(instant.plus(2, ChronoUnit.DAYS)), _serviceContext);
@@ -110,13 +110,13 @@ public class SharingEntryLocalServiceTest {
 		Instant instant = Instant.now();
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW),
 			Date.from(instant.plus(2, ChronoUnit.DAYS)), _serviceContext);
 
 		_sharingEntryLocalService.addOrUpdateSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), false,
 			Arrays.asList(SharingEntryAction.VIEW, SharingEntryAction.UPDATE),
 			Date.from(instant.plus(3, ChronoUnit.DAYS)), _serviceContext);
@@ -132,7 +132,7 @@ public class SharingEntryLocalServiceTest {
 		throws Exception {
 
 		_sharingEntryLocalService.addOrUpdateSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Collections.emptyList(), null, _serviceContext);
 	}
@@ -144,7 +144,7 @@ public class SharingEntryLocalServiceTest {
 		Instant instant = Instant.now();
 
 		_sharingEntryLocalService.addOrUpdateSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW),
 			Date.from(instant.minus(2, ChronoUnit.DAYS)), _serviceContext);
@@ -157,9 +157,10 @@ public class SharingEntryLocalServiceTest {
 		String externalReferenceCode = RandomTestUtil.randomString();
 
 		_sharingEntryLocalService.addOrUpdateSharingEntry(
-			externalReferenceCode, _fromUser.getUserId(), _toUser.getUserId(),
-			_classNameId, _group.getGroupId(), _group.getGroupId(), true,
-			Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
+			externalReferenceCode, _fromUser.getUserId(), 0,
+			_toUser.getUserId(), _classNameId, _group.getGroupId(),
+			_group.getGroupId(), true, Arrays.asList(SharingEntryAction.VIEW),
+			null, _serviceContext);
 
 		SharingEntry sharingEntry =
 			_sharingEntryLocalService.fetchSharingEntryByExternalReferenceCode(
@@ -178,7 +179,7 @@ public class SharingEntryLocalServiceTest {
 				_classNameId, _group.getGroupId()));
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
 
@@ -191,7 +192,7 @@ public class SharingEntryLocalServiceTest {
 	@Test
 	public void testAddSharingEntryActionIds() throws Exception {
 		SharingEntry sharingEntry = _sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
 
@@ -202,7 +203,7 @@ public class SharingEntryLocalServiceTest {
 		_sharingEntryLocalService.deleteSharingEntry(sharingEntry);
 
 		sharingEntry = _sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
 			null, _serviceContext);
@@ -215,7 +216,7 @@ public class SharingEntryLocalServiceTest {
 		_sharingEntryLocalService.deleteSharingEntry(sharingEntry);
 
 		sharingEntry = _sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(
 				SharingEntryAction.ADD_DISCUSSION, SharingEntryAction.VIEW),
@@ -229,7 +230,7 @@ public class SharingEntryLocalServiceTest {
 		_sharingEntryLocalService.deleteSharingEntry(sharingEntry);
 
 		sharingEntry = _sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(
 				SharingEntryAction.ADD_DISCUSSION, SharingEntryAction.UPDATE,
@@ -248,7 +249,7 @@ public class SharingEntryLocalServiceTest {
 		throws Exception {
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Collections.emptyList(), null, _serviceContext);
 	}
@@ -260,14 +261,16 @@ public class SharingEntryLocalServiceTest {
 		String externalReferenceCode = RandomTestUtil.randomString();
 
 		_sharingEntryLocalService.addSharingEntry(
-			externalReferenceCode, _fromUser.getUserId(), _toUser.getUserId(),
-			_classNameId, _group.getGroupId(), _group.getGroupId(), true,
-			Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
+			externalReferenceCode, 0, _fromUser.getUserId(),
+			_toUser.getUserId(), _classNameId, _group.getGroupId(),
+			_group.getGroupId(), true, Arrays.asList(SharingEntryAction.VIEW),
+			null, _serviceContext);
 
 		_sharingEntryLocalService.addSharingEntry(
-			externalReferenceCode, _fromUser.getUserId(), _toUser.getUserId(),
-			_classNameId, _group.getGroupId(), _group.getGroupId(), true,
-			Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
+			externalReferenceCode, 0, _fromUser.getUserId(),
+			_toUser.getUserId(), _classNameId, _group.getGroupId(),
+			_group.getGroupId(), true, Arrays.asList(SharingEntryAction.VIEW),
+			null, _serviceContext);
 	}
 
 	@Test
@@ -282,7 +285,7 @@ public class SharingEntryLocalServiceTest {
 		Instant instant = Instant.now();
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW),
 			Date.from(instant.plus(2, ChronoUnit.DAYS)), _serviceContext);
@@ -300,7 +303,7 @@ public class SharingEntryLocalServiceTest {
 		Instant instant = Instant.now();
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW),
 			Date.from(instant.minus(2, ChronoUnit.DAYS)), _serviceContext);
@@ -313,9 +316,10 @@ public class SharingEntryLocalServiceTest {
 		String externalReferenceCode = RandomTestUtil.randomString();
 
 		_sharingEntryLocalService.addSharingEntry(
-			externalReferenceCode, _fromUser.getUserId(), _toUser.getUserId(),
-			_classNameId, _group.getGroupId(), _group.getGroupId(), true,
-			Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
+			externalReferenceCode, _fromUser.getUserId(), 0,
+			_toUser.getUserId(), _classNameId, _group.getGroupId(),
+			_group.getGroupId(), true, Arrays.asList(SharingEntryAction.VIEW),
+			null, _serviceContext);
 
 		SharingEntry sharingEntry =
 			_sharingEntryLocalService.fetchSharingEntryByExternalReferenceCode(
@@ -331,7 +335,7 @@ public class SharingEntryLocalServiceTest {
 		throws Exception {
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.UPDATE), null, _serviceContext);
 	}
@@ -341,7 +345,7 @@ public class SharingEntryLocalServiceTest {
 		throws Exception {
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _fromUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _fromUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
 	}
@@ -351,7 +355,7 @@ public class SharingEntryLocalServiceTest {
 		throws Exception {
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW, null), null,
 			_serviceContext);
@@ -362,7 +366,7 @@ public class SharingEntryLocalServiceTest {
 		throws Exception {
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(new SharingEntryAction[] {null}), null,
 			_serviceContext);
@@ -374,13 +378,13 @@ public class SharingEntryLocalServiceTest {
 
 		try {
 			_sharingEntryLocalService.addSharingEntry(
-				null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
-				_group.getGroupId(), _group.getGroupId(), true,
+				null, _fromUser.getUserId(), 0, _toUser.getUserId(),
+				_classNameId, _group.getGroupId(), _group.getGroupId(), true,
 				Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
 
 			SharingEntry sharingEntry =
 				_sharingEntryLocalService.addSharingEntry(
-					null, _fromUser.getUserId(), _toUser.getUserId(),
+					null, _fromUser.getUserId(), 0, _toUser.getUserId(),
 					_classNameId, group.getGroupId(), group.getGroupId(), true,
 					Arrays.asList(SharingEntryAction.VIEW), null,
 					_serviceContext);
@@ -411,7 +415,7 @@ public class SharingEntryLocalServiceTest {
 
 			try {
 				_sharingEntryLocalService.addSharingEntry(
-					null, _fromUser.getUserId(), _toUser.getUserId(),
+					null, _fromUser.getUserId(), 0, _toUser.getUserId(),
 					_classNameId, group.getGroupId(), _group.getGroupId(), true,
 					Arrays.asList(SharingEntryAction.VIEW), null,
 					_serviceContext);
@@ -444,13 +448,13 @@ public class SharingEntryLocalServiceTest {
 
 		try {
 			_sharingEntryLocalService.addSharingEntry(
-				null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
-				group1.getGroupId(), group1.getGroupId(), true,
+				null, _fromUser.getUserId(), 0, _toUser.getUserId(),
+				_classNameId, group1.getGroupId(), group1.getGroupId(), true,
 				Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
 
 			_sharingEntryLocalService.addSharingEntry(
-				null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
-				group2.getGroupId(), group2.getGroupId(), true,
+				null, _fromUser.getUserId(), 0, _toUser.getUserId(),
+				_classNameId, group2.getGroupId(), group2.getGroupId(), true,
 				Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
 
 			Assert.assertEquals(
@@ -492,7 +496,7 @@ public class SharingEntryLocalServiceTest {
 		long classPK1 = _group.getGroupId();
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			classPK1, _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
 
@@ -502,8 +506,8 @@ public class SharingEntryLocalServiceTest {
 			long classPK2 = group.getGroupId();
 
 			_sharingEntryLocalService.addSharingEntry(
-				null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
-				classPK2, _group.getGroupId(), true,
+				null, _fromUser.getUserId(), 0, _toUser.getUserId(),
+				_classNameId, classPK2, _group.getGroupId(), true,
 				Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
 
 			Assert.assertEquals(
@@ -545,7 +549,7 @@ public class SharingEntryLocalServiceTest {
 	@Test
 	public void testDeleteSharingEntry() throws Exception {
 		SharingEntry sharingEntry = _sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
 
@@ -568,9 +572,10 @@ public class SharingEntryLocalServiceTest {
 		String externalReferenceCode = RandomTestUtil.randomString();
 
 		_sharingEntryLocalService.addSharingEntry(
-			externalReferenceCode, _fromUser.getUserId(), _toUser.getUserId(),
-			_classNameId, _group.getGroupId(), _group.getGroupId(), true,
-			Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
+			externalReferenceCode, _fromUser.getUserId(), 0,
+			_toUser.getUserId(), _classNameId, _group.getGroupId(),
+			_group.getGroupId(), true, Arrays.asList(SharingEntryAction.VIEW),
+			null, _serviceContext);
 
 		Assert.assertNotNull(
 			_sharingEntryLocalService.fetchSharingEntryByExternalReferenceCode(
@@ -599,7 +604,7 @@ public class SharingEntryLocalServiceTest {
 
 			try {
 				_sharingEntryLocalService.addSharingEntry(
-					null, _fromUser.getUserId(), _toUser.getUserId(),
+					null, _fromUser.getUserId(), 0, _toUser.getUserId(),
 					_classNameId, group.getGroupId(), _group.getGroupId(), true,
 					Arrays.asList(SharingEntryAction.VIEW), null,
 					_serviceContext);
@@ -634,7 +639,7 @@ public class SharingEntryLocalServiceTest {
 
 			SharingEntry sharingEntry1 =
 				_sharingEntryLocalService.addSharingEntry(
-					null, _fromUser.getUserId(), _toUser.getUserId(),
+					null, _fromUser.getUserId(), 0, _toUser.getUserId(),
 					_classNameId, classPK1, _group.getGroupId(), true,
 					Arrays.asList(SharingEntryAction.VIEW),
 					Date.from(now.plus(2, ChronoUnit.DAYS)), _serviceContext);
@@ -645,7 +650,7 @@ public class SharingEntryLocalServiceTest {
 
 			SharingEntry sharingEntry2 =
 				_sharingEntryLocalService.addSharingEntry(
-					null, _fromUser.getUserId(), _toUser.getUserId(),
+					null, _fromUser.getUserId(), 0, _toUser.getUserId(),
 					_classNameId, classPK2, _group.getGroupId(), true,
 					Arrays.asList(SharingEntryAction.VIEW),
 					Date.from(now.plus(2, ChronoUnit.DAYS)), _serviceContext);
@@ -676,7 +681,7 @@ public class SharingEntryLocalServiceTest {
 		throws Exception {
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(
 				SharingEntryAction.ADD_DISCUSSION, SharingEntryAction.VIEW),
@@ -701,7 +706,7 @@ public class SharingEntryLocalServiceTest {
 		throws Exception {
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), false,
 			Arrays.asList(
 				SharingEntryAction.ADD_DISCUSSION, SharingEntryAction.VIEW),
@@ -726,7 +731,7 @@ public class SharingEntryLocalServiceTest {
 		throws Exception {
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(
 				SharingEntryAction.ADD_DISCUSSION, SharingEntryAction.VIEW),
@@ -751,7 +756,7 @@ public class SharingEntryLocalServiceTest {
 		throws Exception {
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
 
@@ -774,7 +779,7 @@ public class SharingEntryLocalServiceTest {
 		throws Exception {
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
 			null, _serviceContext);
@@ -798,7 +803,7 @@ public class SharingEntryLocalServiceTest {
 		throws Exception {
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
 			null, _serviceContext);
@@ -822,7 +827,7 @@ public class SharingEntryLocalServiceTest {
 		throws Exception {
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, _user.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _user.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
 			null, _serviceContext);
@@ -841,7 +846,7 @@ public class SharingEntryLocalServiceTest {
 				SharingEntryAction.VIEW));
 
 		_sharingEntryLocalService.addOrUpdateSharingEntry(
-			null, _user.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _user.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(
 				SharingEntryAction.ADD_DISCUSSION, SharingEntryAction.VIEW),
@@ -884,7 +889,7 @@ public class SharingEntryLocalServiceTest {
 		throws Exception {
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
 
@@ -905,13 +910,13 @@ public class SharingEntryLocalServiceTest {
 	@Test
 	public void testRetrievesUniqueSharedByMeSharingEntries() throws Exception {
 		_sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
 
 		SharingEntry latestSharingEntry =
 			_sharingEntryLocalService.addSharingEntry(
-				null, _fromUser.getUserId(), _user.getUserId(), _classNameId,
+				null, _fromUser.getUserId(), 0, _user.getUserId(), _classNameId,
 				_group.getGroupId(), _group.getGroupId(), true,
 				Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
 
@@ -947,7 +952,7 @@ public class SharingEntryLocalServiceTest {
 	@Test
 	public void testUpdateSharingEntry() throws Exception {
 		SharingEntry sharingEntry = _sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
 
@@ -995,7 +1000,7 @@ public class SharingEntryLocalServiceTest {
 		throws Exception {
 
 		SharingEntry sharingEntry = _sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
 
@@ -1009,7 +1014,7 @@ public class SharingEntryLocalServiceTest {
 		throws Exception {
 
 		SharingEntry sharingEntry = _sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
 
@@ -1028,7 +1033,7 @@ public class SharingEntryLocalServiceTest {
 		throws Exception {
 
 		SharingEntry sharingEntry = _sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
 
@@ -1043,7 +1048,7 @@ public class SharingEntryLocalServiceTest {
 		throws Exception {
 
 		SharingEntry sharingEntry = _sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
 
@@ -1062,7 +1067,7 @@ public class SharingEntryLocalServiceTest {
 		throws Exception {
 
 		SharingEntry sharingEntry = _sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
 

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/test/SharingEntryLocalServiceTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/test/SharingEntryLocalServiceTest.java
@@ -249,17 +249,19 @@ public class SharingEntryLocalServiceTest {
 			sharingEntry.getActionIds());
 	}
 
-	@Test(expected = NoSuchUserGroupException.class)
-	public void testAddSharingEntryToNonexistingUserGroup() throws Exception {
-		_sharingEntryLocalService.addSharingEntry(
-			RandomTestUtil.randomString(), _fromUser.getUserId(),
-			RandomTestUtil.randomLong(), 0, _classNameId, _group.getGroupId(),
-			_group.getGroupId(), true, Arrays.asList(SharingEntryAction.VIEW),
-			null, _serviceContext);
-	}
-
 	@Test
-	public void testAddSharingEntryToUser() throws Exception {
+	public void testAddSharingEntryToUserOrUserGroup() throws Exception {
+		try {
+			_sharingEntryLocalService.addSharingEntry(
+				RandomTestUtil.randomString(), _fromUser.getUserId(),
+				RandomTestUtil.randomLong(), 0, _classNameId,
+				_group.getGroupId(), _group.getGroupId(), true,
+				Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
+		}
+		catch (Exception exception) {
+			Assert.assertTrue(exception instanceof NoSuchUserGroupException);
+		}
+
 		String externalReferenceCode = RandomTestUtil.randomString();
 
 		_sharingEntryLocalService.addSharingEntry(
@@ -275,10 +277,7 @@ public class SharingEntryLocalServiceTest {
 		Assert.assertNotNull(sharingEntry);
 		Assert.assertEquals(0, sharingEntry.getToUserGroupId());
 		Assert.assertEquals(_toUser.getUserId(), sharingEntry.getToUserId());
-	}
 
-	@Test(expected = InvalidSharingEntryUserAndUserGroupException.class)
-	public void testAddSharingEntryToUserAndUserGroup() throws Exception {
 		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
 
 		try {
@@ -288,27 +287,22 @@ public class SharingEntryLocalServiceTest {
 				_group.getGroupId(), _group.getGroupId(), true,
 				Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
 		}
-		finally {
-			if (userGroup != null) {
-				_userGroupLocalService.deleteUserGroup(userGroup);
-			}
+		catch (Exception exception) {
+			Assert.assertTrue(
+				exception instanceof
+					InvalidSharingEntryUserAndUserGroupException);
 		}
-	}
-
-	@Test
-	public void testAddSharingEntryToUserGroup() throws Exception {
-		String externalReferenceCode = RandomTestUtil.randomString();
-
-		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
 
 		try {
+			externalReferenceCode = RandomTestUtil.randomString();
+
 			_sharingEntryLocalService.addSharingEntry(
 				externalReferenceCode, _fromUser.getUserId(),
 				userGroup.getUserGroupId(), 0, _classNameId,
 				_group.getGroupId(), _group.getGroupId(), true,
 				Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
 
-			SharingEntry sharingEntry =
+			sharingEntry =
 				_sharingEntryLocalService.
 					fetchSharingEntryByExternalReferenceCode(
 						externalReferenceCode, _group.getGroupId());
@@ -319,9 +313,7 @@ public class SharingEntryLocalServiceTest {
 			Assert.assertEquals(0, sharingEntry.getToUserId());
 		}
 		finally {
-			if (userGroup != null) {
-				_userGroupLocalService.deleteUserGroup(userGroup);
-			}
+			_userGroupLocalService.deleteUserGroup(userGroup);
 		}
 	}
 

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/test/SharingEntryLocalServiceTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/test/SharingEntryLocalServiceTest.java
@@ -6,18 +6,22 @@
 package com.liferay.sharing.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.exception.NoSuchUserGroupException;
 import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -26,6 +30,7 @@ import com.liferay.portal.test.rule.SynchronousMailTestRule;
 import com.liferay.sharing.exception.DuplicateSharingEntryException;
 import com.liferay.sharing.exception.InvalidSharingEntryActionException;
 import com.liferay.sharing.exception.InvalidSharingEntryExpirationDateException;
+import com.liferay.sharing.exception.InvalidSharingEntryUserAndUserGroupException;
 import com.liferay.sharing.exception.InvalidSharingEntryUserException;
 import com.liferay.sharing.exception.NoSuchEntryException;
 import com.liferay.sharing.model.SharingEntry;
@@ -244,6 +249,82 @@ public class SharingEntryLocalServiceTest {
 			sharingEntry.getActionIds());
 	}
 
+	@Test(expected = NoSuchUserGroupException.class)
+	public void testAddSharingEntryToNonexistingUserGroup() throws Exception {
+		_sharingEntryLocalService.addSharingEntry(
+			RandomTestUtil.randomString(), _fromUser.getUserId(),
+			RandomTestUtil.randomLong(), 0, _classNameId, _group.getGroupId(),
+			_group.getGroupId(), true, Arrays.asList(SharingEntryAction.VIEW),
+			null, _serviceContext);
+	}
+
+	@Test
+	public void testAddSharingEntryToUser() throws Exception {
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		_sharingEntryLocalService.addSharingEntry(
+			externalReferenceCode, _fromUser.getUserId(), 0,
+			_toUser.getUserId(), _classNameId, _group.getGroupId(),
+			_group.getGroupId(), true, Arrays.asList(SharingEntryAction.VIEW),
+			null, _serviceContext);
+
+		SharingEntry sharingEntry =
+			_sharingEntryLocalService.fetchSharingEntryByExternalReferenceCode(
+				externalReferenceCode, _group.getGroupId());
+
+		Assert.assertNotNull(sharingEntry);
+		Assert.assertEquals(0, sharingEntry.getToUserGroupId());
+		Assert.assertEquals(_toUser.getUserId(), sharingEntry.getToUserId());
+	}
+
+	@Test(expected = InvalidSharingEntryUserAndUserGroupException.class)
+	public void testAddSharingEntryToUserAndUserGroup() throws Exception {
+		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
+
+		try {
+			_sharingEntryLocalService.addSharingEntry(
+				RandomTestUtil.randomString(), _fromUser.getUserId(),
+				userGroup.getUserGroupId(), _toUser.getUserId(), _classNameId,
+				_group.getGroupId(), _group.getGroupId(), true,
+				Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
+		}
+		finally {
+			if (userGroup != null) {
+				_userGroupLocalService.deleteUserGroup(userGroup);
+			}
+		}
+	}
+
+	@Test
+	public void testAddSharingEntryToUserGroup() throws Exception {
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
+
+		try {
+			_sharingEntryLocalService.addSharingEntry(
+				externalReferenceCode, _fromUser.getUserId(),
+				userGroup.getUserGroupId(), 0, _classNameId,
+				_group.getGroupId(), _group.getGroupId(), true,
+				Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
+
+			SharingEntry sharingEntry =
+				_sharingEntryLocalService.
+					fetchSharingEntryByExternalReferenceCode(
+						externalReferenceCode, _group.getGroupId());
+
+			Assert.assertNotNull(sharingEntry);
+			Assert.assertEquals(
+				userGroup.getUserGroupId(), sharingEntry.getToUserGroupId());
+			Assert.assertEquals(0, sharingEntry.getToUserId());
+		}
+		finally {
+			if (userGroup != null) {
+				_userGroupLocalService.deleteUserGroup(userGroup);
+			}
+		}
+	}
+
 	@Test(expected = InvalidSharingEntryActionException.class)
 	public void testAddSharingEntryWithEmptySharingEntryActions()
 		throws Exception {
@@ -261,13 +342,13 @@ public class SharingEntryLocalServiceTest {
 		String externalReferenceCode = RandomTestUtil.randomString();
 
 		_sharingEntryLocalService.addSharingEntry(
-			externalReferenceCode, 0, _fromUser.getUserId(),
+			externalReferenceCode, _fromUser.getUserId(), 0,
 			_toUser.getUserId(), _classNameId, _group.getGroupId(),
 			_group.getGroupId(), true, Arrays.asList(SharingEntryAction.VIEW),
 			null, _serviceContext);
 
 		_sharingEntryLocalService.addSharingEntry(
-			externalReferenceCode, 0, _fromUser.getUserId(),
+			externalReferenceCode, _fromUser.getUserId(), 0,
 			_toUser.getUserId(), _classNameId, _group.getGroupId(),
 			_group.getGroupId(), true, Arrays.asList(SharingEntryAction.VIEW),
 			null, _serviceContext);
@@ -1113,5 +1194,8 @@ public class SharingEntryLocalServiceTest {
 
 	@DeleteAfterTestRun
 	private User _user;
+
+	@Inject
+	private UserGroupLocalService _userGroupLocalService;
 
 }

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/test/SharingEntryServiceTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/test/SharingEntryServiceTest.java
@@ -106,7 +106,7 @@ public class SharingEntryServiceTest {
 
 		SharingEntry sharingEntry =
 			_sharingEntryService.addOrUpdateSharingEntry(
-				null, _toUser.getUserId(), _classNameId, _group.getGroupId(),
+				null, 0, _toUser.getUserId(), _classNameId, _group.getGroupId(),
 				_group.getGroupId(), true,
 				Collections.singletonList(SharingEntryAction.VIEW),
 				expirationDate, _serviceContext);
@@ -133,7 +133,7 @@ public class SharingEntryServiceTest {
 		Date expirationDate = Date.from(instant.plus(2, ChronoUnit.DAYS));
 
 		SharingEntry addSharingEntry = _sharingEntryService.addSharingEntry(
-			null, _toUser.getUserId(), _classNameId, _group.getGroupId(),
+			null, 0, _toUser.getUserId(), _classNameId, _group.getGroupId(),
 			_group.getGroupId(), true,
 			Collections.singletonList(SharingEntryAction.VIEW), expirationDate,
 			_serviceContext);
@@ -147,7 +147,7 @@ public class SharingEntryServiceTest {
 
 		SharingEntry updateSharingEntry =
 			_sharingEntryService.addOrUpdateSharingEntry(
-				null, _toUser.getUserId(), _classNameId, _group.getGroupId(),
+				null, 0, _toUser.getUserId(), _classNameId, _group.getGroupId(),
 				_group.getGroupId(), false,
 				Arrays.asList(
 					SharingEntryAction.VIEW, SharingEntryAction.UPDATE),
@@ -171,7 +171,7 @@ public class SharingEntryServiceTest {
 			SharingEntryAction.UPDATE, SharingEntryAction.VIEW);
 
 		_sharingEntryService.addOrUpdateSharingEntry(
-			null, _toUser.getUserId(), _classNameId, _group.getGroupId(),
+			null, _toUser.getUserId(), 0, _classNameId, _group.getGroupId(),
 			_group.getGroupId(), true, Collections.emptyList(), null,
 			_serviceContext);
 	}
@@ -187,7 +187,7 @@ public class SharingEntryServiceTest {
 		Date expirationDate = Date.from(instant.minus(2, ChronoUnit.DAYS));
 
 		_sharingEntryService.addOrUpdateSharingEntry(
-			null, _toUser.getUserId(), _classNameId, _group.getGroupId(),
+			null, 0, _toUser.getUserId(), _classNameId, _group.getGroupId(),
 			_group.getGroupId(), true,
 			Collections.singletonList(SharingEntryAction.VIEW), expirationDate,
 			_serviceContext);
@@ -202,7 +202,7 @@ public class SharingEntryServiceTest {
 		String externalReferenceCode = RandomTestUtil.randomString();
 
 		_sharingEntryService.addOrUpdateSharingEntry(
-			externalReferenceCode, _toUser.getUserId(), _classNameId,
+			externalReferenceCode, 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
 
@@ -224,12 +224,12 @@ public class SharingEntryServiceTest {
 		String externalReferenceCode = RandomTestUtil.randomString();
 
 		_sharingEntryService.addSharingEntry(
-			externalReferenceCode, _toUser.getUserId(), _classNameId,
+			externalReferenceCode, 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
 
 		_sharingEntryService.addSharingEntry(
-			externalReferenceCode, _toUser.getUserId(), _classNameId,
+			externalReferenceCode, 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
 	}
@@ -243,7 +243,7 @@ public class SharingEntryServiceTest {
 		String externalReferenceCode = RandomTestUtil.randomString();
 
 		_sharingEntryService.addSharingEntry(
-			externalReferenceCode, _toUser.getUserId(), _classNameId,
+			externalReferenceCode, 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
 
@@ -266,7 +266,7 @@ public class SharingEntryServiceTest {
 			"InvalidClassName");
 
 		_sharingEntryService.addSharingEntry(
-			null, _toUser.getUserId(), invalidClassName.getClassNameId(),
+			null, 0, _toUser.getUserId(), invalidClassName.getClassNameId(),
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
 			null, _serviceContext);
@@ -280,7 +280,7 @@ public class SharingEntryServiceTest {
 			SharingEntryAction.UPDATE, SharingEntryAction.VIEW);
 
 		SharingEntry sharingEntry = _sharingEntryService.addSharingEntry(
-			null, _toUser.getUserId(), _classNameId, _group.getGroupId(),
+			null, 0, _toUser.getUserId(), _classNameId, _group.getGroupId(),
 			_group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
 			null, _serviceContext);
@@ -301,14 +301,14 @@ public class SharingEntryServiceTest {
 		_registerSharingPermissionChecker(SharingEntryAction.VIEW);
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, _user.getUserId(), _fromUser.getUserId(), _classNameId,
+			null, _user.getUserId(), 0, _fromUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(
 				SharingEntryAction.ADD_DISCUSSION, SharingEntryAction.VIEW),
 			null, _serviceContext);
 
 		_sharingEntryService.addSharingEntry(
-			null, _toUser.getUserId(), _classNameId, _group.getGroupId(),
+			null, 0, _toUser.getUserId(), _classNameId, _group.getGroupId(),
 			_group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
 			null, _serviceContext);
@@ -321,13 +321,13 @@ public class SharingEntryServiceTest {
 		_registerSharingPermissionChecker(SharingEntryAction.VIEW);
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, _user.getUserId(), _fromUser.getUserId(), _classNameId,
+			null, _user.getUserId(), 0, _fromUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
 			null, _serviceContext);
 
 		_sharingEntryService.addSharingEntry(
-			null, _toUser.getUserId(), _classNameId, _group.getGroupId(),
+			null, 0, _toUser.getUserId(), _classNameId, _group.getGroupId(),
 			_group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
 			null, _serviceContext);
@@ -340,13 +340,13 @@ public class SharingEntryServiceTest {
 		_registerSharingPermissionChecker(SharingEntryAction.VIEW);
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, _user.getUserId(), _fromUser.getUserId(), _classNameId,
+			null, _user.getUserId(), 0, _fromUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), false,
 			Arrays.asList(SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
 			null, _serviceContext);
 
 		_sharingEntryService.addSharingEntry(
-			null, _toUser.getUserId(), _classNameId, _group.getGroupId(),
+			null, 0, _toUser.getUserId(), _classNameId, _group.getGroupId(),
 			_group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
 			null, _serviceContext);
@@ -359,13 +359,13 @@ public class SharingEntryServiceTest {
 		_registerSharingPermissionChecker(SharingEntryAction.UPDATE);
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, _user.getUserId(), _fromUser.getUserId(), _classNameId,
+			null, _user.getUserId(), 0, _fromUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Collections.singletonList(SharingEntryAction.VIEW), null,
 			_serviceContext);
 
 		_sharingEntryService.addSharingEntry(
-			null, _toUser.getUserId(), _classNameId, _group.getGroupId(),
+			null, 0, _toUser.getUserId(), _classNameId, _group.getGroupId(),
 			_group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
 			null, _serviceContext);
@@ -378,7 +378,7 @@ public class SharingEntryServiceTest {
 		_registerSharingPermissionChecker(SharingEntryAction.VIEW);
 
 		_sharingEntryService.addSharingEntry(
-			null, _toUser.getUserId(), _classNameId, _group.getGroupId(),
+			null, 0, _toUser.getUserId(), _classNameId, _group.getGroupId(),
 			_group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
 			null, _serviceContext);
@@ -391,7 +391,7 @@ public class SharingEntryServiceTest {
 		_registerSharingPermissionChecker(SharingEntryAction.VIEW);
 
 		_sharingEntryService.addSharingEntry(
-			null, _toUser.getUserId(), _classNameId, _group.getGroupId(),
+			null, 0, _toUser.getUserId(), _classNameId, _group.getGroupId(),
 			_group.getGroupId(), true,
 			Collections.singletonList(SharingEntryAction.UPDATE), null,
 			_serviceContext);
@@ -402,7 +402,7 @@ public class SharingEntryServiceTest {
 		_registerSharingPermissionChecker(SharingEntryAction.VIEW);
 
 		SharingEntry sharingEntry = _sharingEntryService.addSharingEntry(
-			null, _toUser.getUserId(), _classNameId, _group.getGroupId(),
+			null, 0, _toUser.getUserId(), _classNameId, _group.getGroupId(),
 			_group.getGroupId(), true,
 			Collections.singletonList(SharingEntryAction.VIEW), null,
 			_serviceContext);
@@ -423,13 +423,13 @@ public class SharingEntryServiceTest {
 		_registerSharingPermissionChecker(SharingEntryAction.VIEW);
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, _user.getUserId(), _fromUser.getUserId(), _classNameId,
+			null, _user.getUserId(), 0, _fromUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.UPDATE, SharingEntryAction.VIEW),
 			null, _serviceContext);
 
 		_sharingEntryService.addSharingEntry(
-			null, _toUser.getUserId(), _classNameId, _group.getGroupId(),
+			null, 0, _toUser.getUserId(), _classNameId, _group.getGroupId(),
 			_group.getGroupId(), true,
 			Collections.singletonList(SharingEntryAction.VIEW), null,
 			_serviceContext);
@@ -442,13 +442,13 @@ public class SharingEntryServiceTest {
 		_registerSharingPermissionChecker(SharingEntryAction.VIEW);
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, _user.getUserId(), _fromUser.getUserId(), _classNameId,
+			null, _user.getUserId(), 0, _fromUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), true,
 			Collections.singletonList(SharingEntryAction.VIEW), null,
 			_serviceContext);
 
 		_sharingEntryService.addSharingEntry(
-			null, _toUser.getUserId(), _classNameId, _group.getGroupId(),
+			null, 0, _toUser.getUserId(), _classNameId, _group.getGroupId(),
 			_group.getGroupId(), true,
 			Collections.singletonList(SharingEntryAction.VIEW), null,
 			_serviceContext);
@@ -461,13 +461,13 @@ public class SharingEntryServiceTest {
 		_registerSharingPermissionChecker(SharingEntryAction.VIEW);
 
 		_sharingEntryLocalService.addSharingEntry(
-			null, _user.getUserId(), _fromUser.getUserId(), _classNameId,
+			null, _user.getUserId(), 0, _fromUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), false,
 			Collections.singletonList(SharingEntryAction.VIEW), null,
 			_serviceContext);
 
 		_sharingEntryService.addSharingEntry(
-			null, _toUser.getUserId(), _classNameId, _group.getGroupId(),
+			null, 0, _toUser.getUserId(), _classNameId, _group.getGroupId(),
 			_group.getGroupId(), true,
 			Collections.singletonList(SharingEntryAction.VIEW), null,
 			_serviceContext);
@@ -488,7 +488,7 @@ public class SharingEntryServiceTest {
 		_registerSharingPermissionChecker(SharingEntryAction.VIEW);
 
 		SharingEntry sharingEntry = _sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), false,
 			Collections.singletonList(SharingEntryAction.VIEW), null,
 			_serviceContext);
@@ -510,9 +510,10 @@ public class SharingEntryServiceTest {
 		String externalReferenceCode = RandomTestUtil.randomString();
 
 		_sharingEntryLocalService.addSharingEntry(
-			externalReferenceCode, _fromUser.getUserId(), _toUser.getUserId(),
-			_classNameId, _group.getGroupId(), _group.getGroupId(), true,
-			Arrays.asList(SharingEntryAction.VIEW), null, _serviceContext);
+			externalReferenceCode, _fromUser.getUserId(), 0,
+			_toUser.getUserId(), _classNameId, _group.getGroupId(),
+			_group.getGroupId(), true, Arrays.asList(SharingEntryAction.VIEW),
+			null, _serviceContext);
 
 		Assert.assertNotNull(
 			_sharingEntryLocalService.fetchSharingEntryByExternalReferenceCode(
@@ -541,7 +542,7 @@ public class SharingEntryServiceTest {
 		_registerSharingPermissionChecker(SharingEntryAction.VIEW);
 
 		SharingEntry sharingEntry = _sharingEntryLocalService.addSharingEntry(
-			null, _fromUser.getUserId(), _toUser.getUserId(), _classNameId,
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
 			_group.getGroupId(), _group.getGroupId(), false,
 			Collections.singletonList(SharingEntryAction.VIEW), null,
 			_serviceContext);
@@ -562,7 +563,7 @@ public class SharingEntryServiceTest {
 			SharingEntryAction.UPDATE, SharingEntryAction.VIEW);
 
 		SharingEntry sharingEntry = _sharingEntryService.addSharingEntry(
-			null, _toUser.getUserId(), _classNameId, _group.getGroupId(),
+			null, 0, _toUser.getUserId(), _classNameId, _group.getGroupId(),
 			_group.getGroupId(), true,
 			Collections.singletonList(SharingEntryAction.VIEW), null,
 			_serviceContext);
@@ -585,7 +586,7 @@ public class SharingEntryServiceTest {
 			SharingEntryAction.UPDATE, SharingEntryAction.VIEW);
 
 		SharingEntry sharingEntry = _sharingEntryService.addSharingEntry(
-			null, _toUser.getUserId(), _classNameId, _group.getGroupId(),
+			null, 0, _toUser.getUserId(), _classNameId, _group.getGroupId(),
 			_group.getGroupId(), true,
 			Collections.singletonList(SharingEntryAction.VIEW), null,
 			_serviceContext);
@@ -612,7 +613,7 @@ public class SharingEntryServiceTest {
 			SharingEntryAction.UPDATE, SharingEntryAction.VIEW);
 
 		SharingEntry sharingEntry = _sharingEntryService.addSharingEntry(
-			null, _toUser.getUserId(), _classNameId, _group.getGroupId(),
+			null, 0, _toUser.getUserId(), _classNameId, _group.getGroupId(),
 			_group.getGroupId(), true,
 			Collections.singletonList(SharingEntryAction.VIEW), null,
 			_serviceContext);
@@ -635,7 +636,7 @@ public class SharingEntryServiceTest {
 			SharingEntryAction.UPDATE, SharingEntryAction.VIEW);
 
 		SharingEntry sharingEntry = _sharingEntryService.addSharingEntry(
-			null, _toUser.getUserId(), _classNameId, _group.getGroupId(),
+			null, 0, _toUser.getUserId(), _classNameId, _group.getGroupId(),
 			_group.getGroupId(), true,
 			Collections.singletonList(SharingEntryAction.VIEW), null,
 			_serviceContext);
@@ -662,7 +663,7 @@ public class SharingEntryServiceTest {
 		_registerSharingPermissionChecker(SharingEntryAction.VIEW);
 
 		SharingEntry sharingEntry = _sharingEntryService.addSharingEntry(
-			null, _toUser.getUserId(), _classNameId, _group.getGroupId(),
+			null, 0, _toUser.getUserId(), _classNameId, _group.getGroupId(),
 			_group.getGroupId(), true,
 			Collections.singletonList(SharingEntryAction.VIEW), null,
 			_serviceContext);
@@ -682,7 +683,7 @@ public class SharingEntryServiceTest {
 		_registerSharingPermissionChecker(SharingEntryAction.VIEW);
 
 		SharingEntry sharingEntry = _sharingEntryService.addSharingEntry(
-			null, _toUser.getUserId(), _classNameId, _group.getGroupId(),
+			null, 0, _toUser.getUserId(), _classNameId, _group.getGroupId(),
 			_group.getGroupId(), true,
 			Collections.singletonList(SharingEntryAction.VIEW), null,
 			_serviceContext);

--- a/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/portlet/action/ShareEntryMVCActionCommand.java
+++ b/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/portlet/action/ShareEntryMVCActionCommand.java
@@ -92,7 +92,7 @@ public class ShareEntryMVCActionCommand extends BaseMVCActionCommand {
 							(user.getUserId() != themeDisplay.getUserId())) {
 
 							_sharingEntryService.addOrUpdateSharingEntry(
-								null, user.getUserId(), classNameId, classPK,
+								null, 0, user.getUserId(), classNameId, classPK,
 								themeDisplay.getScopeGroupId(), shareable,
 								sharingEntryPermissionDisplayAction.
 									getSharingEntryActions(),


### PR DESCRIPTION
Hi @brianchandotcom ,

I send the PR again making the changes you requested me [here](https://github.com/brianchandotcom/liferay-portal/pull/159996#issuecomment-2733486547).

Regards!

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-51094

# How am I fixing it?

Support sharing for user groups. Include new toAssetGroupId and take into account it to share for all users belongs to the user group. So for that, we are  

1. Save the user group for the shared entry
2. Send a user notification for all user belongs to the user
3. Contribute the information of the shared user groups  for an asset in order to search asset for an user shared to the user group to which it belongs
4. The api does not allow to create a shared entry in the same time for a user and a user group, in that case an expection is trowed
5. Contribute user group shared entries when we are checking permissions for an asset, for example for a dl file entry.

# How can you verify that it works?

Run included tests

# Notes

I have added commits from[ LPD-51094](https://github.com/liferay-content-management/liferay-portal/pull/6460) to avoid conflicts