### PR TITLE
LPD-51419 Site initializer breaks when adding noninstanceable widget in other segments experience

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/internal/model/listener/FragmentEntryLinkModelListener.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/internal/model/listener/FragmentEntryLinkModelListener.java
@@ -5,7 +5,6 @@
 
 package com.liferay.fragment.entry.processor.portlet.internal.model.listener;
 
-import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.processor.PortletRegistry;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
@@ -39,10 +38,6 @@ public class FragmentEntryLinkModelListener
 	@Override
 	public void onAfterRemove(FragmentEntryLink fragmentEntryLink)
 		throws ModelListenerException {
-
-		if (ExportImportThreadLocal.isImportInProcess()) {
-			return;
-		}
 
 		List<String> portletIds =
 			_portletRegistry.getFragmentEntryLinkPortletIds(fragmentEntryLink);

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
@@ -373,8 +373,7 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 			new WidgetLayoutStructureItemImporter(
 				_fragmentEntryLinkLocalService, _fragmentEntryProcessorRegistry,
 				_portletConfigurationImporterHelper, _portletLocalService,
-				_portletPermissionsImporterHelper, _portletRegistry,
-				_segmentsExperienceLocalService));
+				_portletPermissionsImporterHelper, _portletRegistry));
 	}
 
 	private void _addClientExtensionEntryRel(

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
@@ -20,6 +20,7 @@ import com.liferay.fragment.listener.FragmentEntryLinkListener;
 import com.liferay.fragment.listener.FragmentEntryLinkListenerRegistry;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.processor.FragmentEntryProcessorRegistry;
+import com.liferay.fragment.processor.PortletRegistry;
 import com.liferay.fragment.renderer.FragmentRendererRegistry;
 import com.liferay.fragment.service.FragmentCollectionLocalService;
 import com.liferay.fragment.service.FragmentCollectionService;
@@ -372,8 +373,7 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 			new WidgetLayoutStructureItemImporter(
 				_fragmentEntryLinkLocalService, _fragmentEntryProcessorRegistry,
 				_portletConfigurationImporterHelper, _portletLocalService,
-				_portletPermissionsImporterHelper,
-				_portletPreferencesLocalService,
+				_portletPermissionsImporterHelper, _portletRegistry,
 				_segmentsExperienceLocalService));
 	}
 
@@ -2442,6 +2442,9 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 
 	@Reference
 	private PortletPreferencesLocalService _portletPreferencesLocalService;
+
+	@Reference
+	private PortletRegistry _portletRegistry;
 
 	@Reference
 	private SegmentsExperienceLocalService _segmentsExperienceLocalService;

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/WidgetLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/WidgetLayoutStructureItemImporter.java
@@ -30,7 +30,6 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.segments.service.SegmentsExperienceLocalService;
 
 import java.util.HashSet;
 import java.util.List;
@@ -51,8 +50,7 @@ public class WidgetLayoutStructureItemImporter
 		PortletConfigurationImporterHelper portletConfigurationImporterHelper,
 		PortletLocalService portletLocalService,
 		PortletPermissionsImporterHelper portletPermissionsImporterHelper,
-		PortletRegistry portletRegistry,
-		SegmentsExperienceLocalService segmentsExperienceLocalService) {
+		PortletRegistry portletRegistry) {
 
 		_fragmentEntryLinkLocalService = fragmentEntryLinkLocalService;
 		_fragmentEntryProcessorRegistry = fragmentEntryProcessorRegistry;
@@ -61,7 +59,6 @@ public class WidgetLayoutStructureItemImporter
 		_portletLocalService = portletLocalService;
 		_portletPermissionsImporterHelper = portletPermissionsImporterHelper;
 		_portletRegistry = portletRegistry;
-		_segmentsExperienceLocalService = segmentsExperienceLocalService;
 	}
 
 	@Override
@@ -74,6 +71,7 @@ public class WidgetLayoutStructureItemImporter
 
 		FragmentEntryLink fragmentEntryLink = _addFragmentEntryLink(
 			layoutStructureItemImporterContext.getLayout(), pageElement,
+			layoutStructureItemImporterContext.getSegmentsExperienceId(),
 			warningMessages);
 
 		if (fragmentEntryLink == null) {
@@ -160,7 +158,8 @@ public class WidgetLayoutStructureItemImporter
 	}
 
 	private FragmentEntryLink _addFragmentEntryLink(
-			Layout layout, PageElement pageElement, Set<String> warningMessages)
+			Layout layout, PageElement pageElement, long segmentsExperienceId,
+			Set<String> warningMessages)
 		throws Exception {
 
 		Map<String, Object> definitionMap = getDefinitionMap(
@@ -200,10 +199,6 @@ public class WidgetLayoutStructureItemImporter
 		if (Validator.isNull(widgetInstanceId)) {
 			widgetInstanceId = StringUtil.randomId();
 		}
-
-		long segmentsExperienceId =
-			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
-				layout.getPlid());
 
 		widgetInstanceId = _getPortletInstanceId(
 			layout, portlet, widgetInstanceId, segmentsExperienceId);
@@ -282,7 +277,5 @@ public class WidgetLayoutStructureItemImporter
 	private final PortletPermissionsImporterHelper
 		_portletPermissionsImporterHelper;
 	private final PortletRegistry _portletRegistry;
-	private final SegmentsExperienceLocalService
-		_segmentsExperienceLocalService;
 
 }

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/WidgetLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/WidgetLayoutStructureItemImporter.java
@@ -8,6 +8,7 @@ package com.liferay.layout.internal.importer.structure.util;
 import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.processor.FragmentEntryProcessorRegistry;
+import com.liferay.fragment.processor.PortletRegistry;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.headless.delivery.dto.v1_0.PageElement;
 import com.liferay.layout.internal.importer.LayoutStructureItemImporterContext;
@@ -24,11 +25,9 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.service.PortletLocalService;
-import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
@@ -36,6 +35,7 @@ import com.liferay.segments.service.SegmentsExperienceLocalService;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -51,7 +51,7 @@ public class WidgetLayoutStructureItemImporter
 		PortletConfigurationImporterHelper portletConfigurationImporterHelper,
 		PortletLocalService portletLocalService,
 		PortletPermissionsImporterHelper portletPermissionsImporterHelper,
-		PortletPreferencesLocalService portletPreferencesLocalService,
+		PortletRegistry portletRegistry,
 		SegmentsExperienceLocalService segmentsExperienceLocalService) {
 
 		_fragmentEntryLinkLocalService = fragmentEntryLinkLocalService;
@@ -60,7 +60,7 @@ public class WidgetLayoutStructureItemImporter
 			portletConfigurationImporterHelper;
 		_portletLocalService = portletLocalService;
 		_portletPermissionsImporterHelper = portletPermissionsImporterHelper;
-		_portletPreferencesLocalService = portletPreferencesLocalService;
+		_portletRegistry = portletRegistry;
 		_segmentsExperienceLocalService = segmentsExperienceLocalService;
 	}
 
@@ -201,8 +201,12 @@ public class WidgetLayoutStructureItemImporter
 			widgetInstanceId = StringUtil.randomId();
 		}
 
+		long segmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				layout.getPlid());
+
 		widgetInstanceId = _getPortletInstanceId(
-			layout, portlet, widgetInstanceId);
+			layout, portlet, widgetInstanceId, segmentsExperienceId);
 
 		editableValueJSONObject.put(
 			"instanceId", widgetInstanceId
@@ -231,29 +235,39 @@ public class WidgetLayoutStructureItemImporter
 
 		return _fragmentEntryLinkLocalService.addFragmentEntryLink(
 			null, serviceContext.getUserId(), layout.getGroupId(), 0, 0,
-			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
-				layout.getPlid()),
-			layout.getPlid(), StringPool.BLANK, StringPool.BLANK,
-			StringPool.BLANK, StringPool.BLANK,
+			segmentsExperienceId, layout.getPlid(), StringPool.BLANK,
+			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			editableValueJSONObject.toString(), widgetInstanceId, 0, null,
 			FragmentConstants.TYPE_PORTLET, serviceContext);
 	}
 
 	private String _getPortletInstanceId(
-			Layout layout, Portlet portlet, String portletInstanceId)
+			Layout layout, Portlet portlet, String portletInstanceId,
+			long segmentsExperienceId)
 		throws Exception {
 
 		if (portlet.isInstanceable()) {
 			return portletInstanceId;
 		}
 
-		long count = _portletPreferencesLocalService.getPortletPreferencesCount(
-			PortletKeys.PREFS_OWNER_TYPE_LAYOUT, layout.getPlid(),
-			portlet.getPortletId());
+		for (FragmentEntryLink fragmentEntryLink :
+				_fragmentEntryLinkLocalService.
+					getFragmentEntryLinksBySegmentsExperienceId(
+						layout.getGroupId(), segmentsExperienceId,
+						layout.getPlid(), false)) {
 
-		if (count > 0) {
-			throw new PortletIdException(
-				"Unable to add uninstanceable portlet more than once");
+			for (String portletId :
+					_portletRegistry.getFragmentEntryLinkPortletIds(
+						null, fragmentEntryLink)) {
+
+				if (Objects.equals(
+						PortletIdCodec.decodePortletName(portletId),
+						portlet.getPortletName())) {
+
+					throw new PortletIdException(
+						"Unable to add uninstanceable portlet more than once");
+				}
+			}
 		}
 
 		return StringPool.BLANK;
@@ -267,8 +281,7 @@ public class WidgetLayoutStructureItemImporter
 	private final PortletLocalService _portletLocalService;
 	private final PortletPermissionsImporterHelper
 		_portletPermissionsImporterHelper;
-	private final PortletPreferencesLocalService
-		_portletPreferencesLocalService;
+	private final PortletRegistry _portletRegistry;
 	private final SegmentsExperienceLocalService
 		_segmentsExperienceLocalService;
 

--- a/modules/apps/layout/layout-page-template-admin-web-test/build.gradle
+++ b/modules/apps/layout/layout-page-template-admin-web-test/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	testIntegrationImplementation group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.18.2"
 	testIntegrationImplementation group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.18.2"
 	testIntegrationImplementation group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	testIntegrationImplementation group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	testIntegrationImplementation project(":apps:application-list:application-list-api")
 	testIntegrationImplementation project(":apps:asset:asset-display-page-api")
 	testIntegrationImplementation project(":apps:asset:asset-list-api")

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
@@ -33,18 +33,22 @@ import com.liferay.layout.exporter.LayoutsExporter;
 import com.liferay.layout.importer.LayoutsImportStrategy;
 import com.liferay.layout.importer.LayoutsImporter;
 import com.liferay.layout.importer.LayoutsImporterResultEntry;
+import com.liferay.layout.page.template.admin.web.internal.portlet.constants.LayoutPageTemplateAdminWebPortletKeys;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateCollectionTypeConstants;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRel;
 import com.liferay.layout.page.template.service.LayoutPageTemplateCollectionLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelLocalService;
 import com.liferay.layout.page.template.test.util.LayoutPageTemplateTestUtil;
 import com.liferay.layout.provider.LayoutStructureProvider;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.layout.util.structure.ColumnLayoutStructureItem;
 import com.liferay.layout.util.structure.ContainerStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
@@ -75,6 +79,7 @@ import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
@@ -99,6 +104,7 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.zip.ZipWriter;
@@ -106,6 +112,7 @@ import com.liferay.portal.kernel.zip.ZipWriterFactory;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.segments.model.SegmentsExperience;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
 import com.liferay.style.book.model.StyleBookEntry;
 import com.liferay.style.book.service.StyleBookEntryLocalService;
@@ -685,6 +692,109 @@ public class LayoutsImporterTest {
 		_assertLayoutPageTemplateEntry(
 			configurationJSONObject, editableValuesJSONObject, curFragmentEntry,
 			_getLayoutPageTemplateEntryKey(layoutsImporterResultEntries));
+	}
+
+	@Test
+	@TestInfo("LPD-51419")
+	public void testImportLayoutWithSegmentExperiencesWithNoninstanceablePortlet()
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group1);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		ContentLayoutTestUtil.addPortletToLayout(
+			draftLayout,
+			LayoutPageTemplateAdminWebPortletKeys.
+				LAYOUT_PAGE_TEMPLATE_ADMIN_WEB_NONINSTANCEABLE_TEST_PORTLET);
+
+		Assert.assertEquals(
+			1,
+			_fragmentEntryLinkLocalService.getFragmentEntryLinksCountByPlid(
+				draftLayout.getGroupId(), draftLayout.getPlid()));
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.addSegmentsExperience(
+				null, TestPropsValues.getUserId(), _group1.getGroupId(), 0,
+				draftLayout.getPlid(), RandomTestUtil.randomLocaleStringMap(),
+				false, new UnicodeProperties(true), _serviceContext1);
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			_layoutPageTemplateStructureLocalService.
+				fetchLayoutPageTemplateStructure(
+					draftLayout.getGroupId(), draftLayout.getPlid());
+
+		LayoutPageTemplateStructureRel layoutPageTemplateStructureRel =
+			_layoutPageTemplateStructureRelLocalService.
+				fetchLayoutPageTemplateStructureRel(
+					layoutPageTemplateStructure.
+						getLayoutPageTemplateStructureId(),
+					segmentsExperience.getSegmentsExperienceId());
+
+		if (layoutPageTemplateStructureRel == null) {
+			layoutPageTemplateStructureRel =
+				_layoutPageTemplateStructureRelLocalService.
+					addLayoutPageTemplateStructureRel(
+						PrincipalThreadLocal.getUserId(),
+						draftLayout.getGroupId(),
+						layoutPageTemplateStructure.
+							getLayoutPageTemplateStructureId(),
+						segmentsExperience.getSegmentsExperienceId(),
+						StringPool.BLANK, _serviceContext1);
+		}
+
+		LayoutStructure layoutStructure = LayoutStructure.of(
+			layoutPageTemplateStructureRel.getData());
+
+		ServiceContextThreadLocal.pushServiceContext(_serviceContext1);
+
+		try {
+			_layoutsImporter.importPageElement(
+				draftLayout, layoutStructure, layoutStructure.getMainItemId(),
+				JSONUtil.put(
+					"definition",
+					JSONUtil.put(
+						"widgetInstance",
+						JSONUtil.put(
+							"widgetName",
+							LayoutPageTemplateAdminWebPortletKeys.
+								LAYOUT_PAGE_TEMPLATE_ADMIN_WEB_NONINSTANCEABLE_TEST_PORTLET))
+				).put(
+					"type", "Widget"
+				).toString(),
+				0, true, segmentsExperience.getSegmentsExperienceId());
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
+
+		Assert.assertEquals(
+			2,
+			_fragmentEntryLinkLocalService.getFragmentEntryLinksCountByPlid(
+				draftLayout.getGroupId(), draftLayout.getPlid()));
+
+		List<FragmentEntryLink> fragmentEntryLinks =
+			_fragmentEntryLinkLocalService.
+				getFragmentEntryLinksBySegmentsExperienceId(
+					draftLayout.getGroupId(),
+					segmentsExperience.getSegmentsExperienceId(),
+					draftLayout.getPlid());
+
+		Assert.assertEquals(
+			fragmentEntryLinks.toString(), 1, fragmentEntryLinks.size());
+
+		FragmentEntryLink fragmentEntryLink = fragmentEntryLinks.get(0);
+
+		Assert.assertEquals(
+			FragmentConstants.TYPE_PORTLET, fragmentEntryLink.getType());
+
+		JSONObject jsonObject = _jsonFactory.createJSONObject(
+			fragmentEntryLink.getEditableValues());
+
+		Assert.assertEquals(
+			LayoutPageTemplateAdminWebPortletKeys.
+				LAYOUT_PAGE_TEMPLATE_ADMIN_WEB_NONINSTANCEABLE_TEST_PORTLET,
+			jsonObject.getString("portletId"));
 	}
 
 	@Test
@@ -1914,6 +2024,10 @@ public class LayoutsImporterTest {
 	@Inject
 	private LayoutPageTemplateStructureLocalService
 		_layoutPageTemplateStructureLocalService;
+
+	@Inject
+	private LayoutPageTemplateStructureRelLocalService
+		_layoutPageTemplateStructureRelLocalService;
 
 	@Inject
 	private LayoutsExporter _layoutsExporter;

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
@@ -64,10 +64,13 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
+import com.liferay.portal.kernel.exception.PortletIdException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -713,16 +716,51 @@ public class LayoutsImporterTest {
 			_fragmentEntryLinkLocalService.getFragmentEntryLinksCountByPlid(
 				draftLayout.getGroupId(), draftLayout.getPlid()));
 
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			_layoutPageTemplateStructureLocalService.
+				fetchLayoutPageTemplateStructure(
+					draftLayout.getGroupId(), draftLayout.getPlid());
+
+		LayoutStructure layoutStructure = LayoutStructure.of(
+			layoutPageTemplateStructure.getDefaultSegmentsExperienceData());
+
+		String pageElementJSON = JSONUtil.put(
+			"definition",
+			JSONUtil.put(
+				"widgetInstance",
+				JSONUtil.put(
+					"widgetName",
+					LayoutPageTemplateAdminWebPortletKeys.
+						LAYOUT_PAGE_TEMPLATE_ADMIN_WEB_NONINSTANCEABLE_TEST_PORTLET))
+		).put(
+			"type", "Widget"
+		).toString();
+
+		ServiceContextThreadLocal.pushServiceContext(_serviceContext1);
+
+		try {
+			_layoutsImporter.importPageElement(
+				draftLayout, layoutStructure, layoutStructure.getMainItemId(),
+				pageElementJSON, 0, true,
+				_segmentsExperienceLocalService.
+					fetchDefaultSegmentsExperienceId(draftLayout.getPlid()));
+
+			Assert.fail();
+		}
+		catch (PortletIdException portletIdException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portletIdException);
+			}
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
+
 		SegmentsExperience segmentsExperience =
 			_segmentsExperienceLocalService.addSegmentsExperience(
 				null, TestPropsValues.getUserId(), _group1.getGroupId(), 0,
 				draftLayout.getPlid(), RandomTestUtil.randomLocaleStringMap(),
 				false, new UnicodeProperties(true), _serviceContext1);
-
-		LayoutPageTemplateStructure layoutPageTemplateStructure =
-			_layoutPageTemplateStructureLocalService.
-				fetchLayoutPageTemplateStructure(
-					draftLayout.getGroupId(), draftLayout.getPlid());
 
 		LayoutPageTemplateStructureRel layoutPageTemplateStructureRel =
 			_layoutPageTemplateStructureRelLocalService.
@@ -743,7 +781,7 @@ public class LayoutsImporterTest {
 						StringPool.BLANK, _serviceContext1);
 		}
 
-		LayoutStructure layoutStructure = LayoutStructure.of(
+		layoutStructure = LayoutStructure.of(
 			layoutPageTemplateStructureRel.getData());
 
 		ServiceContextThreadLocal.pushServiceContext(_serviceContext1);
@@ -751,18 +789,8 @@ public class LayoutsImporterTest {
 		try {
 			_layoutsImporter.importPageElement(
 				draftLayout, layoutStructure, layoutStructure.getMainItemId(),
-				JSONUtil.put(
-					"definition",
-					JSONUtil.put(
-						"widgetInstance",
-						JSONUtil.put(
-							"widgetName",
-							LayoutPageTemplateAdminWebPortletKeys.
-								LAYOUT_PAGE_TEMPLATE_ADMIN_WEB_NONINSTANCEABLE_TEST_PORTLET))
-				).put(
-					"type", "Widget"
-				).toString(),
-				0, true, segmentsExperience.getSegmentsExperienceId());
+				pageElementJSON, 0, true,
+				segmentsExperience.getSegmentsExperienceId());
 		}
 		finally {
 			ServiceContextThreadLocal.popServiceContext();
@@ -795,6 +823,25 @@ public class LayoutsImporterTest {
 			LayoutPageTemplateAdminWebPortletKeys.
 				LAYOUT_PAGE_TEMPLATE_ADMIN_WEB_NONINSTANCEABLE_TEST_PORTLET,
 			jsonObject.getString("portletId"));
+
+		ServiceContextThreadLocal.pushServiceContext(_serviceContext1);
+
+		try {
+			_layoutsImporter.importPageElement(
+				draftLayout, layoutStructure, layoutStructure.getMainItemId(),
+				pageElementJSON, 0, true,
+				segmentsExperience.getSegmentsExperienceId());
+
+			Assert.fail();
+		}
+		catch (PortletIdException portletIdException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portletIdException);
+			}
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
 	}
 
 	@Test
@@ -1972,6 +2019,9 @@ public class LayoutsImporterTest {
 	private static final String _RESOURCES_PATH_PAGE_TEMPLATES =
 		"com/liferay/layout/page/template/admin/web/internal/importer/test" +
 			"/dependencies/page-templates";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		LayoutsImporterTest.class);
 
 	@Inject
 	private AssetListEntryLocalService _assetListEntryLocalService;

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/LayoutPageTemplateAdminWebNoninstanceableTestPortlet.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/LayoutPageTemplateAdminWebNoninstanceableTestPortlet.java
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.page.template.admin.web.internal.portlet;
+
+import com.liferay.layout.page.template.admin.web.internal.portlet.constants.LayoutPageTemplateAdminWebPortletKeys;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+
+import javax.portlet.Portlet;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+@Component(
+	property = {
+		"com.liferay.portlet.add-default-resource=true",
+		"com.liferay.portlet.instanceable=false",
+		"com.liferay.portlet.preferences-owned-by-group=true",
+		"com.liferay.portlet.scopeable=true",
+		"javax.portlet.display-name=Noninstanciable Test",
+		"javax.portlet.expiration-cache=0",
+		"javax.portlet.init-param.template-path=/META-INF/resources/",
+		"javax.portlet.init-param.view-template=/view.jsp",
+		"javax.portlet.name=" + LayoutPageTemplateAdminWebPortletKeys.LAYOUT_PAGE_TEMPLATE_ADMIN_WEB_NONINSTANCEABLE_TEST_PORTLET,
+		"javax.portlet.version=3.0"
+	},
+	service = Portlet.class
+)
+public class LayoutPageTemplateAdminWebNoninstanceableTestPortlet
+	extends MVCPortlet {
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/constants/LayoutPageTemplateAdminWebPortletKeys.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/constants/LayoutPageTemplateAdminWebPortletKeys.java
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.page.template.admin.web.internal.portlet.constants;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+public class LayoutPageTemplateAdminWebPortletKeys {
+
+	public static final String
+		LAYOUT_PAGE_TEMPLATE_ADMIN_WEB_NONINSTANCEABLE_TEST_PORTLET =
+			"com_liferay_layout_page_template_admin_web_internal_portlet_" +
+				"LayoutPageTemplateAdminWebNoninstanceableTestPortlet";
+
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/META-INF/resources/view.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/META-INF/resources/view.jsp
@@ -1,0 +1,6 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -2849,6 +2849,7 @@ public class BundleSiteInitializer implements SiteInitializer {
 							layoutPageTemplateStructure.
 								getLayoutPageTemplateStructureId(),
 							segmentsExperienceId, layoutStructure.toString());
+
 					_fragmentEntryLinkLocalService.
 						deleteLayoutPageTemplateEntryFragmentEntryLinks(
 							draftLayout.getGroupId(),

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -59,6 +59,7 @@ import com.liferay.expando.kernel.service.ExpandoValueLocalService;
 import com.liferay.expando.kernel.util.ExpandoBridgeFactoryUtil;
 import com.liferay.fragment.importer.FragmentsImportStrategy;
 import com.liferay.fragment.importer.FragmentsImporter;
+import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.headless.admin.list.type.dto.v1_0.ListTypeDefinition;
 import com.liferay.headless.admin.list.type.dto.v1_0.ListTypeEntry;
 import com.liferay.headless.admin.list.type.resource.v1_0.ListTypeDefinitionResource;
@@ -296,6 +297,7 @@ public class BundleSiteInitializer implements SiteInitializer {
 		DocumentFolderResource.Factory documentFolderResourceFactory,
 		DocumentResource.Factory documentResourceFactory,
 		ExpandoValueLocalService expandoValueLocalService,
+		FragmentEntryLinkLocalService fragmentEntryLinkLocalService,
 		FragmentsImporter fragmentsImporter,
 		GroupLocalService groupLocalService,
 		JournalArticleLocalService journalArticleLocalService,
@@ -387,6 +389,7 @@ public class BundleSiteInitializer implements SiteInitializer {
 		_documentFolderResourceFactory = documentFolderResourceFactory;
 		_documentResourceFactory = documentResourceFactory;
 		_expandoValueLocalService = expandoValueLocalService;
+		_fragmentEntryLinkLocalService = fragmentEntryLinkLocalService;
 		_fragmentsImporter = fragmentsImporter;
 		_groupLocalService = groupLocalService;
 		_journalArticleLocalService = journalArticleLocalService;
@@ -2849,6 +2852,11 @@ public class BundleSiteInitializer implements SiteInitializer {
 							layoutPageTemplateStructure.
 								getLayoutPageTemplateStructureId(),
 							segmentsExperienceId, layoutStructure.toString());
+					_fragmentEntryLinkLocalService.
+						deleteLayoutPageTemplateEntryFragmentEntryLinks(
+							draftLayout.getGroupId(),
+							new long[] {segmentsExperienceId},
+							draftLayout.getPlid());
 					_portletPreferencesLocalService.deletePortletPreferences(
 						0, PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
 						draftLayout.getPlid());
@@ -6062,6 +6070,7 @@ public class BundleSiteInitializer implements SiteInitializer {
 	private final DocumentFolderResource.Factory _documentFolderResourceFactory;
 	private final DocumentResource.Factory _documentResourceFactory;
 	private final ExpandoValueLocalService _expandoValueLocalService;
+	private final FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
 	private final FragmentsImporter _fragmentsImporter;
 	private final GroupLocalService _groupLocalService;
 	private final JournalArticleLocalService _journalArticleLocalService;

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -167,7 +167,6 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
-import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
@@ -335,7 +334,6 @@ public class BundleSiteInitializer implements SiteInitializer {
 		OrganizationLocalService organizationLocalService,
 		OrganizationResource.Factory organizationResourceFactory,
 		PLOEntryLocalService ploEntryLocalService, Portal portal,
-		PortletPreferencesLocalService portletPreferencesLocalService,
 		ResourceActionLocalService resourceActionLocalService,
 		ResourcePermissionLocalService resourcePermissionLocalService,
 		RoleLocalService roleLocalService,
@@ -432,7 +430,6 @@ public class BundleSiteInitializer implements SiteInitializer {
 		_organizationResourceFactory = organizationResourceFactory;
 		_ploEntryLocalService = ploEntryLocalService;
 		_portal = portal;
-		_portletPreferencesLocalService = portletPreferencesLocalService;
 		_resourceActionLocalService = resourceActionLocalService;
 		_resourcePermissionLocalService = resourcePermissionLocalService;
 		_roleLocalService = roleLocalService;
@@ -2857,9 +2854,6 @@ public class BundleSiteInitializer implements SiteInitializer {
 							draftLayout.getGroupId(),
 							new long[] {segmentsExperienceId},
 							draftLayout.getPlid());
-					_portletPreferencesLocalService.deletePortletPreferences(
-						0, PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
-						draftLayout.getPlid());
 				}
 
 				for (int i = 0; i < jsonArray.length(); i++) {
@@ -6118,8 +6112,6 @@ public class BundleSiteInitializer implements SiteInitializer {
 	private final OrganizationResource.Factory _organizationResourceFactory;
 	private final PLOEntryLocalService _ploEntryLocalService;
 	private final Portal _portal;
-	private final PortletPreferencesLocalService
-		_portletPreferencesLocalService;
 	private final Map<String, String> _releaseInfoStringUtilReplaceValues;
 	private final ResourceActionLocalService _resourceActionLocalService;
 	private final ResourcePermissionLocalService

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerExtender.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerExtender.java
@@ -68,7 +68,6 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
-import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
@@ -176,11 +175,11 @@ public class SiteInitializerExtender
 				_objectFolderResourceFactory, _objectRelationshipLocalService,
 				_objectRelationshipResourceFactory, _organizationLocalService,
 				_organizationResourceFactory, _ploEntryLocalService, _portal,
-				_portletPreferencesLocalService, _resourceActionLocalService,
-				_resourcePermissionLocalService, _roleLocalService,
-				_sapEntryLocalService, _segmentsEntryLocalService,
-				_segmentsExperienceLocalService, null, bundle,
-				_bundleContext.getBundle(), _siteNavigationMenuItemLocalService,
+				_resourceActionLocalService, _resourcePermissionLocalService,
+				_roleLocalService, _sapEntryLocalService,
+				_segmentsEntryLocalService, _segmentsExperienceLocalService,
+				null, bundle, _bundleContext.getBundle(),
+				_siteNavigationMenuItemLocalService,
 				_siteNavigationMenuItemTypeRegistry,
 				_siteNavigationMenuLocalService,
 				_structuredContentFolderResourceFactory,
@@ -298,10 +297,9 @@ public class SiteInitializerExtender
 				_objectFolderResourceFactory, _objectRelationshipLocalService,
 				_objectRelationshipResourceFactory, _organizationLocalService,
 				_organizationResourceFactory, _ploEntryLocalService, _portal,
-				_portletPreferencesLocalService, _resourceActionLocalService,
-				_resourcePermissionLocalService, _roleLocalService,
-				_sapEntryLocalService, _segmentsEntryLocalService,
-				_segmentsExperienceLocalService,
+				_resourceActionLocalService, _resourcePermissionLocalService,
+				_roleLocalService, _sapEntryLocalService,
+				_segmentsEntryLocalService, _segmentsExperienceLocalService,
 				ProxyUtil.newDelegateProxyInstance(
 					ServletContext.class.getClassLoader(), ServletContext.class,
 					new FileBackedServletContextDelegate(
@@ -538,9 +536,6 @@ public class SiteInitializerExtender
 
 	@Reference
 	private Portal _portal;
-
-	@Reference
-	private PortletPreferencesLocalService _portletPreferencesLocalService;
 
 	@Reference
 	private ResourceActionLocalService _resourceActionLocalService;

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerExtender.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerExtender.java
@@ -26,6 +26,7 @@ import com.liferay.dynamic.data.mapping.service.DDMTemplateLocalService;
 import com.liferay.dynamic.data.mapping.util.DefaultDDMStructureHelper;
 import com.liferay.expando.kernel.service.ExpandoValueLocalService;
 import com.liferay.fragment.importer.FragmentsImporter;
+import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.headless.admin.list.type.resource.v1_0.ListTypeDefinitionResource;
 import com.liferay.headless.admin.list.type.resource.v1_0.ListTypeEntryResource;
 import com.liferay.headless.admin.taxonomy.resource.v1_0.KeywordResource;
@@ -155,8 +156,9 @@ public class SiteInitializerExtender
 				_depotEntryGroupRelLocalService, _depotEntryLocalService,
 				_dlFileEntryTypeLocalService, _dlURLHelper,
 				_documentFolderResourceFactory, _documentResourceFactory,
-				_expandoValueLocalService, _fragmentsImporter,
-				_groupLocalService, _journalArticleLocalService, _jsonFactory,
+				_expandoValueLocalService, _fragmentEntryLinkLocalService,
+				_fragmentsImporter, _groupLocalService,
+				_journalArticleLocalService, _jsonFactory,
 				_keywordResourceFactory, _knowledgeBaseArticleResourceFactory,
 				_knowledgeBaseFolderResourceFactory, _layoutLocalService,
 				_layoutPageTemplateEntryLocalService,
@@ -276,8 +278,9 @@ public class SiteInitializerExtender
 				_depotEntryGroupRelLocalService, _depotEntryLocalService,
 				_dlFileEntryTypeLocalService, _dlURLHelper,
 				_documentFolderResourceFactory, _documentResourceFactory,
-				_expandoValueLocalService, _fragmentsImporter,
-				_groupLocalService, _journalArticleLocalService, _jsonFactory,
+				_expandoValueLocalService, _fragmentEntryLinkLocalService,
+				_fragmentsImporter, _groupLocalService,
+				_journalArticleLocalService, _jsonFactory,
 				_keywordResourceFactory, _knowledgeBaseArticleResourceFactory,
 				_knowledgeBaseFolderResourceFactory, _layoutLocalService,
 				_layoutPageTemplateEntryLocalService,
@@ -418,6 +421,9 @@ public class SiteInitializerExtender
 	private final Map<String, File> _files = new HashMap<>();
 	private final List<SiteInitializerExtension>
 		_fileSiteInitializerExtensions = new ArrayList<>();
+
+	@Reference
+	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
 
 	@Reference
 	private FragmentsImporter _fragmentsImporter;

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerExtension.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerExtension.java
@@ -26,6 +26,7 @@ import com.liferay.dynamic.data.mapping.service.DDMTemplateLocalService;
 import com.liferay.dynamic.data.mapping.util.DefaultDDMStructureHelper;
 import com.liferay.expando.kernel.service.ExpandoValueLocalService;
 import com.liferay.fragment.importer.FragmentsImporter;
+import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.headless.admin.list.type.resource.v1_0.ListTypeDefinitionResource;
 import com.liferay.headless.admin.list.type.resource.v1_0.ListTypeEntryResource;
 import com.liferay.headless.admin.taxonomy.resource.v1_0.KeywordResource;
@@ -135,6 +136,7 @@ public class SiteInitializerExtension {
 		DocumentFolderResource.Factory documentFolderResourceFactory,
 		DocumentResource.Factory documentResourceFactory,
 		ExpandoValueLocalService expandoValueLocalService,
+		FragmentEntryLinkLocalService fragmentEntryLinkLocalService,
 		FragmentsImporter fragmentsImporter,
 		GroupLocalService groupLocalService,
 		JournalArticleLocalService journalArticleLocalService,
@@ -216,8 +218,9 @@ public class SiteInitializerExtension {
 			defaultDDMStructureHelper, depotEntryGroupRelLocalService,
 			depotEntryLocalService, dlFileEntryTypeLocalService, dlURLHelper,
 			documentFolderResourceFactory, documentResourceFactory,
-			expandoValueLocalService, fragmentsImporter, groupLocalService,
-			journalArticleLocalService, jsonFactory, keywordResourceFactory,
+			expandoValueLocalService, fragmentEntryLinkLocalService,
+			fragmentsImporter, groupLocalService, journalArticleLocalService,
+			jsonFactory, keywordResourceFactory,
 			knowledgeBaseArticleResourceFactory,
 			knowledgeBaseFolderResourceFactory, layoutLocalService,
 			layoutPageTemplateEntryLocalService, layoutsImporter,

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerExtension.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerExtension.java
@@ -68,7 +68,6 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
-import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
@@ -174,7 +173,6 @@ public class SiteInitializerExtension {
 		OrganizationLocalService organizationLocalService,
 		OrganizationResource.Factory organizationResourceFactory,
 		PLOEntryLocalService ploEntryLocalService, Portal portal,
-		PortletPreferencesLocalService portletPreferencesLocalService,
 		ResourceActionLocalService resourceActionLocalService,
 		ResourcePermissionLocalService resourcePermissionLocalService,
 		RoleLocalService roleLocalService,
@@ -236,9 +234,9 @@ public class SiteInitializerExtension {
 			objectFieldResourceFactory, objectFolderResourceFactory,
 			objectRelationshipLocalService, objectRelationshipResourceFactory,
 			organizationLocalService, organizationResourceFactory,
-			ploEntryLocalService, portal, portletPreferencesLocalService,
-			resourceActionLocalService, resourcePermissionLocalService,
-			roleLocalService, sapEntryLocalService, segmentsEntryLocalService,
+			ploEntryLocalService, portal, resourceActionLocalService,
+			resourcePermissionLocalService, roleLocalService,
+			sapEntryLocalService, segmentsEntryLocalService,
 			segmentsExperienceLocalService, siteBundle,
 			siteInitializerExtenderBundle, siteNavigationMenuItemLocalService,
 			siteNavigationMenuItemTypeRegistry, siteNavigationMenuLocalService,

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerFactoryImpl.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerFactoryImpl.java
@@ -68,7 +68,6 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
-import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
@@ -161,11 +160,11 @@ public class SiteInitializerFactoryImpl implements SiteInitializerFactory {
 			_objectfolderResourceFactory, _objectRelationshipLocalService,
 			_objectRelationshipResourceFactory, _organizationLocalService,
 			_organizationResourceFactory, _ploEntryLocalService, _portal,
-			_portletPreferencesLocalService, _resourceActionLocalService,
-			_resourcePermissionLocalService, _roleLocalService,
-			_sapEntryLocalService, _segmentsEntryLocalService,
-			_segmentsExperienceLocalService, siteBundle,
-			_bundleContext.getBundle(), _siteNavigationMenuItemLocalService,
+			_resourceActionLocalService, _resourcePermissionLocalService,
+			_roleLocalService, _sapEntryLocalService,
+			_segmentsEntryLocalService, _segmentsExperienceLocalService,
+			siteBundle, _bundleContext.getBundle(),
+			_siteNavigationMenuItemLocalService,
 			_siteNavigationMenuItemTypeRegistry,
 			_siteNavigationMenuLocalService,
 			_structuredContentFolderResourceFactory,
@@ -394,9 +393,6 @@ public class SiteInitializerFactoryImpl implements SiteInitializerFactory {
 
 	@Reference
 	private Portal _portal;
-
-	@Reference
-	private PortletPreferencesLocalService _portletPreferencesLocalService;
 
 	@Reference
 	private ResourceActionLocalService _resourceActionLocalService;

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerFactoryImpl.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerFactoryImpl.java
@@ -26,6 +26,7 @@ import com.liferay.dynamic.data.mapping.service.DDMTemplateLocalService;
 import com.liferay.dynamic.data.mapping.util.DefaultDDMStructureHelper;
 import com.liferay.expando.kernel.service.ExpandoValueLocalService;
 import com.liferay.fragment.importer.FragmentsImporter;
+import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.headless.admin.list.type.resource.v1_0.ListTypeDefinitionResource;
 import com.liferay.headless.admin.list.type.resource.v1_0.ListTypeEntryResource;
 import com.liferay.headless.admin.taxonomy.resource.v1_0.KeywordResource;
@@ -141,8 +142,9 @@ public class SiteInitializerFactoryImpl implements SiteInitializerFactory {
 			_defaultDDMStructureHelper, _depotEntryGroupRelLocalService,
 			_depotEntryLocalService, _dlFileEntryTypeLocalService, _dlURLHelper,
 			_documentFolderResourceFactory, _documentResourceFactory,
-			_expandoValueLocalService, _fragmentsImporter, _groupLocalService,
-			_journalArticleLocalService, _jsonFactory, _keywordResourceFactory,
+			_expandoValueLocalService, _fragmentEntryLinkLocalService,
+			_fragmentsImporter, _groupLocalService, _journalArticleLocalService,
+			_jsonFactory, _keywordResourceFactory,
 			_knowledgeBaseArticleResourceFactory,
 			_knowledgeBaseFolderResourceFactory, _layoutLocalService,
 			_layoutPageTemplateEntryLocalService, _layoutsImporter,
@@ -275,6 +277,9 @@ public class SiteInitializerFactoryImpl implements SiteInitializerFactory {
 
 	@Reference
 	private ExpandoValueLocalService _expandoValueLocalService;
+
+	@Reference
+	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
 
 	@Reference
 	private FragmentsImporter _fragmentsImporter;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-51419

Previous PR: https://github.com/brianchandotcom/liferay-portal/pull/160032
Resent because of: https://github.com/brianchandotcom/liferay-portal/pull/160032#issuecomment-2734231508

I am only adding the last commit with a like break because of:
- The order does matter. References to fragments must be deleted before deleting the fragments themselves.
- The testInitializeFromBundle and testInitializeFromFile tests in BundleSiteInitializerTest are already covering the changes in site-initializer-extender.

Thank you!