### PR TITLE
LRDOCS-14921 Remove Help Center Links

### DIFF
--- a/learn-resources/data/headless-discovery-web.json
+++ b/learn-resources/data/headless-discovery-web.json
@@ -2,13 +2,13 @@
 	"filter": {
 		"en_US": {
 			"message": "Use this filter to narrow down results using query conditions.",
-			"url": "https://help.liferay.com/hc/en-us/articles/360031163631-Filter-Sort-and-Search"
+			"url": "https://learn.liferay.com/w/dxp/headless-delivery/consuming-apis/api-query-parameters"
 		}
 	},
 	"search": {
 		"en_US": {
 			"message": "Use this search to find specific results within your data.",
-			"url": "https://help.liferay.com/hc/en-us/articles/360031163631-Filter-Sort-and-Search"
+			"url": "https://learn.liferay.com/w/dxp/headless-delivery/consuming-apis/api-query-parameters"
 		}
 	}
 }

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-site-initializer/site-initializer/notification-templates/new-app-submitted/en-US.html
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-site-initializer/site-initializer/notification-templates/new-app-submitted/en-US.html
@@ -179,7 +179,7 @@
 				<div class="submitted-app-class-788">
 					<a class="submitted-app-class-814" href="https://www.liferay.com/contact-us" target="_blank">Contact Support</a>
 						|
-					<a class="submitted-app-class-814" href="https://help.liferay.com/hc/categories/360000868172-Documentation" target="_blank">Documentation</a>
+					<a class="submitted-app-class-814" href="https://learn.liferay.com" target="_blank">Documentation</a>
 						|
 					<a class="submitted-app-class-814" href="https://help.liferay.com/hc" target="_blank">Help Center</a>
 						|

--- a/workspaces/liferay-testray-workspace/client-extensions/liferay-testray-custom-element/src/core/SearchBuilder.ts
+++ b/workspaces/liferay-testray-workspace/client-extensions/liferay-testray-custom-element/src/core/SearchBuilder.ts
@@ -29,7 +29,7 @@ export interface SearchBuilderConstructor {
 
 /**
  * @description
- * Based in the following article https://help.liferay.com/hc/pt/articles/360031163631-Filter-Sort-and-Search
+ * Based on the following article https://learn.liferay.com/w/dxp/headless-delivery/consuming-apis/api-query-parameters
  */
 
 export default class SearchBuilder {

--- a/workspaces/liferay-testray-workspace/client-extensions/liferay-testray-etc-jira/src/lib/SearchBuilder.ts
+++ b/workspaces/liferay-testray-workspace/client-extensions/liferay-testray-etc-jira/src/lib/SearchBuilder.ts
@@ -12,7 +12,7 @@ export interface SearchBuilderConstructor {
 
 /**
  * @description
- * Based in the following article https://help.liferay.com/hc/pt/articles/360031163631-Filter-Sort-and-Search
+ * Based on the following article https://learn.liferay.com/w/dxp/headless-delivery/consuming-apis/api-query-parameters
  */
 
 export default class SearchBuilder {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRDOCS-14921 

There are still a lot of links left which will have to be changed later. They fall into these categories: 

- Links to Liferay support matrix, Search support matrix, and compatibility matrix 
- Links to create a new support ticket
- Links to Liferay Analytics Cloud Announcements (need to move these to another platform)
- A link to old `Senna.js` documentation for 7.2, an article we'll have to port 
- Links in Customer Portal to Customer Portal's documentation, which is on Help Center. All this documentation will have to be moved to Liferay Learn. 
- Many links to Help Center home page as a home for Liferay Support; must identify what Support's new home is.

Links for which I have questions out to various people: 

- Links in Sharepoint REST and Sharepoint SOAP; are these apps still supported? 
- Broken link in Marketplace to an unknown article that returns a 404

