### PR TITLE
LPD-51055 Only show content in "Contents" section

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ContentsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ContentsSectionDisplayContext.java
@@ -138,7 +138,7 @@ public class ContentsSectionDisplayContext extends BaseSectionDisplayContext {
 
 	@Override
 	protected String getCMSSectionFilterString() {
-		return "cmsSection in ('contents', 'files')";
+		return "cmsSection eq 'contents'";
 	}
 
 	private final Language _language;


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-51055

The "Contents" section should display only content, not files.