### PR TITLE
LPD-41528 Add batch GET method to Language Override APIs

### DIFF
--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -16602,6 +16602,7 @@ service-access-policy-entry-default-asset-entry-title=Public Access to the Asset
 service-access-policy-entry-default-asset-tag-title=Public Access to the Asset Tag API
 service-access-policy-entry-default-calendar-title=Public Access to the Calendar Search API
 service-access-policy-entry-default-captcha-title=Public Access to CAPTCHA API
+service-access-policy-entry-default-language-title=Public Access to the Language API
 service-access-policy-entry-default-object-title=Public Access to the Object Search API
 service-access-policy-name=Service Access Policy Name
 service-access-policy-name-is-required=Service access policy name is required.

--- a/modules/apps/portal-language/portal-language-rest-api/bnd.bnd
+++ b/modules/apps/portal-language/portal-language-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Language REST API
 Bundle-SymbolicName: com.liferay.portal.language.rest.api
-Bundle-Version: 1.0.6
+Bundle-Version: 1.1.0
 Export-Package:\
 	com.liferay.portal.language.rest.dto.v1_0,\
 	com.liferay.portal.language.rest.resource.v1_0

--- a/modules/apps/portal-language/portal-language-rest-api/src/main/java/com/liferay/portal/language/rest/resource/v1_0/MessageResource.java
+++ b/modules/apps/portal-language/portal-language-rest-api/src/main/java/com/liferay/portal/language/rest/resource/v1_0/MessageResource.java
@@ -17,6 +17,7 @@ import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
+import com.liferay.portal.vulcan.pagination.Page;
 
 import java.util.Collections;
 import java.util.List;
@@ -61,6 +62,10 @@ public interface MessageResource {
 	public Message putMessage(Message message) throws Exception;
 
 	public Response putMessageBatch(String callbackURL, Object object)
+		throws Exception;
+
+	public Page<Message> postMessagesExportPage(
+			String languageId, String[] strings)
 		throws Exception;
 
 	public void postMessageImport(

--- a/modules/apps/portal-language/portal-language-rest-api/src/main/resources/com/liferay/portal/language/rest/resource/v1_0/packageinfo
+++ b/modules/apps/portal-language/portal-language-rest-api/src/main/resources/com/liferay/portal/language/rest/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/portal-language/portal-language-rest-client/src/main/java/com/liferay/portal/language/rest/client/resource/v1_0/MessageResource.java
+++ b/modules/apps/portal-language/portal-language-rest-client/src/main/java/com/liferay/portal/language/rest/client/resource/v1_0/MessageResource.java
@@ -7,6 +7,7 @@ package com.liferay.portal.language.rest.client.resource.v1_0;
 
 import com.liferay.portal.language.rest.client.dto.v1_0.Message;
 import com.liferay.portal.language.rest.client.http.HttpInvoker;
+import com.liferay.portal.language.rest.client.pagination.Page;
 import com.liferay.portal.language.rest.client.problem.Problem;
 import com.liferay.portal.language.rest.client.serdes.v1_0.MessageSerDes;
 
@@ -14,7 +15,9 @@ import java.io.File;
 
 import java.net.URL;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -76,6 +79,14 @@ public interface MessageResource {
 
 	public HttpInvoker.HttpResponse putMessageBatchHttpResponse(
 			String callbackURL, Object object)
+		throws Exception;
+
+	public Page<Message> postMessagesExportPage(
+			String languageId, String[] strings)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postMessagesExportPageHttpResponse(
+			String languageId, String[] strings)
 		throws Exception;
 
 	public void postMessageImport(
@@ -922,6 +933,122 @@ public interface MessageResource {
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
 						"/o/language/v1.0/messages/batch");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public Page<Message> postMessagesExportPage(
+				String languageId, String[] strings)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postMessagesExportPageHttpResponse(languageId, strings);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, MessageSerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse postMessagesExportPageHttpResponse(
+				String languageId, String[] strings)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			List<String> values = new ArrayList<>();
+
+			for (String stringValue : strings) {
+				values.add("\"" + String.valueOf(stringValue) + "\"");
+			}
+
+			httpInvoker.body(values.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (languageId != null) {
+				httpInvoker.parameter("languageId", String.valueOf(languageId));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/language/v1.0/messages/export");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(

--- a/modules/apps/portal-language/portal-language-rest-impl/build.gradle
+++ b/modules/apps/portal-language/portal-language-rest-impl/build.gradle
@@ -15,6 +15,9 @@ dependencies {
 	compileOnly project(":apps:portal-language:portal-language-rest-api")
 	compileOnly project(":apps:portal-odata:portal-odata-api")
 	compileOnly project(":apps:portal-search:portal-search-api")
+	compileOnly project(":apps:portal-security:portal-security-service-access-policy-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
+	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
 	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/portal-language/portal-language-rest-impl/rest-openapi.yaml
+++ b/modules/apps/portal-language/portal-language-rest-impl/rest-openapi.yaml
@@ -103,6 +103,41 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Message"
             tags: ["Message"]
+    "/messages/export":
+        post:
+            operationId: getExportPage
+            parameters:
+                - in: query
+                  name: languageId
+                  required: true
+                  schema:
+                      type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            items:
+                                type: string
+                            type: array
+                    application/xml:
+                        schema:
+                            items:
+                                type: string
+                            type: array
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/Message"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/Message"
+                                type: array
+            tags: ["Message"]
     "/messages/import":
         post:
             operationId: postMessageImport

--- a/modules/apps/portal-language/portal-language-rest-impl/rest-openapi.yaml
+++ b/modules/apps/portal-language/portal-language-rest-impl/rest-openapi.yaml
@@ -105,7 +105,7 @@ paths:
             tags: ["Message"]
     "/messages/export":
         post:
-            operationId: getExportPage
+            operationId: postMessagesExportPage
             parameters:
                 - in: query
                   name: languageId

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/BaseMessageResourceImpl.java
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/BaseMessageResourceImpl.java
@@ -323,6 +323,38 @@ public abstract class BaseMessageResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/language/v1.0/messages/export'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "languageId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Message")}
+	)
+	@javax.ws.rs.Consumes({"application/json", "application/xml"})
+	@javax.ws.rs.Path("/messages/export")
+	@javax.ws.rs.POST
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<Message> postMessagesExportPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.QueryParam("languageId")
+			String languageId,
+			String[] strings)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -X 'POST' 'http://localhost:8080/o/language/v1.0/messages/import'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/MessageResourceImpl.java
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/MessageResourceImpl.java
@@ -78,6 +78,19 @@ public class MessageResourceImpl extends BaseMessageResourceImpl {
 	}
 
 	@Override
+	public Page<Message> postMessagesExportPage(
+		String languageId, String[] keys) {
+
+		List<Message> messages = new ArrayList<>();
+
+		for (String key : keys) {
+			messages.add(getMessage(key, languageId));
+		}
+
+		return Page.of(messages);
+	}
+
+	@Override
 	public Message postMessage(Message message) throws PortalException {
 		return _addOrUpdatePLOEntry(message);
 	}

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/MessageResourceImpl.java
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/MessageResourceImpl.java
@@ -78,19 +78,6 @@ public class MessageResourceImpl extends BaseMessageResourceImpl {
 	}
 
 	@Override
-	public Page<Message> postMessagesExportPage(
-		String languageId, String[] keys) {
-
-		List<Message> messages = new ArrayList<>();
-
-		for (String key : keys) {
-			messages.add(getMessage(key, languageId));
-		}
-
-		return Page.of(messages);
-	}
-
-	@Override
 	public Message postMessage(Message message) throws PortalException {
 		return _addOrUpdatePLOEntry(message);
 	}
@@ -124,6 +111,19 @@ public class MessageResourceImpl extends BaseMessageResourceImpl {
 
 			_ploEntryService.importPLOEntries(languageId, properties);
 		}
+	}
+
+	@Override
+	public Page<Message> postMessagesExportPage(
+		String languageId, String[] keys) {
+
+		List<Message> messages = new ArrayList<>();
+
+		for (String key : keys) {
+			messages.add(getMessage(key, languageId));
+		}
+
+		return Page.of(messages);
 	}
 
 	@Override

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/service/access/policy/LanguagePortalInstanceLifecycleListener.java
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/service/access/policy/LanguagePortalInstanceLifecycleListener.java
@@ -1,0 +1,84 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.language.rest.internal.service.access.policy;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener;
+import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoaderUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.security.service.access.policy.model.SAPEntry;
+import com.liferay.portal.security.service.access.policy.service.SAPEntryLocalService;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Raymond Augé
+ * @author Thiago Buarque
+ */
+@Component(service = PortalInstanceLifecycleListener.class)
+public class LanguagePortalInstanceLifecycleListener
+	extends BasePortalInstanceLifecycleListener {
+
+	@Override
+	public void portalInstanceRegistered(Company company) {
+		try {
+			_addSAPEntries(company.getCompanyId());
+		}
+		catch (PortalException portalException) {
+			_log.error(
+				"Unable to add service access policy entry for company " +
+					company.getCompanyId(),
+				portalException);
+		}
+	}
+
+	private void _addSAPEntries(long companyId) throws PortalException {
+		SAPEntry sapEntry = _sapEntryLocalService.fetchSAPEntry(
+			companyId, _SAP_ENTRY_NAME);
+
+		if (sapEntry != null) {
+			return;
+		}
+
+		_sapEntryLocalService.addSAPEntry(
+			_userLocalService.getGuestUserId(companyId), _SAP_ENTRY_SIGNATURES,
+			false, true, _SAP_ENTRY_NAME,
+			ResourceBundleUtil.getLocalizationMap(
+				ResourceBundleLoaderUtil.getPortalResourceBundleLoader(),
+				_ACCESS_POLICY_ENTRY_LANGUAGE_ID),
+			new ServiceContext());
+	}
+
+	private static final String _ACCESS_POLICY_ENTRY_LANGUAGE_ID =
+		"service-access-policy-entry-default-language-title";
+
+	private static final String _SAP_ENTRY_NAME = "LANGUAGE_MESSAGE";
+
+	private static final String _SAP_ENTRY_SIGNATURES = StringBundler.concat(
+		"com.liferay.portal.language.rest.internal.resource.v1_0.",
+		"MessageResourceImpl#getMessages", StringPool.NEW_LINE,
+		"com.liferay.portal.language.rest.internal.resource.v1_0.",
+		"MessageResourceImpl#postMessagesExportPage");
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		LanguagePortalInstanceLifecycleListener.class);
+
+	@Reference
+	private SAPEntryLocalService _sapEntryLocalService;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/service/access/policy/LanguagePortalInstanceLifecycleListener.java
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/service/access/policy/LanguagePortalInstanceLifecycleListener.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/service/access/policy/LanguagePortalInstanceLifecycleListener.java
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/service/access/policy/LanguagePortalInstanceLifecycleListener.java
@@ -54,7 +54,7 @@ public class LanguagePortalInstanceLifecycleListener
 
 		_sapEntryLocalService.addSAPEntry(
 			_userLocalService.getGuestUserId(companyId), _SAP_ENTRY_SIGNATURES,
-			false, true, _SAP_ENTRY_NAME,
+			true, true, _SAP_ENTRY_NAME,
 			ResourceBundleUtil.getLocalizationMap(
 				ResourceBundleLoaderUtil.getPortalResourceBundleLoader(),
 				_ACCESS_POLICY_ENTRY_LANGUAGE_ID),

--- a/modules/apps/portal-language/portal-language-rest-test/src/testIntegration/java/com/liferay/portal/language/rest/resource/v1_0/test/BaseMessageResourceTestCase.java
+++ b/modules/apps/portal-language/portal-language-rest-test/src/testIntegration/java/com/liferay/portal/language/rest/resource/v1_0/test/BaseMessageResourceTestCase.java
@@ -213,6 +213,11 @@ public abstract class BaseMessageResourceTestCase {
 	}
 
 	@Test
+	public void testPostMessagesExportPage() throws Exception {
+		Assert.assertTrue(false);
+	}
+
+	@Test
 	public void testPostMessageImport() throws Exception {
 		Assert.assertTrue(false);
 	}

--- a/modules/apps/portal-language/portal-language-rest-test/src/testIntegration/java/com/liferay/portal/language/rest/resource/v1_0/test/MessageResourceTest.java
+++ b/modules/apps/portal-language/portal-language-rest-test/src/testIntegration/java/com/liferay/portal/language/rest/resource/v1_0/test/MessageResourceTest.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.language.override.service.PLOEntryLocalService;
 import com.liferay.portal.language.rest.client.dto.v1_0.Message;
+import com.liferay.portal.language.rest.client.pagination.Page;
 import com.liferay.portal.test.rule.Inject;
 
 import java.io.File;
@@ -131,6 +132,40 @@ public class MessageResourceTest extends BaseMessageResourceTestCase {
 		finally {
 			FileUtil.delete(file);
 		}
+	}
+
+	@Override
+	@Test
+	public void testPostMessagesExportPage() throws Exception {
+		Message message1 = _createMessage();
+		Message message2 = _createMessage();
+		Message message3 = _createMessage();
+
+		_postMessage(message1);
+		_postMessage(message2);
+		_postMessage(message3);
+
+		Page<Message> messagesPage = messageResource.postMessagesExportPage(
+			"en_US",
+			new String[] {
+				message1.getKey(), message2.getKey(), message3.getKey()
+			});
+
+		Assert.assertEquals(3, messagesPage.getTotalCount());
+
+		List<Message> items = new ArrayList<>(messagesPage.getItems());
+
+		Message message4 = items.get(0);
+
+		Assert.assertEquals(message1.getValue(), message4.getValue());
+
+		message4 = items.get(1);
+
+		Assert.assertEquals(message2.getValue(), message4.getValue());
+
+		message4 = items.get(2);
+
+		Assert.assertEquals(message3.getValue(), message4.getValue());
 	}
 
 	@Override


### PR DESCRIPTION
@brianchandotcom answering your [comment](https://github.com/brianchandotcom/liferay-portal/pull/160251#issuecomment-2749534168): that was introduced by Ray Auge in a draft PR he sent us [here](https://github.com/liferay-platform-experience/liferay-portal/pull/786/commits/84b1a619925de7bb8e5c8946a575a2c516ccd43c#diff-8ad92b1e9712dc7d19859f0de225d51e8e4df38c87fc73f357123cb179eb062fR50). Since it stayed open for a while, I got lots of conflicts, so I just remade the commits by hand.

--------

From https://github.com/liferay-platform-experience/liferay-portal/pull/786

### Original description (kind of)

https://liferay.atlassian.net/browse/LPD-41528

Imagine the customer define the following reusable function:

```javascript
/*
 * Fetch the translation of the keys for the current language.
 * @param {Array<String>} keys The array of keys.
 * @returns {{[name:string]: string}} map of translations by key
 */
const fetchTranslations = async (keys) => {
    return await fetch(
        '/o/language/v1.0/messages/export?' + new URLSearchParams({
            languageId: Liferay.ThemeDisplay.getLanguageId()
        }), {
            body: JSON.stringify(keys),
            headers: {
                "Accept": "application/json",
                "Content-Type": "application/json"
            },
            method: 'POST'
        }
    ).then(
        r => r.json()
    ).then(
        r => r.items.reduce(
            (map, obj) => (map[obj.key] = obj.value, map), {}
        )
    );
};
```

Next in custom code, a developer would collect the language keys used by their application in a JSON array:

```javascript
// collect the keys somewhere in the app (maybe with tooling support)
const keys = [
    "800-by-600-pixels",
    "1024-by-768-pixels",
    "AUTHORIZATION_CODE",
    "AUTHORIZATION_CODE_PKCE",
    "AUTHORIZED_OAUTH2_SAP"
];
```
and finally, early in the initialization of their app, before any rendering occurs the following function would be invoked:

```javascript
const translations = await fetchTranslations(keys);
```

Use the following to test the api with curl:
```shell
curl http://localhost:8080/o/language/v1.0/messages/export?languageId=en_US   -s   --json '["800-by-600-pixels","1024-by-768-pixels","AUTHORIZATION_CODE","AUTHORIZATION_CODE_PKCE","AUTHORIZED_OAUTH2_SAP"]' -v
```
