### PR TITLE
LPD-51508 AntiSamy adds rel='noopener noreferrer' to target blank links and displays WARN after updating the content

### DIFF
--- a/modules/apps/portal-security/portal-security-antisamy-test/bnd.bnd
+++ b/modules/apps/portal-security/portal-security-antisamy-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Portal Security AntiSamy Test
+Bundle-SymbolicName: com.liferay.portal.security.antisamy.test
+Bundle-Version: 1.0.0

--- a/modules/apps/portal-security/portal-security-antisamy-test/build.gradle
+++ b/modules/apps/portal-security/portal-security-antisamy-test/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/portal-security/portal-security-antisamy-test/src/testIntegration/java/com/liferay/portal/security/antisamy/internal/test/AntiSamySanitizerImplTest.java
+++ b/modules/apps/portal-security/portal-security-antisamy-test/src/testIntegration/java/com/liferay/portal/security/antisamy/internal/test/AntiSamySanitizerImplTest.java
@@ -11,14 +11,13 @@ import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.test.log.LogCapture;
-import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.HashMap;
-import java.util.List;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -39,10 +38,6 @@ public class AntiSamySanitizerImplTest {
 
 	@Test
 	public void testSanitize() throws Exception {
-		String content =
-			"<p><a href=\"test\" rel=\"noopener noreferrer\" " +
-				"target=\"_blank\"></a></p>";
-
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				"com.liferay.portal.security.antisamy.internal." +
 					"AntiSamySanitizerImpl",
@@ -50,12 +45,12 @@ public class AntiSamySanitizerImplTest {
 
 			_antiSamySanitizer.sanitize(
 				TestPropsValues.getCompanyId(), 0, 0, StringPool.BLANK, 0,
-				ContentTypes.TEXT_HTML, new String[0], content,
+				ContentTypes.TEXT_HTML, new String[0],
+				"<p><a href=\"test\" rel=\"noopener noreferrer\" " +
+					"target=\"_blank\"></a></p>",
 				new HashMap<>());
 
-			List<LogEntry> logEntries = logCapture.getLogEntries();
-
-			Assert.assertTrue(logEntries.isEmpty());
+			Assert.assertTrue(ListUtil.isEmpty(logCapture.getLogEntries()));
 		}
 	}
 

--- a/modules/apps/portal-security/portal-security-antisamy-test/src/testIntegration/java/com/liferay/portal/security/antisamy/internal/test/AntiSamySanitizerImplTest.java
+++ b/modules/apps/portal-security/portal-security-antisamy-test/src/testIntegration/java/com/liferay/portal/security/antisamy/internal/test/AntiSamySanitizerImplTest.java
@@ -55,7 +55,7 @@ public class AntiSamySanitizerImplTest {
 	}
 
 	@Inject(
-		filter = "(&(objectClass=com.liferay.portal.kernel.sanitizer.Sanitizer)(!(component.name=*)))"
+		filter = "component.name=com.liferay.portal.security.antisamy.internal.AntiSamySanitizerImpl"
 	)
 	private Sanitizer _antiSamySanitizer;
 

--- a/modules/apps/portal-security/portal-security-antisamy-test/src/testIntegration/java/com/liferay/portal/security/antisamy/internal/test/AntiSamySanitizerImplTest.java
+++ b/modules/apps/portal-security/portal-security-antisamy-test/src/testIntegration/java/com/liferay/portal/security/antisamy/internal/test/AntiSamySanitizerImplTest.java
@@ -1,0 +1,74 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.antisamy.internal.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.sanitizer.Sanitizer;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Pedro Victor Silvestre
+ */
+@RunWith(Arquillian.class)
+public class AntiSamySanitizerImplTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_companyId = TestPropsValues.getCompanyId();
+	}
+
+	@Test
+	public void test() throws Exception {
+		String content =
+			"<p><a href=\"test\" rel=\"noopener noreferrer\" " +
+				"target=\"_blank\"></a></p>";
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.portal.security.antisamy.internal." +
+					"AntiSamySanitizerImpl",
+				LoggerTestUtil.WARN)) {
+
+			_antiSamySanitizer.sanitize(
+				_companyId, 0, 0, StringPool.BLANK, 0, ContentTypes.TEXT_HTML,
+				new String[0], content, new HashMap<>());
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertTrue(logEntries.isEmpty());
+		}
+	}
+
+	@Inject(
+		filter = "(&(objectClass=com.liferay.portal.kernel.sanitizer.Sanitizer)(!(component.name=*)))"
+	)
+	private Sanitizer _antiSamySanitizer;
+
+	private long _companyId;
+
+}

--- a/modules/apps/portal-security/portal-security-antisamy-test/src/testIntegration/java/com/liferay/portal/security/antisamy/internal/test/AntiSamySanitizerImplTest.java
+++ b/modules/apps/portal-security/portal-security-antisamy-test/src/testIntegration/java/com/liferay/portal/security/antisamy/internal/test/AntiSamySanitizerImplTest.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.List;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -38,11 +37,6 @@ public class AntiSamySanitizerImplTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@Before
-	public void setUp() throws Exception {
-		_companyId = TestPropsValues.getCompanyId();
-	}
-
 	@Test
 	public void test() throws Exception {
 		String content =
@@ -55,8 +49,9 @@ public class AntiSamySanitizerImplTest {
 				LoggerTestUtil.WARN)) {
 
 			_antiSamySanitizer.sanitize(
-				_companyId, 0, 0, StringPool.BLANK, 0, ContentTypes.TEXT_HTML,
-				new String[0], content, new HashMap<>());
+				TestPropsValues.getCompanyId(), 0, 0, StringPool.BLANK, 0,
+				ContentTypes.TEXT_HTML, new String[0], content,
+				new HashMap<>());
 
 			List<LogEntry> logEntries = logCapture.getLogEntries();
 
@@ -68,7 +63,5 @@ public class AntiSamySanitizerImplTest {
 		filter = "(&(objectClass=com.liferay.portal.kernel.sanitizer.Sanitizer)(!(component.name=*)))"
 	)
 	private Sanitizer _antiSamySanitizer;
-
-	private long _companyId;
 
 }

--- a/modules/apps/portal-security/portal-security-antisamy-test/src/testIntegration/java/com/liferay/portal/security/antisamy/internal/test/AntiSamySanitizerImplTest.java
+++ b/modules/apps/portal-security/portal-security-antisamy-test/src/testIntegration/java/com/liferay/portal/security/antisamy/internal/test/AntiSamySanitizerImplTest.java
@@ -38,7 +38,7 @@ public class AntiSamySanitizerImplTest {
 		new LiferayIntegrationTestRule();
 
 	@Test
-	public void test() throws Exception {
+	public void testSanitize() throws Exception {
 		String content =
 			"<p><a href=\"test\" rel=\"noopener noreferrer\" " +
 				"target=\"_blank\"></a></p>";

--- a/modules/apps/portal-security/portal-security-antisamy-test/test.properties
+++ b/modules/apps/portal-security/portal-security-antisamy-test/test.properties
@@ -1,0 +1,30 @@
+##
+## Test Suites
+##
+
+    modified.files.includes[relevant][antisamy-java-rule]=\
+        **/*.java,\
+        **/test/**,\
+        **/testIntegration/**
+
+    relevant.rule.names=antisamy-java-rule
+
+    test.batch.names[relevant][antisamy-java-rule]=\
+        modules-integration-mysql57,\
+        modules-unit
+
+    #
+    # Relevant
+    #
+
+    modules.includes.required.test.batch.class.names.includes[modules-integration-mysql57][relevant][antisamy-java-rule]=\
+        apps/portal-security/portal-security-antisamy*/*Test.java
+
+    modules.includes.required.test.batch.class.names.includes[modules-unit][relevant][antisamy-java-rule]=\
+        apps/portal-security/portal-security-antisamy*/*Test.java
+
+##
+## Testray
+##
+
+    testray.main.component.name=AntiSamy

--- a/modules/apps/portal-security/portal-security-antisamy/build.gradle
+++ b/modules/apps/portal-security/portal-security-antisamy/build.gradle
@@ -54,10 +54,11 @@ processDefaultSanitizerConfiguration {
 			|				</regexp-list>
 			|			</attribute>""".stripMargin()
 
-		ant.replaceregexp(file: sanitizerConfigurationFile,
-			match: '<attribute name="rel">\\s*<literal-list>\\s*<literal value="nofollow"/>\\s*</literal-list>\\s*</attribute>',
-			replace: replace,
-			flags: 'g')
+		ant.replaceregexp(
+			file: sanitizerConfigurationFile,
+			flags: "g",
+			match: "<attribute name=\"rel\">\\s*<literal-list>\\s*<literal value=\"nofollow\"/>\\s*</literal-list>\\s*</attribute>",
+			replace: replace)
 	}
 
 	ext {

--- a/modules/apps/portal-security/portal-security-antisamy/build.gradle
+++ b/modules/apps/portal-security/portal-security-antisamy/build.gradle
@@ -46,6 +46,20 @@ jarSources {
 }
 
 processDefaultSanitizerConfiguration {
+	doLast {
+		String replace = """\
+			|<attribute name="rel">
+			|				<regexp-list>
+			|					<regexp value="(\\\\\\\\s*(nofollow|noopener|noreferrer)(\\\\\\\\s(nofollow|noopener|noreferrer))*\\\\\\\\s*)?"/>
+			|				</regexp-list>
+			|			</attribute>""".stripMargin()
+
+		ant.replaceregexp(file: sanitizerConfigurationFile,
+			match: '<attribute name="rel">\\s*<literal-list>\\s*<literal value="nofollow"/>\\s*</literal-list>\\s*</attribute>',
+			replace: replace,
+			flags: 'g')
+	}
+
 	ext {
 		autoClean = false
 	}

--- a/modules/apps/portal-security/portal-security-antisamy/src/main/java/com/liferay/portal/security/antisamy/internal/configuration/admin/service/AntiSamySanitizerPublisherManagedServiceFactory.java
+++ b/modules/apps/portal-security/portal-security-antisamy/src/main/java/com/liferay/portal/security/antisamy/internal/configuration/admin/service/AntiSamySanitizerPublisherManagedServiceFactory.java
@@ -7,6 +7,7 @@ package com.liferay.portal.security.antisamy.internal.configuration.admin.servic
 
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.security.antisamy.configuration.AntiSamyClassNameConfiguration;
 import com.liferay.portal.security.antisamy.configuration.AntiSamyConfiguration;
 import com.liferay.portal.security.antisamy.internal.AntiSamySanitizerImpl;
@@ -110,7 +111,10 @@ public class AntiSamySanitizerPublisherManagedServiceFactory
 			antiSamyConfiguration.whitelist());
 
 		_sanitizerServiceRegistration = bundleContext.registerService(
-			Sanitizer.class, _antiSamySanitizerImpl, null);
+			Sanitizer.class, _antiSamySanitizerImpl,
+			MapUtil.singletonDictionary(
+				"component.name",
+				AntiSamySanitizerImpl.class.getCanonicalName()));
 	}
 
 	@Deactivate

--- a/modules/apps/portal-security/portal-security-antisamy/src/main/resources/META-INF/resources/blogs-sanitizer-configuration.xml
+++ b/modules/apps/portal-security/portal-security-antisamy/src/main/resources/META-INF/resources/blogs-sanitizer-configuration.xml
@@ -764,9 +764,9 @@ http://www.w3.org/TR/html401/struct/global.html
 				</regexp-list>
 			</attribute>
 			<attribute name="rel">
-				<literal-list>
-					<literal value="nofollow"/>
-				</literal-list>
+				<regexp-list>
+					<regexp value="(\s*(nofollow|noopener|noreferrer)(\s(nofollow|noopener|noreferrer))*\s*)?"/>
+				</regexp-list>
 			</attribute>
 			<attribute name="name"/>
 

--- a/modules/apps/portal-security/portal-security-antisamy/src/main/resources/META-INF/resources/knowledge-base-sanitizer-configuration.xml
+++ b/modules/apps/portal-security/portal-security-antisamy/src/main/resources/META-INF/resources/knowledge-base-sanitizer-configuration.xml
@@ -772,9 +772,9 @@ http://www.w3.org/TR/html401/struct/global.html
 				</regexp-list>
 			</attribute>
 			<attribute name="rel">
-				<literal-list>
-					<literal value="nofollow"/>
-				</literal-list>
+				<regexp-list>
+					<regexp value="(\s*(nofollow|noopener|noreferrer)(\s(nofollow|noopener|noreferrer))*\s*)?"/>
+				</regexp-list>
 			</attribute>
 			<attribute name="name"/>
 

--- a/modules/apps/portal-security/portal-security-antisamy/src/main/resources/META-INF/resources/sanitizer-configuration.xml
+++ b/modules/apps/portal-security/portal-security-antisamy/src/main/resources/META-INF/resources/sanitizer-configuration.xml
@@ -702,9 +702,9 @@ http://www.w3.org/TR/html401/struct/global.html
 				</regexp-list>
 			</attribute>
 			<attribute name="rel">
-				<literal-list>
-					<literal value="nofollow"/>
-				</literal-list>
+				<regexp-list>
+					<regexp value="(\s*(nofollow|noopener|noreferrer)(\s(nofollow|noopener|noreferrer))*\s*)?"/>
+				</regexp-list>
 			</attribute>
 			<attribute name="name"/>
 


### PR DESCRIPTION
Previous PR: https://github.com/brianchandotcom/liferay-portal/pull/160285

Hi Brian, changed the wrapping of the attributes and reorganized the parameters.