### PR TITLE
LPD-52515 resolve typo exposed by new tests being added

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/DeleteDuplicateUniqueFinderRowsUpgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/DeleteDuplicateUniqueFinderRowsUpgradeProcess.java
@@ -72,7 +72,7 @@ public class DeleteDuplicateUniqueFinderRowsUpgradeProcess
 					sb.append(primaryKeyColumnName);
 					sb.append(" = ");
 					sb.append(duplicateRow.get(primaryKeyColumnName));
-					sb.append("and ");
+					sb.append(" and ");
 				}
 
 				sb.setIndex(sb.index() - 1);


### PR DESCRIPTION
There was a typo fix commit that seems to have been left out for LPD-47268.
I'm not sure how, I wrote new tests and re-encountered the error believing it was new. 

Here's the PR for Alan when he reviewed the SF commits:
https://github.com/ling-alan-huang/liferay-portal/pull/3252/commits/88449cb17f1ba6e9f3b02335d6735fc1e4a4df5f

