### PR TITLE
LPD-52461 Fix page height for EditVocabulary page

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/categorization/Categorization.scss
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/categorization/Categorization.scss
@@ -9,6 +9,14 @@
 		border-style: none;
 	}
 
+	.cms-parent-container {
+		height: calc(100vh - 6rem - var(--control-menu-container-height, 0));
+
+		.cms-container-child {
+			height: 100%;
+		}
+	}
+
 	.edit-vocabulary {
 		.asset-icon {
 			padding-right: 15px;

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/categorization/vocabularies/EditVocabulary.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/categorization/vocabularies/EditVocabulary.tsx
@@ -153,8 +153,11 @@ export default function EditVocabulary({
 					</ManagementToolbar.ItemList>
 				</ManagementToolbar.Container>
 
-				<ClayLayout.ContainerFluid className="m-0" size={false}>
-					<ClayLayout.Row>
+				<ClayLayout.ContainerFluid
+					className="cms-parent-container m-0"
+					size={false}
+				>
+					<ClayLayout.Row className="cms-container-child">
 						<ClayLayout.Col
 							className="categorization-vertical-nav p-0"
 							md={3}


### PR DESCRIPTION
Manually forwarding to you because the PR was being blocked by the following unrelated SF error: 
```
../../layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/marketplace/MarketplaceModal.tsx(43,4): error TS2741: Property 'permissions' is missing in type '\{ children: (Element | ReactNode)[]; baseResourceURL: string; settings: \{ productFilter: "fragments"; \}; \}' but required in type 'MarketplaceContextProviderProps'.
```

**Original PR:** https://github.com/liferay-site-management/liferay-portal/pull/1978

**All relevant tests are passing and it can be safely merged.** Just some small minor CSS changes to 1 component. 