### PR TITLE
LCD-45717 Remove Kind installation from Helm test workflow

### DIFF
--- a/.github/workflows/ci-test-cloud-helm-chart.yaml
+++ b/.github/workflows/ci-test-cloud-helm-chart.yaml
@@ -7,15 +7,6 @@ jobs:
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v4
-            -   name: Install latest version of Kind
-                run: |
-                    curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
-
-                    chmod +x ./kind
-
-                    sudo mv ./kind /usr/local/bin/kind
-            -   name: Verify Kind installation
-                run: kind version
             -   name: Create Kind cluster
                 run: kind create cluster
             -   name: Run Helm test


### PR DESCRIPTION
[LCD-45717](https://liferay.atlassian.net/browse/LCD-45717)

Kind is already installed on the Github runner. Proof: https://github.com/jaredgorski/liferay-portal/actions/runs/14316366295