### PR TITLE
Changes requested by Rafa based on https://liferay.atlassian.net/browse/LPD-44142

### DIFF
--- a/workspaces/liferay-tryitnow-workspace/client-extensions/liferay-tryitnow-site-initializer/site-initializer/fragments/group/tryitnow-custom-fragments/fragments/tryitnow-icon-button/index.html
+++ b/workspaces/liferay-tryitnow-workspace/client-extensions/liferay-tryitnow-site-initializer/site-initializer/fragments/group/tryitnow-custom-fragments/fragments/tryitnow-icon-button/index.html
@@ -1,3 +1,9 @@
-<span style="font-size: ${configuration.iconSize}">
+[@liferay_aui.style]
+	.${fragmentEntryLinkNamespace}_iconSize{
+		font-size: ${configuration.iconSize};
+	}
+[/@]
+
+<span class="${fragmentEntryLinkNamespace}_iconSize">
 	[@clay["icon"] symbol="${configuration.iconName}" /]
 </span>

--- a/workspaces/liferay-tryitnow-workspace/client-extensions/liferay-tryitnow-site-initializer/site-initializer/fragments/group/tryitnow-custom-fragments/fragments/tryitnow-image-icon/index.html
+++ b/workspaces/liferay-tryitnow-workspace/client-extensions/liferay-tryitnow-site-initializer/site-initializer/fragments/group/tryitnow-custom-fragments/fragments/tryitnow-image-icon/index.html
@@ -36,8 +36,7 @@
 <div class="${fragmentEntryLinkNamespace}_fragment_icon_container${fragmentEntryLinkNamespace}">
 	<div class="icon-container rounded-circle containerBgColor containerSize containerPadding">
 		<div class="icon-background rounded-circle iconBgColor iconSize">
-			<img class="imageSize" data-lfr-editable-id="image-square" data-lfr-editable-type="image"
-				src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAABECAYAAABK3PEEAAAACXBIWXMAAC4jAAAuIwF4pT92AAABBUlEQVR4Xu3VAQkAIBDFUO0fRLCD2RSM8dg12Mbn5trnjo41MAvMtv1gBbb7FhjvW+AC6wZwvn5wgXEDOF4LLjBuAMdrwQXGDeB4LbjAuAEcrwUXGDeA47XgAuMGcLwWXGDcAI7XgguMG8DxWnCBcQM4XgsuMG4Ax2vBBcYN4HgtuMC4ARyvBRcYN4DjteAC4wZwvBZcYNwAjteCC4wbwPFacIFxAzheCy4wbgDHa8EFxg3geC24wLgBHK8FFxg3gOO14ALjBnC8Flxg3ACO14ILjBvA8VpwgXEDOF4LLjBuAMdrwQXGDeB4LbjAuAEcrwUXGDeA47XgAuMGcLwWXGDcAI73ADVez7kdh2y/AAAAAElFTkSuQmCC" />
+			<img class="imageSize" data-lfr-editable-id="image-square" data-lfr-editable-type="image" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAABECAYAAABK3PEEAAAACXBIWXMAAC4jAAAuIwF4pT92AAABBUlEQVR4Xu3VAQkAIBDFUO0fRLCD2RSM8dg12Mbn5trnjo41MAvMtv1gBbb7FhjvW+AC6wZwvn5wgXEDOF4LLjBuAMdrwQXGDeB4LbjAuAEcrwUXGDeA47XgAuMGcLwWXGDcAI7XgguMG8DxWnCBcQM4XgsuMG4Ax2vBBcYN4HgtuMC4ARyvBRcYN4DjteAC4wZwvBZcYNwAjteCC4wbwPFacIFxAzheCy4wbgDHa8EFxg3geC24wLgBHK8FFxg3gOO14ALjBnC8Flxg3ACO14ILjBvA8VpwgXEDOF4LLjBuAMdrwQXGDeB4LbjAuAEcrwUXGDeA47XgAuMGcLwWXGDcAI73ADVez7kdh2y/AAAAAElFTkSuQmCC" />
 		</div>
 	</div>
 </div>

--- a/workspaces/liferay-tryitnow-workspace/client-extensions/liferay-tryitnow-site-initializer/site-initializer/fragments/group/tryitnow-custom-fragments/fragments/tryitnow-image-icon/index.html
+++ b/workspaces/liferay-tryitnow-workspace/client-extensions/liferay-tryitnow-site-initializer/site-initializer/fragments/group/tryitnow-custom-fragments/fragments/tryitnow-image-icon/index.html
@@ -1,7 +1,43 @@
-<div class="fragment_444">
-	<div class="icon-container rounded-circle" style="background-color: ${configuration.containerBackgroundColor};width: ${configuration.containerWidthAndHeight}; height: ${configuration.containerWidthAndHeight}; padding: ${configuration.containerPadding} ">
-		<div class="icon-background rounded-circle" style="background-color: ${configuration.iconBackgroundColor}; width: ${configuration.iconWidthAndHeight}; height: ${configuration.iconWidthAndHeight}">
-			<img data-lfr-editable-id="image-square" data-lfr-editable-type="image" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAABECAYAAABK3PEEAAAACXBIWXMAAC4jAAAuIwF4pT92AAABBUlEQVR4Xu3VAQkAIBDFUO0fRLCD2RSM8dg12Mbn5trnjo41MAvMtv1gBbb7FhjvW+AC6wZwvn5wgXEDOF4LLjBuAMdrwQXGDeB4LbjAuAEcrwUXGDeA47XgAuMGcLwWXGDcAI7XgguMG8DxWnCBcQM4XgsuMG4Ax2vBBcYN4HgtuMC4ARyvBRcYN4DjteAC4wZwvBZcYNwAjteCC4wbwPFacIFxAzheCy4wbgDHa8EFxg3geC24wLgBHK8FFxg3gOO14ALjBnC8Flxg3ACO14ILjBvA8VpwgXEDOF4LLjBuAMdrwQXGDeB4LbjAuAEcrwUXGDeA47XgAuMGcLwWXGDcAI73ADVez7kdh2y/AAAAAElFTkSuQmCC" style="width: ${configuration.imageWidthAndHeight}; height: ${configuration.imageWidthAndHeight}" />
+[@liferay_aui.style]
+	.${fragmentEntryLinkNamespace}_fragment_icon_container${fragmentEntryLinkNamespace} .iconBgColor {
+		background-color: ${configuration.iconBackgroundColor};
+	}
+
+	.${fragmentEntryLinkNamespace}_fragment_icon_container${fragmentEntryLinkNamespace} .iconSize{
+		width: ${configuration.iconWidthAndHeight};
+		height: ${configuration.iconWidthAndHeight};
+	}
+
+	.${fragmentEntryLinkNamespace}_fragment_icon_container${fragmentEntryLinkNamespace} .containerBgColor {
+		background-color: ${configuration.containerBackgroundColor};
+	}
+
+	.${fragmentEntryLinkNamespace}_fragment_icon_container${fragmentEntryLinkNamespace} .containerPadding{
+		padding: ${configuration.containerPadding};
+	}
+
+	.${fragmentEntryLinkNamespace}_fragment_icon_container${fragmentEntryLinkNamespace} .containerSize{
+		width: ${configuration.containerWidthAndHeight};
+		height: ${configuration.containerWidthAndHeight};
+	}
+
+	.${fragmentEntryLinkNamespace}_fragment_icon_container${fragmentEntryLinkNamespace} .imageSize{
+		height: ${configuration.imageWidthAndHeight};
+		width: ${configuration.imageWidthAndHeight};
+	}
+
+	.${fragmentEntryLinkNamespace}_fragment_icon_container${fragmentEntryLinkNamespace} .icon-background {
+		align-items: center;
+		display: flex;
+		justify-content: center;
+	}
+[/@]
+
+<div class="${fragmentEntryLinkNamespace}_fragment_icon_container${fragmentEntryLinkNamespace}">
+	<div class="icon-container rounded-circle containerBgColor containerSize containerPadding">
+		<div class="icon-background rounded-circle iconBgColor iconSize">
+			<img class="imageSize" data-lfr-editable-id="image-square" data-lfr-editable-type="image"
+				src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAABECAYAAABK3PEEAAAACXBIWXMAAC4jAAAuIwF4pT92AAABBUlEQVR4Xu3VAQkAIBDFUO0fRLCD2RSM8dg12Mbn5trnjo41MAvMtv1gBbb7FhjvW+AC6wZwvn5wgXEDOF4LLjBuAMdrwQXGDeB4LbjAuAEcrwUXGDeA47XgAuMGcLwWXGDcAI7XgguMG8DxWnCBcQM4XgsuMG4Ax2vBBcYN4HgtuMC4ARyvBRcYN4DjteAC4wZwvBZcYNwAjteCC4wbwPFacIFxAzheCy4wbgDHa8EFxg3geC24wLgBHK8FFxg3gOO14ALjBnC8Flxg3ACO14ILjBvA8VpwgXEDOF4LLjBuAMdrwQXGDeB4LbjAuAEcrwUXGDeA47XgAuMGcLwWXGDcAI73ADVez7kdh2y/AAAAAElFTkSuQmCC" />
 		</div>
 	</div>
 </div>

--- a/workspaces/liferay-tryitnow-workspace/client-extensions/liferay-tryitnow-site-initializer/site-initializer/fragments/group/tryitnow-custom-fragments/fragments/tryitnow-product-update/index.css
+++ b/workspaces/liferay-tryitnow-workspace/client-extensions/liferay-tryitnow-site-initializer/site-initializer/fragments/group/tryitnow-custom-fragments/fragments/tryitnow-product-update/index.css
@@ -1,14 +1,15 @@
-.fragment_549 h5 {
+.fragmentcss_product-update_container h5 {
 	max-width: 300px;
 }
-.fragment_549 .icon-container {
+
+.fragmentcss_product-update_container .icon-container {
 	align-items: center;
 	display: flex;
 	justify-content: center;
 	position: relative;
 }
 
-.fragment_549 .product-update-container {
+.fragmentcss_product-update_container .product-update-container {
 	border-radius: 10px;
 	border-style: solid;
 	border-width: 1px;
@@ -17,12 +18,12 @@
 	padding: 16px;
 }
 
-.fragment_549 .product-update-info {
+.fragmentcss_product-update_container .product-update-info {
 	display: flex;
 	flex-direction: column;
 	margin-left: 20px;
 }
 
-.fragment_549 .product-update-info .info-item {
+.fragmentcss_product-update_container .product-update-info .info-item {
 	margin-bottom: 4px;
 }

--- a/workspaces/liferay-tryitnow-workspace/client-extensions/liferay-tryitnow-site-initializer/site-initializer/fragments/group/tryitnow-custom-fragments/fragments/tryitnow-product-update/index.html
+++ b/workspaces/liferay-tryitnow-workspace/client-extensions/liferay-tryitnow-site-initializer/site-initializer/fragments/group/tryitnow-custom-fragments/fragments/tryitnow-product-update/index.html
@@ -1,6 +1,24 @@
-<div class="fragment_549">
-	<div class="border-neutral-2 product-update-container" style="min-height:${configuration.minHeight}">
-		<div class="icon-container rounded-lg" style="background-color:${configuration.separatorColor}; height: ${configuration.iconWidthAndHeight}; width: ${configuration.iconWidthAndHeight}">
+[@liferay_aui.style]
+	.${fragmentEntryLinkNamespace}_fragment_product-update_container .minHeight{
+		min-height:${configuration.minHeight};
+	}
+
+	.${fragmentEntryLinkNamespace}_fragment_product-update_container .separatorColor {
+		background-color:${configuration.separatorColor};
+	}
+
+	.${fragmentEntryLinkNamespace}_fragment_product-update_container .iconWidth{
+		width: ${configuration.iconWidthAndHeight};
+	}
+
+	.${fragmentEntryLinkNamespace}_fragment_product-update_container .iconHeight{
+		height: ${configuration.iconWidthAndHeight};
+	}
+[/@]
+
+<div class="${fragmentEntryLinkNamespace}_fragment_product-update_container fragmentcss_product-update_container">
+	<div class="border-neutral-2 product-update-container minHeight">
+		<div class="icon-container rounded-lg separatorColor iconWidth iconHeight">
 			<lfr-drop-zone data-lfr-drop-zone-id="1"></lfr-drop-zone>
 		</div>
 


### PR DESCRIPTION
In general, inline (those included inside an HTML tag) style attributes are discouraged when implementing CSPs → [CSP: style-src - HTTP | MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src#unsafe_inline_styles) so the goal of this epic is to extract all inline styles ingrained in the module code to their own CSS files or, if that’s not possible, to an <aui:style> tag at the very least, so that it contains a CSP nonce attribute when rendered.