### PR TITLE
LPD-51632 set account's defaults at CommerceOrders creation

### DIFF
--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/model/listener/CommerceOrderModelListener.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/model/listener/CommerceOrderModelListener.java
@@ -56,7 +56,7 @@ import com.liferay.portal.kernel.util.Validator;
 
 import java.math.BigDecimal;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -94,30 +94,40 @@ public class CommerceOrderModelListener
 								customerCommerceOrderId);
 
 						_updateOrderStatus(
-							originalCommerceOrder, commerceOrder,
-							customerCommerceOrder);
+							customerCommerceOrder,
+							commerceOrder.getOrderStatus(),
+							originalCommerceOrder.getOrderStatus());
 
 						if (_updateShippingAmount(
-								originalCommerceOrder, commerceOrder,
-								customerCommerceOrder) ||
+								customerCommerceOrder,
+								commerceOrder.getShippingAmount(),
+								originalCommerceOrder.getShippingAmount()) ||
 							_updateShippingDiscountAmount(
-								originalCommerceOrder, commerceOrder,
-								customerCommerceOrder) ||
+								customerCommerceOrder,
+								commerceOrder.getShippingDiscountAmount(),
+								originalCommerceOrder.
+									getShippingDiscountAmount()) ||
 							_updateSubtotal(
-								originalCommerceOrder, commerceOrder,
-								customerCommerceOrder) ||
+								customerCommerceOrder,
+								commerceOrder.getSubtotal(),
+								originalCommerceOrder.getSubtotal()) ||
 							_updateSubtotalDiscountAmount(
-								originalCommerceOrder, commerceOrder,
-								customerCommerceOrder) ||
+								customerCommerceOrder,
+								commerceOrder.getSubtotalDiscountAmount(),
+								originalCommerceOrder.
+									getSubtotalDiscountAmount()) ||
 							_updateTaxAmount(
-								originalCommerceOrder, commerceOrder,
-								customerCommerceOrder) ||
+								customerCommerceOrder,
+								commerceOrder.getTaxAmount(),
+								originalCommerceOrder.getTaxAmount()) ||
 							_updateTotal(
-								originalCommerceOrder, commerceOrder,
-								customerCommerceOrder) ||
+								customerCommerceOrder, commerceOrder.getTotal(),
+								originalCommerceOrder.getTotal()) ||
 							_updateTotalDiscountAmount(
-								originalCommerceOrder, commerceOrder,
-								customerCommerceOrder)) {
+								customerCommerceOrder,
+								commerceOrder.getTotalDiscountAmount(),
+								originalCommerceOrder.
+									getTotalDiscountAmount())) {
 
 							_commerceOrderLocalService.updateCommerceOrder(
 								customerCommerceOrder);
@@ -148,17 +158,12 @@ public class CommerceOrderModelListener
 				_commerceChannelLocalService.getCommerceChannelByOrderGroupId(
 					commerceOrder.getGroupId());
 
-			_setBillingAddress(commerceOrder, commerceChannel);
-
-			_setShippingAddress(commerceOrder, commerceChannel);
-
-			_setPaymentIntegration(user, commerceOrder, commerceChannel);
-
-			_setShippingOption(user, commerceOrder, commerceChannel);
-
-			_setDeliveryTerm(user, commerceOrder, commerceChannel);
-
-			_setPaymentTerm(user, commerceOrder, commerceChannel);
+			_setBillingAddress(commerceChannel, commerceOrder);
+			_setShippingAddress(commerceChannel, commerceOrder);
+			_setPaymentIntegration(commerceChannel, commerceOrder, user);
+			_setShippingOption(commerceChannel, commerceOrder, user);
+			_setDeliveryTerm(commerceChannel, commerceOrder, user);
+			_setPaymentTerm(commerceChannel, commerceOrder, user);
 		}
 		catch (PortalException portalException) {
 			if (_log.isWarnEnabled()) {
@@ -169,9 +174,13 @@ public class CommerceOrderModelListener
 
 	private List<CommercePaymentMethodGroupRel>
 		_filterCommercePaymentMethodGroupRels(
-			User user,
+			long commerceOrderTypeId,
 			List<CommercePaymentMethodGroupRel> commercePaymentMethodGroupRels,
-			long commerceOrderTypeId, boolean subscriptionOrder) {
+			boolean subscriptionOrder, User user) {
+
+		if (ListUtil.isEmpty(commercePaymentMethodGroupRels)) {
+			return Collections.emptyList();
+		}
 
 		List<CommercePaymentMethodGroupRel>
 			filteredCommercePaymentMethodGroupRels = new LinkedList<>();
@@ -205,21 +214,21 @@ public class CommerceOrderModelListener
 				continue;
 			}
 
-			CommercePaymentMethod commercePaymentMethod =
-				_commercePaymentMethodRegistry.getCommercePaymentMethod(
-					commercePaymentMethodGroupRel.getPaymentIntegrationKey());
-
 			CommercePaymentIntegration commercePaymentIntegration =
 				_commercePaymentIntegrationRegistry.
 					getCommercePaymentIntegration(
 						commercePaymentMethodGroupRel.
 							getPaymentIntegrationKey());
 
+			CommercePaymentMethod commercePaymentMethod =
+				_commercePaymentMethodRegistry.getCommercePaymentMethod(
+					commercePaymentMethodGroupRel.getPaymentIntegrationKey());
+
 			PermissionChecker permissionChecker =
 				_permissionCheckerFactory.create(user);
 
-			if (((commercePaymentMethod == null) &&
-				 (commercePaymentIntegration == null)) ||
+			if (((commercePaymentIntegration == null) &&
+				 (commercePaymentMethod == null)) ||
 				!permissionChecker.hasPermission(
 					commercePaymentMethodGroupRel.getGroupId(),
 					CommercePaymentMethodGroupRel.class.getName(),
@@ -243,104 +252,112 @@ public class CommerceOrderModelListener
 	}
 
 	private void _setBillingAddress(
-			CommerceOrder commerceOrder, CommerceChannel commerceChannel)
+			CommerceChannel commerceChannel, CommerceOrder commerceOrder)
 		throws PortalException {
 
-		if (commerceOrder.getBillingAddressId() <= 0) {
-			CommerceChannelAccountEntryRel commerceChannelAccountEntryRel =
-				_commerceChannelAccountEntryRelLocalService.
-					fetchCommerceChannelAccountEntryRel(
-						commerceOrder.getCommerceAccountId(),
-						commerceChannel.getCommerceChannelId(),
-						CommerceChannelAccountEntryRelConstants.
-							TYPE_BILLING_ADDRESS);
+		if (commerceOrder.getBillingAddressId() > 0) {
+			return;
+		}
 
-			if (commerceChannelAccountEntryRel != null) {
-				List<CommerceAddress> billingCommerceAddresses =
-					_commerceAddressLocalService.getBillingCommerceAddresses(
-						commerceChannel.getCommerceChannelId(),
-						AccountEntry.class.getName(),
-						commerceOrder.getCommerceAccountId(), QueryUtil.ALL_POS,
-						QueryUtil.ALL_POS);
+		CommerceChannelAccountEntryRel commerceChannelAccountEntryRel =
+			_commerceChannelAccountEntryRelLocalService.
+				fetchCommerceChannelAccountEntryRel(
+					commerceOrder.getCommerceAccountId(),
+					commerceChannel.getCommerceChannelId(),
+					CommerceChannelAccountEntryRelConstants.
+						TYPE_BILLING_ADDRESS);
 
-				CommerceAddress commerceAddress =
-					_commerceAddressLocalService.getCommerceAddress(
-						commerceChannelAccountEntryRel.getClassPK());
+		if (commerceChannelAccountEntryRel == null) {
+			return;
+		}
 
-				if ((commerceAddress != null) &&
-					billingCommerceAddresses.contains(commerceAddress)) {
+		CommerceAddress commerceAddress =
+			_commerceAddressLocalService.getCommerceAddress(
+				commerceChannelAccountEntryRel.getClassPK());
 
-					commerceOrder.setBillingAddressId(
-						commerceAddress.getCommerceAddressId());
-				}
-			}
+		if (commerceAddress == null) {
+			return;
+		}
+
+		List<CommerceAddress> billingCommerceAddresses =
+			_commerceAddressLocalService.getBillingCommerceAddresses(
+				commerceChannel.getCommerceChannelId(),
+				AccountEntry.class.getName(),
+				commerceOrder.getCommerceAccountId(), QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS);
+
+		if (billingCommerceAddresses.contains(commerceAddress)) {
+			commerceOrder.setBillingAddressId(
+				commerceAddress.getCommerceAddressId());
 		}
 	}
 
 	private void _setDeliveryTerm(
-		User user, CommerceOrder commerceOrder,
-		CommerceChannel commerceChannel) {
+		CommerceChannel commerceChannel, CommerceOrder commerceOrder,
+		User user) {
 
-		if (commerceOrder.getDeliveryCommerceTermEntryId() <= 0) {
-			CommerceChannelAccountEntryRel commerceChannelAccountEntryRel =
-				_commerceChannelAccountEntryRelLocalService.
-					fetchCommerceChannelAccountEntryRel(
-						commerceOrder.getCommerceAccountId(),
-						commerceChannel.getCommerceChannelId(),
-						CommerceChannelAccountEntryRelConstants.
-							TYPE_DELIVERY_TERM);
-
-			if (commerceChannelAccountEntryRel != null) {
-				CommerceTermEntry commerceTermEntry =
-					_commerceTermEntryLocalService.fetchCommerceTermEntry(
-						commerceChannelAccountEntryRel.getClassPK());
-
-				if (commerceTermEntry != null) {
-					commerceOrder.setDeliveryCommerceTermEntryId(
-						commerceTermEntry.getCommerceTermEntryId());
-					commerceOrder.setDeliveryCommerceTermEntryDescription(
-						commerceTermEntry.getDescription(
-							user.getLanguageId(), true));
-					commerceOrder.setDeliveryCommerceTermEntryName(
-						commerceTermEntry.getLabel(user.getLanguageId(), true));
-				}
-			}
+		if (commerceOrder.getDeliveryCommerceTermEntryId() > 0) {
+			return;
 		}
+
+		CommerceChannelAccountEntryRel commerceChannelAccountEntryRel =
+			_commerceChannelAccountEntryRelLocalService.
+				fetchCommerceChannelAccountEntryRel(
+					commerceOrder.getCommerceAccountId(),
+					commerceChannel.getCommerceChannelId(),
+					CommerceChannelAccountEntryRelConstants.TYPE_DELIVERY_TERM);
+
+		if (commerceChannelAccountEntryRel == null) {
+			return;
+		}
+
+		CommerceTermEntry commerceTermEntry =
+			_commerceTermEntryLocalService.fetchCommerceTermEntry(
+				commerceChannelAccountEntryRel.getClassPK());
+
+		if (commerceTermEntry == null) {
+			return;
+		}
+
+		commerceOrder.setDeliveryCommerceTermEntryId(
+			commerceTermEntry.getCommerceTermEntryId());
+		commerceOrder.setDeliveryCommerceTermEntryDescription(
+			commerceTermEntry.getDescription(user.getLanguageId(), true));
+		commerceOrder.setDeliveryCommerceTermEntryName(
+			commerceTermEntry.getLabel(user.getLanguageId(), true));
 	}
 
 	private void _setPaymentIntegration(
-			User user, CommerceOrder commerceOrder,
-			CommerceChannel commerceChannel)
+			CommerceChannel commerceChannel, CommerceOrder commerceOrder,
+			User user)
 		throws PortalException {
 
 		if (Validator.isNotNull(commerceOrder.getCommercePaymentMethodKey())) {
 			return;
 		}
 
-		List<CommercePaymentMethodGroupRel> commercePaymentMethodGroupRels =
-			new ArrayList<>();
-
 		CommerceAddress commerceAddress = commerceOrder.getBillingAddress();
 
 		if (commerceAddress == null) {
 			commerceAddress = commerceOrder.getShippingAddress();
+
+			if (commerceAddress == null) {
+				return;
+			}
 		}
 
-		if (commerceAddress != null) {
-			commercePaymentMethodGroupRels.addAll(
+		List<CommercePaymentMethodGroupRel> commercePaymentMethodGroupRels =
+			_filterCommercePaymentMethodGroupRels(
+				commerceOrder.getCommerceOrderTypeId(),
 				_commercePaymentMethodGroupRelLocalService.
 					getCommercePaymentMethodGroupRels(
 						commerceOrder.getGroupId(),
-						commerceAddress.getCountryId(), true));
-		}
-		else {
+						commerceAddress.getCountryId(), true),
+				commerceOrder.isSubscriptionOrder(), user);
+
+		if (ListUtil.isEmpty(commercePaymentMethodGroupRels)) {
 			return;
 		}
-
-		commercePaymentMethodGroupRels = _filterCommercePaymentMethodGroupRels(
-			user, commercePaymentMethodGroupRels,
-			commerceOrder.getCommerceOrderTypeId(),
-			commerceOrder.isSubscriptionOrder());
 
 		if (commercePaymentMethodGroupRels.size() == 1) {
 			CommercePaymentMethodGroupRel commercePaymentMethodGroupRel =
@@ -352,106 +369,116 @@ public class CommerceOrderModelListener
 
 		AccountEntry accountEntry = commerceOrder.getAccountEntry();
 
-		if ((accountEntry != null) &&
-			!commercePaymentMethodGroupRels.isEmpty()) {
+		if (accountEntry == null) {
+			return;
+		}
 
-			CommerceChannelAccountEntryRel commerceChannelAccountEntryRel =
-				_commerceChannelAccountEntryRelLocalService.
-					fetchCommerceChannelAccountEntryRel(
-						accountEntry.getAccountEntryId(),
-						commerceChannel.getCommerceChannelId(),
-						CommerceChannelAccountEntryRelConstants.TYPE_PAYMENT);
+		CommerceChannelAccountEntryRel commerceChannelAccountEntryRel =
+			_commerceChannelAccountEntryRelLocalService.
+				fetchCommerceChannelAccountEntryRel(
+					accountEntry.getAccountEntryId(),
+					commerceChannel.getCommerceChannelId(),
+					CommerceChannelAccountEntryRelConstants.TYPE_PAYMENT);
 
-			if (commerceChannelAccountEntryRel != null) {
-				CommercePaymentMethodGroupRel commercePaymentMethodGroupRel =
-					_commercePaymentMethodGroupRelLocalService.
-						fetchCommercePaymentMethodGroupRel(
-							commerceChannelAccountEntryRel.getClassPK());
+		if (commerceChannelAccountEntryRel == null) {
+			return;
+		}
 
-				if ((commercePaymentMethodGroupRel != null) &&
-					commercePaymentMethodGroupRel.isActive() &&
-					commercePaymentMethodGroupRels.contains(
-						commercePaymentMethodGroupRel) &&
-					Validator.isNull(
-						commerceOrder.getCommercePaymentMethodKey())) {
+		CommercePaymentMethodGroupRel commercePaymentMethodGroupRel =
+			_commercePaymentMethodGroupRelLocalService.
+				fetchCommercePaymentMethodGroupRel(
+					commerceChannelAccountEntryRel.getClassPK());
 
-					commerceOrder.setCommercePaymentMethodKey(
-						commercePaymentMethodGroupRel.
-							getPaymentIntegrationKey());
-				}
-			}
+		if ((commercePaymentMethodGroupRel != null) &&
+			commercePaymentMethodGroupRel.isActive() &&
+			commercePaymentMethodGroupRels.contains(
+				commercePaymentMethodGroupRel) &&
+			Validator.isNull(commerceOrder.getCommercePaymentMethodKey())) {
+
+			commerceOrder.setCommercePaymentMethodKey(
+				commercePaymentMethodGroupRel.getPaymentIntegrationKey());
 		}
 	}
 
 	private void _setPaymentTerm(
-		User user, CommerceOrder commerceOrder,
-		CommerceChannel commerceChannel) {
+		CommerceChannel commerceChannel, CommerceOrder commerceOrder,
+		User user) {
 
-		if (commerceOrder.getPaymentCommerceTermEntryId() <= 0) {
-			CommerceChannelAccountEntryRel commerceChannelAccountEntryRel =
-				_commerceChannelAccountEntryRelLocalService.
-					fetchCommerceChannelAccountEntryRel(
-						commerceOrder.getCommerceAccountId(),
-						commerceChannel.getCommerceChannelId(),
-						CommerceChannelAccountEntryRelConstants.
-							TYPE_PAYMENT_TERM);
-
-			if (commerceChannelAccountEntryRel != null) {
-				CommerceTermEntry commerceTermEntry =
-					_commerceTermEntryLocalService.fetchCommerceTermEntry(
-						commerceChannelAccountEntryRel.getClassPK());
-
-				if (commerceTermEntry != null) {
-					commerceOrder.setPaymentCommerceTermEntryId(
-						commerceTermEntry.getCommerceTermEntryId());
-					commerceOrder.setPaymentCommerceTermEntryDescription(
-						commerceTermEntry.getDescription(
-							user.getLanguageId(), true));
-					commerceOrder.setPaymentCommerceTermEntryName(
-						commerceTermEntry.getLabel(user.getLanguageId(), true));
-				}
-			}
+		if (commerceOrder.getPaymentCommerceTermEntryId() > 0) {
+			return;
 		}
+
+		CommerceChannelAccountEntryRel commerceChannelAccountEntryRel =
+			_commerceChannelAccountEntryRelLocalService.
+				fetchCommerceChannelAccountEntryRel(
+					commerceOrder.getCommerceAccountId(),
+					commerceChannel.getCommerceChannelId(),
+					CommerceChannelAccountEntryRelConstants.TYPE_PAYMENT_TERM);
+
+		if (commerceChannelAccountEntryRel == null) {
+			return;
+		}
+
+		CommerceTermEntry commerceTermEntry =
+			_commerceTermEntryLocalService.fetchCommerceTermEntry(
+				commerceChannelAccountEntryRel.getClassPK());
+
+		if (commerceTermEntry == null) {
+			return;
+		}
+
+		commerceOrder.setPaymentCommerceTermEntryId(
+			commerceTermEntry.getCommerceTermEntryId());
+		commerceOrder.setPaymentCommerceTermEntryDescription(
+			commerceTermEntry.getDescription(user.getLanguageId(), true));
+		commerceOrder.setPaymentCommerceTermEntryName(
+			commerceTermEntry.getLabel(user.getLanguageId(), true));
 	}
 
 	private void _setShippingAddress(
-			CommerceOrder commerceOrder, CommerceChannel commerceChannel)
+			CommerceChannel commerceChannel, CommerceOrder commerceOrder)
 		throws PortalException {
 
-		if (commerceOrder.getShippingAddressId() <= 0) {
-			CommerceChannelAccountEntryRel commerceChannelAccountEntryRel =
-				_commerceChannelAccountEntryRelLocalService.
-					fetchCommerceChannelAccountEntryRel(
-						commerceOrder.getCommerceAccountId(),
-						commerceChannel.getCommerceChannelId(),
-						CommerceChannelAccountEntryRelConstants.
-							TYPE_SHIPPING_ADDRESS);
+		if (commerceOrder.getShippingAddressId() > 0) {
+			return;
+		}
 
-			if (commerceChannelAccountEntryRel != null) {
-				List<CommerceAddress> shippingCommerceAddresses =
-					_commerceAddressLocalService.getShippingCommerceAddresses(
-						commerceChannel.getCommerceChannelId(),
-						AccountEntry.class.getName(),
-						commerceOrder.getCommerceAccountId(), QueryUtil.ALL_POS,
-						QueryUtil.ALL_POS);
+		CommerceChannelAccountEntryRel commerceChannelAccountEntryRel =
+			_commerceChannelAccountEntryRelLocalService.
+				fetchCommerceChannelAccountEntryRel(
+					commerceOrder.getCommerceAccountId(),
+					commerceChannel.getCommerceChannelId(),
+					CommerceChannelAccountEntryRelConstants.
+						TYPE_SHIPPING_ADDRESS);
 
-				CommerceAddress commerceAddress =
-					_commerceAddressLocalService.getCommerceAddress(
-						commerceChannelAccountEntryRel.getClassPK());
+		if (commerceChannelAccountEntryRel == null) {
+			return;
+		}
 
-				if ((commerceAddress != null) &&
-					shippingCommerceAddresses.contains(commerceAddress)) {
+		CommerceAddress commerceAddress =
+			_commerceAddressLocalService.getCommerceAddress(
+				commerceChannelAccountEntryRel.getClassPK());
 
-					commerceOrder.setShippingAddressId(
-						commerceAddress.getCommerceAddressId());
-				}
-			}
+		if (commerceAddress == null) {
+			return;
+		}
+
+		List<CommerceAddress> shippingCommerceAddresses =
+			_commerceAddressLocalService.getShippingCommerceAddresses(
+				commerceChannel.getCommerceChannelId(),
+				AccountEntry.class.getName(),
+				commerceOrder.getCommerceAccountId(), QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS);
+
+		if (shippingCommerceAddresses.contains(commerceAddress)) {
+			commerceOrder.setShippingAddressId(
+				commerceAddress.getCommerceAddressId());
 		}
 	}
 
 	private void _setShippingOption(
-			User user, CommerceOrder commerceOrder,
-			CommerceChannel commerceChannel)
+			CommerceChannel commerceChannel, CommerceOrder commerceOrder,
+			User user)
 		throws PortalException {
 
 		if ((commerceOrder.getCommerceShippingMethodId() > 0) &&
@@ -466,18 +493,31 @@ public class CommerceOrderModelListener
 			return;
 		}
 
-		List<CommerceShippingMethod> commerceShippingMethods =
-			_commerceShippingMethodLocalService.getCommerceShippingMethods(
-				commerceOrder.getGroupId(), true, QueryUtil.ALL_POS,
-				QueryUtil.ALL_POS,
-				CommerceShippingMethodPriorityComparator.getInstance(false));
-
 		CommerceShippingOptionAccountEntryRel
 			commerceShippingOptionAccountEntryRel =
 				_commerceShippingOptionAccountEntryRelService.
 					fetchCommerceShippingOptionAccountEntryRel(
 						accountEntry.getAccountEntryId(),
 						commerceChannel.getCommerceChannelId());
+
+		if (commerceShippingOptionAccountEntryRel == null) {
+			return;
+		}
+
+		List<CommerceShippingMethod> commerceShippingMethods =
+			_commerceShippingMethodLocalService.getCommerceShippingMethods(
+				commerceOrder.getGroupId(), true, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS,
+				CommerceShippingMethodPriorityComparator.getInstance(false));
+
+		if (ListUtil.isEmpty(commerceShippingMethods)) {
+			return;
+		}
+
+		CommerceContext commerceContext = _commerceContextFactory.create(
+			accountEntry.getAccountEntryId(), commerceChannel.getGroupId(),
+			commerceOrder.getCommerceCurrencyCode(),
+			commerceOrder.getCommerceOrderId(), commerceOrder.getCompanyId());
 
 		for (CommerceShippingMethod commerceShippingMethod :
 				commerceShippingMethods) {
@@ -486,44 +526,40 @@ public class CommerceOrderModelListener
 				_commerceShippingEngineRegistry.getCommerceShippingEngine(
 					commerceShippingMethod.getEngineKey());
 
-			CommerceContext commerceContext = _commerceContextFactory.create(
-				accountEntry.getAccountEntryId(), commerceChannel.getGroupId(),
-				commerceOrder.getCommerceCurrencyCode(),
-				commerceOrder.getCommerceOrderId(),
-				commerceOrder.getCompanyId());
+			if (commerceShippingEngine == null) {
+				continue;
+			}
 
 			List<CommerceShippingOption> commerceShippingOptions =
 				commerceShippingEngine.getEnabledCommerceShippingOptions(
 					commerceContext, commerceOrder, user.getLocale());
 
-			if (commerceShippingOptions.isEmpty()) {
+			if (ListUtil.isEmpty(commerceShippingOptions)) {
 				continue;
 			}
 
-			if (commerceShippingOptionAccountEntryRel != null) {
-				CommerceShippingOption defaultCommerceShippingOption = null;
+			CommerceShippingOption defaultCommerceShippingOption = null;
 
-				for (CommerceShippingOption commerceShippingOption :
-						commerceShippingOptions) {
+			for (CommerceShippingOption commerceShippingOption :
+					commerceShippingOptions) {
 
-					String key = commerceShippingOption.getKey();
+				String key = commerceShippingOption.getKey();
 
-					if (key.equals(
-							commerceShippingOptionAccountEntryRel.
-								getCommerceShippingOptionKey())) {
+				if (key.equals(
+						commerceShippingOptionAccountEntryRel.
+							getCommerceShippingOptionKey())) {
 
-						defaultCommerceShippingOption = commerceShippingOption;
+					defaultCommerceShippingOption = commerceShippingOption;
 
-						break;
-					}
+					break;
 				}
+			}
 
-				if (defaultCommerceShippingOption != null) {
-					commerceOrder.setCommerceShippingMethodId(
-						commerceShippingMethod.getCommerceShippingMethodId());
-					commerceOrder.setShippingOptionName(
-						defaultCommerceShippingOption.getKey());
-				}
+			if (defaultCommerceShippingOption != null) {
+				commerceOrder.setCommerceShippingMethodId(
+					commerceShippingMethod.getCommerceShippingMethodId());
+				commerceOrder.setShippingOptionName(
+					defaultCommerceShippingOption.getKey());
 			}
 		}
 	}
@@ -538,11 +574,9 @@ public class CommerceOrderModelListener
 			return false;
 		}
 
-		Long firstSupplierCommerceOrderId = supplierCommerceOrderIds.get(0);
-
 		CommerceOrder firstSupplierCommerceOrder =
 			_commerceOrderLocalService.getCommerceOrder(
-				firstSupplierCommerceOrderId);
+				supplierCommerceOrderIds.get(0));
 
 		int orderStatus = firstSupplierCommerceOrder.getOrderStatus();
 
@@ -552,10 +586,10 @@ public class CommerceOrderModelListener
 			return true;
 		}
 
-		for (int i = 1; i < supplierCommerceOrderIds.size(); i++) {
+		for (Long supplierCommerceOrderId : supplierCommerceOrderIds) {
 			CommerceOrder supplierCommerceOrder =
 				_commerceOrderLocalService.getCommerceOrder(
-					supplierCommerceOrderIds.get(i));
+					supplierCommerceOrderId);
 
 			if (orderStatus != supplierCommerceOrder.getOrderStatus()) {
 				return false;
@@ -566,211 +600,181 @@ public class CommerceOrderModelListener
 	}
 
 	private void _updateOrderStatus(
-			CommerceOrder originalCommerceOrder, CommerceOrder commerceOrder,
-			CommerceOrder customerCommerceOrder)
+			CommerceOrder customerCommerceOrder, int newOrderStatus,
+			int originalOrderStatus)
 		throws PortalException {
 
-		int newOrderStatus = commerceOrder.getOrderStatus();
-		int originalOrderStatus = originalCommerceOrder.getOrderStatus();
+		if (originalOrderStatus == newOrderStatus) {
+			return;
+		}
 
-		if (originalOrderStatus != newOrderStatus) {
-			_commerceOrderEngine.checkCommerceOrderShipmentStatus(
-				customerCommerceOrder, false);
+		_commerceOrderEngine.checkCommerceOrderShipmentStatus(
+			customerCommerceOrder, false);
 
-			if ((newOrderStatus ==
-					CommerceOrderConstants.ORDER_STATUS_COMPLETED) &&
-				_transitionOrderStatusCompleted(customerCommerceOrder)) {
+		if ((newOrderStatus == CommerceOrderConstants.ORDER_STATUS_COMPLETED) &&
+			_transitionOrderStatusCompleted(customerCommerceOrder)) {
 
-				_commerceOrderEngine.transitionCommerceOrder(
-					customerCommerceOrder, newOrderStatus, 0, false);
-			}
+			_commerceOrderEngine.transitionCommerceOrder(
+				customerCommerceOrder, newOrderStatus, 0, false);
 		}
 	}
 
 	private boolean _updateShippingAmount(
-		CommerceOrder originalCommerceOrder, CommerceOrder commerceOrder,
-		CommerceOrder customerCommerceOrder) {
-
-		BigDecimal originalShippingAmount =
-			originalCommerceOrder.getShippingAmount();
-		BigDecimal newShippingAmount = commerceOrder.getShippingAmount();
+		CommerceOrder customerCommerceOrder, BigDecimal newShippingAmount,
+		BigDecimal originalShippingAmount) {
 
 		int compareShippingAmount = originalShippingAmount.compareTo(
 			newShippingAmount);
 
-		if (compareShippingAmount != 0) {
-			BigDecimal customerShippingAmount =
-				customerCommerceOrder.getShippingAmount();
-
-			BigDecimal subtractOriginalValue = customerShippingAmount.subtract(
-				originalShippingAmount);
-
-			customerCommerceOrder.setShippingAmount(
-				subtractOriginalValue.add(newShippingAmount));
-
-			return true;
+		if (compareShippingAmount == 0) {
+			return false;
 		}
 
-		return false;
+		BigDecimal customerShippingAmount =
+			customerCommerceOrder.getShippingAmount();
+
+		BigDecimal subtractOriginalValue = customerShippingAmount.subtract(
+			originalShippingAmount);
+
+		customerCommerceOrder.setShippingAmount(
+			subtractOriginalValue.add(newShippingAmount));
+
+		return true;
 	}
 
 	private boolean _updateShippingDiscountAmount(
-		CommerceOrder originalCommerceOrder, CommerceOrder commerceOrder,
-		CommerceOrder customerCommerceOrder) {
-
-		BigDecimal originalShippingDiscountAmount =
-			originalCommerceOrder.getShippingDiscountAmount();
-		BigDecimal newShippingDiscountAmount =
-			commerceOrder.getShippingDiscountAmount();
+		CommerceOrder customerCommerceOrder,
+		BigDecimal newShippingDiscountAmount,
+		BigDecimal originalShippingDiscountAmount) {
 
 		int compareShippingDiscountAmount =
 			originalShippingDiscountAmount.compareTo(newShippingDiscountAmount);
 
-		if (compareShippingDiscountAmount != 0) {
-			BigDecimal customerShippingDiscountAmount =
-				customerCommerceOrder.getShippingDiscountAmount();
-
-			BigDecimal subtractOriginalValue =
-				customerShippingDiscountAmount.subtract(
-					originalShippingDiscountAmount);
-
-			customerCommerceOrder.setShippingDiscountAmount(
-				subtractOriginalValue.add(newShippingDiscountAmount));
-
-			return true;
+		if (compareShippingDiscountAmount == 0) {
+			return false;
 		}
 
-		return false;
+		BigDecimal customerShippingDiscountAmount =
+			customerCommerceOrder.getShippingDiscountAmount();
+
+		BigDecimal subtractOriginalValue =
+			customerShippingDiscountAmount.subtract(
+				originalShippingDiscountAmount);
+
+		customerCommerceOrder.setShippingDiscountAmount(
+			subtractOriginalValue.add(newShippingDiscountAmount));
+
+		return true;
 	}
 
 	private boolean _updateSubtotal(
-		CommerceOrder originalCommerceOrder, CommerceOrder commerceOrder,
-		CommerceOrder customerCommerceOrder) {
-
-		BigDecimal originalSubtotal = originalCommerceOrder.getSubtotal();
-		BigDecimal newSubtotal = commerceOrder.getSubtotal();
+		CommerceOrder customerCommerceOrder, BigDecimal newSubtotal,
+		BigDecimal originalSubtotal) {
 
 		int compareSubtotal = originalSubtotal.compareTo(newSubtotal);
 
-		if (compareSubtotal != 0) {
-			BigDecimal customerSubtotal = customerCommerceOrder.getSubtotal();
-
-			BigDecimal subtractOriginalValue = customerSubtotal.subtract(
-				originalSubtotal);
-
-			customerCommerceOrder.setSubtotal(
-				subtractOriginalValue.add(newSubtotal));
-
-			return true;
+		if (compareSubtotal == 0) {
+			return false;
 		}
 
-		return false;
+		BigDecimal customerSubtotal = customerCommerceOrder.getSubtotal();
+
+		BigDecimal subtractOriginalValue = customerSubtotal.subtract(
+			originalSubtotal);
+
+		customerCommerceOrder.setSubtotal(
+			subtractOriginalValue.add(newSubtotal));
+
+		return true;
 	}
 
 	private boolean _updateSubtotalDiscountAmount(
-		CommerceOrder originalCommerceOrder, CommerceOrder commerceOrder,
-		CommerceOrder customerCommerceOrder) {
-
-		BigDecimal originalSubtotalDiscountAmount =
-			originalCommerceOrder.getSubtotalDiscountAmount();
-
-		BigDecimal newSubtotalDiscountAmount =
-			commerceOrder.getSubtotalDiscountAmount();
+		CommerceOrder customerCommerceOrder,
+		BigDecimal newSubtotalDiscountAmount,
+		BigDecimal originalSubtotalDiscountAmount) {
 
 		int compareSubtotalDiscountAmount =
 			originalSubtotalDiscountAmount.compareTo(newSubtotalDiscountAmount);
 
-		if (compareSubtotalDiscountAmount != 0) {
-			BigDecimal customerSubtotalDiscountAmount =
-				customerCommerceOrder.getSubtotalDiscountAmount();
-
-			BigDecimal subtractOriginalValue =
-				customerSubtotalDiscountAmount.subtract(
-					originalSubtotalDiscountAmount);
-
-			customerCommerceOrder.setSubtotalDiscountAmount(
-				subtractOriginalValue.add(newSubtotalDiscountAmount));
-
-			return true;
+		if (compareSubtotalDiscountAmount == 0) {
+			return false;
 		}
 
-		return false;
+		BigDecimal customerSubtotalDiscountAmount =
+			customerCommerceOrder.getSubtotalDiscountAmount();
+
+		BigDecimal subtractOriginalValue =
+			customerSubtotalDiscountAmount.subtract(
+				originalSubtotalDiscountAmount);
+
+		customerCommerceOrder.setSubtotalDiscountAmount(
+			subtractOriginalValue.add(newSubtotalDiscountAmount));
+
+		return true;
 	}
 
 	private boolean _updateTaxAmount(
-		CommerceOrder originalCommerceOrder, CommerceOrder commerceOrder,
-		CommerceOrder customerCommerceOrder) {
-
-		BigDecimal originalTaxAmount = originalCommerceOrder.getTaxAmount();
-		BigDecimal newTaxAmount = commerceOrder.getTaxAmount();
+		CommerceOrder customerCommerceOrder, BigDecimal newTaxAmount,
+		BigDecimal originalTaxAmount) {
 
 		int compareTaxAmount = originalTaxAmount.compareTo(newTaxAmount);
 
-		if (compareTaxAmount != 0) {
-			BigDecimal customerTaxAmount = customerCommerceOrder.getTaxAmount();
-
-			BigDecimal subtractOriginalValue = customerTaxAmount.subtract(
-				originalTaxAmount);
-
-			customerCommerceOrder.setTaxAmount(
-				subtractOriginalValue.add(newTaxAmount));
-
-			return true;
+		if (compareTaxAmount == 0) {
+			return false;
 		}
 
-		return false;
+		BigDecimal customerTaxAmount = customerCommerceOrder.getTaxAmount();
+
+		BigDecimal subtractOriginalValue = customerTaxAmount.subtract(
+			originalTaxAmount);
+
+		customerCommerceOrder.setTaxAmount(
+			subtractOriginalValue.add(newTaxAmount));
+
+		return true;
 	}
 
 	private boolean _updateTotal(
-		CommerceOrder originalCommerceOrder, CommerceOrder commerceOrder,
-		CommerceOrder customerCommerceOrder) {
-
-		BigDecimal originalTotal = originalCommerceOrder.getTotal();
-		BigDecimal newTotal = commerceOrder.getTotal();
+		CommerceOrder customerCommerceOrder, BigDecimal newTotal,
+		BigDecimal originalTotal) {
 
 		int compareTotal = originalTotal.compareTo(newTotal);
 
-		if (compareTotal != 0) {
-			BigDecimal customerTotal = customerCommerceOrder.getTotal();
-
-			BigDecimal subtractOriginalValue = customerTotal.subtract(
-				originalTotal);
-
-			customerCommerceOrder.setTotal(subtractOriginalValue.add(newTotal));
-
-			return true;
+		if (compareTotal == 0) {
+			return false;
 		}
 
-		return false;
+		BigDecimal customerTotal = customerCommerceOrder.getTotal();
+
+		BigDecimal subtractOriginalValue = customerTotal.subtract(
+			originalTotal);
+
+		customerCommerceOrder.setTotal(subtractOriginalValue.add(newTotal));
+
+		return true;
 	}
 
 	private boolean _updateTotalDiscountAmount(
-		CommerceOrder originalCommerceOrder, CommerceOrder commerceOrder,
-		CommerceOrder customerCommerceOrder) {
-
-		BigDecimal originalTotalDiscountAmount =
-			originalCommerceOrder.getTotalDiscountAmount();
-		BigDecimal newTotalDiscountAmount =
-			commerceOrder.getTotalDiscountAmount();
+		CommerceOrder customerCommerceOrder, BigDecimal newTotalDiscountAmount,
+		BigDecimal originalTotalDiscountAmount) {
 
 		int compareTotalDiscountAmount = originalTotalDiscountAmount.compareTo(
 			newTotalDiscountAmount);
 
 		if (compareTotalDiscountAmount != 0) {
-			BigDecimal customerTotalDiscountAmount =
-				customerCommerceOrder.getTotalDiscountAmount();
-
-			BigDecimal subtractOriginalValue =
-				customerTotalDiscountAmount.subtract(
-					originalTotalDiscountAmount);
-
-			customerCommerceOrder.setTotalDiscountAmount(
-				subtractOriginalValue.add(newTotalDiscountAmount));
-
-			return true;
+			return false;
 		}
 
-		return false;
+		BigDecimal customerTotalDiscountAmount =
+			customerCommerceOrder.getTotalDiscountAmount();
+
+		BigDecimal subtractOriginalValue = customerTotalDiscountAmount.subtract(
+			originalTotalDiscountAmount);
+
+		customerCommerceOrder.setTotalDiscountAmount(
+			subtractOriginalValue.add(newTotalDiscountAmount));
+
+		return true;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/model/listener/CommerceOrderModelListener.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/model/listener/CommerceOrderModelListener.java
@@ -5,19 +5,59 @@
 
 package com.liferay.commerce.internal.model.listener;
 
+import com.liferay.account.model.AccountEntry;
 import com.liferay.commerce.constants.CommerceOrderConstants;
+import com.liferay.commerce.context.CommerceContext;
+import com.liferay.commerce.context.CommerceContextFactory;
+import com.liferay.commerce.model.CommerceAddress;
 import com.liferay.commerce.model.CommerceOrder;
+import com.liferay.commerce.model.CommerceOrderType;
+import com.liferay.commerce.model.CommerceShippingEngine;
+import com.liferay.commerce.model.CommerceShippingMethod;
+import com.liferay.commerce.model.CommerceShippingOption;
+import com.liferay.commerce.model.CommerceShippingOptionAccountEntryRel;
 import com.liferay.commerce.order.engine.CommerceOrderEngine;
+import com.liferay.commerce.payment.integration.CommercePaymentIntegration;
+import com.liferay.commerce.payment.integration.CommercePaymentIntegrationRegistry;
+import com.liferay.commerce.payment.method.CommercePaymentMethod;
+import com.liferay.commerce.payment.method.CommercePaymentMethodRegistry;
+import com.liferay.commerce.payment.model.CommercePaymentMethodGroupRel;
+import com.liferay.commerce.payment.model.CommercePaymentMethodGroupRelQualifier;
+import com.liferay.commerce.payment.service.CommercePaymentMethodGroupRelLocalService;
+import com.liferay.commerce.payment.service.CommercePaymentMethodGroupRelQualifierLocalService;
+import com.liferay.commerce.payment.util.comparator.CommercePaymentMethodPriorityComparator;
+import com.liferay.commerce.product.constants.CommerceChannelAccountEntryRelConstants;
+import com.liferay.commerce.product.model.CommerceChannel;
+import com.liferay.commerce.product.model.CommerceChannelAccountEntryRel;
+import com.liferay.commerce.product.service.CommerceChannelAccountEntryRelLocalService;
+import com.liferay.commerce.product.service.CommerceChannelLocalService;
+import com.liferay.commerce.service.CommerceAddressLocalService;
 import com.liferay.commerce.service.CommerceOrderLocalService;
+import com.liferay.commerce.service.CommerceShippingMethodLocalService;
+import com.liferay.commerce.service.CommerceShippingOptionAccountEntryRelService;
+import com.liferay.commerce.term.model.CommerceTermEntry;
+import com.liferay.commerce.term.service.CommerceTermEntryLocalService;
+import com.liferay.commerce.util.CommerceShippingEngineRegistry;
+import com.liferay.commerce.util.comparator.CommerceShippingMethodPriorityComparator;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.math.BigDecimal;
 
+import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
@@ -93,6 +133,397 @@ public class CommerceOrderModelListener
 		catch (PortalException portalException) {
 			if (_log.isWarnEnabled()) {
 				_log.warn(portalException);
+			}
+		}
+	}
+
+	@Override
+	public void onBeforeCreate(CommerceOrder commerceOrder)
+		throws ModelListenerException {
+
+		try {
+			User user = _userLocalService.getUser(commerceOrder.getUserId());
+
+			CommerceChannel commerceChannel =
+				_commerceChannelLocalService.getCommerceChannelByOrderGroupId(
+					commerceOrder.getGroupId());
+
+			_setBillingAddress(commerceOrder, commerceChannel);
+
+			_setShippingAddress(commerceOrder, commerceChannel);
+
+			_setPaymentIntegration(user, commerceOrder, commerceChannel);
+
+			_setShippingOption(user, commerceOrder, commerceChannel);
+
+			_setDeliveryTerm(user, commerceOrder, commerceChannel);
+
+			_setPaymentTerm(user, commerceOrder, commerceChannel);
+		}
+		catch (PortalException portalException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(portalException);
+			}
+		}
+	}
+
+	private List<CommercePaymentMethodGroupRel>
+		_filterCommercePaymentMethodGroupRels(
+			User user,
+			List<CommercePaymentMethodGroupRel> commercePaymentMethodGroupRels,
+			long commerceOrderTypeId, boolean subscriptionOrder) {
+
+		List<CommercePaymentMethodGroupRel>
+			filteredCommercePaymentMethodGroupRels = new LinkedList<>();
+
+		ListUtil.sort(
+			commercePaymentMethodGroupRels,
+			new CommercePaymentMethodPriorityComparator());
+
+		for (CommercePaymentMethodGroupRel commercePaymentMethodGroupRel :
+				commercePaymentMethodGroupRels) {
+
+			List<CommercePaymentMethodGroupRelQualifier>
+				commercePaymentMethodGroupRelQualifiers =
+					_commercePaymentMethodGroupRelQualifierLocalService.
+						getCommercePaymentMethodGroupRelQualifiers(
+							CommerceOrderType.class.getName(),
+							commercePaymentMethodGroupRel.
+								getCommercePaymentMethodGroupRelId());
+
+			if ((commerceOrderTypeId > 0) &&
+				ListUtil.isNotEmpty(commercePaymentMethodGroupRelQualifiers) &&
+				!ListUtil.exists(
+					commercePaymentMethodGroupRelQualifiers,
+					commercePaymentMethodGroupRelQualifier -> {
+						long classPK =
+							commercePaymentMethodGroupRelQualifier.getClassPK();
+
+						return classPK == commerceOrderTypeId;
+					})) {
+
+				continue;
+			}
+
+			CommercePaymentMethod commercePaymentMethod =
+				_commercePaymentMethodRegistry.getCommercePaymentMethod(
+					commercePaymentMethodGroupRel.getPaymentIntegrationKey());
+
+			CommercePaymentIntegration commercePaymentIntegration =
+				_commercePaymentIntegrationRegistry.
+					getCommercePaymentIntegration(
+						commercePaymentMethodGroupRel.
+							getPaymentIntegrationKey());
+
+			PermissionChecker permissionChecker =
+				_permissionCheckerFactory.create(user);
+
+			if (((commercePaymentMethod == null) &&
+				 (commercePaymentIntegration == null)) ||
+				!permissionChecker.hasPermission(
+					commercePaymentMethodGroupRel.getGroupId(),
+					CommercePaymentMethodGroupRel.class.getName(),
+					commercePaymentMethodGroupRel.
+						getCommercePaymentMethodGroupRelId(),
+					ActionKeys.VIEW) ||
+				((commercePaymentMethod == null) && subscriptionOrder) ||
+				((commercePaymentMethod != null) && subscriptionOrder &&
+				 !commercePaymentMethod.isProcessRecurringEnabled()) ||
+				((commercePaymentMethod != null) && !subscriptionOrder &&
+				 !commercePaymentMethod.isProcessPaymentEnabled())) {
+
+				continue;
+			}
+
+			filteredCommercePaymentMethodGroupRels.add(
+				commercePaymentMethodGroupRel);
+		}
+
+		return filteredCommercePaymentMethodGroupRels;
+	}
+
+	private void _setBillingAddress(
+			CommerceOrder commerceOrder, CommerceChannel commerceChannel)
+		throws PortalException {
+
+		if (commerceOrder.getBillingAddressId() <= 0) {
+			CommerceChannelAccountEntryRel commerceChannelAccountEntryRel =
+				_commerceChannelAccountEntryRelLocalService.
+					fetchCommerceChannelAccountEntryRel(
+						commerceOrder.getCommerceAccountId(),
+						commerceChannel.getCommerceChannelId(),
+						CommerceChannelAccountEntryRelConstants.
+							TYPE_BILLING_ADDRESS);
+
+			if (commerceChannelAccountEntryRel != null) {
+				List<CommerceAddress> billingCommerceAddresses =
+					_commerceAddressLocalService.getBillingCommerceAddresses(
+						commerceChannel.getCommerceChannelId(),
+						AccountEntry.class.getName(),
+						commerceOrder.getCommerceAccountId(), QueryUtil.ALL_POS,
+						QueryUtil.ALL_POS);
+
+				CommerceAddress commerceAddress =
+					_commerceAddressLocalService.getCommerceAddress(
+						commerceChannelAccountEntryRel.getClassPK());
+
+				if ((commerceAddress != null) &&
+					billingCommerceAddresses.contains(commerceAddress)) {
+
+					commerceOrder.setBillingAddressId(
+						commerceAddress.getCommerceAddressId());
+				}
+			}
+		}
+	}
+
+	private void _setDeliveryTerm(
+		User user, CommerceOrder commerceOrder,
+		CommerceChannel commerceChannel) {
+
+		if (commerceOrder.getDeliveryCommerceTermEntryId() <= 0) {
+			CommerceChannelAccountEntryRel commerceChannelAccountEntryRel =
+				_commerceChannelAccountEntryRelLocalService.
+					fetchCommerceChannelAccountEntryRel(
+						commerceOrder.getCommerceAccountId(),
+						commerceChannel.getCommerceChannelId(),
+						CommerceChannelAccountEntryRelConstants.
+							TYPE_DELIVERY_TERM);
+
+			if (commerceChannelAccountEntryRel != null) {
+				CommerceTermEntry commerceTermEntry =
+					_commerceTermEntryLocalService.fetchCommerceTermEntry(
+						commerceChannelAccountEntryRel.getClassPK());
+
+				if (commerceTermEntry != null) {
+					commerceOrder.setDeliveryCommerceTermEntryId(
+						commerceTermEntry.getCommerceTermEntryId());
+					commerceOrder.setDeliveryCommerceTermEntryDescription(
+						commerceTermEntry.getDescription(
+							user.getLanguageId(), true));
+					commerceOrder.setDeliveryCommerceTermEntryName(
+						commerceTermEntry.getLabel(user.getLanguageId(), true));
+				}
+			}
+		}
+	}
+
+	private void _setPaymentIntegration(
+			User user, CommerceOrder commerceOrder,
+			CommerceChannel commerceChannel)
+		throws PortalException {
+
+		if (Validator.isNotNull(commerceOrder.getCommercePaymentMethodKey())) {
+			return;
+		}
+
+		List<CommercePaymentMethodGroupRel> commercePaymentMethodGroupRels =
+			new ArrayList<>();
+
+		CommerceAddress commerceAddress = commerceOrder.getBillingAddress();
+
+		if (commerceAddress == null) {
+			commerceAddress = commerceOrder.getShippingAddress();
+		}
+
+		if (commerceAddress != null) {
+			commercePaymentMethodGroupRels.addAll(
+				_commercePaymentMethodGroupRelLocalService.
+					getCommercePaymentMethodGroupRels(
+						commerceOrder.getGroupId(),
+						commerceAddress.getCountryId(), true));
+		}
+		else {
+			return;
+		}
+
+		commercePaymentMethodGroupRels = _filterCommercePaymentMethodGroupRels(
+			user, commercePaymentMethodGroupRels,
+			commerceOrder.getCommerceOrderTypeId(),
+			commerceOrder.isSubscriptionOrder());
+
+		if (commercePaymentMethodGroupRels.size() == 1) {
+			CommercePaymentMethodGroupRel commercePaymentMethodGroupRel =
+				commercePaymentMethodGroupRels.get(0);
+
+			commerceOrder.setCommercePaymentMethodKey(
+				commercePaymentMethodGroupRel.getPaymentIntegrationKey());
+		}
+
+		AccountEntry accountEntry = commerceOrder.getAccountEntry();
+
+		if ((accountEntry != null) &&
+			!commercePaymentMethodGroupRels.isEmpty()) {
+
+			CommerceChannelAccountEntryRel commerceChannelAccountEntryRel =
+				_commerceChannelAccountEntryRelLocalService.
+					fetchCommerceChannelAccountEntryRel(
+						accountEntry.getAccountEntryId(),
+						commerceChannel.getCommerceChannelId(),
+						CommerceChannelAccountEntryRelConstants.TYPE_PAYMENT);
+
+			if (commerceChannelAccountEntryRel != null) {
+				CommercePaymentMethodGroupRel commercePaymentMethodGroupRel =
+					_commercePaymentMethodGroupRelLocalService.
+						fetchCommercePaymentMethodGroupRel(
+							commerceChannelAccountEntryRel.getClassPK());
+
+				if ((commercePaymentMethodGroupRel != null) &&
+					commercePaymentMethodGroupRel.isActive() &&
+					commercePaymentMethodGroupRels.contains(
+						commercePaymentMethodGroupRel) &&
+					Validator.isNull(
+						commerceOrder.getCommercePaymentMethodKey())) {
+
+					commerceOrder.setCommercePaymentMethodKey(
+						commercePaymentMethodGroupRel.
+							getPaymentIntegrationKey());
+				}
+			}
+		}
+	}
+
+	private void _setPaymentTerm(
+		User user, CommerceOrder commerceOrder,
+		CommerceChannel commerceChannel) {
+
+		if (commerceOrder.getPaymentCommerceTermEntryId() <= 0) {
+			CommerceChannelAccountEntryRel commerceChannelAccountEntryRel =
+				_commerceChannelAccountEntryRelLocalService.
+					fetchCommerceChannelAccountEntryRel(
+						commerceOrder.getCommerceAccountId(),
+						commerceChannel.getCommerceChannelId(),
+						CommerceChannelAccountEntryRelConstants.
+							TYPE_PAYMENT_TERM);
+
+			if (commerceChannelAccountEntryRel != null) {
+				CommerceTermEntry commerceTermEntry =
+					_commerceTermEntryLocalService.fetchCommerceTermEntry(
+						commerceChannelAccountEntryRel.getClassPK());
+
+				if (commerceTermEntry != null) {
+					commerceOrder.setPaymentCommerceTermEntryId(
+						commerceTermEntry.getCommerceTermEntryId());
+					commerceOrder.setPaymentCommerceTermEntryDescription(
+						commerceTermEntry.getDescription(
+							user.getLanguageId(), true));
+					commerceOrder.setPaymentCommerceTermEntryName(
+						commerceTermEntry.getLabel(user.getLanguageId(), true));
+				}
+			}
+		}
+	}
+
+	private void _setShippingAddress(
+			CommerceOrder commerceOrder, CommerceChannel commerceChannel)
+		throws PortalException {
+
+		if (commerceOrder.getShippingAddressId() <= 0) {
+			CommerceChannelAccountEntryRel commerceChannelAccountEntryRel =
+				_commerceChannelAccountEntryRelLocalService.
+					fetchCommerceChannelAccountEntryRel(
+						commerceOrder.getCommerceAccountId(),
+						commerceChannel.getCommerceChannelId(),
+						CommerceChannelAccountEntryRelConstants.
+							TYPE_SHIPPING_ADDRESS);
+
+			if (commerceChannelAccountEntryRel != null) {
+				List<CommerceAddress> shippingCommerceAddresses =
+					_commerceAddressLocalService.getShippingCommerceAddresses(
+						commerceChannel.getCommerceChannelId(),
+						AccountEntry.class.getName(),
+						commerceOrder.getCommerceAccountId(), QueryUtil.ALL_POS,
+						QueryUtil.ALL_POS);
+
+				CommerceAddress commerceAddress =
+					_commerceAddressLocalService.getCommerceAddress(
+						commerceChannelAccountEntryRel.getClassPK());
+
+				if ((commerceAddress != null) &&
+					shippingCommerceAddresses.contains(commerceAddress)) {
+
+					commerceOrder.setShippingAddressId(
+						commerceAddress.getCommerceAddressId());
+				}
+			}
+		}
+	}
+
+	private void _setShippingOption(
+			User user, CommerceOrder commerceOrder,
+			CommerceChannel commerceChannel)
+		throws PortalException {
+
+		if ((commerceOrder.getCommerceShippingMethodId() > 0) &&
+			Validator.isNotNull(commerceOrder.getShippingOptionName())) {
+
+			return;
+		}
+
+		AccountEntry accountEntry = commerceOrder.getAccountEntry();
+
+		if (accountEntry.isPersonalAccount()) {
+			return;
+		}
+
+		List<CommerceShippingMethod> commerceShippingMethods =
+			_commerceShippingMethodLocalService.getCommerceShippingMethods(
+				commerceOrder.getGroupId(), true, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS,
+				CommerceShippingMethodPriorityComparator.getInstance(false));
+
+		CommerceShippingOptionAccountEntryRel
+			commerceShippingOptionAccountEntryRel =
+				_commerceShippingOptionAccountEntryRelService.
+					fetchCommerceShippingOptionAccountEntryRel(
+						accountEntry.getAccountEntryId(),
+						commerceChannel.getCommerceChannelId());
+
+		for (CommerceShippingMethod commerceShippingMethod :
+				commerceShippingMethods) {
+
+			CommerceShippingEngine commerceShippingEngine =
+				_commerceShippingEngineRegistry.getCommerceShippingEngine(
+					commerceShippingMethod.getEngineKey());
+
+			CommerceContext commerceContext = _commerceContextFactory.create(
+				accountEntry.getAccountEntryId(), commerceChannel.getGroupId(),
+				commerceOrder.getCommerceCurrencyCode(),
+				commerceOrder.getCommerceOrderId(),
+				commerceOrder.getCompanyId());
+
+			List<CommerceShippingOption> commerceShippingOptions =
+				commerceShippingEngine.getEnabledCommerceShippingOptions(
+					commerceContext, commerceOrder, user.getLocale());
+
+			if (commerceShippingOptions.isEmpty()) {
+				continue;
+			}
+
+			if (commerceShippingOptionAccountEntryRel != null) {
+				CommerceShippingOption defaultCommerceShippingOption = null;
+
+				for (CommerceShippingOption commerceShippingOption :
+						commerceShippingOptions) {
+
+					String key = commerceShippingOption.getKey();
+
+					if (key.equals(
+							commerceShippingOptionAccountEntryRel.
+								getCommerceShippingOptionKey())) {
+
+						defaultCommerceShippingOption = commerceShippingOption;
+
+						break;
+					}
+				}
+
+				if (defaultCommerceShippingOption != null) {
+					commerceOrder.setCommerceShippingMethodId(
+						commerceShippingMethod.getCommerceShippingMethodId());
+					commerceOrder.setShippingOptionName(
+						defaultCommerceShippingOption.getKey());
+				}
 			}
 		}
 	}
@@ -346,9 +777,57 @@ public class CommerceOrderModelListener
 		CommerceOrderModelListener.class);
 
 	@Reference
+	private CommerceAddressLocalService _commerceAddressLocalService;
+
+	@Reference
+	private CommerceChannelAccountEntryRelLocalService
+		_commerceChannelAccountEntryRelLocalService;
+
+	@Reference
+	private CommerceChannelLocalService _commerceChannelLocalService;
+
+	@Reference
+	private CommerceContextFactory _commerceContextFactory;
+
+	@Reference
 	private CommerceOrderEngine _commerceOrderEngine;
 
 	@Reference
 	private CommerceOrderLocalService _commerceOrderLocalService;
+
+	@Reference
+	private CommercePaymentIntegrationRegistry
+		_commercePaymentIntegrationRegistry;
+
+	@Reference
+	private CommercePaymentMethodGroupRelLocalService
+		_commercePaymentMethodGroupRelLocalService;
+
+	@Reference
+	private CommercePaymentMethodGroupRelQualifierLocalService
+		_commercePaymentMethodGroupRelQualifierLocalService;
+
+	@Reference
+	private CommercePaymentMethodRegistry _commercePaymentMethodRegistry;
+
+	@Reference
+	private CommerceShippingEngineRegistry _commerceShippingEngineRegistry;
+
+	@Reference
+	private CommerceShippingMethodLocalService
+		_commerceShippingMethodLocalService;
+
+	@Reference
+	private CommerceShippingOptionAccountEntryRelService
+		_commerceShippingOptionAccountEntryRelService;
+
+	@Reference
+	private CommerceTermEntryLocalService _commerceTermEntryLocalService;
+
+	@Reference
+	private PermissionCheckerFactory _permissionCheckerFactory;
+
+	@Reference
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/commerce/commerce-test/build.gradle
+++ b/modules/apps/commerce/commerce-test/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:commerce:commerce-service")
 	testIntegrationImplementation project(":apps:commerce:commerce-shipping-engine-fixed-api")
 	testIntegrationImplementation project(":apps:commerce:commerce-tax-api")
+	testIntegrationImplementation project(":apps:commerce:commerce-term-api")
 	testIntegrationImplementation project(":apps:commerce:commerce-test-util")
 	testIntegrationImplementation project(":apps:export-import:export-import-test-util")
 	testIntegrationImplementation project(":apps:friendly-url:friendly-url-api")

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/internal/model/listener/test/CommerceOrderModelListenerTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/internal/model/listener/test/CommerceOrderModelListenerTest.java
@@ -83,6 +83,15 @@ public class CommerceOrderModelListenerTest {
 
 		_user = UserTestUtil.addUser(_company);
 
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_group.getGroupId());
+
+		_accountEntry = CommerceAccountTestUtil.addBusinessAccountEntry(
+			_user.getUserId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), new long[] {_user.getUserId()}, null,
+			_serviceContext);
+
 		_commerceCurrency =
 			CommerceCurrencyLocalServiceUtil.fetchPrimaryCommerceCurrency(
 				_group.getCompanyId());
@@ -94,45 +103,6 @@ public class CommerceOrderModelListenerTest {
 
 		_commerceChannel = CommerceTestUtil.addCommerceChannel(
 			_group.getGroupId(), _commerceCurrency.getCode());
-
-		_commercePaymentMethodGroupRel =
-			_commercePaymentMethodGroupRelLocalService.
-				addCommercePaymentMethodGroupRel(
-					_user.getUserId(), _commerceChannel.getGroupId(),
-					RandomTestUtil.randomLocaleStringMap(),
-					RandomTestUtil.randomLocaleStringMap(), true, null,
-					TestCommercePaymentMethod.KEY, 99, null);
-
-		_commerceShippingMethod =
-			_commerceShippingMethodLocalService.addCommerceShippingMethod(
-				_user.getUserId(), _commerceChannel.getGroupId(),
-				Collections.singletonMap(
-					LocaleUtil.US, RandomTestUtil.randomString()),
-				Collections.singletonMap(
-					LocaleUtil.US, RandomTestUtil.randomString()),
-				true, "fixed", null, 1, RandomTestUtil.randomString());
-
-		String shippingOptionName = RandomTestUtil.randomString();
-
-		_commerceShippingFixedOption =
-			_commerceShippingFixedOptionLocalService.
-				addCommerceShippingFixedOption(
-					_user.getUserId(), _commerceChannel.getGroupId(),
-					_commerceShippingMethod.getCommerceShippingMethodId(),
-					BigDecimal.valueOf(RandomTestUtil.nextDouble()),
-					RandomTestUtil.randomLocaleStringMap(),
-					RandomTestUtil.randomString(),
-					Collections.singletonMap(LocaleUtil.US, shippingOptionName),
-					RandomTestUtil.nextDouble());
-
-		_serviceContext = ServiceContextTestUtil.getServiceContext(
-			_group.getGroupId());
-
-		_accountEntry = CommerceAccountTestUtil.addBusinessAccountEntry(
-			_user.getUserId(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString() + "@liferay.com",
-			RandomTestUtil.randomString(), new long[] {_user.getUserId()}, null,
-			_serviceContext);
 
 		_commerceDeliveryTerm =
 			_commerceTermEntryLocalService.addCommerceTermEntry(
@@ -146,6 +116,14 @@ public class CommerceOrderModelListenerTest {
 				CommerceTermEntryConstants.TYPE_DELIVERY_TERMS, null,
 				_serviceContext);
 
+		_commercePaymentMethodGroupRel =
+			_commercePaymentMethodGroupRelLocalService.
+				addCommercePaymentMethodGroupRel(
+					_user.getUserId(), _commerceChannel.getGroupId(),
+					RandomTestUtil.randomLocaleStringMap(),
+					RandomTestUtil.randomLocaleStringMap(), true, null,
+					TestCommercePaymentMethod.KEY, 99, null);
+
 		_commercePaymentTerm =
 			_commerceTermEntryLocalService.addCommerceTermEntry(
 				RandomTestUtil.randomString(), _user.getUserId(), true,
@@ -157,6 +135,27 @@ public class CommerceOrderModelListenerTest {
 				RandomTestUtil.randomString(), 1000,
 				CommerceTermEntryConstants.TYPE_PAYMENT_TERMS, null,
 				_serviceContext);
+
+		_commerceShippingMethod =
+			_commerceShippingMethodLocalService.addCommerceShippingMethod(
+				_user.getUserId(), _commerceChannel.getGroupId(),
+				Collections.singletonMap(
+					LocaleUtil.US, RandomTestUtil.randomString()),
+				Collections.singletonMap(
+					LocaleUtil.US, RandomTestUtil.randomString()),
+				true, "fixed", null, 1, RandomTestUtil.randomString());
+
+		_commerceShippingFixedOption =
+			_commerceShippingFixedOptionLocalService.
+				addCommerceShippingFixedOption(
+					_user.getUserId(), _commerceChannel.getGroupId(),
+					_commerceShippingMethod.getCommerceShippingMethodId(),
+					BigDecimal.valueOf(RandomTestUtil.nextDouble()),
+					RandomTestUtil.randomLocaleStringMap(),
+					RandomTestUtil.randomString(),
+					Collections.singletonMap(
+						LocaleUtil.US, RandomTestUtil.randomString()),
+					RandomTestUtil.nextDouble());
 
 		_country = _countryLocalService.addCountry(
 			"ZZ", "ZZZ", true, true, null, RandomTestUtil.randomString(), "000",

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/internal/model/listener/test/CommerceOrderModelListenerTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/internal/model/listener/test/CommerceOrderModelListenerTest.java
@@ -1,0 +1,312 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.commerce.internal.model.listener.test;
+
+import com.liferay.account.model.AccountEntry;
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.commerce.account.test.util.CommerceAccountTestUtil;
+import com.liferay.commerce.constants.CommerceAddressConstants;
+import com.liferay.commerce.currency.model.CommerceCurrency;
+import com.liferay.commerce.currency.service.CommerceCurrencyLocalServiceUtil;
+import com.liferay.commerce.currency.test.util.CommerceCurrencyTestUtil;
+import com.liferay.commerce.model.CommerceAddress;
+import com.liferay.commerce.model.CommerceOrder;
+import com.liferay.commerce.model.CommerceShippingMethod;
+import com.liferay.commerce.payment.model.CommercePaymentMethodGroupRel;
+import com.liferay.commerce.payment.service.CommercePaymentMethodGroupRelLocalService;
+import com.liferay.commerce.payment.test.util.TestCommercePaymentMethod;
+import com.liferay.commerce.product.constants.CommerceChannelAccountEntryRelConstants;
+import com.liferay.commerce.product.model.CommerceChannel;
+import com.liferay.commerce.product.service.CommerceChannelAccountEntryRelLocalService;
+import com.liferay.commerce.service.CommerceAddressLocalService;
+import com.liferay.commerce.service.CommerceShippingMethodLocalService;
+import com.liferay.commerce.service.CommerceShippingOptionAccountEntryRelService;
+import com.liferay.commerce.shipping.engine.fixed.model.CommerceShippingFixedOption;
+import com.liferay.commerce.shipping.engine.fixed.service.CommerceShippingFixedOptionLocalService;
+import com.liferay.commerce.term.constants.CommerceTermEntryConstants;
+import com.liferay.commerce.term.model.CommerceTermEntry;
+import com.liferay.commerce.term.service.CommerceTermEntryLocalService;
+import com.liferay.commerce.test.util.CommerceTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Address;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Country;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Region;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.service.CountryLocalService;
+import com.liferay.portal.kernel.service.RegionLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.math.BigDecimal;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Luca Pellizzon
+ */
+@RunWith(Arquillian.class)
+public class CommerceOrderModelListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_company = CompanyLocalServiceUtil.getCompany(_group.getCompanyId());
+
+		_user = UserTestUtil.addUser(_company);
+
+		_commerceCurrency =
+			CommerceCurrencyLocalServiceUtil.fetchPrimaryCommerceCurrency(
+				_group.getCompanyId());
+
+		if (_commerceCurrency == null) {
+			_commerceCurrency = CommerceCurrencyTestUtil.addCommerceCurrency(
+				_group.getCompanyId());
+		}
+
+		_commerceChannel = CommerceTestUtil.addCommerceChannel(
+			_group.getGroupId(), _commerceCurrency.getCode());
+
+		_commercePaymentMethodGroupRel =
+			_commercePaymentMethodGroupRelLocalService.
+				addCommercePaymentMethodGroupRel(
+					_user.getUserId(), _commerceChannel.getGroupId(),
+					RandomTestUtil.randomLocaleStringMap(),
+					RandomTestUtil.randomLocaleStringMap(), true, null,
+					TestCommercePaymentMethod.KEY, 99, null);
+
+		_commerceShippingMethod =
+			_commerceShippingMethodLocalService.addCommerceShippingMethod(
+				_user.getUserId(), _commerceChannel.getGroupId(),
+				Collections.singletonMap(
+					LocaleUtil.US, RandomTestUtil.randomString()),
+				Collections.singletonMap(
+					LocaleUtil.US, RandomTestUtil.randomString()),
+				true, "fixed", null, 1, RandomTestUtil.randomString());
+
+		String shippingOptionName = RandomTestUtil.randomString();
+
+		_commerceShippingFixedOption =
+			_commerceShippingFixedOptionLocalService.
+				addCommerceShippingFixedOption(
+					_user.getUserId(), _commerceChannel.getGroupId(),
+					_commerceShippingMethod.getCommerceShippingMethodId(),
+					BigDecimal.valueOf(RandomTestUtil.nextDouble()),
+					RandomTestUtil.randomLocaleStringMap(),
+					RandomTestUtil.randomString(),
+					Collections.singletonMap(LocaleUtil.US, shippingOptionName),
+					RandomTestUtil.nextDouble());
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_group.getGroupId());
+
+		_accountEntry = CommerceAccountTestUtil.addBusinessAccountEntry(
+			_user.getUserId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), new long[] {_user.getUserId()}, null,
+			_serviceContext);
+
+		_commerceDeliveryTerm =
+			_commerceTermEntryLocalService.addCommerceTermEntry(
+				RandomTestUtil.randomString(), _user.getUserId(), true,
+				Collections.singletonMap(
+					LocaleUtil.getSiteDefault(), RandomTestUtil.randomString()),
+				1, 1, 2022, 12, 0, 0, 0, 0, 0, 0, true,
+				Collections.singletonMap(
+					LocaleUtil.getSiteDefault(), RandomTestUtil.randomString()),
+				RandomTestUtil.randomString(), 1000,
+				CommerceTermEntryConstants.TYPE_DELIVERY_TERMS, null,
+				_serviceContext);
+
+		_commercePaymentTerm =
+			_commerceTermEntryLocalService.addCommerceTermEntry(
+				RandomTestUtil.randomString(), _user.getUserId(), true,
+				Collections.singletonMap(
+					LocaleUtil.getSiteDefault(), RandomTestUtil.randomString()),
+				1, 1, 2022, 12, 0, 0, 0, 0, 0, 0, true,
+				Collections.singletonMap(
+					LocaleUtil.getSiteDefault(), RandomTestUtil.randomString()),
+				RandomTestUtil.randomString(), 1000,
+				CommerceTermEntryConstants.TYPE_PAYMENT_TERMS, null,
+				_serviceContext);
+
+		_country = _countryLocalService.addCountry(
+			"ZZ", "ZZZ", true, true, null, RandomTestUtil.randomString(), "000",
+			RandomTestUtil.randomDouble(), true, false, false, _serviceContext);
+
+		_region = _regionLocalService.addRegion(
+			_country.getCountryId(), true, RandomTestUtil.randomString(),
+			RandomTestUtil.randomDouble(), "ZZ", _serviceContext);
+	}
+
+	@Test
+	public void testAddCommerceOrder() throws Exception {
+		CommerceAddress commerceAddress =
+			_commerceAddressLocalService.addCommerceAddress(
+				StringPool.BLANK, AccountEntry.class.getName(),
+				_accountEntry.getAccountEntryId(), _country.getCountryId(),
+				_region.getRegionId(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				StringPool.BLANK,
+				CommerceAddressConstants.ADDRESS_TYPE_BILLING_AND_SHIPPING,
+				String.valueOf(30133), _serviceContext);
+
+		_commerceChannelAccountEntryRelLocalService.
+			addCommerceChannelAccountEntryRel(
+				_user.getUserId(), _accountEntry.getAccountEntryId(),
+				Address.class.getName(), commerceAddress.getCommerceAddressId(),
+				_commerceChannel.getCommerceChannelId(), true, 0,
+				CommerceChannelAccountEntryRelConstants.TYPE_BILLING_ADDRESS);
+
+		_commerceChannelAccountEntryRelLocalService.
+			addCommerceChannelAccountEntryRel(
+				_user.getUserId(), _accountEntry.getAccountEntryId(),
+				Address.class.getName(), commerceAddress.getCommerceAddressId(),
+				_commerceChannel.getCommerceChannelId(), true, 0,
+				CommerceChannelAccountEntryRelConstants.TYPE_SHIPPING_ADDRESS);
+
+		_commerceChannelAccountEntryRelLocalService.
+			addCommerceChannelAccountEntryRel(
+				_user.getUserId(), _accountEntry.getAccountEntryId(),
+				CommercePaymentMethodGroupRel.class.getName(),
+				_commercePaymentMethodGroupRel.
+					getCommercePaymentMethodGroupRelId(),
+				_commerceChannel.getCommerceChannelId(), true, 0,
+				CommerceChannelAccountEntryRelConstants.TYPE_PAYMENT);
+
+		_commerceShippingOptionAccountEntryRelService.
+			addCommerceShippingOptionAccountEntryRel(
+				_accountEntry.getAccountEntryId(),
+				_commerceChannel.getCommerceChannelId(),
+				_commerceShippingMethod.getEngineKey(),
+				_commerceShippingFixedOption.getKey());
+
+		_commerceChannelAccountEntryRelLocalService.
+			addCommerceChannelAccountEntryRel(
+				_user.getUserId(), _accountEntry.getAccountEntryId(),
+				CommerceTermEntry.class.getName(),
+				_commerceDeliveryTerm.getCommerceTermEntryId(),
+				_commerceChannel.getCommerceChannelId(), true, 0,
+				CommerceChannelAccountEntryRelConstants.TYPE_DELIVERY_TERM);
+
+		_commerceChannelAccountEntryRelLocalService.
+			addCommerceChannelAccountEntryRel(
+				_user.getUserId(), _accountEntry.getAccountEntryId(),
+				CommerceTermEntry.class.getName(),
+				_commercePaymentTerm.getCommerceTermEntryId(),
+				_commerceChannel.getCommerceChannelId(), true, 0,
+				CommerceChannelAccountEntryRelConstants.TYPE_PAYMENT_TERM);
+
+		CommerceOrder commerceOrder = CommerceTestUtil.addB2BCommerceOrder(
+			_group.getGroupId(), _user.getUserId(),
+			_accountEntry.getAccountEntryId(),
+			_commerceCurrency.getCommerceCurrencyId());
+
+		Assert.assertEquals(
+			commerceAddress.getCommerceAddressId(),
+			commerceOrder.getBillingAddressId());
+		Assert.assertEquals(
+			commerceAddress.getCommerceAddressId(),
+			commerceOrder.getShippingAddressId());
+		Assert.assertEquals(
+			_commercePaymentMethodGroupRel.getPaymentIntegrationKey(),
+			commerceOrder.getCommercePaymentMethodKey());
+		Assert.assertEquals(
+			_commerceShippingMethod.getCommerceShippingMethodId(),
+			commerceOrder.getCommerceShippingMethodId());
+		Assert.assertEquals(
+			_commerceShippingFixedOption.getKey(),
+			commerceOrder.getShippingOptionName());
+		Assert.assertEquals(
+			_commerceDeliveryTerm.getCommerceTermEntryId(),
+			commerceOrder.getDeliveryCommerceTermEntryId());
+		Assert.assertEquals(
+			_commercePaymentTerm.getCommerceTermEntryId(),
+			commerceOrder.getPaymentCommerceTermEntryId());
+	}
+
+	private AccountEntry _accountEntry;
+
+	@Inject
+	private CommerceAddressLocalService _commerceAddressLocalService;
+
+	private CommerceChannel _commerceChannel;
+
+	@Inject
+	private CommerceChannelAccountEntryRelLocalService
+		_commerceChannelAccountEntryRelLocalService;
+
+	private CommerceCurrency _commerceCurrency;
+	private CommerceTermEntry _commerceDeliveryTerm;
+	private CommercePaymentMethodGroupRel _commercePaymentMethodGroupRel;
+
+	@Inject
+	private CommercePaymentMethodGroupRelLocalService
+		_commercePaymentMethodGroupRelLocalService;
+
+	private CommerceTermEntry _commercePaymentTerm;
+	private CommerceShippingFixedOption _commerceShippingFixedOption;
+
+	@Inject
+	private CommerceShippingFixedOptionLocalService
+		_commerceShippingFixedOptionLocalService;
+
+	private CommerceShippingMethod _commerceShippingMethod;
+
+	@Inject
+	private CommerceShippingMethodLocalService
+		_commerceShippingMethodLocalService;
+
+	@Inject
+	private CommerceShippingOptionAccountEntryRelService
+		_commerceShippingOptionAccountEntryRelService;
+
+	@Inject
+	private CommerceTermEntryLocalService _commerceTermEntryLocalService;
+
+	private Company _company;
+	private Country _country;
+
+	@Inject
+	private CountryLocalService _countryLocalService;
+
+	private Group _group;
+	private Region _region;
+
+	@Inject
+	private RegionLocalService _regionLocalService;
+
+	private ServiceContext _serviceContext;
+	private User _user;
+
+}


### PR DESCRIPTION
from https://github.com/brianchandotcom/liferay-portal/pull/160732 

@brianchandotcom 
There was an error in the Listener with the order of the methods calls.
The order is important because there can be dependencies (based on the values of those fields), so the order should be:
1- billing address
2- shipping address
3- payment integration (dependent on addresses)
4- shipping option (dependent on addresses and it also sets the shipping method that is a pre-requisite for the shipping option)
5- delivery term (dependent on shipping option)
6- payment term (dependent on payment integration)

The dependencies are not visible but there are validations under the hood.

Maybe I can space them differently

The test is following the same order.

If something is still unclear, just let me know.
Thanks
