### PR TITLE
LCD 45750

### DIFF
--- a/cloud/helm/default/Chart.yaml
+++ b/cloud/helm/default/Chart.yaml
@@ -5,4 +5,4 @@ description:
 icon: https://www-cdn.liferay.com/documents/d/guest/liferay-logo
 name: liferay-default
 type: application
-version: 0.0.2
+version: 0.0.3

--- a/cloud/helm/default/values.yaml
+++ b/cloud/helm/default/values.yaml
@@ -255,6 +255,6 @@ volumeMounts:
         subPath: 000_jdk_java_options.sh
 volumes:
     -   configMap:
-            name: liferay
+            name: liferay-default
             optional: true
         name: liferay-configmap

--- a/cloud/helm/default/values.yaml
+++ b/cloud/helm/default/values.yaml
@@ -74,9 +74,9 @@ initContainers:
                                 cp -frv /opt/liferay/data/* /temp/liferay/data
                             fi
 
-                            if [ -d /opt/liferay/deploy ] && [ ! -z "$(ls -A /opt/liferay/deploy)" ]
+                            if [ -d /opt/liferay/deploy ] && [ -z "$(ls -A /temp/liferay/deploy/*license* 2>/dev/null)" ]
                             then
-                                if [ ! -d /temp/liferay/data/license ] || [ ! -e /temp/liferay/data/license/*.li ]
+                                if [ ! -d /temp/liferay/data/license ] || [ -z "$(ls -A /temp/liferay/data/license/*.li)" ]
                                 then
                                     mkdir -p /temp/liferay/deploy
 

--- a/cloud/helm/default/values.yaml
+++ b/cloud/helm/default/values.yaml
@@ -64,7 +64,7 @@ ingress:
 initContainers:
     -   containerTemplate: |
             -   command:
-                    -   /bin/sh
+                    -   bash
                     -   -c
                     -   |
                             if [ ! -d /temp/liferay/data ] || [ -z "$(ls -A /temp/liferay/data)" ]
@@ -91,7 +91,7 @@ initContainers:
                         name: liferay-persistent-volume
     -   containerTemplate: |
             -   command:
-                    -   /bin/sh
+                    -   bash
                     -   -c
                     -   |
                             trap "echo 'Received signal to terminate.'; exit 0" SIGINT SIGTERM
@@ -106,7 +106,7 @@ initContainers:
                                     done
                                 {{- end }}
                             {{- end }}
-                image: busybox:latest
+                image: bash:5.2
                 imagePullPolicy: IfNotPresent
                 name: liferay-wait-on-services
 livenessProbe:

--- a/cloud/helm/default/values.yaml
+++ b/cloud/helm/default/values.yaml
@@ -33,6 +33,8 @@ dependencies:
         portalProperties: ""
         source: external
 env:
+    -   name: DNS_MEMBERSHIP_SERVICE_NAME
+        value: liferay-default-headless
     -   name: LIFERAY_CLUSTER_PERIOD_LINK_PERIOD_BIND_PERIOD_ADDR_OPENBRACKET__QUOTE_CLUSTER_MINUS_LINK_MINUS_CONTROL_QUOTE__CLOSEBRACKET_
         value: "${env.POD_ID}"
     -   name: LIFERAY_CLUSTER_PERIOD_LINK_PERIOD_BIND_PERIOD_ADDR_OPENBRACKET__QUOTE_CLUSTER_MINUS_LINK_MINUS_UDP_QUOTE__CLOSEBRACKET_
@@ -82,6 +84,38 @@ initContainers:
 
                                     cp -fv /opt/liferay/deploy/* /temp/liferay/deploy
                                 fi
+                            fi
+
+                            if [ ! -f /temp/tomcat/conf/server.xml ]
+                            then
+                                mkdir -p /temp/tomcat/conf
+
+                                cat /opt/liferay/tomcat/conf/server.xml | sed '/<!--.*-->/d' | sed '/<!--/,/-->/d' > /temp/tomcat/conf/server.xml
+
+                                IFS='' read -r -d '' cluster <<EOF
+                                <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster">
+                                    <Manager className="com.liferay.support.tomcat.session.LiferayDeltaManager" />
+                                    <Channel className="org.apache.catalina.tribes.group.GroupChannel">
+                                        <Membership
+                                            className="org.apache.catalina.tribes.membership.cloud.CloudMembershipService"
+                                            membershipProviderClassName="org.apache.catalina.tribes.membership.cloud.DNSMembershipProvider"
+                                        />
+
+                                        <Sender
+                                            className="org.apache.catalina.tribes.transport.ReplicationTransmitter">
+                                            <Transport
+                                                className="org.apache.catalina.tribes.transport.nio.PooledParallelSender"
+                                                timeout="300000" />
+                                        </Sender>
+                                    </Channel>
+                                </Cluster>
+                            EOF
+
+                                sed -i '/<Engine/r'<(echo "$cluster") /temp/tomcat/conf/server.xml
+
+                                cp /opt/liferay/tomcat/conf/logging.properties /temp/tomcat/conf/logging.properties
+
+                                echo -e "\norg.apache.catalina.tribes.membership.cloud.level=SEVERE" >> /temp/tomcat/conf/logging.properties
                             fi
                 image: {{ printf "%s:%s" .image.repository (.image.tag | toString) }}
                 imagePullPolicy: {{ .image.pullPolicy }}
@@ -235,6 +269,12 @@ volumeMounts:
     -   mountPath: /opt/liferay/routes
         name: liferay-persistent-volume
         subPath: liferay/routes
+    -   mountPath: /opt/liferay/tomcat/conf/logging.properties
+        name: liferay-persistent-volume
+        subPath: tomcat/conf/logging.properties
+    -   mountPath: /opt/liferay/tomcat/conf/server.xml
+        name: liferay-persistent-volume
+        subPath: tomcat/conf/server.xml
     -   mountPath: /opt/liferay/tomcat/logs
         name: liferay-persistent-volume
         subPath: tomcat/logs


### PR DESCRIPTION
- **LCD-45234 reference the correct configmap after renaming the chart**
- **LCD-45234 more directory checking safety**
- **LCD-45750 use bash in init scripts**
- **LCD-45750 enable Tomcat's Kubernetes membership based session replication support**
- **LCD-45750 increment chart version to trigger release**
