### PR TITLE
LPD-53797 Due to the jakarta patching naming conversion difference. m…

### DIFF
--- a/modules/build-app.xml
+++ b/modules/build-app.xml
@@ -215,6 +215,9 @@
 				</antcall>
 			</sequential>
 		</for>
+
+		<delete dir="${osgi.dir}/portal" />
+		<delete dir="${osgi.dir}/static" />
 	</target>
 
 	<target name="build-app-lpkg-release">
@@ -248,6 +251,9 @@
 				</if>
 			</sequential>
 		</for>
+
+		<delete dir="${osgi.dir}/portal" />
+		<delete dir="${osgi.dir}/static" />
 	</target>
 
 	<target name="check-current-branch">


### PR DESCRIPTION
…ove-artifact-dependencies target can no longer properly remove dependency jars from the original deployment folder. Do a cheap global cleanup in the end of the lpkg packaging to get rid of the leftover jars.