### PR TITLE
LCD-45920 update workspace usage

### DIFF
--- a/workspaces/liferay-adyen-workspace/client-extensions/liferay-adyen-commerce-payment-integration/src/main/java/com/liferay/adyen/NotificationsRestController.java
+++ b/workspaces/liferay-adyen-workspace/client-extensions/liferay-adyen-commerce-payment-integration/src/main/java/com/liferay/adyen/NotificationsRestController.java
@@ -10,7 +10,7 @@ import com.adyen.model.notification.NotificationRequestItem;
 import com.adyen.util.HMACValidator;
 
 import com.liferay.client.extension.util.spring.boot3.BaseRestController;
-import com.liferay.client.extension.util.spring.boot3.LiferayOAuth2AccessTokenManager;
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
 
 import java.nio.charset.StandardCharsets;
 

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-cron/src/main/java/com/liferay/customer/CustomerCommandLineRunner.java
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-cron/src/main/java/com/liferay/customer/CustomerCommandLineRunner.java
@@ -6,7 +6,7 @@
 package com.liferay.customer;
 
 import com.liferay.client.extension.util.spring.boot3.BaseRestController;
-import com.liferay.client.extension.util.spring.boot3.LiferayOAuth2AccessTokenManager;
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
 import com.liferay.osb.spring.boot.client.zendesk.model.ZendeskTicket;
 import com.liferay.osb.spring.boot.client.zendesk.search.SearchHits;
 import com.liferay.osb.spring.boot.client.zendesk.search.ZendeskTicketQuery;

--- a/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-etc-spring-boot/src/main/java/com/liferay/jethr0/entity/dalo/BaseDALO.java
+++ b/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-etc-spring-boot/src/main/java/com/liferay/jethr0/entity/dalo/BaseDALO.java
@@ -6,7 +6,7 @@
 package com.liferay.jethr0.entity.dalo;
 
 import com.liferay.client.extension.util.spring.boot3.BaseRestController;
-import com.liferay.client.extension.util.spring.boot3.LiferayOAuth2AccessTokenManager;
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;

--- a/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-etc-spring-boot/src/main/java/com/liferay/jethr0/event/jenkins/client/JenkinsClient.java
+++ b/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-etc-spring-boot/src/main/java/com/liferay/jethr0/event/jenkins/client/JenkinsClient.java
@@ -6,7 +6,7 @@
 package com.liferay.jethr0.event.jenkins.client;
 
 import com.liferay.client.extension.util.spring.boot3.BaseRestController;
-import com.liferay.client.extension.util.spring.boot3.LiferayOAuth2AccessTokenManager;
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
 import com.liferay.jethr0.git.repository.GitBranchEntityRepository;
 import com.liferay.jethr0.util.StringUtil;
 import com.liferay.petra.function.RetryableUnsafeSupplier;

--- a/workspaces/liferay-learn-workspace/client-extensions/liferay-learn-etc-cron-2/src/main/java/com/liferay/learn/LearnCommandLineRunner.java
+++ b/workspaces/liferay-learn-workspace/client-extensions/liferay-learn-etc-cron-2/src/main/java/com/liferay/learn/LearnCommandLineRunner.java
@@ -6,7 +6,7 @@
 package com.liferay.learn;
 
 import com.liferay.client.extension.util.spring.boot3.BaseRestController;
-import com.liferay.client.extension.util.spring.boot3.LiferayOAuth2AccessTokenManager;
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
 
 import org.json.JSONObject;
 

--- a/workspaces/liferay-learn-workspace/client-extensions/liferay-learn-etc-spring-boot/src/main/java/com/liferay/learn/LearnRestController.java
+++ b/workspaces/liferay-learn-workspace/client-extensions/liferay-learn-etc-spring-boot/src/main/java/com/liferay/learn/LearnRestController.java
@@ -6,7 +6,7 @@
 package com.liferay.learn;
 
 import com.liferay.client.extension.util.spring.boot3.BaseRestController;
-import com.liferay.client.extension.util.spring.boot3.LiferayOAuth2AccessTokenManager;
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.GetterUtil;

--- a/workspaces/liferay-learn-workspace/client-extensions/liferay-learn-etc-spring-boot/src/main/java/com/liferay/learn/ObjectActionExamResultsSynchronizationRestController.java
+++ b/workspaces/liferay-learn-workspace/client-extensions/liferay-learn-etc-spring-boot/src/main/java/com/liferay/learn/ObjectActionExamResultsSynchronizationRestController.java
@@ -6,7 +6,7 @@
 package com.liferay.learn;
 
 import com.liferay.client.extension.util.spring.boot3.BaseRestController;
-import com.liferay.client.extension.util.spring.boot3.LiferayOAuth2AccessTokenManager;
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.GetterUtil;
 

--- a/workspaces/liferay-learn-workspace/client-extensions/liferay-learn-etc-spring-boot/src/main/java/com/liferay/learn/ObjectActionPermissionRestController.java
+++ b/workspaces/liferay-learn-workspace/client-extensions/liferay-learn-etc-spring-boot/src/main/java/com/liferay/learn/ObjectActionPermissionRestController.java
@@ -6,7 +6,7 @@
 package com.liferay.learn;
 
 import com.liferay.client.extension.util.spring.boot3.BaseRestController;
-import com.liferay.client.extension.util.spring.boot3.LiferayOAuth2AccessTokenManager;
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.GetterUtil;
 

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-cron/src/main/java/com/liferay/marketplace/MarketplaceCommandLineRunner.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-cron/src/main/java/com/liferay/marketplace/MarketplaceCommandLineRunner.java
@@ -6,7 +6,7 @@
 package com.liferay.marketplace;
 
 import com.liferay.client.extension.util.spring.boot3.BaseRestController;
-import com.liferay.client.extension.util.spring.boot3.LiferayOAuth2AccessTokenManager;
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
 import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Order;
 import com.liferay.headless.commerce.admin.order.client.pagination.Page;
 import com.liferay.headless.commerce.admin.order.client.pagination.Pagination;

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/ProvisioningRestController.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/ProvisioningRestController.java
@@ -6,7 +6,7 @@
 package com.liferay.marketplace;
 
 import com.liferay.client.extension.util.spring.boot3.BaseRestController;
-import com.liferay.client.extension.util.spring.boot3.LiferayOAuth2AccessTokenManager;
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
 import com.liferay.marketplace.service.KoroneikiService;
 import com.liferay.osb.koroneiki.phloem.rest.client.dto.v1_0.ProductPurchase;
 import com.liferay.osb.provisioning.marketplace.rest.client.dto.v1_0.AppLicenseKey;

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/TrialRestController.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/TrialRestController.java
@@ -6,7 +6,7 @@
 package com.liferay.marketplace;
 
 import com.liferay.client.extension.util.spring.boot3.BaseRestController;
-import com.liferay.client.extension.util.spring.boot3.LiferayOAuth2AccessTokenManager;
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Order;
 import com.liferay.headless.portal.instances.client.dto.v1_0.Admin;

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/service/MarketplaceService.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/service/MarketplaceService.java
@@ -5,7 +5,7 @@
 
 package com.liferay.marketplace.service;
 
-import com.liferay.client.extension.util.spring.boot3.LiferayOAuth2AccessTokenManager;
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
 import com.liferay.client.extension.util.spring.boot3.service.BaseService;
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.headless.admin.user.client.resource.v1_0.AccountResource;

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-etc-cron/src/main/java/com/liferay/partner/PartnerCommandLineRunner.java
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-etc-cron/src/main/java/com/liferay/partner/PartnerCommandLineRunner.java
@@ -6,7 +6,7 @@
 package com.liferay.partner;
 
 import com.liferay.client.extension.util.spring.boot3.BaseRestController;
-import com.liferay.client.extension.util.spring.boot3.LiferayOAuth2AccessTokenManager;
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
 import com.liferay.petra.string.StringBundler;
 
 import java.time.ZonedDateTime;

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-etc-cron/src/main/java/com/liferay/partner/PartnerSpringBootApplication.java
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-etc-cron/src/main/java/com/liferay/partner/PartnerSpringBootApplication.java
@@ -6,7 +6,7 @@
 package com.liferay.partner;
 
 import com.liferay.client.extension.util.spring.boot3.ClientExtensionUtilSpringBootComponentScan;
-import com.liferay.client.extension.util.spring.boot3.LiferayOAuth2Util;
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2Util;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.WebApplicationType;

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-etc-spring-boot/src/main/java/com/liferay/partner/ObjectActionMDFClaimStatusManagementRestController.java
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-etc-spring-boot/src/main/java/com/liferay/partner/ObjectActionMDFClaimStatusManagementRestController.java
@@ -6,7 +6,7 @@
 package com.liferay.partner;
 
 import com.liferay.client.extension.util.spring.boot3.BaseRestController;
-import com.liferay.client.extension.util.spring.boot3.LiferayOAuth2AccessTokenManager;
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
 
 import org.json.JSONObject;
 

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-etc-spring-boot/src/main/java/com/liferay/partner/ObjectActionMDFRequestStatusManagementRestController.java
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-etc-spring-boot/src/main/java/com/liferay/partner/ObjectActionMDFRequestStatusManagementRestController.java
@@ -6,7 +6,7 @@
 package com.liferay.partner;
 
 import com.liferay.client.extension.util.spring.boot3.BaseRestController;
-import com.liferay.client.extension.util.spring.boot3.LiferayOAuth2AccessTokenManager;
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
 
 import org.json.JSONArray;
 import org.json.JSONObject;

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-etc-spring-boot/src/main/java/com/liferay/partner/QueueListener.java
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-etc-spring-boot/src/main/java/com/liferay/partner/QueueListener.java
@@ -6,7 +6,7 @@
 package com.liferay.partner;
 
 import com.liferay.client.extension.util.spring.boot3.BaseRestController;
-import com.liferay.client.extension.util.spring.boot3.LiferayOAuth2AccessTokenManager;
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringUtil;
 

--- a/workspaces/liferay-paypal-workspace/client-extensions/liferay-paypal-commerce-payment-integration/src/main/java/com/liferay/paypal/NotificationsRestController.java
+++ b/workspaces/liferay-paypal-workspace/client-extensions/liferay-paypal-commerce-payment-integration/src/main/java/com/liferay/paypal/NotificationsRestController.java
@@ -5,7 +5,7 @@
 
 package com.liferay.paypal;
 
-import com.liferay.client.extension.util.spring.boot3.LiferayOAuth2AccessTokenManager;
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-cron/Dockerfile
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-cron/Dockerfile
@@ -2,4 +2,5 @@ FROM liferay/jar-runner:latest
 
 COPY --chown=liferay:liferay *.jar /opt/liferay/jar-runner.jar
 
-#ENV LIFERAY_JAR_RUNNER_JAVA_OPTS="-Xmx512m"
+ENV JAVA_VERSION="zulu21"
+ENV LIFERAY_JAR_RUNNER_JAVA_OPTS="--add-opens=java.base/java.net=ALL-UNNAMED"

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-cron/build.gradle
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-cron/build.gradle
@@ -25,6 +25,10 @@ bootRun {
 	//environment "EXTERNAL_LIFERAY_OAUTH2_HEADLESS_SERVER_CLIENT_SECRET", "myclientsecret"
 	//environment "EXTERNAL_LIFERAY_OAUTH2_HEADLESS_SERVER_HOME_PAGE_URL", "https://myhomepage.com"
 	//environment "EXTERNAL_LIFERAY_OAUTH2_TOKEN_URI", "https://myhomepage.com/o/oauth2/token"
+
+	jvmArgs([
+		'--add-opens', 'java.base/java.net=ALL-UNNAMED'
+	])
 }
 
 dependencies {

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-cron/build.gradle
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-cron/build.gradle
@@ -20,10 +20,11 @@ apply plugin: "java-library"
 apply plugin: "org.springframework.boot"
 
 bootRun {
-	environment "EXTERNAL_LIFERAY_OAUTH2_HEADLESS_SERVER_CLIENT_ID", "myclientid"
-	environment "EXTERNAL_LIFERAY_OAUTH2_HEADLESS_SERVER_CLIENT_SECRET", "myclientsecret"
-	environment "EXTERNAL_LIFERAY_OAUTH2_HEADLESS_SERVER_HOME_PAGE_URL", "https://myhomepage.com"
-	environment "EXTERNAL_LIFERAY_OAUTH2_TOKEN_URI", "https://myhomepage.com/o/oauth2/token"
+	//Uncomment lines to connect to an external Liferay server
+	//environment "EXTERNAL_LIFERAY_OAUTH2_HEADLESS_SERVER_CLIENT_ID", "myclientid"
+	//environment "EXTERNAL_LIFERAY_OAUTH2_HEADLESS_SERVER_CLIENT_SECRET", "myclientsecret"
+	//environment "EXTERNAL_LIFERAY_OAUTH2_HEADLESS_SERVER_HOME_PAGE_URL", "https://myhomepage.com"
+	//environment "EXTERNAL_LIFERAY_OAUTH2_TOKEN_URI", "https://myhomepage.com/o/oauth2/token"
 }
 
 dependencies {

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-cron/src/main/java/com/liferay/sample/SampleCommandLineRunner.java
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-cron/src/main/java/com/liferay/sample/SampleCommandLineRunner.java
@@ -7,6 +7,7 @@ package com.liferay.sample;
 
 import com.liferay.client.extension.util.spring.boot3.BaseRestController;
 import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2Util;
 import com.liferay.headless.admin.user.client.dto.v1_0.Site;
 import com.liferay.headless.admin.user.client.resource.v1_0.SiteResource;
 import com.liferay.headless.delivery.client.dto.v1_0.MessageBoardThread;
@@ -86,7 +87,15 @@ public class SampleCommandLineRunner
 
 	@Override
 	protected String getWebClientBaseURL() {
-		return _liferaySampleEtcSpringBootHomePageURL.toString();
+		String homePageURL = LiferayOAuth2Util.getHomePageURL(
+			"liferay-sample-etc-spring-boot-oauth-application-user-agent",
+			_lxcDXPMainDomain, _lxcDXPServerProtocol);
+
+		if (_log.isDebugEnabled()) {
+			_log.debug("Home page URL: " + homePageURL);
+		}
+
+		return homePageURL;
 	}
 
 	private void _countMessageBoardThreads(
@@ -160,9 +169,6 @@ public class SampleCommandLineRunner
 
 	@Autowired
 	private LiferayOAuth2AccessTokenManager _liferayOAuth2AccessTokenManager;
-
-	@Value("${liferay.sample.etc.spring.boot.home.page.url}")
-	private URL _liferaySampleEtcSpringBootHomePageURL;
 
 	@Value("${com.liferay.lxc.dxp.mainDomain}")
 	private String _lxcDXPMainDomain;

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-cron/src/main/java/com/liferay/sample/SampleCommandLineRunner.java
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-cron/src/main/java/com/liferay/sample/SampleCommandLineRunner.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import java.net.URL;
 
 import java.util.Collection;
+import java.util.Optional;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -52,12 +53,15 @@ public class SampleCommandLineRunner
 
 		// Call another Liferay
 
-		try {
-			_countMessageBoardThreads(
-				"external-liferay", _externalLiferayHomePageURL);
-		}
-		catch (Exception exception) {
-			_log.error(exception);
+		if (_externalLiferayHomePageURLOptional.isPresent()) {
+			try {
+				_countMessageBoardThreads(
+					"external-liferay",
+					_externalLiferayHomePageURLOptional.get());
+			}
+			catch (Exception exception) {
+				_log.error(exception);
+			}
 		}
 
 		// Call another client extension (liferay-sample-etc-spring-boot)
@@ -151,8 +155,8 @@ public class SampleCommandLineRunner
 	private static final Log _log = LogFactory.getLog(
 		SampleCommandLineRunner.class);
 
-	@Value("${external.liferay.oauth2.headless.server.home.page.url}")
-	private URL _externalLiferayHomePageURL;
+	@Value("${external.liferay.oauth2.headless.server.home.page.url:#{null}}")
+	private Optional<URL> _externalLiferayHomePageURLOptional;
 
 	@Autowired
 	private LiferayOAuth2AccessTokenManager _liferayOAuth2AccessTokenManager;

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-cron/src/main/java/com/liferay/sample/SampleCommandLineRunner.java
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-cron/src/main/java/com/liferay/sample/SampleCommandLineRunner.java
@@ -6,7 +6,7 @@
 package com.liferay.sample;
 
 import com.liferay.client.extension.util.spring.boot3.BaseRestController;
-import com.liferay.client.extension.util.spring.boot3.LiferayOAuth2AccessTokenManager;
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
 import com.liferay.headless.admin.user.client.dto.v1_0.Site;
 import com.liferay.headless.admin.user.client.resource.v1_0.SiteResource;
 import com.liferay.headless.delivery.client.dto.v1_0.MessageBoardThread;

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-cron/src/main/java/com/liferay/sample/SampleSpringBootApplication.java
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-cron/src/main/java/com/liferay/sample/SampleSpringBootApplication.java
@@ -5,7 +5,7 @@
 
 package com.liferay.sample;
 
-import com.liferay.client.extension.util.spring.boot3.ClientExtensionUtilSpringBootComponentScan;
+import com.liferay.client.extension.util.spring.boot3.client.ClientExtensionUtilSpringBootClientComponentScan;
 
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -15,7 +15,7 @@ import org.springframework.context.annotation.Import;
 /**
  * @author Gregory Amerson
  */
-@Import(ClientExtensionUtilSpringBootComponentScan.class)
+@Import(ClientExtensionUtilSpringBootClientComponentScan.class)
 @SpringBootApplication
 public class SampleSpringBootApplication {
 

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-cron/src/main/resources/application-default.properties
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-cron/src/main/resources/application-default.properties
@@ -1,12 +1,4 @@
 #
-# LXC
-#
-
-com.liferay.lxc.dxp.domains=localhost:8080
-com.liferay.lxc.dxp.mainDomain=localhost:8080
-com.liferay.lxc.dxp.server.protocol=http
-
-#
 # OAuth
 #
 

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-cron/src/main/resources/application-default.properties
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-cron/src/main/resources/application-default.properties
@@ -1,10 +1,4 @@
 #
-# Application
-#
-
-liferay.sample.etc.spring.boot.home.page.url=http://localhost:58081
-
-#
 # LXC
 #
 

--- a/workspaces/liferay-testray-workspace/client-extensions/liferay-testray-etc-cron/src/main/java/com/liferay/testray/TestrayCommandLineRunner.java
+++ b/workspaces/liferay-testray-workspace/client-extensions/liferay-testray-etc-cron/src/main/java/com/liferay/testray/TestrayCommandLineRunner.java
@@ -6,7 +6,7 @@
 package com.liferay.testray;
 
 import com.liferay.client.extension.util.spring.boot3.BaseRestController;
-import com.liferay.client.extension.util.spring.boot3.LiferayOAuth2AccessTokenManager;
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;

--- a/workspaces/liferay-ticket-workspace/client-extensions/liferay-ticket-etc-cron/src/main/java/com/liferay/ticket/TicketSpringBootApplication.java
+++ b/workspaces/liferay-ticket-workspace/client-extensions/liferay-ticket-etc-cron/src/main/java/com/liferay/ticket/TicketSpringBootApplication.java
@@ -6,7 +6,7 @@
 package com.liferay.ticket;
 
 import com.liferay.client.extension.util.spring.boot3.ClientExtensionUtilSpringBootComponentScan;
-import com.liferay.client.extension.util.spring.boot3.LiferayOAuth2Util;
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2Util;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.WebApplicationType;

--- a/workspaces/source-formatter-suppressions.xml
+++ b/workspaces/source-formatter-suppressions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<suppressions>
+	<source-check>
+		<suppress checks="IllegalImportsCheck" files="liferay-sample-workspace/client-extensions/liferay-sample-etc-cron/src/main/java/com/liferay/sample/SampleCommandLineRunner\.java" />
+	</source-check>
+</suppressions>


### PR DESCRIPTION
- **LCD-45920 use new client component**
- **LCD-45920 allow sample to still run even if there is no external liferay server defined**
- **LCD-45920 use new getHomePageURL API to get value at runtime**
- **LCD-45920 these values should always be loaded from ${liferayHome}/routes folder**
- **LCD-45920 add java21 support**
- **LCD-45920 update all workspace imports**
