### PR TITLE
LPD-53848 Null safe

### DIFF
--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtil.java
@@ -320,6 +320,10 @@ public class OpenAPIUtil {
 
 		Components components = openAPIYAML.getComponents();
 
+		if (components == null) {
+			return new HashMap<>();
+		}
+
 		return getEnumSchemas(configYAML, components.getSchemas());
 	}
 


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-53848

---

7.3
```
> Task :apps:data-engine:data-engine-rest-impl:buildREST
Writing /home/me/dev/projects/liferay-portal-7.3.x/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionResourceTestCase.java
Writing /home/me/dev/projects/liferay-portal-7.3.x/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataLayoutResourceTestCase.java
Writing /home/me/dev/projects/liferay-portal-7.3.x/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataListViewResourceTestCase.java
Writing /home/me/dev/projects/liferay-portal-7.3.x/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordResourceTestCase.java
Writing /home/me/dev/projects/liferay-portal-7.3.x/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordCollectionResourceTestCase.java

> Task :apps:headless:headless-admin-content:headless-admin-content-impl:buildREST FAILED
Exception in thread "main" java.lang.RuntimeException: Error generating REST API
null
        at com.liferay.portal.tools.rest.builder.RESTBuilder.main(RESTBuilder.java:117)
Caused by: java.lang.NullPointerException
        at com.liferay.portal.tools.rest.builder.internal.freemarker.util.OpenAPIUtil.getGlobalEnumSchemas(OpenAPIUtil.java:323)
        at com.liferay.portal.tools.rest.builder.RESTBuilder.build(RESTBuilder.java:238)
        at com.liferay.portal.tools.rest.builder.RESTBuilder.main(RESTBuilder.java:106)


FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':apps:headless:headless-admin-content:headless-admin-content-impl:buildREST'.
> Process 'command '/opt/java/zulu8.74.0.17-ca-jdk8.0.392-linux_x64/bin/java'' finished with non-zero exit value 1

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
```