### PR TITLE
LPD-4507 Improved keyword navigation for better accessibility in the Sort Widget

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/sort/display/context/SortDisplayContext.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/sort/display/context/SortDisplayContext.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.search.web.internal.sort.display.context;
 
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.portal.search.web.internal.sort.configuration.SortPortletInstanceConfiguration;
 
 import java.util.List;
@@ -14,6 +15,10 @@ import java.util.List;
  * @author André de Oliveira
  */
 public class SortDisplayContext {
+
+	public List<DropdownItem> getActionDropdownItems() {
+		return _actionDropdownItems;
+	}
 
 	public long getDisplayStyleGroupId() {
 		return _displayStyleGroupId;
@@ -25,6 +30,10 @@ public class SortDisplayContext {
 
 	public String getParameterValue() {
 		return _parameterValue;
+	}
+
+	public SortTermDisplayContext getSelectedSortTermDisplayContext() {
+		return _selectedSortTermDisplayContext;
 	}
 
 	public SortPortletInstanceConfiguration
@@ -43,6 +52,10 @@ public class SortDisplayContext {
 
 	public boolean isRenderNothing() {
 		return _renderNothing;
+	}
+
+	public void setActionDropdownItems(List<DropdownItem> actionDropdownItems) {
+		_actionDropdownItems = actionDropdownItems;
 	}
 
 	public void setAnySelected(boolean anySelected) {
@@ -65,6 +78,12 @@ public class SortDisplayContext {
 		_renderNothing = renderNothing;
 	}
 
+	public void setSelectedSortTermDisplayContext(
+		SortTermDisplayContext selectedSortTermDisplayContext) {
+
+		_selectedSortTermDisplayContext = selectedSortTermDisplayContext;
+	}
+
 	public void setSortPortletInstanceConfiguration(
 		SortPortletInstanceConfiguration sortPortletInstanceConfiguration) {
 
@@ -77,11 +96,13 @@ public class SortDisplayContext {
 		_sortTermDisplayContexts = sortTermDisplayContexts;
 	}
 
+	private List<DropdownItem> _actionDropdownItems;
 	private boolean _anySelected;
 	private long _displayStyleGroupId;
 	private String _parameterName;
 	private String _parameterValue;
 	private boolean _renderNothing;
+	private SortTermDisplayContext _selectedSortTermDisplayContext;
 	private SortPortletInstanceConfiguration _sortPortletInstanceConfiguration;
 	private List<SortTermDisplayContext> _sortTermDisplayContexts;
 

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/sort/display/context/builder/SortDisplayContextBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/sort/display/context/builder/SortDisplayContextBuilder.java
@@ -57,7 +57,7 @@ public class SortDisplayContextBuilder {
 		SortDisplayContext sortDisplayContext = new SortDisplayContext();
 
 		List<SortTermDisplayContext> sortTermDisplayContexts =
-			_buildTermDisplayContexts();
+			_buildSortTermDisplayContexts();
 
 		sortDisplayContext.setActionDropdownItems(
 			_getActionDropdownItems(sortTermDisplayContexts));
@@ -164,7 +164,7 @@ public class SortDisplayContextBuilder {
 		return false;
 	}
 
-	private SortTermDisplayContext _buildTermDisplayContext(
+	private SortTermDisplayContext _buildSortTermDisplayContext(
 		String label, String field, int index) {
 
 		SortTermDisplayContext sortTermDisplayContext =
@@ -186,7 +186,7 @@ public class SortDisplayContextBuilder {
 		return sortTermDisplayContext;
 	}
 
-	private List<SortTermDisplayContext> _buildTermDisplayContexts() {
+	private List<SortTermDisplayContext> _buildSortTermDisplayContexts() {
 		List<SortTermDisplayContext> sortTermDisplayContexts =
 			new ArrayList<>();
 
@@ -197,7 +197,7 @@ public class SortDisplayContextBuilder {
 			JSONObject jsonObject = fieldsJSONArray.getJSONObject(i);
 
 			sortTermDisplayContexts.add(
-				_buildTermDisplayContext(
+				_buildSortTermDisplayContext(
 					jsonObject.getString("label"),
 					jsonObject.getString("field"), i));
 		}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/sort/display/context/builder/SortDisplayContextBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/sort/display/context/builder/SortDisplayContextBuilder.java
@@ -5,12 +5,15 @@
 
 package com.liferay.portal.search.web.internal.sort.display.context.builder;
 
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProviderUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.search.web.internal.sort.configuration.SortPortletInstanceConfiguration;
@@ -56,6 +59,8 @@ public class SortDisplayContextBuilder {
 		List<SortTermDisplayContext> sortTermDisplayContexts =
 			_buildTermDisplayContexts();
 
+		sortDisplayContext.setActionDropdownItems(
+			_getActionDropdownItems(sortTermDisplayContexts));
 		sortDisplayContext.setAnySelected(
 			isAnySelected(sortTermDisplayContexts));
 
@@ -63,11 +68,19 @@ public class SortDisplayContextBuilder {
 		sortDisplayContext.setParameterName(_parameterName);
 		sortDisplayContext.setParameterValue(getParameterValue());
 		sortDisplayContext.setRenderNothing(isRenderNothing());
+		sortDisplayContext.setSelectedSortTermDisplayContext(
+			getSelectedSortTermDisplayContext(sortTermDisplayContexts));
 		sortDisplayContext.setSortPortletInstanceConfiguration(
 			_sortPortletInstanceConfiguration);
 		sortDisplayContext.setSortTermDisplayContexts(sortTermDisplayContexts);
 
 		return sortDisplayContext;
+	}
+
+	public SortDisplayContextBuilder currentURL(String currentURL) {
+		_currentURL = currentURL;
+
+		return this;
 	}
 
 	public SortDisplayContextBuilder parameterName(String parameterName) {
@@ -111,6 +124,20 @@ public class SortDisplayContextBuilder {
 		return null;
 	}
 
+	protected SortTermDisplayContext getSelectedSortTermDisplayContext(
+		List<SortTermDisplayContext> sortTermDisplayContexts) {
+
+		for (SortTermDisplayContext sortTermDisplayContext :
+				sortTermDisplayContexts) {
+
+			if (sortTermDisplayContext.isSelected()) {
+				return sortTermDisplayContext;
+			}
+		}
+
+		return null;
+	}
+
 	protected boolean isAnySelected(
 		List<SortTermDisplayContext> sortTermDisplayContexts) {
 
@@ -120,15 +147,6 @@ public class SortDisplayContextBuilder {
 			if (sortTermDisplayContext.isSelected()) {
 				return true;
 			}
-		}
-
-		if (!sortTermDisplayContexts.isEmpty()) {
-			SortTermDisplayContext sortTermDisplayContext =
-				sortTermDisplayContexts.get(0);
-
-			sortTermDisplayContext.setSelected(true);
-
-			return true;
 		}
 
 		return false;
@@ -147,7 +165,7 @@ public class SortDisplayContextBuilder {
 	}
 
 	private SortTermDisplayContext _buildTermDisplayContext(
-		String label, String field) {
+		String label, String field, int index) {
 
 		SortTermDisplayContext sortTermDisplayContext =
 			new SortTermDisplayContext();
@@ -157,7 +175,13 @@ public class SortDisplayContextBuilder {
 			_language.get(
 				_portal.getHttpServletRequest(_renderRequest), label));
 		sortTermDisplayContext.setField(field);
-		sortTermDisplayContext.setSelected(_selectedFields.contains(field));
+
+		if (_selectedFields.isEmpty() && (index == 0)) {
+			sortTermDisplayContext.setSelected(true);
+		}
+		else {
+			sortTermDisplayContext.setSelected(_selectedFields.contains(field));
+		}
 
 		return sortTermDisplayContext;
 	}
@@ -175,12 +199,49 @@ public class SortDisplayContextBuilder {
 			sortTermDisplayContexts.add(
 				_buildTermDisplayContext(
 					jsonObject.getString("label"),
-					jsonObject.getString("field")));
+					jsonObject.getString("field"), i));
 		}
 
 		return sortTermDisplayContexts;
 	}
 
+	private List<DropdownItem> _getActionDropdownItems(
+		List<SortTermDisplayContext> sortTermDisplayContexts) {
+
+		DropdownItemListBuilder.DropdownItemListWrapper
+			dropdownItemListWrapper =
+				new DropdownItemListBuilder.DropdownItemListWrapper();
+
+		for (SortTermDisplayContext sortTermDisplayContext :
+				sortTermDisplayContexts) {
+
+			dropdownItemListWrapper.add(
+				dropdownItem -> {
+					dropdownItem.setHref(
+						_getSortURL(sortTermDisplayContext.getField()));
+					dropdownItem.setLabel(
+						_language.get(
+							_portal.getHttpServletRequest(_renderRequest),
+							sortTermDisplayContext.getLabel()));
+
+					if (sortTermDisplayContext.isSelected()) {
+						dropdownItem.setActive(true);
+						dropdownItem.setIcon("check-small");
+					}
+				});
+		}
+
+		return dropdownItemListWrapper.build();
+	}
+
+	private String _getSortURL(String field) {
+		String sortURL = HttpComponentsUtil.removeParameter(
+			_currentURL, _parameterName);
+
+		return HttpComponentsUtil.setParameter(sortURL, _parameterName, field);
+	}
+
+	private String _currentURL;
 	private final Language _language;
 	private String _parameterName;
 	private final Portal _portal;

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/sort/portlet/SortPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/sort/portlet/SortPortlet.java
@@ -98,6 +98,8 @@ public class SortPortlet extends MVCPortlet {
 
 		return _createSortDisplayContextBuilder(
 			renderRequest, sortPortletPreferences
+		).currentURL(
+			portal.getCurrentURL(renderRequest)
 		).parameterName(
 			parameterName
 		).parameterValues(

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/sort/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/sort/view.jsp
@@ -18,7 +18,6 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
-page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %><%@
 page import="com.liferay.portal.search.web.internal.sort.configuration.SortPortletInstanceConfiguration" %><%@
 page import="com.liferay.portal.search.web.internal.sort.display.context.SortDisplayContext" %><%@
@@ -58,6 +57,8 @@ SortPortletInstanceConfiguration sortPortletInstanceConfiguration = sortDisplayC
 				className="<%= SortDisplayContext.class.getName() %>"
 				contextObjects='<%=
 					HashMapBuilder.<String, Object>put(
+						"namespace", liferayPortletResponse.getNamespace()
+					).put(
 						"sortDisplayContext", sortDisplayContext
 					).build()
 				%>'
@@ -65,24 +66,25 @@ SortPortletInstanceConfiguration sortPortletInstanceConfiguration = sortDisplayC
 				displayStyleGroupId="<%= sortDisplayContext.getDisplayStyleGroupId() %>"
 				entries="<%= sortDisplayContext.getSortTermDisplayContexts() %>"
 			>
-				<aui:fieldset>
-					<aui:select class="sort-term" label="sort-by" name="sortSelection">
-						<c:if test="<%= !sortDisplayContext.isAnySelected() %>">
-							<aui:option disabled="<%= true %>" label="relevance" selected="<%= true %>" />
-						</c:if>
+				<div class="form-group">
 
-						<%
-						for (SortTermDisplayContext sortTermDisplayContext : sortDisplayContext.getSortTermDisplayContexts()) {
-						%>
+					<%
+					SortTermDisplayContext selectedSortTermDisplayContext = sortDisplayContext.getSelectedSortTermDisplayContext();
+					%>
 
-							<aui:option label="<%= HtmlUtil.escapeAttribute(sortTermDisplayContext.getLabel()) %>" selected="<%= sortTermDisplayContext.isSelected() %>" value="<%= HtmlUtil.escapeAttribute(sortTermDisplayContext.getField()) %>" />
+					<label for="<portlet:namespace />sortSelectionDropdown">
+						<liferay-ui:message key="sort-by" />
+					</label>
 
-						<%
-						}
-						%>
-
-					</aui:select>
-				</aui:fieldset>
+					<clay:dropdown-menu
+						aria-label='<%= LanguageUtil.get(request, "sort-by") %>'
+						cssClass="form-control form-control-select"
+						displayType="secondary"
+						dropdownItems="<%= sortDisplayContext.getActionDropdownItems() %>"
+						id='<%= liferayPortletResponse.getNamespace() + "sortSelectionDropdown" %>'
+						label='<%= (selectedSortTermDisplayContext == null) ? "relevance" : selectedSortTermDisplayContext.getLabel() %>'
+					/>
+				</div>
 			</liferay-ddm:template-renderer>
 		</aui:form>
 	</c:otherwise>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/sort/portlet/display/template/dependencies/portlet_display_template_compact.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/sort/portlet/display/template/dependencies/portlet_display_template_compact.ftl
@@ -1,6 +1,6 @@
 <div class="form-group-autofit">
 	<div class="form-group-item form-group-item-label form-group-item-shrink">
-		<label>
+		<label for="${namespace + 'sortSelectionDropdown'}">
 			<span class="text-truncate-inline">
 				<span class="text-truncate">
 					${languageUtil.get(locale, "sort-by")}
@@ -9,21 +9,19 @@
 		</label>
 	</div>
 
+	<#if sortDisplayContext.getSelectedSortTermDisplayContext()??>
+		<#assign sortTermLabel = sortDisplayContext.getSelectedSortTermDisplayContext().getLabel() />
+	<#else>
+		<#assign sortTermLabel = "relevance" />
+	</#if>
+
 	<div class="form-group-item">
-		<@liferay_aui.select
-			cssClass="sort-term"
-			label=""
-			name="sortSelection"
-		>
-			<#if entries?has_content>
-				<#list entries as entry>
-					<@liferay_aui.option
-						label="${entry.getLanguageLabel()}"
-						selected=entry.isSelected()
-						value="${entry.getField()}"
-					/>
-				</#list>
-			</#if>
-		</@liferay_aui.select>
+		<@clay["dropdown-menu"]
+			cssClass="form-control form-control-select"
+			displayType="secondary"
+			dropdownItems=sortDisplayContext.getActionDropdownItems()
+			id="${namespace + 'sortSelectionDropdown'}"
+			label=sortTermLabel
+		/>
 	</div>
 </div>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/SearchPage.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/SearchPage.macro
@@ -126,7 +126,7 @@ definition {
 	macro chooseSortOption(sortOption = null) {
 		Click(locator1 = "Search#SORT_WIDGET_DROPDOWN");
 
-		Click.clickNoMouseOver(
+		Click(
 			locator1 = "Search#SORT_WIDGET_SORT_OPTION",
 			sortOption = ${sortOption});
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/search/Search.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/search/Search.path
@@ -287,17 +287,17 @@
 </tr>
 <tr>
 	<td>SORT_WIDGET_DROPDOWN</td>
-	<td>//div/select[contains(@id, "SortPortlet")]</td>
+	<td>//div/button[contains(@class, 'dropdown-toggle') and contains(@id, 'SortPortlet')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>SORT_WIDGET_SORT_OPTION</td>
-	<td>//div/select[contains(@id, "SortPortlet")]/option[contains(., "${sortOption}")]</td>
+	<td>//*[contains(@class,'dropdown-item')][contains(@href, 'sort') and contains(., '${sortOption}')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>SORT_WIDGET_SORT_OPTION_POSITION</td>
-	<td>xpath=(//div/select[contains(@id, "SortPortlet")]/option)[${key_position}]</td>
+	<td>xpath=(//*[contains(@class, "dropdown-item")][contains(@href, 'sort')])[${key_position}]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
@@ -3298,6 +3298,8 @@ definition {
 		}
 
 		task ("Assert that 'User' shows up at the top of the dropdown list since it was repositioned earlier") {
+			Click(locator1 = "Search#SORT_WIDGET_DROPDOWN");
+
 			AssertTextEquals(
 				key_position = 1,
 				locator1 = "Search#SORT_WIDGET_SORT_OPTION_POSITION",
@@ -3325,6 +3327,8 @@ definition {
 		}
 
 		task ("Assert that the renamed 'Relevance' sort option appears and is at the top of the Sort dropdown list ") {
+			Click(locator1 = "Search#SORT_WIDGET_DROPDOWN");
+
 			AssertElementPresent(
 				locator1 = "Search#SORT_WIDGET_SORT_OPTION",
 				sortOption = "Relevant Test");


### PR DESCRIPTION
Sent from https://github.com/liferay-search/liferay-portal/pull/1631

https://liferay.atlassian.net/browse/LPD-4507 - Improved keyword navigation for better accessibility in the Sort Widget

Adopts the Clay Dropdown taglib in order to have better accessibility.
- Adds `getActionDropdownItems` and `getSelectedSortTerm` into the display context to be put into the taglib
- Compact sample widget template was updated to adopt the Clay Dropdown component
- Updates the poshi tests
- Includes a change from https://github.com/liferay-frontend/liferay-portal/pull/4869, in order to pass associated poshi test for XSS

What it looks like:
![Screenshot 2025-04-23 at 4 14 03 PM](https://github.com/user-attachments/assets/ef7e32e8-3040-4d3c-b1d2-59d1130a1f08)

