### PR TITLE
LPD-54611 Object validations fails to load when the object definition contains a many to many relationship

### DIFF
--- a/modules/apps/object/object-api/bnd.bnd
+++ b/modules/apps/object/object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object API
 Bundle-SymbolicName: com.liferay.object.api
-Bundle-Version: 104.0.1
+Bundle-Version: 104.1.0
 Export-Package:\
 	com.liferay.object.action.engine,\
 	com.liferay.object.action.executor,\

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalService.java
@@ -380,6 +380,10 @@ public interface ObjectRelationshipLocalService
 	public List<ObjectRelationship> getObjectRelationshipsByObjectDefinitionId2(
 		long objectDefinitionId2);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<ObjectRelationship> getObjectRelationshipsByObjectDefinitionId2(
+		long objectDefinitionId2, String type);
+
 	/**
 	 * Returns the number of object relationships.
 	 *

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalServiceUtil.java
@@ -498,6 +498,14 @@ public class ObjectRelationshipLocalServiceUtil {
 			objectDefinitionId2);
 	}
 
+	public static List<ObjectRelationship>
+		getObjectRelationshipsByObjectDefinitionId2(
+			long objectDefinitionId2, String type) {
+
+		return getService().getObjectRelationshipsByObjectDefinitionId2(
+			objectDefinitionId2, type);
+	}
+
 	/**
 	 * Returns the number of object relationships.
 	 *

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalServiceWrapper.java
@@ -579,6 +579,16 @@ public class ObjectRelationshipLocalServiceWrapper
 			getObjectRelationshipsByObjectDefinitionId2(objectDefinitionId2);
 	}
 
+	@Override
+	public java.util.List<com.liferay.object.model.ObjectRelationship>
+		getObjectRelationshipsByObjectDefinitionId2(
+			long objectDefinitionId2, String type) {
+
+		return _objectRelationshipLocalService.
+			getObjectRelationshipsByObjectDefinitionId2(
+				objectDefinitionId2, type);
+	}
+
 	/**
 	 * Returns the number of object relationships.
 	 *

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
@@ -1,1 +1,1 @@
-version 71.0.0
+version 71.1.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -3717,8 +3717,9 @@ public class ObjectEntryLocalServiceImpl
 		Map<String, Object> queryExpressions = new HashMap<>();
 
 		for (ObjectRelationship objectRelationship :
-				_objectRelationshipPersistence.findByObjectDefinitionId2(
-					objectDefinition2.getObjectDefinitionId())) {
+				_objectRelationshipPersistence.findByODI2_R_T(
+					objectDefinition2.getObjectDefinitionId(), false,
+					ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
 
 			ObjectField relationshipObjectField =
 				_objectFieldLocalService.fetchObjectField(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -829,6 +829,14 @@ public class ObjectRelationshipLocalServiceImpl
 	}
 
 	@Override
+	public List<ObjectRelationship> getObjectRelationshipsByObjectDefinitionId2(
+		long objectDefinitionId2, String type) {
+
+		return objectRelationshipPersistence.findByODI2_R_T(
+			objectDefinitionId2, false, type);
+	}
+
+	@Override
 	public Map<Long, List<ObjectRelationship>> getObjectRelationshipsMap(
 		long companyId) {
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectValidationRuleLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectValidationRuleLocalServiceImpl.java
@@ -8,6 +8,7 @@ package com.liferay.object.service.impl;
 import com.liferay.dynamic.data.mapping.expression.CreateExpressionRequest;
 import com.liferay.dynamic.data.mapping.expression.DDMExpressionFactory;
 import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.constants.ObjectValidationRuleConstants;
 import com.liferay.object.constants.ObjectValidationRuleSettingConstants;
 import com.liferay.object.definition.util.ObjectDefinitionUtil;
@@ -509,8 +510,9 @@ public class ObjectValidationRuleLocalServiceImpl
 		throws PortalException {
 
 		for (ObjectRelationship objectRelationship :
-				_objectRelationshipPersistence.findByObjectDefinitionId2(
-					objectDefinitionId)) {
+				_objectRelationshipPersistence.findByODI2_R_T(
+					objectDefinitionId, false,
+					ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
 
 			ObjectField relationshipObjectField =
 				_objectFieldPersistence.findByPrimaryKey(

--- a/modules/apps/object/object-test-util/bnd.bnd
+++ b/modules/apps/object/object-test-util/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Object Test Utilities
 Bundle-SymbolicName: com.liferay.object.test.util
-Bundle-Version: 5.1.5
+Bundle-Version: 5.2.0
 Export-Package: com.liferay.object.test.util

--- a/modules/apps/object/object-test-util/src/main/java/com/liferay/object/test/util/ObjectRelationshipTestUtil.java
+++ b/modules/apps/object/object-test-util/src/main/java/com/liferay/object/test/util/ObjectRelationshipTestUtil.java
@@ -64,12 +64,25 @@ public class ObjectRelationshipTestUtil {
 			String name)
 		throws PortalException {
 
+		return addObjectRelationship(
+			objectRelationshipLocalService, objectDefinition1,
+			objectDefinition2, deletionType, name,
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+	}
+
+	public static ObjectRelationship addObjectRelationship(
+			ObjectRelationshipLocalService objectRelationshipLocalService,
+			ObjectDefinition objectDefinition1,
+			ObjectDefinition objectDefinition2, String deletionType,
+			String name, String type)
+		throws PortalException {
+
 		return objectRelationshipLocalService.addObjectRelationship(
 			null, TestPropsValues.getUserId(),
 			objectDefinition1.getObjectDefinitionId(),
 			objectDefinition2.getObjectDefinitionId(), 0, deletionType, false,
 			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-			name, false, ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+			name, false, type, null);
 	}
 
 }

--- a/modules/apps/object/object-test-util/src/main/resources/com/liferay/object/test/util/packageinfo
+++ b/modules/apps/object/object-test-util/src/main/resources/com/liferay/object/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 5.1.0
+version 5.2.0

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -512,6 +512,13 @@ public class ObjectEntryLocalServiceTest {
 		ObjectDefinition objectDefinition2 =
 			ObjectDefinitionTestUtil.publishObjectDefinition();
 
+		ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectRelationshipLocalService, objectDefinition1,
+			objectDefinition2,
+			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+			StringUtil.randomId(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
 		ObjectRelationship objectRelationship1 =
 			ObjectRelationshipTestUtil.addObjectRelationship(
 				_objectRelationshipLocalService, objectDefinition1,
@@ -1690,7 +1697,13 @@ public class ObjectEntryLocalServiceTest {
 			_objectRelationshipLocalService, objectDefinition1,
 			objectDefinition2,
 			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
-			"objectRelationship");
+			StringUtil.randomId(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+		ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectRelationshipLocalService, objectDefinition1,
+			objectDefinition2,
+			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+			"objectRelationship", ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		ObjectField objectField1 = ObjectFieldUtil.addCustomObjectField(
 			new IntegerObjectFieldBuilder(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/definitions/frontend/taglib/servlet/taglib/test/ValidationsObjectDefinitionsScreenNavigationEntryTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/definitions/frontend/taglib/servlet/taglib/test/ValidationsObjectDefinitionsScreenNavigationEntryTest.java
@@ -8,6 +8,7 @@ package com.liferay.object.web.internal.object.definitions.frontend.taglib.servl
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.frontend.taglib.servlet.taglib.ScreenNavigationEntry;
 import com.liferay.object.constants.ObjectPortletKeys;
+import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.constants.ObjectValidationRuleConstants;
 import com.liferay.object.constants.ObjectWebKeys;
 import com.liferay.object.model.ObjectDefinition;
@@ -38,6 +39,7 @@ import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -100,6 +102,13 @@ public class ValidationsObjectDefinitionsScreenNavigationEntryTest {
 			ObjectDefinitionTestUtil.addCustomObjectDefinition();
 		ObjectDefinition objectDefinition2 =
 			ObjectDefinitionTestUtil.addCustomObjectDefinition();
+
+		ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectRelationshipLocalService, objectDefinition1,
+			objectDefinition2,
+			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+			StringUtil.randomId(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		ObjectRelationship objectRelationship =
 			ObjectRelationshipTestUtil.addObjectRelationship(

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/util/ObjectCodeEditorUtil.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/util/ObjectCodeEditorUtil.java
@@ -5,6 +5,7 @@
 
 package com.liferay.object.web.internal.object.definitions.display.context.util;
 
+import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
@@ -402,7 +403,8 @@ public class ObjectCodeEditorUtil {
 		for (ObjectRelationship objectRelationship :
 				ObjectRelationshipLocalServiceUtil.
 					getObjectRelationshipsByObjectDefinitionId2(
-						objectDefinitionId)) {
+						objectDefinitionId,
+						ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
 
 			ObjectDefinition objectDefinition =
 				ObjectDefinitionLocalServiceUtil.fetchObjectDefinition(


### PR DESCRIPTION
We ran CI tests [here](https://github.com/liferay-bpm/liferay-portal/pull/4466) and the errors are not related.