### PR TITLE
LPD-54558 Remove the outdated ClassLoader parameter from the getHelperUtilities method in the TemplateContextHelper class

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -4229,6 +4229,14 @@
 		"to": "fetchCommercePriceEntryByExternalReferenceCode(param#1#, param#0#)"
 	},
 	{
+		"classNames": [
+			"TemplateContextHelper"
+		],
+		"from": "getHelperUtilities(ClassLoader paramName, boolean paramName)",
+		"issueKey": "LPD-54558",
+		"to": "getHelperUtilities(param#1#)"
+	},
+	{
 		"from": "CookieKeys.COMMERCE_CONTINUE_AS_GUEST",
 		"issueKey": "LPS-159679",
 		"newImports": [

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_54558.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/upgrade-catch-all-check/LPD_54558.testjava
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Renan Vasconcelos
+ */
+public class LPD_54558 {
+
+	public void method(ClassLoader classLoader, boolean restricted) {
+		_templateContextHelper.getHelperUtilities(restricted);
+		_templateContextHelper.getHelperUtilities(null, restricted);
+	}
+
+	@Reference
+	private TemplateContextHelper _templateContextHelper;
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_54558.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_54558.testjava
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Renan Vasconcelos
+ */
+public class LPD_54558 {
+
+	public void method(ClassLoader classLoader, boolean restricted) {
+		_templateContextHelper.getHelperUtilities(classLoader, restricted);
+		_templateContextHelper.getHelperUtilities(null, restricted);
+	}
+
+	@Reference
+	private TemplateContextHelper _templateContextHelper;
+
+}


### PR DESCRIPTION
Issue: [LPD-54558](https://liferay.atlassian.net/browse/LPD-54558)
Manually forwarded from https://github.com/liferay-upgrades/liferay-portal/pull/117 - All CI tests passed.
Cc @linolaoj @nicolas-sss