### PR TITLE
LPD-52794 Create individual sharing entries headless endpoints

### DIFF
--- a/modules/apps/headless/headless-object/headless-object-api/bnd.bnd
+++ b/modules/apps/headless/headless-object/headless-object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Object API
 Bundle-SymbolicName: com.liferay.headless.object.api
-Bundle-Version: 2.0.1
+Bundle-Version: 3.0.0
 Export-Package:\
 	com.liferay.headless.object.dto.v1_0,\
 	com.liferay.headless.object.resource.v1_0,\

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/dto/v1_0/Collaborator.java
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/dto/v1_0/Collaborator.java
@@ -35,7 +35,6 @@ import java.util.function.Supplier;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -51,7 +50,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 )
 @io.swagger.v3.oas.annotations.media.Schema(
 	description = "Represents a collaborator for an entry.",
-	requiredProperties = {"actionIds", "externalReferenceCode", "type"}
+	requiredProperties = {"actionIds", "type"}
 )
 @JsonFilter("Liferay.Vulcan")
 @XmlRootElement(name = "Collaborator")
@@ -283,12 +282,52 @@ public class Collaborator implements Serializable {
 	}
 
 	@GraphQLField(description = "The collaborator external reference code.")
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	@NotEmpty
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String externalReferenceCode;
 
 	@JsonIgnore
 	private Supplier<String> _externalReferenceCodeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The collaborator ID."
+	)
+	public Long getId() {
+		if (_idSupplier != null) {
+			id = _idSupplier.get();
+
+			_idSupplier = null;
+		}
+
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+
+		_idSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		_idSupplier = () -> {
+			try {
+				return idUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The collaborator ID.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Long id;
+
+	@JsonIgnore
+	private Supplier<Long> _idSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "The collaborator name."
@@ -584,6 +623,18 @@ public class Collaborator implements Serializable {
 			sb.append(_escape(externalReferenceCode));
 
 			sb.append("\"");
+		}
+
+		Long id = getId();
+
+		if (id != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(id);
 		}
 
 		String name = getName();

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/resource/v1_0/CollaboratorResource.java
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/resource/v1_0/CollaboratorResource.java
@@ -48,8 +48,32 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface CollaboratorResource {
 
+	public void
+			deleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator(
+				Long objectEntryFolderId, String collaboratorType,
+				Long collaboratorId)
+		throws Exception;
+
+	public void
+			deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+				String scopeKey, String externalReferenceCode,
+				String collaboratorType, Long collaboratorId)
+		throws Exception;
+
+	public Collaborator
+			getObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator(
+				Long objectEntryFolderId, String collaboratorType,
+				Long collaboratorId)
+		throws Exception;
+
 	public Page<Collaborator> getObjectEntryFolderCollaboratorsPage(
 			Long objectEntryFolderId, Pagination pagination)
+		throws Exception;
+
+	public Collaborator
+			getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+				String scopeKey, String externalReferenceCode,
+				String collaboratorType, Long collaboratorId)
 		throws Exception;
 
 	public Page<Collaborator>
@@ -71,6 +95,19 @@ public interface CollaboratorResource {
 			postScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
 				String scopeKey, String externalReferenceCode,
 				Collaborator[] collaborators)
+		throws Exception;
+
+	public Collaborator
+			putObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator(
+				Long objectEntryFolderId, String collaboratorType,
+				Long collaboratorId, Collaborator collaborator)
+		throws Exception;
+
+	public Collaborator
+			putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+				String scopeKey, String externalReferenceCode,
+				String collaboratorType, Long collaboratorId,
+				Collaborator collaborator)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
@@ -9,6 +9,8 @@ import com.liferay.headless.object.dto.v1_0.Collaborator;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.NoSuchGroupException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -20,9 +22,11 @@ import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.GroupUtil;
 import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.security.permission.SharingEntryAction;
+import com.liferay.sharing.service.SharingEntryLocalService;
 import com.liferay.sharing.service.SharingEntryService;
 
 import java.util.ArrayList;
@@ -37,9 +41,29 @@ import javax.ws.rs.core.UriInfo;
  */
 public class CollaboratorUtil {
 
+	public static Collaborator addOrUpdateCollaborator(
+			AcceptLanguage acceptLanguage, long classNameId, long classPK,
+			Collaborator collaborator, long collaboratorId,
+			String collaboratorType,
+			DTOConverter<SharingEntry, Collaborator> dtoConverter,
+			DTOConverterRegistry dtoConverterRegistry, long groupId,
+			SharingEntryService sharingEntryService,
+			UserGroupLocalService userGroupLocalService, UriInfo uriInfo,
+			User user, UserLocalService userLocalService)
+		throws Exception {
+
+		return toCollaborator(
+			acceptLanguage, dtoConverter, dtoConverterRegistry,
+			_addOrUpdateSharingEntry(
+				classNameId, classPK, collaborator, collaboratorId,
+				getCollaboratorType(collaboratorType), groupId,
+				sharingEntryService, userGroupLocalService, userLocalService),
+			uriInfo, user);
+	}
+
 	public static Page<Collaborator> addOrUpdateCollaborators(
 			AcceptLanguage acceptLanguage, long classNameId, long classPK,
-			Collaborator[] collaborators, long companyId,
+			Collaborator[] collaborators,
 			DTOConverter<SharingEntry, Collaborator> dtoConverter,
 			DTOConverterRegistry dtoConverterRegistry, long groupId,
 			SharingEntryService sharingEntryService, UriInfo uriInfo, User user,
@@ -58,8 +82,9 @@ public class CollaboratorUtil {
 
 		for (Collaborator collaborator : collaborators) {
 			SharingEntry sharingEntry = _addOrUpdateSharingEntry(
-				classNameId, classPK, collaborator, companyId, groupId,
-				sharingEntryService, userGroupLocalService, userLocalService);
+				classNameId, classPK, collaborator, collaborator.getId(),
+				collaborator.getType(), groupId, sharingEntryService,
+				userGroupLocalService, userLocalService);
 
 			newSharingEntries.add(sharingEntry);
 			sharingEntriesIds.add(sharingEntry.getSharingEntryId());
@@ -77,6 +102,89 @@ public class CollaboratorUtil {
 				sharingEntry -> toCollaborator(
 					acceptLanguage, dtoConverter, dtoConverterRegistry,
 					sharingEntry, uriInfo, user)));
+	}
+
+	public static void deleteCollaborator(
+			long classNameId, long classPK, Long collaboratorId,
+			Collaborator.Type collaboratorType,
+			SharingEntryService sharingEntryService)
+		throws Exception {
+
+		if (Objects.equals(Collaborator.Type.USER, collaboratorType)) {
+			sharingEntryService.deleteSharingEntry(
+				0, collaboratorId, classNameId, classPK);
+		}
+		else {
+			sharingEntryService.deleteSharingEntry(
+				collaboratorId, 0, classNameId, classPK);
+		}
+	}
+
+	public static Collaborator getCollaborator(
+			AcceptLanguage acceptLanguage, long classNameId, long classPK,
+			Long collaboratorId, Collaborator.Type collaboratorType,
+			DTOConverter<SharingEntry, Collaborator> dtoConverter,
+			DTOConverterRegistry dtoConverterRegistry,
+			SharingEntryService sharingEntryService, UriInfo uriInfo, User user)
+		throws Exception {
+
+		if (Objects.equals(Collaborator.Type.USER, collaboratorType)) {
+			return toCollaborator(
+				acceptLanguage, dtoConverter, dtoConverterRegistry,
+				sharingEntryService.getSharingEntry(
+					0, collaboratorId, classNameId, classPK),
+				uriInfo, user);
+		}
+
+		return toCollaborator(
+			acceptLanguage, dtoConverter, dtoConverterRegistry,
+			sharingEntryService.getSharingEntry(
+				collaboratorId, 0, classNameId, classPK),
+			uriInfo, user);
+	}
+
+	public static Page<Collaborator> getCollaborators(
+			AcceptLanguage acceptLanguage, long classNameId, long classPK,
+			DTOConverter<SharingEntry, Collaborator> dtoConverter,
+			DTOConverterRegistry dtoConverterRegistry, long groupId,
+			Pagination pagination,
+			SharingEntryLocalService sharingEntryLocalService,
+			SharingEntryService sharingEntryService, UriInfo uriInfo, User user)
+		throws Exception {
+
+		return Page.of(
+			TransformUtil.transform(
+				sharingEntryService.getSharingEntries(
+					classNameId, classPK, groupId,
+					pagination.getStartPosition(), pagination.getEndPosition()),
+				sharingEntry -> toCollaborator(
+					acceptLanguage, dtoConverter, dtoConverterRegistry,
+					sharingEntry, uriInfo, user)),
+			pagination,
+			sharingEntryLocalService.getSharingEntriesCount(
+				classNameId, classPK));
+	}
+
+	public static Collaborator.Type getCollaboratorType(
+		String collaboratorType) {
+
+		Collaborator.Type collaboratorTypeEnum = null;
+
+		try {
+			collaboratorTypeEnum = Collaborator.Type.create(collaboratorType);
+		}
+		catch (IllegalArgumentException illegalArgumentException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(illegalArgumentException);
+			}
+		}
+
+		if (collaboratorTypeEnum == null) {
+			throw new IllegalArgumentException(
+				"CollaboratorType parameter must be 'User' or 'UserGroup'");
+		}
+
+		return collaboratorTypeEnum;
 	}
 
 	public static long getGroupId(
@@ -115,8 +223,8 @@ public class CollaboratorUtil {
 
 	private static SharingEntry _addOrUpdateSharingEntry(
 			long classNameId, long classPK, Collaborator collaborator,
-			long companyId, long groupId,
-			SharingEntryService sharingEntryService,
+			long collaboratorId, Collaborator.Type collaboratorType,
+			long groupId, SharingEntryService sharingEntryService,
 			UserGroupLocalService userGroupLocalService,
 			UserLocalService userLocalService)
 		throws Exception {
@@ -124,18 +232,14 @@ public class CollaboratorUtil {
 		long toUserGroupId = 0;
 		long toUserId = 0;
 
-		if (Objects.equals(
-				Collaborator.Type.USER_GROUP, collaborator.getType())) {
-
-			UserGroup userGroup =
-				userGroupLocalService.getUserGroupByExternalReferenceCode(
-					collaborator.getExternalReferenceCode(), companyId);
+		if (Objects.equals(Collaborator.Type.USER_GROUP, collaboratorType)) {
+			UserGroup userGroup = userGroupLocalService.getUserGroup(
+				collaboratorId);
 
 			toUserGroupId = userGroup.getUserGroupId();
 		}
 		else {
-			User user = userLocalService.getUserByExternalReferenceCode(
-				collaborator.getExternalReferenceCode(), companyId);
+			User user = userLocalService.getUser(collaboratorId);
 
 			toUserId = user.getUserId();
 		}
@@ -154,5 +258,8 @@ public class CollaboratorUtil {
 				SharingEntryAction::parseFromActionId),
 			collaborator.getDateExpired(), new ServiceContext());
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		CollaboratorUtil.class.getName());
 
 }

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
@@ -181,7 +181,7 @@ public class CollaboratorUtil {
 
 		if (collaboratorTypeEnum == null) {
 			throw new IllegalArgumentException(
-				"CollaboratorType parameter must be 'User' or 'UserGroup'");
+				"Collaborator type must be \"User\" or \"UserGroup\"");
 		}
 
 		return collaboratorTypeEnum;

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/resources/com/liferay/headless/object/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/resources/com/liferay/headless/object/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/resources/com/liferay/headless/object/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/resources/com/liferay/headless/object/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/resources/com/liferay/headless/object/util/v1_0/packageinfo
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/resources/com/liferay/headless/object/util/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0

--- a/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/dto/v1_0/Collaborator.java
+++ b/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/dto/v1_0/Collaborator.java
@@ -132,6 +132,25 @@ public class Collaborator implements Cloneable, Serializable {
 
 	protected String externalReferenceCode;
 
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long id;
+
 	public String getName() {
 		return name;
 	}

--- a/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/resource/v1_0/CollaboratorResource.java
+++ b/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/resource/v1_0/CollaboratorResource.java
@@ -36,6 +36,42 @@ public interface CollaboratorResource {
 		return new Builder();
 	}
 
+	public void
+			deleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator(
+				Long objectEntryFolderId, String collaboratorType,
+				Long collaboratorId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			deleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaboratorHttpResponse(
+				Long objectEntryFolderId, String collaboratorType,
+				Long collaboratorId)
+		throws Exception;
+
+	public void
+			deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+				String scopeKey, String externalReferenceCode,
+				String collaboratorType, Long collaboratorId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaboratorHttpResponse(
+				String scopeKey, String externalReferenceCode,
+				String collaboratorType, Long collaboratorId)
+		throws Exception;
+
+	public Collaborator
+			getObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator(
+				Long objectEntryFolderId, String collaboratorType,
+				Long collaboratorId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			getObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaboratorHttpResponse(
+				Long objectEntryFolderId, String collaboratorType,
+				Long collaboratorId)
+		throws Exception;
+
 	public Page<Collaborator> getObjectEntryFolderCollaboratorsPage(
 			Long objectEntryFolderId, Pagination pagination)
 		throws Exception;
@@ -43,6 +79,18 @@ public interface CollaboratorResource {
 	public HttpInvoker.HttpResponse
 			getObjectEntryFolderCollaboratorsPageHttpResponse(
 				Long objectEntryFolderId, Pagination pagination)
+		throws Exception;
+
+	public Collaborator
+			getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+				String scopeKey, String externalReferenceCode,
+				String collaboratorType, Long collaboratorId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaboratorHttpResponse(
+				String scopeKey, String externalReferenceCode,
+				String collaboratorType, Long collaboratorId)
 		throws Exception;
 
 	public Page<Collaborator>
@@ -87,6 +135,32 @@ public interface CollaboratorResource {
 			postScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPageHttpResponse(
 				String scopeKey, String externalReferenceCode,
 				Collaborator[] collaborators)
+		throws Exception;
+
+	public Collaborator
+			putObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator(
+				Long objectEntryFolderId, String collaboratorType,
+				Long collaboratorId, Collaborator collaborator)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			putObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaboratorHttpResponse(
+				Long objectEntryFolderId, String collaboratorType,
+				Long collaboratorId, Collaborator collaborator)
+		throws Exception;
+
+	public Collaborator
+			putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+				String scopeKey, String externalReferenceCode,
+				String collaboratorType, Long collaboratorId,
+				Collaborator collaborator)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaboratorHttpResponse(
+				String scopeKey, String externalReferenceCode,
+				String collaboratorType, Long collaboratorId,
+				Collaborator collaborator)
 		throws Exception;
 
 	public static class Builder {
@@ -198,6 +272,347 @@ public interface CollaboratorResource {
 	public static class CollaboratorResourceImpl
 		implements CollaboratorResource {
 
+		public void
+				deleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator(
+					Long objectEntryFolderId, String collaboratorType,
+					Long collaboratorId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				deleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaboratorHttpResponse(
+					objectEntryFolderId, collaboratorType, collaboratorId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return;
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				deleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaboratorHttpResponse(
+					Long objectEntryFolderId, String collaboratorType,
+					Long collaboratorId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-object/v1.0/object-entry-folders/{objectEntryFolderId}/collaborators/by-type/{collaboratorType}/{collaboratorId}");
+
+			httpInvoker.path("objectEntryFolderId", objectEntryFolderId);
+			httpInvoker.path("collaboratorType", collaboratorType);
+			httpInvoker.path("collaboratorId", collaboratorId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void
+				deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+					String scopeKey, String externalReferenceCode,
+					String collaboratorType, Long collaboratorId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaboratorHttpResponse(
+					scopeKey, externalReferenceCode, collaboratorType,
+					collaboratorId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return;
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaboratorHttpResponse(
+					String scopeKey, String externalReferenceCode,
+					String collaboratorType, Long collaboratorId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-object/v1.0/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{collaboratorType}/{collaboratorId}");
+
+			httpInvoker.path("scopeKey", scopeKey);
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
+			httpInvoker.path("collaboratorType", collaboratorType);
+			httpInvoker.path("collaboratorId", collaboratorId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public Collaborator
+				getObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator(
+					Long objectEntryFolderId, String collaboratorType,
+					Long collaboratorId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaboratorHttpResponse(
+					objectEntryFolderId, collaboratorType, collaboratorId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return CollaboratorSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaboratorHttpResponse(
+					Long objectEntryFolderId, String collaboratorType,
+					Long collaboratorId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-object/v1.0/object-entry-folders/{objectEntryFolderId}/collaborators/by-type/{collaboratorType}/{collaboratorId}");
+
+			httpInvoker.path("objectEntryFolderId", objectEntryFolderId);
+			httpInvoker.path("collaboratorType", collaboratorType);
+			httpInvoker.path("collaboratorId", collaboratorId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
 		public Page<Collaborator> getObjectEntryFolderCollaboratorsPage(
 				Long objectEntryFolderId, Pagination pagination)
 			throws Exception {
@@ -304,6 +719,121 @@ public interface CollaboratorResource {
 						"/o/headless-object/v1.0/object-entry-folders/{objectEntryFolderId}/collaborators");
 
 			httpInvoker.path("objectEntryFolderId", objectEntryFolderId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public Collaborator
+				getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+					String scopeKey, String externalReferenceCode,
+					String collaboratorType, Long collaboratorId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaboratorHttpResponse(
+					scopeKey, externalReferenceCode, collaboratorType,
+					collaboratorId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return CollaboratorSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaboratorHttpResponse(
+					String scopeKey, String externalReferenceCode,
+					String collaboratorType, Long collaboratorId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-object/v1.0/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{collaboratorType}/{collaboratorId}");
+
+			httpInvoker.path("scopeKey", scopeKey);
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
+			httpInvoker.path("collaboratorType", collaboratorType);
+			httpInvoker.path("collaboratorId", collaboratorId);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -774,6 +1304,241 @@ public interface CollaboratorResource {
 
 			httpInvoker.path("scopeKey", scopeKey);
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public Collaborator
+				putObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator(
+					Long objectEntryFolderId, String collaboratorType,
+					Long collaboratorId, Collaborator collaborator)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				putObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaboratorHttpResponse(
+					objectEntryFolderId, collaboratorType, collaboratorId,
+					collaborator);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return CollaboratorSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				putObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaboratorHttpResponse(
+					Long objectEntryFolderId, String collaboratorType,
+					Long collaboratorId, Collaborator collaborator)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(collaborator.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.PUT);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-object/v1.0/object-entry-folders/{objectEntryFolderId}/collaborators/by-type/{collaboratorType}/{collaboratorId}");
+
+			httpInvoker.path("objectEntryFolderId", objectEntryFolderId);
+			httpInvoker.path("collaboratorType", collaboratorType);
+			httpInvoker.path("collaboratorId", collaboratorId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public Collaborator
+				putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+					String scopeKey, String externalReferenceCode,
+					String collaboratorType, Long collaboratorId,
+					Collaborator collaborator)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaboratorHttpResponse(
+					scopeKey, externalReferenceCode, collaboratorType,
+					collaboratorId, collaborator);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return CollaboratorSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaboratorHttpResponse(
+					String scopeKey, String externalReferenceCode,
+					String collaboratorType, Long collaboratorId,
+					Collaborator collaborator)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(collaborator.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.PUT);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-object/v1.0/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{collaboratorType}/{collaboratorId}");
+
+			httpInvoker.path("scopeKey", scopeKey);
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
+			httpInvoker.path("collaboratorType", collaboratorType);
+			httpInvoker.path("collaboratorId", collaboratorId);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(

--- a/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/serdes/v1_0/CollaboratorSerDes.java
+++ b/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/serdes/v1_0/CollaboratorSerDes.java
@@ -121,6 +121,16 @@ public class CollaboratorSerDes {
 			sb.append("\"");
 		}
 
+		if (collaborator.getId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(collaborator.getId());
+		}
+
 		if (collaborator.getName() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -234,6 +244,13 @@ public class CollaboratorSerDes {
 				String.valueOf(collaborator.getExternalReferenceCode()));
 		}
 
+		if (collaborator.getId() == null) {
+			map.put("id", null);
+		}
+		else {
+			map.put("id", String.valueOf(collaborator.getId()));
+		}
+
 		if (collaborator.getName() == null) {
 			map.put("name", null);
 		}
@@ -297,6 +314,9 @@ public class CollaboratorSerDes {
 
 				return false;
 			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "name")) {
 				return false;
 			}
@@ -348,6 +368,12 @@ public class CollaboratorSerDes {
 				if (jsonParserFieldValue != null) {
 					collaborator.setExternalReferenceCode(
 						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				if (jsonParserFieldValue != null) {
+					collaborator.setId(
+						Long.valueOf((String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "name")) {

--- a/modules/apps/headless/headless-object/headless-object-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-object/headless-object-impl/rest-openapi.yaml
@@ -366,7 +366,7 @@ paths:
         delete:
             description:
                 Deletes the collaborator for an object entry folder and returns a 204 if the operation succeeds.
-            operationId: deleteObjectEntryFolderCollaborator
+            operationId: deleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator
             parameters:
                 -   in: path
                     name: objectEntryFolderId
@@ -394,7 +394,7 @@ paths:
         get:
             description:
                 Retrieves the collaborator of an object entry.
-            operationId: getObjectEntryFolderCollaborator
+            operationId: getObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator
             parameters:
                 -   in: path
                     name: objectEntryFolderId
@@ -438,7 +438,7 @@ paths:
         put:
             description:
                 Add or update a collaborator received in the request.
-            operationId: putObjectEntryFolderCollaborator
+            operationId: putObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator
             parameters:
                 -   in: path
                     name: objectEntryFolderId
@@ -779,7 +779,7 @@ paths:
         delete:
             description:
                 Deletes the collaborator for an object entry folder and returns a 204 if the operation succeeds.
-            operationId: deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaborator
+            operationId: deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator
             parameters:
                 -   in: path
                     name: scopeKey
@@ -811,7 +811,7 @@ paths:
         get:
             description:
                 Retrieves the collaborator for an object entry folder.
-            operationId: getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaborator
+            operationId: getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator
             parameters:
                 -   in: path
                     name: scopeKey
@@ -859,7 +859,7 @@ paths:
         put:
             description:
                 Add or update a collaborator received in the request.
-            operationId: putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaborator
+            operationId: putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator
             parameters:
                 -   in: path
                     name: scopeKey

--- a/modules/apps/headless/headless-object/headless-object-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-object/headless-object-impl/rest-openapi.yaml
@@ -318,7 +318,6 @@ paths:
                                 items:
                                     $ref: "#/components/schemas/Collaborator"
                                 type: array
-            tags: ["Collaborator"]
         post:
             description:
                 Add or update all the collaborators received in the request. Delete existing collaborators that are not
@@ -357,6 +356,119 @@ paths:
                                 items:
                                     $ref: "#/components/schemas/Collaborator"
                                 type: array
+            tags: ["Collaborator"]
+    "/object-entry-folders/{objectEntryFolderId}/collaborators/by-type/{collaboratorType}/{collaboratorId}":
+        delete:
+            description:
+                Deletes the collaborator for an object entry folder and returns a 204 if the operation succeeds.
+            operationId: deleteObjectEntryFolderCollaborator
+            parameters:
+                -   in: path
+                    name: objectEntryFolderId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: path
+                    name: collaboratorType
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["Collaborator"]
+        get:
+            description:
+                Retrieves the collaborator of an object entry.
+            operationId: getObjectEntryFolderCollaborator
+            parameters:
+                -   in: path
+                    name: objectEntryFolderId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: path
+                    name: collaboratorType
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: fields
+                    schema:
+                        type: string
+                -   in: query
+                    name: nestedFields
+                    schema:
+                        type: string
+                -   in: query
+                    name: restrictFields
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Collaborator"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/Collaborator"
+            tags: ["Collaborator"]
+        put:
+            description:
+                Add or update a collaborator received in the request.
+            operationId: putObjectEntryFolderCollaborator
+            parameters:
+                -   in: path
+                    name: objectEntryFolderId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: path
+                    name: collaboratorType
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/Collaborator"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/Collaborator"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Collaborator"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/Collaborator"
             tags: ["Collaborator"]
     "/scopes/{scopeKey}/object-entry-folder/by-external-reference-code/{externalReferenceCode}":
         delete:
@@ -615,7 +727,6 @@ paths:
                                 items:
                                     $ref: "#/components/schemas/Collaborator"
                                 type: array
-            tags: ["Collaborator"]
         post:
             description:
                 Add or update all the collaborators received in the request. Delete existing collaborators that are not
@@ -658,4 +769,129 @@ paths:
                                 items:
                                     $ref: "#/components/schemas/Collaborator"
                                 type: array
+            tags: ["Collaborator"]
+    "/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{collaboratorType}/{collaboratorId}":
+        delete:
+            description:
+                Deletes the collaborator for an object entry folder and returns a 204 if the operation succeeds.
+            operationId: deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaborator
+            parameters:
+                -   in: path
+                    name: scopeKey
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: externalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorType
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["Collaborator"]
+        get:
+            description:
+                Retrieves the collaborator for an object entry folder.
+            operationId: getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaborator
+            parameters:
+                -   in: path
+                    name: scopeKey
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: externalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorType
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: fields
+                    schema:
+                        type: string
+                -   in: query
+                    name: nestedFields
+                    schema:
+                        type: string
+                -   in: query
+                    name: restrictFields
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Collaborator"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/Collaborator"
+            tags: ["Collaborator"]
+        put:
+            description:
+                Add or update a collaborator received in the request.
+            operationId: putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaborator
+            parameters:
+                -   in: path
+                    name: scopeKey
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: externalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorType
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/Collaborator"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/Collaborator"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Collaborator"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/Collaborator"
             tags: ["Collaborator"]

--- a/modules/apps/headless/headless-object/headless-object-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-object/headless-object-impl/rest-openapi.yaml
@@ -32,7 +32,13 @@ components:
                     # @review
                     description:
                         The collaborator external reference code.
+                    readOnly: true
                     type: string
+                id:
+                    description:
+                        The collaborator ID.
+                    format: int64
+                    type: integer
                 name:
                     description:
                         The collaborator name.
@@ -55,7 +61,6 @@ components:
                     type: string
             required:
                 -   actionIds
-                -   externalReferenceCode
                 -   type
             type: object
         ObjectEntryFolder:

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/dto/v1_0/converter/CollaboratorDTOConverter.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/dto/v1_0/converter/CollaboratorDTOConverter.java
@@ -65,6 +65,14 @@ public class CollaboratorDTOConverter
 
 						return userGroup.getExternalReferenceCode();
 					});
+				setId(
+					() -> {
+						if (user != null) {
+							return user.getUserId();
+						}
+
+						return userGroup.getUserGroupId();
+					});
 				setName(
 					() -> {
 						if (user != null) {

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/graphql/mutation/v1_0/Mutation.java
@@ -56,6 +56,51 @@ public class Mutation {
 	}
 
 	@GraphQLField(
+		description = "Deletes the collaborator for an object entry folder and returns a 204 if the operation succeeds."
+	)
+	public boolean
+			deleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator(
+				@GraphQLName("objectEntryFolderId") Long objectEntryFolderId,
+				@GraphQLName("collaboratorType") String collaboratorType,
+				@GraphQLName("collaboratorId") Long collaboratorId)
+		throws Exception {
+
+		_applyVoidComponentServiceObjects(
+			_collaboratorResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			collaboratorResource ->
+				collaboratorResource.
+					deleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator(
+						objectEntryFolderId, collaboratorType, collaboratorId));
+
+		return true;
+	}
+
+	@GraphQLField(
+		description = "Deletes the collaborator for an object entry folder and returns a 204 if the operation succeeds."
+	)
+	public boolean
+			deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+				@GraphQLName("scopeKey") String scopeKey,
+				@GraphQLName("externalReferenceCode") String
+					externalReferenceCode,
+				@GraphQLName("collaboratorType") String collaboratorType,
+				@GraphQLName("collaboratorId") Long collaboratorId)
+		throws Exception {
+
+		_applyVoidComponentServiceObjects(
+			_collaboratorResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			collaboratorResource ->
+				collaboratorResource.
+					deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+						scopeKey, externalReferenceCode, collaboratorType,
+						collaboratorId));
+
+		return true;
+	}
+
+	@GraphQLField(
 		description = "Add or update all the collaborators received in the request. Delete existing collaborators that are not included in the request. Send a notification for the new collaborators and those whose permissions are different."
 	)
 	public java.util.Collection<Collaborator>
@@ -116,6 +161,50 @@ public class Mutation {
 
 				return paginationPage.getItems();
 			});
+	}
+
+	@GraphQLField(
+		description = "Add or update a collaborator received in the request."
+	)
+	public Collaborator
+			updateObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator(
+				@GraphQLName("objectEntryFolderId") Long objectEntryFolderId,
+				@GraphQLName("collaboratorType") String collaboratorType,
+				@GraphQLName("collaboratorId") Long collaboratorId,
+				@GraphQLName("collaborator") Collaborator collaborator)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_collaboratorResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			collaboratorResource ->
+				collaboratorResource.
+					putObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator(
+						objectEntryFolderId, collaboratorType, collaboratorId,
+						collaborator));
+	}
+
+	@GraphQLField(
+		description = "Add or update a collaborator received in the request."
+	)
+	public Collaborator
+			updateScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+				@GraphQLName("scopeKey") String scopeKey,
+				@GraphQLName("externalReferenceCode") String
+					externalReferenceCode,
+				@GraphQLName("collaboratorType") String collaboratorType,
+				@GraphQLName("collaboratorId") Long collaboratorId,
+				@GraphQLName("collaborator") Collaborator collaborator)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_collaboratorResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			collaboratorResource ->
+				collaboratorResource.
+					putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+						scopeKey, externalReferenceCode, collaboratorType,
+						collaboratorId, collaborator));
 	}
 
 	@GraphQLField(

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/graphql/query/v1_0/Query.java
@@ -61,6 +61,30 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {objectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator(collaboratorId: ___, collaboratorType: ___, objectEntryFolderId: ___){actionIds, actions, creator, dateExpired, externalReferenceCode, id, name, portrait, share, type}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField(
+		description = "Retrieves the collaborator of an object entry."
+	)
+	public Collaborator
+			objectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator(
+				@GraphQLName("objectEntryFolderId") Long objectEntryFolderId,
+				@GraphQLName("collaboratorType") String collaboratorType,
+				@GraphQLName("collaboratorId") Long collaboratorId)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_collaboratorResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			collaboratorResource ->
+				collaboratorResource.
+					getObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator(
+						objectEntryFolderId, collaboratorType, collaboratorId));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {objectEntryFolderCollaborators(objectEntryFolderId: ___, page: ___, pageSize: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(
@@ -78,6 +102,33 @@ public class Query {
 			collaboratorResource -> new CollaboratorPage(
 				collaboratorResource.getObjectEntryFolderCollaboratorsPage(
 					objectEntryFolderId, Pagination.of(page, pageSize))));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {scopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(collaboratorId: ___, collaboratorType: ___, externalReferenceCode: ___, scopeKey: ___){actionIds, actions, creator, dateExpired, externalReferenceCode, id, name, portrait, share, type}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField(
+		description = "Retrieves the collaborator for an object entry folder."
+	)
+	public Collaborator
+			scopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+				@GraphQLName("scopeKey") String scopeKey,
+				@GraphQLName("externalReferenceCode") String
+					externalReferenceCode,
+				@GraphQLName("collaboratorType") String collaboratorType,
+				@GraphQLName("collaboratorId") Long collaboratorId)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_collaboratorResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			collaboratorResource ->
+				collaboratorResource.
+					getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+						scopeKey, externalReferenceCode, collaboratorType,
+						collaboratorId));
 	}
 
 	/**
@@ -204,6 +255,38 @@ public class Query {
 					collaboratorResource.getObjectEntryFolderCollaboratorsPage(
 						_objectEntryFolder.getId(),
 						Pagination.of(page, pageSize))));
+		}
+
+		private ObjectEntryFolder _objectEntryFolder;
+
+	}
+
+	@GraphQLTypeExtension(ObjectEntryFolder.class)
+	public class
+		GetObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaboratorTypeExtension {
+
+		public GetObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaboratorTypeExtension(
+			ObjectEntryFolder objectEntryFolder) {
+
+			_objectEntryFolder = objectEntryFolder;
+		}
+
+		@GraphQLField(
+			description = "Retrieves the collaborator of an object entry."
+		)
+		public Collaborator collaboratorByTypeCollaboratorTypeCollaborator(
+				@GraphQLName("collaboratorType") String collaboratorType,
+				@GraphQLName("collaboratorId") Long collaboratorId)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_collaboratorResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				collaboratorResource ->
+					collaboratorResource.
+						getObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator(
+							_objectEntryFolder.getId(), collaboratorType,
+							collaboratorId));
 		}
 
 		private ObjectEntryFolder _objectEntryFolder;

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -82,6 +82,16 @@ public class ServletDataImpl implements ServletData {
 			new HashMap<String, ObjectValuePair<Class<?>, String>>() {
 				{
 					put(
+						"mutation#deleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator",
+						new ObjectValuePair<>(
+							CollaboratorResourceImpl.class,
+							"deleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator"));
+					put(
+						"mutation#deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator",
+						new ObjectValuePair<>(
+							CollaboratorResourceImpl.class,
+							"deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator"));
+					put(
 						"mutation#createObjectEntryFolderCollaboratorsPage",
 						new ObjectValuePair<>(
 							CollaboratorResourceImpl.class,
@@ -96,6 +106,16 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							CollaboratorResourceImpl.class,
 							"postScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage"));
+					put(
+						"mutation#updateObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator",
+						new ObjectValuePair<>(
+							CollaboratorResourceImpl.class,
+							"putObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator"));
+					put(
+						"mutation#updateScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator",
+						new ObjectValuePair<>(
+							CollaboratorResourceImpl.class,
+							"putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator"));
 					put(
 						"mutation#deleteObjectEntryFolder",
 						new ObjectValuePair<>(
@@ -133,10 +153,20 @@ public class ServletDataImpl implements ServletData {
 							"putScopeScopeKeyObjectEntryFolderByExternalReferenceCode"));
 
 					put(
+						"query#objectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator",
+						new ObjectValuePair<>(
+							CollaboratorResourceImpl.class,
+							"getObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator"));
+					put(
 						"query#objectEntryFolderCollaborators",
 						new ObjectValuePair<>(
 							CollaboratorResourceImpl.class,
 							"getObjectEntryFolderCollaboratorsPage"));
+					put(
+						"query#scopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator",
+						new ObjectValuePair<>(
+							CollaboratorResourceImpl.class,
+							"getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator"));
 					put(
 						"query#scopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaborators",
 						new ObjectValuePair<>(
@@ -163,6 +193,11 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							CollaboratorResourceImpl.class,
 							"getObjectEntryFolderCollaboratorsPage"));
+					put(
+						"query#ObjectEntryFolder.collaboratorByTypeCollaboratorTypeCollaborator",
+						new ObjectValuePair<>(
+							CollaboratorResourceImpl.class,
+							"getObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator"));
 
 					put(
 						"query#ObjectEntryFolder.parentObjectEntryFolder",

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/BaseCollaboratorResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/BaseCollaboratorResourceImpl.java
@@ -70,6 +70,178 @@ public abstract class BaseCollaboratorResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-object/v1.0/object-entry-folders/{objectEntryFolderId}/collaborators/by-type/{collaboratorType}/{collaboratorId}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Deletes the collaborator for an object entry folder and returns a 204 if the operation succeeds."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectEntryFolderId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorType"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@javax.ws.rs.DELETE
+	@javax.ws.rs.Path(
+		"/object-entry-folders/{objectEntryFolderId}/collaborators/by-type/{collaboratorType}/{collaboratorId}"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public void
+			deleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("objectEntryFolderId")
+				Long objectEntryFolderId,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("collaboratorType")
+				String collaboratorType,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("collaboratorId")
+				Long collaboratorId)
+		throws Exception {
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-object/v1.0/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{collaboratorType}/{collaboratorId}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Deletes the collaborator for an object entry folder and returns a 204 if the operation succeeds."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "scopeKey"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorType"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@javax.ws.rs.DELETE
+	@javax.ws.rs.Path(
+		"/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{collaboratorType}/{collaboratorId}"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public void
+			deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("scopeKey")
+				String scopeKey,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("collaboratorType")
+				String collaboratorType,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("collaboratorId")
+				Long collaboratorId)
+		throws Exception {
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-object/v1.0/object-entry-folders/{objectEntryFolderId}/collaborators/by-type/{collaboratorType}/{collaboratorId}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves the collaborator of an object entry."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectEntryFolderId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorType"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "nestedFields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "restrictFields"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path(
+		"/object-entry-folders/{objectEntryFolderId}/collaborators/by-type/{collaboratorType}/{collaboratorId}"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Collaborator
+			getObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("objectEntryFolderId")
+				Long objectEntryFolderId,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("collaboratorType")
+				String collaboratorType,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("collaboratorId")
+				Long collaboratorId)
+		throws Exception {
+
+		return new Collaborator();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -X 'GET' 'http://localhost:8080/o/headless-object/v1.0/object-entry-folders/{objectEntryFolderId}/collaborators'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
@@ -103,9 +275,7 @@ public abstract class BaseCollaboratorResourceImpl
 			)
 		}
 	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
-	)
+	@io.swagger.v3.oas.annotations.tags.Tags(value = {})
 	@javax.ws.rs.GET
 	@javax.ws.rs.Path(
 		"/object-entry-folders/{objectEntryFolderId}/collaborators"
@@ -121,6 +291,78 @@ public abstract class BaseCollaboratorResourceImpl
 		throws Exception {
 
 		return Page.of(Collections.emptyList());
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-object/v1.0/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{collaboratorType}/{collaboratorId}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves the collaborator for an object entry folder."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "scopeKey"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorType"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "nestedFields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "restrictFields"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path(
+		"/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{collaboratorType}/{collaboratorId}"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Collaborator
+			getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("scopeKey")
+				String scopeKey,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("collaboratorType")
+				String collaboratorType,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("collaboratorId")
+				Long collaboratorId)
+		throws Exception {
+
+		return new Collaborator();
 	}
 
 	/**
@@ -163,9 +405,7 @@ public abstract class BaseCollaboratorResourceImpl
 			)
 		}
 	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
-	)
+	@io.swagger.v3.oas.annotations.tags.Tags(value = {})
 	@javax.ws.rs.GET
 	@javax.ws.rs.Path(
 		"/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators"
@@ -250,9 +490,7 @@ public abstract class BaseCollaboratorResourceImpl
 			)
 		}
 	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
-	)
+	@io.swagger.v3.oas.annotations.tags.Tags(value = {})
 	@javax.ws.rs.Consumes("application/json")
 	@javax.ws.rs.Path(
 		"/object-entry-folders/{objectEntryFolderId}/collaborators/export-batch"
@@ -340,6 +578,122 @@ public abstract class BaseCollaboratorResourceImpl
 		throws Exception {
 
 		return Page.of(Collections.emptyList());
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-object/v1.0/object-entry-folders/{objectEntryFolderId}/collaborators/by-type/{collaboratorType}/{collaboratorId}' -d $'{"actionIds": ___, "dateExpired": ___, "id": ___, "share": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Add or update a collaborator received in the request."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectEntryFolderId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorType"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@javax.ws.rs.Consumes({"application/json", "application/xml"})
+	@javax.ws.rs.Path(
+		"/object-entry-folders/{objectEntryFolderId}/collaborators/by-type/{collaboratorType}/{collaboratorId}"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@javax.ws.rs.PUT
+	@Override
+	public Collaborator
+			putObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("objectEntryFolderId")
+				Long objectEntryFolderId,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("collaboratorType")
+				String collaboratorType,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("collaboratorId")
+				Long collaboratorId,
+				Collaborator collaborator)
+		throws Exception {
+
+		return new Collaborator();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-object/v1.0/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{collaboratorType}/{collaboratorId}' -d $'{"actionIds": ___, "dateExpired": ___, "id": ___, "share": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Add or update a collaborator received in the request."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "scopeKey"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorType"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@javax.ws.rs.Consumes({"application/json", "application/xml"})
+	@javax.ws.rs.Path(
+		"/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{collaboratorType}/{collaboratorId}"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@javax.ws.rs.PUT
+	@Override
+	public Collaborator
+			putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("scopeKey")
+				String scopeKey,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("collaboratorType")
+				String collaboratorType,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("collaboratorId")
+				Long collaboratorId,
+				Collaborator collaborator)
+		throws Exception {
+
+		return new Collaborator();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/CollaboratorResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/CollaboratorResourceImpl.java
@@ -37,6 +37,82 @@ import org.osgi.service.component.annotations.ServiceScope;
 public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 
 	@Override
+	public void
+			deleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator(
+				Long objectEntryFolderId, String collaboratorType,
+				Long collaboratorId)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.getObjectEntryFolder(
+				objectEntryFolderId);
+
+		CollaboratorUtil.deleteCollaborator(
+			_classNameLocalService.getClassNameId(
+				ObjectEntryFolder.class.getName()),
+			objectEntryFolder.getObjectEntryFolderId(), collaboratorId,
+			CollaboratorUtil.getCollaboratorType(collaboratorType),
+			_sharingEntryService);
+	}
+
+	@Override
+	public void
+			deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+				String scopeKey, String externalReferenceCode,
+				String collaboratorType, Long collaboratorId)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					externalReferenceCode,
+					CollaboratorUtil.getGroupId(
+						contextCompany.getCompanyId(), _groupLocalService,
+						scopeKey),
+					contextCompany.getCompanyId());
+
+		CollaboratorUtil.deleteCollaborator(
+			_classNameLocalService.getClassNameId(
+				ObjectEntryFolder.class.getName()),
+			objectEntryFolder.getObjectEntryFolderId(), collaboratorId,
+			CollaboratorUtil.getCollaboratorType(collaboratorType),
+			_sharingEntryService);
+	}
+
+	@Override
+	public Collaborator
+			getObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator(
+				Long objectEntryFolderId, String collaboratorType,
+				Long collaboratorId)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.getObjectEntryFolder(
+				objectEntryFolderId);
+
+		return CollaboratorUtil.getCollaborator(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				ObjectEntryFolder.class.getName()),
+			objectEntryFolder.getObjectEntryFolderId(), collaboratorId,
+			CollaboratorUtil.getCollaboratorType(collaboratorType),
+			_collaboratorDTOConverter, _dtoConverterRegistry,
+			_sharingEntryService, contextUriInfo, contextUser);
+	}
+
+	@Override
 	public Page<Collaborator> getObjectEntryFolderCollaboratorsPage(
 			Long objectEntryFolderId, Pagination pagination)
 		throws Exception {
@@ -45,10 +121,49 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		return _getObjectEntryFolderCollaboratorsPage(
+		ObjectEntryFolder objectEntryFolder =
 			_objectEntryFolderLocalService.getObjectEntryFolder(
-				objectEntryFolderId),
-			pagination);
+				objectEntryFolderId);
+
+		return CollaboratorUtil.getCollaborators(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				ObjectEntryFolder.class.getName()),
+			objectEntryFolder.getObjectEntryFolderId(),
+			_collaboratorDTOConverter, _dtoConverterRegistry,
+			objectEntryFolder.getGroupId(), pagination,
+			_sharingEntryLocalService, _sharingEntryService, contextUriInfo,
+			contextUser);
+	}
+
+	@Override
+	public Collaborator
+			getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+				String scopeKey, String externalReferenceCode,
+				String collaboratorType, Long collaboratorId)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					externalReferenceCode,
+					CollaboratorUtil.getGroupId(
+						contextCompany.getCompanyId(), _groupLocalService,
+						scopeKey),
+					contextCompany.getCompanyId());
+
+		return CollaboratorUtil.getCollaborator(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				ObjectEntryFolder.class.getName()),
+			objectEntryFolder.getObjectEntryFolderId(), collaboratorId,
+			CollaboratorUtil.getCollaboratorType(collaboratorType),
+			_collaboratorDTOConverter, _dtoConverterRegistry,
+			_sharingEntryService, contextUriInfo, contextUser);
 	}
 
 	@Override
@@ -62,15 +177,24 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		return _getObjectEntryFolderCollaboratorsPage(
+		ObjectEntryFolder objectEntryFolder =
 			_objectEntryFolderLocalService.
 				getObjectEntryFolderByExternalReferenceCode(
 					externalReferenceCode,
 					CollaboratorUtil.getGroupId(
 						contextCompany.getCompanyId(), _groupLocalService,
 						scopeKey),
-					contextCompany.getCompanyId()),
-			pagination);
+					contextCompany.getCompanyId());
+
+		return CollaboratorUtil.getCollaborators(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				ObjectEntryFolder.class.getName()),
+			objectEntryFolder.getObjectEntryFolderId(),
+			_collaboratorDTOConverter, _dtoConverterRegistry,
+			objectEntryFolder.getGroupId(), pagination,
+			_sharingEntryLocalService, _sharingEntryService, contextUriInfo,
+			contextUser);
 	}
 
 	@Override
@@ -82,10 +206,19 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		return _postObjectEntryFolderCollaboratorsPage(
-			collaborators,
+		ObjectEntryFolder objectEntryFolder =
 			_objectEntryFolderLocalService.getObjectEntryFolder(
-				objectEntryFolderId));
+				objectEntryFolderId);
+
+		return CollaboratorUtil.addOrUpdateCollaborators(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				ObjectEntryFolder.class.getName()),
+			objectEntryFolder.getObjectEntryFolderId(), collaborators,
+			_collaboratorDTOConverter, _dtoConverterRegistry,
+			objectEntryFolder.getGroupId(), _sharingEntryService,
+			contextUriInfo, contextUser, _userGroupLocalService,
+			_userLocalService);
 	}
 
 	@Override
@@ -99,52 +232,82 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		return _postObjectEntryFolderCollaboratorsPage(
-			collaborators,
+		ObjectEntryFolder objectEntryFolder =
 			_objectEntryFolderLocalService.
 				getObjectEntryFolderByExternalReferenceCode(
 					externalReferenceCode,
 					CollaboratorUtil.getGroupId(
 						contextCompany.getCompanyId(), _groupLocalService,
 						scopeKey),
-					contextCompany.getCompanyId()));
-	}
-
-	private Page<Collaborator> _getObjectEntryFolderCollaboratorsPage(
-			ObjectEntryFolder objectEntryFolder, Pagination pagination)
-		throws Exception {
-
-		long classNameId = _classNameLocalService.getClassNameId(
-			ObjectEntryFolder.class.getName());
-
-		return Page.of(
-			transform(
-				_sharingEntryService.getSharingEntries(
-					classNameId, objectEntryFolder.getObjectEntryFolderId(),
-					objectEntryFolder.getGroupId(),
-					pagination.getStartPosition(), pagination.getEndPosition()),
-				sharingEntry -> CollaboratorUtil.toCollaborator(
-					contextAcceptLanguage, _collaboratorDTOConverter,
-					_dtoConverterRegistry, sharingEntry, contextUriInfo,
-					contextUser)),
-			pagination,
-			_sharingEntryLocalService.getSharingEntriesCount(
-				classNameId, objectEntryFolder.getObjectEntryFolderId()));
-	}
-
-	private Page<Collaborator> _postObjectEntryFolderCollaboratorsPage(
-			Collaborator[] collaborators, ObjectEntryFolder objectEntryFolder)
-		throws Exception {
+					contextCompany.getCompanyId());
 
 		return CollaboratorUtil.addOrUpdateCollaborators(
 			contextAcceptLanguage,
 			_classNameLocalService.getClassNameId(
 				ObjectEntryFolder.class.getName()),
 			objectEntryFolder.getObjectEntryFolderId(), collaborators,
-			contextCompany.getCompanyId(), _collaboratorDTOConverter,
+			_collaboratorDTOConverter, _dtoConverterRegistry,
+			objectEntryFolder.getGroupId(), _sharingEntryService,
+			contextUriInfo, contextUser, _userGroupLocalService,
+			_userLocalService);
+	}
+
+	@Override
+	public Collaborator
+			putObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator(
+				Long objectEntryFolderId, String collaboratorType,
+				Long collaboratorId, Collaborator collaborator)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.getObjectEntryFolder(
+				objectEntryFolderId);
+
+		return CollaboratorUtil.addOrUpdateCollaborator(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				ObjectEntryFolder.class.getName()),
+			objectEntryFolder.getObjectEntryFolderId(), collaborator,
+			collaboratorId, collaboratorType, _collaboratorDTOConverter,
 			_dtoConverterRegistry, objectEntryFolder.getGroupId(),
-			_sharingEntryService, contextUriInfo, contextUser,
-			_userGroupLocalService, _userLocalService);
+			_sharingEntryService, _userGroupLocalService, contextUriInfo,
+			contextUser, _userLocalService);
+	}
+
+	@Override
+	public Collaborator
+			putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+				String scopeKey, String externalReferenceCode,
+				String collaboratorType, Long collaboratorId,
+				Collaborator collaborator)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					externalReferenceCode,
+					CollaboratorUtil.getGroupId(
+						contextCompany.getCompanyId(), _groupLocalService,
+						scopeKey),
+					contextCompany.getCompanyId());
+
+		return CollaboratorUtil.addOrUpdateCollaborator(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				ObjectEntryFolder.class.getName()),
+			objectEntryFolder.getObjectEntryFolderId(), collaborator,
+			collaboratorId, collaboratorType, _collaboratorDTOConverter,
+			_dtoConverterRegistry, objectEntryFolder.getGroupId(),
+			_sharingEntryService, _userGroupLocalService, contextUriInfo,
+			contextUser, _userLocalService);
 	}
 
 	@Reference

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/BaseCollaboratorResourceTestCase.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/BaseCollaboratorResourceTestCase.java
@@ -184,6 +184,327 @@ public abstract class BaseCollaboratorResourceTestCase {
 	}
 
 	@Test
+	public void testDeleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator()
+		throws Exception {
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Collaborator collaborator =
+			testDeleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_addCollaborator();
+
+		assertHttpResponseStatusCode(
+			204,
+			collaboratorResource.
+				deleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaboratorHttpResponse(
+					testDeleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getObjectEntryFolderId(),
+					testDeleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType(),
+					collaborator.getId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			collaboratorResource.
+				getObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaboratorHttpResponse(
+					testDeleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getObjectEntryFolderId(),
+					testDeleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType(),
+					collaborator.getId()));
+		assertHttpResponseStatusCode(
+			404,
+			collaboratorResource.
+				getObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaboratorHttpResponse(
+					testDeleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getObjectEntryFolderId(),
+					testDeleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType(),
+					0L));
+	}
+
+	protected Long
+			testDeleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getObjectEntryFolderId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testDeleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Collaborator
+			testDeleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator()
+		throws Exception {
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Collaborator collaborator =
+			testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_addCollaborator();
+
+		assertHttpResponseStatusCode(
+			204,
+			collaboratorResource.
+				deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaboratorHttpResponse(
+					testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getScopeKey(),
+					testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getExternalReferenceCode(
+						collaborator),
+					testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType(),
+					collaborator.getId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			collaboratorResource.
+				getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaboratorHttpResponse(
+					testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getScopeKey(),
+					collaborator.getExternalReferenceCode(),
+					testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType(),
+					collaborator.getId()));
+		assertHttpResponseStatusCode(
+			404,
+			collaboratorResource.
+				getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaboratorHttpResponse(
+					testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getScopeKey(),
+					"-",
+					testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType(),
+					0L));
+	}
+
+	protected String
+			testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getScopeKey()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getExternalReferenceCode(
+				Collaborator collaborator)
+		throws Exception {
+
+		return collaborator.getExternalReferenceCode();
+	}
+
+	protected String
+			testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Collaborator
+			testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGetObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator()
+		throws Exception {
+
+		Collaborator postCollaborator =
+			testGetObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_addCollaborator();
+
+		Collaborator getCollaborator =
+			collaboratorResource.
+				getObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator(
+					testGetObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getObjectEntryFolderId(),
+					testGetObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType(),
+					postCollaborator.getId());
+
+		assertEquals(postCollaborator, getCollaborator);
+		assertValid(getCollaborator);
+	}
+
+	protected Long
+			testGetObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getObjectEntryFolderId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testGetObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Collaborator
+			testGetObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGraphQLGetObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator()
+		throws Exception {
+
+		Collaborator collaborator =
+			testGraphQLGetObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_addCollaborator();
+
+		// No namespace
+
+		Assert.assertTrue(
+			equals(
+				collaborator,
+				CollaboratorSerDes.toDTO(
+					JSONUtil.getValueAsString(
+						invokeGraphQLQuery(
+							new GraphQLField(
+								"objectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator",
+								new HashMap<String, Object>() {
+									{
+										put(
+											"objectEntryFolderId",
+											testGraphQLGetObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getObjectEntryFolderId());
+
+										put(
+											"collaboratorType",
+											"\"" +
+												testGraphQLGetObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType() +
+													"\"");
+
+										put(
+											"collaboratorId",
+											collaborator.getId());
+									}
+								},
+								getGraphQLFields())),
+						"JSONObject/data",
+						"Object/objectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator"))));
+
+		// Using the namespace headlessObject_v1_0
+
+		Assert.assertTrue(
+			equals(
+				collaborator,
+				CollaboratorSerDes.toDTO(
+					JSONUtil.getValueAsString(
+						invokeGraphQLQuery(
+							new GraphQLField(
+								"headlessObject_v1_0",
+								new GraphQLField(
+									"objectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator",
+									new HashMap<String, Object>() {
+										{
+											put(
+												"objectEntryFolderId",
+												testGraphQLGetObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getObjectEntryFolderId());
+
+											put(
+												"collaboratorType",
+												"\"" +
+													testGraphQLGetObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType() +
+														"\"");
+
+											put(
+												"collaboratorId",
+												collaborator.getId());
+										}
+									},
+									getGraphQLFields()))),
+						"JSONObject/data", "JSONObject/headlessObject_v1_0",
+						"Object/objectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator"))));
+	}
+
+	protected Long
+			testGraphQLGetObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getObjectEntryFolderId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testGraphQLGetObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGraphQLGetObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaboratorNotFound()
+		throws Exception {
+
+		Long irrelevantObjectEntryFolderId = RandomTestUtil.randomLong();
+		String irrelevantCollaboratorType =
+			"\"" + RandomTestUtil.randomString() + "\"";
+		Long irrelevantCollaboratorId = RandomTestUtil.randomLong();
+
+		// No namespace
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				invokeGraphQLQuery(
+					new GraphQLField(
+						"objectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator",
+						new HashMap<String, Object>() {
+							{
+								put(
+									"objectEntryFolderId",
+									irrelevantObjectEntryFolderId);
+								put(
+									"collaboratorType",
+									irrelevantCollaboratorType);
+								put("collaboratorId", irrelevantCollaboratorId);
+							}
+						},
+						getGraphQLFields())),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+
+		// Using the namespace headlessObject_v1_0
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				invokeGraphQLQuery(
+					new GraphQLField(
+						"headlessObject_v1_0",
+						new GraphQLField(
+							"objectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator",
+							new HashMap<String, Object>() {
+								{
+									put(
+										"objectEntryFolderId",
+										irrelevantObjectEntryFolderId);
+									put(
+										"collaboratorType",
+										irrelevantCollaboratorType);
+									put(
+										"collaboratorId",
+										irrelevantCollaboratorId);
+								}
+							},
+							getGraphQLFields()))),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+	}
+
+	protected Collaborator
+			testGraphQLGetObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		return testGraphQLCollaborator_addCollaborator();
+	}
+
+	@Test
 	public void testGetObjectEntryFolderCollaboratorsPage() throws Exception {
 		Long objectEntryFolderId =
 			testGetObjectEntryFolderCollaboratorsPage_getObjectEntryFolderId();
@@ -363,6 +684,241 @@ public abstract class BaseCollaboratorResourceTestCase {
 		throws Exception {
 
 		return null;
+	}
+
+	@Test
+	public void testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator()
+		throws Exception {
+
+		Collaborator postCollaborator =
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_addCollaborator();
+
+		Collaborator getCollaborator =
+			collaboratorResource.
+				getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+					testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getScopeKey(),
+					testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getExternalReferenceCode(
+						postCollaborator),
+					testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType(),
+					postCollaborator.getId());
+
+		assertEquals(postCollaborator, getCollaborator);
+		assertValid(getCollaborator);
+	}
+
+	protected String
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getScopeKey()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getExternalReferenceCode(
+				Collaborator collaborator)
+		throws Exception {
+
+		return collaborator.getExternalReferenceCode();
+	}
+
+	protected String
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Collaborator
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator()
+		throws Exception {
+
+		Collaborator collaborator =
+			testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_addCollaborator();
+
+		// No namespace
+
+		Assert.assertTrue(
+			equals(
+				collaborator,
+				CollaboratorSerDes.toDTO(
+					JSONUtil.getValueAsString(
+						invokeGraphQLQuery(
+							new GraphQLField(
+								"scopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator",
+								new HashMap<String, Object>() {
+									{
+										put(
+											"scopeKey",
+											"\"" +
+												testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getScopeKey() +
+													"\"");
+
+										put(
+											"externalReferenceCode",
+											"\"" +
+												testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getExternalReferenceCode(
+													collaborator) + "\"");
+
+										put(
+											"collaboratorType",
+											"\"" +
+												testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType() +
+													"\"");
+
+										put(
+											"collaboratorId",
+											collaborator.getId());
+									}
+								},
+								getGraphQLFields())),
+						"JSONObject/data",
+						"Object/scopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator"))));
+
+		// Using the namespace headlessObject_v1_0
+
+		Assert.assertTrue(
+			equals(
+				collaborator,
+				CollaboratorSerDes.toDTO(
+					JSONUtil.getValueAsString(
+						invokeGraphQLQuery(
+							new GraphQLField(
+								"headlessObject_v1_0",
+								new GraphQLField(
+									"scopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator",
+									new HashMap<String, Object>() {
+										{
+											put(
+												"scopeKey",
+												"\"" +
+													testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getScopeKey() +
+														"\"");
+
+											put(
+												"externalReferenceCode",
+												"\"" +
+													testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getExternalReferenceCode(
+														collaborator) + "\"");
+
+											put(
+												"collaboratorType",
+												"\"" +
+													testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType() +
+														"\"");
+
+											put(
+												"collaboratorId",
+												collaborator.getId());
+										}
+									},
+									getGraphQLFields()))),
+						"JSONObject/data", "JSONObject/headlessObject_v1_0",
+						"Object/scopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator"))));
+	}
+
+	protected String
+			testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getScopeKey()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getExternalReferenceCode(
+				Collaborator collaborator)
+		throws Exception {
+
+		return collaborator.getExternalReferenceCode();
+	}
+
+	protected String
+			testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaboratorNotFound()
+		throws Exception {
+
+		String irrelevantScopeKey = "\"" + RandomTestUtil.randomString() + "\"";
+		String irrelevantExternalReferenceCode =
+			"\"" + RandomTestUtil.randomString() + "\"";
+		String irrelevantCollaboratorType =
+			"\"" + RandomTestUtil.randomString() + "\"";
+		Long irrelevantCollaboratorId = RandomTestUtil.randomLong();
+
+		// No namespace
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				invokeGraphQLQuery(
+					new GraphQLField(
+						"scopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator",
+						new HashMap<String, Object>() {
+							{
+								put("scopeKey", irrelevantScopeKey);
+								put(
+									"externalReferenceCode",
+									irrelevantExternalReferenceCode);
+								put(
+									"collaboratorType",
+									irrelevantCollaboratorType);
+								put("collaboratorId", irrelevantCollaboratorId);
+							}
+						},
+						getGraphQLFields())),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+
+		// Using the namespace headlessObject_v1_0
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				invokeGraphQLQuery(
+					new GraphQLField(
+						"headlessObject_v1_0",
+						new GraphQLField(
+							"scopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator",
+							new HashMap<String, Object>() {
+								{
+									put("scopeKey", irrelevantScopeKey);
+									put(
+										"externalReferenceCode",
+										irrelevantExternalReferenceCode);
+									put(
+										"collaboratorType",
+										irrelevantCollaboratorType);
+									put(
+										"collaboratorId",
+										irrelevantCollaboratorId);
+								}
+							},
+							getGraphQLFields()))),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+	}
+
+	protected Collaborator
+			testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		return testGraphQLCollaborator_addCollaborator();
 	}
 
 	@Test
@@ -600,6 +1156,132 @@ public abstract class BaseCollaboratorResourceTestCase {
 		Assert.assertTrue(false);
 	}
 
+	@Test
+	public void testPutObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator()
+		throws Exception {
+
+		Collaborator postCollaborator =
+			testPutObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_addCollaborator();
+
+		Collaborator randomCollaborator = randomCollaborator();
+
+		Collaborator putCollaborator =
+			collaboratorResource.
+				putObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator(
+					testPutObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getObjectEntryFolderId(),
+					testPutObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType(),
+					postCollaborator.getId(), randomCollaborator);
+
+		assertEquals(randomCollaborator, putCollaborator);
+		assertValid(putCollaborator);
+
+		Collaborator getCollaborator =
+			collaboratorResource.
+				getObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator(
+					testPutObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getObjectEntryFolderId(),
+					testPutObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType(),
+					putCollaborator.getId());
+
+		assertEquals(randomCollaborator, getCollaborator);
+		assertValid(getCollaborator);
+	}
+
+	protected Long
+			testPutObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getObjectEntryFolderId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testPutObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Collaborator
+			testPutObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator()
+		throws Exception {
+
+		Collaborator postCollaborator =
+			testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_addCollaborator();
+
+		Collaborator randomCollaborator = randomCollaborator();
+
+		Collaborator putCollaborator =
+			collaboratorResource.
+				putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+					testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getScopeKey(),
+					testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getExternalReferenceCode(
+						postCollaborator),
+					testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType(),
+					postCollaborator.getId(), randomCollaborator);
+
+		assertEquals(randomCollaborator, putCollaborator);
+		assertValid(putCollaborator);
+
+		Collaborator getCollaborator =
+			collaboratorResource.
+				getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+					testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getScopeKey(),
+					putCollaborator.getExternalReferenceCode(),
+					testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType(),
+					putCollaborator.getId());
+
+		assertEquals(randomCollaborator, getCollaborator);
+		assertValid(getCollaborator);
+	}
+
+	protected String
+			testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getScopeKey()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getExternalReferenceCode(
+				Collaborator collaborator)
+		throws Exception {
+
+		return collaborator.getExternalReferenceCode();
+	}
+
+	protected String
+			testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Collaborator
+			testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Collaborator testGraphQLCollaborator_addCollaborator()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
 	protected void assertContains(
 		Collaborator collaborator, List<Collaborator> collaborators) {
 
@@ -670,6 +1352,10 @@ public abstract class BaseCollaboratorResourceTestCase {
 
 	protected void assertValid(Collaborator collaborator) throws Exception {
 		boolean valid = true;
+
+		if (collaborator.getId() == null) {
+			valid = false;
+		}
 
 		for (String additionalAssertFieldName :
 				getAdditionalAssertFieldNames()) {
@@ -923,6 +1609,16 @@ public abstract class BaseCollaboratorResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("id", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						collaborator1.getId(), collaborator2.getId())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("name", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
 						collaborator1.getName(), collaborator2.getName())) {
@@ -1161,6 +1857,11 @@ public abstract class BaseCollaboratorResourceTestCase {
 			return sb.toString();
 		}
 
+		if (entityFieldName.equals("id")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
 		if (entityFieldName.equals("name")) {
 			Object object = collaborator.getName();
 
@@ -1311,6 +2012,7 @@ public abstract class BaseCollaboratorResourceTestCase {
 				dateExpired = RandomTestUtil.nextDate();
 				externalReferenceCode = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
+				id = RandomTestUtil.randomLong();
 				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				portrait = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/CollaboratorResourceTest.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/CollaboratorResourceTest.java
@@ -78,30 +78,10 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 	public void testGraphQLGetObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaboratorNotFound()
 		throws Exception {
 
+		// Namespace headlessObject_v1_0
+
 		Long irrelevantObjectEntryFolderId = RandomTestUtil.randomLong();
 		Long irrelevantCollaboratorId = RandomTestUtil.randomLong();
-
-		// No namespace
-
-		Assert.assertEquals(
-			"Not Found",
-			JSONUtil.getValueAsString(
-				invokeGraphQLQuery(
-					new GraphQLField(
-						"objectEntryFolderCollaboratorByTypeCollaborator" +
-							"TypeCollaborator",
-						HashMapBuilder.<String, Object>put(
-							"collaboratorId", irrelevantCollaboratorId
-						).put(
-							"collaboratorType", "\"User\""
-						).put(
-							"objectEntryFolderId", irrelevantObjectEntryFolderId
-						).build(),
-						getGraphQLFields())),
-				"JSONArray/errors", "Object/0", "JSONObject/extensions",
-				"Object/code"));
-
-		// Using the namespace headlessObject_v1_0
 
 		Assert.assertEquals(
 			"Not Found",
@@ -123,17 +103,6 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 							getGraphQLFields()))),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
-	}
-
-	@Override
-	@Test
-	public void testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaboratorNotFound()
-		throws Exception {
-
-		String irrelevantScopeKey = "\"" + RandomTestUtil.randomString() + "\"";
-		String irrelevantExternalReferenceCode =
-			"\"" + RandomTestUtil.randomString() + "\"";
-		Long irrelevantCollaboratorId = RandomTestUtil.randomLong();
 
 		// No namespace
 
@@ -142,24 +111,31 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 			JSONUtil.getValueAsString(
 				invokeGraphQLQuery(
 					new GraphQLField(
-						"scopeScopeKeyObjectEntryFolderByExternalReference" +
-							"CodeCollaboratorByTypeCollaboratorType" +
-								"Collaborator",
+						"objectEntryFolderCollaboratorByTypeCollaborator" +
+							"TypeCollaborator",
 						HashMapBuilder.<String, Object>put(
 							"collaboratorId", irrelevantCollaboratorId
 						).put(
 							"collaboratorType", "\"User\""
 						).put(
-							"externalReferenceCode",
-							irrelevantExternalReferenceCode
-						).put(
-							"scopeKey", irrelevantScopeKey
+							"objectEntryFolderId", irrelevantObjectEntryFolderId
 						).build(),
 						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
+	}
 
-		// Using the namespace headlessObject_v1_0
+	@Override
+	@Test
+	public void testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaboratorNotFound()
+		throws Exception {
+
+		// Namespace headlessObject_v1_0
+
+		Long irrelevantCollaboratorId = RandomTestUtil.randomLong();
+		String irrelevantExternalReferenceCode =
+			"\"" + RandomTestUtil.randomString() + "\"";
+		String irrelevantScopeKey = "\"" + RandomTestUtil.randomString() + "\"";
 
 		Assert.assertEquals(
 			"Not Found",
@@ -182,6 +158,30 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 								"scopeKey", irrelevantScopeKey
 							).build(),
 							getGraphQLFields()))),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+
+		// No namespace
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				invokeGraphQLQuery(
+					new GraphQLField(
+						"scopeScopeKeyObjectEntryFolderByExternalReference" +
+							"CodeCollaboratorByTypeCollaboratorType" +
+								"Collaborator",
+						HashMapBuilder.<String, Object>put(
+							"collaboratorId", irrelevantCollaboratorId
+						).put(
+							"collaboratorType", "\"User\""
+						).put(
+							"externalReferenceCode",
+							irrelevantExternalReferenceCode
+						).put(
+							"scopeKey", irrelevantScopeKey
+						).build(),
+						getGraphQLFields())),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
 	}
@@ -238,7 +238,6 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 
 		Collaborator postCollaborator =
 			testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_addCollaborator();
-
 		Collaborator randomCollaborator = randomCollaborator();
 
 		Collaborator putCollaborator =

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/CollaboratorResourceTest.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/CollaboratorResourceTest.java
@@ -12,6 +12,7 @@ import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
@@ -45,6 +46,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -64,15 +66,132 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
 
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+
+		_objectEntryFolder = _addObjectEntryFolder();
+	}
+
+	@Override
+	@Test
+	public void testGraphQLGetObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaboratorNotFound()
+		throws Exception {
+
+		Long irrelevantObjectEntryFolderId = RandomTestUtil.randomLong();
+		Long irrelevantCollaboratorId = RandomTestUtil.randomLong();
+
+		// No namespace
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				invokeGraphQLQuery(
+					new GraphQLField(
+						"objectEntryFolderCollaboratorByTypeCollaborator" +
+							"TypeCollaborator",
+						HashMapBuilder.<String, Object>put(
+							"collaboratorId", irrelevantCollaboratorId
+						).put(
+							"collaboratorType", "\"User\""
+						).put(
+							"objectEntryFolderId", irrelevantObjectEntryFolderId
+						).build(),
+						getGraphQLFields())),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+
+		// Using the namespace headlessObject_v1_0
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				invokeGraphQLQuery(
+					new GraphQLField(
+						"headlessObject_v1_0",
+						new GraphQLField(
+							"objectEntryFolderCollaboratorByType" +
+								"CollaboratorTypeCollaborator",
+							HashMapBuilder.<String, Object>put(
+								"collaboratorId", irrelevantCollaboratorId
+							).put(
+								"collaboratorType", "\"User\""
+							).put(
+								"objectEntryFolderId",
+								irrelevantObjectEntryFolderId
+							).build(),
+							getGraphQLFields()))),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+	}
+
+	@Override
+	@Test
+	public void testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaboratorNotFound()
+		throws Exception {
+
+		String irrelevantScopeKey = "\"" + RandomTestUtil.randomString() + "\"";
+		String irrelevantExternalReferenceCode =
+			"\"" + RandomTestUtil.randomString() + "\"";
+		Long irrelevantCollaboratorId = RandomTestUtil.randomLong();
+
+		// No namespace
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				invokeGraphQLQuery(
+					new GraphQLField(
+						"scopeScopeKeyObjectEntryFolderByExternalReference" +
+							"CodeCollaboratorByTypeCollaboratorType" +
+								"Collaborator",
+						HashMapBuilder.<String, Object>put(
+							"collaboratorId", irrelevantCollaboratorId
+						).put(
+							"collaboratorType", "\"User\""
+						).put(
+							"externalReferenceCode",
+							irrelevantExternalReferenceCode
+						).put(
+							"scopeKey", irrelevantScopeKey
+						).build(),
+						getGraphQLFields())),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+
+		// Using the namespace headlessObject_v1_0
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				invokeGraphQLQuery(
+					new GraphQLField(
+						"headlessObject_v1_0",
+						new GraphQLField(
+							"scopeScopeKeyObjectEntryFolderByExternal" +
+								"ReferenceCodeCollaboratorByTypeCollaborator" +
+									"TypeCollaborator",
+							HashMapBuilder.<String, Object>put(
+								"collaboratorId", irrelevantCollaboratorId
+							).put(
+								"collaboratorType", "\"User\""
+							).put(
+								"externalReferenceCode",
+								irrelevantExternalReferenceCode
+							).put(
+								"scopeKey", irrelevantScopeKey
+							).build(),
+							getGraphQLFields()))),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+	}
+
 	@Override
 	@Test
 	public void testPostObjectEntryFolderCollaboratorsPage() throws Exception {
 		ObjectEntryFolder objectEntryFolder = _addObjectEntryFolder();
 
-		_addUserCollaborator(
-			_classNameLocalService.getClassNameId(
-				ObjectEntryFolder.class.getName()),
-			objectEntryFolder.getObjectEntryFolderId());
+		_addUserCollaborator(objectEntryFolder);
 
 		Collaborator[] collaborators = {
 			_getUserCollaborator(), _getUserGroupCollaborator(),
@@ -94,10 +213,7 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 
 		ObjectEntryFolder objectEntryFolder = _addObjectEntryFolder();
 
-		_addUserCollaborator(
-			_classNameLocalService.getClassNameId(
-				ObjectEntryFolder.class.getName()),
-			objectEntryFolder.getObjectEntryFolderId());
+		_addUserCollaborator(objectEntryFolder);
 
 		Collaborator[] collaborators = {
 			_getUserCollaborator(), _getUserGroupCollaborator(),
@@ -116,21 +232,53 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 	}
 
 	@Override
+	@Test
+	public void testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator()
+		throws Exception {
+
+		Collaborator postCollaborator =
+			testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_addCollaborator();
+
+		Collaborator randomCollaborator = randomCollaborator();
+
+		Collaborator putCollaborator =
+			collaboratorResource.
+				putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+					testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getScopeKey(),
+					testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getExternalReferenceCode(
+						postCollaborator),
+					testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType(),
+					postCollaborator.getId(), randomCollaborator);
+
+		assertEquals(randomCollaborator, putCollaborator);
+		assertValid(putCollaborator);
+
+		Collaborator getCollaborator =
+			collaboratorResource.
+				getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+					testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getScopeKey(),
+					testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getExternalReferenceCode(
+						postCollaborator),
+					testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType(),
+					putCollaborator.getId());
+
+		assertEquals(randomCollaborator, getCollaborator);
+		assertValid(getCollaborator);
+	}
+
+	@Override
 	protected String[] getAdditionalAssertFieldNames() {
-		return new String[] {
-			"actionIds", "dateExpired", "externalReferenceCode", "name",
-			"share", "type"
-		};
+		return new String[] {"actionIds", "dateExpired", "share", "type"};
 	}
 
 	@Override
 	protected Collaborator randomCollaborator() throws Exception {
 		return new Collaborator() {
 			{
+				actionIds = new String[] {
+					SharingEntryAction.VIEW.getActionId()
+				};
 				dateExpired = _randomDatePlusAYear();
-				externalReferenceCode = StringUtil.toLowerCase(
-					RandomTestUtil.randomString());
-				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				portrait = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				share = RandomTestUtil.randomBoolean();
@@ -141,14 +289,94 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 
 	@Override
 	protected Collaborator
+			testDeleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		return _addUserCollaborator(_objectEntryFolder);
+	}
+
+	@Override
+	protected String
+			testDeleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType()
+		throws Exception {
+
+		return Collaborator.Type.USER.getValue();
+	}
+
+	@Override
+	protected Long
+			testDeleteObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getObjectEntryFolderId()
+		throws Exception {
+
+		return _objectEntryFolder.getObjectEntryFolderId();
+	}
+
+	@Override
+	protected Collaborator
+			testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		return _addUserCollaborator(_objectEntryFolder);
+	}
+
+	@Override
+	protected String
+			testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType()
+		throws Exception {
+
+		return Collaborator.Type.USER.getValue();
+	}
+
+	@Override
+	protected String
+			testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getExternalReferenceCode(
+				Collaborator collaborator)
+		throws Exception {
+
+		return _objectEntryFolder.getExternalReferenceCode();
+	}
+
+	@Override
+	protected String
+			testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getScopeKey()
+		throws Exception {
+
+		return testGroup.getGroupKey();
+	}
+
+	@Override
+	protected Collaborator
+			testGetObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		return _addUserGroupCollaborator(_objectEntryFolder);
+	}
+
+	@Override
+	protected String
+			testGetObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType()
+		throws Exception {
+
+		return Collaborator.Type.USER_GROUP.getValue();
+	}
+
+	@Override
+	protected Long
+			testGetObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getObjectEntryFolderId()
+		throws Exception {
+
+		return _objectEntryFolder.getObjectEntryFolderId();
+	}
+
+	@Override
+	protected Collaborator
 			testGetObjectEntryFolderCollaboratorsPage_addCollaborator(
 				Long objectEntryFolderId, Collaborator collaborator)
 		throws Exception {
 
 		return _addUserGroupCollaborator(
-			_classNameLocalService.getClassNameId(
-				ObjectEntryFolder.class.getName()),
-			objectEntryFolderId);
+			_objectEntryFolderLocalService.getObjectEntryFolder(
+				objectEntryFolderId));
 	}
 
 	@Override
@@ -156,9 +384,40 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 			testGetObjectEntryFolderCollaboratorsPage_getObjectEntryFolderId()
 		throws Exception {
 
-		ObjectEntryFolder objectEntryFolder = _addObjectEntryFolder();
+		return _objectEntryFolder.getObjectEntryFolderId();
+	}
 
-		return objectEntryFolder.getObjectEntryFolderId();
+	@Override
+	protected Collaborator
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		return _addUserCollaborator(_objectEntryFolder);
+	}
+
+	@Override
+	protected String
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType()
+		throws Exception {
+
+		return Collaborator.Type.USER.getValue();
+	}
+
+	@Override
+	protected String
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getExternalReferenceCode(
+				Collaborator collaborator)
+		throws Exception {
+
+		return _objectEntryFolder.getExternalReferenceCode();
+	}
+
+	@Override
+	protected String
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getScopeKey()
+		throws Exception {
+
+		return testGroup.getGroupKey();
 	}
 
 	@Override
@@ -168,16 +427,11 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 				Collaborator collaborator)
 		throws Exception {
 
-		ObjectEntryFolder objectEntryFolder =
+		return _addUserCollaborator(
 			_objectEntryFolderLocalService.
 				getObjectEntryFolderByExternalReferenceCode(
 					externalReferenceCode, testGroup.getGroupId(),
-					testCompany.getCompanyId());
-
-		return _addUserCollaborator(
-			_classNameLocalService.getClassNameId(
-				ObjectEntryFolder.class.getName()),
-			objectEntryFolder.getObjectEntryFolderId());
+					testCompany.getCompanyId()));
 	}
 
 	@Override
@@ -198,6 +452,111 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 		return testGroup.getGroupKey();
 	}
 
+	@Override
+	protected Collaborator testGraphQLCollaborator_addCollaborator()
+		throws Exception {
+
+		return _addUserCollaborator(_objectEntryFolder);
+	}
+
+	@Override
+	protected String
+			testGraphQLGetObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType()
+		throws Exception {
+
+		return Collaborator.Type.USER.getValue();
+	}
+
+	@Override
+	protected Long
+			testGraphQLGetObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getObjectEntryFolderId()
+		throws Exception {
+
+		return _objectEntryFolder.getObjectEntryFolderId();
+	}
+
+	@Override
+	protected String
+			testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType()
+		throws Exception {
+
+		return Collaborator.Type.USER.getValue();
+	}
+
+	@Override
+	protected String
+			testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getExternalReferenceCode(
+				Collaborator collaborator)
+		throws Exception {
+
+		return _objectEntryFolder.getExternalReferenceCode();
+	}
+
+	@Override
+	protected String
+			testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getScopeKey()
+		throws Exception {
+
+		return testGroup.getGroupKey();
+	}
+
+	@Override
+	protected Collaborator
+			testPutObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		return _addUserCollaborator(_objectEntryFolder);
+	}
+
+	@Override
+	protected String
+			testPutObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType()
+		throws Exception {
+
+		return Collaborator.Type.USER.getValue();
+	}
+
+	@Override
+	protected Long
+			testPutObjectEntryFolderCollaboratorByTypeCollaboratorTypeCollaborator_getObjectEntryFolderId()
+		throws Exception {
+
+		return _objectEntryFolder.getObjectEntryFolderId();
+	}
+
+	@Override
+	protected Collaborator
+			testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		return _addUserCollaborator(_objectEntryFolder);
+	}
+
+	@Override
+	protected String
+			testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getCollaboratorType()
+		throws Exception {
+
+		return Collaborator.Type.USER.getValue();
+	}
+
+	@Override
+	protected String
+			testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getExternalReferenceCode(
+				Collaborator collaborator)
+		throws Exception {
+
+		return _objectEntryFolder.getExternalReferenceCode();
+	}
+
+	@Override
+	protected String
+			testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator_getScopeKey()
+		throws Exception {
+
+		return testGroup.getGroupKey();
+	}
+
 	private ObjectEntryFolder _addObjectEntryFolder() throws Exception {
 		return _objectEntryFolderLocalService.addObjectEntryFolder(
 			null, TestPropsValues.getUserId(), testGroup.getGroupId(),
@@ -208,7 +567,8 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 			RandomTestUtil.randomString(), new ServiceContext());
 	}
 
-	private Collaborator _addUserCollaborator(long classNameId, long classPK)
+	private Collaborator _addUserCollaborator(
+			ObjectEntryFolder objectEntryFolder)
 		throws Exception {
 
 		User user = _getUser();
@@ -216,14 +576,17 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 		return _toCollaborator(
 			_sharingEntryLocalService.addSharingEntry(
 				null, TestPropsValues.getUserId(), 0, user.getUserId(),
-				classNameId, classPK, testGroup.getGroupId(), true,
-				Arrays.asList(SharingEntryAction.VIEW), null,
+				_classNameLocalService.getClassNameId(
+					ObjectEntryFolder.class.getName()),
+				objectEntryFolder.getObjectEntryFolderId(),
+				objectEntryFolder.getGroupId(), true,
+				Arrays.asList(SharingEntryAction.VIEW), _randomDatePlusAYear(),
 				ServiceContextTestUtil.getServiceContext(
 					testGroup.getGroupId(), TestPropsValues.getUserId())));
 	}
 
 	private Collaborator _addUserGroupCollaborator(
-			long classNameId, long classPK)
+			ObjectEntryFolder objectEntryFolder)
 		throws Exception {
 
 		UserGroup userGroup = _getUserGroup();
@@ -231,8 +594,12 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 		return _toCollaborator(
 			_sharingEntryLocalService.addSharingEntry(
 				null, TestPropsValues.getUserId(), userGroup.getUserGroupId(),
-				0, classNameId, classPK, testGroup.getGroupId(), true,
-				Arrays.asList(SharingEntryAction.VIEW), null,
+				0,
+				_classNameLocalService.getClassNameId(
+					ObjectEntryFolder.class.getName()),
+				objectEntryFolder.getObjectEntryFolderId(),
+				testGroup.getGroupId(), true,
+				Arrays.asList(SharingEntryAction.VIEW), _randomDatePlusAYear(),
 				ServiceContextTestUtil.getServiceContext(
 					testGroup.getGroupId(), TestPropsValues.getUserId())));
 	}
@@ -268,6 +635,7 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 				};
 				dateExpired = _randomDatePlusAYear();
 				externalReferenceCode = user.getExternalReferenceCode();
+				id = user.getUserId();
 				name = user.getFullName();
 				share = true;
 				type = Type.USER;
@@ -293,6 +661,7 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 				};
 				dateExpired = _randomDatePlusAYear();
 				externalReferenceCode = userGroup.getExternalReferenceCode();
+				id = userGroup.getUserGroupId();
 				name = userGroup.getName();
 				share = true;
 				type = Type.USER_GROUP;
@@ -324,6 +693,7 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 						SharingEntryAction::getActionId, String.class);
 					dateExpired = sharingEntry.getExpirationDate();
 					externalReferenceCode = user.getExternalReferenceCode();
+					id = user.getUserId();
 					name = user.getFullName();
 					share = sharingEntry.isShareable();
 					type = Type.USER;
@@ -342,6 +712,7 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 					SharingEntryAction::getActionId, String.class);
 				dateExpired = sharingEntry.getExpirationDate();
 				externalReferenceCode = userGroup.getExternalReferenceCode();
+				id = userGroup.getUserGroupId();
 				name = userGroup.getName();
 				share = sharingEntry.isShareable();
 				type = Type.USER_GROUP;
@@ -354,6 +725,8 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 
 	@Inject
 	private GroupLocalService _groupLocalService;
+
+	private ObjectEntryFolder _objectEntryFolder;
 
 	@Inject
 	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/resource/v1_0/CollaboratorResource.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/resource/v1_0/CollaboratorResource.java
@@ -41,9 +41,31 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface CollaboratorResource {
 
+	public void deleteObjectEntryCollaboratorByTypeCollaboratorTypeCollaborator(
+			Long objectEntryId, String collaboratorType, Long collaboratorId)
+		throws Exception;
+
+	public void
+			deleteScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+				String scopeKey, String externalReferenceCode,
+				String collaboratorType, Long collaboratorId)
+		throws Exception;
+
+	public com.liferay.headless.object.dto.v1_0.Collaborator
+			getObjectEntryCollaboratorByTypeCollaboratorTypeCollaborator(
+				Long objectEntryId, String collaboratorType,
+				Long collaboratorId)
+		throws Exception;
+
 	public Page<com.liferay.headless.object.dto.v1_0.Collaborator>
 			getObjectEntryCollaboratorsPage(
 				Long objectEntryId, Pagination pagination)
+		throws Exception;
+
+	public com.liferay.headless.object.dto.v1_0.Collaborator
+			getScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+				String scopeKey, String externalReferenceCode,
+				String collaboratorType, Long collaboratorId)
 		throws Exception;
 
 	public Page<com.liferay.headless.object.dto.v1_0.Collaborator>
@@ -69,6 +91,20 @@ public interface CollaboratorResource {
 				String scopeKey, String externalReferenceCode,
 				com.liferay.headless.object.dto.v1_0.Collaborator[]
 					collaborators)
+		throws Exception;
+
+	public com.liferay.headless.object.dto.v1_0.Collaborator
+			putObjectEntryCollaboratorByTypeCollaboratorTypeCollaborator(
+				Long objectEntryId, String collaboratorType,
+				Long collaboratorId,
+				com.liferay.headless.object.dto.v1_0.Collaborator collaborator)
+		throws Exception;
+
+	public com.liferay.headless.object.dto.v1_0.Collaborator
+			putScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+				String scopeKey, String externalReferenceCode,
+				String collaboratorType, Long collaboratorId,
+				com.liferay.headless.object.dto.v1_0.Collaborator collaborator)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/resource/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 4.1.0

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -797,7 +797,7 @@ paths:
         delete:
             description:
                 Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.
-            operationId: deleteScopeScopeKeyObjectEntryByExternalReferenceCodeCollaborator
+            operationId: deleteScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator
             parameters:
                 -   in: path
                     name: scopeKey
@@ -829,7 +829,7 @@ paths:
         get:
             description:
                 Retrieves the collaborator for an object entry.
-            operationId: getScopeScopeKeyObjectEntryByExternalReferenceCodeCollaborator
+            operationId: getScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator
             parameters:
                 -   in: path
                     name: scopeKey
@@ -877,7 +877,7 @@ paths:
         put:
             description:
                 Add or update a collaborator received in the request.
-            operationId: putScopeScopeKeyObjectEntryByExternalReferenceCodeCollaborator
+            operationId: putScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator
             parameters:
                 -   in: path
                     name: scopeKey
@@ -1233,7 +1233,7 @@ paths:
         delete:
             description:
                 Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.
-            operationId: deleteObjectEntryCollaborator
+            operationId: deleteObjectEntryCollaboratorByTypeCollaboratorTypeCollaborator
             parameters:
                 -   in: path
                     name: objectEntryId
@@ -1261,7 +1261,7 @@ paths:
         get:
             description:
                 Retrieves the collaborator for an object entry.
-            operationId: getObjectEntryCollaborator
+            operationId: getObjectEntryCollaboratorByTypeCollaboratorTypeCollaborator
             parameters:
                 -   in: path
                     name: objectEntryId
@@ -1305,7 +1305,7 @@ paths:
         put:
             description:
                 Add or update a collaborator received in the request.
-            operationId: putObjectEntryCollaborator
+            operationId: putObjectEntryCollaboratorByTypeCollaboratorTypeCollaborator
             parameters:
                 -   in: path
                     name: objectEntryId

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -869,10 +869,10 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                                $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
                         application/xml:
                             schema:
-                                $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                                $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
             tags: ["Collaborator"]
         put:
             description:
@@ -904,19 +904,19 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                            $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
                     application/xml:
                         schema:
-                            $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                            $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
             responses:
                 200:
                     content:
                         application/json:
                             schema:
-                                $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                                $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
                         application/xml:
                             schema:
-                                $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                                $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
             tags: ["Collaborator"]
     "/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/object-actions/{objectActionName}":
         put:
@@ -1297,10 +1297,10 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                                $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
                         application/xml:
                             schema:
-                                $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                                $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
             tags: ["Collaborator"]
         put:
             description:
@@ -1328,19 +1328,19 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                            $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
                     application/xml:
                         schema:
-                            $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                            $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
             responses:
                 200:
                     content:
                         application/json:
                             schema:
-                                $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                                $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
                         application/xml:
                             schema:
-                                $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                                $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
             tags: ["Collaborator"]
     "/{objectEntryId}/object-actions/{objectActionName}":
         put:

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -793,6 +793,131 @@ paths:
                                     $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
                                 type: array
             tags: ["Collaborator"]
+    "/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{collaboratorType}/{collaboratorId}":
+        delete:
+            description:
+                Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.
+            operationId: deleteScopeScopeKeyObjectEntryByExternalReferenceCodeCollaborator
+            parameters:
+                -   in: path
+                    name: scopeKey
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: externalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorType
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["Collaborator"]
+        get:
+            description:
+                Retrieves the collaborator for an object entry.
+            operationId: getScopeScopeKeyObjectEntryByExternalReferenceCodeCollaborator
+            parameters:
+                -   in: path
+                    name: scopeKey
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: externalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorType
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: fields
+                    schema:
+                        type: string
+                -   in: query
+                    name: nestedFields
+                    schema:
+                        type: string
+                -   in: query
+                    name: restrictFields
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                        application/xml:
+                            schema:
+                                $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+            tags: ["Collaborator"]
+        put:
+            description:
+                Add or update a collaborator received in the request.
+            operationId: putScopeScopeKeyObjectEntryByExternalReferenceCodeCollaborator
+            parameters:
+                -   in: path
+                    name: scopeKey
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: externalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorType
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                    application/xml:
+                        schema:
+                            $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                        application/xml:
+                            schema:
+                                $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+            tags: ["Collaborator"]
     "/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/object-actions/{objectActionName}":
         put:
             operationId: putScopeScopeKeyByExternalReferenceCodeObjectActionObjectActionName
@@ -1103,6 +1228,119 @@ paths:
                                 items:
                                     $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
                                 type: array
+            tags: ["Collaborator"]
+    "/{objectEntryId}/collaborators/by-type/{collaboratorType}/{collaboratorId}":
+        delete:
+            description:
+                Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.
+            operationId: deleteObjectEntryCollaborator
+            parameters:
+                -   in: path
+                    name: objectEntryId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: path
+                    name: collaboratorType
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["Collaborator"]
+        get:
+            description:
+                Retrieves the collaborator for an object entry.
+            operationId: getObjectEntryCollaborator
+            parameters:
+                -   in: path
+                    name: objectEntryId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: path
+                    name: collaboratorType
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: fields
+                    schema:
+                        type: string
+                -   in: query
+                    name: nestedFields
+                    schema:
+                        type: string
+                -   in: query
+                    name: restrictFields
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                        application/xml:
+                            schema:
+                                $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+            tags: ["Collaborator"]
+        put:
+            description:
+                Add or update a collaborator received in the request.
+            operationId: putObjectEntryCollaborator
+            parameters:
+                -   in: path
+                    name: objectEntryId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: path
+                    name: collaboratorType
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                    application/xml:
+                        schema:
+                            $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                        application/xml:
+                            schema:
+                                $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
             tags: ["Collaborator"]
     "/{objectEntryId}/object-actions/{objectActionName}":
         put:

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseCollaboratorResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseCollaboratorResourceImpl.java
@@ -67,6 +67,162 @@ public abstract class BaseCollaboratorResourceImpl
 				   <com.liferay.headless.object.dto.v1_0.Collaborator> {
 
 	@io.swagger.v3.oas.annotations.Operation(
+		description = "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectEntryId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorType"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@javax.ws.rs.DELETE
+	@javax.ws.rs.Path(
+		"/{objectEntryId}/collaborators/by-type/{collaboratorType}/{collaboratorId}"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public void deleteObjectEntryCollaboratorByTypeCollaboratorTypeCollaborator(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("objectEntryId")
+			Long objectEntryId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("collaboratorType")
+			String collaboratorType,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("collaboratorId")
+			Long collaboratorId)
+		throws Exception {
+	}
+
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "scopeKey"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorType"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@javax.ws.rs.DELETE
+	@javax.ws.rs.Path(
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{collaboratorType}/{collaboratorId}"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public void
+			deleteScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("scopeKey")
+				String scopeKey,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("collaboratorType")
+				String collaboratorType,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("collaboratorId")
+				Long collaboratorId)
+		throws Exception {
+	}
+
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves the collaborator for an object entry."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectEntryId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorType"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "nestedFields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "restrictFields"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path(
+		"/{objectEntryId}/collaborators/by-type/{collaboratorType}/{collaboratorId}"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public com.liferay.headless.object.dto.v1_0.Collaborator
+			getObjectEntryCollaboratorByTypeCollaboratorTypeCollaborator(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("objectEntryId")
+				Long objectEntryId,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("collaboratorType")
+				String collaboratorType,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("collaboratorId")
+				Long collaboratorId)
+		throws Exception {
+
+		return new com.liferay.headless.object.dto.v1_0.Collaborator();
+	}
+
+	@io.swagger.v3.oas.annotations.Operation(
 		description = "Retrieves the collaborators of an object entry."
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
@@ -114,6 +270,73 @@ public abstract class BaseCollaboratorResourceImpl
 		throws Exception {
 
 		return Page.of(Collections.emptyList());
+	}
+
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves the collaborator for an object entry."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "scopeKey"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorType"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "nestedFields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "restrictFields"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path(
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{collaboratorType}/{collaboratorId}"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public com.liferay.headless.object.dto.v1_0.Collaborator
+			getScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("scopeKey")
+				String scopeKey,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("collaboratorType")
+				String collaboratorType,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("collaboratorId")
+				Long collaboratorId)
+		throws Exception {
+
+		return new com.liferay.headless.object.dto.v1_0.Collaborator();
 	}
 
 	@io.swagger.v3.oas.annotations.Operation(
@@ -313,6 +536,112 @@ public abstract class BaseCollaboratorResourceImpl
 		throws Exception {
 
 		return Page.of(Collections.emptyList());
+	}
+
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Add or update a collaborator received in the request."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectEntryId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorType"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@javax.ws.rs.Consumes({"application/json", "application/xml"})
+	@javax.ws.rs.Path(
+		"/{objectEntryId}/collaborators/by-type/{collaboratorType}/{collaboratorId}"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@javax.ws.rs.PUT
+	@Override
+	public com.liferay.headless.object.dto.v1_0.Collaborator
+			putObjectEntryCollaboratorByTypeCollaboratorTypeCollaborator(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("objectEntryId")
+				Long objectEntryId,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("collaboratorType")
+				String collaboratorType,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("collaboratorId")
+				Long collaboratorId,
+				com.liferay.headless.object.dto.v1_0.Collaborator collaborator)
+		throws Exception {
+
+		return new com.liferay.headless.object.dto.v1_0.Collaborator();
+	}
+
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Add or update a collaborator received in the request."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "scopeKey"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorType"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@javax.ws.rs.Consumes({"application/json", "application/xml"})
+	@javax.ws.rs.Path(
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{collaboratorType}/{collaboratorId}"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@javax.ws.rs.PUT
+	@Override
+	public com.liferay.headless.object.dto.v1_0.Collaborator
+			putScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("scopeKey")
+				String scopeKey,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("collaboratorType")
+				String collaboratorType,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("collaboratorId")
+				Long collaboratorId,
+				com.liferay.headless.object.dto.v1_0.Collaborator collaborator)
+		throws Exception {
+
+		return new com.liferay.headless.object.dto.v1_0.Collaborator();
 	}
 
 	@Override

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CollaboratorResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CollaboratorResourceImpl.java
@@ -8,6 +8,7 @@ package com.liferay.object.rest.internal.resource.v1_0;
 import com.liferay.headless.object.dto.v1_0.Collaborator;
 import com.liferay.headless.object.util.v1_0.CollaboratorUtil;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
@@ -143,12 +144,11 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 		return CollaboratorUtil.addOrUpdateCollaborators(
 			contextAcceptLanguage,
 			_classNameLocalService.getClassNameId(
-				objectEntry.getModelClassName()),
-			objectEntry.getObjectEntryId(), collaborators,
-			contextCompany.getCompanyId(), _collaboratorDTOConverter,
-			_dtoConverterRegistry, objectEntry.getGroupId(),
-			_sharingEntryService, contextUriInfo, contextUser,
-			_userGroupLocalService, _userLocalService);
+				ObjectEntryFolder.class.getName()),
+			objectEntry.getObjectEntryFolderId(), collaborators,
+			_collaboratorDTOConverter, _dtoConverterRegistry,
+			objectEntry.getGroupId(), _sharingEntryService, contextUriInfo,
+			contextUser, _userGroupLocalService, _userLocalService);
 	}
 
 	private final ClassNameLocalService _classNameLocalService;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CollaboratorResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CollaboratorResourceImpl.java
@@ -8,7 +8,6 @@ package com.liferay.object.rest.internal.resource.v1_0;
 import com.liferay.headless.object.dto.v1_0.Collaborator;
 import com.liferay.headless.object.util.v1_0.CollaboratorUtil;
 import com.liferay.object.model.ObjectEntry;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
@@ -51,6 +50,74 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 	}
 
 	@Override
+	public void deleteObjectEntryCollaboratorByTypeCollaboratorTypeCollaborator(
+			Long objectEntryId, String collaboratorType, Long collaboratorId)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			objectEntryId);
+
+		CollaboratorUtil.deleteCollaborator(
+			_classNameLocalService.getClassNameId(
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), collaboratorId,
+			CollaboratorUtil.getCollaboratorType(collaboratorType),
+			_sharingEntryService);
+	}
+
+	@Override
+	public void
+			deleteScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+				String scopeKey, String externalReferenceCode,
+				String collaboratorType, Long collaboratorId)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			externalReferenceCode, contextCompany.getCompanyId(),
+			CollaboratorUtil.getGroupId(
+				contextCompany.getCompanyId(), _groupLocalService, scopeKey));
+
+		CollaboratorUtil.deleteCollaborator(
+			_classNameLocalService.getClassNameId(
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), collaboratorId,
+			CollaboratorUtil.getCollaboratorType(collaboratorType),
+			_sharingEntryService);
+	}
+
+	@Override
+	public Collaborator
+			getObjectEntryCollaboratorByTypeCollaboratorTypeCollaborator(
+				Long objectEntryId, String collaboratorType,
+				Long collaboratorId)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			objectEntryId);
+
+		return CollaboratorUtil.getCollaborator(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), collaboratorId,
+			CollaboratorUtil.getCollaboratorType(collaboratorType),
+			_collaboratorDTOConverter, _dtoConverterRegistry,
+			_sharingEntryService, contextUriInfo, contextUser);
+	}
+
+	@Override
 	public Page<Collaborator> getObjectEntryCollaboratorsPage(
 			Long objectEntryId, Pagination pagination)
 		throws Exception {
@@ -59,8 +126,43 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		return _getObjectEntryCollaboratorsPage(
-			_objectEntryLocalService.getObjectEntry(objectEntryId), pagination);
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			objectEntryId);
+
+		return CollaboratorUtil.getCollaborators(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), _collaboratorDTOConverter,
+			_dtoConverterRegistry, objectEntry.getGroupId(), pagination,
+			_sharingEntryLocalService, _sharingEntryService, contextUriInfo,
+			contextUser);
+	}
+
+	@Override
+	public Collaborator
+			getScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+				String scopeKey, String externalReferenceCode,
+				String collaboratorType, Long collaboratorId)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			externalReferenceCode, contextCompany.getCompanyId(),
+			CollaboratorUtil.getGroupId(
+				contextCompany.getCompanyId(), _groupLocalService, scopeKey));
+
+		return CollaboratorUtil.getCollaborator(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), collaboratorId,
+			CollaboratorUtil.getCollaboratorType(collaboratorType),
+			_collaboratorDTOConverter, _dtoConverterRegistry,
+			_sharingEntryService, contextUriInfo, contextUser);
 	}
 
 	@Override
@@ -74,13 +176,19 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		return _getObjectEntryCollaboratorsPage(
-			_objectEntryLocalService.getObjectEntry(
-				externalReferenceCode, contextCompany.getCompanyId(),
-				CollaboratorUtil.getGroupId(
-					contextCompany.getCompanyId(), _groupLocalService,
-					scopeKey)),
-			pagination);
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			externalReferenceCode, contextCompany.getCompanyId(),
+			CollaboratorUtil.getGroupId(
+				contextCompany.getCompanyId(), _groupLocalService, scopeKey));
+
+		return CollaboratorUtil.getCollaborators(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), _collaboratorDTOConverter,
+			_dtoConverterRegistry, objectEntry.getGroupId(), pagination,
+			_sharingEntryLocalService, _sharingEntryService, contextUriInfo,
+			contextUser);
 	}
 
 	@Override
@@ -92,9 +200,17 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		return _postObjectEntryCollaboratorsPage(
-			collaborators,
-			_objectEntryLocalService.getObjectEntry(objectEntryId));
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			objectEntryId);
+
+		return CollaboratorUtil.addOrUpdateCollaborators(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), collaborators,
+			_collaboratorDTOConverter, _dtoConverterRegistry,
+			objectEntry.getGroupId(), _sharingEntryService, contextUriInfo,
+			contextUser, _userGroupLocalService, _userLocalService);
 	}
 
 	@Override
@@ -108,47 +224,72 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		return _postObjectEntryCollaboratorsPage(
-			collaborators,
-			_objectEntryLocalService.getObjectEntry(
-				externalReferenceCode, contextCompany.getCompanyId(),
-				CollaboratorUtil.getGroupId(
-					contextCompany.getCompanyId(), _groupLocalService,
-					scopeKey)));
-	}
-
-	private Page<Collaborator> _getObjectEntryCollaboratorsPage(
-		ObjectEntry objectEntry, Pagination pagination) {
-
-		long classNameId = _classNameLocalService.getClassNameId(
-			objectEntry.getModelClassName());
-
-		return Page.of(
-			transform(
-				_sharingEntryLocalService.getSharingEntries(
-					classNameId, objectEntry.getObjectEntryId(),
-					pagination.getStartPosition(), pagination.getEndPosition()),
-				sharingEntry -> CollaboratorUtil.toCollaborator(
-					contextAcceptLanguage, _collaboratorDTOConverter,
-					_dtoConverterRegistry, sharingEntry, contextUriInfo,
-					contextUser)),
-			pagination,
-			_sharingEntryLocalService.getSharingEntriesCount(
-				classNameId, objectEntry.getObjectEntryId()));
-	}
-
-	private Page<Collaborator> _postObjectEntryCollaboratorsPage(
-			Collaborator[] collaborators, ObjectEntry objectEntry)
-		throws Exception {
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			externalReferenceCode, contextCompany.getCompanyId(),
+			CollaboratorUtil.getGroupId(
+				contextCompany.getCompanyId(), _groupLocalService, scopeKey));
 
 		return CollaboratorUtil.addOrUpdateCollaborators(
 			contextAcceptLanguage,
 			_classNameLocalService.getClassNameId(
-				ObjectEntryFolder.class.getName()),
-			objectEntry.getObjectEntryFolderId(), collaborators,
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), collaborators,
 			_collaboratorDTOConverter, _dtoConverterRegistry,
 			objectEntry.getGroupId(), _sharingEntryService, contextUriInfo,
 			contextUser, _userGroupLocalService, _userLocalService);
+	}
+
+	@Override
+	public Collaborator
+			putObjectEntryCollaboratorByTypeCollaboratorTypeCollaborator(
+				Long objectEntryId, String collaboratorType,
+				Long collaboratorId, Collaborator collaborator)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			objectEntryId);
+
+		return CollaboratorUtil.addOrUpdateCollaborator(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), collaborator, collaboratorId,
+			collaboratorType, _collaboratorDTOConverter, _dtoConverterRegistry,
+			objectEntry.getGroupId(), _sharingEntryService,
+			_userGroupLocalService, contextUriInfo, contextUser,
+			_userLocalService);
+	}
+
+	@Override
+	public Collaborator
+			putScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator(
+				String scopeKey, String externalReferenceCode,
+				String collaboratorType, Long collaboratorId,
+				Collaborator collaborator)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			externalReferenceCode, contextCompany.getCompanyId(),
+			CollaboratorUtil.getGroupId(
+				contextCompany.getCompanyId(), _groupLocalService, scopeKey));
+
+		return CollaboratorUtil.addOrUpdateCollaborator(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), collaborator, collaboratorId,
+			collaboratorType, _collaboratorDTOConverter, _dtoConverterRegistry,
+			objectEntry.getGroupId(), _sharingEntryService,
+			_userGroupLocalService, contextUriInfo, contextUser,
+			_userLocalService);
 	}
 
 	private final ClassNameLocalService _classNameLocalService;

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CollaboratorResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CollaboratorResourceTest.java
@@ -415,6 +415,17 @@ public class CollaboratorResourceTest {
 				continue;
 			}
 
+			if (Objects.equals(assertFieldName, "id")) {
+				if (!StringUtil.equals(
+						jsonObject1.getString("id"),
+						jsonObject2.getString("id"))) {
+
+					return false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals(assertFieldName, "name")) {
 				if (!StringUtil.equals(
 						jsonObject1.getString("name"),
@@ -468,6 +479,8 @@ public class CollaboratorResourceTest {
 		).put(
 			"externalReferenceCode", user.getExternalReferenceCode()
 		).put(
+			"id", user.getUserId()
+		).put(
 			"name", user.getFullName()
 		).put(
 			"share", true
@@ -495,6 +508,8 @@ public class CollaboratorResourceTest {
 			"actionIds", JSONUtil.put(SharingEntryAction.VIEW.getActionId())
 		).put(
 			"externalReferenceCode", userGroup.getExternalReferenceCode()
+		).put(
+			"id", userGroup.getUserGroupId()
 		).put(
 			"name", userGroup.getName()
 		).put(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CollaboratorResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CollaboratorResourceTest.java
@@ -32,7 +32,6 @@ import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
-import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
@@ -40,7 +39,6 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.sharing.security.permission.SharingEntryAction;
-import com.liferay.sharing.service.SharingEntryLocalService;
 
 import java.io.Serializable;
 
@@ -533,12 +531,6 @@ public class CollaboratorResourceTest {
 
 	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;
-
-	@Inject
-	private Portal _portal;
-
-	@Inject
-	private SharingEntryLocalService _sharingEntryLocalService;
 
 	@DeleteAfterTestRun
 	private List<UserGroup> _userGroups = new ArrayList<>();

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CollaboratorResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CollaboratorResourceTest.java
@@ -88,6 +88,55 @@ public class CollaboratorResourceTest {
 	}
 
 	@Test
+	public void testDeleteObjectEntryCollaboratorByTypeCollaboratorTypeCollaborator()
+		throws Exception {
+
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		User user = _getUser();
+
+		_assertDeleteObjectEntryCollaborator(
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry.getObjectEntryId(), "/collaborators/by-type/User/",
+				user.getUserId()),
+			user);
+	}
+
+	@Test
+	public void testDeleteScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator()
+		throws Exception {
+
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		User user = _getUser();
+
+		_assertDeleteObjectEntryCollaborator(
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), "/scopes/",
+				_group.getGroupId(), "/by-external-reference-code/",
+				objectEntry.getExternalReferenceCode(),
+				"/collaborators/by-type/User/", user.getUserId()),
+			user);
+	}
+
+	@Test
+	public void testGetObjectEntryCollaboratorByTypeCollaboratorTypeCollaborator()
+		throws Exception {
+
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		User user = _getUser();
+
+		_assertGetObjectEntryCollaborator(
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry.getObjectEntryId(), "/collaborators/by-type/User/",
+				user.getUserId()),
+			user);
+	}
+
+	@Test
 	public void testGetObjectEntryCollaboratorsPage() throws Exception {
 		JSONArray jsonArray = JSONUtil.putAll(
 			_getUserCollaboratorJSONObject(),
@@ -110,6 +159,23 @@ public class CollaboratorResourceTest {
 			Http.Method.GET);
 
 		_assertEquals(jsonArray, jsonObject.getJSONArray("items"));
+	}
+
+	@Test
+	public void testGetScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator()
+		throws Exception {
+
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		User user = _getUser();
+
+		_assertGetObjectEntryCollaborator(
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), "/scopes/",
+				_group.getGroupId(), "/by-external-reference-code/",
+				objectEntry.getExternalReferenceCode(),
+				"/collaborators/by-type/User/", user.getUserId()),
+			user);
 	}
 
 	@Test
@@ -179,6 +245,41 @@ public class CollaboratorResourceTest {
 		_assertEquals(jsonArray, jsonObject.getJSONArray("items"));
 	}
 
+	@Test
+	public void testPutObjectEntryCollaboratorByTypeCollaboratorTypeCollaborator()
+		throws Exception {
+
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		UserGroup userGroup = _getUserGroup();
+
+		_assertPutObjectEntryCollaborator(
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry.getObjectEntryId(),
+				"/collaborators/by-type/UserGroup/",
+				userGroup.getUserGroupId()),
+			userGroup);
+	}
+
+	@Test
+	public void testPutScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator()
+		throws Exception {
+
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		UserGroup userGroup = _getUserGroup();
+
+		_assertPutObjectEntryCollaborator(
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), "/scopes/",
+				_group.getGroupId(), "/by-external-reference-code/",
+				objectEntry.getExternalReferenceCode(),
+				"/collaborators/by-type/UserGroup/",
+				userGroup.getUserGroupId()),
+			userGroup);
+	}
+
 	private static ObjectDefinition _getObjectDefinition() throws Exception {
 		return ObjectDefinitionTestUtil.publishObjectDefinition(
 			true, ObjectDefinitionTestUtil.getRandomName(),
@@ -228,6 +329,25 @@ public class CollaboratorResourceTest {
 		Assert.assertTrue(contains);
 	}
 
+	private void _assertDeleteObjectEntryCollaborator(
+			String endPoint, User user)
+		throws Exception {
+
+		JSONObject jsonObject1 = _getUserCollaboratorJSONObject(user);
+
+		_assertEquals(
+			jsonObject1,
+			HTTPTestUtil.invokeToJSONObject(
+				jsonObject1.toString(), endPoint, Http.Method.PUT));
+
+		HTTPTestUtil.invokeToJSONObject(null, endPoint, Http.Method.DELETE);
+
+		JSONObject jsonObject2 = HTTPTestUtil.invokeToJSONObject(
+			null, endPoint, Http.Method.GET);
+
+		Assert.assertEquals("NOT_FOUND", jsonObject2.getString("status"));
+	}
+
 	private void _assertEquals(
 		JSONArray actualJSONArray, JSONArray expectedJSONArray) {
 
@@ -238,6 +358,37 @@ public class CollaboratorResourceTest {
 			_assertContains(
 				actualJSONArray, expectedJSONArray.getJSONObject(i));
 		}
+	}
+
+	private void _assertEquals(JSONObject jsonObject1, JSONObject jsonObject2) {
+		Assert.assertTrue(_equals(jsonObject1, jsonObject2));
+	}
+
+	private void _assertGetObjectEntryCollaborator(String endpoint, User user)
+		throws Exception {
+
+		JSONObject jsonObject = _getUserCollaboratorJSONObject(user);
+
+		HTTPTestUtil.invokeToJSONObject(
+			jsonObject.toString(), endpoint, Http.Method.PUT);
+
+		_assertEquals(
+			jsonObject,
+			HTTPTestUtil.invokeToJSONObject(null, endpoint, Http.Method.GET));
+	}
+
+	private void _assertPutObjectEntryCollaborator(
+			String endPoint, UserGroup userGroup)
+		throws Exception {
+
+		JSONObject jsonObject = _getUserGroupCollaboratorJSONObject(userGroup);
+
+		HTTPTestUtil.invokeToJSONObject(
+			jsonObject.toString(), endPoint, Http.Method.PUT);
+
+		_assertEquals(
+			jsonObject,
+			HTTPTestUtil.invokeToJSONObject(null, endPoint, Http.Method.GET));
 	}
 
 	private boolean _equals(JSONObject jsonObject1, JSONObject jsonObject2) {
@@ -306,7 +457,11 @@ public class CollaboratorResourceTest {
 	}
 
 	private JSONObject _getUserCollaboratorJSONObject() throws Exception {
-		User user = _getUser();
+		return _getUserCollaboratorJSONObject(_getUser());
+	}
+
+	private JSONObject _getUserCollaboratorJSONObject(User user)
+		throws Exception {
 
 		return JSONUtil.put(
 			"actionIds", JSONUtil.put(SharingEntryAction.VIEW.getActionId())
@@ -330,7 +485,11 @@ public class CollaboratorResourceTest {
 	}
 
 	private JSONObject _getUserGroupCollaboratorJSONObject() throws Exception {
-		UserGroup userGroup = _getUserGroup();
+		return _getUserGroupCollaboratorJSONObject(_getUserGroup());
+	}
+
+	private JSONObject _getUserGroupCollaboratorJSONObject(UserGroup userGroup)
+		throws Exception {
 
 		return JSONUtil.put(
 			"actionIds", JSONUtil.put(SharingEntryAction.VIEW.getActionId())

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
@@ -90,7 +90,13 @@
 					},
 					"externalReferenceCode": {
 						"description": "The collaborator external reference code.",
+						"readOnly": true,
 						"type": "string"
+					},
+					"id": {
+						"description": "The collaborator ID.",
+						"format": "int64",
+						"type": "integer"
 					},
 					"name": {
 						"description": "The collaborator name.",
@@ -123,7 +129,6 @@
 				},
 				"required": [
 					"actionIds",
-					"externalReferenceCode",
 					"type"
 				],
 				"type": "object",
@@ -2332,6 +2337,211 @@
 				]
 			}
 		},
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{collaboratorType}/{collaboratorId}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
 		"/validate": {
 			"post": {
 				"operationId": "postValidate",
@@ -2748,6 +2958,187 @@
 							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/PageCollaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
+		"/{object1Id}/collaborators/by-type/{collaboratorType}/{collaboratorId}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteObject1CollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getObject1CollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putObject1CollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
 								}
 							}
 						},

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
@@ -90,7 +90,13 @@
 					},
 					"externalReferenceCode": {
 						"description": "The collaborator external reference code.",
+						"readOnly": true,
 						"type": "string"
+					},
+					"id": {
+						"description": "The collaborator ID.",
+						"format": "int64",
+						"type": "integer"
 					},
 					"name": {
 						"description": "The collaborator name.",
@@ -123,7 +129,6 @@
 				},
 				"required": [
 					"actionIds",
-					"externalReferenceCode",
 					"type"
 				],
 				"type": "object",
@@ -1790,6 +1795,211 @@
 				]
 			}
 		},
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{collaboratorType}/{collaboratorId}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
 		"/validate": {
 			"post": {
 				"operationId": "postValidate",
@@ -2206,6 +2416,187 @@
 							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/PageCollaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
+		"/{object1Id}/collaborators/by-type/{collaboratorType}/{collaboratorId}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteObject1CollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getObject1CollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putObject1CollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
 								}
 							}
 						},

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
@@ -90,7 +90,13 @@
 					},
 					"externalReferenceCode": {
 						"description": "The collaborator external reference code.",
+						"readOnly": true,
 						"type": "string"
+					},
+					"id": {
+						"description": "The collaborator ID.",
+						"format": "int64",
+						"type": "integer"
 					},
 					"name": {
 						"description": "The collaborator name.",
@@ -123,7 +129,6 @@
 				},
 				"required": [
 					"actionIds",
-					"externalReferenceCode",
 					"type"
 				],
 				"type": "object",
@@ -1843,6 +1848,211 @@
 				]
 			}
 		},
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{collaboratorType}/{collaboratorId}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
 		"/validate": {
 			"post": {
 				"operationId": "postValidate",
@@ -2259,6 +2469,187 @@
 							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/PageCollaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
+		"/{object1Id}/collaborators/by-type/{collaboratorType}/{collaboratorId}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteObject1CollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getObject1CollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putObject1CollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
 								}
 							}
 						},

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_categorization_disabled.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_categorization_disabled.json
@@ -90,7 +90,13 @@
 					},
 					"externalReferenceCode": {
 						"description": "The collaborator external reference code.",
+						"readOnly": true,
 						"type": "string"
+					},
+					"id": {
+						"description": "The collaborator ID.",
+						"format": "int64",
+						"type": "integer"
 					},
 					"name": {
 						"description": "The collaborator name.",
@@ -123,7 +129,6 @@
 				},
 				"required": [
 					"actionIds",
-					"externalReferenceCode",
 					"type"
 				],
 				"type": "object",
@@ -1443,6 +1448,211 @@
 				]
 			}
 		},
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{collaboratorType}/{collaboratorId}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
 		"/validate": {
 			"post": {
 				"operationId": "postValidate",
@@ -1859,6 +2069,187 @@
 							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/PageCollaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
+		"/{object9Id}/collaborators/by-type/{collaboratorType}/{collaboratorId}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteObject9CollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object9Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getObject9CollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object9Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putObject9CollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object9Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
 								}
 							}
 						},

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
@@ -90,7 +90,13 @@
 					},
 					"externalReferenceCode": {
 						"description": "The collaborator external reference code.",
+						"readOnly": true,
 						"type": "string"
+					},
+					"id": {
+						"description": "The collaborator ID.",
+						"format": "int64",
+						"type": "integer"
 					},
 					"name": {
 						"description": "The collaborator name.",
@@ -123,7 +129,6 @@
 				},
 				"required": [
 					"actionIds",
-					"externalReferenceCode",
 					"type"
 				],
 				"type": "object",
@@ -2811,6 +2816,211 @@
 				]
 			}
 		},
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{collaboratorType}/{collaboratorId}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
 		"/validate": {
 			"post": {
 				"operationId": "postValidate",
@@ -3227,6 +3437,187 @@
 							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/PageCollaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
+		"/{object2Id}/collaborators/by-type/{collaboratorType}/{collaboratorId}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteObject2CollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object2Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getObject2CollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object2Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putObject2CollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object2Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
 								}
 							}
 						},

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_site.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_site.json
@@ -90,7 +90,13 @@
 					},
 					"externalReferenceCode": {
 						"description": "The collaborator external reference code.",
+						"readOnly": true,
 						"type": "string"
+					},
+					"id": {
+						"description": "The collaborator ID.",
+						"format": "int64",
+						"type": "integer"
 					},
 					"name": {
 						"description": "The collaborator name.",
@@ -123,7 +129,6 @@
 				},
 				"required": [
 					"actionIds",
-					"externalReferenceCode",
 					"type"
 				],
 				"type": "object",
@@ -1264,6 +1269,211 @@
 				]
 			}
 		},
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{collaboratorType}/{collaboratorId}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
 		"/scopes/{scopeKey}/validate": {
 			"post": {
 				"operationId": "postScopeScopeKeyValidate",
@@ -1690,6 +1900,187 @@
 							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/PageCollaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
+		"/{object8Id}/collaborators/by-type/{collaboratorType}/{collaboratorId}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteObject8CollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object8Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getObject8CollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object8Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putObject8CollaboratorByTypeCollaboratorTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object8Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorType",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
 								}
 							}
 						},

--- a/modules/apps/sharing/sharing-api/bnd.bnd
+++ b/modules/apps/sharing/sharing-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Sharing API
 Bundle-SymbolicName: com.liferay.sharing.api
-Bundle-Version: 13.0.1
+Bundle-Version: 13.1.0
 Export-Package:\
 	com.liferay.sharing.configuration,\
 	com.liferay.sharing.constants,\

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryService.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryService.java
@@ -101,6 +101,10 @@ public interface SharingEntryService extends BaseService {
 		throws PortalException;
 
 	public SharingEntry deleteSharingEntry(
+			long toUserGroupId, long toUserId, long classNameId, long classPK)
+		throws PortalException;
+
+	public SharingEntry deleteSharingEntry(
 			long sharingEntryId, ServiceContext serviceContext)
 		throws PortalException;
 
@@ -130,6 +134,11 @@ public interface SharingEntryService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public SharingEntry getSharingEntry(long sharingEntryId)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public SharingEntry getSharingEntry(
+			long toUserGroupId, long toUserId, long classNameId, long classPK)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryServiceUtil.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryServiceUtil.java
@@ -103,6 +103,14 @@ public class SharingEntryServiceUtil {
 	}
 
 	public static SharingEntry deleteSharingEntry(
+			long toUserGroupId, long toUserId, long classNameId, long classPK)
+		throws PortalException {
+
+		return getService().deleteSharingEntry(
+			toUserGroupId, toUserId, classNameId, classPK);
+	}
+
+	public static SharingEntry deleteSharingEntry(
 			long sharingEntryId,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
@@ -153,6 +161,14 @@ public class SharingEntryServiceUtil {
 		throws PortalException {
 
 		return getService().getSharingEntry(sharingEntryId);
+	}
+
+	public static SharingEntry getSharingEntry(
+			long toUserGroupId, long toUserId, long classNameId, long classPK)
+		throws PortalException {
+
+		return getService().getSharingEntry(
+			toUserGroupId, toUserId, classNameId, classPK);
 	}
 
 	public static SharingEntry getSharingEntryByExternalReferenceCode(

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryServiceWrapper.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryServiceWrapper.java
@@ -100,6 +100,15 @@ public class SharingEntryServiceWrapper
 
 	@Override
 	public com.liferay.sharing.model.SharingEntry deleteSharingEntry(
+			long toUserGroupId, long toUserId, long classNameId, long classPK)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _sharingEntryService.deleteSharingEntry(
+			toUserGroupId, toUserId, classNameId, classPK);
+	}
+
+	@Override
+	public com.liferay.sharing.model.SharingEntry deleteSharingEntry(
 			long sharingEntryId,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -163,6 +172,15 @@ public class SharingEntryServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _sharingEntryService.getSharingEntry(sharingEntryId);
+	}
+
+	@Override
+	public com.liferay.sharing.model.SharingEntry getSharingEntry(
+			long toUserGroupId, long toUserId, long classNameId, long classPK)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _sharingEntryService.getSharingEntry(
+			toUserGroupId, toUserId, classNameId, classPK);
 	}
 
 	@Override

--- a/modules/apps/sharing/sharing-api/src/main/resources/com/liferay/sharing/service/packageinfo
+++ b/modules/apps/sharing/sharing-api/src/main/resources/com/liferay/sharing/service/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 3.3.0

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/http/SharingEntryServiceHttp.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/http/SharingEntryServiceHttp.java
@@ -141,6 +141,47 @@ public class SharingEntryServiceHttp {
 	}
 
 	public static com.liferay.sharing.model.SharingEntry deleteSharingEntry(
+			HttpPrincipal httpPrincipal, long toUserGroupId, long toUserId,
+			long classNameId, long classPK)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				SharingEntryServiceUtil.class, "deleteSharingEntry",
+				_deleteSharingEntryParameterTypes2);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, toUserGroupId, toUserId, classNameId, classPK);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.sharing.model.SharingEntry)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.sharing.model.SharingEntry deleteSharingEntry(
 			HttpPrincipal httpPrincipal, long sharingEntryId,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -148,7 +189,7 @@ public class SharingEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SharingEntryServiceUtil.class, "deleteSharingEntry",
-				_deleteSharingEntryParameterTypes2);
+				_deleteSharingEntryParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, sharingEntryId, serviceContext);
@@ -189,7 +230,7 @@ public class SharingEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SharingEntryServiceUtil.class, "deleteSharingEntry",
-				_deleteSharingEntryParameterTypes3);
+				_deleteSharingEntryParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, sharingEntry);
@@ -232,7 +273,7 @@ public class SharingEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				SharingEntryServiceUtil.class,
 				"deleteSharingEntryByExternalReferenceCode",
-				_deleteSharingEntryByExternalReferenceCodeParameterTypes4);
+				_deleteSharingEntryByExternalReferenceCodeParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId);
@@ -275,7 +316,7 @@ public class SharingEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				SharingEntryServiceUtil.class,
 				"fetchSharingEntryByExternalReferenceCode",
-				_fetchSharingEntryByExternalReferenceCodeParameterTypes5);
+				_fetchSharingEntryByExternalReferenceCodeParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId);
@@ -317,7 +358,7 @@ public class SharingEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SharingEntryServiceUtil.class, "getSharingEntries",
-				_getSharingEntriesParameterTypes6);
+				_getSharingEntriesParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, classNameId, classPK, groupId, start, end);
@@ -358,10 +399,51 @@ public class SharingEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SharingEntryServiceUtil.class, "getSharingEntry",
-				_getSharingEntryParameterTypes7);
+				_getSharingEntryParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, sharingEntryId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.sharing.model.SharingEntry)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.sharing.model.SharingEntry getSharingEntry(
+			HttpPrincipal httpPrincipal, long toUserGroupId, long toUserId,
+			long classNameId, long classPK)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				SharingEntryServiceUtil.class, "getSharingEntry",
+				_getSharingEntryParameterTypes9);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, toUserGroupId, toUserId, classNameId, classPK);
 
 			Object returnObj = null;
 
@@ -401,7 +483,7 @@ public class SharingEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				SharingEntryServiceUtil.class,
 				"getSharingEntryByExternalReferenceCode",
-				_getSharingEntryByExternalReferenceCodeParameterTypes8);
+				_getSharingEntryByExternalReferenceCodeParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId);
@@ -446,7 +528,7 @@ public class SharingEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SharingEntryServiceUtil.class, "updateSharingEntry",
-				_updateSharingEntryParameterTypes9);
+				_updateSharingEntryParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, sharingEntryId, sharingEntryActions, shareable,
@@ -498,27 +580,31 @@ public class SharingEntryServiceHttp {
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _deleteSharingEntryParameterTypes2 =
+		new Class[] {long.class, long.class, long.class, long.class};
+	private static final Class<?>[] _deleteSharingEntryParameterTypes3 =
 		new Class[] {
 			long.class, com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _deleteSharingEntryParameterTypes3 =
+	private static final Class<?>[] _deleteSharingEntryParameterTypes4 =
 		new Class[] {com.liferay.sharing.model.SharingEntry.class};
 	private static final Class<?>[]
-		_deleteSharingEntryByExternalReferenceCodeParameterTypes4 =
+		_deleteSharingEntryByExternalReferenceCodeParameterTypes5 =
 			new Class[] {String.class, long.class};
 	private static final Class<?>[]
-		_fetchSharingEntryByExternalReferenceCodeParameterTypes5 = new Class[] {
+		_fetchSharingEntryByExternalReferenceCodeParameterTypes6 = new Class[] {
 			String.class, long.class
 		};
-	private static final Class<?>[] _getSharingEntriesParameterTypes6 =
+	private static final Class<?>[] _getSharingEntriesParameterTypes7 =
 		new Class[] {long.class, long.class, long.class, int.class, int.class};
-	private static final Class<?>[] _getSharingEntryParameterTypes7 =
+	private static final Class<?>[] _getSharingEntryParameterTypes8 =
 		new Class[] {long.class};
+	private static final Class<?>[] _getSharingEntryParameterTypes9 =
+		new Class[] {long.class, long.class, long.class, long.class};
 	private static final Class<?>[]
-		_getSharingEntryByExternalReferenceCodeParameterTypes8 = new Class[] {
+		_getSharingEntryByExternalReferenceCodeParameterTypes10 = new Class[] {
 			String.class, long.class
 		};
-	private static final Class<?>[] _updateSharingEntryParameterTypes9 =
+	private static final Class<?>[] _updateSharingEntryParameterTypes11 =
 		new Class[] {
 			long.class, java.util.Collection.class, boolean.class,
 			java.util.Date.class,

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryServiceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryServiceImpl.java
@@ -122,6 +122,21 @@ public class SharingEntryServiceImpl extends SharingEntryServiceBaseImpl {
 
 	@Override
 	public SharingEntry deleteSharingEntry(
+			long toUserGroupId, long toUserId, long classNameId, long classPK)
+		throws PortalException {
+
+		SharingEntry sharingEntry = sharingEntryPersistence.findByTUG_TU_C_C(
+			toUserGroupId, toUserId, classNameId, classPK);
+
+		sharingPermission.checkManageCollaboratorsPermission(
+			getPermissionChecker(), sharingEntry.getClassNameId(),
+			sharingEntry.getClassPK(), sharingEntry.getGroupId());
+
+		return sharingEntryLocalService.deleteSharingEntry(sharingEntry);
+	}
+
+	@Override
+	public SharingEntry deleteSharingEntry(
 			long sharingEntryId, ServiceContext serviceContext)
 		throws PortalException {
 
@@ -187,6 +202,22 @@ public class SharingEntryServiceImpl extends SharingEntryServiceBaseImpl {
 
 		SharingEntry sharingEntry = sharingEntryLocalService.getSharingEntry(
 			sharingEntryId);
+
+		sharingPermission.check(
+			getPermissionChecker(), sharingEntry.getClassNameId(),
+			sharingEntry.getClassPK(), sharingEntry.getGroupId(),
+			Collections.singletonList(SharingEntryAction.VIEW));
+
+		return sharingEntry;
+	}
+
+	@Override
+	public SharingEntry getSharingEntry(
+			long toUserGroupId, long toUserId, long classNameId, long classPK)
+		throws PortalException {
+
+		SharingEntry sharingEntry = sharingEntryPersistence.findByTUG_TU_C_C(
+			toUserGroupId, toUserId, classNameId, classPK);
 
 		sharingPermission.check(
 			getPermissionChecker(), sharingEntry.getClassNameId(),

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryServiceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryServiceImpl.java
@@ -68,7 +68,7 @@ public class SharingEntryServiceImpl extends SharingEntryServiceBaseImpl {
 		throws PortalException {
 
 		SharingEntry sharingEntry = sharingEntryPersistence.fetchByTUG_TU_C_C(
-			0, toUserId, classNameId, classPK);
+			toUserGroupId, toUserId, classNameId, classPK);
 
 		if (sharingEntry == null) {
 			return sharingEntryService.addSharingEntry(


### PR DESCRIPTION
Hi @brianchandotcom ,

about your comment: https://github.com/brianchandotcom/liferay-portal/pull/161517#issuecomment-2853094878

I am resending again with the same code because there are some conflicts with the change from collaboratorType to type , the generated code is not good. Also, I'm checking and we already have this pattern in the code: https://github.com/liferay/liferay-portal/blob/c5ce5a8f92113bcbff5576100d4623f4d6b7bc94/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/rest-openapi.yaml#L1599

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-52794

# How am I fixing it?

Add individual headless apis to manage a sharing entry for an object entry folder and an object entry. So, with these apis you can add, update, get and delete a collaborator for an object entry or a object folder. Add and update have been merged into the PUT method following headless recommendations, for more info please see : https://liferay.slack.com/archives/C08N71T5VGT/p1744646885361209

# How can you verify that it works?

Run included tests