### PR TITLE
LPD-54604 Remove the definitions after their usage is complete

### DIFF
--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/test/RenderLayoutStructureTagTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/test/RenderLayoutStructureTagTest.java
@@ -554,6 +554,10 @@ public class RenderLayoutStructureTagTest {
 			Assert.assertTrue(
 				content, StringUtil.contains(content, value, StringPool.BLANK));
 		}
+
+		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			relationshipObjectDefinition);
 	}
 
 	@Test


### PR DESCRIPTION
We ran the CI tests [here](https://github.com/liferay-bpm/liferay-portal/pull/4463#issuecomment-2850915004), the failures are not related.