### PR TITLE
LPD-55709 Ensure output of permissionWherePredicate is parenthesized

### DIFF
--- a/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/InlineSQLHelperImpl.java
+++ b/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/InlineSQLHelperImpl.java
@@ -480,7 +480,7 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 				permissionWherePredicate.withParentheses();
 		}
 
-		return permissionWherePredicate;
+		return permissionWherePredicate.withParentheses();
 	}
 
 	private DSLQuery _getResourcePermissionQuery(


### PR DESCRIPTION
When using a Custom PermissionSQLContributor, in some cases the composite permission predicate is not parenthesized. This means that it has a lower precedence than other passed filtering predicates, e.g. group ID, fields filters, causing them to be ignored.

Please see https://liferay-support.zendesk.com/agent/tickets/132906 for a detailed explanation of the issue.