### PR TITLE
LPD-54757 Updating CustomFieldsUtil class to avoid ClassCastExceptions when the data type is not the final one

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/EditAPISchema.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/EditAPISchema.tsx
@@ -274,9 +274,7 @@ export default function EditAPISchema({
 						mainObjectDefinitionERC:
 							localUIData.mainObjectDefinitionERC,
 					},
-					method: localUIData.schemaProperties.length
-						? 'PATCH'
-						: 'PUT',
+					method: 'PATCH',
 					onError: (error: string) => {
 						openToast({
 							message: error,

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalService.java
@@ -485,6 +485,11 @@ public interface ObjectEntryLocalService
 			Map<String, Serializable> values)
 		throws PortalException;
 
+	public ObjectEntry partialUpdateObjectEntry(
+			long userId, long objectEntryId, Map<String, Serializable> values,
+			ServiceContext serviceContext)
+		throws PortalException;
+
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public BaseModelSearchResult<ObjectEntry> searchObjectEntries(
 			long groupId, long objectDefinitionId, String keywords, int cur,

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceUtil.java
@@ -645,6 +645,15 @@ public class ObjectEntryLocalServiceUtil {
 			userId, objectDefinitionId, primaryKey, values);
 	}
 
+	public static ObjectEntry partialUpdateObjectEntry(
+			long userId, long objectEntryId, Map<String, Serializable> values,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().partialUpdateObjectEntry(
+			userId, objectEntryId, values, serviceContext);
+	}
+
 	public static com.liferay.portal.kernel.search.BaseModelSearchResult
 		<ObjectEntry> searchObjectEntries(
 				long groupId, long objectDefinitionId, String keywords, int cur,

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceWrapper.java
@@ -740,6 +740,17 @@ public class ObjectEntryLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.object.model.ObjectEntry partialUpdateObjectEntry(
+			long userId, long objectEntryId,
+			java.util.Map<String, java.io.Serializable> values,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _objectEntryLocalService.partialUpdateObjectEntry(
+			userId, objectEntryId, values, serviceContext);
+	}
+
+	@Override
 	public com.liferay.portal.kernel.search.BaseModelSearchResult
 		<com.liferay.object.model.ObjectEntry> searchObjectEntries(
 				long groupId, long objectDefinitionId, String keywords, int cur,

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryService.java
@@ -156,6 +156,11 @@ public interface ObjectEntryService extends BaseService {
 			long groupId, long objectDefinitionId, String actionId)
 		throws PortalException;
 
+	public ObjectEntry partialUpdateObjectEntry(
+			long objectEntryId, Map<String, Serializable> values,
+			ServiceContext serviceContext)
+		throws PortalException;
+
 	public ObjectEntry updateObjectEntry(
 			long objectEntryId, Map<String, Serializable> values,
 			ServiceContext serviceContext)

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceUtil.java
@@ -210,6 +210,15 @@ public class ObjectEntryServiceUtil {
 			groupId, objectDefinitionId, actionId);
 	}
 
+	public static ObjectEntry partialUpdateObjectEntry(
+			long objectEntryId, Map<String, Serializable> values,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().partialUpdateObjectEntry(
+			objectEntryId, values, serviceContext);
+	}
+
 	public static ObjectEntry updateObjectEntry(
 			long objectEntryId, Map<String, Serializable> values,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceWrapper.java
@@ -234,6 +234,17 @@ public class ObjectEntryServiceWrapper
 	}
 
 	@Override
+	public com.liferay.object.model.ObjectEntry partialUpdateObjectEntry(
+			long objectEntryId,
+			java.util.Map<String, java.io.Serializable> values,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _objectEntryService.partialUpdateObjectEntry(
+			objectEntryId, values, serviceContext);
+	}
+
+	@Override
 	public com.liferay.object.model.ObjectEntry updateObjectEntry(
 			long objectEntryId,
 			java.util.Map<String, java.io.Serializable> values,

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/util/ObjectEntryManagerUtil.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/util/ObjectEntryManagerUtil.java
@@ -69,12 +69,20 @@ public class ObjectEntryManagerUtil {
 							NAME_OBJECT_RELATIONSHIP_ERC_OBJECT_FIELD_NAME,
 						objectField);
 
-				if (properties.containsKey(objectField.getName()) &&
+				String relationshipFieldName = objectField.getName();
+
+				if (properties.containsKey(relationshipFieldName) &&
 					!properties.containsKey(
 						objectRelationshipERCObjectFieldName)) {
 
 					existingProperties.remove(
 						objectRelationshipERCObjectFieldName);
+				}
+				else if (properties.containsKey(
+							objectRelationshipERCObjectFieldName) &&
+						 !properties.containsKey(relationshipFieldName)) {
+
+					existingProperties.remove(relationshipFieldName);
 				}
 			}
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -849,9 +849,9 @@ public class DefaultObjectEntryManagerImpl
 					dtoConverterContext, objectDefinition, objectEntryId),
 				objectDefinition.getObjectDefinitionId(), objectEntry);
 
-		return updateObjectEntry(
+		return _updateObjectEntry(
 			dtoConverterContext, objectDefinition, objectEntryId,
-			existingObjectEntry);
+			existingObjectEntry, true);
 	}
 
 	@Override
@@ -887,35 +887,9 @@ public class DefaultObjectEntryManagerImpl
 			ObjectEntry objectEntry)
 		throws Exception {
 
-		com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry =
-			_objectEntryService.getObjectEntry(objectEntryId);
-
-		_checkObjectEntryObjectDefinitionId(
-			objectDefinition, serviceBuilderObjectEntry);
-
-		validateReadOnlyObjectFields(
-			serviceBuilderObjectEntry.getExternalReferenceCode(),
-			objectDefinition, objectEntry);
-
-		String scopeKey = String.valueOf(
-			serviceBuilderObjectEntry.getGroupId());
-
-		ServiceContext serviceContext = _createServiceContext(
-			dtoConverterContext, objectDefinition, objectEntry);
-
-		serviceBuilderObjectEntry = _objectEntryService.updateObjectEntry(
-			objectEntryId,
-			_toObjectValues(
-				dtoConverterContext.getLocale(), objectDefinition, objectEntry,
-				scopeKey, serviceContext),
-			serviceContext);
-
-		return _toObjectEntry(
-			dtoConverterContext, objectDefinition,
-			_addOrUpdateNestedObjectEntries(
-				dtoConverterContext, objectDefinition, objectEntry,
-				_getObjectRelationships(objectDefinition, objectEntry),
-				serviceBuilderObjectEntry, scopeKey));
+		return _updateObjectEntry(
+			dtoConverterContext, objectDefinition, objectEntryId, objectEntry,
+			false);
 	}
 
 	@Override
@@ -2105,6 +2079,54 @@ public class DefaultObjectEntryManagerImpl
 		}
 
 		return values;
+	}
+
+	private ObjectEntry _updateObjectEntry(
+			DTOConverterContext dtoConverterContext,
+			ObjectDefinition objectDefinition, long objectEntryId,
+			ObjectEntry objectEntry, boolean partialUpdate)
+		throws Exception {
+
+		com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry =
+			_objectEntryService.getObjectEntry(objectEntryId);
+
+		_checkObjectEntryObjectDefinitionId(
+			objectDefinition, serviceBuilderObjectEntry);
+
+		validateReadOnlyObjectFields(
+			serviceBuilderObjectEntry.getExternalReferenceCode(),
+			objectDefinition, objectEntry);
+
+		String scopeKey = String.valueOf(
+			serviceBuilderObjectEntry.getGroupId());
+
+		ServiceContext serviceContext = _createServiceContext(
+			dtoConverterContext, objectDefinition, objectEntry);
+
+		if (partialUpdate) {
+			serviceBuilderObjectEntry =
+				_objectEntryService.partialUpdateObjectEntry(
+					objectEntryId,
+					_toObjectValues(
+						dtoConverterContext.getLocale(), objectDefinition,
+						objectEntry, scopeKey, serviceContext),
+					serviceContext);
+		}
+		else {
+			serviceBuilderObjectEntry = _objectEntryService.updateObjectEntry(
+				objectEntryId,
+				_toObjectValues(
+					dtoConverterContext.getLocale(), objectDefinition,
+					objectEntry, scopeKey, serviceContext),
+				serviceContext);
+		}
+
+		return _toObjectEntry(
+			dtoConverterContext, objectDefinition,
+			_addOrUpdateNestedObjectEntries(
+				dtoConverterContext, objectDefinition, objectEntry,
+				_getObjectRelationships(objectDefinition, objectEntry),
+				serviceBuilderObjectEntry, scopeKey));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -29,6 +29,7 @@ import com.liferay.headless.admin.taxonomy.client.resource.v1_0.TaxonomyCategory
 import com.liferay.headless.delivery.dto.v1_0.Creator;
 import com.liferay.list.type.entry.util.ListTypeEntryUtil;
 import com.liferay.list.type.model.ListTypeDefinition;
+import com.liferay.list.type.model.ListTypeEntry;
 import com.liferay.list.type.service.ListTypeDefinitionLocalService;
 import com.liferay.list.type.service.ListTypeEntryLocalService;
 import com.liferay.object.constants.ObjectActionExecutorConstants;
@@ -121,6 +122,7 @@ import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUti
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -129,6 +131,7 @@ import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.ModelPermissionsFactory;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -186,6 +189,9 @@ import java.io.Serializable;
 import java.lang.reflect.Method;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import java.sql.Timestamp;
 
 import java.text.DateFormat;
 
@@ -232,7 +238,10 @@ import org.springframework.transaction.support.DefaultTransactionStatus;
  * @author Luis Miguel Barcos
  */
 @FeatureFlags(
-	featureFlags = {@FeatureFlag("LPD-45945"), @FeatureFlag("LPS-164801")}
+	featureFlags = {
+		@FeatureFlag(value = "LPD-45945"), @FeatureFlag(value = "LPS-164801"),
+		@FeatureFlag(enable = false, value = "LPD-54417")
+	}
 )
 @RunWith(Arquillian.class)
 public class ObjectEntryResourceTest {
@@ -287,21 +296,21 @@ public class ObjectEntryResourceTest {
 					LocaleUtil.US, RandomTestUtil.randomString()),
 				false, Collections.emptyList());
 
-		_listTypeEntryLocalService.addListTypeEntry(
+		_listTypeEntry1 = _listTypeEntryLocalService.addListTypeEntry(
 			null, TestPropsValues.getUserId(),
 			_listTypeDefinition.getListTypeDefinitionId(),
 			_LIST_TYPE_ENTRY_KEY_1,
 			Collections.singletonMap(
 				LocaleUtil.US, RandomTestUtil.randomString()),
 			_listTypeDefinition.isSystem());
-		_listTypeEntryLocalService.addListTypeEntry(
+		_listTypeEntry2 = _listTypeEntryLocalService.addListTypeEntry(
 			null, TestPropsValues.getUserId(),
 			_listTypeDefinition.getListTypeDefinitionId(),
 			_LIST_TYPE_ENTRY_KEY_2,
 			Collections.singletonMap(
 				LocaleUtil.US, RandomTestUtil.randomString()),
 			_listTypeDefinition.isSystem());
-		_listTypeEntryLocalService.addListTypeEntry(
+		_listTypeEntry3 = _listTypeEntryLocalService.addListTypeEntry(
 			null, TestPropsValues.getUserId(),
 			_listTypeDefinition.getListTypeDefinitionId(),
 			_LIST_TYPE_ENTRY_KEY_3,
@@ -480,6 +489,11 @@ public class ObjectEntryResourceTest {
 					ObjectFieldConstants.DB_TYPE_BIG_DECIMAL, true, false, null,
 					RandomTestUtil.randomString(),
 					_OBJECT_FIELD_NAME_PRECISION_DECIMAL, false),
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_RICH_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
+					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_RICH_TEXT,
+					false),
 				ObjectFieldUtil.createObjectField(
 					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
@@ -682,9 +696,6 @@ public class ObjectEntryResourceTest {
 					null, RandomTestUtil.randomString(),
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, false, false)));
 
-		_objectEntry4 = ObjectEntryTestUtil.addObjectEntry(
-			_objectDefinition4, _OBJECT_FIELD_NAME_4, _OBJECT_FIELD_VALUE_4);
-
 		_objectDefinition5 = ObjectDefinitionTestUtil.publishObjectDefinition(
 			true, ObjectDefinitionTestUtil.getRandomName(),
 			Arrays.asList(
@@ -762,11 +773,6 @@ public class ObjectEntryResourceTest {
 			ObjectDefinitionTestUtil.publishObjectDefinition(
 				objectDefinitionName,
 				Arrays.asList(
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-						ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
-						RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_1,
-						false),
 					ObjectFieldUtil.createObjectField(
 						ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT,
 						ObjectFieldConstants.DB_TYPE_LONG, true, false, null,
@@ -858,6 +864,95 @@ public class ObjectEntryResourceTest {
 							).value(
 								StringPool.SLASH + objectDefinitionName
 							).build()),
+						false),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_BOOLEAN,
+						ObjectFieldConstants.DB_TYPE_BOOLEAN, true, false, null,
+						RandomTestUtil.randomString(),
+						_OBJECT_FIELD_NAME_BOOLEAN, false),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_DATE,
+						ObjectFieldConstants.DB_TYPE_DATE,
+						RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_DATE,
+						false),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_DATE_TIME,
+						ObjectFieldConstants.DB_TYPE_DATE_TIME, true, true,
+						null, RandomTestUtil.randomString(),
+						_OBJECT_FIELD_NAME_DATE_TIME_INPUT,
+						Collections.singletonList(
+							new ObjectFieldSettingBuilder(
+							).name(
+								ObjectFieldSettingConstants.NAME_TIME_STORAGE
+							).value(
+								ObjectFieldSettingConstants.
+									VALUE_USE_INPUT_AS_ENTERED
+							).build()),
+						false),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_DATE_TIME,
+						ObjectFieldConstants.DB_TYPE_DATE_TIME, true, true,
+						null, RandomTestUtil.randomString(),
+						_OBJECT_FIELD_NAME_DATE_TIME_UTC,
+						Collections.singletonList(
+							new ObjectFieldSettingBuilder(
+							).name(
+								ObjectFieldSettingConstants.NAME_TIME_STORAGE
+							).value(
+								ObjectFieldSettingConstants.VALUE_CONVERT_TO_UTC
+							).build()),
+						false),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_DECIMAL,
+						ObjectFieldConstants.DB_TYPE_DOUBLE, true, false, null,
+						RandomTestUtil.randomString(),
+						_OBJECT_FIELD_NAME_DECIMAL, false),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
+						ObjectFieldConstants.DB_TYPE_INTEGER, true, true, null,
+						RandomTestUtil.randomString(),
+						_OBJECT_FIELD_NAME_INTEGER, false),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
+						ObjectFieldConstants.DB_TYPE_LONG, true, false, null,
+						RandomTestUtil.randomString(),
+						_OBJECT_FIELD_NAME_LONG_INTEGER, false),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_LONG_TEXT,
+						ObjectFieldConstants.DB_TYPE_CLOB, false, false, null,
+						RandomTestUtil.randomString(),
+						_OBJECT_FIELD_NAME_LONG_TEXT, false),
+					ObjectFieldUtil.createObjectField(
+						_listTypeDefinition.getListTypeDefinitionId(),
+						ObjectFieldConstants.BUSINESS_TYPE_MULTISELECT_PICKLIST,
+						null, ObjectFieldConstants.DB_TYPE_STRING, true, false,
+						null, RandomTestUtil.randomString(),
+						_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, false, false),
+					ObjectFieldUtil.createObjectField(
+						_listTypeDefinition.getListTypeDefinitionId(),
+						ObjectFieldConstants.BUSINESS_TYPE_PICKLIST, null,
+						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+						RandomTestUtil.randomString(),
+						_OBJECT_FIELD_NAME_PICKLIST, false, false),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_PRECISION_DECIMAL,
+						ObjectFieldConstants.DB_TYPE_BIG_DECIMAL, true, false,
+						null, RandomTestUtil.randomString(),
+						_OBJECT_FIELD_NAME_PRECISION_DECIMAL, false),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_RICH_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
+						RandomTestUtil.randomString(),
+						_OBJECT_FIELD_NAME_RICH_TEXT, false),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
+						RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_TEXT,
+						false),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
+						RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_1,
 						false)),
 				ObjectDefinitionConstants.SCOPE_SITE);
 
@@ -7562,6 +7657,34 @@ public class ObjectEntryResourceTest {
 		_assertItem(0, jsonObject, _OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1);
 	}
 
+	@Test
+	@TestInfo("LPD-53245")
+	public void testPatchByExternalReferenceCodeCustomObjectEntry()
+		throws Exception {
+
+		_testPatchByExternalReferenceCodeCustomObjectEntry(
+			_objectDefinition1, _objectDefinition2,
+			TestPropsValues.getGroupId());
+	}
+
+	@Test
+	@TestInfo("LPD-53245")
+	public void testPatchByExternalReferenceCodeSiteScopedCustomObjectEntry()
+		throws Exception {
+
+		_testPatchByExternalReferenceCodeCustomObjectEntry(
+			_siteScopedObjectDefinition1, _siteScopedObjectDefinition2,
+			TestPropsValues.getGroupId());
+	}
+
+	@Test
+	@TestInfo("LPD-53245")
+	public void testPatchCustomObjectEntry() throws Exception {
+		_testPatchCustomObjectEntry(
+			_objectDefinition1, _objectDefinition2,
+			TestPropsValues.getGroupId());
+	}
+
 	@FeatureFlag("LPD-21926")
 	@Test
 	public void testPatchObjectEntryWithFriendlyURL() throws Exception {
@@ -8001,10 +8124,42 @@ public class ObjectEntryResourceTest {
 	public void testPatchPutScopeScopeKeyByExternalReferenceCode()
 		throws Exception {
 
-		_testPatchPutScopeScopeKeyByExternalReferenceCode(
-			Http.Method.PATCH, _siteScopedObjectDefinition1);
-		_testPatchPutScopeScopeKeyByExternalReferenceCode(
-			Http.Method.PUT, _siteScopedObjectDefinition1);
+		Group group = GroupLocalServiceUtil.getGroup(
+			TestPropsValues.getCompanyId(), GroupConstants.GUEST);
+
+		// Scope key as external reference code
+
+		_testPatchByExternalReferenceCodeCustomObjectEntry(
+			_objectDefinition1, _objectDefinition2,
+			group.getExternalReferenceCode());
+
+		_testPutByExternalReferenceCodeCustomObjectEntry(
+			_objectDefinition1, _objectDefinition2,
+			group.getExternalReferenceCode());
+
+		// Scope key as group ID
+
+		_testPatchByExternalReferenceCodeCustomObjectEntry(
+			_objectDefinition1, _objectDefinition2, group.getGroupId());
+
+		_testPutByExternalReferenceCodeCustomObjectEntry(
+			_objectDefinition1, _objectDefinition2, group.getGroupId());
+
+		// Scope key as group key
+
+		_testPatchByExternalReferenceCodeCustomObjectEntry(
+			_objectDefinition1, _objectDefinition2, group.getGroupKey());
+
+		_testPutByExternalReferenceCodeCustomObjectEntry(
+			_objectDefinition1, _objectDefinition2, group.getGroupKey());
+	}
+
+	@Test
+	@TestInfo("LPD-53245")
+	public void testPatchSiteScopedCustomObjectEntry() throws Exception {
+		_testPatchCustomObjectEntry(
+			_siteScopedObjectDefinition1, _siteScopedObjectDefinition2,
+			TestPropsValues.getGroupId());
 	}
 
 	@FeatureFlag("LPD-39967")
@@ -9461,6 +9616,27 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	@TestInfo("LPD-53245")
+	public void testPutByExternalReferenceCodeCustomObjectEntry()
+		throws Exception {
+
+		_testPutByExternalReferenceCodeCustomObjectEntry(
+			_objectDefinition1, _objectDefinition2,
+			TestPropsValues.getGroupId());
+	}
+
+	@FeatureFlag("LPD-54417")
+	@Test
+	@TestInfo("LPD-53245")
+	public void testPutByExternalReferenceCodeCustomObjectEntryWithDeprecatedFeatureFlag()
+		throws Exception {
+
+		_testPatchByExternalReferenceCodeCustomObjectEntry(
+			_objectDefinition1, _objectDefinition2,
+			TestPropsValues.getGroupId());
+	}
+
+	@Test
 	public void testPutByExternalReferenceCodeManyToManyRelationship()
 		throws Exception {
 
@@ -9705,126 +9881,41 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	@TestInfo("LPD-53245")
 	public void testPutByExternalReferenceCodeMultipleOneToManyRelationships()
 		throws Exception {
 
-		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
-			_objectDefinition1, _objectDefinition2, TestPropsValues.getUserId(),
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		_testPutByExternalReferenceCodeMultipleOneToManyRelationships(true);
+	}
 
-		_objectRelationship2 = ObjectRelationshipTestUtil.addObjectRelationship(
-			_objectDefinition2, _objectDefinition3, TestPropsValues.getUserId(),
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+	@FeatureFlag("LPD-54417")
+	@Test
+	@TestInfo("LPD-53245")
+	public void testPutByExternalReferenceCodeMultipleOneToManyRelationshipsWithDeprecatedFeatureFlag()
+		throws Exception {
 
-		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
-			JSONUtil.put(
-				_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
-			).put(
-				"externalReferenceCode", _ERC_VALUE_2
-			).put(
-				_objectRelationship1.getName(),
-				JSONUtil.put(
-					_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
-				).put(
-					"externalReferenceCode", _ERC_VALUE_1
-				)
-			).put(
-				_objectRelationship2.getName(),
-				JSONUtil.putAll(
-					JSONUtil.put(
-						_OBJECT_FIELD_NAME_3, RandomTestUtil.randomString()
-					).put(
-						"externalReferenceCode", _ERC_VALUE_3
-					),
-					JSONUtil.put(
-						_OBJECT_FIELD_NAME_3, RandomTestUtil.randomString()
-					).put(
-						"externalReferenceCode", RandomTestUtil.randomString()
-					))
-			).toString(),
-			_objectDefinition2.getRESTContextPath(), Http.Method.POST);
+		_testPutByExternalReferenceCodeMultipleOneToManyRelationships(false);
+	}
 
-		Assert.assertEquals(
-			200,
-			HTTPTestUtil.invokeToHttpCode(
-				JSONUtil.put(
-					_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2
-				).put(
-					_objectRelationship2.getName(),
-					_createObjectEntriesJSONArray(
-						new String[] {_ERC_VALUE_3}, _OBJECT_FIELD_NAME_3,
-						new String[] {_NEW_OBJECT_FIELD_VALUE_3})
-				).toString(),
-				StringBundler.concat(
-					_objectDefinition2.getRESTContextPath(),
-					"/by-external-reference-code/", _ERC_VALUE_2),
-				Http.Method.PUT));
+	@Test
+	@TestInfo("LPD-53245")
+	public void testPutByExternalReferenceCodeSiteScopedCustomObjectEntry()
+		throws Exception {
 
-		String objectEntryId = HTTPTestUtil.invokeToJSONObject(
-			null,
-			StringBundler.concat(
-				_objectDefinition1.getRESTContextPath(),
-				"/by-external-reference-code/", _ERC_VALUE_1),
-			Http.Method.GET
-		).get(
-			"id"
-		).toString();
+		_testPutByExternalReferenceCodeCustomObjectEntry(
+			_siteScopedObjectDefinition1, _siteScopedObjectDefinition2,
+			TestPropsValues.getGroupId());
+	}
 
-		JSONAssert.assertEquals(
-			JSONUtil.put(
-				"items",
-				JSONUtil.putAll(
-					JSONUtil.put(
-						_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2
-					).put(
-						"externalReferenceCode", _ERC_VALUE_2
-					))
-			).put(
-				"lastPage", 1
-			).put(
-				"page", 1
-			).put(
-				"pageSize", 20
-			).put(
-				"totalCount", 1
-			).toString(),
-			HTTPTestUtil.invokeToJSONObject(
-				null,
-				StringBundler.concat(
-					_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
-					objectEntryId, StringPool.SLASH,
-					_objectRelationship1.getName()),
-				Http.Method.GET
-			).toString(),
-			JSONCompareMode.LENIENT);
+	@FeatureFlag("LPD-54417")
+	@Test
+	@TestInfo("LPD-53245")
+	public void testPutByExternalReferenceCodeSiteScopedCustomObjectEntryWithDeprecatedFeatureFlag()
+		throws Exception {
 
-		JSONAssert.assertEquals(
-			JSONUtil.put(
-				"items",
-				JSONUtil.putAll(
-					JSONUtil.put(
-						_OBJECT_FIELD_NAME_3, _NEW_OBJECT_FIELD_VALUE_3
-					).put(
-						"externalReferenceCode", _ERC_VALUE_3
-					))
-			).put(
-				"lastPage", 1
-			).put(
-				"page", 1
-			).put(
-				"pageSize", 20
-			).put(
-				"totalCount", 1
-			).toString(),
-			HTTPTestUtil.invokeToJSONObject(
-				null,
-				StringBundler.concat(
-					_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
-					jsonObject.get("id"), StringPool.SLASH,
-					_objectRelationship2.getName()),
-				Http.Method.GET
-			).toString(),
-			JSONCompareMode.LENIENT);
+		_testPatchByExternalReferenceCodeCustomObjectEntry(
+			_siteScopedObjectDefinition1, _siteScopedObjectDefinition2,
+			TestPropsValues.getGroupId());
 	}
 
 	@Test
@@ -9868,6 +9959,14 @@ public class ObjectEntryResourceTest {
 				Http.Method.GET
 			).toString(),
 			JSONCompareMode.LENIENT);
+	}
+
+	@Test
+	@TestInfo("LPD-53245")
+	public void testPutCustomObjectEntry() throws Exception {
+		_testPutCustomObjectEntry(
+			_objectDefinition1, _objectDefinition2,
+			TestPropsValues.getGroupId());
 	}
 
 	@Test
@@ -10025,6 +10124,17 @@ public class ObjectEntryResourceTest {
 
 		_testPutCustomObjectEntryUnlinkNestedCustomObjectEntriesByExternalReferenceCode(
 			false);
+	}
+
+	@FeatureFlag("LPD-54417")
+	@Test
+	@TestInfo("LPD-53245")
+	public void testPutCustomObjectEntryWithDeprecatedFeatureFlag()
+		throws Exception {
+
+		_testPatchCustomObjectEntry(
+			_objectDefinition1, _objectDefinition2,
+			TestPropsValues.getGroupId());
 	}
 
 	@FeatureFlag("LPD-32050")
@@ -10468,6 +10578,25 @@ public class ObjectEntryResourceTest {
 		_assertObjectEntryField(
 			(JSONObject)nestedObjectEntriesJSONArray.get(0),
 			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_1);
+	}
+
+	@Test
+	@TestInfo("LPD-53245")
+	public void testPutSiteScopedCustomObjectEntry() throws Exception {
+		_testPutCustomObjectEntry(
+			_siteScopedObjectDefinition1, _siteScopedObjectDefinition2,
+			TestPropsValues.getGroupId());
+	}
+
+	@FeatureFlag("LPD-54417")
+	@Test
+	@TestInfo("LPD-53245")
+	public void testPutSiteScopedCustomObjectEntryWithDeprecatedFeatureFlag()
+		throws Exception {
+
+		_testPatchCustomObjectEntry(
+			_siteScopedObjectDefinition1, _siteScopedObjectDefinition2,
+			TestPropsValues.getGroupId());
 	}
 
 	@Test
@@ -13822,6 +13951,17 @@ public class ObjectEntryResourceTest {
 		Assert.assertEquals(expectedSize, jsonObject.getLong("totalCount"));
 	}
 
+	private JSONObject _cloneJSONObject(
+			JSONObject jsonObject, String objectFieldName,
+			Object objectFieldValue)
+		throws Exception {
+
+		JSONObject clonedJSONObject = JSONFactoryUtil.createJSONObject(
+			jsonObject.toString());
+
+		return clonedJSONObject.put(objectFieldName, objectFieldValue);
+	}
+
 	private JSONArray _createObjectEntriesJSONArray(
 			String[] externalReferenceCodeValues, String objectFieldName,
 			String[] objectFieldValues)
@@ -14539,6 +14679,391 @@ public class ObjectEntryResourceTest {
 		unsafeTriConsumer.accept(actionJSONObject, jsonObject, objectAction);
 	}
 
+	private void _testPatchByExternalReferenceCodeCustomObjectEntry(
+			ObjectDefinition objectDefinition1,
+			ObjectDefinition objectDefinition2, Object scopeKey)
+		throws Exception {
+
+		_testPatchCustomObjectEntry(
+			_getEndpoint(objectDefinition1, scopeKey) +
+				"/by-external-reference-code",
+			jsonObject -> jsonObject.getString("externalReferenceCode"),
+			objectDefinition1, objectDefinition2, scopeKey);
+	}
+
+	private void _testPatchCustomObjectEntry(
+			ObjectDefinition objectDefinition1,
+			ObjectDefinition objectDefinition2, Object scopeKey)
+		throws Exception {
+
+		_testPatchCustomObjectEntry(
+			objectDefinition1.getRESTContextPath(),
+			jsonObject -> jsonObject.getLong("id"), objectDefinition1,
+			objectDefinition2, scopeKey);
+	}
+
+	private void _testPatchCustomObjectEntry(
+			String contextPath, Function<JSONObject, Object> keyGetterFunction,
+			ObjectDefinition objectDefinition1,
+			ObjectDefinition objectDefinition2, Object scopeKey)
+		throws Exception {
+
+		_objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
+			objectDefinition2, _OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
+
+		_objectEntry3 = ObjectEntryTestUtil.addObjectEntry(
+			objectDefinition2, _OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
+
+		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
+			objectDefinition2, objectDefinition1, TestPropsValues.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_objectRelationship2 = ObjectRelationshipTestUtil.addObjectRelationship(
+			objectDefinition2, objectDefinition1, TestPropsValues.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		String objectRelationship1ERCObjectFieldName =
+			ObjectFieldSettingUtil.getValue(
+				ObjectFieldSettingConstants.
+					NAME_OBJECT_RELATIONSHIP_ERC_OBJECT_FIELD_NAME,
+				_objectFieldLocalService.getObjectField(
+					_objectRelationship1.getObjectFieldId2()));
+
+		String objectRelationship2IdObjectFieldName =
+			ObjectFieldSettingUtil.getValue(
+				ObjectFieldSettingConstants.
+					NAME_OBJECT_RELATIONSHIP_ERC_OBJECT_FIELD_NAME,
+				_objectFieldLocalService.getObjectField(
+					_objectRelationship2.getObjectFieldId2())
+			).replace(
+				"ERC", "Id"
+			);
+
+		BigDecimal randomBigDecimal = BigDecimal.valueOf(
+			RandomTestUtil.randomDouble()
+		).setScale(
+			5, RoundingMode.HALF_UP
+		);
+		boolean randomBoolean = RandomTestUtil.randomBoolean();
+		Date randomDate1 = RandomTestUtil.nextDate();
+		Date randomDate2 = RandomTestUtil.nextDate();
+		Date randomDate3 = RandomTestUtil.nextDate();
+		String randomExternalReferenceCode = RandomTestUtil.randomString();
+		float randomFloat = RandomTestUtil.randomFloat();
+		int randomInt = RandomTestUtil.randomInt();
+		long randomLong = RandomTestUtil.randomLong(
+			ObjectFieldValidationConstants.BUSINESS_TYPE_LONG_VALUE_MIN,
+			ObjectFieldValidationConstants.BUSINESS_TYPE_LONG_VALUE_MAX);
+		String randomString1 = RandomTestUtil.randomString();
+		String randomString2 = RandomTestUtil.randomString();
+		String randomString3 = RandomTestUtil.randomString();
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_OBJECT_FIELD_NAME_BOOLEAN, randomBoolean
+			).put(
+				_OBJECT_FIELD_NAME_DATE, _dateFormat.format(randomDate1)
+			).put(
+				_OBJECT_FIELD_NAME_DATE_TIME_INPUT,
+				_dateTimeDateFormat.format(randomDate2)
+			).put(
+				_OBJECT_FIELD_NAME_DATE_TIME_UTC,
+				_dateTimeDateFormat.format(randomDate3)
+			).put(
+				_OBJECT_FIELD_NAME_DECIMAL, randomFloat
+			).put(
+				_OBJECT_FIELD_NAME_INTEGER, randomInt
+			).put(
+				_OBJECT_FIELD_NAME_LONG_INTEGER, randomLong
+			).put(
+				_OBJECT_FIELD_NAME_LONG_TEXT, randomString1
+			).put(
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				JSONUtil.putAll(_LIST_TYPE_ENTRY_KEY_1, _LIST_TYPE_ENTRY_KEY_2)
+			).put(
+				_OBJECT_FIELD_NAME_PICKLIST, _LIST_TYPE_ENTRY_KEY_3
+			).put(
+				_OBJECT_FIELD_NAME_PRECISION_DECIMAL, randomBigDecimal
+			).put(
+				_OBJECT_FIELD_NAME_RICH_TEXT, randomString2
+			).put(
+				_OBJECT_FIELD_NAME_TEXT, randomString3
+			).put(
+				objectRelationship1ERCObjectFieldName,
+				_objectEntry2.getExternalReferenceCode()
+			).put(
+				objectRelationship2IdObjectFieldName,
+				_objectEntry2.getObjectEntryId()
+			).put(
+				"externalReferenceCode", randomExternalReferenceCode
+			).toString(),
+			_getEndpoint(objectDefinition1, scopeKey), Http.Method.POST);
+
+		JSONObject expectedJSONObject = JSONUtil.put(
+			_OBJECT_FIELD_NAME_BOOLEAN, randomBoolean
+		).put(
+			_OBJECT_FIELD_NAME_DATE,
+			_dateFormat.format(randomDate1) + "T00:00:00.000Z"
+		).put(
+			_OBJECT_FIELD_NAME_DATE_TIME_INPUT,
+			StringUtil.removeLast(_dateTimeDateFormat.format(randomDate2), "Z")
+		).put(
+			_OBJECT_FIELD_NAME_DATE_TIME_UTC,
+			_dateTimeDateFormat.format(randomDate3)
+		).put(
+			_OBJECT_FIELD_NAME_DECIMAL, randomFloat
+		).put(
+			_OBJECT_FIELD_NAME_INTEGER, randomInt
+		).put(
+			_OBJECT_FIELD_NAME_LONG_INTEGER, (double)randomLong
+		).put(
+			_OBJECT_FIELD_NAME_LONG_TEXT, randomString1
+		).put(
+			_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+			JSONUtil.putAll(
+				JSONUtil.put(
+					"key", _LIST_TYPE_ENTRY_KEY_1
+				).put(
+					"name", _listTypeEntry1.getName(LocaleUtil.getDefault())
+				),
+				JSONUtil.put(
+					"key", _LIST_TYPE_ENTRY_KEY_2
+				).put(
+					"name", _listTypeEntry2.getName(LocaleUtil.getDefault())
+				))
+		).put(
+			_OBJECT_FIELD_NAME_PICKLIST,
+			JSONUtil.put(
+				"key", _LIST_TYPE_ENTRY_KEY_3
+			).put(
+				"name", _listTypeEntry3.getName(LocaleUtil.getDefault())
+			)
+		).put(
+			_OBJECT_FIELD_NAME_PRECISION_DECIMAL, randomBigDecimal
+		).put(
+			_OBJECT_FIELD_NAME_RICH_TEXT, randomString2
+		).put(
+			_OBJECT_FIELD_NAME_TEXT, randomString3
+		).put(
+			objectRelationship1ERCObjectFieldName,
+			_objectEntry2.getExternalReferenceCode()
+		).put(
+			objectRelationship2IdObjectFieldName,
+			(int)_objectEntry2.getObjectEntryId()
+		).put(
+			"externalReferenceCode", randomExternalReferenceCode
+		).put(
+			"id", (Object)jsonObject.getLong("id")
+		);
+
+		String endpoint =
+			contextPath + "/" + keyGetterFunction.apply(jsonObject);
+
+		JSONAssert.assertEquals(
+			expectedJSONObject.toString(),
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					"externalReferenceCode", randomExternalReferenceCode
+				).toString(),
+				endpoint, Http.Method.PATCH
+			).toString(),
+			JSONCompareMode.LENIENT);
+
+		JSONAssert.assertEquals(
+			expectedJSONObject.toString(),
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					"externalReferenceCode", randomExternalReferenceCode
+				).toString(),
+				endpoint, Http.Method.GET
+			).toString(),
+			JSONCompareMode.LENIENT);
+
+		// Boolean field
+
+		expectedJSONObject = _cloneJSONObject(
+			expectedJSONObject, _OBJECT_FIELD_NAME_BOOLEAN, !randomBoolean);
+
+		_testPatchCustomObjectEntry(
+			endpoint, expectedJSONObject, _OBJECT_FIELD_NAME_BOOLEAN,
+			!randomBoolean);
+
+		// Date field
+
+		Date date = new Date(randomDate1.getTime() + (24 * 3600 * 1000));
+
+		expectedJSONObject = _cloneJSONObject(
+			expectedJSONObject, _OBJECT_FIELD_NAME_DATE,
+			_dateFormat.format(date) + "T00:00:00.000Z");
+
+		_testPatchCustomObjectEntry(
+			endpoint, expectedJSONObject, _OBJECT_FIELD_NAME_DATE,
+			_dateFormat.format(date));
+
+		// Date time field ('Input as value' type)
+
+		expectedJSONObject = _cloneJSONObject(
+			expectedJSONObject, _OBJECT_FIELD_NAME_DATE_TIME_INPUT,
+			StringUtil.removeLast(_dateTimeDateFormat.format(date), "Z"));
+
+		_testPatchCustomObjectEntry(
+			endpoint, expectedJSONObject, _OBJECT_FIELD_NAME_DATE_TIME_INPUT,
+			_dateTimeDateFormat.format(date));
+
+		// Date time field ('UTC' type)
+
+		expectedJSONObject = _cloneJSONObject(
+			expectedJSONObject, _OBJECT_FIELD_NAME_DATE_TIME_UTC,
+			_dateTimeDateFormat.format(date));
+
+		_testPatchCustomObjectEntry(
+			endpoint, expectedJSONObject, _OBJECT_FIELD_NAME_DATE_TIME_UTC,
+			_dateTimeDateFormat.format(date));
+
+		// Decimal field
+
+		expectedJSONObject = _cloneJSONObject(
+			expectedJSONObject, _OBJECT_FIELD_NAME_DECIMAL, randomFloat + 1);
+
+		_testPatchCustomObjectEntry(
+			endpoint, expectedJSONObject, _OBJECT_FIELD_NAME_DECIMAL,
+			randomFloat + 1);
+
+		// Integer field
+
+		expectedJSONObject = _cloneJSONObject(
+			expectedJSONObject, _OBJECT_FIELD_NAME_INTEGER, randomInt + 1);
+
+		_testPatchCustomObjectEntry(
+			endpoint, expectedJSONObject, _OBJECT_FIELD_NAME_INTEGER,
+			randomInt + 1);
+
+		// Long integer field
+
+		expectedJSONObject = _cloneJSONObject(
+			expectedJSONObject, _OBJECT_FIELD_NAME_LONG_INTEGER,
+			randomLong + 1);
+
+		_testPatchCustomObjectEntry(
+			endpoint, expectedJSONObject, _OBJECT_FIELD_NAME_LONG_INTEGER,
+			randomLong + 1);
+
+		// Long text field
+
+		expectedJSONObject = _cloneJSONObject(
+			expectedJSONObject, _OBJECT_FIELD_NAME_LONG_TEXT,
+			"b" + randomString1);
+
+		_testPatchCustomObjectEntry(
+			endpoint, expectedJSONObject, _OBJECT_FIELD_NAME_LONG_TEXT,
+			"b" + randomString1);
+
+		// Multiselect picklist field
+
+		expectedJSONObject = _cloneJSONObject(
+			expectedJSONObject, _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+			JSONUtil.putAll(
+				JSONUtil.put(
+					"key", _LIST_TYPE_ENTRY_KEY_2
+				).put(
+					"name", _listTypeEntry2.getName(LocaleUtil.getDefault())
+				),
+				JSONUtil.put(
+					"key", _LIST_TYPE_ENTRY_KEY_3
+				).put(
+					"name", _listTypeEntry3.getName(LocaleUtil.getDefault())
+				)));
+
+		_testPatchCustomObjectEntry(
+			endpoint, expectedJSONObject,
+			_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+			JSONUtil.putAll(_LIST_TYPE_ENTRY_KEY_2, _LIST_TYPE_ENTRY_KEY_3));
+
+		// Picklist field
+
+		expectedJSONObject = _cloneJSONObject(
+			expectedJSONObject, _OBJECT_FIELD_NAME_PICKLIST,
+			JSONUtil.put(
+				"key", _LIST_TYPE_ENTRY_KEY_1
+			).put(
+				"name", _listTypeEntry1.getName(LocaleUtil.getDefault())
+			));
+
+		_testPatchCustomObjectEntry(
+			endpoint, expectedJSONObject, _OBJECT_FIELD_NAME_PICKLIST,
+			_LIST_TYPE_ENTRY_KEY_1);
+
+		// Relationship ERC field
+
+		expectedJSONObject = _cloneJSONObject(
+			expectedJSONObject, objectRelationship1ERCObjectFieldName,
+			_objectEntry3.getExternalReferenceCode());
+
+		_testPatchCustomObjectEntry(
+			endpoint, expectedJSONObject, objectRelationship1ERCObjectFieldName,
+			_objectEntry3.getExternalReferenceCode());
+
+		// Relationship Id field
+
+		expectedJSONObject = _cloneJSONObject(
+			expectedJSONObject, objectRelationship2IdObjectFieldName,
+			_objectEntry3.getObjectEntryId());
+
+		_testPatchCustomObjectEntry(
+			endpoint, expectedJSONObject, objectRelationship2IdObjectFieldName,
+			_objectEntry3.getObjectEntryId());
+
+		// Precision decimal field
+
+		BigDecimal bigDecimal = randomBigDecimal.add(BigDecimal.ONE);
+
+		expectedJSONObject = _cloneJSONObject(
+			expectedJSONObject, _OBJECT_FIELD_NAME_PRECISION_DECIMAL,
+			bigDecimal);
+
+		_testPatchCustomObjectEntry(
+			endpoint, expectedJSONObject, _OBJECT_FIELD_NAME_PRECISION_DECIMAL,
+			bigDecimal);
+
+		// Rich text field
+
+		expectedJSONObject = _cloneJSONObject(
+			expectedJSONObject, _OBJECT_FIELD_NAME_RICH_TEXT,
+			"b" + randomString2);
+
+		_testPatchCustomObjectEntry(
+			endpoint, expectedJSONObject, _OBJECT_FIELD_NAME_RICH_TEXT,
+			"b" + randomString2);
+
+		// Text field
+
+		expectedJSONObject = _cloneJSONObject(
+			expectedJSONObject, _OBJECT_FIELD_NAME_TEXT, "b" + randomString3);
+
+		_testPatchCustomObjectEntry(
+			endpoint, expectedJSONObject, _OBJECT_FIELD_NAME_TEXT,
+			"b" + randomString3);
+	}
+
+	private void _testPatchCustomObjectEntry(
+			String endpoint, JSONObject expectedJSONObject, String fieldName,
+			Object fieldValue)
+		throws Exception {
+
+		JSONAssert.assertEquals(
+			expectedJSONObject.toString(),
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					fieldName, fieldValue
+				).put(
+					"externalReferenceCode",
+					expectedJSONObject.get("externalReferenceCode")
+				).toString(),
+				endpoint, Http.Method.PATCH
+			).toString(),
+			JSONCompareMode.LENIENT);
+	}
+
 	private void _testPatchPutCustomObjectEntryExternalReferenceCode(
 			Http.Method httpMethod, long objectEntryId)
 		throws Exception {
@@ -15190,71 +15715,6 @@ public class ObjectEntryResourceTest {
 					"externalReferenceCode", externalReferenceCode2
 				).toString(),
 				endpoint2 + externalReferenceCode1, httpMethod));
-	}
-
-	private void _testPatchPutScopeScopeKeyByExternalReferenceCode(
-			Http.Method httpMethod, ObjectDefinition objectDefinition)
-		throws Exception {
-
-		// Scope key as external reference code
-
-		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
-			objectDefinition, _OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1);
-
-		Group group = _groupLocalService.fetchGroup(objectEntry.getGroupId());
-
-		String objectFieldValue = RandomTestUtil.randomString();
-
-		Assert.assertEquals(
-			objectFieldValue,
-			JSONUtil.getValueAsString(
-				HTTPTestUtil.invokeToJSONObject(
-					JSONUtil.put(
-						_OBJECT_FIELD_NAME_1, objectFieldValue
-					).toString(),
-					StringBundler.concat(
-						_getEndpoint(
-							objectDefinition, group.getExternalReferenceCode()),
-						"/by-external-reference-code/",
-						objectEntry.getExternalReferenceCode()),
-					httpMethod),
-				"Object/" + _OBJECT_FIELD_NAME_1));
-
-		// Scope key as group ID
-
-		objectFieldValue = RandomTestUtil.randomString();
-
-		Assert.assertEquals(
-			objectFieldValue,
-			JSONUtil.getValueAsString(
-				HTTPTestUtil.invokeToJSONObject(
-					JSONUtil.put(
-						_OBJECT_FIELD_NAME_1, objectFieldValue
-					).toString(),
-					StringBundler.concat(
-						_getEndpoint(objectDefinition, group.getGroupId()),
-						"/by-external-reference-code/",
-						objectEntry.getExternalReferenceCode()),
-					httpMethod),
-				"Object/" + _OBJECT_FIELD_NAME_1));
-
-		// Scope key as group key
-
-		objectFieldValue = RandomTestUtil.randomString();
-
-		Assert.assertEquals(
-			objectFieldValue,
-			JSONUtil.getValueAsString(
-				HTTPTestUtil.invokeToJSONObject(
-					JSONUtil.put(
-						_OBJECT_FIELD_NAME_1, objectFieldValue
-					).toString(),
-					StringBundler.concat(
-						_getEndpoint(objectDefinition, group.getGroupKey()),
-						"/by-external-reference-code/",
-						objectEntry.getExternalReferenceCode()),
-					httpMethod),
-				"Object/" + _OBJECT_FIELD_NAME_1));
 	}
 
 	private void _testPostCustomObjectEntryWithAttachmentObjectField(
@@ -16435,6 +16895,437 @@ public class ObjectEntryResourceTest {
 		}
 	}
 
+	private void _testPutByExternalReferenceCodeCustomObjectEntry(
+			ObjectDefinition objectDefinition1,
+			ObjectDefinition objectDefinition2, Object scopeKey)
+		throws Exception {
+
+		_testPutCustomObjectEntry(
+			_getEndpoint(objectDefinition1, scopeKey) +
+				"/by-external-reference-code",
+			jsonObject -> jsonObject.getString("externalReferenceCode"),
+			objectDefinition1, objectDefinition2, scopeKey);
+	}
+
+	private void _testPutByExternalReferenceCodeMultipleOneToManyRelationships(
+			boolean removeRelationship)
+		throws Exception {
+
+		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectDefinition1, _objectDefinition2, TestPropsValues.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_objectRelationship2 = ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectDefinition2, _objectDefinition3, TestPropsValues.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
+			).put(
+				"externalReferenceCode", _ERC_VALUE_2
+			).put(
+				_objectRelationship1.getName(),
+				JSONUtil.put(
+					_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
+				).put(
+					"externalReferenceCode", _ERC_VALUE_1
+				)
+			).put(
+				_objectRelationship2.getName(),
+				JSONUtil.putAll(
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME_3, RandomTestUtil.randomString()
+					).put(
+						"externalReferenceCode", _ERC_VALUE_3
+					),
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME_3, RandomTestUtil.randomString()
+					).put(
+						"externalReferenceCode", RandomTestUtil.randomString()
+					))
+			).toString(),
+			_objectDefinition2.getRESTContextPath(), Http.Method.POST);
+
+		Assert.assertEquals(
+			200,
+			HTTPTestUtil.invokeToHttpCode(
+				JSONUtil.put(
+					_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2
+				).toString(),
+				StringBundler.concat(
+					_objectDefinition2.getRESTContextPath(),
+					"/by-external-reference-code/", _ERC_VALUE_2),
+				Http.Method.PUT));
+
+		String objectEntryId = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				_objectDefinition1.getRESTContextPath(),
+				"/by-external-reference-code/", _ERC_VALUE_1),
+			Http.Method.GET
+		).get(
+			"id"
+		).toString();
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				"items",
+				() -> {
+					if (removeRelationship) {
+						return JSONUtil.putAll();
+					}
+
+					return JSONUtil.putAll(
+						JSONUtil.put("externalReferenceCode", _ERC_VALUE_2));
+				}
+			).put(
+				"lastPage", 1
+			).put(
+				"page", 1
+			).put(
+				"pageSize", 20
+			).put(
+				"totalCount", () -> removeRelationship ? 0 : 1
+			).toString(),
+			HTTPTestUtil.invokeToJSONObject(
+				null,
+				StringBundler.concat(
+					_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
+					objectEntryId, StringPool.SLASH,
+					_objectRelationship1.getName()),
+				Http.Method.GET
+			).toString(),
+			JSONCompareMode.LENIENT);
+
+		Assert.assertEquals(
+			200,
+			HTTPTestUtil.invokeToHttpCode(
+				JSONUtil.put(
+					_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2
+				).put(
+					_objectRelationship1.getName(),
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1
+					).put(
+						"externalReferenceCode", _ERC_VALUE_1
+					)
+				).put(
+					_objectRelationship2.getName(),
+					_createObjectEntriesJSONArray(
+						new String[] {_ERC_VALUE_3}, _OBJECT_FIELD_NAME_3,
+						new String[] {_NEW_OBJECT_FIELD_VALUE_3})
+				).toString(),
+				StringBundler.concat(
+					_objectDefinition2.getRESTContextPath(),
+					"/by-external-reference-code/", _ERC_VALUE_2),
+				Http.Method.PUT));
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				"items",
+				JSONUtil.putAll(
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2
+					).put(
+						"externalReferenceCode", _ERC_VALUE_2
+					))
+			).put(
+				"lastPage", 1
+			).put(
+				"page", 1
+			).put(
+				"pageSize", 20
+			).put(
+				"totalCount", 1
+			).toString(),
+			HTTPTestUtil.invokeToJSONObject(
+				null,
+				StringBundler.concat(
+					_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
+					objectEntryId, StringPool.SLASH,
+					_objectRelationship1.getName()),
+				Http.Method.GET
+			).toString(),
+			JSONCompareMode.LENIENT);
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				"items",
+				JSONUtil.putAll(
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME_3, _NEW_OBJECT_FIELD_VALUE_3
+					).put(
+						"externalReferenceCode", _ERC_VALUE_3
+					))
+			).put(
+				"lastPage", 1
+			).put(
+				"page", 1
+			).put(
+				"pageSize", 20
+			).put(
+				"totalCount", 1
+			).toString(),
+			HTTPTestUtil.invokeToJSONObject(
+				null,
+				StringBundler.concat(
+					_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
+					jsonObject.get("id"), StringPool.SLASH,
+					_objectRelationship2.getName()),
+				Http.Method.GET
+			).toString(),
+			JSONCompareMode.LENIENT);
+	}
+
+	private void _testPutCustomObjectEntry(
+			ObjectDefinition objectDefinition1,
+			ObjectDefinition objectDefinition2, Object scopeKey)
+		throws Exception {
+
+		_testPutCustomObjectEntry(
+			objectDefinition1.getRESTContextPath(),
+			jsonObject -> jsonObject.getLong("id"), objectDefinition1,
+			objectDefinition2, scopeKey);
+	}
+
+	private void _testPutCustomObjectEntry(
+			String contextPath, Function<JSONObject, Object> keyGetterFunction,
+			ObjectDefinition objectDefinition1,
+			ObjectDefinition objectDefinition2, Object scopeKey)
+		throws Exception {
+
+		_objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
+			objectDefinition2, _OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
+
+		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
+			objectDefinition2, objectDefinition1, TestPropsValues.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_objectRelationship2 = ObjectRelationshipTestUtil.addObjectRelationship(
+			objectDefinition2, objectDefinition1, TestPropsValues.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		String objectRelationship1ERCObjectFieldName =
+			ObjectFieldSettingUtil.getValue(
+				ObjectFieldSettingConstants.
+					NAME_OBJECT_RELATIONSHIP_ERC_OBJECT_FIELD_NAME,
+				_objectFieldLocalService.getObjectField(
+					_objectRelationship1.getObjectFieldId2()));
+
+		String objectRelationship2IdObjectFieldName =
+			ObjectFieldSettingUtil.getValue(
+				ObjectFieldSettingConstants.
+					NAME_OBJECT_RELATIONSHIP_ERC_OBJECT_FIELD_NAME,
+				_objectFieldLocalService.getObjectField(
+					_objectRelationship2.getObjectFieldId2())
+			).replace(
+				"ERC", "Id"
+			);
+
+		BigDecimal randomBigDecimal = BigDecimal.valueOf(
+			RandomTestUtil.randomDouble()
+		).setScale(
+			5, RoundingMode.HALF_UP
+		);
+		boolean randomBoolean = RandomTestUtil.randomBoolean();
+		Date randomDate1 = RandomTestUtil.nextDate();
+		Date randomDate2 = RandomTestUtil.nextDate();
+		Date randomDate3 = RandomTestUtil.nextDate();
+		String randomExternalReferenceCode = RandomTestUtil.randomString();
+		float randomFloat = RandomTestUtil.randomFloat();
+		int randomInt = RandomTestUtil.randomInt();
+		long randomLong = RandomTestUtil.randomLong(
+			ObjectFieldValidationConstants.BUSINESS_TYPE_LONG_VALUE_MIN,
+			ObjectFieldValidationConstants.BUSINESS_TYPE_LONG_VALUE_MAX);
+		String randomString1 = RandomTestUtil.randomString();
+		String randomString2 = RandomTestUtil.randomString();
+		String randomString3 = RandomTestUtil.randomString();
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_OBJECT_FIELD_NAME_BOOLEAN, randomBoolean
+			).put(
+				_OBJECT_FIELD_NAME_DATE, _dateFormat.format(randomDate1)
+			).put(
+				_OBJECT_FIELD_NAME_DATE_TIME_INPUT,
+				_dateTimeDateFormat.format(randomDate2)
+			).put(
+				_OBJECT_FIELD_NAME_DATE_TIME_UTC,
+				_dateTimeDateFormat.format(randomDate3)
+			).put(
+				_OBJECT_FIELD_NAME_DECIMAL, randomFloat
+			).put(
+				_OBJECT_FIELD_NAME_INTEGER, randomInt
+			).put(
+				_OBJECT_FIELD_NAME_LONG_INTEGER, randomLong
+			).put(
+				_OBJECT_FIELD_NAME_LONG_TEXT, randomString1
+			).put(
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				JSONUtil.putAll(_LIST_TYPE_ENTRY_KEY_1, _LIST_TYPE_ENTRY_KEY_2)
+			).put(
+				_OBJECT_FIELD_NAME_PICKLIST, _LIST_TYPE_ENTRY_KEY_3
+			).put(
+				_OBJECT_FIELD_NAME_PRECISION_DECIMAL, randomBigDecimal
+			).put(
+				_OBJECT_FIELD_NAME_RICH_TEXT, randomString2
+			).put(
+				_OBJECT_FIELD_NAME_TEXT, randomString3
+			).put(
+				objectRelationship1ERCObjectFieldName,
+				_objectEntry2.getExternalReferenceCode()
+			).put(
+				objectRelationship2IdObjectFieldName,
+				_objectEntry2.getObjectEntryId()
+			).put(
+				"externalReferenceCode", randomExternalReferenceCode
+			).toString(),
+			_getEndpoint(objectDefinition1, scopeKey), Http.Method.POST);
+
+		String endpoint =
+			contextPath + "/" + keyGetterFunction.apply(jsonObject);
+
+		HTTPTestUtil.invokeToJSONObject(
+			JSONFactoryUtil.getNullJSON(), endpoint, Http.Method.PUT);
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				_OBJECT_FIELD_NAME_BOOLEAN, false
+			).put(
+				_OBJECT_FIELD_NAME_DATE, (Timestamp)null
+			).put(
+				_OBJECT_FIELD_NAME_DATE_TIME_INPUT, (Timestamp)null
+			).put(
+				_OBJECT_FIELD_NAME_DATE_TIME_UTC, (Timestamp)null
+			).put(
+				_OBJECT_FIELD_NAME_DECIMAL, 0
+			).put(
+				_OBJECT_FIELD_NAME_INTEGER, 0
+			).put(
+				_OBJECT_FIELD_NAME_LONG_INTEGER, 0
+			).put(
+				_OBJECT_FIELD_NAME_LONG_TEXT, ""
+			).put(
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				JSONFactoryUtil.createJSONArray()
+			).put(
+				_OBJECT_FIELD_NAME_PICKLIST, JSONUtil.put("key", "")
+			).put(
+				_OBJECT_FIELD_NAME_PRECISION_DECIMAL, 0
+			).put(
+				_OBJECT_FIELD_NAME_RICH_TEXT, ""
+			).put(
+				_OBJECT_FIELD_NAME_TEXT, ""
+			).put(
+				objectRelationship1ERCObjectFieldName, ""
+			).put(
+				"externalReferenceCode", randomExternalReferenceCode
+			).toString(),
+			HTTPTestUtil.invokeToJSONObject(
+				null, endpoint, Http.Method.GET
+			).toString(),
+			JSONCompareMode.LENIENT);
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				_OBJECT_FIELD_NAME_BOOLEAN, randomBoolean
+			).put(
+				_OBJECT_FIELD_NAME_DATE,
+				_dateFormat.format(randomDate1) + "T00:00:00.000Z"
+			).put(
+				_OBJECT_FIELD_NAME_DATE_TIME_INPUT,
+				StringUtil.removeLast(
+					_dateTimeDateFormat.format(randomDate2), "Z")
+			).put(
+				_OBJECT_FIELD_NAME_DATE_TIME_UTC,
+				_dateTimeDateFormat.format(randomDate3)
+			).put(
+				_OBJECT_FIELD_NAME_DECIMAL, randomFloat
+			).put(
+				_OBJECT_FIELD_NAME_INTEGER, randomInt
+			).put(
+				_OBJECT_FIELD_NAME_LONG_INTEGER, (double)randomLong
+			).put(
+				_OBJECT_FIELD_NAME_LONG_TEXT, randomString1
+			).put(
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				JSONUtil.putAll(
+					JSONUtil.put(
+						"key", _LIST_TYPE_ENTRY_KEY_1
+					).put(
+						"name", _listTypeEntry1.getName(LocaleUtil.getDefault())
+					),
+					JSONUtil.put(
+						"key", _LIST_TYPE_ENTRY_KEY_2
+					).put(
+						"name", _listTypeEntry2.getName(LocaleUtil.getDefault())
+					))
+			).put(
+				_OBJECT_FIELD_NAME_PICKLIST,
+				JSONUtil.put(
+					"key", _LIST_TYPE_ENTRY_KEY_3
+				).put(
+					"name", _listTypeEntry3.getName(LocaleUtil.getDefault())
+				)
+			).put(
+				_OBJECT_FIELD_NAME_PRECISION_DECIMAL, randomBigDecimal
+			).put(
+				_OBJECT_FIELD_NAME_RICH_TEXT, randomString2
+			).put(
+				_OBJECT_FIELD_NAME_TEXT, randomString3
+			).put(
+				objectRelationship1ERCObjectFieldName,
+				_objectEntry2.getExternalReferenceCode()
+			).put(
+				objectRelationship2IdObjectFieldName,
+				(int)_objectEntry2.getObjectEntryId()
+			).put(
+				"externalReferenceCode", randomExternalReferenceCode
+			).toString(),
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					_OBJECT_FIELD_NAME_BOOLEAN, randomBoolean
+				).put(
+					_OBJECT_FIELD_NAME_DATE, _dateFormat.format(randomDate1)
+				).put(
+					_OBJECT_FIELD_NAME_DATE_TIME_INPUT,
+					_dateTimeDateFormat.format(randomDate2)
+				).put(
+					_OBJECT_FIELD_NAME_DATE_TIME_UTC,
+					_dateTimeDateFormat.format(randomDate3)
+				).put(
+					_OBJECT_FIELD_NAME_DECIMAL, randomFloat
+				).put(
+					_OBJECT_FIELD_NAME_INTEGER, randomInt
+				).put(
+					_OBJECT_FIELD_NAME_LONG_INTEGER, randomLong
+				).put(
+					_OBJECT_FIELD_NAME_LONG_TEXT, randomString1
+				).put(
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+					JSONUtil.putAll(
+						_LIST_TYPE_ENTRY_KEY_1, _LIST_TYPE_ENTRY_KEY_2)
+				).put(
+					_OBJECT_FIELD_NAME_PICKLIST, _LIST_TYPE_ENTRY_KEY_3
+				).put(
+					_OBJECT_FIELD_NAME_PRECISION_DECIMAL, randomBigDecimal
+				).put(
+					_OBJECT_FIELD_NAME_RICH_TEXT, randomString2
+				).put(
+					_OBJECT_FIELD_NAME_TEXT, randomString3
+				).put(
+					objectRelationship1ERCObjectFieldName,
+					_objectEntry2.getExternalReferenceCode()
+				).put(
+					objectRelationship2IdObjectFieldName,
+					_objectEntry2.getObjectEntryId()
+				).toString(),
+				endpoint, Http.Method.PUT
+			).toString(),
+			JSONCompareMode.LENIENT);
+	}
+
 	private void _testPutCustomObjectEntryUnlinkNestedCustomObjectEntries(
 			boolean manyToOne)
 		throws Exception {
@@ -17351,6 +18242,10 @@ public class ObjectEntryResourceTest {
 
 	@Inject
 	private ListTypeDefinitionLocalService _listTypeDefinitionLocalService;
+
+	private ListTypeEntry _listTypeEntry1;
+	private ListTypeEntry _listTypeEntry2;
+	private ListTypeEntry _listTypeEntry3;
 
 	@Inject
 	private ListTypeEntryLocalService _listTypeEntryLocalService;

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -239,8 +239,7 @@ import org.springframework.transaction.support.DefaultTransactionStatus;
  */
 @FeatureFlags(
 	featureFlags = {
-		@FeatureFlag(value = "LPD-45945"), @FeatureFlag(value = "LPS-164801"),
-		@FeatureFlag(enable = false, value = "LPD-54417")
+		@FeatureFlag(value = "LPD-45945"), @FeatureFlag(value = "LPS-164801")
 	}
 )
 @RunWith(Arquillian.class)
@@ -9625,17 +9624,6 @@ public class ObjectEntryResourceTest {
 			TestPropsValues.getGroupId());
 	}
 
-	@FeatureFlag("LPD-54417")
-	@Test
-	@TestInfo("LPD-53245")
-	public void testPutByExternalReferenceCodeCustomObjectEntryWithDeprecatedFeatureFlag()
-		throws Exception {
-
-		_testPatchByExternalReferenceCodeCustomObjectEntry(
-			_objectDefinition1, _objectDefinition2,
-			TestPropsValues.getGroupId());
-	}
-
 	@Test
 	public void testPutByExternalReferenceCodeManyToManyRelationship()
 		throws Exception {
@@ -9885,16 +9873,165 @@ public class ObjectEntryResourceTest {
 	public void testPutByExternalReferenceCodeMultipleOneToManyRelationships()
 		throws Exception {
 
-		_testPutByExternalReferenceCodeMultipleOneToManyRelationships(true);
-	}
+		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectDefinition1, _objectDefinition2, TestPropsValues.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-	@FeatureFlag("LPD-54417")
-	@Test
-	@TestInfo("LPD-53245")
-	public void testPutByExternalReferenceCodeMultipleOneToManyRelationshipsWithDeprecatedFeatureFlag()
-		throws Exception {
+		_objectRelationship2 = ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectDefinition2, _objectDefinition3, TestPropsValues.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		_testPutByExternalReferenceCodeMultipleOneToManyRelationships(false);
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
+			).put(
+				"externalReferenceCode", _ERC_VALUE_2
+			).put(
+				_objectRelationship1.getName(),
+				JSONUtil.put(
+					_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
+				).put(
+					"externalReferenceCode", _ERC_VALUE_1
+				)
+			).put(
+				_objectRelationship2.getName(),
+				JSONUtil.putAll(
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME_3, RandomTestUtil.randomString()
+					).put(
+						"externalReferenceCode", _ERC_VALUE_3
+					),
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME_3, RandomTestUtil.randomString()
+					).put(
+						"externalReferenceCode", RandomTestUtil.randomString()
+					))
+			).toString(),
+			_objectDefinition2.getRESTContextPath(), Http.Method.POST);
+
+		Assert.assertEquals(
+			200,
+			HTTPTestUtil.invokeToHttpCode(
+				JSONUtil.put(
+					_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2
+				).toString(),
+				StringBundler.concat(
+					_objectDefinition2.getRESTContextPath(),
+					"/by-external-reference-code/", _ERC_VALUE_2),
+				Http.Method.PUT));
+
+		String objectEntryId = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				_objectDefinition1.getRESTContextPath(),
+				"/by-external-reference-code/", _ERC_VALUE_1),
+			Http.Method.GET
+		).get(
+			"id"
+		).toString();
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				"items",
+				JSONUtil.putAll(
+					JSONUtil.put("externalReferenceCode", _ERC_VALUE_2))
+			).put(
+				"lastPage", 1
+			).put(
+				"page", 1
+			).put(
+				"pageSize", 20
+			).put(
+				"totalCount", 1
+			).toString(),
+			HTTPTestUtil.invokeToJSONObject(
+				null,
+				StringBundler.concat(
+					_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
+					objectEntryId, StringPool.SLASH,
+					_objectRelationship1.getName()),
+				Http.Method.GET
+			).toString(),
+			JSONCompareMode.LENIENT);
+
+		Assert.assertEquals(
+			200,
+			HTTPTestUtil.invokeToHttpCode(
+				JSONUtil.put(
+					_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2
+				).put(
+					_objectRelationship1.getName(),
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1
+					).put(
+						"externalReferenceCode", _ERC_VALUE_1
+					)
+				).put(
+					_objectRelationship2.getName(),
+					_createObjectEntriesJSONArray(
+						new String[] {_ERC_VALUE_3}, _OBJECT_FIELD_NAME_3,
+						new String[] {_NEW_OBJECT_FIELD_VALUE_3})
+				).toString(),
+				StringBundler.concat(
+					_objectDefinition2.getRESTContextPath(),
+					"/by-external-reference-code/", _ERC_VALUE_2),
+				Http.Method.PUT));
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				"items",
+				JSONUtil.putAll(
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2
+					).put(
+						"externalReferenceCode", _ERC_VALUE_2
+					))
+			).put(
+				"lastPage", 1
+			).put(
+				"page", 1
+			).put(
+				"pageSize", 20
+			).put(
+				"totalCount", 1
+			).toString(),
+			HTTPTestUtil.invokeToJSONObject(
+				null,
+				StringBundler.concat(
+					_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
+					objectEntryId, StringPool.SLASH,
+					_objectRelationship1.getName()),
+				Http.Method.GET
+			).toString(),
+			JSONCompareMode.LENIENT);
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				"items",
+				JSONUtil.putAll(
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME_3, _NEW_OBJECT_FIELD_VALUE_3
+					).put(
+						"externalReferenceCode", _ERC_VALUE_3
+					))
+			).put(
+				"lastPage", 1
+			).put(
+				"page", 1
+			).put(
+				"pageSize", 20
+			).put(
+				"totalCount", 1
+			).toString(),
+			HTTPTestUtil.invokeToJSONObject(
+				null,
+				StringBundler.concat(
+					_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
+					jsonObject.get("id"), StringPool.SLASH,
+					_objectRelationship2.getName()),
+				Http.Method.GET
+			).toString(),
+			JSONCompareMode.LENIENT);
 	}
 
 	@Test
@@ -9903,17 +10040,6 @@ public class ObjectEntryResourceTest {
 		throws Exception {
 
 		_testPutByExternalReferenceCodeCustomObjectEntry(
-			_siteScopedObjectDefinition1, _siteScopedObjectDefinition2,
-			TestPropsValues.getGroupId());
-	}
-
-	@FeatureFlag("LPD-54417")
-	@Test
-	@TestInfo("LPD-53245")
-	public void testPutByExternalReferenceCodeSiteScopedCustomObjectEntryWithDeprecatedFeatureFlag()
-		throws Exception {
-
-		_testPatchByExternalReferenceCodeCustomObjectEntry(
 			_siteScopedObjectDefinition1, _siteScopedObjectDefinition2,
 			TestPropsValues.getGroupId());
 	}
@@ -10124,17 +10250,6 @@ public class ObjectEntryResourceTest {
 
 		_testPutCustomObjectEntryUnlinkNestedCustomObjectEntriesByExternalReferenceCode(
 			false);
-	}
-
-	@FeatureFlag("LPD-54417")
-	@Test
-	@TestInfo("LPD-53245")
-	public void testPutCustomObjectEntryWithDeprecatedFeatureFlag()
-		throws Exception {
-
-		_testPatchCustomObjectEntry(
-			_objectDefinition1, _objectDefinition2,
-			TestPropsValues.getGroupId());
 	}
 
 	@FeatureFlag("LPD-32050")
@@ -10584,17 +10699,6 @@ public class ObjectEntryResourceTest {
 	@TestInfo("LPD-53245")
 	public void testPutSiteScopedCustomObjectEntry() throws Exception {
 		_testPutCustomObjectEntry(
-			_siteScopedObjectDefinition1, _siteScopedObjectDefinition2,
-			TestPropsValues.getGroupId());
-	}
-
-	@FeatureFlag("LPD-54417")
-	@Test
-	@TestInfo("LPD-53245")
-	public void testPutSiteScopedCustomObjectEntryWithDeprecatedFeatureFlag()
-		throws Exception {
-
-		_testPatchCustomObjectEntry(
 			_siteScopedObjectDefinition1, _siteScopedObjectDefinition2,
 			TestPropsValues.getGroupId());
 	}
@@ -16905,177 +17009,6 @@ public class ObjectEntryResourceTest {
 				"/by-external-reference-code",
 			jsonObject -> jsonObject.getString("externalReferenceCode"),
 			objectDefinition1, objectDefinition2, scopeKey);
-	}
-
-	private void _testPutByExternalReferenceCodeMultipleOneToManyRelationships(
-			boolean removeRelationship)
-		throws Exception {
-
-		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
-			_objectDefinition1, _objectDefinition2, TestPropsValues.getUserId(),
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-		_objectRelationship2 = ObjectRelationshipTestUtil.addObjectRelationship(
-			_objectDefinition2, _objectDefinition3, TestPropsValues.getUserId(),
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
-			JSONUtil.put(
-				_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
-			).put(
-				"externalReferenceCode", _ERC_VALUE_2
-			).put(
-				_objectRelationship1.getName(),
-				JSONUtil.put(
-					_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
-				).put(
-					"externalReferenceCode", _ERC_VALUE_1
-				)
-			).put(
-				_objectRelationship2.getName(),
-				JSONUtil.putAll(
-					JSONUtil.put(
-						_OBJECT_FIELD_NAME_3, RandomTestUtil.randomString()
-					).put(
-						"externalReferenceCode", _ERC_VALUE_3
-					),
-					JSONUtil.put(
-						_OBJECT_FIELD_NAME_3, RandomTestUtil.randomString()
-					).put(
-						"externalReferenceCode", RandomTestUtil.randomString()
-					))
-			).toString(),
-			_objectDefinition2.getRESTContextPath(), Http.Method.POST);
-
-		Assert.assertEquals(
-			200,
-			HTTPTestUtil.invokeToHttpCode(
-				JSONUtil.put(
-					_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2
-				).toString(),
-				StringBundler.concat(
-					_objectDefinition2.getRESTContextPath(),
-					"/by-external-reference-code/", _ERC_VALUE_2),
-				Http.Method.PUT));
-
-		String objectEntryId = HTTPTestUtil.invokeToJSONObject(
-			null,
-			StringBundler.concat(
-				_objectDefinition1.getRESTContextPath(),
-				"/by-external-reference-code/", _ERC_VALUE_1),
-			Http.Method.GET
-		).get(
-			"id"
-		).toString();
-
-		JSONAssert.assertEquals(
-			JSONUtil.put(
-				"items",
-				() -> {
-					if (removeRelationship) {
-						return JSONUtil.putAll();
-					}
-
-					return JSONUtil.putAll(
-						JSONUtil.put("externalReferenceCode", _ERC_VALUE_2));
-				}
-			).put(
-				"lastPage", 1
-			).put(
-				"page", 1
-			).put(
-				"pageSize", 20
-			).put(
-				"totalCount", () -> removeRelationship ? 0 : 1
-			).toString(),
-			HTTPTestUtil.invokeToJSONObject(
-				null,
-				StringBundler.concat(
-					_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
-					objectEntryId, StringPool.SLASH,
-					_objectRelationship1.getName()),
-				Http.Method.GET
-			).toString(),
-			JSONCompareMode.LENIENT);
-
-		Assert.assertEquals(
-			200,
-			HTTPTestUtil.invokeToHttpCode(
-				JSONUtil.put(
-					_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2
-				).put(
-					_objectRelationship1.getName(),
-					JSONUtil.put(
-						_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1
-					).put(
-						"externalReferenceCode", _ERC_VALUE_1
-					)
-				).put(
-					_objectRelationship2.getName(),
-					_createObjectEntriesJSONArray(
-						new String[] {_ERC_VALUE_3}, _OBJECT_FIELD_NAME_3,
-						new String[] {_NEW_OBJECT_FIELD_VALUE_3})
-				).toString(),
-				StringBundler.concat(
-					_objectDefinition2.getRESTContextPath(),
-					"/by-external-reference-code/", _ERC_VALUE_2),
-				Http.Method.PUT));
-
-		JSONAssert.assertEquals(
-			JSONUtil.put(
-				"items",
-				JSONUtil.putAll(
-					JSONUtil.put(
-						_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2
-					).put(
-						"externalReferenceCode", _ERC_VALUE_2
-					))
-			).put(
-				"lastPage", 1
-			).put(
-				"page", 1
-			).put(
-				"pageSize", 20
-			).put(
-				"totalCount", 1
-			).toString(),
-			HTTPTestUtil.invokeToJSONObject(
-				null,
-				StringBundler.concat(
-					_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
-					objectEntryId, StringPool.SLASH,
-					_objectRelationship1.getName()),
-				Http.Method.GET
-			).toString(),
-			JSONCompareMode.LENIENT);
-
-		JSONAssert.assertEquals(
-			JSONUtil.put(
-				"items",
-				JSONUtil.putAll(
-					JSONUtil.put(
-						_OBJECT_FIELD_NAME_3, _NEW_OBJECT_FIELD_VALUE_3
-					).put(
-						"externalReferenceCode", _ERC_VALUE_3
-					))
-			).put(
-				"lastPage", 1
-			).put(
-				"page", 1
-			).put(
-				"pageSize", 20
-			).put(
-				"totalCount", 1
-			).toString(),
-			HTTPTestUtil.invokeToJSONObject(
-				null,
-				StringBundler.concat(
-					_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
-					jsonObject.get("id"), StringPool.SLASH,
-					_objectRelationship2.getName()),
-				Http.Method.GET
-			).toString(),
-			JSONCompareMode.LENIENT);
 	}
 
 	private void _testPutCustomObjectEntry(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -122,7 +122,6 @@ import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUti
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -254,10 +253,11 @@ public class ObjectEntryResourceTest {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
+		_testGroupId = TestPropsValues.getGroupId();
+
 		_assetVocabulary = AssetVocabularyLocalServiceUtil.addVocabulary(
 			UserLocalServiceUtil.getGuestUserId(TestPropsValues.getCompanyId()),
-			TestPropsValues.getGroupId(), RandomTestUtil.randomString(),
-			new ServiceContext());
+			_testGroupId, RandomTestUtil.randomString(), new ServiceContext());
 
 		Bundle bundle = FrameworkUtil.getBundle(ObjectEntryResourceTest.class);
 
@@ -7661,27 +7661,29 @@ public class ObjectEntryResourceTest {
 	public void testPatchByExternalReferenceCodeCustomObjectEntry()
 		throws Exception {
 
-		_testPatchByExternalReferenceCodeCustomObjectEntry(
-			_objectDefinition1, _objectDefinition2,
-			TestPropsValues.getGroupId());
-	}
-
-	@Test
-	@TestInfo("LPD-53245")
-	public void testPatchByExternalReferenceCodeSiteScopedCustomObjectEntry()
-		throws Exception {
-
-		_testPatchByExternalReferenceCodeCustomObjectEntry(
-			_siteScopedObjectDefinition1, _siteScopedObjectDefinition2,
-			TestPropsValues.getGroupId());
+		_testPatchCustomObjectEntry(
+			jsonObject ->
+				_objectDefinition1.getRESTContextPath() +
+					"/by-external-reference-code/" +
+						jsonObject.getString("externalReferenceCode"),
+			_objectDefinition1, _objectDefinition2, _testGroupId);
 	}
 
 	@Test
 	@TestInfo("LPD-53245")
 	public void testPatchCustomObjectEntry() throws Exception {
 		_testPatchCustomObjectEntry(
-			_objectDefinition1, _objectDefinition2,
-			TestPropsValues.getGroupId());
+			jsonObject ->
+				_objectDefinition1.getRESTContextPath() + "/" +
+					jsonObject.getLong("id"),
+			_objectDefinition1, _objectDefinition2, _testGroupId);
+
+		_testPatchCustomObjectEntry(
+			jsonObject ->
+				_siteScopedObjectDefinition1.getRESTContextPath() + "/" +
+					jsonObject.getLong("id"),
+			_siteScopedObjectDefinition1, _siteScopedObjectDefinition2,
+			_testGroupId);
 	}
 
 	@FeatureFlag("LPD-21926")
@@ -8120,45 +8122,47 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testPatchPutScopeScopeKeyByExternalReferenceCode()
+	@TestInfo("LPD-53245")
+	public void testPatchScopeScopeKeyByExternalReferenceCode()
 		throws Exception {
 
-		Group group = GroupLocalServiceUtil.getGroup(
-			TestPropsValues.getCompanyId(), GroupConstants.GUEST);
+		Group group = _groupLocalService.fetchGroup(_testGroupId);
 
-		// Scope key as external reference code
+		// scopeKey: externalReferenceCode
 
-		_testPatchByExternalReferenceCodeCustomObjectEntry(
-			_objectDefinition1, _objectDefinition2,
-			group.getExternalReferenceCode());
+		String externalReferenceCodeEndpoint = _getEndpoint(
+			_siteScopedObjectDefinition1, group.getExternalReferenceCode());
 
-		_testPutByExternalReferenceCodeCustomObjectEntry(
-			_objectDefinition1, _objectDefinition2,
-			group.getExternalReferenceCode());
-
-		// Scope key as group ID
-
-		_testPatchByExternalReferenceCodeCustomObjectEntry(
-			_objectDefinition1, _objectDefinition2, group.getGroupId());
-
-		_testPutByExternalReferenceCodeCustomObjectEntry(
-			_objectDefinition1, _objectDefinition2, group.getGroupId());
-
-		// Scope key as group key
-
-		_testPatchByExternalReferenceCodeCustomObjectEntry(
-			_objectDefinition1, _objectDefinition2, group.getGroupKey());
-
-		_testPutByExternalReferenceCodeCustomObjectEntry(
-			_objectDefinition1, _objectDefinition2, group.getGroupKey());
-	}
-
-	@Test
-	@TestInfo("LPD-53245")
-	public void testPatchSiteScopedCustomObjectEntry() throws Exception {
 		_testPatchCustomObjectEntry(
+			jsonObject ->
+				externalReferenceCodeEndpoint + "/by-external-reference-code/" +
+					jsonObject.getString("externalReferenceCode"),
 			_siteScopedObjectDefinition1, _siteScopedObjectDefinition2,
-			TestPropsValues.getGroupId());
+			group.getExternalReferenceCode());
+
+		// scopeKey: groupId
+
+		String groupIdEndpoint = _getEndpoint(
+			_siteScopedObjectDefinition1, _testGroupId);
+
+		_testPatchCustomObjectEntry(
+			jsonObject ->
+				groupIdEndpoint + "/by-external-reference-code/" +
+					jsonObject.getString("externalReferenceCode"),
+			_siteScopedObjectDefinition1, _siteScopedObjectDefinition2,
+			_testGroupId);
+
+		// scopeKey: groupKey
+
+		String groupKeyEndpoint = _getEndpoint(
+			_siteScopedObjectDefinition1, group.getGroupKey());
+
+		_testPatchCustomObjectEntry(
+			jsonObject ->
+				groupKeyEndpoint + "/by-external-reference-code/" +
+					jsonObject.getString("externalReferenceCode"),
+			_siteScopedObjectDefinition1, _siteScopedObjectDefinition2,
+			group.getGroupKey());
 	}
 
 	@FeatureFlag("LPD-39967")
@@ -9619,9 +9623,12 @@ public class ObjectEntryResourceTest {
 	public void testPutByExternalReferenceCodeCustomObjectEntry()
 		throws Exception {
 
-		_testPutByExternalReferenceCodeCustomObjectEntry(
-			_objectDefinition1, _objectDefinition2,
-			TestPropsValues.getGroupId());
+		_testPutCustomObjectEntry(
+			jsonObject ->
+				_objectDefinition1.getRESTContextPath() +
+					"/by-external-reference-code/" +
+						jsonObject.getString("externalReferenceCode"),
+			_objectDefinition1, _objectDefinition2, _testGroupId);
 	}
 
 	@Test
@@ -10035,16 +10042,6 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	@TestInfo("LPD-53245")
-	public void testPutByExternalReferenceCodeSiteScopedCustomObjectEntry()
-		throws Exception {
-
-		_testPutByExternalReferenceCodeCustomObjectEntry(
-			_siteScopedObjectDefinition1, _siteScopedObjectDefinition2,
-			TestPropsValues.getGroupId());
-	}
-
-	@Test
 	public void testPutByExternalReferenceCodeWithNonexistentValueOneToManyRelationship()
 		throws Exception {
 
@@ -10091,8 +10088,17 @@ public class ObjectEntryResourceTest {
 	@TestInfo("LPD-53245")
 	public void testPutCustomObjectEntry() throws Exception {
 		_testPutCustomObjectEntry(
-			_objectDefinition1, _objectDefinition2,
-			TestPropsValues.getGroupId());
+			jsonObject ->
+				_objectDefinition1.getRESTContextPath() + "/" +
+					jsonObject.getLong("id"),
+			_objectDefinition1, _objectDefinition2, _testGroupId);
+
+		_testPutCustomObjectEntry(
+			jsonObject ->
+				_siteScopedObjectDefinition1.getRESTContextPath() + "/" +
+					jsonObject.getLong("id"),
+			_siteScopedObjectDefinition1, _siteScopedObjectDefinition2,
+			_testGroupId);
 	}
 
 	@Test
@@ -10697,10 +10703,44 @@ public class ObjectEntryResourceTest {
 
 	@Test
 	@TestInfo("LPD-53245")
-	public void testPutSiteScopedCustomObjectEntry() throws Exception {
+	public void testPutScopeScopeKeyByExternalReferenceCode() throws Exception {
+		Group group = _groupLocalService.fetchGroup(_testGroupId);
+
+		// scopeKey: externalReferenceCode
+
+		String externalReferenceCodeEndpoint = _getEndpoint(
+			_siteScopedObjectDefinition1, group.getExternalReferenceCode());
+
 		_testPutCustomObjectEntry(
+			jsonObject ->
+				externalReferenceCodeEndpoint + "/by-external-reference-code/" +
+					jsonObject.getString("externalReferenceCode"),
 			_siteScopedObjectDefinition1, _siteScopedObjectDefinition2,
-			TestPropsValues.getGroupId());
+			group.getExternalReferenceCode());
+
+		// scopeKey: groupId
+
+		String groupIdEndpoint = _getEndpoint(
+			_siteScopedObjectDefinition1, _testGroupId);
+
+		_testPutCustomObjectEntry(
+			jsonObject ->
+				groupIdEndpoint + "/by-external-reference-code/" +
+					jsonObject.getString("externalReferenceCode"),
+			_siteScopedObjectDefinition1, _siteScopedObjectDefinition2,
+			_testGroupId);
+
+		// scopeKey: groupKey
+
+		String groupKeyEndpoint = _getEndpoint(
+			_siteScopedObjectDefinition1, group.getGroupKey());
+
+		_testPutCustomObjectEntry(
+			jsonObject ->
+				groupKeyEndpoint + "/by-external-reference-code/" +
+					jsonObject.getString("externalReferenceCode"),
+			_siteScopedObjectDefinition1, _siteScopedObjectDefinition2,
+			group.getGroupKey());
 	}
 
 	@Test
@@ -14783,31 +14823,8 @@ public class ObjectEntryResourceTest {
 		unsafeTriConsumer.accept(actionJSONObject, jsonObject, objectAction);
 	}
 
-	private void _testPatchByExternalReferenceCodeCustomObjectEntry(
-			ObjectDefinition objectDefinition1,
-			ObjectDefinition objectDefinition2, Object scopeKey)
-		throws Exception {
-
-		_testPatchCustomObjectEntry(
-			_getEndpoint(objectDefinition1, scopeKey) +
-				"/by-external-reference-code",
-			jsonObject -> jsonObject.getString("externalReferenceCode"),
-			objectDefinition1, objectDefinition2, scopeKey);
-	}
-
 	private void _testPatchCustomObjectEntry(
-			ObjectDefinition objectDefinition1,
-			ObjectDefinition objectDefinition2, Object scopeKey)
-		throws Exception {
-
-		_testPatchCustomObjectEntry(
-			objectDefinition1.getRESTContextPath(),
-			jsonObject -> jsonObject.getLong("id"), objectDefinition1,
-			objectDefinition2, scopeKey);
-	}
-
-	private void _testPatchCustomObjectEntry(
-			String contextPath, Function<JSONObject, Object> keyGetterFunction,
+			Function<JSONObject, String> endpointFunction,
 			ObjectDefinition objectDefinition1,
 			ObjectDefinition objectDefinition2, Object scopeKey)
 		throws Exception {
@@ -14960,8 +14977,7 @@ public class ObjectEntryResourceTest {
 			"id", (Object)jsonObject.getLong("id")
 		);
 
-		String endpoint =
-			contextPath + "/" + keyGetterFunction.apply(jsonObject);
+		String endpoint = endpointFunction.apply(jsonObject);
 
 		JSONAssert.assertEquals(
 			expectedJSONObject.toString(),
@@ -16999,31 +17015,8 @@ public class ObjectEntryResourceTest {
 		}
 	}
 
-	private void _testPutByExternalReferenceCodeCustomObjectEntry(
-			ObjectDefinition objectDefinition1,
-			ObjectDefinition objectDefinition2, Object scopeKey)
-		throws Exception {
-
-		_testPutCustomObjectEntry(
-			_getEndpoint(objectDefinition1, scopeKey) +
-				"/by-external-reference-code",
-			jsonObject -> jsonObject.getString("externalReferenceCode"),
-			objectDefinition1, objectDefinition2, scopeKey);
-	}
-
 	private void _testPutCustomObjectEntry(
-			ObjectDefinition objectDefinition1,
-			ObjectDefinition objectDefinition2, Object scopeKey)
-		throws Exception {
-
-		_testPutCustomObjectEntry(
-			objectDefinition1.getRESTContextPath(),
-			jsonObject -> jsonObject.getLong("id"), objectDefinition1,
-			objectDefinition2, scopeKey);
-	}
-
-	private void _testPutCustomObjectEntry(
-			String contextPath, Function<JSONObject, Object> keyGetterFunction,
+			Function<JSONObject, String> endpointFunction,
 			ObjectDefinition objectDefinition1,
 			ObjectDefinition objectDefinition2, Object scopeKey)
 		throws Exception {
@@ -17031,30 +17024,36 @@ public class ObjectEntryResourceTest {
 		_objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
 			objectDefinition2, _OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
 
+		_objectEntry3 = ObjectEntryTestUtil.addObjectEntry(
+			objectDefinition2, _OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
+
 		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
 			objectDefinition2, objectDefinition1, TestPropsValues.getUserId(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		ObjectField objectRelationship1ObjectField =
+			_objectFieldLocalService.getObjectField(
+				_objectRelationship1.getObjectFieldId2());
 
 		_objectRelationship2 = ObjectRelationshipTestUtil.addObjectRelationship(
 			objectDefinition2, objectDefinition1, TestPropsValues.getUserId(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
+		ObjectField objectRelationship2ObjectField =
+			_objectFieldLocalService.getObjectField(
+				_objectRelationship2.getObjectFieldId2());
+
 		String objectRelationship1ERCObjectFieldName =
 			ObjectFieldSettingUtil.getValue(
 				ObjectFieldSettingConstants.
 					NAME_OBJECT_RELATIONSHIP_ERC_OBJECT_FIELD_NAME,
-				_objectFieldLocalService.getObjectField(
-					_objectRelationship1.getObjectFieldId2()));
+				objectRelationship1ObjectField);
 
-		String objectRelationship2IdObjectFieldName =
+		String objectRelationship2ERCObjectFieldName =
 			ObjectFieldSettingUtil.getValue(
 				ObjectFieldSettingConstants.
 					NAME_OBJECT_RELATIONSHIP_ERC_OBJECT_FIELD_NAME,
-				_objectFieldLocalService.getObjectField(
-					_objectRelationship2.getObjectFieldId2())
-			).replace(
-				"ERC", "Id"
-			);
+				objectRelationship2ObjectField);
 
 		BigDecimal randomBigDecimal = BigDecimal.valueOf(
 			RandomTestUtil.randomDouble()
@@ -17109,15 +17108,20 @@ public class ObjectEntryResourceTest {
 				objectRelationship1ERCObjectFieldName,
 				_objectEntry2.getExternalReferenceCode()
 			).put(
-				objectRelationship2IdObjectFieldName,
+				objectRelationship1ObjectField.getName(),
+				_objectEntry3.getObjectEntryId()
+			).put(
+				objectRelationship2ERCObjectFieldName,
+				_objectEntry3.getExternalReferenceCode()
+			).put(
+				objectRelationship2ObjectField.getName(),
 				_objectEntry2.getObjectEntryId()
 			).put(
 				"externalReferenceCode", randomExternalReferenceCode
 			).toString(),
 			_getEndpoint(objectDefinition1, scopeKey), Http.Method.POST);
 
-		String endpoint =
-			contextPath + "/" + keyGetterFunction.apply(jsonObject);
+		String endpoint = endpointFunction.apply(jsonObject);
 
 		HTTPTestUtil.invokeToJSONObject(
 			JSONFactoryUtil.getNullJSON(), endpoint, Http.Method.PUT);
@@ -17151,7 +17155,17 @@ public class ObjectEntryResourceTest {
 			).put(
 				_OBJECT_FIELD_NAME_TEXT, ""
 			).put(
-				objectRelationship1ERCObjectFieldName, ""
+				objectRelationship1ERCObjectFieldName,
+				_objectEntry3.getExternalReferenceCode()
+			).put(
+				objectRelationship1ObjectField.getName(),
+				(int)_objectEntry3.getObjectEntryId()
+			).put(
+				objectRelationship2ERCObjectFieldName,
+				_objectEntry2.getExternalReferenceCode()
+			).put(
+				objectRelationship2ObjectField.getName(),
+				(int)_objectEntry2.getObjectEntryId()
 			).put(
 				"externalReferenceCode", randomExternalReferenceCode
 			).toString(),
@@ -17211,8 +17225,14 @@ public class ObjectEntryResourceTest {
 				objectRelationship1ERCObjectFieldName,
 				_objectEntry2.getExternalReferenceCode()
 			).put(
-				objectRelationship2IdObjectFieldName,
+				objectRelationship1ObjectField.getName(),
 				(int)_objectEntry2.getObjectEntryId()
+			).put(
+				objectRelationship2ERCObjectFieldName,
+				_objectEntry3.getExternalReferenceCode()
+			).put(
+				objectRelationship2ObjectField.getName(),
+				(int)_objectEntry3.getObjectEntryId()
 			).put(
 				"externalReferenceCode", randomExternalReferenceCode
 			).toString(),
@@ -17249,10 +17269,16 @@ public class ObjectEntryResourceTest {
 					_OBJECT_FIELD_NAME_TEXT, randomString3
 				).put(
 					objectRelationship1ERCObjectFieldName,
+					_objectEntry3.getExternalReferenceCode()
+				).put(
+					objectRelationship1ObjectField.getName(),
+					_objectEntry2.getObjectEntryId()
+				).put(
+					objectRelationship2ERCObjectFieldName,
 					_objectEntry2.getExternalReferenceCode()
 				).put(
-					objectRelationship2IdObjectFieldName,
-					_objectEntry2.getObjectEntryId()
+					objectRelationship2ObjectField.getName(),
+					_objectEntry3.getObjectEntryId()
 				).toString(),
 				endpoint, Http.Method.PUT
 			).toString(),
@@ -18142,6 +18168,7 @@ public class ObjectEntryResourceTest {
 	private static TaxonomyCategoryResource _taxonomyCategoryResource;
 	private static final TestDLFileEntryModelListener
 		_testDLFileEntryModelListener = new TestDLFileEntryModelListener();
+	private static long _testGroupId;
 	private static final TestObjectEntryModelListener
 		_testObjectEntryModelListener = new TestObjectEntryModelListener();
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -1047,8 +1047,7 @@ public class ObjectEntryResourceTest {
 
 		// Site scope external reference code
 
-		Group group = _groupLocalService.fetchGroup(
-			TestPropsValues.getGroupId());
+		Group group = _groupLocalService.fetchGroup(_testGroupId);
 
 		_siteScopedObjectEntry1 = ObjectEntryTestUtil.addObjectEntry(
 			_siteScopedObjectDefinition1, _OBJECT_FIELD_NAME_1,
@@ -6369,8 +6368,7 @@ public class ObjectEntryResourceTest {
 					JSONUtil.put(
 						"externalReferenceCode", externalReferenceCode
 					).toString(),
-					_getEndpoint(
-						_objectDefinition1, TestPropsValues.getGroupId()),
+					_getEndpoint(_objectDefinition1, _testGroupId),
 					Http.Method.POST);
 
 				jsonObject = HTTPTestUtil.invokeToJSONObject(
@@ -6378,9 +6376,8 @@ public class ObjectEntryResourceTest {
 						_getPermissionsJSONObject(new String[0], role.getName())
 					).toString(),
 					StringBundler.concat(
-						_getEndpoint(
-							_objectDefinition1, TestPropsValues.getGroupId()),
-						"/", jsonObject.getString("id"), "/permissions"),
+						_getEndpoint(_objectDefinition1, _testGroupId), "/",
+						jsonObject.getString("id"), "/permissions"),
 					Http.Method.PUT);
 
 				Assert.assertNotEquals(
@@ -6574,8 +6571,7 @@ public class ObjectEntryResourceTest {
 		JSONObject scopeJSONObject = JSONUtil.put(
 			"externalReferenceCode",
 			() -> {
-				Group group = _groupLocalService.getGroup(
-					TestPropsValues.getGroupId());
+				Group group = _groupLocalService.getGroup(_testGroupId);
 
 				return group.getExternalReferenceCode();
 			}
@@ -6704,8 +6700,7 @@ public class ObjectEntryResourceTest {
 				_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE,
 				dlFileEntry.getFileEntryId()
 			).toString(),
-			_getEndpoint(
-				_siteScopedObjectDefinition1, TestPropsValues.getGroupId()),
+			_getEndpoint(_siteScopedObjectDefinition1, _testGroupId),
 			Http.Method.POST);
 
 		_assertAttachmentJSONObject(
@@ -7245,8 +7240,7 @@ public class ObjectEntryResourceTest {
 				StringBundler.concat(
 					"http://localhost:8080/o",
 					_siteScopedObjectDefinition1.getRESTContextPath(),
-					"/scopes/", TestPropsValues.getGroupId(),
-					"/by-external-reference-code/",
+					"/scopes/", _testGroupId, "/by-external-reference-code/",
 					jsonObject.getString("externalReferenceCode"),
 					"/object-actions/", objectAction.getName()),
 				actionJSONObject.getString("href")));
@@ -7499,8 +7493,7 @@ public class ObjectEntryResourceTest {
 
 		// Site scope external reference code
 
-		Group group = _groupLocalService.fetchGroup(
-			TestPropsValues.getGroupId());
+		Group group = _groupLocalService.fetchGroup(_testGroupId);
 
 		String objectFieldValue = RandomTestUtil.randomString();
 
@@ -7626,8 +7619,7 @@ public class ObjectEntryResourceTest {
 			_siteScopedObjectDefinition1, _OBJECT_FIELD_NAME_1,
 			_OBJECT_FIELD_VALUE_1);
 
-		Group group = _groupLocalService.fetchGroup(
-			TestPropsValues.getGroupId());
+		Group group = _groupLocalService.fetchGroup(_testGroupId);
 
 		jsonObject = HTTPTestUtil.invokeToJSONObject(
 			null,
@@ -8350,8 +8342,7 @@ public class ObjectEntryResourceTest {
 								"-private"
 							).build()))));
 
-		String endpoint = _getEndpoint(
-			objectDefinition, TestPropsValues.getGroupId());
+		String endpoint = _getEndpoint(objectDefinition, _testGroupId);
 
 		HTTPTestUtil.invokeToJSONObject(
 			JSONFactoryUtil.getNullJSON(), endpoint, Http.Method.POST);
@@ -8660,8 +8651,7 @@ public class ObjectEntryResourceTest {
 				).put(
 					"externalReferenceCode", _ERC_VALUE_1
 				).toString(),
-				_getEndpoint(
-					_siteScopedObjectDefinition1, TestPropsValues.getGroupId()),
+				_getEndpoint(_siteScopedObjectDefinition1, _testGroupId),
 				Http.Method.POST));
 
 		Assert.assertEquals(
@@ -8672,8 +8662,7 @@ public class ObjectEntryResourceTest {
 				).put(
 					"externalReferenceCode", _ERC_VALUE_1
 				).toString(),
-				_getEndpoint(
-					_siteScopedObjectDefinition1, TestPropsValues.getGroupId()),
+				_getEndpoint(_siteScopedObjectDefinition1, _testGroupId),
 				Http.Method.POST));
 	}
 
@@ -8868,8 +8857,7 @@ public class ObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invokeToJSONObject(
 			objectEntryJSONObject.toString(),
-			_getEndpoint(
-				_siteScopedObjectDefinition1, TestPropsValues.getGroupId()),
+			_getEndpoint(_siteScopedObjectDefinition1, _testGroupId),
 			Http.Method.POST);
 
 		Assert.assertEquals(
@@ -8983,8 +8971,7 @@ public class ObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invokeToJSONObject(
 			objectEntryJSONObject.toString(),
-			_getEndpoint(
-				_siteScopedObjectDefinition2, TestPropsValues.getGroupId()),
+			_getEndpoint(_siteScopedObjectDefinition2, _testGroupId),
 			Http.Method.POST);
 
 		Assert.assertEquals(
@@ -9099,8 +9086,7 @@ public class ObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invokeToJSONObject(
 			objectEntryJSONObject.toString(),
-			_getEndpoint(
-				_siteScopedObjectDefinition1, TestPropsValues.getGroupId()),
+			_getEndpoint(_siteScopedObjectDefinition1, _testGroupId),
 			Http.Method.POST);
 
 		Assert.assertEquals(
@@ -9355,8 +9341,7 @@ public class ObjectEntryResourceTest {
 
 		// Site scope external reference code
 
-		Group group = _groupLocalService.fetchGroup(
-			TestPropsValues.getGroupId());
+		Group group = _groupLocalService.fetchGroup(_testGroupId);
 
 		String objectFieldValue = RandomTestUtil.randomString();
 
@@ -9408,8 +9393,7 @@ public class ObjectEntryResourceTest {
 
 	@Test
 	public void testPostScopeScopeKeyValidate() throws Exception {
-		Group group = _groupLocalService.fetchGroup(
-			TestPropsValues.getGroupId());
+		Group group = _groupLocalService.fetchGroup(_testGroupId);
 
 		_testPostValidate(
 			group.getExternalReferenceCode(), _siteScopedObjectDefinition1,
@@ -10389,8 +10373,7 @@ public class ObjectEntryResourceTest {
 
 		com.liferay.object.rest.dto.v1_0.FileEntry fileEntry3 = _toFileEntry(
 			content -> null, StringPool.BLANK,
-			existingDLFileEntry.getFileName(), null,
-			TestPropsValues.getGroupId());
+			existingDLFileEntry.getFileName(), null, _testGroupId);
 
 		fileEntry3.setExternalReferenceCode(
 			existingDLFileEntry.getExternalReferenceCode());
@@ -10762,8 +10745,7 @@ public class ObjectEntryResourceTest {
 						_NEW_OBJECT_FIELD_VALUE_1, _NEW_OBJECT_FIELD_VALUE_2
 					})
 			).toString(),
-			_getEndpoint(
-				_siteScopedObjectDefinition1, TestPropsValues.getGroupId()),
+			_getEndpoint(_siteScopedObjectDefinition1, _testGroupId),
 			Http.Method.POST);
 
 		JSONObject putJSONObject = HTTPTestUtil.invokeToJSONObject(
@@ -10792,8 +10774,7 @@ public class ObjectEntryResourceTest {
 
 	@Test
 	public void testSortByCustomObjectField() throws Exception {
-		String endpoint = _getEndpoint(
-			_objectDefinition1, TestPropsValues.getGroupId());
+		String endpoint = _getEndpoint(_objectDefinition1, _testGroupId);
 
 		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
 			_objectDefinition2, _objectDefinition1, TestPropsValues.getUserId(),
@@ -10990,12 +10971,9 @@ public class ObjectEntryResourceTest {
 			_objectDefinition2, _objectDefinition3, TestPropsValues.getUserId(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		String endpoint1 = _getEndpoint(
-			_objectDefinition1, TestPropsValues.getGroupId());
-		String endpoint2 = _getEndpoint(
-			_objectDefinition2, TestPropsValues.getGroupId());
-		String endpoint3 = _getEndpoint(
-			_objectDefinition3, TestPropsValues.getGroupId());
+		String endpoint1 = _getEndpoint(_objectDefinition1, _testGroupId);
+		String endpoint2 = _getEndpoint(_objectDefinition2, _testGroupId);
+		String endpoint3 = _getEndpoint(_objectDefinition3, _testGroupId);
 
 		BigDecimal randomBigDecimal = new BigDecimal(
 			RandomTestUtil.randomDouble());
@@ -11471,12 +11449,9 @@ public class ObjectEntryResourceTest {
 			_objectDefinition3, _objectDefinition2, TestPropsValues.getUserId(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		String endpoint1 = _getEndpoint(
-			_objectDefinition1, TestPropsValues.getGroupId());
-		String endpoint2 = _getEndpoint(
-			_objectDefinition2, TestPropsValues.getGroupId());
-		String endpoint3 = _getEndpoint(
-			_objectDefinition3, TestPropsValues.getGroupId());
+		String endpoint1 = _getEndpoint(_objectDefinition1, _testGroupId);
+		String endpoint2 = _getEndpoint(_objectDefinition2, _testGroupId);
+		String endpoint3 = _getEndpoint(_objectDefinition3, _testGroupId);
 
 		BigDecimal randomBigDecimal = new BigDecimal(
 			RandomTestUtil.randomDouble());
@@ -11996,12 +11971,9 @@ public class ObjectEntryResourceTest {
 			_objectDefinitionLocalService.updateObjectDefinition(
 				_objectDefinition3);
 
-		String endpoint1 = _getEndpoint(
-			_objectDefinition1, TestPropsValues.getGroupId());
-		String endpoint2 = _getEndpoint(
-			_objectDefinition2, TestPropsValues.getGroupId());
-		String endpoint3 = _getEndpoint(
-			_objectDefinition3, TestPropsValues.getGroupId());
+		String endpoint1 = _getEndpoint(_objectDefinition1, _testGroupId);
+		String endpoint2 = _getEndpoint(_objectDefinition2, _testGroupId);
+		String endpoint3 = _getEndpoint(_objectDefinition3, _testGroupId);
 
 		JSONObject[] manyToOneDepth1JSONObjects = new JSONObject[2];
 
@@ -12340,12 +12312,9 @@ public class ObjectEntryResourceTest {
 			_objectDefinition2, _objectDefinition3, TestPropsValues.getUserId(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		String endpoint1 = _getEndpoint(
-			_objectDefinition1, TestPropsValues.getGroupId());
-		String endpoint2 = _getEndpoint(
-			_objectDefinition2, TestPropsValues.getGroupId());
-		String endpoint3 = _getEndpoint(
-			_objectDefinition3, TestPropsValues.getGroupId());
+		String endpoint1 = _getEndpoint(_objectDefinition1, _testGroupId);
+		String endpoint2 = _getEndpoint(_objectDefinition2, _testGroupId);
+		String endpoint3 = _getEndpoint(_objectDefinition3, _testGroupId);
 
 		BigDecimal randomBigDecimal = new BigDecimal(
 			RandomTestUtil.randomDouble());
@@ -13033,12 +13002,9 @@ public class ObjectEntryResourceTest {
 			_objectDefinitionLocalService.updateObjectDefinition(
 				_objectDefinition3);
 
-		String endpoint1 = _getEndpoint(
-			_objectDefinition1, TestPropsValues.getGroupId());
-		String endpoint2 = _getEndpoint(
-			_objectDefinition2, TestPropsValues.getGroupId());
-		String endpoint3 = _getEndpoint(
-			_objectDefinition3, TestPropsValues.getGroupId());
+		String endpoint1 = _getEndpoint(_objectDefinition1, _testGroupId);
+		String endpoint2 = _getEndpoint(_objectDefinition2, _testGroupId);
+		String endpoint3 = _getEndpoint(_objectDefinition3, _testGroupId);
 
 		JSONObject[] oneToManyDepth1JSONObjects = new JSONObject[4];
 
@@ -13424,8 +13390,7 @@ public class ObjectEntryResourceTest {
 			_objectDefinition1, _objectDefinition2, TestPropsValues.getUserId(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
-		String endpoint = _getEndpoint(
-			_objectDefinition1, TestPropsValues.getGroupId());
+		String endpoint = _getEndpoint(_objectDefinition1, _testGroupId);
 
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
@@ -13472,8 +13437,7 @@ public class ObjectEntryResourceTest {
 			_objectDefinitionLocalService.updateObjectDefinition(
 				_objectDefinition1);
 
-		String endpoint = _getEndpoint(
-			_objectDefinition1, TestPropsValues.getGroupId());
+		String endpoint = _getEndpoint(_objectDefinition1, _testGroupId);
 
 		JSONObject[] jsonObjects = new JSONObject[2];
 
@@ -13629,8 +13593,8 @@ public class ObjectEntryResourceTest {
 		throws Exception {
 
 		_resourcePermissionLocalService.addModelResourcePermissions(
-			TestPropsValues.getCompanyId(), TestPropsValues.getGroupId(),
-			userId, className, String.valueOf(objectEntryId),
+			TestPropsValues.getCompanyId(), _testGroupId, userId, className,
+			String.valueOf(objectEntryId),
 			ModelPermissionsFactory.create(
 				HashMapBuilder.put(
 					RoleConstants.USER, actionIds
@@ -13764,7 +13728,7 @@ public class ObjectEntryResourceTest {
 					name = StringUtil.toLowerCase(
 						RandomTestUtil.randomString());
 					numberOfTaxonomyCategories = RandomTestUtil.randomInt();
-					siteId = TestPropsValues.getGroupId();
+					siteId = _testGroupId;
 					taxonomyCategoryUsageCount = RandomTestUtil.randomInt();
 					taxonomyVocabularyId = RandomTestUtil.randomLong();
 				}
@@ -13776,7 +13740,7 @@ public class ObjectEntryResourceTest {
 		throws Exception {
 
 		return TempFileEntryUtil.addTempFileEntry(
-			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
+			_testGroupId, TestPropsValues.getUserId(),
 			objectDefinition.getPortletId(),
 			TempFileEntryUtil.getTempFileName(title + ".txt"),
 			FileUtil.createTempFile(content.getBytes()),
@@ -14142,7 +14106,7 @@ public class ObjectEntryResourceTest {
 				objectDefinition.getScope());
 
 		if (objectScopeProvider.isGroupAware()) {
-			groupId = TestPropsValues.getGroupId();
+			groupId = _testGroupId;
 		}
 		else {
 			Company company = _companyLocalService.getCompany(
@@ -14236,7 +14200,7 @@ public class ObjectEntryResourceTest {
 									objectDefinition.getScope(),
 									ObjectDefinitionConstants.SCOPE_SITE)) {
 
-								repositoryId = TestPropsValues.getGroupId();
+								repositoryId = _testGroupId;
 							}
 							else {
 								Company company =
@@ -14601,7 +14565,7 @@ public class ObjectEntryResourceTest {
 		return HTTPTestUtil.invokeToJSONObject(
 			permissionsJSONArray.toString(),
 			StringBundler.concat(
-				_getEndpoint(_objectDefinition1, TestPropsValues.getGroupId()),
+				_getEndpoint(_objectDefinition1, _testGroupId),
 				StringPool.SLASH, id, "/permissions"),
 			Http.Method.PUT);
 	}
@@ -14810,8 +14774,7 @@ public class ObjectEntryResourceTest {
 			JSONUtil.put(
 				_OBJECT_FIELD_NAME_1, "value"
 			).toString(),
-			_getEndpoint(objectDefinition, TestPropsValues.getGroupId()),
-			Http.Method.POST);
+			_getEndpoint(objectDefinition, _testGroupId), Http.Method.POST);
 
 		JSONObject actionsJSONObject = jsonObject.getJSONObject("actions");
 
@@ -15224,7 +15187,7 @@ public class ObjectEntryResourceTest {
 		// File from URL
 
 		FileEntry customFileEntry1 = TempFileEntryUtil.addTempFileEntry(
-			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
+			_testGroupId, TestPropsValues.getUserId(),
 			StringUtil.randomString(),
 			TempFileEntryUtil.getTempFileName(
 				StringUtil.randomString() + ".txt"),
@@ -15340,8 +15303,7 @@ public class ObjectEntryResourceTest {
 
 		// File from documents and media
 
-		DLFolder dlFolder1 = DLTestUtil.addDLFolder(
-			TestPropsValues.getGroupId());
+		DLFolder dlFolder1 = DLTestUtil.addDLFolder(_testGroupId);
 
 		_testPatchPutCustomObjectEntryWithAttachmentField(
 			fileEntry -> JSONUtil.put(
@@ -15377,8 +15339,7 @@ public class ObjectEntryResourceTest {
 				_getFileEntryJSONObject(null, fileEntry, objectDefinition)),
 			_toFileEntry(
 				Base64::encode, RandomTestUtil.randomString(),
-				RandomTestUtil.randomString() + ".txt", null,
-				TestPropsValues.getGroupId()),
+				RandomTestUtil.randomString() + ".txt", null, _testGroupId),
 			httpMethod, null, objectDefinition,
 			_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE,
 			useExternalReferenceCode);
@@ -15522,8 +15483,7 @@ public class ObjectEntryResourceTest {
 			userName + "@liferay.com", userPassword
 		).apply(
 			() -> {
-				DLFolder dlFolder = DLTestUtil.addDLFolder(
-					TestPropsValues.getGroupId());
+				DLFolder dlFolder = DLTestUtil.addDLFolder(_testGroupId);
 
 				Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
 
@@ -15538,8 +15498,7 @@ public class ObjectEntryResourceTest {
 
 				_resourcePermissionLocalService.setResourcePermissions(
 					TestPropsValues.getCompanyId(), DLConstants.RESOURCE_NAME,
-					ResourceConstants.SCOPE_GROUP,
-					String.valueOf(TestPropsValues.getGroupId()),
+					ResourceConstants.SCOPE_GROUP, String.valueOf(_testGroupId),
 					role.getRoleId(), new String[] {ActionKeys.ADD_DOCUMENT});
 
 				com.liferay.object.rest.dto.v1_0.FileEntry testFileEntry =
@@ -15589,7 +15548,7 @@ public class ObjectEntryResourceTest {
 			_toFileEntry(
 				Base64::encode, RandomTestUtil.randomString(),
 				RandomTestUtil.randomString() + ".txt",
-				randomExternalReferenceCode, TestPropsValues.getGroupId()),
+				randomExternalReferenceCode, _testGroupId),
 			httpMethod, null, objectDefinition,
 			_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE,
 			useExternalReferenceCode);
@@ -15740,8 +15699,7 @@ public class ObjectEntryResourceTest {
 					RandomTestUtil.randomString(),
 					RandomTestUtil.randomString() + ".txt", objectFieldName)
 			).toString(),
-			_getEndpoint(objectDefinition, TestPropsValues.getGroupId()),
-			Http.Method.POST);
+			_getEndpoint(objectDefinition, _testGroupId), Http.Method.POST);
 
 		String endpoint =
 			objectDefinition.getRESTContextPath() + "/" +
@@ -15749,7 +15707,7 @@ public class ObjectEntryResourceTest {
 
 		if (useExternalReferenceCode) {
 			endpoint =
-				_getEndpoint(objectDefinition, TestPropsValues.getGroupId()) +
+				_getEndpoint(objectDefinition, _testGroupId) +
 					"/by-external-reference-code/" +
 						jsonObject.getString("externalReferenceCode");
 		}
@@ -15796,7 +15754,7 @@ public class ObjectEntryResourceTest {
 			httpMethod);
 
 		String endpoint = _getEndpoint(
-			siteScopedObjectDefinition, TestPropsValues.getGroupId());
+			siteScopedObjectDefinition, _testGroupId);
 
 		_testPatchPutCustomObjectEntryWithDuplicateExternalReferenceCode(
 			endpoint, endpoint + "/by-external-reference-code/", httpMethod);
@@ -15844,7 +15802,7 @@ public class ObjectEntryResourceTest {
 		// File from URL
 
 		FileEntry customFileEntry1 = TempFileEntryUtil.addTempFileEntry(
-			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
+			_testGroupId, TestPropsValues.getUserId(),
 			StringUtil.randomString(),
 			TempFileEntryUtil.getTempFileName(
 				StringUtil.randomString() + ".txt"),
@@ -15957,8 +15915,7 @@ public class ObjectEntryResourceTest {
 
 		// File from documents and media
 
-		DLFolder dlFolder1 = DLTestUtil.addDLFolder(
-			TestPropsValues.getGroupId());
+		DLFolder dlFolder1 = DLTestUtil.addDLFolder(_testGroupId);
 
 		_testPostCustomObjectEntryWithAttachmentObjectField(
 			fileEntry -> JSONUtil.put(
@@ -15992,8 +15949,7 @@ public class ObjectEntryResourceTest {
 				_getFileEntryJSONObject(null, fileEntry, objectDefinition)),
 			_toFileEntry(
 				Base64::encode, RandomTestUtil.randomString(),
-				RandomTestUtil.randomString() + ".txt", null,
-				TestPropsValues.getGroupId()),
+				RandomTestUtil.randomString() + ".txt", null, _testGroupId),
 			null, objectDefinition,
 			_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE);
 		_testPostCustomObjectEntryWithAttachmentObjectField(
@@ -16018,11 +15974,10 @@ public class ObjectEntryResourceTest {
 
 		// File from documents and media with generated thumbnail
 
-		DLFolder dlFolder3 = DLTestUtil.addDLFolder(
-			TestPropsValues.getGroupId());
+		DLFolder dlFolder3 = DLTestUtil.addDLFolder(_testGroupId);
 
 		FileEntry customFileEntry2 = _dlAppLocalService.addFileEntry(
-			null, TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
+			null, TestPropsValues.getUserId(), _testGroupId,
 			dlFolder3.getFolderId(), StringUtil.randomString() + ".jpg",
 			ContentTypes.IMAGE_JPEG,
 			FileUtil.getBytes(getClass(), "dependencies/image.jpg"), null, null,
@@ -16154,8 +16109,7 @@ public class ObjectEntryResourceTest {
 			userName + "@liferay.com", userPassword
 		).apply(
 			() -> {
-				DLFolder dlFolder = DLTestUtil.addDLFolder(
-					TestPropsValues.getGroupId());
+				DLFolder dlFolder = DLTestUtil.addDLFolder(_testGroupId);
 
 				Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
 
@@ -16216,7 +16170,7 @@ public class ObjectEntryResourceTest {
 			_toFileEntry(
 				Base64::encode, RandomTestUtil.randomString(),
 				RandomTestUtil.randomString() + ".txt",
-				randomExternalReferenceCode, TestPropsValues.getGroupId()),
+				randomExternalReferenceCode, _testGroupId),
 			null, objectDefinition,
 			_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE);
 
@@ -16292,7 +16246,7 @@ public class ObjectEntryResourceTest {
 
 		testFileEntry = _toFileEntry(
 			Base64::encode, fileContent, existingDLFileEntry.getFileName(),
-			null, TestPropsValues.getGroupId());
+			null, _testGroupId);
 
 		testFileEntry.setExternalReferenceCode(
 			existingDLFileEntry.getExternalReferenceCode());
@@ -16322,7 +16276,7 @@ public class ObjectEntryResourceTest {
 
 		testFileEntry = _toFileEntry(
 			Base64::encode, fileContent, existingDLFileEntry.getFileName(),
-			null, TestPropsValues.getGroupId());
+			null, _testGroupId);
 
 		testFileEntry.setExternalReferenceCode(
 			existingDLFileEntry.getExternalReferenceCode());
@@ -16503,8 +16457,7 @@ public class ObjectEntryResourceTest {
 			String objectFieldName)
 		throws Exception {
 
-		String endpoint = _getEndpoint(
-			objectDefinition, TestPropsValues.getGroupId());
+		String endpoint = _getEndpoint(objectDefinition, _testGroupId);
 
 		if (nestedFields != null) {
 			endpoint = StringBundler.concat(
@@ -16979,7 +16932,7 @@ public class ObjectEntryResourceTest {
 				objectField2.getObjectFieldId());
 
 			FileEntry fileEntry = TempFileEntryUtil.addTempFileEntry(
-				TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
+				_testGroupId, TestPropsValues.getUserId(),
 				objectDefinition.getPortletId(),
 				TempFileEntryUtil.getTempFileName("foo.pdf"),
 				FileUtil.createTempFile(
@@ -17873,8 +17826,7 @@ public class ObjectEntryResourceTest {
 					"WebApplicationExceptionMapper",
 				LoggerTestUtil.ERROR)) {
 
-			String endpoint = _getEndpoint(
-				objectDefinition, TestPropsValues.getGroupId());
+			String endpoint = _getEndpoint(objectDefinition, _testGroupId);
 
 			JSONAssert.assertEquals(
 				JSONUtil.put(
@@ -18025,7 +17977,7 @@ public class ObjectEntryResourceTest {
 
 			Folder folder = new Folder();
 
-			folder.setSiteId(TestPropsValues.getGroupId());
+			folder.setSiteId(_testGroupId);
 
 			fileEntry.setFolder(folder);
 		}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1to1ObjectRelatedModelsProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1to1ObjectRelatedModelsProviderImpl.java
@@ -75,7 +75,7 @@ public class ObjectEntry1to1ObjectRelatedModelsProviderImpl
 					deletionType,
 					ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE)) {
 
-			_objectEntryService.updateObjectEntry(
+			_objectEntryService.partialUpdateObjectEntry(
 				objectEntry.getObjectEntryId(),
 				HashMapBuilder.<String, Serializable>put(
 					() -> {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1toMObjectRelatedModelsProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1toMObjectRelatedModelsProviderImpl.java
@@ -81,7 +81,7 @@ public class ObjectEntry1toMObjectRelatedModelsProviderImpl
 				objectRelationship.getObjectFieldId2());
 
 			for (ObjectEntry objectEntry : relatedModels) {
-				_objectEntryService.updateObjectEntry(
+				_objectEntryService.partialUpdateObjectEntry(
 					objectEntry.getObjectEntryId(),
 					HashMapBuilder.<String, Serializable>put(
 						objectField.getName(), 0
@@ -103,14 +103,9 @@ public class ObjectEntry1toMObjectRelatedModelsProviderImpl
 			long primaryKey2)
 		throws PortalException {
 
-		ObjectEntry objectEntry = _objectEntryService.getObjectEntry(
-			primaryKey2);
-
-		_objectEntryService.updateObjectEntry(
+		_objectEntryService.partialUpdateObjectEntry(
 			primaryKey2,
-			HashMapBuilder.<String, Serializable>putAll(
-				objectEntry.getValues()
-			).put(
+			HashMapBuilder.<String, Serializable>put(
 				() -> {
 					ObjectRelationship objectRelationship =
 						_objectRelationshipLocalService.getObjectRelationship(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/http/ObjectEntryServiceHttp.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/http/ObjectEntryServiceHttp.java
@@ -878,6 +878,48 @@ public class ObjectEntryServiceHttp {
 		}
 	}
 
+	public static com.liferay.object.model.ObjectEntry partialUpdateObjectEntry(
+			HttpPrincipal httpPrincipal, long objectEntryId,
+			java.util.Map<String, java.io.Serializable> values,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				ObjectEntryServiceUtil.class, "partialUpdateObjectEntry",
+				_partialUpdateObjectEntryParameterTypes20);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, objectEntryId, values, serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.object.model.ObjectEntry)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static com.liferay.object.model.ObjectEntry updateObjectEntry(
 			HttpPrincipal httpPrincipal, long objectEntryId,
 			java.util.Map<String, java.io.Serializable> values,
@@ -887,7 +929,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "updateObjectEntry",
-				_updateObjectEntryParameterTypes20);
+				_updateObjectEntryParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntryId, values, serviceContext);
@@ -930,7 +972,7 @@ public class ObjectEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectEntryServiceUtil.class, "validate",
-				_validateParameterTypes21);
+				_validateParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, objectEntry,
@@ -1035,12 +1077,17 @@ public class ObjectEntryServiceHttp {
 		_hasPortletResourcePermissionParameterTypes19 = new Class[] {
 			long.class, long.class, String.class
 		};
-	private static final Class<?>[] _updateObjectEntryParameterTypes20 =
+	private static final Class<?>[] _partialUpdateObjectEntryParameterTypes20 =
 		new Class[] {
 			long.class, java.util.Map.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _validateParameterTypes21 = new Class[] {
+	private static final Class<?>[] _updateObjectEntryParameterTypes21 =
+		new Class[] {
+			long.class, java.util.Map.class,
+			com.liferay.portal.kernel.service.ServiceContext.class
+		};
+	private static final Class<?>[] _validateParameterTypes22 = new Class[] {
 		long.class, com.liferay.object.model.ObjectEntry.class,
 		java.util.List.class,
 		com.liferay.portal.kernel.service.ServiceContext.class

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -340,7 +340,7 @@ public class ObjectEntryLocalServiceImpl
 			user.isGuestUser(), objectDefinition, null,
 			_objectFieldLocalService.getObjectFields(
 				objectDefinition.getObjectDefinitionId()),
-			serviceContext, null, userId, null, values);
+			false, serviceContext, null, userId, null, values);
 
 		_addDLFileEntries(
 			dlFileEntriesMap, objectDefinition, objectEntryId, serviceContext,
@@ -349,14 +349,15 @@ public class ObjectEntryLocalServiceImpl
 		Map<String, Serializable> insertedValues = new HashMap<>();
 
 		_insertIntoLocalizationTable(
-			insertedValues, objectDefinition, objectEntryId, values);
+			insertedValues, objectDefinition, objectEntryId, null, false,
+			values);
 
 		boolean dynamicObjectDefinitionStaticValues = _insertIntoTable(
 			_getDynamicObjectDefinitionTable(objectDefinitionId),
-			insertedValues, objectEntryId, values);
+			insertedValues, objectEntryId, false, values);
 		boolean extensionDynamicObjectDefinitionStaticValues = _insertIntoTable(
 			_getExtensionDynamicObjectDefinitionTable(objectDefinitionId),
-			insertedValues, objectEntryId, values);
+			insertedValues, objectEntryId, false, values);
 
 		ObjectEntry objectEntry = objectEntryPersistence.create(objectEntryId);
 
@@ -514,29 +515,30 @@ public class ObjectEntryLocalServiceImpl
 					objectDefinition, primaryKey),
 				GroupConstants.DEFAULT_PARENT_GROUP_ID, user.isGuestUser(),
 				objectDefinition, null,
-				dynamicObjectDefinitionTable.getObjectFields(), serviceContext,
-				null, userId, null, values);
+				dynamicObjectDefinitionTable.getObjectFields(), true,
+				serviceContext, null, userId, null, values);
 
 			_addDLFileEntries(
 				dlFileEntriesMap, objectDefinition, primaryKey, serviceContext,
 				userId, values);
 
-			_updateTable(dynamicObjectDefinitionTable, primaryKey, values);
+			_updateTable(
+				dynamicObjectDefinitionTable, primaryKey, true, values);
 		}
 		else {
 			_validateValues(
 				defaultLanguageId, dlFileEntriesMap, null,
 				GroupConstants.DEFAULT_PARENT_GROUP_ID, user.isGuestUser(),
 				objectDefinition, null,
-				dynamicObjectDefinitionTable.getObjectFields(), serviceContext,
-				null, userId, null, values);
+				dynamicObjectDefinitionTable.getObjectFields(), true,
+				serviceContext, null, userId, null, values);
 
 			_addDLFileEntries(
 				dlFileEntriesMap, objectDefinition, primaryKey, serviceContext,
 				userId, values);
 
 			_insertIntoTable(
-				dynamicObjectDefinitionTable, new HashMap<>(), primaryKey,
+				dynamicObjectDefinitionTable, new HashMap<>(), primaryKey, true,
 				values);
 		}
 
@@ -1618,21 +1620,22 @@ public class ObjectEntryLocalServiceImpl
 					objectDefinition, primaryKey),
 				GroupConstants.DEFAULT_PARENT_GROUP_ID, user.isGuestUser(),
 				objectDefinition, null,
-				dynamicObjectDefinitionTable.getObjectFields(),
+				dynamicObjectDefinitionTable.getObjectFields(), true,
 				new ServiceContext(), null, userId, null, values);
 
-			_updateTable(dynamicObjectDefinitionTable, primaryKey, values);
+			_updateTable(
+				dynamicObjectDefinitionTable, primaryKey, true, values);
 		}
 		else {
 			_validateValues(
 				defaultLanguageId, Collections.emptyMap(), null,
 				GroupConstants.DEFAULT_PARENT_GROUP_ID, user.isGuestUser(),
 				objectDefinition, null,
-				dynamicObjectDefinitionTable.getObjectFields(),
+				dynamicObjectDefinitionTable.getObjectFields(), true,
 				new ServiceContext(), null, userId, null, values);
 
 			_insertIntoTable(
-				dynamicObjectDefinitionTable, new HashMap<>(), primaryKey,
+				dynamicObjectDefinitionTable, new HashMap<>(), primaryKey, true,
 				values);
 		}
 	}
@@ -1643,120 +1646,8 @@ public class ObjectEntryLocalServiceImpl
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		User user = _userLocalService.getUser(userId);
-
-		ObjectEntry objectEntry = objectEntryPersistence.findByPrimaryKey(
-			objectEntryId);
-
-		ObjectDefinition objectDefinition =
-			_objectDefinitionPersistence.findByPrimaryKey(
-				objectEntry.getObjectDefinitionId());
-
-		_contributeValues(
-			objectEntry.getGroupId(), objectDefinition, userId, values);
-
-		Map<ObjectField, Set<DLFileEntry>> dlFileEntriesMap = new HashMap<>();
-
-		_validateValues(
-			objectEntry.getDefaultLanguageId(), dlFileEntriesMap,
-			objectEntry.getValues(), objectEntry.getGroupId(),
-			user.isGuestUser(), objectDefinition,
-			objectEntry.getObjectEntryId(),
-			_objectFieldLocalService.getObjectFields(
-				objectDefinition.getObjectDefinitionId()),
-			serviceContext, objectEntry.getStatus(), userId, null, values);
-
-		_addDLFileEntries(
-			dlFileEntriesMap, objectDefinition, objectEntryId, serviceContext,
-			userId, values);
-
-		int workflowAction = serviceContext.getWorkflowAction();
-
-		_validateWorkflowAction(
-			objectDefinition.isEnableObjectEntryDraft(), objectDefinition,
-			objectEntry.getStatus(), workflowAction);
-
-		Map<String, Serializable> transientValues = objectEntry.getValues();
-
-		_deleteFromLocalizationTable(objectDefinition, objectEntryId);
-		_insertIntoLocalizationTable(
-			new HashMap<>(), objectDefinition, objectEntryId, values);
-		_updateTable(
-			_getDynamicObjectDefinitionTable(
-				objectEntry.getObjectDefinitionId()),
-			objectEntryId, values);
-		_updateTable(
-			_getExtensionDynamicObjectDefinitionTable(
-				objectEntry.getObjectDefinitionId()),
-			objectEntryId, values);
-
-		objectEntryPersistence.clearCache(SetUtil.fromArray(objectEntryId));
-
-		objectEntry = objectEntryPersistence.findByPrimaryKey(objectEntryId);
-
-		_setExternalReferenceCode(objectEntry, values);
-
-		objectEntry.setModifiedDate(serviceContext.getModifiedDate(null));
-
-		_setRootObjectEntryId(objectDefinition, objectEntry, values);
-
-		if ((workflowAction == WorkflowConstants.ACTION_SAVE_DRAFT) &&
-			!objectEntry.isPending()) {
-
-			objectEntry.setStatus(WorkflowConstants.STATUS_DRAFT);
-			objectEntry.setStatusByUserId(user.getUserId());
-			objectEntry.setStatusDate(serviceContext.getModifiedDate(null));
-		}
-
-		objectEntry.setTransientValues(transientValues);
-
-		ObjectEntry originalObjectEntry = objectEntry.cloneWithOriginalValues();
-
-		try {
-			if (workflowAction == WorkflowConstants.ACTION_SAVE_DRAFT) {
-				ObjectEntryThreadLocal.setSkipObjectValidationRules(true);
-			}
-
-			objectEntry = objectEntryPersistence.update(objectEntry);
-		}
-		finally {
-			ObjectEntryThreadLocal.setSkipObjectValidationRules(false);
-		}
-
-		_updateAsset(
-			serviceContext.getUserId(), objectEntry,
-			serviceContext.getAssetCategoryIds(),
-			serviceContext.getAssetTagNames(),
-			serviceContext.getAssetLinkEntryIds(),
-			serviceContext.getAssetPriority(), serviceContext);
-
-		_addFriendlyURLEntry(
-			objectDefinition, objectEntry, serviceContext, values);
-
-		_startWorkflowInstance(userId, objectEntry, serviceContext, true);
-
-		_updateResourcePermissions(
-			objectDefinition, objectEntry, serviceContext);
-
-		_deleteFileEntries(
-			objectEntry.getValues(), objectEntry.getObjectDefinitionId(),
-			transientValues);
-
-		_executeObjectActions(
-			objectEntry.getCompanyId(),
-			ObjectActionTriggerConstants.KEY_ON_AFTER_UPDATE, objectDefinition,
-			objectEntry, originalObjectEntry, serviceContext.getLanguageId(),
-			user);
-
-		_deleteTempFileEntries(dlFileEntriesMap);
-
-		if (objectEntry.isPending() || originalObjectEntry.isDraft()) {
-			_updateLatestObjectEntryVersion(objectDefinition, objectEntry);
-
-			return objectEntry;
-		}
-
-		return _addObjectEntryVersion(objectDefinition, objectEntry);
+		return _updateObjectEntry(
+			objectEntryId, true, serviceContext, userId, values);
 	}
 
 	@Override
@@ -1839,122 +1730,8 @@ public class ObjectEntryLocalServiceImpl
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		User user = _userLocalService.getUser(userId);
-
-		ObjectEntry objectEntry = objectEntryPersistence.findByPrimaryKey(
-			objectEntryId);
-
-		ObjectDefinition objectDefinition =
-			_objectDefinitionPersistence.findByPrimaryKey(
-				objectEntry.getObjectDefinitionId());
-
-		_contributeValues(
-			objectEntry.getGroupId(), objectDefinition, userId, values);
-
-		Map<ObjectField, Set<DLFileEntry>> dlFileEntriesMap = new HashMap<>();
-
-		_validateValues(
-			objectEntry.getDefaultLanguageId(), dlFileEntriesMap,
-			objectEntry.getValues(), objectEntry.getGroupId(),
-			user.isGuestUser(), objectDefinition,
-			objectEntry.getObjectEntryId(),
-			_objectFieldLocalService.getObjectFields(
-				objectDefinition.getObjectDefinitionId()),
-			serviceContext, objectEntry.getStatus(), userId, null, values);
-
-		_addDLFileEntries(
-			dlFileEntriesMap, objectDefinition, objectEntryId, serviceContext,
-			userId, values);
-
-		int workflowAction = serviceContext.getWorkflowAction();
-
-		_validateWorkflowAction(
-			objectDefinition.isEnableObjectEntryDraft(), objectDefinition,
-			objectEntry.getStatus(), workflowAction);
-
-		Map<String, Serializable> transientValues = objectEntry.getValues();
-
-		_deleteFromLocalizationTable(objectDefinition, objectEntryId);
-		_insertIntoLocalizationTable(
-			new HashMap<>(), objectDefinition, objectEntryId, values);
-		_updateTable(
-			_getDynamicObjectDefinitionTable(
-				objectEntry.getObjectDefinitionId()),
-			objectEntryId, values);
-		_updateTable(
-			_getExtensionDynamicObjectDefinitionTable(
-				objectEntry.getObjectDefinitionId()),
-			objectEntryId, values);
-
-		objectEntryPersistence.clearCache(SetUtil.fromArray(objectEntryId));
-
-		objectEntry = objectEntryPersistence.findByPrimaryKey(objectEntryId);
-
-		_setExternalReferenceCode(objectEntry, values);
-
-		objectEntry.setModifiedDate(serviceContext.getModifiedDate(null));
-
-		_setRootObjectEntryId(objectDefinition, objectEntry, values);
-
-		if ((workflowAction == WorkflowConstants.ACTION_SAVE_DRAFT) &&
-			!objectEntry.isPending()) {
-
-			objectEntry.setStatus(WorkflowConstants.STATUS_DRAFT);
-			objectEntry.setStatusByUserId(user.getUserId());
-			objectEntry.setStatusDate(serviceContext.getModifiedDate(null));
-		}
-
-		objectEntry.setTransientValues(transientValues);
-
-		ObjectEntry originalObjectEntry = objectEntry.cloneWithOriginalValues();
-
-		try {
-			if (workflowAction == WorkflowConstants.ACTION_SAVE_DRAFT) {
-				ObjectEntryThreadLocal.setSkipObjectValidationRules(true);
-			}
-
-			objectEntry = objectEntryPersistence.update(objectEntry);
-		}
-		finally {
-			ObjectEntryThreadLocal.setSkipObjectValidationRules(false);
-		}
-
-		_updateAsset(
-			serviceContext.getUserId(), objectEntry,
-			serviceContext.getAssetCategoryIds(),
-			serviceContext.getAssetTagNames(),
-			serviceContext.getAssetLinkEntryIds(),
-			serviceContext.getAssetPriority(), serviceContext);
-
-		_addFriendlyURLEntry(
-			objectDefinition, objectEntry, serviceContext, values);
-
-		_startWorkflowInstance(userId, objectEntry, serviceContext, true);
-
-		_updateResourcePermissions(
-			objectDefinition, objectEntry, serviceContext);
-
-		_deleteFileEntries(
-			objectEntry.getValues(), objectEntry.getObjectDefinitionId(),
-			transientValues);
-
-		_executeObjectActions(
-			objectEntry.getCompanyId(),
-			ObjectActionTriggerConstants.KEY_ON_AFTER_UPDATE, objectDefinition,
-			objectEntry, originalObjectEntry, serviceContext.getLanguageId(),
-			user);
-
-		_deleteTempFileEntries(dlFileEntriesMap);
-
-		if (objectEntry.isPending() || originalObjectEntry.isDraft() ||
-			originalObjectEntry.isExpired()) {
-
-			_updateLatestObjectEntryVersion(objectDefinition, objectEntry);
-
-			return objectEntry;
-		}
-
-		return _addObjectEntryVersion(objectDefinition, objectEntry);
+		return _updateObjectEntry(
+			objectEntryId, false, serviceContext, userId, values);
 	}
 
 	@Override
@@ -2207,8 +1984,9 @@ public class ObjectEntryLocalServiceImpl
 			null,
 			_objectFieldLocalService.getObjectFields(
 				objectEntry.getObjectDefinitionId()),
-			serviceContext, objectEntry.getStatus(), serviceContext.getUserId(),
-			validationErrors, objectEntry.getValues());
+			true, serviceContext, objectEntry.getStatus(),
+			serviceContext.getUserId(), validationErrors,
+			objectEntry.getValues());
 
 		if (ListUtil.isNotEmpty(validationErrors)) {
 			throw new ObjectEntryValidationException() {
@@ -3539,6 +3317,7 @@ public class ObjectEntryLocalServiceImpl
 
 	private Set<Locale> _getLocales(
 		long companyId, List<ObjectField> objectFields,
+		Map<String, Serializable> originalValues, boolean partialUpdate,
 		Map<String, Serializable> values) {
 
 		Set<Locale> locales = new HashSet<>();
@@ -3547,6 +3326,11 @@ public class ObjectEntryLocalServiceImpl
 			Map<String, String> localizedValues =
 				(Map<String, String>)values.get(
 					objectField.getI18nObjectFieldName());
+
+			if (MapUtil.isEmpty(localizedValues) && partialUpdate) {
+				localizedValues = (Map<String, String>)originalValues.get(
+					objectField.getI18nObjectFieldName());
+			}
 
 			if (MapUtil.isEmpty(localizedValues)) {
 				continue;
@@ -4418,6 +4202,7 @@ public class ObjectEntryLocalServiceImpl
 	private void _insertIntoLocalizationTable(
 			Map<String, Serializable> insertedValues,
 			ObjectDefinition objectDefinition, long objectEntryId,
+			Map<String, Serializable> originalValues, boolean partialUpdate,
 			Map<String, Serializable> values)
 		throws PortalException {
 
@@ -4464,7 +4249,8 @@ public class ObjectEntryLocalServiceImpl
 		}
 
 		Set<Locale> locales = _getLocales(
-			objectDefinition.getCompanyId(), objectFields, values);
+			objectDefinition.getCompanyId(), objectFields, originalValues,
+			partialUpdate, values);
 
 		if (locales.isEmpty()) {
 			return;
@@ -4510,13 +4296,24 @@ public class ObjectEntryLocalServiceImpl
 					Map<String, Serializable> insertedLocalizedValue =
 						new HashMap<>(1);
 
+					Object localizedValue = _getLocalizedValue(
+						languageId,
+						(Map<String, Object>)values.get(
+							objectField.getI18nObjectFieldName()));
+
+					if (Validator.isBlank(
+							GetterUtil.getString(localizedValue)) &&
+						partialUpdate) {
+
+						localizedValue = _getLocalizedValue(
+							languageId,
+							(Map<String, Object>)originalValues.get(
+								objectField.getI18nObjectFieldName()));
+					}
+
 					_setColumn(
 						column, columnNames, index++, insertedLocalizedValue,
-						objectField, preparedStatement,
-						_getLocalizedValue(
-							languageId,
-							(Map<String, Object>)values.get(
-								objectField.getI18nObjectFieldName())));
+						objectField, preparedStatement, localizedValue);
 
 					Map<String, Serializable> localizedValues =
 						(Map<String, Serializable>)insertedValues.getOrDefault(
@@ -4549,7 +4346,7 @@ public class ObjectEntryLocalServiceImpl
 	private boolean _insertIntoTable(
 			DynamicObjectDefinitionTable dynamicObjectDefinitionTable,
 			Map<String, Serializable> insertedValues, long objectEntryId,
-			Map<String, Serializable> values)
+			boolean partialUpdate, Map<String, Serializable> values)
 		throws PortalException {
 
 		List<String> columnNames = new ArrayList<>();
@@ -4581,7 +4378,9 @@ public class ObjectEntryLocalServiceImpl
 				staticValues = false;
 			}
 
-			if (!objectField.hasInsertValues() || objectField.isLocalized()) {
+			if (!_processObjectField(
+					true, objectField, partialUpdate, values)) {
+
 				continue;
 			}
 
@@ -4601,16 +4400,6 @@ public class ObjectEntryLocalServiceImpl
 				columnNames.add(objectField.getSortableDBColumnName());
 
 				count += 2;
-
-				continue;
-			}
-
-			if (!values.containsKey(objectField.getName())) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(
-						"No value was provided for object field \"" +
-							objectField.getName() + "\"");
-				}
 
 				continue;
 			}
@@ -4660,8 +4449,8 @@ public class ObjectEntryLocalServiceImpl
 				Types.BIGINT, objectEntryId);
 
 			for (ObjectField objectField : objectFields) {
-				if (!objectField.hasInsertValues() ||
-					objectField.isLocalized()) {
+				if (!_processObjectField(
+						true, objectField, partialUpdate, values)) {
 
 					continue;
 				}
@@ -4699,10 +4488,6 @@ public class ObjectEntryLocalServiceImpl
 						column.getSQLType(),
 						_getAutoIncrementSortableValue(prefix, suffix, value));
 
-					continue;
-				}
-
-				if (!values.containsKey(objectField.getName())) {
 					continue;
 				}
 
@@ -4775,6 +4560,37 @@ public class ObjectEntryLocalServiceImpl
 		actionableDynamicQuery.setPerformActionMethod(performActionMethod);
 
 		actionableDynamicQuery.performActions();
+	}
+
+	private boolean _processObjectField(
+		boolean insert, ObjectField objectField, boolean partialUpdate,
+		Map<String, Serializable> values) {
+
+		Supplier<Boolean> supplier =
+			insert ? objectField::hasInsertValues :
+				objectField::hasUpdateValues;
+
+		if (!supplier.get() || objectField.isLocalized()) {
+			return false;
+		}
+
+		if (!values.containsKey(objectField.getName())) {
+			if (_log.isDebugEnabled()) {
+				String logMessage =
+					"No value was provided for object field \"" +
+						objectField.getName() + "\"";
+
+				if (!partialUpdate) {
+					logMessage += ". The field is set as null";
+				}
+
+				_log.debug(logMessage);
+			}
+
+			return !partialUpdate;
+		}
+
+		return true;
 	}
 
 	private void _putInsertedValue(
@@ -4979,8 +4795,13 @@ public class ObjectEntryLocalServiceImpl
 			PreparedStatement preparedStatement, Object value)
 		throws Exception {
 
-		if (objectField.compareBusinessType(
-				ObjectFieldConstants.BUSINESS_TYPE_ENCRYPTED)) {
+		if (value == null) {
+			_setColumn(
+				columnNames, index, insertedValues, preparedStatement,
+				column.getSQLType(), value);
+		}
+		else if (objectField.compareBusinessType(
+					ObjectFieldConstants.BUSINESS_TYPE_ENCRYPTED)) {
 
 			_setColumn(
 				columnNames, index, insertedValues, preparedStatement,
@@ -5051,9 +4872,13 @@ public class ObjectEntryLocalServiceImpl
 				insertedValues, columnNames.get(index - 1), booleanValue);
 		}
 		else if (sqlType == Types.CLOB) {
-			String valueString = String.valueOf(value);
+			String valueString = null;
 
-			if (valueString.isEmpty() ||
+			if (value != null) {
+				valueString = String.valueOf(value);
+			}
+
+			if (Validator.isBlank(valueString) ||
 				(DBManagerUtil.getDBType() == DBType.POSTGRESQL)) {
 
 				preparedStatement.setString(index, valueString);
@@ -5085,7 +4910,7 @@ public class ObjectEntryLocalServiceImpl
 
 				preparedStatement.setTimestamp(index, timestamp);
 			}
-			else if (valueString.isEmpty()) {
+			else if (Validator.isNull(valueString)) {
 				preparedStatement.setTimestamp(index, null);
 			}
 			else {
@@ -5435,6 +5260,145 @@ public class ObjectEntryLocalServiceImpl
 			objectEntry);
 	}
 
+	private ObjectEntry _updateObjectEntry(
+			long objectEntryId, boolean partialUpdate,
+			ServiceContext serviceContext, long userId,
+			Map<String, Serializable> values)
+		throws PortalException {
+
+		User user = _userLocalService.getUser(userId);
+
+		ObjectEntry objectEntry = objectEntryPersistence.findByPrimaryKey(
+			objectEntryId);
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionPersistence.findByPrimaryKey(
+				objectEntry.getObjectDefinitionId());
+
+		if (!partialUpdate &&
+			FeatureFlagManagerUtil.isEnabled(
+				objectEntry.getCompanyId(), "LPD-54417")) {
+
+			partialUpdate = true;
+		}
+
+		if (!partialUpdate) {
+			_fillDefaultValue(
+				objectEntry.getDefaultLanguageId(),
+				objectDefinition.getObjectDefinitionId(), values);
+		}
+
+		_contributeValues(
+			objectEntry.getGroupId(), objectDefinition, userId, values);
+
+		Map<ObjectField, Set<DLFileEntry>> dlFileEntriesMap = new HashMap<>();
+
+		_validateValues(
+			objectEntry.getDefaultLanguageId(), dlFileEntriesMap,
+			objectEntry.getValues(), objectEntry.getGroupId(),
+			user.isGuestUser(), objectDefinition,
+			objectEntry.getObjectEntryId(),
+			_objectFieldLocalService.getObjectFields(
+				objectDefinition.getObjectDefinitionId()),
+			partialUpdate, serviceContext, objectEntry.getStatus(), userId,
+			null, values);
+
+		_addDLFileEntries(
+			dlFileEntriesMap, objectDefinition, objectEntryId, serviceContext,
+			userId, values);
+
+		int workflowAction = serviceContext.getWorkflowAction();
+
+		_validateWorkflowAction(
+			objectDefinition.isEnableObjectEntryDraft(), objectDefinition,
+			objectEntry.getStatus(), workflowAction);
+
+		Map<String, Serializable> transientValues = objectEntry.getValues();
+
+		_deleteFromLocalizationTable(objectDefinition, objectEntryId);
+		_insertIntoLocalizationTable(
+			new HashMap<>(), objectDefinition, objectEntryId, transientValues,
+			partialUpdate, values);
+		_updateTable(
+			_getDynamicObjectDefinitionTable(
+				objectEntry.getObjectDefinitionId()),
+			objectEntryId, partialUpdate, values);
+		_updateTable(
+			_getExtensionDynamicObjectDefinitionTable(
+				objectEntry.getObjectDefinitionId()),
+			objectEntryId, partialUpdate, values);
+
+		objectEntryPersistence.clearCache(SetUtil.fromArray(objectEntryId));
+
+		objectEntry = objectEntryPersistence.findByPrimaryKey(objectEntryId);
+
+		_setExternalReferenceCode(objectEntry, values);
+
+		objectEntry.setModifiedDate(serviceContext.getModifiedDate(null));
+
+		_setRootObjectEntryId(objectDefinition, objectEntry, values);
+
+		if ((workflowAction == WorkflowConstants.ACTION_SAVE_DRAFT) &&
+			!objectEntry.isPending()) {
+
+			objectEntry.setStatus(WorkflowConstants.STATUS_DRAFT);
+			objectEntry.setStatusByUserId(user.getUserId());
+			objectEntry.setStatusDate(serviceContext.getModifiedDate(null));
+		}
+
+		objectEntry.setTransientValues(transientValues);
+
+		ObjectEntry originalObjectEntry = objectEntry.cloneWithOriginalValues();
+
+		try {
+			if (workflowAction == WorkflowConstants.ACTION_SAVE_DRAFT) {
+				ObjectEntryThreadLocal.setSkipObjectValidationRules(true);
+			}
+
+			objectEntry = objectEntryPersistence.update(objectEntry);
+		}
+		finally {
+			ObjectEntryThreadLocal.setSkipObjectValidationRules(false);
+		}
+
+		_updateAsset(
+			serviceContext.getUserId(), objectEntry,
+			serviceContext.getAssetCategoryIds(),
+			serviceContext.getAssetTagNames(),
+			serviceContext.getAssetLinkEntryIds(),
+			serviceContext.getAssetPriority(), serviceContext);
+
+		_addFriendlyURLEntry(
+			objectDefinition, objectEntry, serviceContext, values);
+
+		_startWorkflowInstance(userId, objectEntry, serviceContext, true);
+
+		_updateResourcePermissions(
+			objectDefinition, objectEntry, serviceContext);
+
+		_deleteFileEntries(
+			objectEntry.getValues(), objectEntry.getObjectDefinitionId(),
+			transientValues);
+
+		_executeObjectActions(
+			objectEntry.getCompanyId(),
+			ObjectActionTriggerConstants.KEY_ON_AFTER_UPDATE, objectDefinition,
+			objectEntry, originalObjectEntry, serviceContext.getLanguageId(),
+			user);
+
+		_deleteTempFileEntries(dlFileEntriesMap);
+
+		if (objectEntry.isPending() || originalObjectEntry.isDraft() ||
+			originalObjectEntry.isExpired()) {
+
+			_updateLatestObjectEntryVersion(objectDefinition, objectEntry);
+
+			return objectEntry;
+		}
+
+		return _addObjectEntryVersion(objectDefinition, objectEntry);
+	}
+
 	private void _updateResourcePermissions(
 			ObjectDefinition objectDefinition, ObjectEntry objectEntry,
 			ServiceContext serviceContext)
@@ -5566,7 +5530,8 @@ public class ObjectEntryLocalServiceImpl
 
 	private void _updateTable(
 			DynamicObjectDefinitionTable dynamicObjectDefinitionTable,
-			long objectEntryId, Map<String, Serializable> values)
+			long objectEntryId, boolean partialUpdate,
+			Map<String, Serializable> values)
 		throws PortalException {
 
 		List<String> columnNames = new ArrayList<>();
@@ -5582,16 +5547,8 @@ public class ObjectEntryLocalServiceImpl
 			dynamicObjectDefinitionTable.getObjectFields();
 
 		for (ObjectField objectField : objectFields) {
-			if (!objectField.hasUpdateValues() || objectField.isLocalized()) {
-				continue;
-			}
-
-			if (!values.containsKey(objectField.getName())) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(
-						"No value was provided for object field \"" +
-							objectField.getName() + "\"");
-				}
+			if (!_processObjectField(
+					false, objectField, partialUpdate, values)) {
 
 				continue;
 			}
@@ -5654,9 +5611,8 @@ public class ObjectEntryLocalServiceImpl
 			int index = 1;
 
 			for (ObjectField objectField : objectFields) {
-				if (!objectField.hasUpdateValues() ||
-					objectField.isLocalized() ||
-					!values.containsKey(objectField.getName())) {
+				if (!_processObjectField(
+						false, objectField, partialUpdate, values)) {
 
 					continue;
 				}
@@ -6005,15 +5961,16 @@ public class ObjectEntryLocalServiceImpl
 
 	private void _validateRequiredValues(
 			String defaultLanguageId, Map<String, Serializable> existingValues,
-			ObjectField objectField, ServiceContext serviceContext,
-			Integer status, List<ValidationError> validationErrors,
+			ObjectField objectField, boolean partialUpdate,
+			ServiceContext serviceContext, Integer status,
+			List<ValidationError> validationErrors,
 			Map<String, Serializable> values)
 		throws PortalException {
 
 		try {
 			_validateRequiredValues(
-				defaultLanguageId, existingValues, objectField, serviceContext,
-				status, values);
+				defaultLanguageId, existingValues, objectField, partialUpdate,
+				serviceContext, status, values);
 		}
 		catch (ObjectEntryValuesException.Required objectEntryValuesException) {
 			if (!objectField.isLocalized()) {
@@ -6029,8 +5986,9 @@ public class ObjectEntryLocalServiceImpl
 
 	private void _validateRequiredValues(
 			String defaultLanguageId, Map<String, Serializable> existingValues,
-			ObjectField objectField, ServiceContext serviceContext,
-			Integer status, Map<String, Serializable> values)
+			ObjectField objectField, boolean partialUpdate,
+			ServiceContext serviceContext, Integer status,
+			Map<String, Serializable> values)
 		throws PortalException {
 
 		if (!objectField.isRequired() ||
@@ -6047,7 +6005,7 @@ public class ObjectEntryLocalServiceImpl
 		}
 
 		if (!values.containsKey(name)) {
-			if ((existingValues == null) ||
+			if ((existingValues == null) || !partialUpdate ||
 				(status.equals(WorkflowConstants.STATUS_DRAFT) &&
 				 Validator.isNull(MapUtil.getString(existingValues, name)))) {
 
@@ -6426,18 +6384,18 @@ public class ObjectEntryLocalServiceImpl
 			Map<String, Serializable> existingValues, long groupId,
 			boolean guestUser, ObjectDefinition objectDefinition,
 			Long objectEntryId, List<ObjectField> objectFields,
-			ServiceContext serviceContext, Integer status, long userId,
-			List<ValidationError> validationErrors,
+			boolean partialUpdate, ServiceContext serviceContext,
+			Integer status, long userId, List<ValidationError> validationErrors,
 			Map<String, Serializable> values)
 		throws PortalException {
 
 		for (ObjectField objectField : objectFields) {
 			_validateRequiredValues(
-				defaultLanguageId, existingValues, objectField, serviceContext,
-				status, validationErrors, values);
+				defaultLanguageId, existingValues, objectField, partialUpdate,
+				serviceContext, status, validationErrors, values);
 
 			if (!objectField.isLocalized() &&
-				values.containsKey(objectField.getName())) {
+				(values.get(objectField.getName()) != null)) {
 
 				_validateValues(
 					dlFileEntriesMap, existingValues, groupId, guestUser,

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -530,7 +530,7 @@ public class ObjectEntryLocalServiceImpl
 				defaultLanguageId, dlFileEntriesMap, null,
 				GroupConstants.DEFAULT_PARENT_GROUP_ID, user.isGuestUser(),
 				objectDefinition, null,
-				dynamicObjectDefinitionTable.getObjectFields(), true,
+				dynamicObjectDefinitionTable.getObjectFields(), false,
 				serviceContext, null, userId, null, values);
 
 			_addDLFileEntries(
@@ -538,8 +538,8 @@ public class ObjectEntryLocalServiceImpl
 				userId, values);
 
 			_insertIntoTable(
-				dynamicObjectDefinitionTable, new HashMap<>(), primaryKey, true,
-				values);
+				dynamicObjectDefinitionTable, new HashMap<>(), primaryKey,
+				false, values);
 		}
 
 		_deleteTempFileEntries(dlFileEntriesMap);
@@ -1631,12 +1631,12 @@ public class ObjectEntryLocalServiceImpl
 				defaultLanguageId, Collections.emptyMap(), null,
 				GroupConstants.DEFAULT_PARENT_GROUP_ID, user.isGuestUser(),
 				objectDefinition, null,
-				dynamicObjectDefinitionTable.getObjectFields(), true,
+				dynamicObjectDefinitionTable.getObjectFields(), false,
 				new ServiceContext(), null, userId, null, values);
 
 			_insertIntoTable(
-				dynamicObjectDefinitionTable, new HashMap<>(), primaryKey, true,
-				values);
+				dynamicObjectDefinitionTable, new HashMap<>(), primaryKey,
+				false, values);
 		}
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -4575,6 +4575,12 @@ public class ObjectEntryLocalServiceImpl
 		}
 
 		if (!values.containsKey(objectField.getName())) {
+			if (objectField.compareBusinessType(
+					ObjectFieldConstants.BUSINESS_TYPE_RELATIONSHIP)) {
+
+				return false;
+			}
+
 			if (_log.isDebugEnabled()) {
 				String logMessage =
 					"No value was provided for object field \"" +

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -5275,13 +5275,6 @@ public class ObjectEntryLocalServiceImpl
 			_objectDefinitionPersistence.findByPrimaryKey(
 				objectEntry.getObjectDefinitionId());
 
-		if (!partialUpdate &&
-			FeatureFlagManagerUtil.isEnabled(
-				objectEntry.getCompanyId(), "LPD-54417")) {
-
-			partialUpdate = true;
-		}
-
 		if (!partialUpdate) {
 			_fillDefaultValue(
 				objectEntry.getDefaultLanguageId(),

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -3348,9 +3348,10 @@ public class ObjectEntryLocalServiceImpl
 	private Object _getLocalizedValue(
 		String languageId, Map<String, Object> localizedValues) {
 
-		if ((localizedValues == null) ||
-			!localizedValues.containsKey(languageId)) {
-
+		if (localizedValues == null) {
+			return null;
+		}
+		else if (!localizedValues.containsKey(languageId)) {
 			return StringPool.BLANK;
 		}
 
@@ -4301,14 +4302,16 @@ public class ObjectEntryLocalServiceImpl
 						(Map<String, Object>)values.get(
 							objectField.getI18nObjectFieldName()));
 
-					if (Validator.isBlank(
-							GetterUtil.getString(localizedValue)) &&
-						partialUpdate) {
+					if (localizedValue == null) {
+						if (partialUpdate) {
+							localizedValue = _getLocalizedValue(
+								languageId,
+								(Map<String, Object>)originalValues.get(
+									objectField.getI18nObjectFieldName()));
+						}
 
-						localizedValue = _getLocalizedValue(
-							languageId,
-							(Map<String, Object>)originalValues.get(
-								objectField.getI18nObjectFieldName()));
+						localizedValue = GetterUtil.getObject(
+							localizedValue, StringPool.BLANK);
 					}
 
 					_setColumn(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -1638,6 +1638,128 @@ public class ObjectEntryLocalServiceImpl
 	}
 
 	@Override
+	public ObjectEntry partialUpdateObjectEntry(
+			long userId, long objectEntryId, Map<String, Serializable> values,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		User user = _userLocalService.getUser(userId);
+
+		ObjectEntry objectEntry = objectEntryPersistence.findByPrimaryKey(
+			objectEntryId);
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionPersistence.findByPrimaryKey(
+				objectEntry.getObjectDefinitionId());
+
+		_contributeValues(
+			objectEntry.getGroupId(), objectDefinition, userId, values);
+
+		Map<ObjectField, Set<DLFileEntry>> dlFileEntriesMap = new HashMap<>();
+
+		_validateValues(
+			objectEntry.getDefaultLanguageId(), dlFileEntriesMap,
+			objectEntry.getValues(), objectEntry.getGroupId(),
+			user.isGuestUser(), objectDefinition,
+			objectEntry.getObjectEntryId(),
+			_objectFieldLocalService.getObjectFields(
+				objectDefinition.getObjectDefinitionId()),
+			serviceContext, objectEntry.getStatus(), userId, null, values);
+
+		_addDLFileEntries(
+			dlFileEntriesMap, objectDefinition, objectEntryId, serviceContext,
+			userId, values);
+
+		int workflowAction = serviceContext.getWorkflowAction();
+
+		_validateWorkflowAction(
+			objectDefinition.isEnableObjectEntryDraft(), objectDefinition,
+			objectEntry.getStatus(), workflowAction);
+
+		Map<String, Serializable> transientValues = objectEntry.getValues();
+
+		_deleteFromLocalizationTable(objectDefinition, objectEntryId);
+		_insertIntoLocalizationTable(
+			new HashMap<>(), objectDefinition, objectEntryId, values);
+		_updateTable(
+			_getDynamicObjectDefinitionTable(
+				objectEntry.getObjectDefinitionId()),
+			objectEntryId, values);
+		_updateTable(
+			_getExtensionDynamicObjectDefinitionTable(
+				objectEntry.getObjectDefinitionId()),
+			objectEntryId, values);
+
+		objectEntryPersistence.clearCache(SetUtil.fromArray(objectEntryId));
+
+		objectEntry = objectEntryPersistence.findByPrimaryKey(objectEntryId);
+
+		_setExternalReferenceCode(objectEntry, values);
+
+		objectEntry.setModifiedDate(serviceContext.getModifiedDate(null));
+
+		_setRootObjectEntryId(objectDefinition, objectEntry, values);
+
+		if ((workflowAction == WorkflowConstants.ACTION_SAVE_DRAFT) &&
+			!objectEntry.isPending()) {
+
+			objectEntry.setStatus(WorkflowConstants.STATUS_DRAFT);
+			objectEntry.setStatusByUserId(user.getUserId());
+			objectEntry.setStatusDate(serviceContext.getModifiedDate(null));
+		}
+
+		objectEntry.setTransientValues(transientValues);
+
+		ObjectEntry originalObjectEntry = objectEntry.cloneWithOriginalValues();
+
+		try {
+			if (workflowAction == WorkflowConstants.ACTION_SAVE_DRAFT) {
+				ObjectEntryThreadLocal.setSkipObjectValidationRules(true);
+			}
+
+			objectEntry = objectEntryPersistence.update(objectEntry);
+		}
+		finally {
+			ObjectEntryThreadLocal.setSkipObjectValidationRules(false);
+		}
+
+		_updateAsset(
+			serviceContext.getUserId(), objectEntry,
+			serviceContext.getAssetCategoryIds(),
+			serviceContext.getAssetTagNames(),
+			serviceContext.getAssetLinkEntryIds(),
+			serviceContext.getAssetPriority(), serviceContext);
+
+		_addFriendlyURLEntry(
+			objectDefinition, objectEntry, serviceContext, values);
+
+		_startWorkflowInstance(userId, objectEntry, serviceContext, true);
+
+		_updateResourcePermissions(
+			objectDefinition, objectEntry, serviceContext);
+
+		_deleteFileEntries(
+			objectEntry.getValues(), objectEntry.getObjectDefinitionId(),
+			transientValues);
+
+		_executeObjectActions(
+			objectEntry.getCompanyId(),
+			ObjectActionTriggerConstants.KEY_ON_AFTER_UPDATE, objectDefinition,
+			objectEntry, originalObjectEntry, serviceContext.getLanguageId(),
+			user);
+
+		_deleteTempFileEntries(dlFileEntriesMap);
+
+		if (objectEntry.isPending() || originalObjectEntry.isDraft()) {
+			_updateLatestObjectEntryVersion(objectDefinition, objectEntry);
+
+			return objectEntry;
+		}
+
+		return _addObjectEntryVersion(objectDefinition, objectEntry);
+	}
+
+	@Override
 	public BaseModelSearchResult<ObjectEntry> searchObjectEntries(
 			long groupId, long objectDefinitionId, String keywords, int cur,
 			int delta)

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -4381,9 +4381,7 @@ public class ObjectEntryLocalServiceImpl
 				staticValues = false;
 			}
 
-			if (!_processObjectField(
-					true, objectField, partialUpdate, values)) {
-
+			if (!objectField.hasInsertValues() || objectField.isLocalized()) {
 				continue;
 			}
 
@@ -4403,6 +4401,12 @@ public class ObjectEntryLocalServiceImpl
 				columnNames.add(objectField.getSortableDBColumnName());
 
 				count += 2;
+
+				continue;
+			}
+
+			if (!values.containsKey(objectField.getName()) &&
+				!_processMissingObjectField(objectField, partialUpdate)) {
 
 				continue;
 			}
@@ -4452,8 +4456,8 @@ public class ObjectEntryLocalServiceImpl
 				Types.BIGINT, objectEntryId);
 
 			for (ObjectField objectField : objectFields) {
-				if (!_processObjectField(
-						true, objectField, partialUpdate, values)) {
+				if (!objectField.hasInsertValues() ||
+					objectField.isLocalized()) {
 
 					continue;
 				}
@@ -4490,6 +4494,12 @@ public class ObjectEntryLocalServiceImpl
 						columnNames, index++, insertedValues, preparedStatement,
 						column.getSQLType(),
 						_getAutoIncrementSortableValue(prefix, suffix, value));
+
+					continue;
+				}
+
+				if (!values.containsKey(objectField.getName()) &&
+					!_processMissingObjectField(objectField, partialUpdate)) {
 
 					continue;
 				}
@@ -4565,41 +4575,28 @@ public class ObjectEntryLocalServiceImpl
 		actionableDynamicQuery.performActions();
 	}
 
-	private boolean _processObjectField(
-		boolean insert, ObjectField objectField, boolean partialUpdate,
-		Map<String, Serializable> values) {
+	private boolean _processMissingObjectField(
+		ObjectField objectField, boolean partialUpdate) {
 
-		Supplier<Boolean> supplier =
-			insert ? objectField::hasInsertValues :
-				objectField::hasUpdateValues;
+		if (objectField.compareBusinessType(
+				ObjectFieldConstants.BUSINESS_TYPE_RELATIONSHIP)) {
 
-		if (!supplier.get() || objectField.isLocalized()) {
 			return false;
 		}
 
-		if (!values.containsKey(objectField.getName())) {
-			if (objectField.compareBusinessType(
-					ObjectFieldConstants.BUSINESS_TYPE_RELATIONSHIP)) {
+		if (_log.isDebugEnabled()) {
+			String logMessage =
+				"No value was provided for object field \"" +
+					objectField.getName() + "\"";
 
-				return false;
+			if (!partialUpdate) {
+				logMessage += ". The field is set as null";
 			}
 
-			if (_log.isDebugEnabled()) {
-				String logMessage =
-					"No value was provided for object field \"" +
-						objectField.getName() + "\"";
-
-				if (!partialUpdate) {
-					logMessage += ". The field is set as null";
-				}
-
-				_log.debug(logMessage);
-			}
-
-			return !partialUpdate;
+			_log.debug(logMessage);
 		}
 
-		return true;
+		return !partialUpdate;
 	}
 
 	private void _putInsertedValue(
@@ -5549,8 +5546,12 @@ public class ObjectEntryLocalServiceImpl
 			dynamicObjectDefinitionTable.getObjectFields();
 
 		for (ObjectField objectField : objectFields) {
-			if (!_processObjectField(
-					false, objectField, partialUpdate, values)) {
+			if (!objectField.hasUpdateValues() || objectField.isLocalized()) {
+				continue;
+			}
+
+			if (!values.containsKey(objectField.getName()) &&
+				!_processMissingObjectField(objectField, partialUpdate)) {
 
 				continue;
 			}
@@ -5613,8 +5614,14 @@ public class ObjectEntryLocalServiceImpl
 			int index = 1;
 
 			for (ObjectField objectField : objectFields) {
-				if (!_processObjectField(
-						false, objectField, partialUpdate, values)) {
+				if (!objectField.hasUpdateValues() ||
+					objectField.isLocalized()) {
+
+					continue;
+				}
+
+				if (!values.containsKey(objectField.getName()) &&
+					!_processMissingObjectField(objectField, partialUpdate)) {
 
 					continue;
 				}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java
@@ -420,6 +420,25 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 	}
 
 	@Override
+	public ObjectEntry partialUpdateObjectEntry(
+			long objectEntryId, Map<String, Serializable> values,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		ObjectEntry objectEntry = objectEntryLocalService.getObjectEntry(
+			objectEntryId);
+
+		if (!ObjectEntryThreadLocal.isSkipObjectEntryResourcePermission()) {
+			checkModelResourcePermission(
+				objectEntry.getObjectDefinitionId(),
+				objectEntry.getObjectEntryId(), ActionKeys.UPDATE);
+		}
+
+		return objectEntryLocalService.partialUpdateObjectEntry(
+			getUserId(), objectEntryId, values, serviceContext);
+	}
+
+	@Override
 	public ObjectEntry updateObjectEntry(
 			long objectEntryId, Map<String, Serializable> values,
 			ServiceContext serviceContext)

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -242,11 +242,9 @@ public class ObjectRelationshipLocalServiceImpl
 				).build());
 		}
 		else {
-			_objectEntryLocalService.updateObjectEntry(
+			_objectEntryLocalService.partialUpdateObjectEntry(
 				userId, primaryKey2,
-				HashMapBuilder.<String, Serializable>putAll(
-					_objectEntryLocalService.getValues(primaryKey2)
-				).put(
+				HashMapBuilder.<String, Serializable>put(
 					objectField2.getName(), primaryKey1
 				).build(),
 				serviceContext);

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
@@ -726,7 +726,7 @@ public class ObjectActionLocalServiceTest {
 
 			Assert.assertEquals(0, _argumentsList.size());
 
-			objectEntry = _objectEntryLocalService.updateObjectEntry(
+			objectEntry = _objectEntryLocalService.partialUpdateObjectEntry(
 				TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
 				HashMapBuilder.<String, Serializable>put(
 					"firstName", "João"
@@ -784,7 +784,7 @@ public class ObjectActionLocalServiceTest {
 			// Execute standalone system action to update the current object
 			// entry
 
-			objectEntry = _objectEntryLocalService.updateObjectEntry(
+			objectEntry = _objectEntryLocalService.partialUpdateObjectEntry(
 				TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
 				HashMapBuilder.<String, Serializable>put(
 					"firstName", RandomTestUtil.randomString()

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -7449,10 +7449,11 @@ public class ObjectEntryLocalServiceTest {
 
 		Assert.assertEquals("Julia", values.get("firstName"));
 		Assert.assertEquals(
-			StringPool.BLANK,
+			objectEntry2.getExternalReferenceCode(),
 			values.get("r_objectRelationship_c_relatedObjectDefinitionERC"));
 		Assert.assertEquals(
-			0L, values.get("r_objectRelationship_c_relatedObjectDefinitionId"));
+			objectEntry2.getObjectEntryId(),
+			values.get("r_objectRelationship_c_relatedObjectDefinitionId"));
 
 		objectEntry1 = _objectEntryLocalService.updateObjectEntry(
 			TestPropsValues.getUserId(), objectEntryId1,

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -6967,7 +6967,13 @@ public class ObjectEntryLocalServiceTest {
 			_objectRelationshipLocalService, objectDefinition,
 			_objectDefinition,
 			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
-			"objectRelationship");
+			"objectRelationship1");
+
+		ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectRelationshipLocalService, objectDefinition,
+			_objectDefinition,
+			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+			"objectRelationship2");
 
 		ObjectEntry objectEntry1 = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
@@ -6990,11 +6996,24 @@ public class ObjectEntryLocalServiceTest {
 		Assert.assertEquals("Charles", values.get("firstName"));
 		Assert.assertEquals(
 			StringPool.BLANK,
-			values.get("r_objectRelationship_c_relatedObjectDefinitionERC"));
+			values.get("r_objectRelationship1_c_relatedObjectDefinitionERC"));
 		Assert.assertEquals(
-			0L, values.get("r_objectRelationship_c_relatedObjectDefinitionId"));
+			0L,
+			values.get("r_objectRelationship1_c_relatedObjectDefinitionId"));
+		Assert.assertEquals(
+			StringPool.BLANK,
+			values.get("r_objectRelationship2_c_relatedObjectDefinitionERC"));
+		Assert.assertEquals(
+			0L,
+			values.get("r_objectRelationship2_c_relatedObjectDefinitionId"));
 
 		ObjectEntry objectEntry2 = _addObjectEntry(
+			0, objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"name", RandomTestUtil.randomString()
+			).build());
+
+		ObjectEntry objectEntry3 = _addObjectEntry(
 			0, objectDefinition.getObjectDefinitionId(),
 			HashMapBuilder.<String, Serializable>put(
 				"name", RandomTestUtil.randomString()
@@ -7003,7 +7022,16 @@ public class ObjectEntryLocalServiceTest {
 		objectEntry1 = _objectEntryLocalService.partialUpdateObjectEntry(
 			TestPropsValues.getUserId(), objectEntryId1,
 			HashMapBuilder.<String, Serializable>put(
-				"r_objectRelationship_c_relatedObjectDefinitionId",
+				"r_objectRelationship1_c_relatedObjectDefinitionERC",
+				objectEntry2.getObjectEntryId()
+			).put(
+				"r_objectRelationship1_c_relatedObjectDefinitionId",
+				objectEntry3.getObjectEntryId()
+			).put(
+				"r_objectRelationship2_c_relatedObjectDefinitionERC",
+				objectEntry3.getObjectEntryId()
+			).put(
+				"r_objectRelationship2_c_relatedObjectDefinitionId",
 				objectEntry2.getObjectEntryId()
 			).build(),
 			ServiceContextTestUtil.getServiceContext());
@@ -7012,11 +7040,17 @@ public class ObjectEntryLocalServiceTest {
 
 		Assert.assertEquals("Charles", values.get("firstName"));
 		Assert.assertEquals(
+			objectEntry3.getExternalReferenceCode(),
+			values.get("r_objectRelationship1_c_relatedObjectDefinitionERC"));
+		Assert.assertEquals(
+			objectEntry3.getObjectEntryId(),
+			values.get("r_objectRelationship1_c_relatedObjectDefinitionId"));
+		Assert.assertEquals(
 			objectEntry2.getExternalReferenceCode(),
-			values.get("r_objectRelationship_c_relatedObjectDefinitionERC"));
+			values.get("r_objectRelationship2_c_relatedObjectDefinitionERC"));
 		Assert.assertEquals(
 			objectEntry2.getObjectEntryId(),
-			values.get("r_objectRelationship_c_relatedObjectDefinitionId"));
+			values.get("r_objectRelationship2_c_relatedObjectDefinitionId"));
 
 		objectEntry1 = _objectEntryLocalService.partialUpdateObjectEntry(
 			TestPropsValues.getUserId(), objectEntryId1,
@@ -7029,18 +7063,27 @@ public class ObjectEntryLocalServiceTest {
 
 		Assert.assertEquals("Julia", values.get("firstName"));
 		Assert.assertEquals(
+			objectEntry3.getExternalReferenceCode(),
+			values.get("r_objectRelationship1_c_relatedObjectDefinitionERC"));
+		Assert.assertEquals(
+			objectEntry3.getObjectEntryId(),
+			values.get("r_objectRelationship1_c_relatedObjectDefinitionId"));
+		Assert.assertEquals(
 			objectEntry2.getExternalReferenceCode(),
-			values.get("r_objectRelationship_c_relatedObjectDefinitionERC"));
+			values.get("r_objectRelationship2_c_relatedObjectDefinitionERC"));
 		Assert.assertEquals(
 			objectEntry2.getObjectEntryId(),
-			values.get("r_objectRelationship_c_relatedObjectDefinitionId"));
+			values.get("r_objectRelationship2_c_relatedObjectDefinitionId"));
 
 		objectEntry1 = _objectEntryLocalService.partialUpdateObjectEntry(
 			TestPropsValues.getUserId(), objectEntryId1,
 			HashMapBuilder.<String, Serializable>put(
 				"firstName", "Zape"
 			).put(
-				"r_objectRelationship_c_relatedObjectDefinitionId", 0L
+				"r_objectRelationship1_c_relatedObjectDefinitionId", 0L
+			).put(
+				"r_objectRelationship2_c_relatedObjectDefinitionERC",
+				StringPool.BLANK
 			).build(),
 			ServiceContextTestUtil.getServiceContext());
 
@@ -7049,13 +7092,22 @@ public class ObjectEntryLocalServiceTest {
 		Assert.assertEquals("Zape", values.get("firstName"));
 		Assert.assertEquals(
 			StringPool.BLANK,
-			values.get("r_objectRelationship_c_relatedObjectDefinitionERC"));
+			values.get("r_objectRelationship1_c_relatedObjectDefinitionERC"));
 		Assert.assertEquals(
-			0L, values.get("r_objectRelationship_c_relatedObjectDefinitionId"));
+			0L,
+			values.get("r_objectRelationship1_c_relatedObjectDefinitionId"));
+		Assert.assertEquals(
+			objectEntry2.getExternalReferenceCode(),
+			values.get("r_objectRelationship2_c_relatedObjectDefinitionERC"));
+		Assert.assertEquals(
+			objectEntry2.getObjectEntryId(),
+			values.get("r_objectRelationship2_c_relatedObjectDefinitionId"));
 
 		_objectEntryLocalService.deleteObjectEntry(objectEntryId1);
 		_objectEntryLocalService.deleteObjectEntry(
 			objectEntry2.getObjectEntryId());
+		_objectEntryLocalService.deleteObjectEntry(
+			objectEntry3.getObjectEntryId());
 
 		_objectDefinitionLocalService.deleteObjectDefinition(
 			objectDefinition.getObjectDefinitionId());
@@ -7375,7 +7427,13 @@ public class ObjectEntryLocalServiceTest {
 			_objectRelationshipLocalService, objectDefinition,
 			_objectDefinition,
 			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
-			"objectRelationship");
+			"objectRelationship1");
+
+		ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectRelationshipLocalService, objectDefinition,
+			_objectDefinition,
+			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+			"objectRelationship2");
 
 		Map<String, Serializable> requiredValues =
 			HashMapBuilder.<String, Serializable>put(
@@ -7406,11 +7464,24 @@ public class ObjectEntryLocalServiceTest {
 		Assert.assertEquals("Charles", values.get("firstName"));
 		Assert.assertEquals(
 			StringPool.BLANK,
-			values.get("r_objectRelationship_c_relatedObjectDefinitionERC"));
+			values.get("r_objectRelationship1_c_relatedObjectDefinitionERC"));
 		Assert.assertEquals(
-			0L, values.get("r_objectRelationship_c_relatedObjectDefinitionId"));
+			0L,
+			values.get("r_objectRelationship1_c_relatedObjectDefinitionId"));
+		Assert.assertEquals(
+			StringPool.BLANK,
+			values.get("r_objectRelationship2_c_relatedObjectDefinitionERC"));
+		Assert.assertEquals(
+			0L,
+			values.get("r_objectRelationship2_c_relatedObjectDefinitionId"));
 
 		ObjectEntry objectEntry2 = _addObjectEntry(
+			0, objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"name", RandomTestUtil.randomString()
+			).build());
+
+		ObjectEntry objectEntry3 = _addObjectEntry(
 			0, objectDefinition.getObjectDefinitionId(),
 			HashMapBuilder.<String, Serializable>put(
 				"name", RandomTestUtil.randomString()
@@ -7419,7 +7490,16 @@ public class ObjectEntryLocalServiceTest {
 		objectEntry1 = _objectEntryLocalService.updateObjectEntry(
 			TestPropsValues.getUserId(), objectEntryId1,
 			HashMapBuilder.<String, Serializable>put(
-				"r_objectRelationship_c_relatedObjectDefinitionId",
+				"r_objectRelationship1_c_relatedObjectDefinitionERC",
+				objectEntry2.getObjectEntryId()
+			).put(
+				"r_objectRelationship1_c_relatedObjectDefinitionId",
+				objectEntry3.getObjectEntryId()
+			).put(
+				"r_objectRelationship2_c_relatedObjectDefinitionERC",
+				objectEntry3.getObjectEntryId()
+			).put(
+				"r_objectRelationship2_c_relatedObjectDefinitionId",
 				objectEntry2.getObjectEntryId()
 			).putAll(
 				requiredValues
@@ -7430,11 +7510,17 @@ public class ObjectEntryLocalServiceTest {
 
 		Assert.assertEquals(StringPool.BLANK, values.get("firstName"));
 		Assert.assertEquals(
+			objectEntry3.getExternalReferenceCode(),
+			values.get("r_objectRelationship1_c_relatedObjectDefinitionERC"));
+		Assert.assertEquals(
+			objectEntry3.getObjectEntryId(),
+			values.get("r_objectRelationship1_c_relatedObjectDefinitionId"));
+		Assert.assertEquals(
 			objectEntry2.getExternalReferenceCode(),
-			values.get("r_objectRelationship_c_relatedObjectDefinitionERC"));
+			values.get("r_objectRelationship2_c_relatedObjectDefinitionERC"));
 		Assert.assertEquals(
 			objectEntry2.getObjectEntryId(),
-			values.get("r_objectRelationship_c_relatedObjectDefinitionId"));
+			values.get("r_objectRelationship2_c_relatedObjectDefinitionId"));
 
 		objectEntry1 = _objectEntryLocalService.updateObjectEntry(
 			TestPropsValues.getUserId(), objectEntryId1,
@@ -7449,18 +7535,27 @@ public class ObjectEntryLocalServiceTest {
 
 		Assert.assertEquals("Julia", values.get("firstName"));
 		Assert.assertEquals(
+			objectEntry3.getExternalReferenceCode(),
+			values.get("r_objectRelationship1_c_relatedObjectDefinitionERC"));
+		Assert.assertEquals(
+			objectEntry3.getObjectEntryId(),
+			values.get("r_objectRelationship1_c_relatedObjectDefinitionId"));
+		Assert.assertEquals(
 			objectEntry2.getExternalReferenceCode(),
-			values.get("r_objectRelationship_c_relatedObjectDefinitionERC"));
+			values.get("r_objectRelationship2_c_relatedObjectDefinitionERC"));
 		Assert.assertEquals(
 			objectEntry2.getObjectEntryId(),
-			values.get("r_objectRelationship_c_relatedObjectDefinitionId"));
+			values.get("r_objectRelationship2_c_relatedObjectDefinitionId"));
 
 		objectEntry1 = _objectEntryLocalService.updateObjectEntry(
 			TestPropsValues.getUserId(), objectEntryId1,
 			HashMapBuilder.<String, Serializable>put(
 				"firstName", "Zape"
 			).put(
-				"r_objectRelationship_c_relatedObjectDefinitionId", 0L
+				"r_objectRelationship1_c_relatedObjectDefinitionId", 0L
+			).put(
+				"r_objectRelationship2_c_relatedObjectDefinitionERC",
+				StringPool.BLANK
 			).putAll(
 				requiredValues
 			).build(),
@@ -7471,13 +7566,22 @@ public class ObjectEntryLocalServiceTest {
 		Assert.assertEquals("Zape", values.get("firstName"));
 		Assert.assertEquals(
 			StringPool.BLANK,
-			values.get("r_objectRelationship_c_relatedObjectDefinitionERC"));
+			values.get("r_objectRelationship1_c_relatedObjectDefinitionERC"));
 		Assert.assertEquals(
-			0L, values.get("r_objectRelationship_c_relatedObjectDefinitionId"));
+			0L,
+			values.get("r_objectRelationship1_c_relatedObjectDefinitionId"));
+		Assert.assertEquals(
+			objectEntry2.getExternalReferenceCode(),
+			values.get("r_objectRelationship2_c_relatedObjectDefinitionERC"));
+		Assert.assertEquals(
+			objectEntry2.getObjectEntryId(),
+			values.get("r_objectRelationship2_c_relatedObjectDefinitionId"));
 
 		_objectEntryLocalService.deleteObjectEntry(objectEntryId1);
 		_objectEntryLocalService.deleteObjectEntry(
 			objectEntry2.getObjectEntryId());
+		_objectEntryLocalService.deleteObjectEntry(
+			objectEntry3.getObjectEntryId());
 
 		_objectDefinitionLocalService.deleteObjectDefinition(
 			objectDefinition.getObjectDefinitionId());

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -153,6 +153,7 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerBumper;
 import com.liferay.portal.kernel.test.randomizerbumpers.UniqueStringRandomizerBumper;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -194,6 +195,7 @@ import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -259,7 +261,12 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
  * @author Marco Leo
  * @author Brian Wing Shun Chan
  */
-@FeatureFlag("LPD-34594")
+@FeatureFlags(
+	featureFlags = {
+		@FeatureFlag(value = "LPD-34594"),
+		@FeatureFlag(enable = false, value = "LPD-54417")
+	}
+)
 @RunWith(Arquillian.class)
 public class ObjectEntryLocalServiceTest {
 
@@ -1206,7 +1213,7 @@ public class ObjectEntryLocalServiceTest {
 
 		// LPS-180587 Partial updates should not delete existing files
 
-		_objectEntryLocalService.updateObjectEntry(
+		_objectEntryLocalService.partialUpdateObjectEntry(
 			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
 			HashMapBuilder.<String, Serializable>put(
 				"state", "listTypeEntryKey3"
@@ -1216,7 +1223,7 @@ public class ObjectEntryLocalServiceTest {
 		Assert.assertNotNull(
 			_dlAppLocalService.getFileEntry(persistedFileEntryId1));
 
-		_objectEntryLocalService.updateObjectEntry(
+		_objectEntryLocalService.partialUpdateObjectEntry(
 			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
 			HashMapBuilder.<String, Serializable>put(
 				"upload", 0L
@@ -1232,7 +1239,7 @@ public class ObjectEntryLocalServiceTest {
 
 		// Delete object entry should delete existing files
 
-		objectEntry = _objectEntryLocalService.updateObjectEntry(
+		objectEntry = _objectEntryLocalService.partialUpdateObjectEntry(
 			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
 			HashMapBuilder.<String, Serializable>put(
 				"upload",
@@ -4258,6 +4265,350 @@ public class ObjectEntryLocalServiceTest {
 	}
 
 	@Test
+	public void testPartialUpdateObjectEntry() throws Exception {
+		_assertCount(0);
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired", "john@liferay.com"
+			).put(
+				"firstName", "John"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey1"
+			).put(
+				"multipleListTypeEntriesKey",
+				(Serializable)Arrays.asList(
+					"multipleListTypeEntryKey1", "multipleListTypeEntryKey2")
+			).build());
+
+		_assertCount(1);
+
+		Assert.assertNotNull(
+			ReflectionTestUtil.getFieldValue(objectEntry, "_values"));
+
+		_getValuesFromCacheField(objectEntry);
+
+		objectEntry = _objectEntryLocalService.partialUpdateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.putAll(
+				_objectEntryLocalService.getValues(objectEntry)
+			).put(
+				"firstName", "João"
+			).put(
+				"lastName", "o Discípulo Amado"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey2"
+			).put(
+				"multipleListTypeEntriesKey",
+				(Serializable)Arrays.asList(
+					"multipleListTypeEntryKey3", "multipleListTypeEntryKey4")
+			).put(
+				"state", "listTypeEntryKey1"
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		_assertCount(1);
+
+		objectEntry = _objectEntryLocalService.getObjectEntry(
+			objectEntry.getObjectEntryId());
+
+		Assert.assertNull(
+			ReflectionTestUtil.getFieldValue(objectEntry, "_values"));
+
+		Map<String, Serializable> values = objectEntry.getValues();
+
+		Assert.assertEquals(_getValuesFromCacheField(objectEntry), values);
+		Assert.assertEquals(0L, values.get("ageOfDeath"));
+		Assert.assertFalse((boolean)values.get("authorOfGospel"));
+		Assert.assertEquals(null, values.get("birthday"));
+		Assert.assertEquals(
+			"john@liferay.com", values.get("emailAddressRequired"));
+		Assert.assertEquals("João", values.get("firstName"));
+		Assert.assertEquals(0D, values.get("height"));
+		Assert.assertEquals("o Discípulo Amado", values.get("lastName"));
+		Assert.assertEquals(StringPool.BLANK, values.get("listTypeEntryKey"));
+		Assert.assertEquals(
+			"listTypeEntryKey2", values.get("listTypeEntryKeyRequired"));
+		Assert.assertEquals(StringPool.BLANK, values.get("middleName"));
+		Assert.assertEquals(
+			"multipleListTypeEntryKey3, multipleListTypeEntryKey4",
+			values.get("multipleListTypeEntriesKey"));
+		Assert.assertEquals(0, values.get("numberOfBooksWritten"));
+		Assert.assertEquals(StringPool.BLANK, values.get("script"));
+		Assert.assertEquals(_getBigDecimal(0L), values.get("speed"));
+		Assert.assertEquals("listTypeEntryKey1", values.get("state"));
+		Assert.assertEquals(null, values.get("time"));
+		Assert.assertEquals(0L, values.get("upload"));
+		Assert.assertEquals(0D, values.get("weight"));
+		Assert.assertEquals(
+			objectEntry.getObjectEntryId(),
+			values.get(_objectDefinition.getPKObjectFieldName()));
+		Assert.assertEquals(values.toString(), 23, values.size());
+
+		Calendar calendar = new GregorianCalendar();
+
+		calendar.set(6, Calendar.DECEMBER, 28);
+		calendar.setTimeInMillis(0);
+
+		Date birthdayDate = calendar.getTime();
+
+		String script = RandomTestUtil.randomString(1500);
+		Timestamp timestamp = Timestamp.valueOf(
+			LocalDateTime.now(
+			).withNano(
+				0
+			));
+
+		_objectEntryLocalService.partialUpdateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>put(
+				"ageOfDeath", "94"
+			).put(
+				"authorOfGospel", true
+			).put(
+				"birthday", birthdayDate
+			).put(
+				"height", 180
+			).put(
+				"listTypeEntryKey", "listTypeEntryKey1"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey3"
+			).put(
+				"multipleListTypeEntriesKey",
+				(Serializable)Arrays.asList(
+					"multipleListTypeEntryKey5", "multipleListTypeEntryKey6")
+			).put(
+				"numberOfBooksWritten", 5
+			).put(
+				"script", script
+			).put(
+				"speed", BigDecimal.valueOf(45L)
+			).put(
+				"state", "listTypeEntryKey2"
+			).put(
+				"time", timestamp
+			).put(
+				"upload", 0L
+			).put(
+				"weight", 60
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		_assertCount(1);
+
+		values = _objectEntryLocalService.getValues(
+			objectEntry.getObjectEntryId());
+
+		Assert.assertEquals(94L, values.get("ageOfDeath"));
+		Assert.assertTrue((boolean)values.get("authorOfGospel"));
+		Assert.assertEquals(birthdayDate, values.get("birthday"));
+		Assert.assertEquals(
+			"john@liferay.com", values.get("emailAddressRequired"));
+		Assert.assertEquals("João", values.get("firstName"));
+		Assert.assertEquals(180D, values.get("height"));
+		Assert.assertEquals("o Discípulo Amado", values.get("lastName"));
+		Assert.assertEquals(
+			"listTypeEntryKey1", values.get("listTypeEntryKey"));
+		Assert.assertEquals(
+			"listTypeEntryKey3", values.get("listTypeEntryKeyRequired"));
+		Assert.assertEquals(StringPool.BLANK, values.get("middleName"));
+		Assert.assertEquals(
+			"multipleListTypeEntryKey5, multipleListTypeEntryKey6",
+			values.get("multipleListTypeEntriesKey"));
+		Assert.assertEquals(5, values.get("numberOfBooksWritten"));
+		Assert.assertEquals(script, values.get("script"));
+		Assert.assertEquals(_getBigDecimal(45L), values.get("speed"));
+		Assert.assertEquals("listTypeEntryKey2", values.get("state"));
+		Assert.assertEquals(timestamp, values.get("time"));
+		Assert.assertEquals(0L, values.get("upload"));
+		Assert.assertEquals(60D, values.get("weight"));
+		Assert.assertEquals(
+			objectEntry.getObjectEntryId(),
+			values.get(_objectDefinition.getPKObjectFieldName()));
+		Assert.assertEquals(values.toString(), 23, values.size());
+
+		_objectEntryLocalService.partialUpdateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>put(
+				"state", "listTypeEntryKey3"
+			).put(
+				"upload", 0L
+			).put(
+				"weight", 65D
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		_assertCount(1);
+
+		values = _objectEntryLocalService.getValues(
+			objectEntry.getObjectEntryId());
+
+		Assert.assertEquals(94L, values.get("ageOfDeath"));
+		Assert.assertTrue((boolean)values.get("authorOfGospel"));
+		Assert.assertEquals(birthdayDate, values.get("birthday"));
+		Assert.assertEquals(
+			"john@liferay.com", values.get("emailAddressRequired"));
+		Assert.assertEquals("João", values.get("firstName"));
+		Assert.assertEquals(180D, values.get("height"));
+		Assert.assertEquals("o Discípulo Amado", values.get("lastName"));
+		Assert.assertEquals(
+			"listTypeEntryKey1", values.get("listTypeEntryKey"));
+		Assert.assertEquals(
+			"listTypeEntryKey3", values.get("listTypeEntryKeyRequired"));
+		Assert.assertEquals(StringPool.BLANK, values.get("middleName"));
+		Assert.assertEquals(
+			"multipleListTypeEntryKey5, multipleListTypeEntryKey6",
+			values.get("multipleListTypeEntriesKey"));
+		Assert.assertEquals(5, values.get("numberOfBooksWritten"));
+		Assert.assertEquals(script, values.get("script"));
+		Assert.assertEquals(_getBigDecimal(45L), values.get("speed"));
+		Assert.assertEquals("listTypeEntryKey3", values.get("state"));
+		Assert.assertEquals(timestamp, values.get("time"));
+		Assert.assertEquals(0L, values.get("upload"));
+		Assert.assertEquals(65D, values.get("weight"));
+		Assert.assertEquals(
+			objectEntry.getObjectEntryId(),
+			values.get(_objectDefinition.getPKObjectFieldName()));
+		Assert.assertEquals(values.toString(), 23, values.size());
+
+		_objectEntryLocalService.partialUpdateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>put(
+				"ageOfDeath", StringPool.BLANK
+			).put(
+				"authorOfGospel", StringPool.BLANK
+			).put(
+				"birthday", StringPool.BLANK
+			).put(
+				"firstName", StringPool.BLANK
+			).put(
+				"time", StringPool.BLANK
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		values = _objectEntryLocalService.getValues(
+			objectEntry.getObjectEntryId());
+
+		Assert.assertEquals(0L, values.get("ageOfDeath"));
+		Assert.assertFalse((boolean)values.get("authorOfGospel"));
+		Assert.assertNull(values.get("birthday"));
+		Assert.assertEquals(StringPool.BLANK, values.get("firstName"));
+		Assert.assertNull(values.get("time"));
+
+		_objectEntryLocalService.partialUpdateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			new HashMap<String, Serializable>(),
+			ServiceContextTestUtil.getServiceContext());
+
+		_objectEntryLocalService.partialUpdateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>put(
+				_objectDefinition.getPKObjectFieldName(), ""
+			).put(
+				"invalidName", ""
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		long objectEntryId = objectEntry.getObjectEntryId();
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.ExceedsIntegerSize.class,
+			"Object entry value exceeds integer field allowed size",
+			() -> _objectEntryLocalService.partialUpdateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId,
+				HashMapBuilder.<String, Serializable>put(
+					"numberOfBooksWritten", "2147483648"
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.ExceedsIntegerSize.class,
+			"Object entry value exceeds integer field allowed size",
+			() -> _objectEntryLocalService.partialUpdateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId,
+				HashMapBuilder.<String, Serializable>put(
+					"numberOfBooksWritten", "-2147483649"
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.ExceedsLongMaxSize.class,
+			"Object entry value exceeds maximum long field allowed size",
+			() -> _objectEntryLocalService.partialUpdateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId,
+				HashMapBuilder.<String, Serializable>put(
+					"ageOfDeath", "9007199254740992"
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.ExceedsLongMinSize.class,
+			"Object entry value falls below minimum long field allowed size",
+			() -> _objectEntryLocalService.partialUpdateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId,
+				HashMapBuilder.<String, Serializable>put(
+					"ageOfDeath", "-9007199254740992"
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.ExceedsLongSize.class,
+			"Object entry value exceeds long field allowed size",
+			() -> _objectEntryLocalService.partialUpdateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId,
+				HashMapBuilder.<String, Serializable>put(
+					"ageOfDeath", "9223372036854775808"
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.ExceedsLongSize.class,
+			"Object entry value exceeds long field allowed size",
+			() -> _objectEntryLocalService.partialUpdateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId,
+				HashMapBuilder.<String, Serializable>put(
+					"ageOfDeath", "-9223372036854775809"
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.ExceedsTextMaxLength.class,
+			"Object entry value exceeds the maximum length of 280 characters " +
+				"for object field \"firstName\"",
+			() -> _objectEntryLocalService.partialUpdateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId,
+				HashMapBuilder.<String, Serializable>put(
+					"firstName", RandomTestUtil.randomString(281)
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		_addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddress", "james@liferay.com"
+			).put(
+				"emailAddressRequired", "james@liferay.com"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey1"
+			).build());
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.UniqueValueConstraintViolation.class,
+			"Unique value constraint violation for " +
+				_objectDefinition.getDBTableName() +
+					".emailAddress_ with value james@liferay.com",
+			() -> _objectEntryLocalService.partialUpdateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId,
+				HashMapBuilder.<String, Serializable>put(
+					"emailAddress", "james@liferay.com"
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		_testPartialUpdateObjectEntryExternalReferenceCode();
+		_testPartialUpdateObjectEntryObjectStateTransitions();
+		_testPartialUpdateObjectEntryWithObjectRelationship();
+	}
+
+	@Test
 	public void testScope() throws Exception {
 
 		// Scope by company
@@ -4605,349 +4956,18 @@ public class ObjectEntryLocalServiceTest {
 	}
 
 	@Test
+	@TestInfo("LPD-53245")
 	public void testUpdateObjectEntry() throws Exception {
-		_assertCount(0);
+		_testUpdateObjectEntry(false);
+	}
 
-		ObjectEntry objectEntry = _addObjectEntry(
-			HashMapBuilder.<String, Serializable>put(
-				"emailAddressRequired", "john@liferay.com"
-			).put(
-				"firstName", "John"
-			).put(
-				"listTypeEntryKeyRequired", "listTypeEntryKey1"
-			).put(
-				"multipleListTypeEntriesKey",
-				(Serializable)Arrays.asList(
-					"multipleListTypeEntryKey1", "multipleListTypeEntryKey2")
-			).build());
+	@FeatureFlag("LPD-54417")
+	@Test
+	@TestInfo("LPD-53245")
+	public void testUpdateObjectEntryWithDeprecatedFeatureFlag()
+		throws Exception {
 
-		_assertCount(1);
-
-		Assert.assertNotNull(
-			ReflectionTestUtil.getFieldValue(objectEntry, "_values"));
-
-		_getValuesFromCacheField(objectEntry);
-
-		//Assert.assertNotNull(
-		//	ReflectionTestUtil.getFieldValue(objectEntry, "_values"));
-
-		objectEntry = _objectEntryLocalService.updateObjectEntry(
-			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
-			HashMapBuilder.putAll(
-				_objectEntryLocalService.getValues(objectEntry)
-			).put(
-				"firstName", "João"
-			).put(
-				"lastName", "o Discípulo Amado"
-			).put(
-				"listTypeEntryKeyRequired", "listTypeEntryKey2"
-			).put(
-				"multipleListTypeEntriesKey",
-				(Serializable)Arrays.asList(
-					"multipleListTypeEntryKey3", "multipleListTypeEntryKey4")
-			).put(
-				"state", "listTypeEntryKey1"
-			).build(),
-			ServiceContextTestUtil.getServiceContext());
-
-		_assertCount(1);
-
-		objectEntry = _objectEntryLocalService.getObjectEntry(
-			objectEntry.getObjectEntryId());
-
-		Assert.assertNull(
-			ReflectionTestUtil.getFieldValue(objectEntry, "_values"));
-
-		Map<String, Serializable> values = objectEntry.getValues();
-
-		Assert.assertEquals(_getValuesFromCacheField(objectEntry), values);
-		Assert.assertEquals(0L, values.get("ageOfDeath"));
-		Assert.assertFalse((boolean)values.get("authorOfGospel"));
-		Assert.assertEquals(null, values.get("birthday"));
-		Assert.assertEquals(
-			"john@liferay.com", values.get("emailAddressRequired"));
-		Assert.assertEquals("João", values.get("firstName"));
-		Assert.assertEquals(0D, values.get("height"));
-		Assert.assertEquals("o Discípulo Amado", values.get("lastName"));
-		Assert.assertEquals(StringPool.BLANK, values.get("listTypeEntryKey"));
-		Assert.assertEquals(
-			"listTypeEntryKey2", values.get("listTypeEntryKeyRequired"));
-		Assert.assertEquals(StringPool.BLANK, values.get("middleName"));
-		Assert.assertEquals(
-			"multipleListTypeEntryKey3, multipleListTypeEntryKey4",
-			values.get("multipleListTypeEntriesKey"));
-		Assert.assertEquals(0, values.get("numberOfBooksWritten"));
-		Assert.assertEquals(StringPool.BLANK, values.get("script"));
-		Assert.assertEquals(_getBigDecimal(0L), values.get("speed"));
-		Assert.assertEquals("listTypeEntryKey1", values.get("state"));
-		Assert.assertEquals(null, values.get("time"));
-		Assert.assertEquals(0L, values.get("upload"));
-		Assert.assertEquals(0D, values.get("weight"));
-		Assert.assertEquals(
-			objectEntry.getObjectEntryId(),
-			values.get(_objectDefinition.getPKObjectFieldName()));
-		Assert.assertEquals(values.toString(), 23, values.size());
-
-		Calendar calendar = new GregorianCalendar();
-
-		calendar.set(6, Calendar.DECEMBER, 28);
-		calendar.setTimeInMillis(0);
-
-		Date birthdayDate = calendar.getTime();
-
-		String script = RandomTestUtil.randomString(1500);
-		Timestamp timestamp = Timestamp.valueOf(
-			LocalDateTime.now(
-			).withNano(
-				0
-			));
-
-		_objectEntryLocalService.updateObjectEntry(
-			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
-			HashMapBuilder.<String, Serializable>put(
-				"ageOfDeath", "94"
-			).put(
-				"authorOfGospel", true
-			).put(
-				"birthday", birthdayDate
-			).put(
-				"height", 180
-			).put(
-				"listTypeEntryKey", "listTypeEntryKey1"
-			).put(
-				"listTypeEntryKeyRequired", "listTypeEntryKey3"
-			).put(
-				"multipleListTypeEntriesKey",
-				(Serializable)Arrays.asList(
-					"multipleListTypeEntryKey5", "multipleListTypeEntryKey6")
-			).put(
-				"numberOfBooksWritten", 5
-			).put(
-				"script", script
-			).put(
-				"speed", BigDecimal.valueOf(45L)
-			).put(
-				"state", "listTypeEntryKey2"
-			).put(
-				"time", timestamp
-			).put(
-				"upload", 0L
-			).put(
-				"weight", 60
-			).build(),
-			ServiceContextTestUtil.getServiceContext());
-
-		_assertCount(1);
-
-		values = _objectEntryLocalService.getValues(
-			objectEntry.getObjectEntryId());
-
-		Assert.assertEquals(94L, values.get("ageOfDeath"));
-		Assert.assertTrue((boolean)values.get("authorOfGospel"));
-		Assert.assertEquals(birthdayDate, values.get("birthday"));
-		Assert.assertEquals(
-			"john@liferay.com", values.get("emailAddressRequired"));
-		Assert.assertEquals("João", values.get("firstName"));
-		Assert.assertEquals(180D, values.get("height"));
-		Assert.assertEquals("o Discípulo Amado", values.get("lastName"));
-		Assert.assertEquals(
-			"listTypeEntryKey1", values.get("listTypeEntryKey"));
-		Assert.assertEquals(
-			"listTypeEntryKey3", values.get("listTypeEntryKeyRequired"));
-		Assert.assertEquals(StringPool.BLANK, values.get("middleName"));
-		Assert.assertEquals(
-			"multipleListTypeEntryKey5, multipleListTypeEntryKey6",
-			values.get("multipleListTypeEntriesKey"));
-		Assert.assertEquals(5, values.get("numberOfBooksWritten"));
-		Assert.assertEquals(script, values.get("script"));
-		Assert.assertEquals(_getBigDecimal(45L), values.get("speed"));
-		Assert.assertEquals("listTypeEntryKey2", values.get("state"));
-		Assert.assertEquals(timestamp, values.get("time"));
-		Assert.assertEquals(0L, values.get("upload"));
-		Assert.assertEquals(60D, values.get("weight"));
-		Assert.assertEquals(
-			objectEntry.getObjectEntryId(),
-			values.get(_objectDefinition.getPKObjectFieldName()));
-		Assert.assertEquals(values.toString(), 23, values.size());
-
-		_objectEntryLocalService.updateObjectEntry(
-			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
-			HashMapBuilder.<String, Serializable>put(
-				"state", "listTypeEntryKey3"
-			).put(
-				"upload", 0L
-			).put(
-				"weight", 65D
-			).build(),
-			ServiceContextTestUtil.getServiceContext());
-
-		_assertCount(1);
-
-		values = _objectEntryLocalService.getValues(
-			objectEntry.getObjectEntryId());
-
-		Assert.assertEquals(94L, values.get("ageOfDeath"));
-		Assert.assertTrue((boolean)values.get("authorOfGospel"));
-		Assert.assertEquals(birthdayDate, values.get("birthday"));
-		Assert.assertEquals(
-			"john@liferay.com", values.get("emailAddressRequired"));
-		Assert.assertEquals("João", values.get("firstName"));
-		Assert.assertEquals(180D, values.get("height"));
-		Assert.assertEquals("o Discípulo Amado", values.get("lastName"));
-		Assert.assertEquals(
-			"listTypeEntryKey1", values.get("listTypeEntryKey"));
-		Assert.assertEquals(
-			"listTypeEntryKey3", values.get("listTypeEntryKeyRequired"));
-		Assert.assertEquals(StringPool.BLANK, values.get("middleName"));
-		Assert.assertEquals(
-			"multipleListTypeEntryKey5, multipleListTypeEntryKey6",
-			values.get("multipleListTypeEntriesKey"));
-		Assert.assertEquals(5, values.get("numberOfBooksWritten"));
-		Assert.assertEquals(script, values.get("script"));
-		Assert.assertEquals(_getBigDecimal(45L), values.get("speed"));
-		Assert.assertEquals("listTypeEntryKey3", values.get("state"));
-		Assert.assertEquals(timestamp, values.get("time"));
-		Assert.assertEquals(0L, values.get("upload"));
-		Assert.assertEquals(65D, values.get("weight"));
-		Assert.assertEquals(
-			objectEntry.getObjectEntryId(),
-			values.get(_objectDefinition.getPKObjectFieldName()));
-		Assert.assertEquals(values.toString(), 23, values.size());
-
-		_objectEntryLocalService.updateObjectEntry(
-			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
-			HashMapBuilder.<String, Serializable>put(
-				"ageOfDeath", StringPool.BLANK
-			).put(
-				"authorOfGospel", StringPool.BLANK
-			).put(
-				"birthday", StringPool.BLANK
-			).put(
-				"firstName", StringPool.BLANK
-			).put(
-				"time", StringPool.BLANK
-			).build(),
-			ServiceContextTestUtil.getServiceContext());
-
-		values = _objectEntryLocalService.getValues(
-			objectEntry.getObjectEntryId());
-
-		Assert.assertEquals(0L, values.get("ageOfDeath"));
-		Assert.assertFalse((boolean)values.get("authorOfGospel"));
-		Assert.assertNull(values.get("birthday"));
-		Assert.assertEquals(StringPool.BLANK, values.get("firstName"));
-		Assert.assertNull(values.get("time"));
-
-		_objectEntryLocalService.updateObjectEntry(
-			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
-			new HashMap<String, Serializable>(),
-			ServiceContextTestUtil.getServiceContext());
-
-		_objectEntryLocalService.updateObjectEntry(
-			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
-			HashMapBuilder.<String, Serializable>put(
-				_objectDefinition.getPKObjectFieldName(), ""
-			).put(
-				"invalidName", ""
-			).build(),
-			ServiceContextTestUtil.getServiceContext());
-
-		long objectEntryId = objectEntry.getObjectEntryId();
-
-		AssertUtils.assertFailure(
-			ObjectEntryValuesException.ExceedsIntegerSize.class,
-			"Object entry value exceeds integer field allowed size",
-			() -> _objectEntryLocalService.updateObjectEntry(
-				TestPropsValues.getUserId(), objectEntryId,
-				HashMapBuilder.<String, Serializable>put(
-					"numberOfBooksWritten", "2147483648"
-				).build(),
-				ServiceContextTestUtil.getServiceContext()));
-
-		AssertUtils.assertFailure(
-			ObjectEntryValuesException.ExceedsIntegerSize.class,
-			"Object entry value exceeds integer field allowed size",
-			() -> _objectEntryLocalService.updateObjectEntry(
-				TestPropsValues.getUserId(), objectEntryId,
-				HashMapBuilder.<String, Serializable>put(
-					"numberOfBooksWritten", "-2147483649"
-				).build(),
-				ServiceContextTestUtil.getServiceContext()));
-
-		AssertUtils.assertFailure(
-			ObjectEntryValuesException.ExceedsLongMaxSize.class,
-			"Object entry value exceeds maximum long field allowed size",
-			() -> _objectEntryLocalService.updateObjectEntry(
-				TestPropsValues.getUserId(), objectEntryId,
-				HashMapBuilder.<String, Serializable>put(
-					"ageOfDeath", "9007199254740992"
-				).build(),
-				ServiceContextTestUtil.getServiceContext()));
-
-		AssertUtils.assertFailure(
-			ObjectEntryValuesException.ExceedsLongMinSize.class,
-			"Object entry value falls below minimum long field allowed size",
-			() -> _objectEntryLocalService.updateObjectEntry(
-				TestPropsValues.getUserId(), objectEntryId,
-				HashMapBuilder.<String, Serializable>put(
-					"ageOfDeath", "-9007199254740992"
-				).build(),
-				ServiceContextTestUtil.getServiceContext()));
-
-		AssertUtils.assertFailure(
-			ObjectEntryValuesException.ExceedsLongSize.class,
-			"Object entry value exceeds long field allowed size",
-			() -> _objectEntryLocalService.updateObjectEntry(
-				TestPropsValues.getUserId(), objectEntryId,
-				HashMapBuilder.<String, Serializable>put(
-					"ageOfDeath", "9223372036854775808"
-				).build(),
-				ServiceContextTestUtil.getServiceContext()));
-
-		AssertUtils.assertFailure(
-			ObjectEntryValuesException.ExceedsLongSize.class,
-			"Object entry value exceeds long field allowed size",
-			() -> _objectEntryLocalService.updateObjectEntry(
-				TestPropsValues.getUserId(), objectEntryId,
-				HashMapBuilder.<String, Serializable>put(
-					"ageOfDeath", "-9223372036854775809"
-				).build(),
-				ServiceContextTestUtil.getServiceContext()));
-
-		AssertUtils.assertFailure(
-			ObjectEntryValuesException.ExceedsTextMaxLength.class,
-			"Object entry value exceeds the maximum length of 280 characters " +
-				"for object field \"firstName\"",
-			() -> _objectEntryLocalService.updateObjectEntry(
-				TestPropsValues.getUserId(), objectEntryId,
-				HashMapBuilder.<String, Serializable>put(
-					"firstName", RandomTestUtil.randomString(281)
-				).build(),
-				ServiceContextTestUtil.getServiceContext()));
-
-		_addObjectEntry(
-			HashMapBuilder.<String, Serializable>put(
-				"emailAddress", "james@liferay.com"
-			).put(
-				"emailAddressRequired", "james@liferay.com"
-			).put(
-				"listTypeEntryKeyRequired", "listTypeEntryKey1"
-			).build());
-
-		AssertUtils.assertFailure(
-			ObjectEntryValuesException.UniqueValueConstraintViolation.class,
-			"Unique value constraint violation for " +
-				_objectDefinition.getDBTableName() +
-					".emailAddress_ with value james@liferay.com",
-			() -> _objectEntryLocalService.updateObjectEntry(
-				TestPropsValues.getUserId(), objectEntryId,
-				HashMapBuilder.<String, Serializable>put(
-					"emailAddress", "james@liferay.com"
-				).build(),
-				ServiceContextTestUtil.getServiceContext()));
-
-		_testUpdateObjectEntryExternalReferenceCode();
-		_testUpdateObjectEntryObjectStateTransitions();
+		_testUpdateObjectEntry(true);
 	}
 
 	@Test
@@ -6370,6 +6390,311 @@ public class ObjectEntryLocalServiceTest {
 				).build()));
 	}
 
+	private void _testPartialUpdateObjectEntryExternalReferenceCode()
+		throws Exception {
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired", "john@liferay.com"
+			).put(
+				"firstName", "John"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey1"
+			).build());
+
+		Assert.assertEquals(
+			objectEntry1.getUuid(), objectEntry1.getExternalReferenceCode());
+
+		long objectEntryId1 = objectEntry1.getObjectEntryId();
+
+		objectEntry1 = _objectEntryLocalService.partialUpdateObjectEntry(
+			TestPropsValues.getUserId(), objectEntryId1,
+			HashMapBuilder.<String, Serializable>put(
+				"externalReferenceCode", "newExternalReferenceCode"
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertEquals(
+			"newExternalReferenceCode",
+			objectEntry1.getExternalReferenceCode());
+
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired", "matthew@liferay.com"
+			).put(
+				"firstName", "Matthew"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey2"
+			).build());
+
+		long objectEntryId2 = objectEntry2.getObjectEntryId();
+
+		AssertUtils.assertFailure(
+			DuplicateObjectEntryExternalReferenceCodeException.class,
+			"Duplicate object entry with external reference code " +
+				"newExternalReferenceCode and object definition ID " +
+					_objectDefinition.getObjectDefinitionId(),
+			() -> _objectEntryLocalService.partialUpdateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId2,
+				HashMapBuilder.<String, Serializable>put(
+					"externalReferenceCode", "newExternalReferenceCode"
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		objectEntry2 = _objectEntryLocalService.partialUpdateObjectEntry(
+			TestPropsValues.getUserId(), objectEntryId2,
+			HashMapBuilder.<String, Serializable>put(
+				"externalReferenceCode", ""
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertEquals(
+			objectEntry2.getUuid(), objectEntry2.getExternalReferenceCode());
+
+		_objectEntryLocalService.partialUpdateObjectEntry(
+			TestPropsValues.getUserId(), objectEntryId2,
+			HashMapBuilder.<String, Serializable>put(
+				"externalReferenceCode", objectEntry1.getUuid()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		AssertUtils.assertFailure(
+			DuplicateObjectEntryExternalReferenceCodeException.class,
+			StringBundler.concat(
+				"Duplicate object entry with external reference code ",
+				objectEntry1.getUuid(), " and object definition ID ",
+				_objectDefinition.getObjectDefinitionId()),
+			() -> _objectEntryLocalService.partialUpdateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId1,
+				HashMapBuilder.<String, Serializable>put(
+					"externalReferenceCode", ""
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		String randomString = RandomTestUtil.randomString();
+
+		objectEntry1 = _objectEntryLocalService.partialUpdateObjectEntry(
+			TestPropsValues.getUserId(), objectEntryId1,
+			HashMapBuilder.<String, Serializable>put(
+				"externalReferenceCode", randomString
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertEquals(
+			randomString, objectEntry1.getExternalReferenceCode());
+
+		_objectEntryLocalService.deleteObjectEntry(objectEntryId1);
+		_objectEntryLocalService.deleteObjectEntry(objectEntryId2);
+	}
+
+	private void _testPartialUpdateObjectEntryObjectStateTransitions()
+		throws Exception {
+
+		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
+			_objectDefinition.getObjectDefinitionId(), "state");
+
+		ObjectStateFlow objectStateFlow =
+			_objectStateFlowLocalService.fetchObjectFieldObjectStateFlow(
+				objectField.getObjectFieldId());
+
+		List<ObjectState> objectStates =
+			_objectStateLocalService.getObjectStateFlowObjectStates(
+				objectStateFlow.getObjectStateFlowId());
+
+		for (ObjectState objectState : objectStates) {
+			List<ObjectStateTransition> objectStateTransitions =
+				_objectStateTransitionLocalService.
+					getObjectStateObjectStateTransitions(
+						objectState.getObjectStateId());
+
+			objectState.setObjectStateTransitions(
+				Collections.singletonList(objectStateTransitions.get(0)));
+		}
+
+		objectStateFlow.setObjectStates(objectStates);
+
+		_objectStateTransitionLocalService.updateObjectStateTransitions(
+			objectStateFlow);
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired", "john@liferay.com"
+			).put(
+				"firstName", "John"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey1"
+			).put(
+				"state", "listTypeEntryKey1"
+			).build());
+
+		objectEntry = _objectEntryLocalService.partialUpdateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>put(
+				"firstName", "Peter"
+			).put(
+				"state", "listTypeEntryKey1"
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		ObjectState objectStateListTypeEntryKey1 = objectStates.get(0);
+		ObjectState objectStateListTypeEntryKey2 = objectStates.get(1);
+		ObjectState objectStateListTypeEntryKey3 = objectStates.get(2);
+
+		long objectEntryId = objectEntry.getObjectEntryId();
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.InvalidObjectStateTransition.class,
+			StringBundler.concat(
+				"Object state ID ",
+				objectStateListTypeEntryKey1.getObjectStateId(),
+				" cannot be transitioned to object state ID ",
+				objectStateListTypeEntryKey3.getObjectStateId()),
+			() -> _objectEntryLocalService.partialUpdateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId,
+				HashMapBuilder.<String, Serializable>put(
+					"state", "listTypeEntryKey3"
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		objectEntry = _objectEntryLocalService.partialUpdateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>put(
+				"state", "listTypeEntryKey2"
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.InvalidObjectStateTransition.class,
+			StringBundler.concat(
+				"Object state ID ",
+				objectStateListTypeEntryKey2.getObjectStateId(),
+				" cannot be transitioned to object state ID ",
+				objectStateListTypeEntryKey3.getObjectStateId()),
+			() -> _objectEntryLocalService.partialUpdateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId,
+				HashMapBuilder.<String, Serializable>put(
+					"state", "listTypeEntryKey3"
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		_objectEntryLocalService.deleteObjectEntry(
+			objectEntry.getObjectEntryId());
+	}
+
+	private void _testPartialUpdateObjectEntryWithObjectRelationship()
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				"RelatedObjectDefinition",
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).name(
+						"name"
+					).build()),
+				ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectRelationshipLocalService, objectDefinition,
+			_objectDefinition,
+			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+			"objectRelationship");
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired", "carlos@liferay.com"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey1"
+			).build());
+
+		long objectEntryId1 = objectEntry1.getObjectEntryId();
+
+		objectEntry1 = _objectEntryLocalService.partialUpdateObjectEntry(
+			TestPropsValues.getUserId(), objectEntryId1,
+			HashMapBuilder.<String, Serializable>put(
+				"firstName", "Charles"
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Map<String, Serializable> values = objectEntry1.getValues();
+
+		Assert.assertEquals("Charles", values.get("firstName"));
+		Assert.assertEquals(
+			StringPool.BLANK,
+			values.get("r_objectRelationship_c_relatedObjectDefinitionERC"));
+		Assert.assertEquals(
+			0L, values.get("r_objectRelationship_c_relatedObjectDefinitionId"));
+
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			0, objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"name", RandomTestUtil.randomString()
+			).build());
+
+		objectEntry1 = _objectEntryLocalService.partialUpdateObjectEntry(
+			TestPropsValues.getUserId(), objectEntryId1,
+			HashMapBuilder.<String, Serializable>put(
+				"r_objectRelationship_c_relatedObjectDefinitionId",
+				objectEntry2.getObjectEntryId()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		values = objectEntry1.getValues();
+
+		Assert.assertEquals("Charles", values.get("firstName"));
+		Assert.assertEquals(
+			objectEntry2.getExternalReferenceCode(),
+			values.get("r_objectRelationship_c_relatedObjectDefinitionERC"));
+		Assert.assertEquals(
+			objectEntry2.getObjectEntryId(),
+			values.get("r_objectRelationship_c_relatedObjectDefinitionId"));
+
+		objectEntry1 = _objectEntryLocalService.partialUpdateObjectEntry(
+			TestPropsValues.getUserId(), objectEntryId1,
+			HashMapBuilder.<String, Serializable>put(
+				"firstName", "Julia"
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		values = objectEntry1.getValues();
+
+		Assert.assertEquals("Julia", values.get("firstName"));
+		Assert.assertEquals(
+			objectEntry2.getExternalReferenceCode(),
+			values.get("r_objectRelationship_c_relatedObjectDefinitionERC"));
+		Assert.assertEquals(
+			objectEntry2.getObjectEntryId(),
+			values.get("r_objectRelationship_c_relatedObjectDefinitionId"));
+
+		objectEntry1 = _objectEntryLocalService.partialUpdateObjectEntry(
+			TestPropsValues.getUserId(), objectEntryId1,
+			HashMapBuilder.<String, Serializable>put(
+				"firstName", "Zape"
+			).put(
+				"r_objectRelationship_c_relatedObjectDefinitionId", 0L
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		values = objectEntry1.getValues();
+
+		Assert.assertEquals("Zape", values.get("firstName"));
+		Assert.assertEquals(
+			StringPool.BLANK,
+			values.get("r_objectRelationship_c_relatedObjectDefinitionERC"));
+		Assert.assertEquals(
+			0L, values.get("r_objectRelationship_c_relatedObjectDefinitionId"));
+
+		_objectEntryLocalService.deleteObjectEntry(objectEntryId1);
+		_objectEntryLocalService.deleteObjectEntry(
+			objectEntry2.getObjectEntryId());
+
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
+	}
+
 	private void _testScope(long groupId, String scope, boolean expectSuccess)
 		throws Exception {
 
@@ -6443,16 +6768,426 @@ public class ObjectEntryLocalServiceTest {
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
 	}
 
-	private void _testUpdateObjectEntryExternalReferenceCode()
+	private void _testUpdateObjectEntry(boolean partialUpdate)
 		throws Exception {
 
-		ObjectEntry objectEntry1 = _addObjectEntry(
+		_assertCount(0);
+
+		ObjectEntry objectEntry = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
 				"emailAddressRequired", "john@liferay.com"
 			).put(
 				"firstName", "John"
 			).put(
 				"listTypeEntryKeyRequired", "listTypeEntryKey1"
+			).put(
+				"multipleListTypeEntriesKey",
+				(Serializable)Arrays.asList(
+					"multipleListTypeEntryKey1", "multipleListTypeEntryKey2")
+			).build());
+
+		_assertCount(1);
+
+		Assert.assertNotNull(
+			ReflectionTestUtil.getFieldValue(objectEntry, "_values"));
+
+		_getValuesFromCacheField(objectEntry);
+
+		//Assert.assertNotNull(
+		//	ReflectionTestUtil.getFieldValue(objectEntry, "_values"));
+
+		objectEntry = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.putAll(
+				_objectEntryLocalService.getValues(objectEntry)
+			).put(
+				"firstName", "João"
+			).put(
+				"lastName", "o Discípulo Amado"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey2"
+			).put(
+				"multipleListTypeEntriesKey",
+				(Serializable)Arrays.asList(
+					"multipleListTypeEntryKey3", "multipleListTypeEntryKey4")
+			).put(
+				"state", "listTypeEntryKey1"
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		_assertCount(1);
+
+		objectEntry = _objectEntryLocalService.getObjectEntry(
+			objectEntry.getObjectEntryId());
+
+		Assert.assertNull(
+			ReflectionTestUtil.getFieldValue(objectEntry, "_values"));
+
+		Map<String, Serializable> values = objectEntry.getValues();
+
+		Assert.assertEquals(_getValuesFromCacheField(objectEntry), values);
+		Assert.assertEquals(0L, values.get("ageOfDeath"));
+		Assert.assertFalse((boolean)values.get("authorOfGospel"));
+		Assert.assertEquals(null, values.get("birthday"));
+		Assert.assertEquals(
+			"john@liferay.com", values.get("emailAddressRequired"));
+		Assert.assertEquals("João", values.get("firstName"));
+		Assert.assertEquals(0D, values.get("height"));
+		Assert.assertEquals("o Discípulo Amado", values.get("lastName"));
+		Assert.assertEquals(StringPool.BLANK, values.get("listTypeEntryKey"));
+		Assert.assertEquals(
+			"listTypeEntryKey2", values.get("listTypeEntryKeyRequired"));
+		Assert.assertEquals(StringPool.BLANK, values.get("middleName"));
+		Assert.assertEquals(
+			"multipleListTypeEntryKey3, multipleListTypeEntryKey4",
+			values.get("multipleListTypeEntriesKey"));
+		Assert.assertEquals(0, values.get("numberOfBooksWritten"));
+		Assert.assertEquals(StringPool.BLANK, values.get("script"));
+		Assert.assertEquals(_getBigDecimal(0L), values.get("speed"));
+		Assert.assertEquals("listTypeEntryKey1", values.get("state"));
+		Assert.assertEquals(null, values.get("time"));
+		Assert.assertEquals(0L, values.get("upload"));
+		Assert.assertEquals(0D, values.get("weight"));
+		Assert.assertEquals(
+			objectEntry.getObjectEntryId(),
+			values.get(_objectDefinition.getPKObjectFieldName()));
+		Assert.assertEquals(values.toString(), 23, values.size());
+
+		Calendar calendar = new GregorianCalendar();
+
+		calendar.set(6, Calendar.DECEMBER, 28);
+		calendar.setTimeInMillis(0);
+
+		Date birthdayDate = calendar.getTime();
+
+		String script = RandomTestUtil.randomString(1500);
+		Timestamp timestamp = Timestamp.valueOf(
+			LocalDateTime.now(
+			).withNano(
+				0
+			));
+
+		_objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>put(
+				"ageOfDeath", "94"
+			).put(
+				"authorOfGospel", true
+			).put(
+				"birthday", birthdayDate
+			).put(
+				"emailAddressRequired", "joao@liferay.com"
+			).put(
+				"height", 180
+			).put(
+				"listTypeEntryKey", "listTypeEntryKey1"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey3"
+			).put(
+				"multipleListTypeEntriesKey",
+				(Serializable)Arrays.asList(
+					"multipleListTypeEntryKey5", "multipleListTypeEntryKey6")
+			).put(
+				"numberOfBooksWritten", 5
+			).put(
+				"script", script
+			).put(
+				"speed", BigDecimal.valueOf(45L)
+			).put(
+				"state", "listTypeEntryKey2"
+			).put(
+				"time", timestamp
+			).put(
+				"upload", 0L
+			).put(
+				"weight", 60
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		_assertCount(1);
+
+		values = _objectEntryLocalService.getValues(
+			objectEntry.getObjectEntryId());
+
+		Assert.assertEquals(94L, values.get("ageOfDeath"));
+		Assert.assertTrue((boolean)values.get("authorOfGospel"));
+		Assert.assertEquals(birthdayDate, values.get("birthday"));
+		Assert.assertEquals(
+			"joao@liferay.com", values.get("emailAddressRequired"));
+		Assert.assertEquals(
+			partialUpdate ? "João" : StringPool.BLANK, values.get("firstName"));
+		Assert.assertEquals(180D, values.get("height"));
+		Assert.assertEquals(
+			partialUpdate ? "o Discípulo Amado" : StringPool.BLANK,
+			values.get("lastName"));
+		Assert.assertEquals(
+			"listTypeEntryKey1", values.get("listTypeEntryKey"));
+		Assert.assertEquals(
+			"listTypeEntryKey3", values.get("listTypeEntryKeyRequired"));
+		Assert.assertEquals(StringPool.BLANK, values.get("middleName"));
+		Assert.assertEquals(
+			"multipleListTypeEntryKey5, multipleListTypeEntryKey6",
+			values.get("multipleListTypeEntriesKey"));
+		Assert.assertEquals(5, values.get("numberOfBooksWritten"));
+		Assert.assertEquals(script, values.get("script"));
+		Assert.assertEquals(_getBigDecimal(45L), values.get("speed"));
+		Assert.assertEquals("listTypeEntryKey2", values.get("state"));
+		Assert.assertEquals(timestamp, values.get("time"));
+		Assert.assertEquals(0L, values.get("upload"));
+		Assert.assertEquals(60D, values.get("weight"));
+		Assert.assertEquals(
+			objectEntry.getObjectEntryId(),
+			values.get(_objectDefinition.getPKObjectFieldName()));
+		Assert.assertEquals(values.toString(), 23, values.size());
+
+		_objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired", "charles@liferay.com"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey2"
+			).put(
+				"state", "listTypeEntryKey3"
+			).put(
+				"upload", 0L
+			).put(
+				"weight", 65D
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		_assertCount(1);
+
+		values = _objectEntryLocalService.getValues(
+			objectEntry.getObjectEntryId());
+
+		Assert.assertEquals(partialUpdate ? 94L : 0L, values.get("ageOfDeath"));
+		Assert.assertEquals(
+			partialUpdate, (boolean)values.get("authorOfGospel"));
+		Assert.assertEquals(
+			partialUpdate ? birthdayDate : null, values.get("birthday"));
+		Assert.assertEquals(
+			"charles@liferay.com", values.get("emailAddressRequired"));
+		Assert.assertEquals(
+			partialUpdate ? "João" : StringPool.BLANK, values.get("firstName"));
+		Assert.assertEquals(partialUpdate ? 180D : 0D, values.get("height"));
+		Assert.assertEquals(
+			partialUpdate ? "o Discípulo Amado" : StringPool.BLANK,
+			values.get("lastName"));
+		Assert.assertEquals(
+			partialUpdate ? "listTypeEntryKey1" : StringPool.BLANK,
+			values.get("listTypeEntryKey"));
+		Assert.assertEquals(
+			"listTypeEntryKey2", values.get("listTypeEntryKeyRequired"));
+		Assert.assertEquals(StringPool.BLANK, values.get("middleName"));
+		Assert.assertEquals(
+			partialUpdate ?
+				"multipleListTypeEntryKey5, multipleListTypeEntryKey6" :
+					StringPool.BLANK,
+			values.get("multipleListTypeEntriesKey"));
+		Assert.assertEquals(
+			partialUpdate ? 5 : 0, values.get("numberOfBooksWritten"));
+		Assert.assertEquals(
+			partialUpdate ? script : StringPool.BLANK, values.get("script"));
+		Assert.assertEquals(
+			_getBigDecimal(partialUpdate ? 45L : 0L), values.get("speed"));
+		Assert.assertEquals("listTypeEntryKey3", values.get("state"));
+		Assert.assertEquals(
+			partialUpdate ? timestamp : null, values.get("time"));
+		Assert.assertEquals(0L, values.get("upload"));
+		Assert.assertEquals(65D, values.get("weight"));
+		Assert.assertEquals(
+			objectEntry.getObjectEntryId(),
+			values.get(_objectDefinition.getPKObjectFieldName()));
+		Assert.assertEquals(values.toString(), 23, values.size());
+
+		Map<String, Serializable> requiredValues =
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired",
+				RandomTestUtil.randomString() + "@liferay.com"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey1"
+			).build();
+
+		_objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>put(
+				"ageOfDeath", StringPool.BLANK
+			).put(
+				"authorOfGospel", StringPool.BLANK
+			).put(
+				"birthday", StringPool.BLANK
+			).put(
+				"firstName", StringPool.BLANK
+			).put(
+				"time", StringPool.BLANK
+			).putAll(
+				requiredValues
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		values = _objectEntryLocalService.getValues(
+			objectEntry.getObjectEntryId());
+
+		Assert.assertEquals(0L, values.get("ageOfDeath"));
+		Assert.assertFalse((boolean)values.get("authorOfGospel"));
+		Assert.assertNull(values.get("birthday"));
+		Assert.assertEquals(StringPool.BLANK, values.get("firstName"));
+		Assert.assertNull(values.get("time"));
+
+		_objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>putAll(
+				requiredValues
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		_objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>put(
+				_objectDefinition.getPKObjectFieldName(), ""
+			).put(
+				"invalidName", ""
+			).putAll(
+				requiredValues
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		long objectEntryId = objectEntry.getObjectEntryId();
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.Required.class,
+			"No value was provided for required object field " +
+				"\"emailAddressRequired\"",
+			() -> _addObjectEntry(
+				HashMapBuilder.<String, Serializable>put(
+					"listTypeEntryKeyRequired", "listTypeEntryKey1"
+				).build()));
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.ExceedsIntegerSize.class,
+			"Object entry value exceeds integer field allowed size",
+			() -> _objectEntryLocalService.updateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId,
+				HashMapBuilder.<String, Serializable>put(
+					"numberOfBooksWritten", "2147483648"
+				).putAll(
+					requiredValues
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.ExceedsIntegerSize.class,
+			"Object entry value exceeds integer field allowed size",
+			() -> _objectEntryLocalService.updateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId,
+				HashMapBuilder.<String, Serializable>put(
+					"numberOfBooksWritten", "-2147483649"
+				).putAll(
+					requiredValues
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.ExceedsLongMaxSize.class,
+			"Object entry value exceeds maximum long field allowed size",
+			() -> _objectEntryLocalService.updateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId,
+				HashMapBuilder.<String, Serializable>put(
+					"ageOfDeath", "9007199254740992"
+				).putAll(
+					requiredValues
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.ExceedsLongMinSize.class,
+			"Object entry value falls below minimum long field allowed size",
+			() -> _objectEntryLocalService.updateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId,
+				HashMapBuilder.<String, Serializable>put(
+					"ageOfDeath", "-9007199254740992"
+				).putAll(
+					requiredValues
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.ExceedsLongSize.class,
+			"Object entry value exceeds long field allowed size",
+			() -> _objectEntryLocalService.updateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId,
+				HashMapBuilder.<String, Serializable>put(
+					"ageOfDeath", "9223372036854775808"
+				).putAll(
+					requiredValues
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.ExceedsLongSize.class,
+			"Object entry value exceeds long field allowed size",
+			() -> _objectEntryLocalService.updateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId,
+				HashMapBuilder.<String, Serializable>put(
+					"ageOfDeath", "-9223372036854775809"
+				).putAll(
+					requiredValues
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.ExceedsTextMaxLength.class,
+			"Object entry value exceeds the maximum length of 280 characters " +
+				"for object field \"firstName\"",
+			() -> _objectEntryLocalService.updateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId,
+				HashMapBuilder.<String, Serializable>put(
+					"firstName", RandomTestUtil.randomString(281)
+				).putAll(
+					requiredValues
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		_addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddress", "james@liferay.com"
+			).putAll(
+				requiredValues
+			).build());
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.UniqueValueConstraintViolation.class,
+			"Unique value constraint violation for " +
+				_objectDefinition.getDBTableName() +
+					".emailAddress_ with value james@liferay.com",
+			() -> _objectEntryLocalService.updateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId,
+				HashMapBuilder.<String, Serializable>put(
+					"emailAddress", "james@liferay.com"
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		_testUpdateObjectEntryExternalReferenceCode();
+		_testUpdateObjectEntryObjectStateTransitions();
+		_testUpdateObjectEntryWithObjectRelationship(partialUpdate);
+	}
+
+	private void _testUpdateObjectEntryExternalReferenceCode()
+		throws Exception {
+
+		Map<String, Serializable> requiredValues =
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired",
+				RandomTestUtil.randomString() + "@liferay.com"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey1"
+			).build();
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"firstName", "John"
+			).putAll(
+				requiredValues
 			).build());
 
 		Assert.assertEquals(
@@ -6464,6 +7199,8 @@ public class ObjectEntryLocalServiceTest {
 			TestPropsValues.getUserId(), objectEntryId1,
 			HashMapBuilder.<String, Serializable>put(
 				"externalReferenceCode", "newExternalReferenceCode"
+			).putAll(
+				requiredValues
 			).build(),
 			ServiceContextTestUtil.getServiceContext());
 
@@ -6473,11 +7210,9 @@ public class ObjectEntryLocalServiceTest {
 
 		ObjectEntry objectEntry2 = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
-				"emailAddressRequired", "matthew@liferay.com"
-			).put(
 				"firstName", "Matthew"
-			).put(
-				"listTypeEntryKeyRequired", "listTypeEntryKey2"
+			).putAll(
+				requiredValues
 			).build());
 
 		long objectEntryId2 = objectEntry2.getObjectEntryId();
@@ -6491,6 +7226,8 @@ public class ObjectEntryLocalServiceTest {
 				TestPropsValues.getUserId(), objectEntryId2,
 				HashMapBuilder.<String, Serializable>put(
 					"externalReferenceCode", "newExternalReferenceCode"
+				).putAll(
+					requiredValues
 				).build(),
 				ServiceContextTestUtil.getServiceContext()));
 
@@ -6498,6 +7235,8 @@ public class ObjectEntryLocalServiceTest {
 			TestPropsValues.getUserId(), objectEntryId2,
 			HashMapBuilder.<String, Serializable>put(
 				"externalReferenceCode", ""
+			).putAll(
+				requiredValues
 			).build(),
 			ServiceContextTestUtil.getServiceContext());
 
@@ -6508,6 +7247,8 @@ public class ObjectEntryLocalServiceTest {
 			TestPropsValues.getUserId(), objectEntryId2,
 			HashMapBuilder.<String, Serializable>put(
 				"externalReferenceCode", objectEntry1.getUuid()
+			).putAll(
+				requiredValues
 			).build(),
 			ServiceContextTestUtil.getServiceContext());
 
@@ -6521,6 +7262,8 @@ public class ObjectEntryLocalServiceTest {
 				TestPropsValues.getUserId(), objectEntryId1,
 				HashMapBuilder.<String, Serializable>put(
 					"externalReferenceCode", ""
+				).putAll(
+					requiredValues
 				).build(),
 				ServiceContextTestUtil.getServiceContext()));
 
@@ -6530,6 +7273,8 @@ public class ObjectEntryLocalServiceTest {
 			TestPropsValues.getUserId(), objectEntryId1,
 			HashMapBuilder.<String, Serializable>put(
 				"externalReferenceCode", randomString
+			).putAll(
+				requiredValues
 			).build(),
 			ServiceContextTestUtil.getServiceContext());
 
@@ -6569,15 +7314,21 @@ public class ObjectEntryLocalServiceTest {
 		_objectStateTransitionLocalService.updateObjectStateTransitions(
 			objectStateFlow);
 
-		ObjectEntry objectEntry = _addObjectEntry(
+		Map<String, Serializable> requiredValues =
 			HashMapBuilder.<String, Serializable>put(
-				"emailAddressRequired", "john@liferay.com"
-			).put(
-				"firstName", "John"
+				"emailAddressRequired",
+				RandomTestUtil.randomString() + "@liferay.com"
 			).put(
 				"listTypeEntryKeyRequired", "listTypeEntryKey1"
+			).build();
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"firstName", "John"
 			).put(
 				"state", "listTypeEntryKey1"
+			).putAll(
+				requiredValues
 			).build());
 
 		objectEntry = _objectEntryLocalService.updateObjectEntry(
@@ -6586,6 +7337,8 @@ public class ObjectEntryLocalServiceTest {
 				"firstName", "Peter"
 			).put(
 				"state", "listTypeEntryKey1"
+			).putAll(
+				requiredValues
 			).build(),
 			ServiceContextTestUtil.getServiceContext());
 
@@ -6606,6 +7359,8 @@ public class ObjectEntryLocalServiceTest {
 				TestPropsValues.getUserId(), objectEntryId,
 				HashMapBuilder.<String, Serializable>put(
 					"state", "listTypeEntryKey3"
+				).putAll(
+					requiredValues
 				).build(),
 				ServiceContextTestUtil.getServiceContext()));
 
@@ -6613,6 +7368,8 @@ public class ObjectEntryLocalServiceTest {
 			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
 			HashMapBuilder.<String, Serializable>put(
 				"state", "listTypeEntryKey2"
+			).putAll(
+				requiredValues
 			).build(),
 			ServiceContextTestUtil.getServiceContext());
 
@@ -6627,11 +7384,145 @@ public class ObjectEntryLocalServiceTest {
 				TestPropsValues.getUserId(), objectEntryId,
 				HashMapBuilder.<String, Serializable>put(
 					"state", "listTypeEntryKey3"
+				).putAll(
+					requiredValues
 				).build(),
 				ServiceContextTestUtil.getServiceContext()));
 
 		_objectEntryLocalService.deleteObjectEntry(
 			objectEntry.getObjectEntryId());
+	}
+
+	private void _testUpdateObjectEntryWithObjectRelationship(
+			boolean partialUpdate)
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				"RelatedObjectDefinition",
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).name(
+						"name"
+					).build()),
+				ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectRelationshipLocalService, objectDefinition,
+			_objectDefinition,
+			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+			"objectRelationship");
+
+		Map<String, Serializable> requiredValues =
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired",
+				RandomTestUtil.randomString() + "@liferay.com"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey1"
+			).build();
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>putAll(
+				requiredValues
+			).build());
+
+		long objectEntryId1 = objectEntry1.getObjectEntryId();
+
+		objectEntry1 = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntryId1,
+			HashMapBuilder.<String, Serializable>put(
+				"firstName", "Charles"
+			).putAll(
+				requiredValues
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Map<String, Serializable> values = objectEntry1.getValues();
+
+		Assert.assertEquals("Charles", values.get("firstName"));
+		Assert.assertEquals(
+			StringPool.BLANK,
+			values.get("r_objectRelationship_c_relatedObjectDefinitionERC"));
+		Assert.assertEquals(
+			0L, values.get("r_objectRelationship_c_relatedObjectDefinitionId"));
+
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			0, objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"name", RandomTestUtil.randomString()
+			).build());
+
+		objectEntry1 = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntryId1,
+			HashMapBuilder.<String, Serializable>put(
+				"r_objectRelationship_c_relatedObjectDefinitionId",
+				objectEntry2.getObjectEntryId()
+			).putAll(
+				requiredValues
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		values = objectEntry1.getValues();
+
+		Assert.assertEquals(
+			partialUpdate ? "Charles" : StringPool.BLANK,
+			values.get("firstName"));
+		Assert.assertEquals(
+			objectEntry2.getExternalReferenceCode(),
+			values.get("r_objectRelationship_c_relatedObjectDefinitionERC"));
+		Assert.assertEquals(
+			objectEntry2.getObjectEntryId(),
+			values.get("r_objectRelationship_c_relatedObjectDefinitionId"));
+
+		objectEntry1 = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntryId1,
+			HashMapBuilder.<String, Serializable>put(
+				"firstName", "Julia"
+			).putAll(
+				requiredValues
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		values = objectEntry1.getValues();
+
+		Assert.assertEquals("Julia", values.get("firstName"));
+		Assert.assertEquals(
+			partialUpdate ? objectEntry2.getExternalReferenceCode() :
+				StringPool.BLANK,
+			values.get("r_objectRelationship_c_relatedObjectDefinitionERC"));
+		Assert.assertEquals(
+			partialUpdate ? objectEntry2.getObjectEntryId() : 0L,
+			values.get("r_objectRelationship_c_relatedObjectDefinitionId"));
+
+		objectEntry1 = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntryId1,
+			HashMapBuilder.<String, Serializable>put(
+				"firstName", "Zape"
+			).put(
+				"r_objectRelationship_c_relatedObjectDefinitionId", 0L
+			).putAll(
+				requiredValues
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		values = objectEntry1.getValues();
+
+		Assert.assertEquals("Zape", values.get("firstName"));
+		Assert.assertEquals(
+			StringPool.BLANK,
+			values.get("r_objectRelationship_c_relatedObjectDefinitionERC"));
+		Assert.assertEquals(
+			0L, values.get("r_objectRelationship_c_relatedObjectDefinitionId"));
+
+		_objectEntryLocalService.deleteObjectEntry(objectEntryId1);
+		_objectEntryLocalService.deleteObjectEntry(
+			objectEntry2.getObjectEntryId());
+
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
 	}
 
 	private ObjectValidationRule _updateObjectValidationRule(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -195,7 +195,6 @@ import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
-import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -261,12 +260,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
  * @author Marco Leo
  * @author Brian Wing Shun Chan
  */
-@FeatureFlags(
-	featureFlags = {
-		@FeatureFlag(value = "LPD-34594"),
-		@FeatureFlag(enable = false, value = "LPD-54417")
-	}
-)
+@FeatureFlag("LPD-34594")
 @RunWith(Arquillian.class)
 public class ObjectEntryLocalServiceTest {
 
@@ -4958,16 +4952,388 @@ public class ObjectEntryLocalServiceTest {
 	@Test
 	@TestInfo("LPD-53245")
 	public void testUpdateObjectEntry() throws Exception {
-		_testUpdateObjectEntry(false);
-	}
+		_assertCount(0);
 
-	@FeatureFlag("LPD-54417")
-	@Test
-	@TestInfo("LPD-53245")
-	public void testUpdateObjectEntryWithDeprecatedFeatureFlag()
-		throws Exception {
+		ObjectEntry objectEntry = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired", "john@liferay.com"
+			).put(
+				"firstName", "John"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey1"
+			).put(
+				"multipleListTypeEntriesKey",
+				(Serializable)Arrays.asList(
+					"multipleListTypeEntryKey1", "multipleListTypeEntryKey2")
+			).build());
 
-		_testUpdateObjectEntry(true);
+		_assertCount(1);
+
+		Assert.assertNotNull(
+			ReflectionTestUtil.getFieldValue(objectEntry, "_values"));
+
+		_getValuesFromCacheField(objectEntry);
+
+		//Assert.assertNotNull(
+		//	ReflectionTestUtil.getFieldValue(objectEntry, "_values"));
+
+		objectEntry = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.putAll(
+				_objectEntryLocalService.getValues(objectEntry)
+			).put(
+				"firstName", "João"
+			).put(
+				"lastName", "o Discípulo Amado"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey2"
+			).put(
+				"multipleListTypeEntriesKey",
+				(Serializable)Arrays.asList(
+					"multipleListTypeEntryKey3", "multipleListTypeEntryKey4")
+			).put(
+				"state", "listTypeEntryKey1"
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		_assertCount(1);
+
+		objectEntry = _objectEntryLocalService.getObjectEntry(
+			objectEntry.getObjectEntryId());
+
+		Assert.assertNull(
+			ReflectionTestUtil.getFieldValue(objectEntry, "_values"));
+
+		Map<String, Serializable> values = objectEntry.getValues();
+
+		Assert.assertEquals(_getValuesFromCacheField(objectEntry), values);
+		Assert.assertEquals(0L, values.get("ageOfDeath"));
+		Assert.assertFalse((boolean)values.get("authorOfGospel"));
+		Assert.assertEquals(null, values.get("birthday"));
+		Assert.assertEquals(
+			"john@liferay.com", values.get("emailAddressRequired"));
+		Assert.assertEquals("João", values.get("firstName"));
+		Assert.assertEquals(0D, values.get("height"));
+		Assert.assertEquals("o Discípulo Amado", values.get("lastName"));
+		Assert.assertEquals(StringPool.BLANK, values.get("listTypeEntryKey"));
+		Assert.assertEquals(
+			"listTypeEntryKey2", values.get("listTypeEntryKeyRequired"));
+		Assert.assertEquals(StringPool.BLANK, values.get("middleName"));
+		Assert.assertEquals(
+			"multipleListTypeEntryKey3, multipleListTypeEntryKey4",
+			values.get("multipleListTypeEntriesKey"));
+		Assert.assertEquals(0, values.get("numberOfBooksWritten"));
+		Assert.assertEquals(StringPool.BLANK, values.get("script"));
+		Assert.assertEquals(_getBigDecimal(0L), values.get("speed"));
+		Assert.assertEquals("listTypeEntryKey1", values.get("state"));
+		Assert.assertEquals(null, values.get("time"));
+		Assert.assertEquals(0L, values.get("upload"));
+		Assert.assertEquals(0D, values.get("weight"));
+		Assert.assertEquals(
+			objectEntry.getObjectEntryId(),
+			values.get(_objectDefinition.getPKObjectFieldName()));
+		Assert.assertEquals(values.toString(), 23, values.size());
+
+		Calendar calendar = new GregorianCalendar();
+
+		calendar.set(6, Calendar.DECEMBER, 28);
+		calendar.setTimeInMillis(0);
+
+		Date birthdayDate = calendar.getTime();
+
+		String script = RandomTestUtil.randomString(1500);
+		Timestamp timestamp = Timestamp.valueOf(
+			LocalDateTime.now(
+			).withNano(
+				0
+			));
+
+		_objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>put(
+				"ageOfDeath", "94"
+			).put(
+				"authorOfGospel", true
+			).put(
+				"birthday", birthdayDate
+			).put(
+				"emailAddressRequired", "joao@liferay.com"
+			).put(
+				"height", 180
+			).put(
+				"listTypeEntryKey", "listTypeEntryKey1"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey3"
+			).put(
+				"multipleListTypeEntriesKey",
+				(Serializable)Arrays.asList(
+					"multipleListTypeEntryKey5", "multipleListTypeEntryKey6")
+			).put(
+				"numberOfBooksWritten", 5
+			).put(
+				"script", script
+			).put(
+				"speed", BigDecimal.valueOf(45L)
+			).put(
+				"state", "listTypeEntryKey2"
+			).put(
+				"time", timestamp
+			).put(
+				"upload", 0L
+			).put(
+				"weight", 60
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		_assertCount(1);
+
+		values = _objectEntryLocalService.getValues(
+			objectEntry.getObjectEntryId());
+
+		Assert.assertEquals(94L, values.get("ageOfDeath"));
+		Assert.assertTrue((boolean)values.get("authorOfGospel"));
+		Assert.assertEquals(birthdayDate, values.get("birthday"));
+		Assert.assertEquals(
+			"joao@liferay.com", values.get("emailAddressRequired"));
+		Assert.assertEquals(StringPool.BLANK, values.get("firstName"));
+		Assert.assertEquals(180D, values.get("height"));
+		Assert.assertEquals(StringPool.BLANK, values.get("lastName"));
+		Assert.assertEquals(
+			"listTypeEntryKey1", values.get("listTypeEntryKey"));
+		Assert.assertEquals(
+			"listTypeEntryKey3", values.get("listTypeEntryKeyRequired"));
+		Assert.assertEquals(StringPool.BLANK, values.get("middleName"));
+		Assert.assertEquals(
+			"multipleListTypeEntryKey5, multipleListTypeEntryKey6",
+			values.get("multipleListTypeEntriesKey"));
+		Assert.assertEquals(5, values.get("numberOfBooksWritten"));
+		Assert.assertEquals(script, values.get("script"));
+		Assert.assertEquals(_getBigDecimal(45L), values.get("speed"));
+		Assert.assertEquals("listTypeEntryKey2", values.get("state"));
+		Assert.assertEquals(timestamp, values.get("time"));
+		Assert.assertEquals(0L, values.get("upload"));
+		Assert.assertEquals(60D, values.get("weight"));
+		Assert.assertEquals(
+			objectEntry.getObjectEntryId(),
+			values.get(_objectDefinition.getPKObjectFieldName()));
+		Assert.assertEquals(values.toString(), 23, values.size());
+
+		_objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired", "charles@liferay.com"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey2"
+			).put(
+				"state", "listTypeEntryKey3"
+			).put(
+				"upload", 0L
+			).put(
+				"weight", 65D
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		_assertCount(1);
+
+		values = _objectEntryLocalService.getValues(
+			objectEntry.getObjectEntryId());
+
+		Assert.assertEquals(0L, values.get("ageOfDeath"));
+		Assert.assertFalse((boolean)values.get("authorOfGospel"));
+		Assert.assertEquals(null, values.get("birthday"));
+		Assert.assertEquals(
+			"charles@liferay.com", values.get("emailAddressRequired"));
+		Assert.assertEquals(StringPool.BLANK, values.get("firstName"));
+		Assert.assertEquals(0D, values.get("height"));
+		Assert.assertEquals(StringPool.BLANK, values.get("lastName"));
+		Assert.assertEquals(StringPool.BLANK, values.get("listTypeEntryKey"));
+		Assert.assertEquals(
+			"listTypeEntryKey2", values.get("listTypeEntryKeyRequired"));
+		Assert.assertEquals(StringPool.BLANK, values.get("middleName"));
+		Assert.assertEquals(
+			StringPool.BLANK, values.get("multipleListTypeEntriesKey"));
+		Assert.assertEquals(0, values.get("numberOfBooksWritten"));
+		Assert.assertEquals(StringPool.BLANK, values.get("script"));
+		Assert.assertEquals(_getBigDecimal(0L), values.get("speed"));
+		Assert.assertEquals("listTypeEntryKey3", values.get("state"));
+		Assert.assertEquals(null, values.get("time"));
+		Assert.assertEquals(0L, values.get("upload"));
+		Assert.assertEquals(65D, values.get("weight"));
+		Assert.assertEquals(
+			objectEntry.getObjectEntryId(),
+			values.get(_objectDefinition.getPKObjectFieldName()));
+		Assert.assertEquals(values.toString(), 23, values.size());
+
+		Map<String, Serializable> requiredValues =
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired",
+				RandomTestUtil.randomString() + "@liferay.com"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey1"
+			).build();
+
+		_objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>put(
+				"ageOfDeath", StringPool.BLANK
+			).put(
+				"authorOfGospel", StringPool.BLANK
+			).put(
+				"birthday", StringPool.BLANK
+			).put(
+				"firstName", StringPool.BLANK
+			).put(
+				"time", StringPool.BLANK
+			).putAll(
+				requiredValues
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		values = _objectEntryLocalService.getValues(
+			objectEntry.getObjectEntryId());
+
+		Assert.assertEquals(0L, values.get("ageOfDeath"));
+		Assert.assertFalse((boolean)values.get("authorOfGospel"));
+		Assert.assertNull(values.get("birthday"));
+		Assert.assertEquals(StringPool.BLANK, values.get("firstName"));
+		Assert.assertNull(values.get("time"));
+
+		_objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>putAll(
+				requiredValues
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		_objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>put(
+				_objectDefinition.getPKObjectFieldName(), ""
+			).put(
+				"invalidName", ""
+			).putAll(
+				requiredValues
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		long objectEntryId = objectEntry.getObjectEntryId();
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.Required.class,
+			"No value was provided for required object field " +
+				"\"emailAddressRequired\"",
+			() -> _addObjectEntry(
+				HashMapBuilder.<String, Serializable>put(
+					"listTypeEntryKeyRequired", "listTypeEntryKey1"
+				).build()));
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.ExceedsIntegerSize.class,
+			"Object entry value exceeds integer field allowed size",
+			() -> _objectEntryLocalService.updateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId,
+				HashMapBuilder.<String, Serializable>put(
+					"numberOfBooksWritten", "2147483648"
+				).putAll(
+					requiredValues
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.ExceedsIntegerSize.class,
+			"Object entry value exceeds integer field allowed size",
+			() -> _objectEntryLocalService.updateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId,
+				HashMapBuilder.<String, Serializable>put(
+					"numberOfBooksWritten", "-2147483649"
+				).putAll(
+					requiredValues
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.ExceedsLongMaxSize.class,
+			"Object entry value exceeds maximum long field allowed size",
+			() -> _objectEntryLocalService.updateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId,
+				HashMapBuilder.<String, Serializable>put(
+					"ageOfDeath", "9007199254740992"
+				).putAll(
+					requiredValues
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.ExceedsLongMinSize.class,
+			"Object entry value falls below minimum long field allowed size",
+			() -> _objectEntryLocalService.updateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId,
+				HashMapBuilder.<String, Serializable>put(
+					"ageOfDeath", "-9007199254740992"
+				).putAll(
+					requiredValues
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.ExceedsLongSize.class,
+			"Object entry value exceeds long field allowed size",
+			() -> _objectEntryLocalService.updateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId,
+				HashMapBuilder.<String, Serializable>put(
+					"ageOfDeath", "9223372036854775808"
+				).putAll(
+					requiredValues
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.ExceedsLongSize.class,
+			"Object entry value exceeds long field allowed size",
+			() -> _objectEntryLocalService.updateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId,
+				HashMapBuilder.<String, Serializable>put(
+					"ageOfDeath", "-9223372036854775809"
+				).putAll(
+					requiredValues
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.ExceedsTextMaxLength.class,
+			"Object entry value exceeds the maximum length of 280 characters " +
+				"for object field \"firstName\"",
+			() -> _objectEntryLocalService.updateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId,
+				HashMapBuilder.<String, Serializable>put(
+					"firstName", RandomTestUtil.randomString(281)
+				).putAll(
+					requiredValues
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		_addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddress", "james@liferay.com"
+			).putAll(
+				requiredValues
+			).build());
+
+		AssertUtils.assertFailure(
+			ObjectEntryValuesException.UniqueValueConstraintViolation.class,
+			"Unique value constraint violation for " +
+				_objectDefinition.getDBTableName() +
+					".emailAddress_ with value james@liferay.com",
+			() -> _objectEntryLocalService.updateObjectEntry(
+				TestPropsValues.getUserId(), objectEntryId,
+				HashMapBuilder.<String, Serializable>put(
+					"emailAddress", "james@liferay.com"
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+
+		_testUpdateObjectEntryExternalReferenceCode();
+		_testUpdateObjectEntryObjectStateTransitions();
+		_testUpdateObjectEntryWithObjectRelationship();
 	}
 
 	@Test
@@ -6768,410 +7134,6 @@ public class ObjectEntryLocalServiceTest {
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
 	}
 
-	private void _testUpdateObjectEntry(boolean partialUpdate)
-		throws Exception {
-
-		_assertCount(0);
-
-		ObjectEntry objectEntry = _addObjectEntry(
-			HashMapBuilder.<String, Serializable>put(
-				"emailAddressRequired", "john@liferay.com"
-			).put(
-				"firstName", "John"
-			).put(
-				"listTypeEntryKeyRequired", "listTypeEntryKey1"
-			).put(
-				"multipleListTypeEntriesKey",
-				(Serializable)Arrays.asList(
-					"multipleListTypeEntryKey1", "multipleListTypeEntryKey2")
-			).build());
-
-		_assertCount(1);
-
-		Assert.assertNotNull(
-			ReflectionTestUtil.getFieldValue(objectEntry, "_values"));
-
-		_getValuesFromCacheField(objectEntry);
-
-		//Assert.assertNotNull(
-		//	ReflectionTestUtil.getFieldValue(objectEntry, "_values"));
-
-		objectEntry = _objectEntryLocalService.updateObjectEntry(
-			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
-			HashMapBuilder.putAll(
-				_objectEntryLocalService.getValues(objectEntry)
-			).put(
-				"firstName", "João"
-			).put(
-				"lastName", "o Discípulo Amado"
-			).put(
-				"listTypeEntryKeyRequired", "listTypeEntryKey2"
-			).put(
-				"multipleListTypeEntriesKey",
-				(Serializable)Arrays.asList(
-					"multipleListTypeEntryKey3", "multipleListTypeEntryKey4")
-			).put(
-				"state", "listTypeEntryKey1"
-			).build(),
-			ServiceContextTestUtil.getServiceContext());
-
-		_assertCount(1);
-
-		objectEntry = _objectEntryLocalService.getObjectEntry(
-			objectEntry.getObjectEntryId());
-
-		Assert.assertNull(
-			ReflectionTestUtil.getFieldValue(objectEntry, "_values"));
-
-		Map<String, Serializable> values = objectEntry.getValues();
-
-		Assert.assertEquals(_getValuesFromCacheField(objectEntry), values);
-		Assert.assertEquals(0L, values.get("ageOfDeath"));
-		Assert.assertFalse((boolean)values.get("authorOfGospel"));
-		Assert.assertEquals(null, values.get("birthday"));
-		Assert.assertEquals(
-			"john@liferay.com", values.get("emailAddressRequired"));
-		Assert.assertEquals("João", values.get("firstName"));
-		Assert.assertEquals(0D, values.get("height"));
-		Assert.assertEquals("o Discípulo Amado", values.get("lastName"));
-		Assert.assertEquals(StringPool.BLANK, values.get("listTypeEntryKey"));
-		Assert.assertEquals(
-			"listTypeEntryKey2", values.get("listTypeEntryKeyRequired"));
-		Assert.assertEquals(StringPool.BLANK, values.get("middleName"));
-		Assert.assertEquals(
-			"multipleListTypeEntryKey3, multipleListTypeEntryKey4",
-			values.get("multipleListTypeEntriesKey"));
-		Assert.assertEquals(0, values.get("numberOfBooksWritten"));
-		Assert.assertEquals(StringPool.BLANK, values.get("script"));
-		Assert.assertEquals(_getBigDecimal(0L), values.get("speed"));
-		Assert.assertEquals("listTypeEntryKey1", values.get("state"));
-		Assert.assertEquals(null, values.get("time"));
-		Assert.assertEquals(0L, values.get("upload"));
-		Assert.assertEquals(0D, values.get("weight"));
-		Assert.assertEquals(
-			objectEntry.getObjectEntryId(),
-			values.get(_objectDefinition.getPKObjectFieldName()));
-		Assert.assertEquals(values.toString(), 23, values.size());
-
-		Calendar calendar = new GregorianCalendar();
-
-		calendar.set(6, Calendar.DECEMBER, 28);
-		calendar.setTimeInMillis(0);
-
-		Date birthdayDate = calendar.getTime();
-
-		String script = RandomTestUtil.randomString(1500);
-		Timestamp timestamp = Timestamp.valueOf(
-			LocalDateTime.now(
-			).withNano(
-				0
-			));
-
-		_objectEntryLocalService.updateObjectEntry(
-			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
-			HashMapBuilder.<String, Serializable>put(
-				"ageOfDeath", "94"
-			).put(
-				"authorOfGospel", true
-			).put(
-				"birthday", birthdayDate
-			).put(
-				"emailAddressRequired", "joao@liferay.com"
-			).put(
-				"height", 180
-			).put(
-				"listTypeEntryKey", "listTypeEntryKey1"
-			).put(
-				"listTypeEntryKeyRequired", "listTypeEntryKey3"
-			).put(
-				"multipleListTypeEntriesKey",
-				(Serializable)Arrays.asList(
-					"multipleListTypeEntryKey5", "multipleListTypeEntryKey6")
-			).put(
-				"numberOfBooksWritten", 5
-			).put(
-				"script", script
-			).put(
-				"speed", BigDecimal.valueOf(45L)
-			).put(
-				"state", "listTypeEntryKey2"
-			).put(
-				"time", timestamp
-			).put(
-				"upload", 0L
-			).put(
-				"weight", 60
-			).build(),
-			ServiceContextTestUtil.getServiceContext());
-
-		_assertCount(1);
-
-		values = _objectEntryLocalService.getValues(
-			objectEntry.getObjectEntryId());
-
-		Assert.assertEquals(94L, values.get("ageOfDeath"));
-		Assert.assertTrue((boolean)values.get("authorOfGospel"));
-		Assert.assertEquals(birthdayDate, values.get("birthday"));
-		Assert.assertEquals(
-			"joao@liferay.com", values.get("emailAddressRequired"));
-		Assert.assertEquals(
-			partialUpdate ? "João" : StringPool.BLANK, values.get("firstName"));
-		Assert.assertEquals(180D, values.get("height"));
-		Assert.assertEquals(
-			partialUpdate ? "o Discípulo Amado" : StringPool.BLANK,
-			values.get("lastName"));
-		Assert.assertEquals(
-			"listTypeEntryKey1", values.get("listTypeEntryKey"));
-		Assert.assertEquals(
-			"listTypeEntryKey3", values.get("listTypeEntryKeyRequired"));
-		Assert.assertEquals(StringPool.BLANK, values.get("middleName"));
-		Assert.assertEquals(
-			"multipleListTypeEntryKey5, multipleListTypeEntryKey6",
-			values.get("multipleListTypeEntriesKey"));
-		Assert.assertEquals(5, values.get("numberOfBooksWritten"));
-		Assert.assertEquals(script, values.get("script"));
-		Assert.assertEquals(_getBigDecimal(45L), values.get("speed"));
-		Assert.assertEquals("listTypeEntryKey2", values.get("state"));
-		Assert.assertEquals(timestamp, values.get("time"));
-		Assert.assertEquals(0L, values.get("upload"));
-		Assert.assertEquals(60D, values.get("weight"));
-		Assert.assertEquals(
-			objectEntry.getObjectEntryId(),
-			values.get(_objectDefinition.getPKObjectFieldName()));
-		Assert.assertEquals(values.toString(), 23, values.size());
-
-		_objectEntryLocalService.updateObjectEntry(
-			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
-			HashMapBuilder.<String, Serializable>put(
-				"emailAddressRequired", "charles@liferay.com"
-			).put(
-				"listTypeEntryKeyRequired", "listTypeEntryKey2"
-			).put(
-				"state", "listTypeEntryKey3"
-			).put(
-				"upload", 0L
-			).put(
-				"weight", 65D
-			).build(),
-			ServiceContextTestUtil.getServiceContext());
-
-		_assertCount(1);
-
-		values = _objectEntryLocalService.getValues(
-			objectEntry.getObjectEntryId());
-
-		Assert.assertEquals(partialUpdate ? 94L : 0L, values.get("ageOfDeath"));
-		Assert.assertEquals(
-			partialUpdate, (boolean)values.get("authorOfGospel"));
-		Assert.assertEquals(
-			partialUpdate ? birthdayDate : null, values.get("birthday"));
-		Assert.assertEquals(
-			"charles@liferay.com", values.get("emailAddressRequired"));
-		Assert.assertEquals(
-			partialUpdate ? "João" : StringPool.BLANK, values.get("firstName"));
-		Assert.assertEquals(partialUpdate ? 180D : 0D, values.get("height"));
-		Assert.assertEquals(
-			partialUpdate ? "o Discípulo Amado" : StringPool.BLANK,
-			values.get("lastName"));
-		Assert.assertEquals(
-			partialUpdate ? "listTypeEntryKey1" : StringPool.BLANK,
-			values.get("listTypeEntryKey"));
-		Assert.assertEquals(
-			"listTypeEntryKey2", values.get("listTypeEntryKeyRequired"));
-		Assert.assertEquals(StringPool.BLANK, values.get("middleName"));
-		Assert.assertEquals(
-			partialUpdate ?
-				"multipleListTypeEntryKey5, multipleListTypeEntryKey6" :
-					StringPool.BLANK,
-			values.get("multipleListTypeEntriesKey"));
-		Assert.assertEquals(
-			partialUpdate ? 5 : 0, values.get("numberOfBooksWritten"));
-		Assert.assertEquals(
-			partialUpdate ? script : StringPool.BLANK, values.get("script"));
-		Assert.assertEquals(
-			_getBigDecimal(partialUpdate ? 45L : 0L), values.get("speed"));
-		Assert.assertEquals("listTypeEntryKey3", values.get("state"));
-		Assert.assertEquals(
-			partialUpdate ? timestamp : null, values.get("time"));
-		Assert.assertEquals(0L, values.get("upload"));
-		Assert.assertEquals(65D, values.get("weight"));
-		Assert.assertEquals(
-			objectEntry.getObjectEntryId(),
-			values.get(_objectDefinition.getPKObjectFieldName()));
-		Assert.assertEquals(values.toString(), 23, values.size());
-
-		Map<String, Serializable> requiredValues =
-			HashMapBuilder.<String, Serializable>put(
-				"emailAddressRequired",
-				RandomTestUtil.randomString() + "@liferay.com"
-			).put(
-				"listTypeEntryKeyRequired", "listTypeEntryKey1"
-			).build();
-
-		_objectEntryLocalService.updateObjectEntry(
-			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
-			HashMapBuilder.<String, Serializable>put(
-				"ageOfDeath", StringPool.BLANK
-			).put(
-				"authorOfGospel", StringPool.BLANK
-			).put(
-				"birthday", StringPool.BLANK
-			).put(
-				"firstName", StringPool.BLANK
-			).put(
-				"time", StringPool.BLANK
-			).putAll(
-				requiredValues
-			).build(),
-			ServiceContextTestUtil.getServiceContext());
-
-		values = _objectEntryLocalService.getValues(
-			objectEntry.getObjectEntryId());
-
-		Assert.assertEquals(0L, values.get("ageOfDeath"));
-		Assert.assertFalse((boolean)values.get("authorOfGospel"));
-		Assert.assertNull(values.get("birthday"));
-		Assert.assertEquals(StringPool.BLANK, values.get("firstName"));
-		Assert.assertNull(values.get("time"));
-
-		_objectEntryLocalService.updateObjectEntry(
-			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
-			HashMapBuilder.<String, Serializable>putAll(
-				requiredValues
-			).build(),
-			ServiceContextTestUtil.getServiceContext());
-
-		_objectEntryLocalService.updateObjectEntry(
-			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
-			HashMapBuilder.<String, Serializable>put(
-				_objectDefinition.getPKObjectFieldName(), ""
-			).put(
-				"invalidName", ""
-			).putAll(
-				requiredValues
-			).build(),
-			ServiceContextTestUtil.getServiceContext());
-
-		long objectEntryId = objectEntry.getObjectEntryId();
-
-		AssertUtils.assertFailure(
-			ObjectEntryValuesException.Required.class,
-			"No value was provided for required object field " +
-				"\"emailAddressRequired\"",
-			() -> _addObjectEntry(
-				HashMapBuilder.<String, Serializable>put(
-					"listTypeEntryKeyRequired", "listTypeEntryKey1"
-				).build()));
-
-		AssertUtils.assertFailure(
-			ObjectEntryValuesException.ExceedsIntegerSize.class,
-			"Object entry value exceeds integer field allowed size",
-			() -> _objectEntryLocalService.updateObjectEntry(
-				TestPropsValues.getUserId(), objectEntryId,
-				HashMapBuilder.<String, Serializable>put(
-					"numberOfBooksWritten", "2147483648"
-				).putAll(
-					requiredValues
-				).build(),
-				ServiceContextTestUtil.getServiceContext()));
-
-		AssertUtils.assertFailure(
-			ObjectEntryValuesException.ExceedsIntegerSize.class,
-			"Object entry value exceeds integer field allowed size",
-			() -> _objectEntryLocalService.updateObjectEntry(
-				TestPropsValues.getUserId(), objectEntryId,
-				HashMapBuilder.<String, Serializable>put(
-					"numberOfBooksWritten", "-2147483649"
-				).putAll(
-					requiredValues
-				).build(),
-				ServiceContextTestUtil.getServiceContext()));
-
-		AssertUtils.assertFailure(
-			ObjectEntryValuesException.ExceedsLongMaxSize.class,
-			"Object entry value exceeds maximum long field allowed size",
-			() -> _objectEntryLocalService.updateObjectEntry(
-				TestPropsValues.getUserId(), objectEntryId,
-				HashMapBuilder.<String, Serializable>put(
-					"ageOfDeath", "9007199254740992"
-				).putAll(
-					requiredValues
-				).build(),
-				ServiceContextTestUtil.getServiceContext()));
-
-		AssertUtils.assertFailure(
-			ObjectEntryValuesException.ExceedsLongMinSize.class,
-			"Object entry value falls below minimum long field allowed size",
-			() -> _objectEntryLocalService.updateObjectEntry(
-				TestPropsValues.getUserId(), objectEntryId,
-				HashMapBuilder.<String, Serializable>put(
-					"ageOfDeath", "-9007199254740992"
-				).putAll(
-					requiredValues
-				).build(),
-				ServiceContextTestUtil.getServiceContext()));
-
-		AssertUtils.assertFailure(
-			ObjectEntryValuesException.ExceedsLongSize.class,
-			"Object entry value exceeds long field allowed size",
-			() -> _objectEntryLocalService.updateObjectEntry(
-				TestPropsValues.getUserId(), objectEntryId,
-				HashMapBuilder.<String, Serializable>put(
-					"ageOfDeath", "9223372036854775808"
-				).putAll(
-					requiredValues
-				).build(),
-				ServiceContextTestUtil.getServiceContext()));
-
-		AssertUtils.assertFailure(
-			ObjectEntryValuesException.ExceedsLongSize.class,
-			"Object entry value exceeds long field allowed size",
-			() -> _objectEntryLocalService.updateObjectEntry(
-				TestPropsValues.getUserId(), objectEntryId,
-				HashMapBuilder.<String, Serializable>put(
-					"ageOfDeath", "-9223372036854775809"
-				).putAll(
-					requiredValues
-				).build(),
-				ServiceContextTestUtil.getServiceContext()));
-
-		AssertUtils.assertFailure(
-			ObjectEntryValuesException.ExceedsTextMaxLength.class,
-			"Object entry value exceeds the maximum length of 280 characters " +
-				"for object field \"firstName\"",
-			() -> _objectEntryLocalService.updateObjectEntry(
-				TestPropsValues.getUserId(), objectEntryId,
-				HashMapBuilder.<String, Serializable>put(
-					"firstName", RandomTestUtil.randomString(281)
-				).putAll(
-					requiredValues
-				).build(),
-				ServiceContextTestUtil.getServiceContext()));
-
-		_addObjectEntry(
-			HashMapBuilder.<String, Serializable>put(
-				"emailAddress", "james@liferay.com"
-			).putAll(
-				requiredValues
-			).build());
-
-		AssertUtils.assertFailure(
-			ObjectEntryValuesException.UniqueValueConstraintViolation.class,
-			"Unique value constraint violation for " +
-				_objectDefinition.getDBTableName() +
-					".emailAddress_ with value james@liferay.com",
-			() -> _objectEntryLocalService.updateObjectEntry(
-				TestPropsValues.getUserId(), objectEntryId,
-				HashMapBuilder.<String, Serializable>put(
-					"emailAddress", "james@liferay.com"
-				).build(),
-				ServiceContextTestUtil.getServiceContext()));
-
-		_testUpdateObjectEntryExternalReferenceCode();
-		_testUpdateObjectEntryObjectStateTransitions();
-		_testUpdateObjectEntryWithObjectRelationship(partialUpdate);
-	}
-
 	private void _testUpdateObjectEntryExternalReferenceCode()
 		throws Exception {
 
@@ -7393,8 +7355,7 @@ public class ObjectEntryLocalServiceTest {
 			objectEntry.getObjectEntryId());
 	}
 
-	private void _testUpdateObjectEntryWithObjectRelationship(
-			boolean partialUpdate)
+	private void _testUpdateObjectEntryWithObjectRelationship()
 		throws Exception {
 
 		ObjectDefinition objectDefinition =
@@ -7467,9 +7428,7 @@ public class ObjectEntryLocalServiceTest {
 
 		values = objectEntry1.getValues();
 
-		Assert.assertEquals(
-			partialUpdate ? "Charles" : StringPool.BLANK,
-			values.get("firstName"));
+		Assert.assertEquals(StringPool.BLANK, values.get("firstName"));
 		Assert.assertEquals(
 			objectEntry2.getExternalReferenceCode(),
 			values.get("r_objectRelationship_c_relatedObjectDefinitionERC"));
@@ -7490,12 +7449,10 @@ public class ObjectEntryLocalServiceTest {
 
 		Assert.assertEquals("Julia", values.get("firstName"));
 		Assert.assertEquals(
-			partialUpdate ? objectEntry2.getExternalReferenceCode() :
-				StringPool.BLANK,
+			StringPool.BLANK,
 			values.get("r_objectRelationship_c_relatedObjectDefinitionERC"));
 		Assert.assertEquals(
-			partialUpdate ? objectEntry2.getObjectEntryId() : 0L,
-			values.get("r_objectRelationship_c_relatedObjectDefinitionId"));
+			0L, values.get("r_objectRelationship_c_relatedObjectDefinitionId"));
 
 		objectEntry1 = _objectEntryLocalService.updateObjectEntry(
 			TestPropsValues.getUserId(), objectEntryId1,


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-54757

See: https://github.com/liferay-headless/liferay-portal/pull/2812

---

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPP-58709

Updating the custom fields of a structured content via the API results in a ClassCastException.

# How are we fixing it?

Added appropriate condition checks to ensure the field values are converted to the expected types

cc/ @ak-ragnor @jkappler @movaldivia 