### PR TITLE
LPD-44395 Clean up unused dependencies in workspaces

### DIFF
--- a/workspaces/liferay-evp-workspace/client-extensions/liferay-evp-etc-spring-boot/build.gradle
+++ b/workspaces/liferay-evp-workspace/client-extensions/liferay-evp-etc-spring-boot/build.gradle
@@ -22,7 +22,6 @@ apply plugin: "org.springframework.boot"
 dependencies {
 	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot3", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.petra.string", version: "5.3.2"
-	implementation group: "com.liferay", name: "org.apache.commons.logging", version: "1.2.LIFERAY-PATCHED-2"
 	implementation group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "latest.release"
 	implementation group: "net.datafaker", name: "datafaker", version: "1.9.0"
 	implementation group: "org.json", name: "json", version: "20231013"

--- a/workspaces/liferay-learn-workspace/client-extensions/liferay-learn-etc-cron-2/build.gradle
+++ b/workspaces/liferay-learn-workspace/client-extensions/liferay-learn-etc-cron-2/build.gradle
@@ -21,7 +21,6 @@ apply plugin: "org.springframework.boot"
 
 dependencies {
 	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot3", version: "latest.release"
-	implementation group: "com.liferay", name: "org.apache.commons.logging", version: "1.2.LIFERAY-PATCHED-2"
 	implementation group: "org.json", name: "json", version: "20231013"
 	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.18"
 	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.18"


### PR DESCRIPTION
Follow up from: https://github.com/brianchandotcom/liferay-portal/pull/162019

Hey Brian, I took a look in every client extension in `liferay-portal/workspaces` and only found those two cases. Every other client extension using this dependency had a log somewhere in the java classes.