### PR TITLE
LPD-56005 frontend-js-web: Namespace should not be included in the getHREF

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DynamicInlineScroll.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DynamicInlineScroll.es.js
@@ -94,12 +94,12 @@ class DynamicInlineScroll extends PortletBase {
 	 * @return {string} The <code>href</code> value as a string.
 	 */
 	getHREF_(pageIndex) {
-		const {curParam, formName, jsCall, namespace, url, urlAnchor} = this;
+		const {curParam, formName, jsCall, url, urlAnchor} = this;
 
-		let href = `javascript:document.${formName}.${namespace}${curParam}.value = "${pageIndex}; ${jsCall}`;
+		let href = `javascript:document.${formName}.${curParam}.value = "${pageIndex}; ${jsCall}`;
 
 		if (this.url !== null) {
-			href = `${url}&${namespace}${curParam}=${pageIndex}${urlAnchor}`;
+			href = `${url}&${curParam}=${pageIndex}${urlAnchor}`;
 		}
 
 		return href;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DynamicInlineScroll.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/DynamicInlineScroll.es.js
@@ -72,11 +72,12 @@ class DynamicInlineScroll extends PortletBase {
 	addListItem_(listElement, pageIndex) {
 		const listItem = document.createElement('li');
 
-		listItem.innerHTML = `<a class="dropdown-item" href="${this.getHREF_(
+		listItem.innerHTML = `<a aria-label="${Liferay.Util.sub(
+			Liferay.Language.get('page-x'),
+			[pageIndex]
+		)}" class="dropdown-item" href="${this.getHREF_(
 			pageIndex
-		)}"><span class="sr-only">${Liferay.Language.get(
-			'page'
-		)}&nbsp;</span>${pageIndex}</a>`;
+		)}">${pageIndex}</a>`;
 
 		pageIndex++;
 


### PR DESCRIPTION
Manually forwarded from https://github.com/liferay-frontend/liferay-portal/pull/4920, as test failures do not look related.

https://liferay.atlassian.net/browse/LPD-56005 - Incorrect links within page_iterator after dynamic scrolling

A customer using search noticed a bug with the `search-paginator` taglib, when scrolling for page items. It seems like this `getHREF` function within `DynamicInlineScroll` is including the `namespace`, resulting in faulty links. Compared to the `getHREF` within the `page_iterator.jsp`, it does not append `namespace`: https://github.com/liferay-frontend/liferay-portal/blob/b42f46edc9ab35ce9abdb7760889ccb7c019c74a/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp#L528-L534

It seems like in other uses of the search paginator, `namespace` nor `id` are passed in as parameters, so their being empty strings + it takes many items to start dynamic scrolling might have been the reason why it had gone unnoticed until now 😓 

Also included changes for accessibility, after some feedback from frontend infra :)