### PR TITLE
LPD-56260 Proper Handling of Feature Flag Listeners in Integration Tests

### DIFF
--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/exportimport/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/exportimport/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -25,13 +25,10 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
-import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
-import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
-import com.liferay.portal.kernel.feature.flag.FeatureFlagListener;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -39,9 +36,9 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
-import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.FeatureFlagTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -101,12 +98,14 @@ public class BatchEnginePortletDataHandlerTest {
 
 	@BeforeClass
 	public static void setUpClass() {
-		_invokeFeatureFlagListeners(true);
+		FeatureFlagTestUtil.invokeFeatureFlagListeners(
+			CompanyConstants.SYSTEM, true, "LPD-35914");
 	}
 
 	@AfterClass
 	public static void tearDownClass() {
-		_invokeFeatureFlagListeners(false);
+		FeatureFlagTestUtil.invokeFeatureFlagListeners(
+			CompanyConstants.SYSTEM, false, "LPD-35914");
 	}
 
 	@Test
@@ -381,21 +380,6 @@ public class BatchEnginePortletDataHandlerTest {
 		_assertNull(
 			objectDefinition.getObjectDefinitionId(), objectEntries[0],
 			objectEntries[1]);
-	}
-
-	private static void _invokeFeatureFlagListeners(boolean enabled) {
-		try (ServiceTrackerList<FeatureFlagListener> featureFlagListeners =
-				ServiceTrackerListFactory.open(
-					SystemBundleUtil.getBundleContext(),
-					FeatureFlagListener.class, "(featureFlagKey=LPD-35914)")) {
-
-			for (FeatureFlagListener featureFlagListener :
-					featureFlagListeners) {
-
-				featureFlagListener.onValue(
-					CompanyConstants.SYSTEM, "LPD-35914", enabled);
-			}
-		}
 	}
 
 	private ObjectDefinition _addObjectDefinition(String scope)

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/exportimport/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/exportimport/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -25,16 +25,21 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
+import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagListener;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -67,7 +72,9 @@ import java.util.Objects;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -91,6 +98,16 @@ public class BatchEnginePortletDataHandlerTest {
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@BeforeClass
+	public static void setUpClass() {
+		_invokeFeatureFlagListeners(true);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_invokeFeatureFlagListeners(false);
+	}
 
 	@Test
 	@TestInfo("LPD-51604")
@@ -364,6 +381,21 @@ public class BatchEnginePortletDataHandlerTest {
 		_assertNull(
 			objectDefinition.getObjectDefinitionId(), objectEntries[0],
 			objectEntries[1]);
+	}
+
+	private static void _invokeFeatureFlagListeners(boolean enabled) {
+		try (ServiceTrackerList<FeatureFlagListener> featureFlagListeners =
+				ServiceTrackerListFactory.open(
+					SystemBundleUtil.getBundleContext(),
+					FeatureFlagListener.class, "(featureFlagKey=LPD-35914)")) {
+
+			for (FeatureFlagListener featureFlagListener :
+					featureFlagListeners) {
+
+				featureFlagListener.onValue(
+					CompanyConstants.SYSTEM, "LPD-35914", enabled);
+			}
+		}
 	}
 
 	private ObjectDefinition _addObjectDefinition(String scope)

--- a/portal-test/src/com/liferay/portal/kernel/test/util/FeatureFlagTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/FeatureFlagTestUtil.java
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.test.util;
+
+import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
+import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagListener;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+
+/**
+ * @author Thiago Buarque
+ */
+public class FeatureFlagTestUtil {
+
+	public static void invokeFeatureFlagListeners(
+		long companyId, boolean enabled, String key) {
+
+		try (ServiceTrackerList<FeatureFlagListener> featureFlagListeners =
+				ServiceTrackerListFactory.open(
+					SystemBundleUtil.getBundleContext(),
+					FeatureFlagListener.class,
+					StringBundler.concat("(featureFlagKey=", key, ")"))) {
+
+			for (FeatureFlagListener featureFlagListener :
+					featureFlagListeners) {
+
+				featureFlagListener.onValue(companyId, key, enabled);
+			}
+		}
+	}
+
+}

--- a/portal-test/src/com/liferay/portal/test/rule/FeatureFlagTestRule.java
+++ b/portal-test/src/com/liferay/portal/test/rule/FeatureFlagTestRule.java
@@ -5,12 +5,7 @@
 
 package com.liferay.portal.test.rule;
 
-import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
-import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
-import com.liferay.portal.kernel.feature.flag.FeatureFlagListener;
 import com.liferay.portal.kernel.feature.flag.constants.FeatureFlagConstants;
-import com.liferay.portal.kernel.model.CompanyConstants;
-import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.test.rule.AbstractTestRule;
 import com.liferay.portal.kernel.util.KeyValuePair;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
@@ -27,9 +22,8 @@ import org.junit.runner.Description;
 public class FeatureFlagTestRule
 	extends AbstractTestRule<Map<String, String>, Map<String, String>> {
 
-	public FeatureFlagTestRule(boolean enableFeatureFlagListeners) {
-		_enableFeatureFlagListeners = enableFeatureFlagListeners;
-	}
+	public static final FeatureFlagTestRule INSTANCE =
+		new FeatureFlagTestRule();
 
 	@Override
 	protected void afterClass(
@@ -63,28 +57,6 @@ public class FeatureFlagTestRule
 		return _updateFeatureFlags(description);
 	}
 
-	private void _invokeFeatureFlagListeners(
-		String featureFlagKey, boolean enabled) {
-
-		if (!_enableFeatureFlagListeners) {
-			return;
-		}
-
-		try (ServiceTrackerList<FeatureFlagListener> featureFlagListeners =
-				ServiceTrackerListFactory.open(
-					SystemBundleUtil.getBundleContext(),
-					FeatureFlagListener.class,
-					"(featureFlagKey=" + featureFlagKey + ")")) {
-
-			for (FeatureFlagListener featureFlagListener :
-					featureFlagListeners) {
-
-				featureFlagListener.onValue(
-					CompanyConstants.SYSTEM, featureFlagKey, enabled);
-			}
-		}
-	}
-
 	private void _restoreFeatureFlags(Map<String, String> previousValues) {
 		Map<String, String> values = new HashMap<>();
 
@@ -98,9 +70,6 @@ public class FeatureFlagTestRule
 			}
 
 			values.put(entry.getKey(), entry.getValue());
-
-			_invokeFeatureFlagListeners(
-				entry.getKey(), Boolean.parseBoolean(entry.getValue()));
 		}
 
 		PropsUtil.addProperties(
@@ -120,8 +89,6 @@ public class FeatureFlagTestRule
 			UnicodePropertiesBuilder.setProperty(
 				featureFlagKey, String.valueOf(featureFlag.enable())
 			).build());
-
-		_invokeFeatureFlagListeners(featureFlag.value(), featureFlag.enable());
 
 		return previousKeyValuePair;
 	}
@@ -158,7 +125,5 @@ public class FeatureFlagTestRule
 
 		return previousValues;
 	}
-
-	private final boolean _enableFeatureFlagListeners;
 
 }

--- a/portal-test/src/com/liferay/portal/test/rule/LiferayIntegrationTestRule.java
+++ b/portal-test/src/com/liferay/portal/test/rule/LiferayIntegrationTestRule.java
@@ -36,7 +36,7 @@ public class LiferayIntegrationTestRule extends AggregateTestRule {
 			testRules.add(TimeoutTestRule.INSTANCE);
 		}
 
-		testRules.add(new FeatureFlagTestRule(true));
+		testRules.add(FeatureFlagTestRule.INSTANCE);
 		testRules.add(LanguageIdsTestRule.INSTANCE);
 		testRules.add(PortalRunModeClassTestRule.INSTANCE);
 		testRules.add(SynchronousDestinationTestRule.INSTANCE);

--- a/portal-test/src/com/liferay/portal/test/rule/LiferayUnitTestRule.java
+++ b/portal-test/src/com/liferay/portal/test/rule/LiferayUnitTestRule.java
@@ -24,8 +24,7 @@ public class LiferayUnitTestRule extends AggregateTestRule {
 
 	private static TestRule[] _getTestRules() {
 		return new TestRule[] {
-			new FeatureFlagTestRule(false),
-			InitializeKernelUtilTestRule.INSTANCE,
+			FeatureFlagTestRule.INSTANCE, InitializeKernelUtilTestRule.INSTANCE,
 			AspectJNewEnvTestRule.INSTANCE, NewEnvTestRule.INSTANCE
 		};
 	}


### PR DESCRIPTION
Rebasing branch https://github.com/brianchandotcom/liferay-portal/pull/162208

# Context
[A workaround](https://github.com/brianchandotcom/liferay-portal/pull/159036/commits/73935b32d15d1de686a8f978049674032005f52e) was added to call feature flag listeners automatically using the @FeatureFlag annotation.

Imagine a developer creates a test for the feature flag LPD-123, when the test starts, the FeatureFlagRuleTest would call the listeners for that feature flag. But it can't know what company id to pass in to the listener.

# Solution
I created a FeatureFlagTestUtil that can easily call listeners for a given feature flag. The right company id can be passed as well