### PR TITLE
LPD-55602 Create vocabularies, categories and tags in the CMS group

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
@@ -183,8 +183,7 @@ public class KeywordResourceImpl extends BaseKeywordResourceImpl {
 
 				BooleanFilter booleanFilter = new BooleanFilter();
 
-				booleanFilter.addRequiredTerm(
-					Field.GROUP_ID, GroupConstants.DEFAULT_LIVE_GROUP_ID);
+				booleanFilter.addRequiredTerm(Field.GROUP_ID, _getCMSGroupId());
 
 				searchContext.setBooleanClauses(
 					new BooleanClause[] {
@@ -303,15 +302,12 @@ public class KeywordResourceImpl extends BaseKeywordResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		AssetTag assetTag = _assetTagService.addTag(
-			keyword.getExternalReferenceCode(),
-			GroupConstants.DEFAULT_LIVE_GROUP_ID, keyword.getName(),
-			new ServiceContext());
+		Keyword postKeyword = postSiteKeyword(_getCMSGroupId(), keyword);
 
 		_assetTagGroupRelLocalService.setAssetTagGroupRels(
-			assetTag.getTagId(), _getAssetLibraryGroupIds(keyword));
+			postKeyword.getId(), _getAssetLibraryGroupIds(keyword));
 
-		return _toKeyword(assetTag);
+		return keyword;
 	}
 
 	@Override
@@ -464,6 +460,13 @@ public class KeywordResourceImpl extends BaseKeywordResourceImpl {
 		}
 
 		return ArrayUtil.toLongArray(groupIds);
+	}
+
+	private long _getCMSGroupId() {
+		Group group = _groupLocalService.fetchFriendlyURLGroup(
+			contextCompany.getCompanyId(), GroupConstants.CMS_FRIENDLY_URL);
+
+		return group.getGroupId();
 	}
 
 	private Page<Keyword> _getKeywordsPage(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
@@ -435,28 +435,7 @@ public class KeywordResourceImpl extends BaseKeywordResourceImpl {
 		List<Long> groupIds = new ArrayList<>();
 
 		for (AssetLibrary assetLibrary : keyword.getAssetLibraries()) {
-			if (assetLibrary.getId() == GroupConstants.ANY_PARENT_GROUP_ID) {
-				groupIds.add(assetLibrary.getId());
-
-				break;
-			}
-
-			Group group = _groupLocalService.fetchGroup(assetLibrary.getId());
-
-			if (group != null) {
-				groupIds.add(group.getGroupId());
-			}
-			else {
-				DepotEntry depotEntry = _depotEntryLocalService.fetchDepotEntry(
-					assetLibrary.getId());
-
-				if (depotEntry != null) {
-					groupIds.add(depotEntry.getGroupId());
-				}
-				else {
-					throw new Exception();
-				}
-			}
+			groupIds.add(_getGroupId(assetLibrary.getId()));
 		}
 
 		return ArrayUtil.toLongArray(groupIds);
@@ -467,6 +446,22 @@ public class KeywordResourceImpl extends BaseKeywordResourceImpl {
 			contextCompany.getCompanyId(), GroupConstants.CMS_FRIENDLY_URL);
 
 		return group.getGroupId();
+	}
+
+	private long _getGroupId(long classPK) throws Exception {
+		if (classPK == GroupConstants.ANY_PARENT_GROUP_ID) {
+			return classPK;
+		}
+
+		Group group = _groupLocalService.fetchGroup(classPK);
+
+		if (group != null) {
+			return group.getGroupId();
+		}
+
+		DepotEntry depotEntry = _depotEntryLocalService.getDepotEntry(classPK);
+
+		return depotEntry.getGroupId();
 	}
 
 	private Page<Keyword> _getKeywordsPage(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
@@ -9,11 +9,9 @@ import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.asset.kernel.service.AssetTagGroupRelLocalService;
 import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.asset.kernel.service.AssetTagService;
-import com.liferay.depot.model.DepotEntry;
-import com.liferay.depot.service.DepotEntryLocalService;
-import com.liferay.headless.admin.taxonomy.dto.v1_0.AssetLibrary;
 import com.liferay.headless.admin.taxonomy.dto.v1_0.Keyword;
 import com.liferay.headless.admin.taxonomy.internal.odata.entity.v1_0.KeywordEntityModel;
+import com.liferay.headless.admin.taxonomy.internal.util.TaxonomyGroupUtil;
 import com.liferay.headless.admin.taxonomy.resource.v1_0.KeywordResource;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
@@ -23,7 +21,6 @@ import com.liferay.portal.kernel.dao.orm.ProjectionList;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.Type;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.BooleanClauseFactoryUtil;
@@ -35,7 +32,6 @@ import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
-import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -57,9 +53,7 @@ import jakarta.ws.rs.core.MultivaluedMap;
 
 import java.sql.Timestamp;
 
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
@@ -183,7 +177,10 @@ public class KeywordResourceImpl extends BaseKeywordResourceImpl {
 
 				BooleanFilter booleanFilter = new BooleanFilter();
 
-				booleanFilter.addRequiredTerm(Field.GROUP_ID, _getCMSGroupId());
+				booleanFilter.addRequiredTerm(
+					Field.GROUP_ID,
+					TaxonomyGroupUtil.getCMSGroupId(
+						contextCompany.getCompanyId()));
 
 				searchContext.setBooleanClauses(
 					new BooleanClause[] {
@@ -302,10 +299,14 @@ public class KeywordResourceImpl extends BaseKeywordResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		Keyword postKeyword = postSiteKeyword(_getCMSGroupId(), keyword);
+		Keyword postKeyword = postSiteKeyword(
+			TaxonomyGroupUtil.getCMSGroupId(contextCompany.getCompanyId()),
+			keyword);
 
 		_assetTagGroupRelLocalService.setAssetTagGroupRels(
-			postKeyword.getId(), _getAssetLibraryGroupIds(keyword));
+			postKeyword.getId(),
+			TaxonomyGroupUtil.getAssetLibraryGroupIds(
+				keyword.getAssetLibraries()));
 
 		return keyword;
 	}
@@ -354,7 +355,9 @@ public class KeywordResourceImpl extends BaseKeywordResourceImpl {
 			ArrayUtil.isNotEmpty(keyword.getAssetLibraries())) {
 
 			_assetTagGroupRelLocalService.setAssetTagGroupRels(
-				assetTag.getTagId(), _getAssetLibraryGroupIds(keyword));
+				assetTag.getTagId(),
+				TaxonomyGroupUtil.getAssetLibraryGroupIds(
+					keyword.getAssetLibraries()));
 		}
 
 		return _toKeyword(assetTag);
@@ -429,39 +432,6 @@ public class KeywordResourceImpl extends BaseKeywordResourceImpl {
 	@Override
 	protected String getPermissionCheckerResourceName(Object id) {
 		return AssetTagsPermission.RESOURCE_NAME;
-	}
-
-	private long[] _getAssetLibraryGroupIds(Keyword keyword) throws Exception {
-		List<Long> groupIds = new ArrayList<>();
-
-		for (AssetLibrary assetLibrary : keyword.getAssetLibraries()) {
-			groupIds.add(_getGroupId(assetLibrary.getId()));
-		}
-
-		return ArrayUtil.toLongArray(groupIds);
-	}
-
-	private long _getCMSGroupId() {
-		Group group = _groupLocalService.fetchFriendlyURLGroup(
-			contextCompany.getCompanyId(), GroupConstants.CMS_FRIENDLY_URL);
-
-		return group.getGroupId();
-	}
-
-	private long _getGroupId(long classPK) throws Exception {
-		if (classPK == GroupConstants.ANY_PARENT_GROUP_ID) {
-			return classPK;
-		}
-
-		Group group = _groupLocalService.fetchGroup(classPK);
-
-		if (group != null) {
-			return group.getGroupId();
-		}
-
-		DepotEntry depotEntry = _depotEntryLocalService.getDepotEntry(classPK);
-
-		return depotEntry.getGroupId();
 	}
 
 	private Page<Keyword> _getKeywordsPage(
@@ -610,13 +580,7 @@ public class KeywordResourceImpl extends BaseKeywordResourceImpl {
 	private AssetTagService _assetTagService;
 
 	@Reference
-	private DepotEntryLocalService _depotEntryLocalService;
-
-	@Reference
 	private DTOConverterRegistry _dtoConverterRegistry;
-
-	@Reference
-	private GroupLocalService _groupLocalService;
 
 	@Reference(
 		target = "(component.name=com.liferay.headless.admin.taxonomy.internal.dto.v1_0.converter.KeywordDTOConverter)"

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
@@ -435,7 +435,7 @@ public class KeywordResourceImpl extends BaseKeywordResourceImpl {
 		List<Long> groupIds = new ArrayList<>();
 
 		for (AssetLibrary assetLibrary : keyword.getAssetLibraries()) {
-			if (assetLibrary.getId() == -1) {
+			if (assetLibrary.getId() == GroupConstants.ANY_PARENT_GROUP_ID) {
 				groupIds.add(assetLibrary.getId());
 
 				break;

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -586,28 +586,7 @@ public class TaxonomyVocabularyResourceImpl
 		for (AssetLibrary assetLibrary :
 				taxonomyVocabulary.getAssetLibraries()) {
 
-			if (assetLibrary.getId() == GroupConstants.ANY_PARENT_GROUP_ID) {
-				groupIds.add(assetLibrary.getId());
-
-				break;
-			}
-
-			Group group = _groupLocalService.fetchGroup(assetLibrary.getId());
-
-			if (group != null) {
-				groupIds.add(group.getGroupId());
-			}
-			else {
-				DepotEntry depotEntry = _depotEntryLocalService.fetchDepotEntry(
-					assetLibrary.getId());
-
-				if (depotEntry != null) {
-					groupIds.add(depotEntry.getGroupId());
-				}
-				else {
-					throw new Exception();
-				}
-			}
+			groupIds.add(_getGroupId(assetLibrary.getId()));
 		}
 
 		return ArrayUtil.toLongArray(groupIds);
@@ -816,6 +795,22 @@ public class TaxonomyVocabularyResourceImpl
 			contextCompany.getCompanyId(), GroupConstants.CMS_FRIENDLY_URL);
 
 		return group.getGroupId();
+	}
+
+	private long _getGroupId(long classPK) throws Exception {
+		if (classPK == GroupConstants.ANY_PARENT_GROUP_ID) {
+			return classPK;
+		}
+
+		Group group = _groupLocalService.fetchGroup(classPK);
+
+		if (group != null) {
+			return group.getGroupId();
+		}
+
+		DepotEntry depotEntry = _depotEntryLocalService.getDepotEntry(classPK);
+
+		return depotEntry.getGroupId();
 	}
 
 	private String _getModelResource(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -16,14 +16,13 @@ import com.liferay.asset.kernel.model.ClassTypeReader;
 import com.liferay.asset.kernel.service.AssetVocabularyGroupRelLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyService;
-import com.liferay.depot.model.DepotEntry;
-import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.depot.util.SiteConnectedGroupGroupProviderUtil;
 import com.liferay.headless.admin.taxonomy.dto.v1_0.AssetLibrary;
 import com.liferay.headless.admin.taxonomy.dto.v1_0.AssetType;
 import com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyVocabulary;
 import com.liferay.headless.admin.taxonomy.internal.dto.v1_0.util.CreatorUtil;
 import com.liferay.headless.admin.taxonomy.internal.odata.entity.v1_0.VocabularyEntityModel;
+import com.liferay.headless.admin.taxonomy.internal.util.TaxonomyGroupUtil;
 import com.liferay.headless.admin.taxonomy.resource.v1_0.TaxonomyVocabularyResource;
 import com.liferay.headless.common.spi.service.context.ServiceContextBuilder;
 import com.liferay.object.model.ObjectDefinition;
@@ -31,7 +30,6 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.User;
@@ -45,7 +43,6 @@ import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
-import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -303,12 +300,16 @@ public class TaxonomyVocabularyResourceImpl
 				"create",
 				addAction(
 					ActionKeys.ADD_VOCABULARY, "postTaxonomyVocabulary",
-					AssetCategoriesPermission.RESOURCE_NAME, _getCMSGroupId())
+					AssetCategoriesPermission.RESOURCE_NAME,
+					TaxonomyGroupUtil.getCMSGroupId(
+						contextCompany.getCompanyId()))
 			).put(
 				"createBatch",
 				addAction(
 					ActionKeys.ADD_VOCABULARY, "postTaxonomyVocabularyBatch",
-					AssetCategoriesPermission.RESOURCE_NAME, _getCMSGroupId())
+					AssetCategoriesPermission.RESOURCE_NAME,
+					TaxonomyGroupUtil.getCMSGroupId(
+						contextCompany.getCompanyId()))
 			).put(
 				"deleteBatch",
 				addAction(
@@ -318,7 +319,9 @@ public class TaxonomyVocabularyResourceImpl
 				"get",
 				addAction(
 					ActionKeys.VIEW, "getTaxonomyVocabulariesPage",
-					AssetCategoriesPermission.RESOURCE_NAME, _getCMSGroupId())
+					AssetCategoriesPermission.RESOURCE_NAME,
+					TaxonomyGroupUtil.getCMSGroupId(
+						contextCompany.getCompanyId()))
 			).put(
 				"updateBatch",
 				addAction(
@@ -335,7 +338,10 @@ public class TaxonomyVocabularyResourceImpl
 
 				BooleanFilter booleanFilter = new BooleanFilter();
 
-				booleanFilter.addRequiredTerm(Field.GROUP_ID, _getCMSGroupId());
+				booleanFilter.addRequiredTerm(
+					Field.GROUP_ID,
+					TaxonomyGroupUtil.getCMSGroupId(
+						contextCompany.getCompanyId()));
 
 				searchContext.setBooleanClauses(
 					new BooleanClause[] {
@@ -407,7 +413,8 @@ public class TaxonomyVocabularyResourceImpl
 		}
 
 		AssetVocabulary assetVocabulary = _addAssetVocabulary(
-			taxonomyVocabulary.getExternalReferenceCode(), _getCMSGroupId(),
+			taxonomyVocabulary.getExternalReferenceCode(),
+			TaxonomyGroupUtil.getCMSGroupId(contextCompany.getCompanyId()),
 			taxonomyVocabulary);
 
 		_assetVocabularyGroupRelLocalService.setAssetVocabularyGroupRels(
@@ -581,15 +588,8 @@ public class TaxonomyVocabularyResourceImpl
 			TaxonomyVocabulary taxonomyVocabulary)
 		throws Exception {
 
-		List<Long> groupIds = new ArrayList<>();
-
-		for (AssetLibrary assetLibrary :
-				taxonomyVocabulary.getAssetLibraries()) {
-
-			groupIds.add(_getGroupId(assetLibrary.getId()));
-		}
-
-		return ArrayUtil.toLongArray(groupIds);
+		return TaxonomyGroupUtil.getAssetLibraryGroupIds(
+			taxonomyVocabulary.getAssetLibraries());
 	}
 
 	private AssetType _getAssetType(
@@ -788,29 +788,6 @@ public class TaxonomyVocabularyResourceImpl
 		}
 
 		throw new BadRequestException("Invalid subtype " + subtype);
-	}
-
-	private long _getCMSGroupId() {
-		Group group = _groupLocalService.fetchFriendlyURLGroup(
-			contextCompany.getCompanyId(), GroupConstants.CMS_FRIENDLY_URL);
-
-		return group.getGroupId();
-	}
-
-	private long _getGroupId(long classPK) throws Exception {
-		if (classPK == GroupConstants.ANY_PARENT_GROUP_ID) {
-			return classPK;
-		}
-
-		Group group = _groupLocalService.fetchGroup(classPK);
-
-		if (group != null) {
-			return group.getGroupId();
-		}
-
-		DepotEntry depotEntry = _depotEntryLocalService.getDepotEntry(classPK);
-
-		return depotEntry.getGroupId();
 	}
 
 	private String _getModelResource(
@@ -1045,16 +1022,10 @@ public class TaxonomyVocabularyResourceImpl
 	@Reference
 	private AssetVocabularyService _assetVocabularyService;
 
-	@Reference
-	private DepotEntryLocalService _depotEntryLocalService;
-
 	@Reference(
 		target = "(dto.class.name=com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyVocabulary)"
 	)
 	private DTOActionProvider _dtoActionProvider;
-
-	@Reference
-	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -756,8 +756,8 @@ public class TaxonomyVocabularyResourceImpl
 		return _portal.getClassNameId(className);
 	}
 
-	private long _getClassTypePK(long classNameId, String subtype, long groupId)
-		throws Exception {
+	private long _getClassTypePK(
+		long classNameId, String subtype, long groupId) {
 
 		if (Objects.equals(subtype, "AllAssetSubtypes") ||
 			(classNameId == AssetCategoryConstants.ALL_CLASS_NAME_ID) ||
@@ -807,8 +807,7 @@ public class TaxonomyVocabularyResourceImpl
 	}
 
 	private String _getSettings(
-			AssetType[] assetTypes, long groupId, boolean multiValued)
-		throws Exception {
+		AssetType[] assetTypes, long groupId, boolean multiValued) {
 
 		AssetVocabularySettingsHelper assetVocabularySettingsHelper =
 			new AssetVocabularySettingsHelper();

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -586,7 +586,7 @@ public class TaxonomyVocabularyResourceImpl
 		for (AssetLibrary assetLibrary :
 				taxonomyVocabulary.getAssetLibraries()) {
 
-			if (assetLibrary.getId() == -1) {
+			if (assetLibrary.getId() == GroupConstants.ANY_PARENT_GROUP_ID) {
 				groupIds.add(assetLibrary.getId());
 
 				break;

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -303,14 +303,12 @@ public class TaxonomyVocabularyResourceImpl
 				"create",
 				addAction(
 					ActionKeys.ADD_VOCABULARY, "postTaxonomyVocabulary",
-					AssetCategoriesPermission.RESOURCE_NAME,
-					GroupConstants.DEFAULT_LIVE_GROUP_ID)
+					AssetCategoriesPermission.RESOURCE_NAME, _getCMSGroupId())
 			).put(
 				"createBatch",
 				addAction(
 					ActionKeys.ADD_VOCABULARY, "postTaxonomyVocabularyBatch",
-					AssetCategoriesPermission.RESOURCE_NAME,
-					GroupConstants.DEFAULT_LIVE_GROUP_ID)
+					AssetCategoriesPermission.RESOURCE_NAME, _getCMSGroupId())
 			).put(
 				"deleteBatch",
 				addAction(
@@ -320,8 +318,7 @@ public class TaxonomyVocabularyResourceImpl
 				"get",
 				addAction(
 					ActionKeys.VIEW, "getTaxonomyVocabulariesPage",
-					AssetCategoriesPermission.RESOURCE_NAME,
-					GroupConstants.DEFAULT_LIVE_GROUP_ID)
+					AssetCategoriesPermission.RESOURCE_NAME, _getCMSGroupId())
 			).put(
 				"updateBatch",
 				addAction(
@@ -338,8 +335,7 @@ public class TaxonomyVocabularyResourceImpl
 
 				BooleanFilter booleanFilter = new BooleanFilter();
 
-				booleanFilter.addRequiredTerm(
-					Field.GROUP_ID, GroupConstants.DEFAULT_LIVE_GROUP_ID);
+				booleanFilter.addRequiredTerm(Field.GROUP_ID, _getCMSGroupId());
 
 				searchContext.setBooleanClauses(
 					new BooleanClause[] {
@@ -411,8 +407,8 @@ public class TaxonomyVocabularyResourceImpl
 		}
 
 		AssetVocabulary assetVocabulary = _addAssetVocabulary(
-			taxonomyVocabulary.getExternalReferenceCode(),
-			GroupConstants.DEFAULT_LIVE_GROUP_ID, taxonomyVocabulary);
+			taxonomyVocabulary.getExternalReferenceCode(), _getCMSGroupId(),
+			taxonomyVocabulary);
 
 		_assetVocabularyGroupRelLocalService.setAssetVocabularyGroupRels(
 			assetVocabulary.getVocabularyId(),
@@ -813,6 +809,13 @@ public class TaxonomyVocabularyResourceImpl
 		}
 
 		throw new BadRequestException("Invalid subtype " + subtype);
+	}
+
+	private long _getCMSGroupId() {
+		Group group = _groupLocalService.fetchFriendlyURLGroup(
+			contextCompany.getCompanyId(), GroupConstants.CMS_FRIENDLY_URL);
+
+		return group.getGroupId();
 	}
 
 	private String _getModelResource(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/util/TaxonomyGroupUtil.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/util/TaxonomyGroupUtil.java
@@ -8,6 +8,7 @@ package com.liferay.headless.admin.taxonomy.internal.util;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.headless.admin.taxonomy.dto.v1_0.AssetLibrary;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
@@ -22,16 +23,11 @@ import java.util.List;
  */
 public class TaxonomyGroupUtil {
 
-	public static long[] getAssetLibraryGroupIds(AssetLibrary[] assetLibraries)
-		throws Exception {
+	public static long[] getAssetLibraryGroupIds(
+		AssetLibrary[] assetLibraries) {
 
-		List<Long> groupIds = new ArrayList<>();
-
-		for (AssetLibrary assetLibrary : assetLibraries) {
-			groupIds.add(_getGroupId(assetLibrary.getId()));
-		}
-
-		return ArrayUtil.toLongArray(groupIds);
+		return TransformUtil.transformToLongArray(
+			assetLibraries, TaxonomyGroupUtil::_getGroupId);
 	}
 
 	public static long getCMSGroupId(long companyId) throws PortalException {
@@ -41,7 +37,11 @@ public class TaxonomyGroupUtil {
 		return group.getGroupId();
 	}
 
-	private static long _getGroupId(long classPK) throws Exception {
+	private static long _getGroupId(AssetLibrary assetLibrary)
+		throws Exception {
+
+		long classPK = assetLibrary.getId();
+
 		if (classPK == GroupConstants.ANY_PARENT_GROUP_ID) {
 			return classPK;
 		}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/util/TaxonomyGroupUtil.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/util/TaxonomyGroupUtil.java
@@ -8,6 +8,7 @@ package com.liferay.headless.admin.taxonomy.internal.util;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.headless.admin.taxonomy.dto.v1_0.AssetLibrary;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
@@ -33,9 +34,9 @@ public class TaxonomyGroupUtil {
 		return ArrayUtil.toLongArray(groupIds);
 	}
 
-	public static long getCMSGroupId(long companyId) {
-		Group group = GroupLocalServiceUtil.fetchFriendlyURLGroup(
-			companyId, GroupConstants.CMS_FRIENDLY_URL);
+	public static long getCMSGroupId(long companyId) throws PortalException {
+		Group group = GroupLocalServiceUtil.getGroup(
+			companyId, GroupConstants.CMS);
 
 		return group.getGroupId();
 	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/util/TaxonomyGroupUtil.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/util/TaxonomyGroupUtil.java
@@ -1,0 +1,60 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.taxonomy.internal.util;
+
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalServiceUtil;
+import com.liferay.headless.admin.taxonomy.dto.v1_0.AssetLibrary;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class TaxonomyGroupUtil {
+
+	public static long[] getAssetLibraryGroupIds(AssetLibrary[] assetLibraries)
+		throws Exception {
+
+		List<Long> groupIds = new ArrayList<>();
+
+		for (AssetLibrary assetLibrary : assetLibraries) {
+			groupIds.add(_getGroupId(assetLibrary.getId()));
+		}
+
+		return ArrayUtil.toLongArray(groupIds);
+	}
+
+	public static long getCMSGroupId(long companyId) {
+		Group group = GroupLocalServiceUtil.fetchFriendlyURLGroup(
+			companyId, GroupConstants.CMS_FRIENDLY_URL);
+
+		return group.getGroupId();
+	}
+
+	private static long _getGroupId(long classPK) throws Exception {
+		if (classPK == GroupConstants.ANY_PARENT_GROUP_ID) {
+			return classPK;
+		}
+
+		Group group = GroupLocalServiceUtil.fetchGroup(classPK);
+
+		if (group != null) {
+			return group.getGroupId();
+		}
+
+		DepotEntry depotEntry = DepotEntryLocalServiceUtil.getDepotEntry(
+			classPK);
+
+		return depotEntry.getGroupId();
+	}
+
+}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-55602

Currently, vocabularies and keywords are being created in the default group (0); they should be created in the CMS group.

This is a followup to https://github.com/brianchandotcom/liferay-portal/pull/162026; other than the last commit, there are no differences.