### PR TITLE
LPD-56961 During startup, all ObjectDefinition that are NOT unmodifia…

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -92,6 +92,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
+import com.liferay.portal.kernel.servlet.InitialRequestSyncUtil;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -689,22 +690,49 @@ public class ObjectRelationshipLocalServiceImpl
 	public List<ObjectRelationship> getAllObjectRelationships(
 		long objectDefinitionId) {
 
-		return dslQuery(
-			DSLQueryFactoryUtil.select(
-			).from(
-				ObjectRelationshipTable.INSTANCE
-			).where(
-				Predicate.withParentheses(
-					ObjectRelationshipTable.INSTANCE.objectDefinitionId1.eq(
-						objectDefinitionId
-					).or(
-						ObjectRelationshipTable.INSTANCE.objectDefinitionId2.eq(
-							objectDefinitionId)
+		if (InitialRequestSyncUtil.isSynced()) {
+			return dslQuery(
+				DSLQueryFactoryUtil.select(
+				).from(
+					ObjectRelationshipTable.INSTANCE
+				).where(
+					Predicate.withParentheses(
+						ObjectRelationshipTable.INSTANCE.objectDefinitionId1.eq(
+							objectDefinitionId
+						).or(
+							ObjectRelationshipTable.INSTANCE.
+								objectDefinitionId2.eq(objectDefinitionId)
+						)
+					).and(
+						ObjectRelationshipTable.INSTANCE.reverse.eq(false)
 					)
-				).and(
-					ObjectRelationshipTable.INSTANCE.reverse.eq(false)
-				)
-			));
+				));
+		}
+
+		List<ObjectRelationship> objectRelationships = new ArrayList<>();
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionPersistence.fetchByPrimaryKey(objectDefinitionId);
+
+		if (objectDefinition == null) {
+			return objectRelationships;
+		}
+
+		for (ObjectRelationship objectRelationship :
+				objectRelationshipPersistence.findByCompanyId(
+					objectDefinition.getCompanyId())) {
+
+			if (((objectRelationship.getObjectDefinitionId1() ==
+					objectDefinitionId) ||
+				 (objectRelationship.getObjectDefinitionId2() ==
+					 objectDefinitionId)) &&
+				!objectRelationship.isReverse()) {
+
+				objectRelationships.add(objectRelationship);
+			}
+		}
+
+		return objectRelationships;
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/InitialRequestSyncUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/InitialRequestSyncUtil.java
@@ -18,6 +18,10 @@ import java.util.concurrent.Future;
  */
 public class InitialRequestSyncUtil {
 
+	public static boolean isSynced() {
+		return _syncCallableDefaultNoticeableFuture.isDone();
+	}
+
 	public static void registerSyncCallable(Callable<?> syncCallable) {
 		_addFutureListener(
 			_syncCallableDefaultNoticeableFuture,


### PR DESCRIPTION
…ble system object are going through the service call getAllObjectRelationships(long). It will be way more efficient to load up all ObjectRelationship into cache once and do in-memory filtering for all further calls. Once the first request arrives, this service call goes back to original logic to avoid holding up all ObjectRelationship in cache.

CC @gabrielwas @vicnate5 