### PR TITLE
LPD-4218 Follow up - Revert the rename of databaseName parameter for SQL Server URL in a SF commit

### DIFF
--- a/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/Database.java
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/java/com/liferay/portal/tools/db/upgrade/client/Database.java
@@ -90,7 +90,7 @@ public class Database {
 		}
 
 		if (_protocol.contains("sqlserver")) {
-			sb.append(";databaseType=");
+			sb.append(";databaseName=");
 		}
 		else if (_protocol.contains("oracle")) {
 			sb.append(":");


### PR DESCRIPTION
When LPD-4218 was merged this SF commit 099e679729297e0b047bb9ade39ff96dc1 rename `databaseName` var to `databaseType` but the parameter for SQL Server URL was also renamed, this causes the upgrade client to fail to connect to SQL Server unless you manually change this parameter.

I am reverting this rename.