### PR TITLE
LPD-53919 Fix r_<relationshipName>_<objectName>ERC behaviour in PATCH endpoints and the rest of the relationship fields can be null to dissasociate

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/BaseObjectRelationshipElementsParserImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/BaseObjectRelationshipElementsParserImpl.java
@@ -71,7 +71,7 @@ public abstract class BaseObjectRelationshipElementsParserImpl<T>
 	}
 
 	protected void validateOne(Object object) {
-		if ((object != null) && !(object instanceof Map)) {
+		if (!(object instanceof Map)) {
 			throw new BadRequestException(
 				"Unable to create nested object entries");
 		}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/BaseObjectRelationshipElementsParserImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/BaseObjectRelationshipElementsParserImpl.java
@@ -13,6 +13,7 @@ import com.liferay.portal.vulcan.util.ObjectMapperUtil;
 
 import jakarta.ws.rs.BadRequestException;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +44,10 @@ public abstract class BaseObjectRelationshipElementsParserImpl<T>
 	protected List<T> parseMany(Object object) {
 		List<T> objects = null;
 
-		if (object instanceof List) {
+		if (object == null) {
+			objects = new ArrayList<>();
+		}
+		else if (object instanceof List) {
 			objects = (List<T>)object;
 		}
 		else if (object instanceof Object[]) {
@@ -67,7 +71,7 @@ public abstract class BaseObjectRelationshipElementsParserImpl<T>
 	}
 
 	protected void validateOne(Object object) {
-		if (!(object instanceof Map)) {
+		if ((object != null) && !(object instanceof Map)) {
 			throw new BadRequestException(
 				"Unable to create nested object entries");
 		}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntry1toMObjectRelationshipElementsParserImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntry1toMObjectRelationshipElementsParserImpl.java
@@ -57,6 +57,10 @@ public class ObjectEntry1toMObjectRelationshipElementsParserImpl
 	protected ObjectEntry parseOne(Object object) {
 		validateOne(object);
 
+		if (object == null) {
+			return null;
+		}
+
 		Map<String, Object> nestedObjectEntryProperties =
 			(Map<String, Object>)object;
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntry1toMObjectRelationshipElementsParserImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntry1toMObjectRelationshipElementsParserImpl.java
@@ -55,11 +55,11 @@ public class ObjectEntry1toMObjectRelationshipElementsParserImpl
 
 	@Override
 	protected ObjectEntry parseOne(Object object) {
-		validateOne(object);
-
 		if (object == null) {
 			return null;
 		}
+
+		validateOne(object);
 
 		Map<String, Object> nestedObjectEntryProperties =
 			(Map<String, Object>)object;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntryMtoMObjectRelationshipElementsParserImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntryMtoMObjectRelationshipElementsParserImpl.java
@@ -41,11 +41,11 @@ public class ObjectEntryMtoMObjectRelationshipElementsParserImpl
 
 	@Override
 	protected ObjectEntry parseOne(Object object) {
-		validateOne(object);
-
 		if (object == null) {
 			return null;
 		}
+
+		validateOne(object);
 
 		return toObjectEntry((Map<String, Object>)object);
 	}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntryMtoMObjectRelationshipElementsParserImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntryMtoMObjectRelationshipElementsParserImpl.java
@@ -43,6 +43,10 @@ public class ObjectEntryMtoMObjectRelationshipElementsParserImpl
 	protected ObjectEntry parseOne(Object object) {
 		validateOne(object);
 
+		if (object == null) {
+			return null;
+		}
+
 		return toObjectEntry((Map<String, Object>)object);
 	}
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/SystemObjectEntry1toMObjectRelationshipElementsParserImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/SystemObjectEntry1toMObjectRelationshipElementsParserImpl.java
@@ -53,11 +53,11 @@ public class SystemObjectEntry1toMObjectRelationshipElementsParserImpl
 
 	@Override
 	protected Map<String, Object> parseOne(Object object) {
-		validateOne(object);
-
 		if (object == null) {
 			return null;
 		}
+
+		validateOne(object);
 
 		Map<String, Object> nestedSystemObjectEntryProperties =
 			(Map<String, Object>)object;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/SystemObjectEntry1toMObjectRelationshipElementsParserImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/SystemObjectEntry1toMObjectRelationshipElementsParserImpl.java
@@ -55,6 +55,10 @@ public class SystemObjectEntry1toMObjectRelationshipElementsParserImpl
 	protected Map<String, Object> parseOne(Object object) {
 		validateOne(object);
 
+		if (object == null) {
+			return null;
+		}
+
 		Map<String, Object> nestedSystemObjectEntryProperties =
 			(Map<String, Object>)object;
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/SystemObjectEntryMtoMObjectRelationshipElementsParserImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/SystemObjectEntryMtoMObjectRelationshipElementsParserImpl.java
@@ -41,6 +41,10 @@ public class SystemObjectEntryMtoMObjectRelationshipElementsParserImpl
 	protected Map<String, Object> parseOne(Object object) {
 		validateOne(object);
 
+		if (object == null) {
+			return null;
+		}
+
 		return (Map<String, Object>)object;
 	}
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/SystemObjectEntryMtoMObjectRelationshipElementsParserImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/SystemObjectEntryMtoMObjectRelationshipElementsParserImpl.java
@@ -39,11 +39,11 @@ public class SystemObjectEntryMtoMObjectRelationshipElementsParserImpl
 
 	@Override
 	protected Map<String, Object> parseOne(Object object) {
-		validateOne(object);
-
 		if (object == null) {
 			return null;
 		}
+
+		validateOne(object);
 
 		return (Map<String, Object>)object;
 	}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -17329,6 +17329,11 @@ public class ObjectEntryResourceTest {
 				_objectDefinition2, _objectDefinition1,
 				TestPropsValues.getUserId(),
 				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		ObjectRelationship objectRelationship3 =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectDefinition2, _objectDefinition1,
+				TestPropsValues.getUserId(),
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		try {
 			JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
@@ -17339,6 +17344,22 @@ public class ObjectEntryResourceTest {
 							_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
 						).put(
 							"externalReferenceCode", _ERC_VALUE_1
+						).toString())
+				).put(
+					objectRelationship2.getName(),
+					JSONFactoryUtil.createJSONObject(
+						JSONUtil.put(
+							_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
+						).put(
+							"externalReferenceCode", _ERC_VALUE_2
+						).toString())
+				).put(
+					objectRelationship3.getName(),
+					JSONFactoryUtil.createJSONObject(
+						JSONUtil.put(
+							_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
+						).put(
+							"externalReferenceCode", _ERC_VALUE_3
 						).toString())
 				).toString(),
 				_objectDefinition1.getRESTContextPath(), Http.Method.POST);
@@ -17352,6 +17373,13 @@ public class ObjectEntryResourceTest {
 						"r_", objectRelationship2.getName(), "_",
 						_objectDefinition2.getPKObjectFieldName()),
 					0
+				).put(
+					StringBundler.concat(
+						"r_", objectRelationship3.getName(), "_",
+						StringUtil.replaceLast(
+							_objectDefinition2.getPKObjectFieldName(), "Id",
+							"ERC")),
+					""
 				).toString(),
 				StringBundler.concat(
 					_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
@@ -17375,6 +17403,11 @@ public class ObjectEntryResourceTest {
 				objectRelationship2.getName());
 
 			Assert.assertNull(nestedObjectEntryJSONObject2);
+
+			JSONObject nestedObjectEntryJSONObject3 = jsonObject.getJSONObject(
+				objectRelationship3.getName());
+
+			Assert.assertNull(nestedObjectEntryJSONObject3);
 
 			JSONAssert.assertEquals(
 				JSONUtil.put(
@@ -17401,6 +17434,18 @@ public class ObjectEntryResourceTest {
 							_objectDefinition2.getPKObjectFieldName(), "Id",
 							"ERC")),
 					""
+				).put(
+					StringBundler.concat(
+						"r_", objectRelationship3.getName(), "_",
+						_objectDefinition2.getPKObjectFieldName()),
+					0
+				).put(
+					StringBundler.concat(
+						"r_", objectRelationship3.getName(), "_",
+						StringUtil.replaceLast(
+							_objectDefinition2.getPKObjectFieldName(), "Id",
+							"ERC")),
+					""
 				).toString(),
 				jsonObject.toString(), JSONCompareMode.LENIENT);
 		}
@@ -17409,6 +17454,8 @@ public class ObjectEntryResourceTest {
 				objectRelationship1);
 			_objectRelationshipLocalService.deleteObjectRelationship(
 				objectRelationship2);
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				objectRelationship3);
 		}
 	}
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -10234,36 +10234,17 @@ public class ObjectEntryResourceTest {
 
 		// Many to many
 
-		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
-			_objectDefinition1, _objectDefinition2, TestPropsValues.getUserId(),
+		_testPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
-
-		_testPutCustomObjectEntryUnlinkNestedCustomObjectEntries(false);
-
-		_objectRelationshipLocalService.deleteObjectRelationship(
-			_objectRelationship1);
 
 		// Many to one
 
-		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
-			_objectDefinition2, _objectDefinition1, TestPropsValues.getUserId(),
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-		_objectRelationship2 = ObjectRelationshipTestUtil.addObjectRelationship(
-			_objectDefinition2, _objectDefinition1, TestPropsValues.getUserId(),
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-		_testPutCustomObjectEntryUnlinkNestedCustomObjectEntries(true);
-
-		_objectRelationshipLocalService.deleteObjectRelationship(
-			_objectRelationship1);
+		_testPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntries();
 
 		// One to many
 
-		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
-			_objectDefinition1, _objectDefinition2, TestPropsValues.getUserId(),
+		_testPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-		_testPutCustomObjectEntryUnlinkNestedCustomObjectEntries(false);
 	}
 
 	@Test
@@ -17335,101 +17316,87 @@ public class ObjectEntryResourceTest {
 			JSONCompareMode.LENIENT);
 	}
 
-	private void _testPutCustomObjectEntryUnlinkNestedCustomObjectEntries(
-			boolean manyToOne)
+	private void _testPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntries()
 		throws Exception {
 
-		JSONObject objectEntryJSONObject = JSONUtil.put(
-			_objectRelationship1.getName(),
-			() -> {
-				if (manyToOne) {
-					return JSONFactoryUtil.createJSONObject(
+		ObjectRelationship objectRelationship1 =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectDefinition2, _objectDefinition1,
+				TestPropsValues.getUserId(),
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		ObjectRelationship objectRelationship2 =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectDefinition2, _objectDefinition1,
+				TestPropsValues.getUserId(),
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		try {
+			JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					objectRelationship1.getName(),
+					JSONFactoryUtil.createJSONObject(
 						JSONUtil.put(
 							_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
 						).put(
 							"externalReferenceCode", _ERC_VALUE_1
-						).toString());
-				}
+						).toString())
+				).toString(),
+				_objectDefinition1.getRESTContextPath(), Http.Method.POST);
 
-				return _createObjectEntriesJSONArray(
-					new String[] {_ERC_VALUE_1, _ERC_VALUE_2},
-					_OBJECT_FIELD_NAME_2,
-					new String[] {
-						RandomTestUtil.randomString(),
-						RandomTestUtil.randomString()
-					});
-			});
-
-		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
-			objectEntryJSONObject.toString(),
-			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
-
-		JSONObject newObjectEntryJSONObject;
-
-		if (manyToOne) {
-			newObjectEntryJSONObject = JSONUtil.put(
-				_objectRelationship1.getName(),
-				JSONFactoryUtil.createJSONObject()
-			).put(
+			jsonObject = HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					objectRelationship1.getName(),
+					JSONFactoryUtil.createJSONObject()
+				).put(
+					StringBundler.concat(
+						"r_", objectRelationship2.getName(), "_",
+						_objectDefinition2.getPKObjectFieldName()),
+					0
+				).toString(),
 				StringBundler.concat(
-					"r_", _objectRelationship2.getName(), "_",
-					_objectDefinition2.getPKObjectFieldName()),
-				0
-			);
-		}
-		else {
-			newObjectEntryJSONObject = JSONUtil.put(
-				_objectRelationship1.getName(),
-				JSONFactoryUtil.createJSONArray());
-		}
+					_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
+					jsonObject.getString("id")),
+				Http.Method.PUT);
 
-		jsonObject = HTTPTestUtil.invokeToJSONObject(
-			newObjectEntryJSONObject.toString(),
-			StringBundler.concat(
-				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
-				jsonObject.getString("id")),
-			Http.Method.PUT);
+			Assert.assertEquals(
+				0,
+				jsonObject.getJSONObject(
+					"status"
+				).get(
+					"code"
+				));
 
-		Assert.assertEquals(
-			0,
-			jsonObject.getJSONObject(
-				"status"
-			).get(
-				"code"
-			));
-
-		if (manyToOne) {
 			JSONObject nestedObjectEntryJSONObject1 = jsonObject.getJSONObject(
-				_objectRelationship1.getName());
+				objectRelationship1.getName());
 
 			Assert.assertNull(nestedObjectEntryJSONObject1);
 
 			JSONObject nestedObjectEntryJSONObject2 = jsonObject.getJSONObject(
-				_objectRelationship2.getName());
+				objectRelationship2.getName());
 
 			Assert.assertNull(nestedObjectEntryJSONObject2);
 
 			JSONAssert.assertEquals(
 				JSONUtil.put(
 					StringBundler.concat(
-						"r_", _objectRelationship1.getName(), "_",
+						"r_", objectRelationship1.getName(), "_",
 						_objectDefinition2.getPKObjectFieldName()),
 					0
 				).put(
 					StringBundler.concat(
-						"r_", _objectRelationship1.getName(), "_",
+						"r_", objectRelationship1.getName(), "_",
 						StringUtil.replaceLast(
 							_objectDefinition2.getPKObjectFieldName(), "Id",
 							"ERC")),
 					""
 				).put(
 					StringBundler.concat(
-						"r_", _objectRelationship2.getName(), "_",
+						"r_", objectRelationship2.getName(), "_",
 						_objectDefinition2.getPKObjectFieldName()),
 					0
 				).put(
 					StringBundler.concat(
-						"r_", _objectRelationship2.getName(), "_",
+						"r_", objectRelationship2.getName(), "_",
 						StringUtil.replaceLast(
 							_objectDefinition2.getPKObjectFieldName(), "Id",
 							"ERC")),
@@ -17437,11 +17404,11 @@ public class ObjectEntryResourceTest {
 				).toString(),
 				jsonObject.toString(), JSONCompareMode.LENIENT);
 		}
-		else {
-			JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
-				_objectRelationship1.getName());
-
-			Assert.assertEquals(0, nestedObjectEntriesJSONArray.length());
+		finally {
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				objectRelationship1);
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				objectRelationship2);
 		}
 	}
 
@@ -17512,6 +17479,59 @@ public class ObjectEntryResourceTest {
 				_objectRelationship1.getName());
 
 			Assert.assertEquals(0, nestedObjectEntriesJSONArray.length());
+		}
+	}
+
+	private void
+			_testPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
+				String type)
+		throws Exception {
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectDefinition1, _objectDefinition2,
+				TestPropsValues.getUserId(), type);
+
+		try {
+			JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					objectRelationship.getName(),
+					_createObjectEntriesJSONArray(
+						new String[] {_ERC_VALUE_1, _ERC_VALUE_2},
+						_OBJECT_FIELD_NAME_2,
+						new String[] {
+							RandomTestUtil.randomString(),
+							RandomTestUtil.randomString()
+						})
+				).toString(),
+				_objectDefinition1.getRESTContextPath(), Http.Method.POST);
+
+			jsonObject = HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					objectRelationship.getName(),
+					JSONFactoryUtil.createJSONArray()
+				).toString(),
+				StringBundler.concat(
+					_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
+					jsonObject.getString("id")),
+				Http.Method.PUT);
+
+			Assert.assertEquals(
+				0,
+				jsonObject.getJSONObject(
+					"status"
+				).get(
+					"code"
+				));
+
+			JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
+				objectRelationship.getName());
+
+			Assert.assertEquals(0, nestedObjectEntriesJSONArray.length());
+		}
+		finally {
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				objectRelationship);
 		}
 	}
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -10235,15 +10235,24 @@ public class ObjectEntryResourceTest {
 		// Many to many
 
 		_testPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
+			jsonObject ->
+				_objectDefinition1.getRESTContextPath() + "/" +
+					jsonObject.getLong("id"),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		// Many to one
 
-		_testPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntries();
+		_testPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntries(
+			jsonObject ->
+				_objectDefinition1.getRESTContextPath() + "/" +
+					jsonObject.getLong("id"));
 
 		// One to many
 
 		_testPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
+			jsonObject ->
+				_objectDefinition1.getRESTContextPath() + "/" +
+					jsonObject.getLong("id"),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 	}
 
@@ -10253,16 +10262,28 @@ public class ObjectEntryResourceTest {
 
 		// Many to many
 
-		_testPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntriesByExternalReferenceCode(
+		_testPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
+			jsonObject ->
+				_objectDefinition1.getRESTContextPath() +
+					"/by-external-reference-code/" +
+						jsonObject.getString("externalReferenceCode"),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		// Many to one
 
-		_testPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntriesByExternalReferenceCode();
+		_testPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntries(
+			jsonObject ->
+				_objectDefinition1.getRESTContextPath() +
+					"/by-external-reference-code/" +
+						jsonObject.getString("externalReferenceCode"));
 
 		// One to many
 
-		_testPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntriesByExternalReferenceCode(
+		_testPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
+			jsonObject ->
+				_objectDefinition1.getRESTContextPath() +
+					"/by-external-reference-code/" +
+						jsonObject.getString("externalReferenceCode"),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 	}
 
@@ -17297,7 +17318,9 @@ public class ObjectEntryResourceTest {
 			JSONCompareMode.LENIENT);
 	}
 
-	private void _testPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntries()
+	private void
+			_testPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntries(
+				Function<JSONObject, String> endpointFunction)
 		throws Exception {
 
 		ObjectRelationship objectRelationship1 =
@@ -17362,154 +17385,7 @@ public class ObjectEntryResourceTest {
 							"ERC")),
 					""
 				).toString(),
-				StringBundler.concat(
-					_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
-					jsonObject.getString("id")),
-				Http.Method.PUT);
-
-			Assert.assertEquals(
-				0,
-				jsonObject.getJSONObject(
-					"status"
-				).get(
-					"code"
-				));
-
-			JSONObject nestedObjectEntryJSONObject1 = jsonObject.getJSONObject(
-				objectRelationship1.getName());
-
-			Assert.assertNull(nestedObjectEntryJSONObject1);
-
-			JSONObject nestedObjectEntryJSONObject2 = jsonObject.getJSONObject(
-				objectRelationship2.getName());
-
-			Assert.assertNull(nestedObjectEntryJSONObject2);
-
-			JSONObject nestedObjectEntryJSONObject3 = jsonObject.getJSONObject(
-				objectRelationship3.getName());
-
-			Assert.assertNull(nestedObjectEntryJSONObject3);
-
-			JSONAssert.assertEquals(
-				JSONUtil.put(
-					StringBundler.concat(
-						"r_", objectRelationship1.getName(), "_",
-						_objectDefinition2.getPKObjectFieldName()),
-					0
-				).put(
-					StringBundler.concat(
-						"r_", objectRelationship1.getName(), "_",
-						StringUtil.replaceLast(
-							_objectDefinition2.getPKObjectFieldName(), "Id",
-							"ERC")),
-					""
-				).put(
-					StringBundler.concat(
-						"r_", objectRelationship2.getName(), "_",
-						_objectDefinition2.getPKObjectFieldName()),
-					0
-				).put(
-					StringBundler.concat(
-						"r_", objectRelationship2.getName(), "_",
-						StringUtil.replaceLast(
-							_objectDefinition2.getPKObjectFieldName(), "Id",
-							"ERC")),
-					""
-				).put(
-					StringBundler.concat(
-						"r_", objectRelationship3.getName(), "_",
-						_objectDefinition2.getPKObjectFieldName()),
-					0
-				).put(
-					StringBundler.concat(
-						"r_", objectRelationship3.getName(), "_",
-						StringUtil.replaceLast(
-							_objectDefinition2.getPKObjectFieldName(), "Id",
-							"ERC")),
-					""
-				).toString(),
-				jsonObject.toString(), JSONCompareMode.LENIENT);
-		}
-		finally {
-			_objectRelationshipLocalService.deleteObjectRelationship(
-				objectRelationship1);
-			_objectRelationshipLocalService.deleteObjectRelationship(
-				objectRelationship2);
-			_objectRelationshipLocalService.deleteObjectRelationship(
-				objectRelationship3);
-		}
-	}
-
-	private void _testPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntriesByExternalReferenceCode()
-		throws Exception {
-
-		ObjectRelationship objectRelationship1 =
-			ObjectRelationshipTestUtil.addObjectRelationship(
-				_objectDefinition2, _objectDefinition1,
-				TestPropsValues.getUserId(),
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-		ObjectRelationship objectRelationship2 =
-			ObjectRelationshipTestUtil.addObjectRelationship(
-				_objectDefinition2, _objectDefinition1,
-				TestPropsValues.getUserId(),
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-		ObjectRelationship objectRelationship3 =
-			ObjectRelationshipTestUtil.addObjectRelationship(
-				_objectDefinition2, _objectDefinition1,
-				TestPropsValues.getUserId(),
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-		try {
-			JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
-				JSONUtil.put(
-					objectRelationship1.getName(),
-					JSONFactoryUtil.createJSONObject(
-						JSONUtil.put(
-							_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
-						).put(
-							"externalReferenceCode", _ERC_VALUE_1
-						).toString())
-				).put(
-					objectRelationship2.getName(),
-					JSONFactoryUtil.createJSONObject(
-						JSONUtil.put(
-							_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
-						).put(
-							"externalReferenceCode", _ERC_VALUE_2
-						).toString())
-				).put(
-					objectRelationship3.getName(),
-					JSONFactoryUtil.createJSONObject(
-						JSONUtil.put(
-							_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
-						).put(
-							"externalReferenceCode", _ERC_VALUE_3
-						).toString())
-				).toString(),
-				_objectDefinition1.getRESTContextPath(), Http.Method.POST);
-
-			jsonObject = HTTPTestUtil.invokeToJSONObject(
-				JSONUtil.put(
-					objectRelationship1.getName(),
-					JSONFactoryUtil.createJSONObject()
-				).put(
-					StringBundler.concat(
-						"r_", objectRelationship2.getName(), "_",
-						_objectDefinition2.getPKObjectFieldName()),
-					0
-				).put(
-					StringBundler.concat(
-						"r_", objectRelationship3.getName(), "_",
-						StringUtil.replaceLast(
-							_objectDefinition2.getPKObjectFieldName(), "Id",
-							"ERC")),
-					""
-				).toString(),
-				StringBundler.concat(
-					_objectDefinition1.getRESTContextPath(),
-					"/by-external-reference-code/",
-					jsonObject.getString("externalReferenceCode")),
-				Http.Method.PUT);
+				endpointFunction.apply(jsonObject), Http.Method.PUT);
 
 			Assert.assertEquals(
 				0,
@@ -17586,7 +17462,7 @@ public class ObjectEntryResourceTest {
 
 	private void
 			_testPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
-				String type)
+				Function<JSONObject, String> endpointFunction, String type)
 		throws Exception {
 
 		ObjectRelationship objectRelationship =
@@ -17613,65 +17489,7 @@ public class ObjectEntryResourceTest {
 					objectRelationship.getName(),
 					JSONFactoryUtil.createJSONArray()
 				).toString(),
-				StringBundler.concat(
-					_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
-					jsonObject.getString("id")),
-				Http.Method.PUT);
-
-			Assert.assertEquals(
-				0,
-				jsonObject.getJSONObject(
-					"status"
-				).get(
-					"code"
-				));
-
-			JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
-				objectRelationship.getName());
-
-			Assert.assertEquals(0, nestedObjectEntriesJSONArray.length());
-		}
-		finally {
-			_objectRelationshipLocalService.deleteObjectRelationship(
-				objectRelationship);
-		}
-	}
-
-	private void
-			_testPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntriesByExternalReferenceCode(
-				String type)
-		throws Exception {
-
-		ObjectRelationship objectRelationship =
-			ObjectRelationshipTestUtil.addObjectRelationship(
-				_objectDefinition1, _objectDefinition2,
-				TestPropsValues.getUserId(), type);
-
-		try {
-			JSONObject objectEntryJSONObject = JSONUtil.put(
-				objectRelationship.getName(),
-				_createObjectEntriesJSONArray(
-					new String[] {_ERC_VALUE_1, _ERC_VALUE_2},
-					_OBJECT_FIELD_NAME_2,
-					new String[] {
-						RandomTestUtil.randomString(),
-						RandomTestUtil.randomString()
-					}));
-
-			JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
-				objectEntryJSONObject.toString(),
-				_objectDefinition1.getRESTContextPath(), Http.Method.POST);
-
-			jsonObject = HTTPTestUtil.invokeToJSONObject(
-				JSONUtil.put(
-					objectRelationship.getName(),
-					JSONFactoryUtil.createJSONArray()
-				).toString(),
-				StringBundler.concat(
-					_objectDefinition1.getRESTContextPath(),
-					"/by-external-reference-code/",
-					jsonObject.getString("externalReferenceCode")),
-				Http.Method.PUT);
+				endpointFunction.apply(jsonObject), Http.Method.PUT);
 
 			Assert.assertEquals(
 				0,

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -10253,36 +10253,17 @@ public class ObjectEntryResourceTest {
 
 		// Many to many
 
-		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
-			_objectDefinition1, _objectDefinition2, TestPropsValues.getUserId(),
+		_testPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntriesByExternalReferenceCode(
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
-
-		_testPutCustomObjectEntryUnlinkNestedCustomObjectEntriesByExternalReferenceCode(
-			false);
-
-		_objectRelationshipLocalService.deleteObjectRelationship(
-			_objectRelationship1);
 
 		// Many to one
 
-		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
-			_objectDefinition2, _objectDefinition1, TestPropsValues.getUserId(),
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-		_testPutCustomObjectEntryUnlinkNestedCustomObjectEntriesByExternalReferenceCode(
-			true);
-
-		_objectRelationshipLocalService.deleteObjectRelationship(
-			_objectRelationship1);
+		_testPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntriesByExternalReferenceCode();
 
 		// One to many
 
-		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
-			_objectDefinition1, _objectDefinition2, TestPropsValues.getUserId(),
+		_testPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntriesByExternalReferenceCode(
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-		_testPutCustomObjectEntryUnlinkNestedCustomObjectEntriesByExternalReferenceCode(
-			false);
 	}
 
 	@FeatureFlag("LPD-32050")
@@ -17459,73 +17440,55 @@ public class ObjectEntryResourceTest {
 		}
 	}
 
-	private void
-			_testPutCustomObjectEntryUnlinkNestedCustomObjectEntriesByExternalReferenceCode(
-				boolean manyToOne)
+	private void _testPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntriesByExternalReferenceCode()
 		throws Exception {
 
-		JSONObject objectEntryJSONObject = JSONUtil.put(
-			_objectRelationship1.getName(),
-			() -> {
-				if (manyToOne) {
-					return JSONFactoryUtil.createJSONObject(
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectDefinition2, _objectDefinition1,
+				TestPropsValues.getUserId(),
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		try {
+			JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					objectRelationship.getName(),
+					JSONFactoryUtil.createJSONObject(
 						JSONUtil.put(
 							_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
 						).put(
 							"externalReferenceCode", _ERC_VALUE_1
-						).toString());
-				}
+						).toString())
+				).toString(),
+				_objectDefinition1.getRESTContextPath(), Http.Method.POST);
 
-				return _createObjectEntriesJSONArray(
-					new String[] {_ERC_VALUE_1, _ERC_VALUE_2},
-					_OBJECT_FIELD_NAME_2,
-					new String[] {
-						RandomTestUtil.randomString(),
-						RandomTestUtil.randomString()
-					});
-			});
+			jsonObject = HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					objectRelationship.getName(),
+					JSONFactoryUtil.createJSONObject()
+				).toString(),
+				StringBundler.concat(
+					_objectDefinition1.getRESTContextPath(),
+					"/by-external-reference-code/",
+					jsonObject.getString("externalReferenceCode")),
+				Http.Method.PUT);
 
-		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
-			objectEntryJSONObject.toString(),
-			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
+			Assert.assertEquals(
+				0,
+				jsonObject.getJSONObject(
+					"status"
+				).get(
+					"code"
+				));
 
-		JSONObject newObjectEntryJSONObject = JSONUtil.put(
-			_objectRelationship1.getName(),
-			() -> {
-				if (manyToOne) {
-					return JSONFactoryUtil.createJSONObject();
-				}
-
-				return JSONFactoryUtil.createJSONArray();
-			});
-
-		jsonObject = HTTPTestUtil.invokeToJSONObject(
-			newObjectEntryJSONObject.toString(),
-			StringBundler.concat(
-				_objectDefinition1.getRESTContextPath(),
-				"/by-external-reference-code/",
-				jsonObject.getString("externalReferenceCode")),
-			Http.Method.PUT);
-
-		Assert.assertEquals(
-			0,
-			jsonObject.getJSONObject(
-				"status"
-			).get(
-				"code"
-			));
-
-		if (manyToOne) {
 			JSONObject systemObjectEntryJSONObject = jsonObject.getJSONObject(
-				_objectRelationship1.getName());
+				objectRelationship.getName());
 
 			Assert.assertNull(systemObjectEntryJSONObject);
 		}
-		else {
-			JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
-				_objectRelationship1.getName());
-
-			Assert.assertEquals(0, nestedObjectEntriesJSONArray.length());
+		finally {
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				objectRelationship);
 		}
 	}
 
@@ -17561,6 +17524,61 @@ public class ObjectEntryResourceTest {
 				StringBundler.concat(
 					_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 					jsonObject.getString("id")),
+				Http.Method.PUT);
+
+			Assert.assertEquals(
+				0,
+				jsonObject.getJSONObject(
+					"status"
+				).get(
+					"code"
+				));
+
+			JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
+				objectRelationship.getName());
+
+			Assert.assertEquals(0, nestedObjectEntriesJSONArray.length());
+		}
+		finally {
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				objectRelationship);
+		}
+	}
+
+	private void
+			_testPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntriesByExternalReferenceCode(
+				String type)
+		throws Exception {
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectDefinition1, _objectDefinition2,
+				TestPropsValues.getUserId(), type);
+
+		try {
+			JSONObject objectEntryJSONObject = JSONUtil.put(
+				objectRelationship.getName(),
+				_createObjectEntriesJSONArray(
+					new String[] {_ERC_VALUE_1, _ERC_VALUE_2},
+					_OBJECT_FIELD_NAME_2,
+					new String[] {
+						RandomTestUtil.randomString(),
+						RandomTestUtil.randomString()
+					}));
+
+			JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+				objectEntryJSONObject.toString(),
+				_objectDefinition1.getRESTContextPath(), Http.Method.POST);
+
+			jsonObject = HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					objectRelationship.getName(),
+					JSONFactoryUtil.createJSONArray()
+				).toString(),
+				StringBundler.concat(
+					_objectDefinition1.getRESTContextPath(),
+					"/by-external-reference-code/",
+					jsonObject.getString("externalReferenceCode")),
 				Http.Method.PUT);
 
 			Assert.assertEquals(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -7753,7 +7753,6 @@ public class ObjectEntryResourceTest {
 					jsonObject.getLong("id"),
 			Http.Method.PATCH, _objectDefinition1, _objectDefinition2,
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
-
 		_testPatchPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
 			jsonObject ->
 				_siteScopedObjectDefinition1.getRESTContextPath() + "/" +
@@ -7769,7 +7768,6 @@ public class ObjectEntryResourceTest {
 				_objectDefinition1.getRESTContextPath() + "/" +
 					jsonObject.getLong("id"),
 			Http.Method.PATCH, _objectDefinition1, _objectDefinition2);
-
 		_testPatchPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntries(
 			jsonObject ->
 				_siteScopedObjectDefinition1.getRESTContextPath() + "/" +
@@ -7785,7 +7783,6 @@ public class ObjectEntryResourceTest {
 					jsonObject.getLong("id"),
 			Http.Method.PATCH, _objectDefinition1, _objectDefinition2,
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
 		_testPatchPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
 			jsonObject ->
 				_siteScopedObjectDefinition1.getRESTContextPath() + "/" +
@@ -7829,7 +7826,6 @@ public class ObjectEntryResourceTest {
 					"/by-external-reference-code/" +
 						jsonObject.getString("externalReferenceCode"),
 			Http.Method.PATCH, _objectDefinition1, _objectDefinition2);
-
 		_testPatchPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntries(
 			jsonObject ->
 				externalReferenceCodeEndpoint + "/by-external-reference-code/" +
@@ -7846,7 +7842,6 @@ public class ObjectEntryResourceTest {
 						jsonObject.getString("externalReferenceCode"),
 			Http.Method.PATCH, _objectDefinition1, _objectDefinition2,
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
 		_testPatchPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
 			jsonObject ->
 				externalReferenceCodeEndpoint + "/by-external-reference-code/" +
@@ -10357,7 +10352,6 @@ public class ObjectEntryResourceTest {
 					jsonObject.getLong("id"),
 			Http.Method.PUT, _objectDefinition1, _objectDefinition2,
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
-
 		_testPatchPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
 			jsonObject ->
 				_siteScopedObjectDefinition1.getRESTContextPath() + "/" +
@@ -10373,7 +10367,6 @@ public class ObjectEntryResourceTest {
 				_objectDefinition1.getRESTContextPath() + "/" +
 					jsonObject.getLong("id"),
 			Http.Method.PUT, _objectDefinition1, _objectDefinition2);
-
 		_testPatchPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntries(
 			jsonObject ->
 				_siteScopedObjectDefinition1.getRESTContextPath() + "/" +
@@ -10389,7 +10382,6 @@ public class ObjectEntryResourceTest {
 					jsonObject.getLong("id"),
 			Http.Method.PUT, _objectDefinition1, _objectDefinition2,
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
 		_testPatchPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
 			jsonObject ->
 				_siteScopedObjectDefinition1.getRESTContextPath() + "/" +
@@ -10433,7 +10425,6 @@ public class ObjectEntryResourceTest {
 					"/by-external-reference-code/" +
 						jsonObject.getString("externalReferenceCode"),
 			Http.Method.PUT, _objectDefinition1, _objectDefinition2);
-
 		_testPatchPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntries(
 			jsonObject ->
 				externalReferenceCodeEndpoint + "/by-external-reference-code/" +
@@ -10450,7 +10441,6 @@ public class ObjectEntryResourceTest {
 						jsonObject.getString("externalReferenceCode"),
 			Http.Method.PUT, _objectDefinition1, _objectDefinition2,
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
 		_testPatchPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
 			jsonObject ->
 				externalReferenceCodeEndpoint + "/by-external-reference-code/" +

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -7751,7 +7751,16 @@ public class ObjectEntryResourceTest {
 			jsonObject ->
 				_objectDefinition1.getRESTContextPath() + "/" +
 					jsonObject.getLong("id"),
-			Http.Method.PATCH, ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+			Http.Method.PATCH, _objectDefinition1, _objectDefinition2,
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		_testPatchPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
+			jsonObject ->
+				_siteScopedObjectDefinition1.getRESTContextPath() + "/" +
+					jsonObject.getLong("id"),
+			Http.Method.PATCH, _siteScopedObjectDefinition1,
+			_siteScopedObjectDefinition2,
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		// Many to one
 
@@ -7759,7 +7768,14 @@ public class ObjectEntryResourceTest {
 			jsonObject ->
 				_objectDefinition1.getRESTContextPath() + "/" +
 					jsonObject.getLong("id"),
-			Http.Method.PATCH);
+			Http.Method.PATCH, _objectDefinition1, _objectDefinition2);
+
+		_testPatchPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntries(
+			jsonObject ->
+				_siteScopedObjectDefinition1.getRESTContextPath() + "/" +
+					jsonObject.getLong("id"),
+			Http.Method.PATCH, _siteScopedObjectDefinition1,
+			_siteScopedObjectDefinition2);
 
 		// One to many
 
@@ -7767,7 +7783,16 @@ public class ObjectEntryResourceTest {
 			jsonObject ->
 				_objectDefinition1.getRESTContextPath() + "/" +
 					jsonObject.getLong("id"),
-			Http.Method.PATCH, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+			Http.Method.PATCH, _objectDefinition1, _objectDefinition2,
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_testPatchPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
+			jsonObject ->
+				_siteScopedObjectDefinition1.getRESTContextPath() + "/" +
+					jsonObject.getLong("id"),
+			Http.Method.PATCH, _siteScopedObjectDefinition1,
+			_siteScopedObjectDefinition2,
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 	}
 
 	@Test
@@ -7782,7 +7807,19 @@ public class ObjectEntryResourceTest {
 				_objectDefinition1.getRESTContextPath() +
 					"/by-external-reference-code/" +
 						jsonObject.getString("externalReferenceCode"),
-			Http.Method.PATCH, ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+			Http.Method.PATCH, _objectDefinition1, _objectDefinition2,
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		String externalReferenceCodeEndpoint = _getEndpoint(
+			_siteScopedObjectDefinition1, _testGroupId);
+
+		_testPatchPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
+			jsonObject ->
+				externalReferenceCodeEndpoint + "/by-external-reference-code/" +
+					jsonObject.getString("externalReferenceCode"),
+			Http.Method.PATCH, _siteScopedObjectDefinition1,
+			_siteScopedObjectDefinition2,
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		// Many to one
 
@@ -7791,7 +7828,14 @@ public class ObjectEntryResourceTest {
 				_objectDefinition1.getRESTContextPath() +
 					"/by-external-reference-code/" +
 						jsonObject.getString("externalReferenceCode"),
-			Http.Method.PATCH);
+			Http.Method.PATCH, _objectDefinition1, _objectDefinition2);
+
+		_testPatchPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntries(
+			jsonObject ->
+				externalReferenceCodeEndpoint + "/by-external-reference-code/" +
+					jsonObject.getString("externalReferenceCode"),
+			Http.Method.PATCH, _siteScopedObjectDefinition1,
+			_siteScopedObjectDefinition2);
 
 		// One to many
 
@@ -7800,7 +7844,16 @@ public class ObjectEntryResourceTest {
 				_objectDefinition1.getRESTContextPath() +
 					"/by-external-reference-code/" +
 						jsonObject.getString("externalReferenceCode"),
-			Http.Method.PATCH, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+			Http.Method.PATCH, _objectDefinition1, _objectDefinition2,
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_testPatchPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
+			jsonObject ->
+				externalReferenceCodeEndpoint + "/by-external-reference-code/" +
+					jsonObject.getString("externalReferenceCode"),
+			Http.Method.PATCH, _siteScopedObjectDefinition1,
+			_siteScopedObjectDefinition2,
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 	}
 
 	@FeatureFlag("LPD-21926")
@@ -10302,7 +10355,16 @@ public class ObjectEntryResourceTest {
 			jsonObject ->
 				_objectDefinition1.getRESTContextPath() + "/" +
 					jsonObject.getLong("id"),
-			Http.Method.PUT, ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+			Http.Method.PUT, _objectDefinition1, _objectDefinition2,
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		_testPatchPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
+			jsonObject ->
+				_siteScopedObjectDefinition1.getRESTContextPath() + "/" +
+					jsonObject.getLong("id"),
+			Http.Method.PUT, _siteScopedObjectDefinition1,
+			_siteScopedObjectDefinition2,
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		// Many to one
 
@@ -10310,7 +10372,14 @@ public class ObjectEntryResourceTest {
 			jsonObject ->
 				_objectDefinition1.getRESTContextPath() + "/" +
 					jsonObject.getLong("id"),
-			Http.Method.PUT);
+			Http.Method.PUT, _objectDefinition1, _objectDefinition2);
+
+		_testPatchPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntries(
+			jsonObject ->
+				_siteScopedObjectDefinition1.getRESTContextPath() + "/" +
+					jsonObject.getLong("id"),
+			Http.Method.PUT, _siteScopedObjectDefinition1,
+			_siteScopedObjectDefinition2);
 
 		// One to many
 
@@ -10318,7 +10387,16 @@ public class ObjectEntryResourceTest {
 			jsonObject ->
 				_objectDefinition1.getRESTContextPath() + "/" +
 					jsonObject.getLong("id"),
-			Http.Method.PUT, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+			Http.Method.PUT, _objectDefinition1, _objectDefinition2,
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_testPatchPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
+			jsonObject ->
+				_siteScopedObjectDefinition1.getRESTContextPath() + "/" +
+					jsonObject.getLong("id"),
+			Http.Method.PUT, _siteScopedObjectDefinition1,
+			_siteScopedObjectDefinition2,
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 	}
 
 	@Test
@@ -10333,7 +10411,19 @@ public class ObjectEntryResourceTest {
 				_objectDefinition1.getRESTContextPath() +
 					"/by-external-reference-code/" +
 						jsonObject.getString("externalReferenceCode"),
-			Http.Method.PUT, ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+			Http.Method.PUT, _objectDefinition1, _objectDefinition2,
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		String externalReferenceCodeEndpoint = _getEndpoint(
+			_siteScopedObjectDefinition1, _testGroupId);
+
+		_testPatchPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
+			jsonObject ->
+				externalReferenceCodeEndpoint + "/by-external-reference-code/" +
+					jsonObject.getString("externalReferenceCode"),
+			Http.Method.PUT, _siteScopedObjectDefinition1,
+			_siteScopedObjectDefinition2,
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		// Many to one
 
@@ -10342,7 +10432,14 @@ public class ObjectEntryResourceTest {
 				_objectDefinition1.getRESTContextPath() +
 					"/by-external-reference-code/" +
 						jsonObject.getString("externalReferenceCode"),
-			Http.Method.PUT);
+			Http.Method.PUT, _objectDefinition1, _objectDefinition2);
+
+		_testPatchPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntries(
+			jsonObject ->
+				externalReferenceCodeEndpoint + "/by-external-reference-code/" +
+					jsonObject.getString("externalReferenceCode"),
+			Http.Method.PUT, _siteScopedObjectDefinition1,
+			_siteScopedObjectDefinition2);
 
 		// One to many
 
@@ -10351,7 +10448,16 @@ public class ObjectEntryResourceTest {
 				_objectDefinition1.getRESTContextPath() +
 					"/by-external-reference-code/" +
 						jsonObject.getString("externalReferenceCode"),
-			Http.Method.PUT, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+			Http.Method.PUT, _objectDefinition1, _objectDefinition2,
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_testPatchPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
+			jsonObject ->
+				externalReferenceCodeEndpoint + "/by-external-reference-code/" +
+					jsonObject.getString("externalReferenceCode"),
+			Http.Method.PUT, _siteScopedObjectDefinition1,
+			_siteScopedObjectDefinition2,
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 	}
 
 	@FeatureFlag("LPD-32050")
@@ -15330,22 +15436,23 @@ public class ObjectEntryResourceTest {
 	private void
 			_testPatchPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntries(
 				Function<JSONObject, String> endpointFunction,
-				Http.Method method)
+				Http.Method method, ObjectDefinition objectDefinition1,
+				ObjectDefinition objectDefinition2)
 		throws Exception {
 
 		ObjectRelationship objectRelationship1 =
 			ObjectRelationshipTestUtil.addObjectRelationship(
-				_objectDefinition2, _objectDefinition1,
+				objectDefinition2, objectDefinition1,
 				TestPropsValues.getUserId(),
 				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 		ObjectRelationship objectRelationship2 =
 			ObjectRelationshipTestUtil.addObjectRelationship(
-				_objectDefinition2, _objectDefinition1,
+				objectDefinition2, objectDefinition1,
 				TestPropsValues.getUserId(),
 				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 		ObjectRelationship objectRelationship3 =
 			ObjectRelationshipTestUtil.addObjectRelationship(
-				_objectDefinition2, _objectDefinition1,
+				objectDefinition2, objectDefinition1,
 				TestPropsValues.getUserId(),
 				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
@@ -15376,7 +15483,8 @@ public class ObjectEntryResourceTest {
 							"externalReferenceCode", _ERC_VALUE_3
 						).toString())
 				).toString(),
-				_objectDefinition1.getRESTContextPath(), Http.Method.POST);
+				_getEndpoint(objectDefinition1, _testGroupId),
+				Http.Method.POST);
 
 			jsonObject = HTTPTestUtil.invokeToJSONObject(
 				JSONUtil.put(
@@ -15385,13 +15493,13 @@ public class ObjectEntryResourceTest {
 				).put(
 					StringBundler.concat(
 						"r_", objectRelationship2.getName(), "_",
-						_objectDefinition2.getPKObjectFieldName()),
+						objectDefinition2.getPKObjectFieldName()),
 					0
 				).put(
 					StringBundler.concat(
 						"r_", objectRelationship3.getName(), "_",
 						StringUtil.replaceLast(
-							_objectDefinition2.getPKObjectFieldName(), "Id",
+							objectDefinition2.getPKObjectFieldName(), "Id",
 							"ERC")),
 					""
 				).toString(),
@@ -15424,37 +15532,37 @@ public class ObjectEntryResourceTest {
 				JSONUtil.put(
 					StringBundler.concat(
 						"r_", objectRelationship1.getName(), "_",
-						_objectDefinition2.getPKObjectFieldName()),
+						objectDefinition2.getPKObjectFieldName()),
 					0
 				).put(
 					StringBundler.concat(
 						"r_", objectRelationship1.getName(), "_",
 						StringUtil.replaceLast(
-							_objectDefinition2.getPKObjectFieldName(), "Id",
+							objectDefinition2.getPKObjectFieldName(), "Id",
 							"ERC")),
 					""
 				).put(
 					StringBundler.concat(
 						"r_", objectRelationship2.getName(), "_",
-						_objectDefinition2.getPKObjectFieldName()),
+						objectDefinition2.getPKObjectFieldName()),
 					0
 				).put(
 					StringBundler.concat(
 						"r_", objectRelationship2.getName(), "_",
 						StringUtil.replaceLast(
-							_objectDefinition2.getPKObjectFieldName(), "Id",
+							objectDefinition2.getPKObjectFieldName(), "Id",
 							"ERC")),
 					""
 				).put(
 					StringBundler.concat(
 						"r_", objectRelationship3.getName(), "_",
-						_objectDefinition2.getPKObjectFieldName()),
+						objectDefinition2.getPKObjectFieldName()),
 					0
 				).put(
 					StringBundler.concat(
 						"r_", objectRelationship3.getName(), "_",
 						StringUtil.replaceLast(
-							_objectDefinition2.getPKObjectFieldName(), "Id",
+							objectDefinition2.getPKObjectFieldName(), "Id",
 							"ERC")),
 					""
 				).toString(),
@@ -15473,12 +15581,13 @@ public class ObjectEntryResourceTest {
 	private void
 			_testPatchPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
 				Function<JSONObject, String> endpointFunction,
-				Http.Method method, String type)
+				Http.Method method, ObjectDefinition objectDefinition1,
+				ObjectDefinition objectDefinition2, String type)
 		throws Exception {
 
 		ObjectRelationship objectRelationship =
 			ObjectRelationshipTestUtil.addObjectRelationship(
-				_objectDefinition1, _objectDefinition2,
+				objectDefinition1, objectDefinition2,
 				TestPropsValues.getUserId(), type);
 
 		try {
@@ -15493,7 +15602,8 @@ public class ObjectEntryResourceTest {
 							RandomTestUtil.randomString()
 						})
 				).toString(),
-				_objectDefinition1.getRESTContextPath(), Http.Method.POST);
+				_getEndpoint(objectDefinition1, _testGroupId),
+				Http.Method.POST);
 
 			jsonObject = HTTPTestUtil.invokeToJSONObject(
 				JSONUtil.put(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -7740,6 +7740,69 @@ public class ObjectEntryResourceTest {
 			_testGroupId);
 	}
 
+	@Test
+	@TestInfo("LPD-53919")
+	public void testPatchCustomObjectEntryUnlinkNestedCustomObjectEntries()
+		throws Exception {
+
+		// Many to many
+
+		_testPatchPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
+			jsonObject ->
+				_objectDefinition1.getRESTContextPath() + "/" +
+					jsonObject.getLong("id"),
+			Http.Method.PATCH, ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		// Many to one
+
+		_testPatchPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntries(
+			jsonObject ->
+				_objectDefinition1.getRESTContextPath() + "/" +
+					jsonObject.getLong("id"),
+			Http.Method.PATCH);
+
+		// One to many
+
+		_testPatchPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
+			jsonObject ->
+				_objectDefinition1.getRESTContextPath() + "/" +
+					jsonObject.getLong("id"),
+			Http.Method.PATCH, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+	}
+
+	@Test
+	@TestInfo("LPD-53919")
+	public void testPatchCustomObjectEntryUnlinkNestedCustomObjectEntriesByExternalReferenceCode()
+		throws Exception {
+
+		// Many to many
+
+		_testPatchPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
+			jsonObject ->
+				_objectDefinition1.getRESTContextPath() +
+					"/by-external-reference-code/" +
+						jsonObject.getString("externalReferenceCode"),
+			Http.Method.PATCH, ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		// Many to one
+
+		_testPatchPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntries(
+			jsonObject ->
+				_objectDefinition1.getRESTContextPath() +
+					"/by-external-reference-code/" +
+						jsonObject.getString("externalReferenceCode"),
+			Http.Method.PATCH);
+
+		// One to many
+
+		_testPatchPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
+			jsonObject ->
+				_objectDefinition1.getRESTContextPath() +
+					"/by-external-reference-code/" +
+						jsonObject.getString("externalReferenceCode"),
+			Http.Method.PATCH, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+	}
+
 	@FeatureFlag("LPD-21926")
 	@Test
 	public void testPatchObjectEntryWithFriendlyURL() throws Exception {
@@ -10229,62 +10292,66 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	@TestInfo("LPD-53919")
 	public void testPutCustomObjectEntryUnlinkNestedCustomObjectEntries()
 		throws Exception {
 
 		// Many to many
 
-		_testPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
+		_testPatchPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
 			jsonObject ->
 				_objectDefinition1.getRESTContextPath() + "/" +
 					jsonObject.getLong("id"),
-			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+			Http.Method.PUT, ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		// Many to one
 
-		_testPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntries(
-			jsonObject ->
-				_objectDefinition1.getRESTContextPath() + "/" +
-					jsonObject.getLong("id"));
-
-		// One to many
-
-		_testPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
+		_testPatchPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntries(
 			jsonObject ->
 				_objectDefinition1.getRESTContextPath() + "/" +
 					jsonObject.getLong("id"),
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+			Http.Method.PUT);
+
+		// One to many
+
+		_testPatchPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
+			jsonObject ->
+				_objectDefinition1.getRESTContextPath() + "/" +
+					jsonObject.getLong("id"),
+			Http.Method.PUT, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 	}
 
 	@Test
+	@TestInfo("LPD-53919")
 	public void testPutCustomObjectEntryUnlinkNestedCustomObjectEntriesByExternalReferenceCode()
 		throws Exception {
 
 		// Many to many
 
-		_testPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
+		_testPatchPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
 			jsonObject ->
 				_objectDefinition1.getRESTContextPath() +
 					"/by-external-reference-code/" +
 						jsonObject.getString("externalReferenceCode"),
-			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+			Http.Method.PUT, ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		// Many to one
 
-		_testPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntries(
-			jsonObject ->
-				_objectDefinition1.getRESTContextPath() +
-					"/by-external-reference-code/" +
-						jsonObject.getString("externalReferenceCode"));
-
-		// One to many
-
-		_testPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
+		_testPatchPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntries(
 			jsonObject ->
 				_objectDefinition1.getRESTContextPath() +
 					"/by-external-reference-code/" +
 						jsonObject.getString("externalReferenceCode"),
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+			Http.Method.PUT);
+
+		// One to many
+
+		_testPatchPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
+			jsonObject ->
+				_objectDefinition1.getRESTContextPath() +
+					"/by-external-reference-code/" +
+						jsonObject.getString("externalReferenceCode"),
+			Http.Method.PUT, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 	}
 
 	@FeatureFlag("LPD-32050")
@@ -15260,6 +15327,200 @@ public class ObjectEntryResourceTest {
 			jsonObject.getString("externalReferenceCode"));
 	}
 
+	private void
+			_testPatchPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntries(
+				Function<JSONObject, String> endpointFunction,
+				Http.Method method)
+		throws Exception {
+
+		ObjectRelationship objectRelationship1 =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectDefinition2, _objectDefinition1,
+				TestPropsValues.getUserId(),
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		ObjectRelationship objectRelationship2 =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectDefinition2, _objectDefinition1,
+				TestPropsValues.getUserId(),
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		ObjectRelationship objectRelationship3 =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectDefinition2, _objectDefinition1,
+				TestPropsValues.getUserId(),
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		try {
+			JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					objectRelationship1.getName(),
+					JSONFactoryUtil.createJSONObject(
+						JSONUtil.put(
+							_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
+						).put(
+							"externalReferenceCode", _ERC_VALUE_1
+						).toString())
+				).put(
+					objectRelationship2.getName(),
+					JSONFactoryUtil.createJSONObject(
+						JSONUtil.put(
+							_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
+						).put(
+							"externalReferenceCode", _ERC_VALUE_2
+						).toString())
+				).put(
+					objectRelationship3.getName(),
+					JSONFactoryUtil.createJSONObject(
+						JSONUtil.put(
+							_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
+						).put(
+							"externalReferenceCode", _ERC_VALUE_3
+						).toString())
+				).toString(),
+				_objectDefinition1.getRESTContextPath(), Http.Method.POST);
+
+			jsonObject = HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					objectRelationship1.getName(),
+					JSONFactoryUtil.createJSONObject()
+				).put(
+					StringBundler.concat(
+						"r_", objectRelationship2.getName(), "_",
+						_objectDefinition2.getPKObjectFieldName()),
+					0
+				).put(
+					StringBundler.concat(
+						"r_", objectRelationship3.getName(), "_",
+						StringUtil.replaceLast(
+							_objectDefinition2.getPKObjectFieldName(), "Id",
+							"ERC")),
+					""
+				).toString(),
+				endpointFunction.apply(jsonObject), method);
+
+			Assert.assertEquals(
+				0,
+				jsonObject.getJSONObject(
+					"status"
+				).get(
+					"code"
+				));
+
+			JSONObject nestedObjectEntryJSONObject1 = jsonObject.getJSONObject(
+				objectRelationship1.getName());
+
+			Assert.assertNull(nestedObjectEntryJSONObject1);
+
+			JSONObject nestedObjectEntryJSONObject2 = jsonObject.getJSONObject(
+				objectRelationship2.getName());
+
+			Assert.assertNull(nestedObjectEntryJSONObject2);
+
+			JSONObject nestedObjectEntryJSONObject3 = jsonObject.getJSONObject(
+				objectRelationship3.getName());
+
+			Assert.assertNull(nestedObjectEntryJSONObject3);
+
+			JSONAssert.assertEquals(
+				JSONUtil.put(
+					StringBundler.concat(
+						"r_", objectRelationship1.getName(), "_",
+						_objectDefinition2.getPKObjectFieldName()),
+					0
+				).put(
+					StringBundler.concat(
+						"r_", objectRelationship1.getName(), "_",
+						StringUtil.replaceLast(
+							_objectDefinition2.getPKObjectFieldName(), "Id",
+							"ERC")),
+					""
+				).put(
+					StringBundler.concat(
+						"r_", objectRelationship2.getName(), "_",
+						_objectDefinition2.getPKObjectFieldName()),
+					0
+				).put(
+					StringBundler.concat(
+						"r_", objectRelationship2.getName(), "_",
+						StringUtil.replaceLast(
+							_objectDefinition2.getPKObjectFieldName(), "Id",
+							"ERC")),
+					""
+				).put(
+					StringBundler.concat(
+						"r_", objectRelationship3.getName(), "_",
+						_objectDefinition2.getPKObjectFieldName()),
+					0
+				).put(
+					StringBundler.concat(
+						"r_", objectRelationship3.getName(), "_",
+						StringUtil.replaceLast(
+							_objectDefinition2.getPKObjectFieldName(), "Id",
+							"ERC")),
+					""
+				).toString(),
+				jsonObject.toString(), JSONCompareMode.LENIENT);
+		}
+		finally {
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				objectRelationship1);
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				objectRelationship2);
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				objectRelationship3);
+		}
+	}
+
+	private void
+			_testPatchPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
+				Function<JSONObject, String> endpointFunction,
+				Http.Method method, String type)
+		throws Exception {
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectDefinition1, _objectDefinition2,
+				TestPropsValues.getUserId(), type);
+
+		try {
+			JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					objectRelationship.getName(),
+					_createObjectEntriesJSONArray(
+						new String[] {_ERC_VALUE_1, _ERC_VALUE_2},
+						_OBJECT_FIELD_NAME_2,
+						new String[] {
+							RandomTestUtil.randomString(),
+							RandomTestUtil.randomString()
+						})
+				).toString(),
+				_objectDefinition1.getRESTContextPath(), Http.Method.POST);
+
+			jsonObject = HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					objectRelationship.getName(),
+					JSONFactoryUtil.createJSONArray()
+				).toString(),
+				endpointFunction.apply(jsonObject), method);
+
+			Assert.assertEquals(
+				0,
+				jsonObject.getJSONObject(
+					"status"
+				).get(
+					"code"
+				));
+
+			JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
+				objectRelationship.getName());
+
+			Assert.assertEquals(0, nestedObjectEntriesJSONArray.length());
+		}
+		finally {
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				objectRelationship);
+		}
+	}
+
 	private void _testPatchPutCustomObjectEntryWithAttachmentField(
 			Http.Method httpMethod, ObjectDefinition objectDefinition,
 			boolean useExternalReferenceCode)
@@ -17316,198 +17577,6 @@ public class ObjectEntryResourceTest {
 				endpoint, Http.Method.PUT
 			).toString(),
 			JSONCompareMode.LENIENT);
-	}
-
-	private void
-			_testPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntries(
-				Function<JSONObject, String> endpointFunction)
-		throws Exception {
-
-		ObjectRelationship objectRelationship1 =
-			ObjectRelationshipTestUtil.addObjectRelationship(
-				_objectDefinition2, _objectDefinition1,
-				TestPropsValues.getUserId(),
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-		ObjectRelationship objectRelationship2 =
-			ObjectRelationshipTestUtil.addObjectRelationship(
-				_objectDefinition2, _objectDefinition1,
-				TestPropsValues.getUserId(),
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-		ObjectRelationship objectRelationship3 =
-			ObjectRelationshipTestUtil.addObjectRelationship(
-				_objectDefinition2, _objectDefinition1,
-				TestPropsValues.getUserId(),
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-		try {
-			JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
-				JSONUtil.put(
-					objectRelationship1.getName(),
-					JSONFactoryUtil.createJSONObject(
-						JSONUtil.put(
-							_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
-						).put(
-							"externalReferenceCode", _ERC_VALUE_1
-						).toString())
-				).put(
-					objectRelationship2.getName(),
-					JSONFactoryUtil.createJSONObject(
-						JSONUtil.put(
-							_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
-						).put(
-							"externalReferenceCode", _ERC_VALUE_2
-						).toString())
-				).put(
-					objectRelationship3.getName(),
-					JSONFactoryUtil.createJSONObject(
-						JSONUtil.put(
-							_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
-						).put(
-							"externalReferenceCode", _ERC_VALUE_3
-						).toString())
-				).toString(),
-				_objectDefinition1.getRESTContextPath(), Http.Method.POST);
-
-			jsonObject = HTTPTestUtil.invokeToJSONObject(
-				JSONUtil.put(
-					objectRelationship1.getName(),
-					JSONFactoryUtil.createJSONObject()
-				).put(
-					StringBundler.concat(
-						"r_", objectRelationship2.getName(), "_",
-						_objectDefinition2.getPKObjectFieldName()),
-					0
-				).put(
-					StringBundler.concat(
-						"r_", objectRelationship3.getName(), "_",
-						StringUtil.replaceLast(
-							_objectDefinition2.getPKObjectFieldName(), "Id",
-							"ERC")),
-					""
-				).toString(),
-				endpointFunction.apply(jsonObject), Http.Method.PUT);
-
-			Assert.assertEquals(
-				0,
-				jsonObject.getJSONObject(
-					"status"
-				).get(
-					"code"
-				));
-
-			JSONObject nestedObjectEntryJSONObject1 = jsonObject.getJSONObject(
-				objectRelationship1.getName());
-
-			Assert.assertNull(nestedObjectEntryJSONObject1);
-
-			JSONObject nestedObjectEntryJSONObject2 = jsonObject.getJSONObject(
-				objectRelationship2.getName());
-
-			Assert.assertNull(nestedObjectEntryJSONObject2);
-
-			JSONObject nestedObjectEntryJSONObject3 = jsonObject.getJSONObject(
-				objectRelationship3.getName());
-
-			Assert.assertNull(nestedObjectEntryJSONObject3);
-
-			JSONAssert.assertEquals(
-				JSONUtil.put(
-					StringBundler.concat(
-						"r_", objectRelationship1.getName(), "_",
-						_objectDefinition2.getPKObjectFieldName()),
-					0
-				).put(
-					StringBundler.concat(
-						"r_", objectRelationship1.getName(), "_",
-						StringUtil.replaceLast(
-							_objectDefinition2.getPKObjectFieldName(), "Id",
-							"ERC")),
-					""
-				).put(
-					StringBundler.concat(
-						"r_", objectRelationship2.getName(), "_",
-						_objectDefinition2.getPKObjectFieldName()),
-					0
-				).put(
-					StringBundler.concat(
-						"r_", objectRelationship2.getName(), "_",
-						StringUtil.replaceLast(
-							_objectDefinition2.getPKObjectFieldName(), "Id",
-							"ERC")),
-					""
-				).put(
-					StringBundler.concat(
-						"r_", objectRelationship3.getName(), "_",
-						_objectDefinition2.getPKObjectFieldName()),
-					0
-				).put(
-					StringBundler.concat(
-						"r_", objectRelationship3.getName(), "_",
-						StringUtil.replaceLast(
-							_objectDefinition2.getPKObjectFieldName(), "Id",
-							"ERC")),
-					""
-				).toString(),
-				jsonObject.toString(), JSONCompareMode.LENIENT);
-		}
-		finally {
-			_objectRelationshipLocalService.deleteObjectRelationship(
-				objectRelationship1);
-			_objectRelationshipLocalService.deleteObjectRelationship(
-				objectRelationship2);
-			_objectRelationshipLocalService.deleteObjectRelationship(
-				objectRelationship3);
-		}
-	}
-
-	private void
-			_testPutCustomObjectEntryUnlinkXToManyNestedCustomObjectEntries(
-				Function<JSONObject, String> endpointFunction, String type)
-		throws Exception {
-
-		ObjectRelationship objectRelationship =
-			ObjectRelationshipTestUtil.addObjectRelationship(
-				_objectDefinition1, _objectDefinition2,
-				TestPropsValues.getUserId(), type);
-
-		try {
-			JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
-				JSONUtil.put(
-					objectRelationship.getName(),
-					_createObjectEntriesJSONArray(
-						new String[] {_ERC_VALUE_1, _ERC_VALUE_2},
-						_OBJECT_FIELD_NAME_2,
-						new String[] {
-							RandomTestUtil.randomString(),
-							RandomTestUtil.randomString()
-						})
-				).toString(),
-				_objectDefinition1.getRESTContextPath(), Http.Method.POST);
-
-			jsonObject = HTTPTestUtil.invokeToJSONObject(
-				JSONUtil.put(
-					objectRelationship.getName(),
-					JSONFactoryUtil.createJSONArray()
-				).toString(),
-				endpointFunction.apply(jsonObject), Http.Method.PUT);
-
-			Assert.assertEquals(
-				0,
-				jsonObject.getJSONObject(
-					"status"
-				).get(
-					"code"
-				));
-
-			JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
-				objectRelationship.getName());
-
-			Assert.assertEquals(0, nestedObjectEntriesJSONArray.length());
-		}
-		finally {
-			_objectRelationshipLocalService.deleteObjectRelationship(
-				objectRelationship);
-		}
 	}
 
 	private void

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -15455,6 +15455,21 @@ public class ObjectEntryResourceTest {
 				objectDefinition2, objectDefinition1,
 				TestPropsValues.getUserId(),
 				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		ObjectRelationship objectRelationship4 =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				objectDefinition2, objectDefinition1,
+				TestPropsValues.getUserId(),
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		ObjectRelationship objectRelationship5 =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				objectDefinition2, objectDefinition1,
+				TestPropsValues.getUserId(),
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		ObjectRelationship objectRelationship6 =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				objectDefinition2, objectDefinition1,
+				TestPropsValues.getUserId(),
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		try {
 			JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
@@ -15463,24 +15478,36 @@ public class ObjectEntryResourceTest {
 					JSONFactoryUtil.createJSONObject(
 						JSONUtil.put(
 							_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
-						).put(
-							"externalReferenceCode", _ERC_VALUE_1
 						).toString())
 				).put(
 					objectRelationship2.getName(),
 					JSONFactoryUtil.createJSONObject(
 						JSONUtil.put(
 							_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
-						).put(
-							"externalReferenceCode", _ERC_VALUE_2
 						).toString())
 				).put(
 					objectRelationship3.getName(),
 					JSONFactoryUtil.createJSONObject(
 						JSONUtil.put(
 							_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
-						).put(
-							"externalReferenceCode", _ERC_VALUE_3
+						).toString())
+				).put(
+					objectRelationship4.getName(),
+					JSONFactoryUtil.createJSONObject(
+						JSONUtil.put(
+							_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
+						).toString())
+				).put(
+					objectRelationship5.getName(),
+					JSONFactoryUtil.createJSONObject(
+						JSONUtil.put(
+							_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
+						).toString())
+				).put(
+					objectRelationship6.getName(),
+					JSONFactoryUtil.createJSONObject(
+						JSONUtil.put(
+							_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
 						).toString())
 				).toString(),
 				_getEndpoint(objectDefinition1, _testGroupId),
@@ -15491,17 +15518,31 @@ public class ObjectEntryResourceTest {
 					objectRelationship1.getName(),
 					JSONFactoryUtil.createJSONObject()
 				).put(
+					objectRelationship2.getName(), org.json.JSONObject.NULL
+				).put(
 					StringBundler.concat(
-						"r_", objectRelationship2.getName(), "_",
+						"r_", objectRelationship3.getName(), "_",
 						objectDefinition2.getPKObjectFieldName()),
 					0
 				).put(
 					StringBundler.concat(
-						"r_", objectRelationship3.getName(), "_",
+						"r_", objectRelationship4.getName(), "_",
+						objectDefinition2.getPKObjectFieldName()),
+					org.json.JSONObject.NULL
+				).put(
+					StringBundler.concat(
+						"r_", objectRelationship5.getName(), "_",
 						StringUtil.replaceLast(
 							objectDefinition2.getPKObjectFieldName(), "Id",
 							"ERC")),
 					""
+				).put(
+					StringBundler.concat(
+						"r_", objectRelationship6.getName(), "_",
+						StringUtil.replaceLast(
+							objectDefinition2.getPKObjectFieldName(), "Id",
+							"ERC")),
+					org.json.JSONObject.NULL
 				).toString(),
 				endpointFunction.apply(jsonObject), method);
 
@@ -15527,6 +15568,21 @@ public class ObjectEntryResourceTest {
 				objectRelationship3.getName());
 
 			Assert.assertNull(nestedObjectEntryJSONObject3);
+
+			JSONObject nestedObjectEntryJSONObject4 = jsonObject.getJSONObject(
+				objectRelationship3.getName());
+
+			Assert.assertNull(nestedObjectEntryJSONObject4);
+
+			JSONObject nestedObjectEntryJSONObject5 = jsonObject.getJSONObject(
+				objectRelationship3.getName());
+
+			Assert.assertNull(nestedObjectEntryJSONObject5);
+
+			JSONObject nestedObjectEntryJSONObject6 = jsonObject.getJSONObject(
+				objectRelationship3.getName());
+
+			Assert.assertNull(nestedObjectEntryJSONObject6);
 
 			JSONAssert.assertEquals(
 				JSONUtil.put(
@@ -15565,6 +15621,42 @@ public class ObjectEntryResourceTest {
 							objectDefinition2.getPKObjectFieldName(), "Id",
 							"ERC")),
 					""
+				).put(
+					StringBundler.concat(
+						"r_", objectRelationship4.getName(), "_",
+						objectDefinition2.getPKObjectFieldName()),
+					0
+				).put(
+					StringBundler.concat(
+						"r_", objectRelationship4.getName(), "_",
+						StringUtil.replaceLast(
+							objectDefinition2.getPKObjectFieldName(), "Id",
+							"ERC")),
+					""
+				).put(
+					StringBundler.concat(
+						"r_", objectRelationship5.getName(), "_",
+						objectDefinition2.getPKObjectFieldName()),
+					0
+				).put(
+					StringBundler.concat(
+						"r_", objectRelationship5.getName(), "_",
+						StringUtil.replaceLast(
+							objectDefinition2.getPKObjectFieldName(), "Id",
+							"ERC")),
+					""
+				).put(
+					StringBundler.concat(
+						"r_", objectRelationship6.getName(), "_",
+						objectDefinition2.getPKObjectFieldName()),
+					0
+				).put(
+					StringBundler.concat(
+						"r_", objectRelationship6.getName(), "_",
+						StringUtil.replaceLast(
+							objectDefinition2.getPKObjectFieldName(), "Id",
+							"ERC")),
+					""
 				).toString(),
 				jsonObject.toString(), JSONCompareMode.LENIENT);
 		}
@@ -15575,6 +15667,12 @@ public class ObjectEntryResourceTest {
 				objectRelationship2);
 			_objectRelationshipLocalService.deleteObjectRelationship(
 				objectRelationship3);
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				objectRelationship4);
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				objectRelationship5);
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				objectRelationship6);
 		}
 	}
 
@@ -15585,7 +15683,12 @@ public class ObjectEntryResourceTest {
 				ObjectDefinition objectDefinition2, String type)
 		throws Exception {
 
-		ObjectRelationship objectRelationship =
+		ObjectRelationship objectRelationship1 =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				objectDefinition1, objectDefinition2,
+				TestPropsValues.getUserId(), type);
+
+		ObjectRelationship objectRelationship2 =
 			ObjectRelationshipTestUtil.addObjectRelationship(
 				objectDefinition1, objectDefinition2,
 				TestPropsValues.getUserId(), type);
@@ -15593,7 +15696,16 @@ public class ObjectEntryResourceTest {
 		try {
 			JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
 				JSONUtil.put(
-					objectRelationship.getName(),
+					objectRelationship1.getName(),
+					_createObjectEntriesJSONArray(
+						new String[] {_ERC_VALUE_1, _ERC_VALUE_2},
+						_OBJECT_FIELD_NAME_2,
+						new String[] {
+							RandomTestUtil.randomString(),
+							RandomTestUtil.randomString()
+						})
+				).put(
+					objectRelationship2.getName(),
 					_createObjectEntriesJSONArray(
 						new String[] {_ERC_VALUE_1, _ERC_VALUE_2},
 						_OBJECT_FIELD_NAME_2,
@@ -15607,8 +15719,10 @@ public class ObjectEntryResourceTest {
 
 			jsonObject = HTTPTestUtil.invokeToJSONObject(
 				JSONUtil.put(
-					objectRelationship.getName(),
+					objectRelationship1.getName(),
 					JSONFactoryUtil.createJSONArray()
+				).put(
+					objectRelationship2.getName(), org.json.JSONObject.NULL
 				).toString(),
 				endpointFunction.apply(jsonObject), method);
 
@@ -15620,14 +15734,21 @@ public class ObjectEntryResourceTest {
 					"code"
 				));
 
-			JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
-				objectRelationship.getName());
+			JSONArray nestedObjectEntriesJSONArray1 = jsonObject.getJSONArray(
+				objectRelationship1.getName());
 
-			Assert.assertEquals(0, nestedObjectEntriesJSONArray.length());
+			Assert.assertEquals(0, nestedObjectEntriesJSONArray1.length());
+
+			JSONArray nestedObjectEntriesJSONArray2 = jsonObject.getJSONArray(
+				objectRelationship2.getName());
+
+			Assert.assertEquals(0, nestedObjectEntriesJSONArray2.length());
 		}
 		finally {
 			_objectRelationshipLocalService.deleteObjectRelationship(
-				objectRelationship);
+				objectRelationship1);
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				objectRelationship2);
 		}
 	}
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -17443,7 +17443,17 @@ public class ObjectEntryResourceTest {
 	private void _testPutCustomObjectEntryUnlinkManyToOneNestedCustomObjectEntriesByExternalReferenceCode()
 		throws Exception {
 
-		ObjectRelationship objectRelationship =
+		ObjectRelationship objectRelationship1 =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectDefinition2, _objectDefinition1,
+				TestPropsValues.getUserId(),
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		ObjectRelationship objectRelationship2 =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectDefinition2, _objectDefinition1,
+				TestPropsValues.getUserId(),
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		ObjectRelationship objectRelationship3 =
 			ObjectRelationshipTestUtil.addObjectRelationship(
 				_objectDefinition2, _objectDefinition1,
 				TestPropsValues.getUserId(),
@@ -17452,20 +17462,48 @@ public class ObjectEntryResourceTest {
 		try {
 			JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
 				JSONUtil.put(
-					objectRelationship.getName(),
+					objectRelationship1.getName(),
 					JSONFactoryUtil.createJSONObject(
 						JSONUtil.put(
 							_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
 						).put(
 							"externalReferenceCode", _ERC_VALUE_1
 						).toString())
+				).put(
+					objectRelationship2.getName(),
+					JSONFactoryUtil.createJSONObject(
+						JSONUtil.put(
+							_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
+						).put(
+							"externalReferenceCode", _ERC_VALUE_2
+						).toString())
+				).put(
+					objectRelationship3.getName(),
+					JSONFactoryUtil.createJSONObject(
+						JSONUtil.put(
+							_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
+						).put(
+							"externalReferenceCode", _ERC_VALUE_3
+						).toString())
 				).toString(),
 				_objectDefinition1.getRESTContextPath(), Http.Method.POST);
 
 			jsonObject = HTTPTestUtil.invokeToJSONObject(
 				JSONUtil.put(
-					objectRelationship.getName(),
+					objectRelationship1.getName(),
 					JSONFactoryUtil.createJSONObject()
+				).put(
+					StringBundler.concat(
+						"r_", objectRelationship2.getName(), "_",
+						_objectDefinition2.getPKObjectFieldName()),
+					0
+				).put(
+					StringBundler.concat(
+						"r_", objectRelationship3.getName(), "_",
+						StringUtil.replaceLast(
+							_objectDefinition2.getPKObjectFieldName(), "Id",
+							"ERC")),
+					""
 				).toString(),
 				StringBundler.concat(
 					_objectDefinition1.getRESTContextPath(),
@@ -17481,14 +17519,68 @@ public class ObjectEntryResourceTest {
 					"code"
 				));
 
-			JSONObject systemObjectEntryJSONObject = jsonObject.getJSONObject(
-				objectRelationship.getName());
+			JSONObject nestedObjectEntryJSONObject1 = jsonObject.getJSONObject(
+				objectRelationship1.getName());
 
-			Assert.assertNull(systemObjectEntryJSONObject);
+			Assert.assertNull(nestedObjectEntryJSONObject1);
+
+			JSONObject nestedObjectEntryJSONObject2 = jsonObject.getJSONObject(
+				objectRelationship2.getName());
+
+			Assert.assertNull(nestedObjectEntryJSONObject2);
+
+			JSONObject nestedObjectEntryJSONObject3 = jsonObject.getJSONObject(
+				objectRelationship3.getName());
+
+			Assert.assertNull(nestedObjectEntryJSONObject3);
+
+			JSONAssert.assertEquals(
+				JSONUtil.put(
+					StringBundler.concat(
+						"r_", objectRelationship1.getName(), "_",
+						_objectDefinition2.getPKObjectFieldName()),
+					0
+				).put(
+					StringBundler.concat(
+						"r_", objectRelationship1.getName(), "_",
+						StringUtil.replaceLast(
+							_objectDefinition2.getPKObjectFieldName(), "Id",
+							"ERC")),
+					""
+				).put(
+					StringBundler.concat(
+						"r_", objectRelationship2.getName(), "_",
+						_objectDefinition2.getPKObjectFieldName()),
+					0
+				).put(
+					StringBundler.concat(
+						"r_", objectRelationship2.getName(), "_",
+						StringUtil.replaceLast(
+							_objectDefinition2.getPKObjectFieldName(), "Id",
+							"ERC")),
+					""
+				).put(
+					StringBundler.concat(
+						"r_", objectRelationship3.getName(), "_",
+						_objectDefinition2.getPKObjectFieldName()),
+					0
+				).put(
+					StringBundler.concat(
+						"r_", objectRelationship3.getName(), "_",
+						StringUtil.replaceLast(
+							_objectDefinition2.getPKObjectFieldName(), "Id",
+							"ERC")),
+					""
+				).toString(),
+				jsonObject.toString(), JSONCompareMode.LENIENT);
 		}
 		finally {
 			_objectRelationshipLocalService.deleteObjectRelationship(
-				objectRelationship);
+				objectRelationship1);
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				objectRelationship2);
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				objectRelationship3);
 		}
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/RelationshipObjectFieldBusinessType.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/RelationshipObjectFieldBusinessType.java
@@ -210,6 +210,10 @@ public class RelationshipObjectFieldBusinessType
 			String externalReferenceCode = MapUtil.getString(
 				values, objectRelationshipERCObjectFieldName);
 
+			if (Validator.isBlank(externalReferenceCode.trim())) {
+				return 0;
+			}
+
 			ObjectDefinition objectDefinition = _getObjectDefinition(
 				objectField);
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/RelationshipObjectFieldBusinessType.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/RelationshipObjectFieldBusinessType.java
@@ -165,7 +165,7 @@ public class RelationshipObjectFieldBusinessType
 			Object value = values.get(objectField.getName());
 
 			if (value == null) {
-				return 0L;
+				return 0;
 			}
 
 			long valueLong = GetterUtil.getLong(value);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/RelationshipObjectFieldBusinessType.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/RelationshipObjectFieldBusinessType.java
@@ -164,6 +164,10 @@ public class RelationshipObjectFieldBusinessType
 		if (values.containsKey(objectField.getName())) {
 			Object value = values.get(objectField.getName());
 
+			if (value == null) {
+				return 0L;
+			}
+
 			long valueLong = GetterUtil.getLong(value);
 
 			if (valueLong == 0) {


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-53919

See: https://github.com/brianchandotcom/liferay-portal/pull/162402