### PR TITLE
LPD-57551 prevent issue with the character ' not being escaped. For i…nstance, the language ca_ES has this breaking thing `d'idioma`

### DIFF
--- a/modules/apps/portal-language/portal-language-override-web/src/main/resources/META-INF/resources/edit_plo_entry.jsp
+++ b/modules/apps/portal-language/portal-language-override-web/src/main/resources/META-INF/resources/edit_plo_entry.jsp
@@ -185,7 +185,7 @@ renderResponse.setTitle(editDisplayContext.getPageTitle());
 
 			Liferay.Util.openToast({
 				message:
-					'<%= LanguageUtil.get(request, "at-least-one-translation-is-required-with-a-new-language-key") %>',
+					'<%= HtmlUtil.escapeJS(LanguageUtil.get(request, "at-least-one-translation-is-required-with-a-new-language-key")) %>',
 				type: 'danger',
 			});
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-57551

A invalid JS code would be generated when the translation had a `'` character.

```javascript
Liferay.Util.openToast({
  message: 'd'idioma'
});
```

I can't just use double quotes or `, SF will remove those  