### PR TITLE
Lpd 57811

### DIFF
--- a/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/service/test/DispatchTriggerLocalServiceTest.java
+++ b/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/service/test/DispatchTriggerLocalServiceTest.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.cache.PortalCache;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.CacheModel;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
@@ -762,6 +763,14 @@ public class DispatchTriggerLocalServiceTest {
 		@Override
 		public void clearLocalCache() {
 			_entityCache.clearLocalCache();
+		}
+
+		@Override
+		public <T extends CacheModel<?>> T fetchCacheModel(
+			Class<?> clazz, Serializable primaryKey, Class<T> cacheModelClass) {
+
+			return _entityCache.fetchCacheModel(
+				clazz, primaryKey, cacheModelClass);
 		}
 
 		@Override

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/bnd.bnd
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Dynamic Data Lists API
 Bundle-SymbolicName: com.liferay.dynamic.data.lists.api
-Bundle-Version: 10.0.3
+Bundle-Version: 10.1.0
 Export-Package:\
 	com.liferay.dynamic.data.lists.constants,\
 	com.liferay.dynamic.data.lists.exception,\

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/model/DDLRecordSet.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/model/DDLRecordSet.java
@@ -65,10 +65,12 @@ public interface DDLRecordSet extends DDLRecordSetModel, PersistedModel {
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	public com.liferay.dynamic.data.mapping.storage.DDMFormValues
-			getSettingsDDMFormValues()
-		throws com.liferay.portal.kernel.exception.PortalException;
+		getSettingsDDMFormValues();
 
 	public DDLRecordSetSettings getSettingsModel()
 		throws com.liferay.portal.kernel.exception.PortalException;
+
+	public void setSettingsDDMFormValues(
+		com.liferay.dynamic.data.mapping.storage.DDMFormValues ddmFormValues);
 
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/model/DDLRecordSetWrapper.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/model/DDLRecordSetWrapper.java
@@ -533,8 +533,7 @@ public class DDLRecordSetWrapper
 
 	@Override
 	public com.liferay.dynamic.data.mapping.storage.DDMFormValues
-			getSettingsDDMFormValues()
-		throws com.liferay.portal.kernel.exception.PortalException {
+		getSettingsDDMFormValues() {
 
 		return model.getSettingsDDMFormValues();
 	}
@@ -914,6 +913,13 @@ public class DDLRecordSetWrapper
 	@Override
 	public void setSettings(String settings) {
 		model.setSettings(settings);
+	}
+
+	@Override
+	public void setSettingsDDMFormValues(
+		com.liferay.dynamic.data.mapping.storage.DDMFormValues ddmFormValues) {
+
+		model.setSettingsDDMFormValues(ddmFormValues);
 	}
 
 	/**

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordSetLocalService.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordSetLocalService.java
@@ -508,8 +508,7 @@ public interface DDLRecordSetLocalService
 	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public DDMFormValues getRecordSetSettingsDDMFormValues(
-			DDLRecordSet recordSet)
-		throws PortalException;
+		DDLRecordSet recordSet);
 
 	/**
 	 * Returns the record set's settings.

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordSetLocalServiceUtil.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordSetLocalServiceUtil.java
@@ -578,8 +578,7 @@ public class DDLRecordSetLocalServiceUtil {
 	 * @throws PortalException if a portal exception occurred
 	 */
 	public static com.liferay.dynamic.data.mapping.storage.DDMFormValues
-			getRecordSetSettingsDDMFormValues(DDLRecordSet recordSet)
-		throws PortalException {
+		getRecordSetSettingsDDMFormValues(DDLRecordSet recordSet) {
 
 		return getService().getRecordSetSettingsDDMFormValues(recordSet);
 	}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordSetLocalServiceWrapper.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordSetLocalServiceWrapper.java
@@ -634,8 +634,7 @@ public class DDLRecordSetLocalServiceWrapper
 	 */
 	@Override
 	public com.liferay.dynamic.data.mapping.storage.DDMFormValues
-			getRecordSetSettingsDDMFormValues(DDLRecordSet recordSet)
-		throws com.liferay.portal.kernel.exception.PortalException {
+		getRecordSetSettingsDDMFormValues(DDLRecordSet recordSet) {
 
 		return _ddlRecordSetLocalService.getRecordSetSettingsDDMFormValues(
 			recordSet);

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/resources/com/liferay/dynamic/data/lists/model/packageinfo
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/resources/com/liferay/dynamic/data/lists/model/packageinfo
@@ -1,1 +1,1 @@
-version 3.1.0
+version 3.2.0

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/build.gradle
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")
+	compileOnly project(":core:petra:petra-reflect")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/model/impl/DDLRecordSetCacheModel.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/model/impl/DDLRecordSetCacheModel.java
@@ -215,7 +215,7 @@ public class DDLRecordSetCacheModel
 
 		ddlRecordSetImpl.resetOriginalValues();
 
-		ddlRecordSetImpl.setDDMFormValues(_ddmFormValues);
+		ddlRecordSetImpl.setSettingsDDMFormValues(_ddmFormValues);
 
 		return ddlRecordSetImpl;
 	}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/model/impl/DDLRecordSetCacheModel.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/model/impl/DDLRecordSetCacheModel.java
@@ -7,6 +7,7 @@ package com.liferay.dynamic.data.lists.model.impl;
 
 import com.liferay.dynamic.data.lists.model.DDLRecordSet;
 import com.liferay.petra.lang.HashUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.CacheModel;
 import com.liferay.portal.kernel.model.MVCCModel;
@@ -15,6 +16,9 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 
 import java.util.Date;
 
@@ -215,7 +219,13 @@ public class DDLRecordSetCacheModel
 
 		ddlRecordSetImpl.resetOriginalValues();
 
-		ddlRecordSetImpl.setSettingsDDMFormValues(_ddmFormValues);
+		try {
+			_ddmFormValuesMethodHandle.invokeExact(
+				ddlRecordSetImpl, ddmFormValues);
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
 
 		return ddlRecordSetImpl;
 	}
@@ -255,7 +265,7 @@ public class DDLRecordSetCacheModel
 		settings = (String)objectInput.readObject();
 		lastPublishDate = objectInput.readLong();
 
-		_ddmFormValues =
+		ddmFormValues =
 			(com.liferay.dynamic.data.mapping.storage.DDMFormValues)
 				objectInput.readObject();
 	}
@@ -343,7 +353,7 @@ public class DDLRecordSetCacheModel
 
 		objectOutput.writeLong(lastPublishDate);
 
-		objectOutput.writeObject(_ddmFormValues);
+		objectOutput.writeObject(ddmFormValues);
 	}
 
 	public long mvccVersion;
@@ -367,7 +377,22 @@ public class DDLRecordSetCacheModel
 	public int scope;
 	public String settings;
 	public long lastPublishDate;
-	public com.liferay.dynamic.data.mapping.storage.DDMFormValues
-		_ddmFormValues;
+	public volatile com.liferay.dynamic.data.mapping.storage.DDMFormValues
+		ddmFormValues;
+
+	private static final MethodHandle _ddmFormValuesMethodHandle;
+
+	static {
+		MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+		try {
+			_ddmFormValuesMethodHandle = lookup.findSetter(
+				DDLRecordSetImpl.class, "_ddmFormValues",
+				com.liferay.dynamic.data.mapping.storage.DDMFormValues.class);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ExceptionInInitializerError(reflectiveOperationException);
+		}
+	}
 
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/model/impl/DDLRecordSetImpl.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/model/impl/DDLRecordSetImpl.java
@@ -73,7 +73,7 @@ public class DDLRecordSetImpl extends DDLRecordSetBaseImpl {
 	}
 
 	@Override
-	public DDMFormValues getSettingsDDMFormValues() throws PortalException {
+	public DDMFormValues getSettingsDDMFormValues() {
 		if (_ddmFormValues == null) {
 			_ddmFormValues =
 				DDLRecordSetLocalServiceUtil.getRecordSetSettingsDDMFormValues(
@@ -100,7 +100,14 @@ public class DDLRecordSetImpl extends DDLRecordSetBaseImpl {
 		_recordSetSettings = null;
 	}
 
-	@CacheField(methodName = "DDMFormValues", propagateToInterface = true)
+	@Override
+	public void setSettingsDDMFormValues(DDMFormValues ddmFormValues) {
+		_ddmFormValues = ddmFormValues;
+	}
+
+	@CacheField(
+		methodName = "SettingsDDMFormValues", propagateToInterface = true
+	)
 	private DDMFormValues _ddmFormValues;
 
 	private DDLRecordSetSettings _recordSetSettings;

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/model/impl/DDLRecordSetImpl.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/model/impl/DDLRecordSetImpl.java
@@ -78,6 +78,8 @@ public class DDLRecordSetImpl extends DDLRecordSetBaseImpl {
 			_ddmFormValues =
 				DDLRecordSetLocalServiceUtil.getRecordSetSettingsDDMFormValues(
 					this);
+
+			ddmFormValuesUpdateEntityCacheConsumer.accept(_ddmFormValues);
 		}
 
 		return _ddmFormValues;

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/model/impl/DDLRecordSetImpl.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/model/impl/DDLRecordSetImpl.java
@@ -48,6 +48,12 @@ public class DDLRecordSetImpl extends DDLRecordSetBaseImpl {
 				ddmStructure = (DDMStructure)ddmStructure.clone();
 
 				ddmStructure.setDefinition(ddmTemplate.getScript());
+
+				// On purposely lowering mvcc version to avoid entity cache
+				// corruption when DDMStructureImpl.getDDMForm() is invoked for
+				// reconstructing the DDMForm cache field.
+
+				ddmStructure.setMvccVersion(ddmStructure.getMvccVersion() - 1);
 			}
 		}
 

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/model/impl/DDLRecordSetModelImpl.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/model/impl/DDLRecordSetModelImpl.java
@@ -10,8 +10,10 @@ import com.liferay.dynamic.data.lists.model.DDLRecordSetModel;
 import com.liferay.expando.kernel.model.ExpandoBridge;
 import com.liferay.expando.kernel.util.ExpandoBridgeFactoryUtil;
 import com.liferay.exportimport.kernel.lar.StagedModelType;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
+import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSON;
@@ -31,6 +33,8 @@ import com.liferay.portal.kernel.util.Validator;
 
 import java.io.Serializable;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationHandler;
 
 import java.sql.Blob;
@@ -46,6 +50,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -1444,9 +1449,17 @@ public class DDLRecordSetModelImpl
 			ddlRecordSetCacheModel.lastPublishDate = Long.MIN_VALUE;
 		}
 
-		setSettingsDDMFormValues(null);
+		try {
+			setSettingsDDMFormValues(null);
 
-		ddlRecordSetCacheModel._ddmFormValues = getSettingsDDMFormValues();
+			ddlRecordSetCacheModel.ddmFormValues =
+				(com.liferay.dynamic.data.mapping.storage.DDMFormValues)
+					_ddmFormValuesMethodHandle.invokeExact(
+						(DDLRecordSetImpl)this);
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
 
 		return ddlRecordSetCacheModel;
 	}
@@ -1655,6 +1668,38 @@ public class DDLRecordSetModelImpl
 	}
 
 	private long _columnBitmask;
+
+	protected final transient Consumer
+		<com.liferay.dynamic.data.mapping.storage.DDMFormValues>
+			ddmFormValuesUpdateEntityCacheConsumer = ddmFormValues -> {
+				DDLRecordSetCacheModel ddlRecordSetCacheModel =
+					EntityCacheUtil.fetchCacheModel(
+						DDLRecordSetImpl.class, _recordSetId,
+						DDLRecordSetCacheModel.class);
+
+				if ((ddlRecordSetCacheModel != null) &&
+					(ddlRecordSetCacheModel.getMvccVersion() ==
+						getMvccVersion())) {
+
+					ddlRecordSetCacheModel.ddmFormValues = ddmFormValues;
+				}
+			};
+
+	private static final MethodHandle _ddmFormValuesMethodHandle;
+
+	static {
+		MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+		try {
+			_ddmFormValuesMethodHandle = lookup.findGetter(
+				DDLRecordSetImpl.class, "_ddmFormValues",
+				com.liferay.dynamic.data.mapping.storage.DDMFormValues.class);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ExceptionInInitializerError(reflectiveOperationException);
+		}
+	}
+
 	private DDLRecordSet _escapedModel;
 
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/model/impl/DDLRecordSetModelImpl.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/model/impl/DDLRecordSetModelImpl.java
@@ -1024,12 +1024,12 @@ public class DDLRecordSetModelImpl
 	}
 
 	public com.liferay.dynamic.data.mapping.storage.DDMFormValues
-		getDDMFormValues() {
+		getSettingsDDMFormValues() {
 
 		return null;
 	}
 
-	public void setDDMFormValues(
+	public void setSettingsDDMFormValues(
 		com.liferay.dynamic.data.mapping.storage.DDMFormValues ddmFormValues) {
 	}
 
@@ -1323,7 +1323,7 @@ public class DDLRecordSetModelImpl
 
 		_setModifiedDate = false;
 
-		setDDMFormValues(null);
+		setSettingsDDMFormValues(null);
 
 		_columnBitmask = 0;
 	}
@@ -1444,9 +1444,9 @@ public class DDLRecordSetModelImpl
 			ddlRecordSetCacheModel.lastPublishDate = Long.MIN_VALUE;
 		}
 
-		setDDMFormValues(null);
+		setSettingsDDMFormValues(null);
 
-		ddlRecordSetCacheModel._ddmFormValues = getDDMFormValues();
+		ddlRecordSetCacheModel._ddmFormValues = getSettingsDDMFormValues();
 
 		return ddlRecordSetCacheModel;
 	}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordSetLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordSetLocalServiceImpl.java
@@ -438,8 +438,7 @@ public class DDLRecordSetLocalServiceImpl
 	 */
 	@Override
 	public DDMFormValues getRecordSetSettingsDDMFormValues(
-			DDLRecordSet recordSet)
-		throws PortalException {
+		DDLRecordSet recordSet) {
 
 		DDMForm ddmForm = DDMFormFactory.create(DDLRecordSetSettings.class);
 

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/persistence/impl/DDLRecordSetPersistenceImpl.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/persistence/impl/DDLRecordSetPersistenceImpl.java
@@ -3858,8 +3858,8 @@ public class DDLRecordSetPersistenceImpl
 					DDLRecordSetModelImpl cachedDDLRecordSetModelImpl =
 						(DDLRecordSetModelImpl)cachedDDLRecordSet;
 
-					ddlRecordSetModelImpl.setDDMFormValues(
-						cachedDDLRecordSetModelImpl.getDDMFormValues());
+					ddlRecordSetModelImpl.setSettingsDDMFormValues(
+						cachedDDLRecordSetModelImpl.getSettingsDDMFormValues());
 				}
 			}
 		}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Dynamic Data Mapping API
 Bundle-SymbolicName: com.liferay.dynamic.data.mapping.api
-Bundle-Version: 35.0.1
+Bundle-Version: 35.1.0
 Export-Package:\
 	com.liferay.dynamic.data.mapping.annotations,\
 	com.liferay.dynamic.data.mapping.configuration,\

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMFormInstance.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMFormInstance.java
@@ -61,8 +61,7 @@ public interface DDMFormInstance extends DDMFormInstanceModel, PersistedModel {
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	public com.liferay.dynamic.data.mapping.storage.DDMFormValues
-			getSettingsDDMFormValues()
-		throws com.liferay.portal.kernel.exception.PortalException;
+		getSettingsDDMFormValues();
 
 	public DDMFormInstanceSettings getSettingsModel()
 		throws com.liferay.portal.kernel.exception.PortalException;
@@ -72,5 +71,8 @@ public interface DDMFormInstance extends DDMFormInstanceModel, PersistedModel {
 
 	public DDMStructure getStructure()
 		throws com.liferay.portal.kernel.exception.PortalException;
+
+	public void setSettingsDDMFormValues(
+		com.liferay.dynamic.data.mapping.storage.DDMFormValues ddmFormValues);
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMFormInstanceWrapper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMFormInstanceWrapper.java
@@ -464,8 +464,7 @@ public class DDMFormInstanceWrapper
 
 	@Override
 	public com.liferay.dynamic.data.mapping.storage.DDMFormValues
-			getSettingsDDMFormValues()
-		throws com.liferay.portal.kernel.exception.PortalException {
+		getSettingsDDMFormValues() {
 
 		return model.getSettingsDDMFormValues();
 	}
@@ -829,6 +828,13 @@ public class DDMFormInstanceWrapper
 	@Override
 	public void setSettings(String settings) {
 		model.setSettings(settings);
+	}
+
+	@Override
+	public void setSettingsDDMFormValues(
+		com.liferay.dynamic.data.mapping.storage.DDMFormValues ddmFormValues) {
+
+		model.setSettingsDDMFormValues(ddmFormValues);
 	}
 
 	/**

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMStructureLayout.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMStructureLayout.java
@@ -59,4 +59,6 @@ public interface DDMStructureLayout
 	public long getDDMStructureId()
 		throws com.liferay.portal.kernel.exception.PortalException;
 
+	public void setDDMFormLayout(DDMFormLayout ddmFormLayout);
+
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMStructureLayoutWrapper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMStructureLayoutWrapper.java
@@ -577,6 +577,11 @@ public class DDMStructureLayoutWrapper
 		model.setCtCollectionId(ctCollectionId);
 	}
 
+	@Override
+	public void setDDMFormLayout(DDMFormLayout ddmFormLayout) {
+		model.setDDMFormLayout(ddmFormLayout);
+	}
+
 	/**
 	 * Sets the definition of this ddm structure layout.
 	 *

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceLocalService.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceLocalService.java
@@ -373,8 +373,7 @@ public interface DDMFormInstanceLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public DDMFormValues getFormInstanceSettingsFormValues(
-			DDMFormInstance formInstance)
-		throws PortalException;
+		DDMFormInstance formInstance);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public DDMFormInstanceSettings getFormInstanceSettingsModel(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceLocalServiceUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceLocalServiceUtil.java
@@ -449,8 +449,7 @@ public class DDMFormInstanceLocalServiceUtil {
 	}
 
 	public static com.liferay.dynamic.data.mapping.storage.DDMFormValues
-			getFormInstanceSettingsFormValues(DDMFormInstance formInstance)
-		throws PortalException {
+		getFormInstanceSettingsFormValues(DDMFormInstance formInstance) {
 
 		return getService().getFormInstanceSettingsFormValues(formInstance);
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceLocalServiceWrapper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceLocalServiceWrapper.java
@@ -507,8 +507,7 @@ public class DDMFormInstanceLocalServiceWrapper
 
 	@Override
 	public com.liferay.dynamic.data.mapping.storage.DDMFormValues
-			getFormInstanceSettingsFormValues(DDMFormInstance formInstance)
-		throws com.liferay.portal.kernel.exception.PortalException {
+		getFormInstanceSettingsFormValues(DDMFormInstance formInstance) {
 
 		return _ddmFormInstanceLocalService.getFormInstanceSettingsFormValues(
 			formInstance);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/model/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/model/packageinfo
@@ -1,1 +1,1 @@
-version 7.6.0
+version 7.7.0

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMFormInstanceCacheModel.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMFormInstanceCacheModel.java
@@ -7,6 +7,7 @@ package com.liferay.dynamic.data.mapping.model.impl;
 
 import com.liferay.dynamic.data.mapping.model.DDMFormInstance;
 import com.liferay.petra.lang.HashUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.CacheModel;
 import com.liferay.portal.kernel.model.MVCCModel;
@@ -15,6 +16,9 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 
 import java.util.Date;
 
@@ -199,7 +203,13 @@ public class DDMFormInstanceCacheModel
 
 		ddmFormInstanceImpl.resetOriginalValues();
 
-		ddmFormInstanceImpl.setSettingsDDMFormValues(_ddmFormValues);
+		try {
+			_ddmFormValuesMethodHandle.invokeExact(
+				ddmFormInstanceImpl, ddmFormValues);
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
 
 		return ddmFormInstanceImpl;
 	}
@@ -234,7 +244,7 @@ public class DDMFormInstanceCacheModel
 		settings = (String)objectInput.readObject();
 		lastPublishDate = objectInput.readLong();
 
-		_ddmFormValues =
+		ddmFormValues =
 			(com.liferay.dynamic.data.mapping.storage.DDMFormValues)
 				objectInput.readObject();
 	}
@@ -311,7 +321,7 @@ public class DDMFormInstanceCacheModel
 
 		objectOutput.writeLong(lastPublishDate);
 
-		objectOutput.writeObject(_ddmFormValues);
+		objectOutput.writeObject(ddmFormValues);
 	}
 
 	public long mvccVersion;
@@ -332,7 +342,22 @@ public class DDMFormInstanceCacheModel
 	public String description;
 	public String settings;
 	public long lastPublishDate;
-	public com.liferay.dynamic.data.mapping.storage.DDMFormValues
-		_ddmFormValues;
+	public volatile com.liferay.dynamic.data.mapping.storage.DDMFormValues
+		ddmFormValues;
+
+	private static final MethodHandle _ddmFormValuesMethodHandle;
+
+	static {
+		MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+		try {
+			_ddmFormValuesMethodHandle = lookup.findSetter(
+				DDMFormInstanceImpl.class, "_ddmFormValues",
+				com.liferay.dynamic.data.mapping.storage.DDMFormValues.class);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ExceptionInInitializerError(reflectiveOperationException);
+		}
+	}
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMFormInstanceCacheModel.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMFormInstanceCacheModel.java
@@ -199,7 +199,7 @@ public class DDMFormInstanceCacheModel
 
 		ddmFormInstanceImpl.resetOriginalValues();
 
-		ddmFormInstanceImpl.setDDMFormValues(_ddmFormValues);
+		ddmFormInstanceImpl.setSettingsDDMFormValues(_ddmFormValues);
 
 		return ddmFormInstanceImpl;
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMFormInstanceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMFormInstanceImpl.java
@@ -65,6 +65,8 @@ public class DDMFormInstanceImpl extends DDMFormInstanceBaseImpl {
 			_ddmFormValues =
 				DDMFormInstanceLocalServiceUtil.
 					getFormInstanceSettingsFormValues(this);
+
+			ddmFormValuesUpdateEntityCacheConsumer.accept(_ddmFormValues);
 		}
 
 		return _ddmFormValues;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMFormInstanceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMFormInstanceImpl.java
@@ -60,7 +60,7 @@ public class DDMFormInstanceImpl extends DDMFormInstanceBaseImpl {
 	}
 
 	@Override
-	public DDMFormValues getSettingsDDMFormValues() throws PortalException {
+	public DDMFormValues getSettingsDDMFormValues() {
 		if (_ddmFormValues == null) {
 			_ddmFormValues =
 				DDMFormInstanceLocalServiceUtil.
@@ -108,7 +108,14 @@ public class DDMFormInstanceImpl extends DDMFormInstanceBaseImpl {
 		_formInstanceSettings = null;
 	}
 
-	@CacheField(methodName = "DDMFormValues", propagateToInterface = true)
+	@Override
+	public void setSettingsDDMFormValues(DDMFormValues ddmFormValues) {
+		_ddmFormValues = ddmFormValues;
+	}
+
+	@CacheField(
+		methodName = "SettingsDDMFormValues", propagateToInterface = true
+	)
 	private DDMFormValues _ddmFormValues;
 
 	private DDMFormInstanceSettings _formInstanceSettings;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMFormInstanceModelImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMFormInstanceModelImpl.java
@@ -953,12 +953,12 @@ public class DDMFormInstanceModelImpl
 	}
 
 	public com.liferay.dynamic.data.mapping.storage.DDMFormValues
-		getDDMFormValues() {
+		getSettingsDDMFormValues() {
 
 		return null;
 	}
 
-	public void setDDMFormValues(
+	public void setSettingsDDMFormValues(
 		com.liferay.dynamic.data.mapping.storage.DDMFormValues ddmFormValues) {
 	}
 
@@ -1246,7 +1246,7 @@ public class DDMFormInstanceModelImpl
 
 		_setModifiedDate = false;
 
-		setDDMFormValues(null);
+		setSettingsDDMFormValues(null);
 
 		_columnBitmask = 0;
 	}
@@ -1356,9 +1356,9 @@ public class DDMFormInstanceModelImpl
 			ddmFormInstanceCacheModel.lastPublishDate = Long.MIN_VALUE;
 		}
 
-		setDDMFormValues(null);
+		setSettingsDDMFormValues(null);
 
-		ddmFormInstanceCacheModel._ddmFormValues = getDDMFormValues();
+		ddmFormInstanceCacheModel._ddmFormValues = getSettingsDDMFormValues();
 
 		return ddmFormInstanceCacheModel;
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMFormInstanceModelImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMFormInstanceModelImpl.java
@@ -10,8 +10,10 @@ import com.liferay.dynamic.data.mapping.model.DDMFormInstanceModel;
 import com.liferay.expando.kernel.model.ExpandoBridge;
 import com.liferay.expando.kernel.util.ExpandoBridgeFactoryUtil;
 import com.liferay.exportimport.kernel.lar.StagedModelType;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
+import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSON;
@@ -31,6 +33,8 @@ import com.liferay.portal.kernel.util.Validator;
 
 import java.io.Serializable;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationHandler;
 
 import java.sql.Blob;
@@ -46,6 +50,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -1356,9 +1361,17 @@ public class DDMFormInstanceModelImpl
 			ddmFormInstanceCacheModel.lastPublishDate = Long.MIN_VALUE;
 		}
 
-		setSettingsDDMFormValues(null);
+		try {
+			setSettingsDDMFormValues(null);
 
-		ddmFormInstanceCacheModel._ddmFormValues = getSettingsDDMFormValues();
+			ddmFormInstanceCacheModel.ddmFormValues =
+				(com.liferay.dynamic.data.mapping.storage.DDMFormValues)
+					_ddmFormValuesMethodHandle.invokeExact(
+						(DDMFormInstanceImpl)this);
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
 
 		return ddmFormInstanceCacheModel;
 	}
@@ -1555,6 +1568,38 @@ public class DDMFormInstanceModelImpl
 	}
 
 	private long _columnBitmask;
+
+	protected final transient Consumer
+		<com.liferay.dynamic.data.mapping.storage.DDMFormValues>
+			ddmFormValuesUpdateEntityCacheConsumer = ddmFormValues -> {
+				DDMFormInstanceCacheModel ddmFormInstanceCacheModel =
+					EntityCacheUtil.fetchCacheModel(
+						DDMFormInstanceImpl.class, _formInstanceId,
+						DDMFormInstanceCacheModel.class);
+
+				if ((ddmFormInstanceCacheModel != null) &&
+					(ddmFormInstanceCacheModel.getMvccVersion() ==
+						getMvccVersion())) {
+
+					ddmFormInstanceCacheModel.ddmFormValues = ddmFormValues;
+				}
+			};
+
+	private static final MethodHandle _ddmFormValuesMethodHandle;
+
+	static {
+		MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+		try {
+			_ddmFormValuesMethodHandle = lookup.findGetter(
+				DDMFormInstanceImpl.class, "_ddmFormValues",
+				com.liferay.dynamic.data.mapping.storage.DDMFormValues.class);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ExceptionInInitializerError(reflectiveOperationException);
+		}
+	}
+
 	private DDMFormInstance _escapedModel;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMStructureCacheModel.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMStructureCacheModel.java
@@ -7,6 +7,7 @@ package com.liferay.dynamic.data.mapping.model.impl;
 
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.petra.lang.HashUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.CacheModel;
 import com.liferay.portal.kernel.model.MVCCModel;
@@ -15,6 +16,9 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 
 import java.util.Date;
 import java.util.Map;
@@ -234,11 +238,17 @@ public class DDMStructureCacheModel
 
 		ddmStructureImpl.resetOriginalValues();
 
-		ddmStructureImpl.setClassName(_className);
+		try {
+			_classNameMethodHandle.invokeExact(ddmStructureImpl, className);
 
-		ddmStructureImpl.setDDMForm(_ddmForm);
+			_ddmFormMethodHandle.invokeExact(ddmStructureImpl, ddmForm);
 
-		ddmStructureImpl.setDDMFormFieldsMap(_ddmFormFieldsMap);
+			_ddmFormFieldsMapMethodHandle.invokeExact(
+				ddmStructureImpl, ddmFormFieldsMap);
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
 
 		return ddmStructureImpl;
 	}
@@ -280,11 +290,11 @@ public class DDMStructureCacheModel
 		type = objectInput.readInt();
 		lastPublishDate = objectInput.readLong();
 
-		_className = (String)objectInput.readObject();
-		_ddmForm =
+		className = (String)objectInput.readObject();
+		ddmForm =
 			(com.liferay.dynamic.data.mapping.model.DDMForm)
 				objectInput.readObject();
-		_ddmFormFieldsMap = (Map)objectInput.readObject();
+		ddmFormFieldsMap = (Map)objectInput.readObject();
 	}
 
 	@Override
@@ -383,9 +393,11 @@ public class DDMStructureCacheModel
 		objectOutput.writeInt(type);
 		objectOutput.writeLong(lastPublishDate);
 
-		objectOutput.writeObject(_className);
-		objectOutput.writeObject(_ddmForm);
-		objectOutput.writeObject(_ddmFormFieldsMap);
+		objectOutput.writeObject(className);
+
+		objectOutput.writeObject(ddmForm);
+
+		objectOutput.writeObject(ddmFormFieldsMap);
 	}
 
 	public long mvccVersion;
@@ -411,8 +423,31 @@ public class DDMStructureCacheModel
 	public String storageType;
 	public int type;
 	public long lastPublishDate;
-	public String _className;
-	public com.liferay.dynamic.data.mapping.model.DDMForm _ddmForm;
-	public Map _ddmFormFieldsMap;
+	public volatile String className;
+	public volatile com.liferay.dynamic.data.mapping.model.DDMForm ddmForm;
+	public volatile Map ddmFormFieldsMap;
+
+	private static final MethodHandle _classNameMethodHandle;
+	private static final MethodHandle _ddmFormMethodHandle;
+	private static final MethodHandle _ddmFormFieldsMapMethodHandle;
+
+	static {
+		MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+		try {
+			_classNameMethodHandle = lookup.findSetter(
+				DDMStructureImpl.class, "_className", String.class);
+
+			_ddmFormMethodHandle = lookup.findSetter(
+				DDMStructureImpl.class, "_ddmForm",
+				com.liferay.dynamic.data.mapping.model.DDMForm.class);
+
+			_ddmFormFieldsMapMethodHandle = lookup.findSetter(
+				DDMStructureImpl.class, "_ddmFormFieldsMap", Map.class);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ExceptionInInitializerError(reflectiveOperationException);
+		}
+	}
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMStructureImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMStructureImpl.java
@@ -48,6 +48,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 
 /**
  * @author Brian Wing Shun Chan
@@ -101,7 +102,7 @@ public class DDMStructureImpl extends DDMStructureBaseImpl {
 
 	@Override
 	public String[] getAvailableLanguageIds() {
-		DDMForm ddmForm = _getDDMForm();
+		DDMForm ddmForm = _getDDMForm(ddmFormUpdateEntityCacheConsumer);
 
 		Set<Locale> availableLocales = ddmForm.getAvailableLocales();
 
@@ -122,6 +123,8 @@ public class DDMStructureImpl extends DDMStructureBaseImpl {
 	public String getClassName() {
 		if (_className == null) {
 			_className = PortalUtil.getClassName(getClassNameId());
+
+			classNameUpdateEntityCacheConsumer.accept(_className);
 		}
 
 		return _className;
@@ -129,7 +132,7 @@ public class DDMStructureImpl extends DDMStructureBaseImpl {
 
 	@Override
 	public DDMForm getDDMForm() {
-		return new DDMForm(_getDDMForm());
+		return new DDMForm(_getDDMForm(ddmFormUpdateEntityCacheConsumer));
 	}
 
 	@Override
@@ -165,9 +168,11 @@ public class DDMStructureImpl extends DDMStructureBaseImpl {
 	@Override
 	public Map<String, DDMFormField> getDDMFormFieldsMap() {
 		if (_ddmFormFieldsMap == null) {
-			DDMForm ddmForm = _getDDMForm();
+			DDMForm ddmForm = _getDDMForm(ddmFormUpdateEntityCacheConsumer);
 
 			_ddmFormFieldsMap = ddmForm.getDDMFormFieldsMap(true);
+
+			ddmFormFieldsMapUpdateEntityCacheConsumer.accept(_ddmFormFieldsMap);
 		}
 
 		return _ddmFormFieldsMap;
@@ -198,7 +203,7 @@ public class DDMStructureImpl extends DDMStructureBaseImpl {
 
 	@Override
 	public String getDefaultLanguageId() {
-		DDMForm ddmForm = _getDDMForm();
+		DDMForm ddmForm = _getDDMForm(ddmFormUpdateEntityCacheConsumer);
 
 		return LocaleUtil.toLanguageId(ddmForm.getDefaultLocale());
 	}
@@ -449,7 +454,7 @@ public class DDMStructureImpl extends DDMStructureBaseImpl {
 
 	@Override
 	public boolean hasFieldByFieldReference(String fieldReference) {
-		DDMForm ddmForm = _getDDMForm();
+		DDMForm ddmForm = _getDDMForm(ddmFormUpdateEntityCacheConsumer);
 
 		DDMFormField ddmFormField = _fetchDDMFormFieldByFieldReference(
 			ddmForm.getDDMFormFields(), fieldReference);
@@ -597,7 +602,9 @@ public class DDMStructureImpl extends DDMStructureBaseImpl {
 		return null;
 	}
 
-	private DDMForm _getDDMForm() {
+	private DDMForm _getDDMForm(
+		Consumer<DDMForm> ddmFormUpdateEntityCacheConsumer) {
+
 		if (_ddmForm == null) {
 			DDMFormDeserializerDeserializeRequest.Builder builder =
 				DDMFormDeserializerDeserializeRequest.Builder.newBuilder(
@@ -619,6 +626,8 @@ public class DDMStructureImpl extends DDMStructureBaseImpl {
 					_setNestedDDMFormFields(ddmFormField);
 				}
 			}
+
+			ddmFormUpdateEntityCacheConsumer.accept(_ddmForm);
 		}
 
 		return _ddmForm;
@@ -652,7 +661,7 @@ public class DDMStructureImpl extends DDMStructureBaseImpl {
 	private DDMFormField _getDDMFormFieldByFieldReference(String fieldReference)
 		throws PortalException {
 
-		DDMForm ddmForm = _getDDMForm();
+		DDMForm ddmForm = _getDDMForm(ddmFormUpdateEntityCacheConsumer);
 
 		DDMFormField ddmFormField = _fetchDDMFormFieldByFieldReference(
 			ddmForm.getDDMFormFields(), fieldReference);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMStructureLayoutCacheModel.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMStructureLayoutCacheModel.java
@@ -7,6 +7,7 @@ package com.liferay.dynamic.data.mapping.model.impl;
 
 import com.liferay.dynamic.data.mapping.model.DDMStructureLayout;
 import com.liferay.petra.lang.HashUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.CacheModel;
 import com.liferay.portal.kernel.model.MVCCModel;
@@ -15,6 +16,9 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 
 import java.util.Date;
 
@@ -183,7 +187,13 @@ public class DDMStructureLayoutCacheModel
 
 		ddmStructureLayoutImpl.resetOriginalValues();
 
-		ddmStructureLayoutImpl.setDDMFormLayout(_ddmFormLayout);
+		try {
+			_ddmFormLayoutMethodHandle.invokeExact(
+				ddmStructureLayoutImpl, ddmFormLayout);
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
 
 		return ddmStructureLayoutImpl;
 	}
@@ -216,7 +226,7 @@ public class DDMStructureLayoutCacheModel
 		description = (String)objectInput.readObject();
 		definition = (String)objectInput.readObject();
 
-		_ddmFormLayout =
+		ddmFormLayout =
 			(com.liferay.dynamic.data.mapping.model.DDMFormLayout)
 				objectInput.readObject();
 	}
@@ -284,7 +294,7 @@ public class DDMStructureLayoutCacheModel
 			objectOutput.writeObject(definition);
 		}
 
-		objectOutput.writeObject(_ddmFormLayout);
+		objectOutput.writeObject(ddmFormLayout);
 	}
 
 	public long mvccVersion;
@@ -303,6 +313,22 @@ public class DDMStructureLayoutCacheModel
 	public String name;
 	public String description;
 	public String definition;
-	public com.liferay.dynamic.data.mapping.model.DDMFormLayout _ddmFormLayout;
+	public volatile com.liferay.dynamic.data.mapping.model.DDMFormLayout
+		ddmFormLayout;
+
+	private static final MethodHandle _ddmFormLayoutMethodHandle;
+
+	static {
+		MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+		try {
+			_ddmFormLayoutMethodHandle = lookup.findSetter(
+				DDMStructureLayoutImpl.class, "_ddmFormLayout",
+				com.liferay.dynamic.data.mapping.model.DDMFormLayout.class);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ExceptionInInitializerError(reflectiveOperationException);
+		}
+	}
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMStructureLayoutImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMStructureLayoutImpl.java
@@ -27,6 +27,8 @@ public class DDMStructureLayoutImpl extends DDMStructureLayoutBaseImpl {
 				_ddmFormLayout =
 					DDMStructureLayoutLocalServiceUtil.
 						getStructureLayoutDDMFormLayout(this);
+
+				ddmFormLayoutUpdateEntityCacheConsumer.accept(_ddmFormLayout);
 			}
 			catch (Exception exception) {
 				_log.error(exception);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMStructureLayoutImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMStructureLayoutImpl.java
@@ -54,6 +54,11 @@ public class DDMStructureLayoutImpl extends DDMStructureLayoutBaseImpl {
 		return ddmStructure.getStructureId();
 	}
 
+	@Override
+	public void setDDMFormLayout(DDMFormLayout ddmFormLayout) {
+		_ddmFormLayout = ddmFormLayout;
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		DDMStructureLayoutImpl.class);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMStructureLayoutModelImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMStructureLayoutModelImpl.java
@@ -10,8 +10,10 @@ import com.liferay.dynamic.data.mapping.model.DDMStructureLayoutModel;
 import com.liferay.expando.kernel.model.ExpandoBridge;
 import com.liferay.expando.kernel.util.ExpandoBridgeFactoryUtil;
 import com.liferay.exportimport.kernel.lar.StagedModelType;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
+import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSON;
@@ -31,6 +33,8 @@ import com.liferay.portal.kernel.util.Validator;
 
 import java.io.Serializable;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationHandler;
 
 import java.sql.Blob;
@@ -46,6 +50,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -1332,9 +1337,17 @@ public class DDMStructureLayoutModelImpl
 			ddmStructureLayoutCacheModel.definition = null;
 		}
 
-		setDDMFormLayout(null);
+		try {
+			setDDMFormLayout(null);
 
-		ddmStructureLayoutCacheModel._ddmFormLayout = getDDMFormLayout();
+			ddmStructureLayoutCacheModel.ddmFormLayout =
+				(com.liferay.dynamic.data.mapping.model.DDMFormLayout)
+					_ddmFormLayoutMethodHandle.invokeExact(
+						(DDMStructureLayoutImpl)this);
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
 
 		return ddmStructureLayoutCacheModel;
 	}
@@ -1523,6 +1536,38 @@ public class DDMStructureLayoutModelImpl
 	}
 
 	private long _columnBitmask;
+
+	protected final transient Consumer
+		<com.liferay.dynamic.data.mapping.model.DDMFormLayout>
+			ddmFormLayoutUpdateEntityCacheConsumer = ddmFormLayout -> {
+				DDMStructureLayoutCacheModel ddmStructureLayoutCacheModel =
+					EntityCacheUtil.fetchCacheModel(
+						DDMStructureLayoutImpl.class, _structureLayoutId,
+						DDMStructureLayoutCacheModel.class);
+
+				if ((ddmStructureLayoutCacheModel != null) &&
+					(ddmStructureLayoutCacheModel.getMvccVersion() ==
+						getMvccVersion())) {
+
+					ddmStructureLayoutCacheModel.ddmFormLayout = ddmFormLayout;
+				}
+			};
+
+	private static final MethodHandle _ddmFormLayoutMethodHandle;
+
+	static {
+		MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+		try {
+			_ddmFormLayoutMethodHandle = lookup.findGetter(
+				DDMStructureLayoutImpl.class, "_ddmFormLayout",
+				com.liferay.dynamic.data.mapping.model.DDMFormLayout.class);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ExceptionInInitializerError(reflectiveOperationException);
+		}
+	}
+
 	private DDMStructureLayout _escapedModel;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMStructureModelImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMStructureModelImpl.java
@@ -10,8 +10,10 @@ import com.liferay.dynamic.data.mapping.model.DDMStructureModel;
 import com.liferay.expando.kernel.model.ExpandoBridge;
 import com.liferay.expando.kernel.util.ExpandoBridgeFactoryUtil;
 import com.liferay.exportimport.kernel.lar.StagedModelType;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
+import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSON;
@@ -31,6 +33,8 @@ import com.liferay.portal.kernel.util.Validator;
 
 import java.io.Serializable;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationHandler;
 
 import java.sql.Blob;
@@ -46,6 +50,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -1606,17 +1611,31 @@ public class DDMStructureModelImpl
 			ddmStructureCacheModel.lastPublishDate = Long.MIN_VALUE;
 		}
 
-		setClassName(null);
+		try {
+			setClassName(null);
 
-		ddmStructureCacheModel._className = getClassName();
+			ddmStructureCacheModel.className =
+				(String)_classNameMethodHandle.invokeExact(
+					(DDMStructureImpl)this);
 
-		setDDMForm(null);
+			setDDMForm(null);
 
-		ddmStructureCacheModel._ddmForm = getDDMForm();
+			ddmStructureCacheModel.ddmForm =
+				(com.liferay.dynamic.data.mapping.model.DDMForm)
+					_ddmFormMethodHandle.invokeExact((DDMStructureImpl)this);
 
-		setDDMFormFieldsMap(null);
+			setDDMFormFieldsMap(null);
 
-		ddmStructureCacheModel._ddmFormFieldsMap = getDDMFormFieldsMap();
+			ddmStructureCacheModel.ddmFormFieldsMap =
+				(Map
+					<String,
+					 com.liferay.dynamic.data.mapping.model.DDMFormField>)
+						 _ddmFormFieldsMapMethodHandle.invokeExact(
+							 (DDMStructureImpl)this);
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
 
 		return ddmStructureCacheModel;
 	}
@@ -1834,6 +1853,78 @@ public class DDMStructureModelImpl
 	}
 
 	private long _columnBitmask;
+
+	protected final transient Consumer<String>
+		classNameUpdateEntityCacheConsumer = className -> {
+			DDMStructureCacheModel ddmStructureCacheModel =
+				EntityCacheUtil.fetchCacheModel(
+					DDMStructureImpl.class, _structureId,
+					DDMStructureCacheModel.class);
+
+			if ((ddmStructureCacheModel != null) &&
+				(ddmStructureCacheModel.getMvccVersion() == getMvccVersion())) {
+
+				ddmStructureCacheModel.className = className;
+			}
+		};
+
+	private static final MethodHandle _classNameMethodHandle;
+
+	protected final transient Consumer
+		<com.liferay.dynamic.data.mapping.model.DDMForm>
+			ddmFormUpdateEntityCacheConsumer = ddmForm -> {
+				DDMStructureCacheModel ddmStructureCacheModel =
+					EntityCacheUtil.fetchCacheModel(
+						DDMStructureImpl.class, _structureId,
+						DDMStructureCacheModel.class);
+
+				if ((ddmStructureCacheModel != null) &&
+					(ddmStructureCacheModel.getMvccVersion() ==
+						getMvccVersion())) {
+
+					ddmStructureCacheModel.ddmForm = ddmForm;
+				}
+			};
+
+	private static final MethodHandle _ddmFormMethodHandle;
+
+	protected final transient Consumer
+		<Map<String, com.liferay.dynamic.data.mapping.model.DDMFormField>>
+			ddmFormFieldsMapUpdateEntityCacheConsumer = ddmFormFieldsMap -> {
+				DDMStructureCacheModel ddmStructureCacheModel =
+					EntityCacheUtil.fetchCacheModel(
+						DDMStructureImpl.class, _structureId,
+						DDMStructureCacheModel.class);
+
+				if ((ddmStructureCacheModel != null) &&
+					(ddmStructureCacheModel.getMvccVersion() ==
+						getMvccVersion())) {
+
+					ddmStructureCacheModel.ddmFormFieldsMap = ddmFormFieldsMap;
+				}
+			};
+
+	private static final MethodHandle _ddmFormFieldsMapMethodHandle;
+
+	static {
+		MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+		try {
+			_classNameMethodHandle = lookup.findGetter(
+				DDMStructureImpl.class, "_className", String.class);
+
+			_ddmFormMethodHandle = lookup.findGetter(
+				DDMStructureImpl.class, "_ddmForm",
+				com.liferay.dynamic.data.mapping.model.DDMForm.class);
+
+			_ddmFormFieldsMapMethodHandle = lookup.findGetter(
+				DDMStructureImpl.class, "_ddmFormFieldsMap", Map.class);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ExceptionInInitializerError(reflectiveOperationException);
+		}
+	}
+
 	private DDMStructure _escapedModel;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMStructureVersionCacheModel.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMStructureVersionCacheModel.java
@@ -7,6 +7,7 @@ package com.liferay.dynamic.data.mapping.model.impl;
 
 import com.liferay.dynamic.data.mapping.model.DDMStructureVersion;
 import com.liferay.petra.lang.HashUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.CacheModel;
 import com.liferay.portal.kernel.model.MVCCModel;
@@ -15,6 +16,9 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 
 import java.util.Date;
 
@@ -201,7 +205,12 @@ public class DDMStructureVersionCacheModel
 
 		ddmStructureVersionImpl.resetOriginalValues();
 
-		ddmStructureVersionImpl.setDDMForm(_ddmForm);
+		try {
+			_ddmFormMethodHandle.invokeExact(ddmStructureVersionImpl, ddmForm);
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
 
 		return ddmStructureVersionImpl;
 	}
@@ -241,7 +250,7 @@ public class DDMStructureVersionCacheModel
 		statusByUserName = objectInput.readUTF();
 		statusDate = objectInput.readLong();
 
-		_ddmForm =
+		ddmForm =
 			(com.liferay.dynamic.data.mapping.model.DDMForm)
 				objectInput.readObject();
 	}
@@ -323,7 +332,7 @@ public class DDMStructureVersionCacheModel
 
 		objectOutput.writeLong(statusDate);
 
-		objectOutput.writeObject(_ddmForm);
+		objectOutput.writeObject(ddmForm);
 	}
 
 	public long mvccVersion;
@@ -346,6 +355,21 @@ public class DDMStructureVersionCacheModel
 	public long statusByUserId;
 	public String statusByUserName;
 	public long statusDate;
-	public com.liferay.dynamic.data.mapping.model.DDMForm _ddmForm;
+	public volatile com.liferay.dynamic.data.mapping.model.DDMForm ddmForm;
+
+	private static final MethodHandle _ddmFormMethodHandle;
+
+	static {
+		MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+		try {
+			_ddmFormMethodHandle = lookup.findSetter(
+				DDMStructureVersionImpl.class, "_ddmForm",
+				com.liferay.dynamic.data.mapping.model.DDMForm.class);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ExceptionInInitializerError(reflectiveOperationException);
+		}
+	}
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMStructureVersionImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMStructureVersionImpl.java
@@ -30,6 +30,8 @@ public class DDMStructureVersionImpl extends DDMStructureVersionBaseImpl {
 				_ddmForm =
 					DDMStructureVersionLocalServiceUtil.
 						getStructureVersionDDMForm(this);
+
+				ddmFormUpdateEntityCacheConsumer.accept(_ddmForm);
 			}
 			catch (Exception exception) {
 				_log.error(exception);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMStructureVersionModelImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMStructureVersionModelImpl.java
@@ -9,8 +9,10 @@ import com.liferay.dynamic.data.mapping.model.DDMStructureVersion;
 import com.liferay.dynamic.data.mapping.model.DDMStructureVersionModel;
 import com.liferay.expando.kernel.model.ExpandoBridge;
 import com.liferay.expando.kernel.util.ExpandoBridgeFactoryUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
+import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSON;
@@ -30,6 +32,8 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.io.Serializable;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationHandler;
 
 import java.sql.Blob;
@@ -45,6 +49,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -1464,9 +1469,17 @@ public class DDMStructureVersionModelImpl
 			ddmStructureVersionCacheModel.statusDate = Long.MIN_VALUE;
 		}
 
-		setDDMForm(null);
+		try {
+			setDDMForm(null);
 
-		ddmStructureVersionCacheModel._ddmForm = getDDMForm();
+			ddmStructureVersionCacheModel.ddmForm =
+				(com.liferay.dynamic.data.mapping.model.DDMForm)
+					_ddmFormMethodHandle.invokeExact(
+						(DDMStructureVersionImpl)this);
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
 
 		return ddmStructureVersionCacheModel;
 	}
@@ -1670,6 +1683,38 @@ public class DDMStructureVersionModelImpl
 	}
 
 	private long _columnBitmask;
+
+	protected final transient Consumer
+		<com.liferay.dynamic.data.mapping.model.DDMForm>
+			ddmFormUpdateEntityCacheConsumer = ddmForm -> {
+				DDMStructureVersionCacheModel ddmStructureVersionCacheModel =
+					EntityCacheUtil.fetchCacheModel(
+						DDMStructureVersionImpl.class, _structureVersionId,
+						DDMStructureVersionCacheModel.class);
+
+				if ((ddmStructureVersionCacheModel != null) &&
+					(ddmStructureVersionCacheModel.getMvccVersion() ==
+						getMvccVersion())) {
+
+					ddmStructureVersionCacheModel.ddmForm = ddmForm;
+				}
+			};
+
+	private static final MethodHandle _ddmFormMethodHandle;
+
+	static {
+		MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+		try {
+			_ddmFormMethodHandle = lookup.findGetter(
+				DDMStructureVersionImpl.class, "_ddmForm",
+				com.liferay.dynamic.data.mapping.model.DDMForm.class);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ExceptionInInitializerError(reflectiveOperationException);
+		}
+	}
+
 	private DDMStructureVersion _escapedModel;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMTemplateCacheModel.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMTemplateCacheModel.java
@@ -7,6 +7,7 @@ package com.liferay.dynamic.data.mapping.model.impl;
 
 import com.liferay.dynamic.data.mapping.model.DDMTemplate;
 import com.liferay.petra.lang.HashUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.CacheModel;
 import com.liferay.portal.kernel.model.MVCCModel;
@@ -15,6 +16,9 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 
 import java.util.Date;
 
@@ -269,7 +273,13 @@ public class DDMTemplateCacheModel
 
 		ddmTemplateImpl.resetOriginalValues();
 
-		ddmTemplateImpl.setResourceClassName(_resourceClassName);
+		try {
+			_resourceClassNameMethodHandle.invokeExact(
+				ddmTemplateImpl, resourceClassName);
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
 
 		return ddmTemplateImpl;
 	}
@@ -320,7 +330,7 @@ public class DDMTemplateCacheModel
 		smallImageURL = objectInput.readUTF();
 		lastPublishDate = objectInput.readLong();
 
-		_resourceClassName = (String)objectInput.readObject();
+		resourceClassName = (String)objectInput.readObject();
 	}
 
 	@Override
@@ -447,7 +457,7 @@ public class DDMTemplateCacheModel
 
 		objectOutput.writeLong(lastPublishDate);
 
-		objectOutput.writeObject(_resourceClassName);
+		objectOutput.writeObject(resourceClassName);
 	}
 
 	public long mvccVersion;
@@ -479,6 +489,20 @@ public class DDMTemplateCacheModel
 	public long smallImageId;
 	public String smallImageURL;
 	public long lastPublishDate;
-	public String _resourceClassName;
+	public volatile String resourceClassName;
+
+	private static final MethodHandle _resourceClassNameMethodHandle;
+
+	static {
+		MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+		try {
+			_resourceClassNameMethodHandle = lookup.findSetter(
+				DDMTemplateImpl.class, "_resourceClassName", String.class);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ExceptionInInitializerError(reflectiveOperationException);
+		}
+	}
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMTemplateImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMTemplateImpl.java
@@ -70,6 +70,9 @@ public class DDMTemplateImpl extends DDMTemplateBaseImpl {
 		if (_resourceClassName == null) {
 			_resourceClassName = PortalUtil.getClassName(
 				getResourceClassNameId());
+
+			resourceClassNameUpdateEntityCacheConsumer.accept(
+				_resourceClassName);
 		}
 
 		return _resourceClassName;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMTemplateModelImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMTemplateModelImpl.java
@@ -10,8 +10,10 @@ import com.liferay.dynamic.data.mapping.model.DDMTemplateModel;
 import com.liferay.expando.kernel.model.ExpandoBridge;
 import com.liferay.expando.kernel.util.ExpandoBridgeFactoryUtil;
 import com.liferay.exportimport.kernel.lar.StagedModelType;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
+import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSON;
@@ -31,6 +33,8 @@ import com.liferay.portal.kernel.util.Validator;
 
 import java.io.Serializable;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationHandler;
 
 import java.sql.Blob;
@@ -46,6 +50,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -1823,9 +1828,16 @@ public class DDMTemplateModelImpl
 			ddmTemplateCacheModel.lastPublishDate = Long.MIN_VALUE;
 		}
 
-		setResourceClassName(null);
+		try {
+			setResourceClassName(null);
 
-		ddmTemplateCacheModel._resourceClassName = getResourceClassName();
+			ddmTemplateCacheModel.resourceClassName =
+				(String)_resourceClassNameMethodHandle.invokeExact(
+					(DDMTemplateImpl)this);
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
 
 		return ddmTemplateCacheModel;
 	}
@@ -2068,6 +2080,35 @@ public class DDMTemplateModelImpl
 	}
 
 	private long _columnBitmask;
+
+	protected final transient Consumer<String>
+		resourceClassNameUpdateEntityCacheConsumer = resourceClassName -> {
+			DDMTemplateCacheModel ddmTemplateCacheModel =
+				EntityCacheUtil.fetchCacheModel(
+					DDMTemplateImpl.class, _templateId,
+					DDMTemplateCacheModel.class);
+
+			if ((ddmTemplateCacheModel != null) &&
+				(ddmTemplateCacheModel.getMvccVersion() == getMvccVersion())) {
+
+				ddmTemplateCacheModel.resourceClassName = resourceClassName;
+			}
+		};
+
+	private static final MethodHandle _resourceClassNameMethodHandle;
+
+	static {
+		MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+		try {
+			_resourceClassNameMethodHandle = lookup.findGetter(
+				DDMTemplateImpl.class, "_resourceClassName", String.class);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ExceptionInInitializerError(reflectiveOperationException);
+		}
+	}
+
 	private DDMTemplate _escapedModel;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceLocalServiceImpl.java
@@ -322,8 +322,7 @@ public class DDMFormInstanceLocalServiceImpl
 
 	@Override
 	public DDMFormValues getFormInstanceSettingsFormValues(
-			DDMFormInstance formInstance)
-		throws PortalException {
+		DDMFormInstance formInstance) {
 
 		return _getFormInstanceSettingsFormValues(formInstance.getSettings());
 	}
@@ -509,8 +508,7 @@ public class DDMFormInstanceLocalServiceImpl
 	}
 
 	private DDMFormValues _getFormInstanceSettingsFormValues(
-			String serializedSettingsDDMFormValues)
-		throws PortalException {
+		String serializedSettingsDDMFormValues) {
 
 		DDMForm ddmForm = DDMFormFactory.create(DDMFormInstanceSettings.class);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMFormInstancePersistenceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMFormInstancePersistenceImpl.java
@@ -3051,8 +3051,9 @@ public class DDMFormInstancePersistenceImpl
 					DDMFormInstanceModelImpl cachedDDMFormInstanceModelImpl =
 						(DDMFormInstanceModelImpl)cachedDDMFormInstance;
 
-					ddmFormInstanceModelImpl.setDDMFormValues(
-						cachedDDMFormInstanceModelImpl.getDDMFormValues());
+					ddmFormInstanceModelImpl.setSettingsDDMFormValues(
+						cachedDDMFormInstanceModelImpl.
+							getSettingsDDMFormValues());
 				}
 			}
 		}

--- a/modules/apps/portal-cache/portal-cache-impl/src/main/java/com/liferay/portal/cache/internal/dao/orm/EntityCacheImpl.java
+++ b/modules/apps/portal-cache/portal-cache-impl/src/main/java/com/liferay/portal/cache/internal/dao/orm/EntityCacheImpl.java
@@ -94,6 +94,22 @@ public class EntityCacheImpl
 	}
 
 	@Override
+	public <T extends CacheModel<?>> T fetchCacheModel(
+		Class<?> clazz, Serializable primaryKey, Class<T> cacheModelClass) {
+
+		PortalCache<Serializable, Serializable> portalCache = getPortalCache(
+			clazz);
+
+		Object result = portalCache.get(primaryKey);
+
+		if (cacheModelClass.isInstance(result)) {
+			return cacheModelClass.cast(result);
+		}
+
+		return null;
+	}
+
+	@Override
 	public Serializable getLocalCacheResult(
 		Class<?> clazz, Serializable primaryKey) {
 

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/bnd.bnd
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Workflow Kaleo API
 Bundle-SymbolicName: com.liferay.portal.workflow.kaleo.api
-Bundle-Version: 19.0.1
+Bundle-Version: 19.1.0
 Export-Package:\
 	com.liferay.portal.workflow.kaleo,\
 	com.liferay.portal.workflow.kaleo.constants,\

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoDefinition.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoDefinition.java
@@ -54,4 +54,6 @@ public interface KaleoDefinition extends KaleoDefinitionModel, PersistedModel {
 	public java.util.List<KaleoDefinitionVersion> getKaleoDefinitionVersions()
 		throws com.liferay.portal.kernel.exception.PortalException;
 
+	public void setContentAsXML(String contentAsXML);
+
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoDefinitionVersion.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoDefinitionVersion.java
@@ -59,4 +59,6 @@ public interface KaleoDefinitionVersion
 	public KaleoNode getKaleoStartNode()
 		throws com.liferay.portal.kernel.exception.PortalException;
 
+	public void setContentAsXML(String contentAsXML);
+
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoDefinitionVersionWrapper.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoDefinitionVersionWrapper.java
@@ -636,6 +636,11 @@ public class KaleoDefinitionVersionWrapper
 		model.setContent(content);
 	}
 
+	@Override
+	public void setContentAsXML(String contentAsXML) {
+		model.setContentAsXML(contentAsXML);
+	}
+
 	/**
 	 * Sets the create date of this kaleo definition version.
 	 *

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoDefinitionWrapper.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoDefinitionWrapper.java
@@ -523,6 +523,11 @@ public class KaleoDefinitionWrapper
 		model.setContent(content);
 	}
 
+	@Override
+	public void setContentAsXML(String contentAsXML) {
+		model.setContentAsXML(contentAsXML);
+	}
+
 	/**
 	 * Sets the create date of this kaleo definition.
 	 *

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/resources/com/liferay/portal/workflow/kaleo/model/packageinfo
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/resources/com/liferay/portal/workflow/kaleo/model/packageinfo
@@ -1,1 +1,1 @@
-version 5.6.0
+version 5.7.0

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/model/impl/KaleoDefinitionCacheModel.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/model/impl/KaleoDefinitionCacheModel.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.workflow.kaleo.model.impl;
 
 import com.liferay.petra.lang.HashUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.CacheModel;
 import com.liferay.portal.kernel.model.MVCCModel;
@@ -15,6 +16,9 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 
 import java.util.Date;
 
@@ -199,7 +203,13 @@ public class KaleoDefinitionCacheModel
 
 		kaleoDefinitionImpl.resetOriginalValues();
 
-		kaleoDefinitionImpl.setContentAsXML(_contentAsXML);
+		try {
+			_contentAsXMLMethodHandle.invokeExact(
+				kaleoDefinitionImpl, contentAsXML);
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
 
 		return kaleoDefinitionImpl;
 	}
@@ -234,7 +244,7 @@ public class KaleoDefinitionCacheModel
 
 		active = objectInput.readBoolean();
 
-		_contentAsXML = (String)objectInput.readObject();
+		contentAsXML = (String)objectInput.readObject();
 	}
 
 	@Override
@@ -314,7 +324,7 @@ public class KaleoDefinitionCacheModel
 
 		objectOutput.writeBoolean(active);
 
-		objectOutput.writeObject(_contentAsXML);
+		objectOutput.writeObject(contentAsXML);
 	}
 
 	public long mvccVersion;
@@ -335,6 +345,20 @@ public class KaleoDefinitionCacheModel
 	public String scope;
 	public int version;
 	public boolean active;
-	public String _contentAsXML;
+	public volatile String contentAsXML;
+
+	private static final MethodHandle _contentAsXMLMethodHandle;
+
+	static {
+		MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+		try {
+			_contentAsXMLMethodHandle = lookup.findSetter(
+				KaleoDefinitionImpl.class, "_contentAsXML", String.class);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ExceptionInInitializerError(reflectiveOperationException);
+		}
+	}
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/model/impl/KaleoDefinitionImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/model/impl/KaleoDefinitionImpl.java
@@ -28,6 +28,8 @@ public class KaleoDefinitionImpl extends KaleoDefinitionBaseImpl {
 
 		try {
 			_contentAsXML = WorkflowDefinitionContentUtil.toXML(getContent());
+
+			contentAsXMLUpdateEntityCacheConsumer.accept(_contentAsXML);
 		}
 		catch (WorkflowException workflowException) {
 			ReflectionUtil.throwException(workflowException);

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/model/impl/KaleoDefinitionImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/model/impl/KaleoDefinitionImpl.java
@@ -44,6 +44,11 @@ public class KaleoDefinitionImpl extends KaleoDefinitionBaseImpl {
 			getKaleoDefinitionVersions(getCompanyId(), getName());
 	}
 
+	@Override
+	public void setContentAsXML(String contentAsXML) {
+		_contentAsXML = contentAsXML;
+	}
+
 	@CacheField(propagateToInterface = true)
 	private String _contentAsXML;
 

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/model/impl/KaleoDefinitionModelImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/model/impl/KaleoDefinitionModelImpl.java
@@ -8,8 +8,10 @@ package com.liferay.portal.workflow.kaleo.model.impl;
 import com.liferay.expando.kernel.model.ExpandoBridge;
 import com.liferay.expando.kernel.util.ExpandoBridgeFactoryUtil;
 import com.liferay.exportimport.kernel.lar.StagedModelType;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
+import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSON;
@@ -31,6 +33,8 @@ import com.liferay.portal.workflow.kaleo.model.KaleoDefinitionModel;
 
 import java.io.Serializable;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationHandler;
 
 import java.sql.Blob;
@@ -46,6 +50,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -1294,9 +1299,16 @@ public class KaleoDefinitionModelImpl
 
 		kaleoDefinitionCacheModel.active = isActive();
 
-		setContentAsXML(null);
+		try {
+			setContentAsXML(null);
 
-		kaleoDefinitionCacheModel._contentAsXML = getContentAsXML();
+			kaleoDefinitionCacheModel.contentAsXML =
+				(String)_contentAsXMLMethodHandle.invokeExact(
+					(KaleoDefinitionImpl)this);
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
 
 		return kaleoDefinitionCacheModel;
 	}
@@ -1493,6 +1505,36 @@ public class KaleoDefinitionModelImpl
 	}
 
 	private long _columnBitmask;
+
+	protected final transient Consumer<String>
+		contentAsXMLUpdateEntityCacheConsumer = contentAsXML -> {
+			KaleoDefinitionCacheModel kaleoDefinitionCacheModel =
+				EntityCacheUtil.fetchCacheModel(
+					KaleoDefinitionImpl.class, _kaleoDefinitionId,
+					KaleoDefinitionCacheModel.class);
+
+			if ((kaleoDefinitionCacheModel != null) &&
+				(kaleoDefinitionCacheModel.getMvccVersion() ==
+					getMvccVersion())) {
+
+				kaleoDefinitionCacheModel.contentAsXML = contentAsXML;
+			}
+		};
+
+	private static final MethodHandle _contentAsXMLMethodHandle;
+
+	static {
+		MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+		try {
+			_contentAsXMLMethodHandle = lookup.findGetter(
+				KaleoDefinitionImpl.class, "_contentAsXML", String.class);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ExceptionInInitializerError(reflectiveOperationException);
+		}
+	}
+
 	private KaleoDefinition _escapedModel;
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/model/impl/KaleoDefinitionVersionCacheModel.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/model/impl/KaleoDefinitionVersionCacheModel.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.workflow.kaleo.model.impl;
 
 import com.liferay.petra.lang.HashUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.CacheModel;
 import com.liferay.portal.kernel.model.MVCCModel;
@@ -15,6 +16,9 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 
 import java.util.Date;
 
@@ -207,7 +211,13 @@ public class KaleoDefinitionVersionCacheModel
 
 		kaleoDefinitionVersionImpl.resetOriginalValues();
 
-		kaleoDefinitionVersionImpl.setContentAsXML(_contentAsXML);
+		try {
+			_contentAsXMLMethodHandle.invokeExact(
+				kaleoDefinitionVersionImpl, contentAsXML);
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
 
 		return kaleoDefinitionVersionImpl;
 	}
@@ -246,7 +256,7 @@ public class KaleoDefinitionVersionCacheModel
 		statusByUserName = objectInput.readUTF();
 		statusDate = objectInput.readLong();
 
-		_contentAsXML = (String)objectInput.readObject();
+		contentAsXML = (String)objectInput.readObject();
 	}
 
 	@Override
@@ -325,7 +335,7 @@ public class KaleoDefinitionVersionCacheModel
 
 		objectOutput.writeLong(statusDate);
 
-		objectOutput.writeObject(_contentAsXML);
+		objectOutput.writeObject(contentAsXML);
 	}
 
 	public long mvccVersion;
@@ -348,6 +358,21 @@ public class KaleoDefinitionVersionCacheModel
 	public long statusByUserId;
 	public String statusByUserName;
 	public long statusDate;
-	public String _contentAsXML;
+	public volatile String contentAsXML;
+
+	private static final MethodHandle _contentAsXMLMethodHandle;
+
+	static {
+		MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+		try {
+			_contentAsXMLMethodHandle = lookup.findSetter(
+				KaleoDefinitionVersionImpl.class, "_contentAsXML",
+				String.class);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ExceptionInInitializerError(reflectiveOperationException);
+		}
+	}
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/model/impl/KaleoDefinitionVersionImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/model/impl/KaleoDefinitionVersionImpl.java
@@ -30,6 +30,8 @@ public class KaleoDefinitionVersionImpl extends KaleoDefinitionVersionBaseImpl {
 
 		try {
 			_contentAsXML = WorkflowDefinitionContentUtil.toXML(getContent());
+
+			contentAsXMLUpdateEntityCacheConsumer.accept(_contentAsXML);
 		}
 		catch (WorkflowException workflowException) {
 			ReflectionUtil.throwException(workflowException);

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/model/impl/KaleoDefinitionVersionImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/model/impl/KaleoDefinitionVersionImpl.java
@@ -49,6 +49,11 @@ public class KaleoDefinitionVersionImpl extends KaleoDefinitionVersionBaseImpl {
 		return KaleoNodeLocalServiceUtil.getKaleoNode(getStartKaleoNodeId());
 	}
 
+	@Override
+	public void setContentAsXML(String contentAsXML) {
+		_contentAsXML = contentAsXML;
+	}
+
 	protected int getVersion(String version) {
 		int[] versionParts = StringUtil.split(version, StringPool.PERIOD, 0);
 

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/model/impl/KaleoDefinitionVersionModelImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/model/impl/KaleoDefinitionVersionModelImpl.java
@@ -7,8 +7,10 @@ package com.liferay.portal.workflow.kaleo.model.impl;
 
 import com.liferay.expando.kernel.model.ExpandoBridge;
 import com.liferay.expando.kernel.util.ExpandoBridgeFactoryUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
+import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSON;
@@ -30,6 +32,8 @@ import com.liferay.portal.workflow.kaleo.model.KaleoDefinitionVersionModel;
 
 import java.io.Serializable;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationHandler;
 
 import java.sql.Blob;
@@ -45,6 +49,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -1377,9 +1382,16 @@ public class KaleoDefinitionVersionModelImpl
 			kaleoDefinitionVersionCacheModel.statusDate = Long.MIN_VALUE;
 		}
 
-		setContentAsXML(null);
+		try {
+			setContentAsXML(null);
 
-		kaleoDefinitionVersionCacheModel._contentAsXML = getContentAsXML();
+			kaleoDefinitionVersionCacheModel.contentAsXML =
+				(String)_contentAsXMLMethodHandle.invokeExact(
+					(KaleoDefinitionVersionImpl)this);
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
 
 		return kaleoDefinitionVersionCacheModel;
 	}
@@ -1572,6 +1584,37 @@ public class KaleoDefinitionVersionModelImpl
 	}
 
 	private long _columnBitmask;
+
+	protected final transient Consumer<String>
+		contentAsXMLUpdateEntityCacheConsumer = contentAsXML -> {
+			KaleoDefinitionVersionCacheModel kaleoDefinitionVersionCacheModel =
+				EntityCacheUtil.fetchCacheModel(
+					KaleoDefinitionVersionImpl.class, _kaleoDefinitionVersionId,
+					KaleoDefinitionVersionCacheModel.class);
+
+			if ((kaleoDefinitionVersionCacheModel != null) &&
+				(kaleoDefinitionVersionCacheModel.getMvccVersion() ==
+					getMvccVersion())) {
+
+				kaleoDefinitionVersionCacheModel.contentAsXML = contentAsXML;
+			}
+		};
+
+	private static final MethodHandle _contentAsXMLMethodHandle;
+
+	static {
+		MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+		try {
+			_contentAsXMLMethodHandle = lookup.findGetter(
+				KaleoDefinitionVersionImpl.class, "_contentAsXML",
+				String.class);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ExceptionInInitializerError(reflectiveOperationException);
+		}
+	}
+
 	private KaleoDefinitionVersion _escapedModel;
 
 }

--- a/modules/util/portal-tools-service-builder-test-service/build.gradle
+++ b/modules/util/portal-tools-service-builder-test-service/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-io")
 	compileOnly project(":core:petra:petra-lang")
+	compileOnly project(":core:petra:petra-reflect")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
 	compileOnly project(":util:portal-tools-service-builder-test-api")

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/CacheFieldEntryCacheModel.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/CacheFieldEntryCacheModel.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.tools.service.builder.test.model.impl;
 
 import com.liferay.petra.lang.HashUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.CacheModel;
 import com.liferay.portal.tools.service.builder.test.model.CacheFieldEntry;
@@ -14,6 +15,9 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 
 /**
  * The cache model class for representing CacheFieldEntry in entity cache.
@@ -80,7 +84,12 @@ public class CacheFieldEntryCacheModel
 
 		cacheFieldEntryImpl.resetOriginalValues();
 
-		cacheFieldEntryImpl.setNickname(_nickname);
+		try {
+			_nicknameMethodHandle.invokeExact(cacheFieldEntryImpl, nickname);
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
 
 		return cacheFieldEntryImpl;
 	}
@@ -94,7 +103,7 @@ public class CacheFieldEntryCacheModel
 		groupId = objectInput.readLong();
 		name = objectInput.readUTF();
 
-		_nickname = (String)objectInput.readObject();
+		nickname = (String)objectInput.readObject();
 	}
 
 	@Override
@@ -110,12 +119,26 @@ public class CacheFieldEntryCacheModel
 			objectOutput.writeUTF(name);
 		}
 
-		objectOutput.writeObject(_nickname);
+		objectOutput.writeObject(nickname);
 	}
 
 	public long cacheFieldEntryId;
 	public long groupId;
 	public String name;
-	public String _nickname;
+	public volatile String nickname;
+
+	private static final MethodHandle _nicknameMethodHandle;
+
+	static {
+		MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+		try {
+			_nicknameMethodHandle = lookup.findSetter(
+				CacheFieldEntryImpl.class, "_nickname", String.class);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ExceptionInInitializerError(reflectiveOperationException);
+		}
+	}
 
 }

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/CacheFieldEntryImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/CacheFieldEntryImpl.java
@@ -18,6 +18,8 @@ public class CacheFieldEntryImpl extends CacheFieldEntryBaseImpl {
 			_nickname = "Nickname_" + getName();
 		}
 
+		nicknameUpdateEntityCacheConsumer.accept(_nickname);
+
 		return _nickname;
 	}
 

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/CacheFieldEntryModelImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/CacheFieldEntryModelImpl.java
@@ -7,8 +7,10 @@ package com.liferay.portal.tools.service.builder.test.model.impl;
 
 import com.liferay.expando.kernel.model.ExpandoBridge;
 import com.liferay.expando.kernel.util.ExpandoBridgeFactoryUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
+import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.model.CacheModel;
 import com.liferay.portal.kernel.model.ModelWrapper;
 import com.liferay.portal.kernel.model.impl.BaseModelImpl;
@@ -21,6 +23,8 @@ import com.liferay.portal.tools.service.builder.test.model.CacheFieldEntryModel;
 
 import java.io.Serializable;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationHandler;
 
 import java.sql.Blob;
@@ -33,6 +37,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -486,9 +491,16 @@ public class CacheFieldEntryModelImpl
 			cacheFieldEntryCacheModel.name = null;
 		}
 
-		setNickname(null);
+		try {
+			setNickname(null);
 
-		cacheFieldEntryCacheModel._nickname = getNickname();
+			cacheFieldEntryCacheModel.nickname =
+				(String)_nicknameMethodHandle.invokeExact(
+					(CacheFieldEntryImpl)this);
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
 
 		return cacheFieldEntryCacheModel;
 	}
@@ -609,6 +621,33 @@ public class CacheFieldEntryModelImpl
 	}
 
 	private long _columnBitmask;
+
+	protected final transient Consumer<String>
+		nicknameUpdateEntityCacheConsumer = nickname -> {
+			CacheFieldEntryCacheModel cacheFieldEntryCacheModel =
+				EntityCacheUtil.fetchCacheModel(
+					CacheFieldEntryImpl.class, _cacheFieldEntryId,
+					CacheFieldEntryCacheModel.class);
+
+			if (cacheFieldEntryCacheModel != null) {
+				cacheFieldEntryCacheModel.nickname = nickname;
+			}
+		};
+
+	private static final MethodHandle _nicknameMethodHandle;
+
+	static {
+		MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+		try {
+			_nicknameMethodHandle = lookup.findGetter(
+				CacheFieldEntryImpl.class, "_nickname", String.class);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ExceptionInInitializerError(reflectiveOperationException);
+		}
+	}
+
 	private CacheFieldEntry _escapedModel;
 
 }

--- a/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
+++ b/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
@@ -5625,12 +5625,6 @@ public class ServiceBuilder {
 	}
 
 	private List<JavaMethod> _getMethods(JavaClass javaClass) {
-		return _getMethods(javaClass, false);
-	}
-
-	private List<JavaMethod> _getMethods(
-		JavaClass javaClass, boolean superclasses) {
-
 		List<JavaMethod> methods = new ArrayList<>();
 
 		List<String> cacheFieldMethods = new ArrayList<>();
@@ -5674,7 +5668,7 @@ public class ServiceBuilder {
 			}
 		}
 
-		for (JavaMethod javaMethod : javaClass.getMethods(superclasses)) {
+		for (JavaMethod javaMethod : javaClass.getMethods(false)) {
 			if (!cacheFieldMethods.contains(javaMethod.getName())) {
 				methods.add(javaMethod);
 			}

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/model_cache.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/model_cache.ftl
@@ -9,6 +9,7 @@ import ${apiPackagePath}.model.${entity.name};
 	import ${apiPackagePath}.service.persistence.${entity.name}PK;
 </#if>
 
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.model.CacheModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 
@@ -17,6 +18,9 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.Serializable;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 
 import java.math.BigDecimal;
 
@@ -151,11 +155,20 @@ public class ${entity.name}CacheModel implements CacheModel<${entity.name}>, Ext
 
 		${entity.variableName}Impl.resetOriginalValues();
 
-		<#list cacheFields as cacheField>
-			<#assign methodName = serviceBuilder.getCacheFieldMethodName(cacheField) />
+		<#if cacheFields?size != 0>
+			try {
+				<#list cacheFields as cacheField>
+					<#assign
+						variableName = serviceBuilder.getVariableName(cacheField)
+					/>
 
-			${entity.variableName}Impl.set${methodName}(${cacheField.name});
-		</#list>
+					_${variableName}MethodHandle.invokeExact(${entity.variableName}Impl, ${variableName});
+				</#list>
+			}
+			catch (Throwable throwable) {
+				ReflectionUtil.throwException(throwable);
+			}
+		</#if>
 
 		return ${entity.variableName}Impl;
 	}
@@ -202,7 +215,8 @@ public class ${entity.name}CacheModel implements CacheModel<${entity.name}>, Ext
 		</#list>
 
 		<#list cacheFields as cacheField>
-			${cacheField.name} = (${serviceBuilder.getGenericValue(cacheField.type)})objectInput.readObject();
+			<#assign variableName = serviceBuilder.getVariableName(cacheField) />
+			${variableName} = (${serviceBuilder.getGenericValue(cacheField.type)})objectInput.readObject();
 		</#list>
 
 		<#if entity.hasCompoundPK()>
@@ -252,7 +266,9 @@ public class ${entity.name}CacheModel implements CacheModel<${entity.name}>, Ext
 		</#list>
 
 		<#list cacheFields as cacheField>
-			objectOutput.writeObject(${cacheField.name});
+			<#assign variableName = serviceBuilder.getVariableName(cacheField) />
+
+			objectOutput.writeObject(${variableName});
 		</#list>
 	}
 
@@ -269,11 +285,41 @@ public class ${entity.name}CacheModel implements CacheModel<${entity.name}>, Ext
 	</#list>
 
 	<#list cacheFields as cacheField>
-		public ${serviceBuilder.getGenericValue(cacheField.type)} ${cacheField.name};
+		<#assign variableName = serviceBuilder.getVariableName(cacheField) />
+
+		public volatile ${serviceBuilder.getGenericValue(cacheField.type)} ${variableName};
 	</#list>
 
 	<#if entity.hasCompoundPK()>
 		public transient ${entity.name}PK ${entity.PKVariableName};
 	</#if>
 
+	<#list cacheFields as cacheField>
+		<#assign
+			variableName = serviceBuilder.getVariableName(cacheField)
+		/>
+
+		private static final MethodHandle _${variableName}MethodHandle;
+	</#list>
+
+	<#if cacheFields?size != 0>
+		static {
+			MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+			try {
+				<#list cacheFields as cacheField>
+					<#assign
+						variableName = serviceBuilder.getVariableName(cacheField)
+					/>
+
+					_${variableName}MethodHandle = lookup.findSetter(
+						${entity.name}Impl.class, "${cacheField.name}", ${cacheField.type.canonicalName}.class);
+				</#list>
+			}
+			catch (ReflectiveOperationException reflectiveOperationException) {
+				throw new ExceptionInInitializerError(
+					reflectiveOperationException);
+			}
+		}
+	</#if>
 }

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/model_impl.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/model_impl.ftl
@@ -54,7 +54,9 @@ import ${apiPackagePath}.service.${entity.name}LocalServiceUtil;
 import com.liferay.expando.kernel.model.ExpandoBridge;
 import com.liferay.expando.kernel.util.ExpandoBridgeFactoryUtil;
 import com.liferay.exportimport.kernel.lar.StagedModelType;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
+import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.exception.NoSuchModelException;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -62,6 +64,7 @@ import com.liferay.portal.kernel.json.JSON;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.CacheModel;
 import com.liferay.portal.kernel.model.ContainerModel;
+import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ModelWrapper;
 import com.liferay.portal.kernel.model.TrashedModel;
 import com.liferay.portal.kernel.model.User;
@@ -81,6 +84,8 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.io.Serializable;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
 
@@ -101,6 +106,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -1103,6 +1109,7 @@ public class ${entity.name}ModelImpl extends BaseModelImpl<${entity.name}> imple
 			variableName = serviceBuilder.getVariableName(cacheField)
 			methodName = serviceBuilder.getCacheFieldMethodName(cacheField)
 			typeGenericsName = serviceBuilder.getTypeGenericsName(cacheField.getType())
+			typeWrapperName = serviceBuilder.getPrimitiveObj(typeGenericsName)
 		/>
 
 		<#if !stringUtil.equals(methodName, "DefaultLanguageId")>
@@ -1835,15 +1842,26 @@ public class ${entity.name}ModelImpl extends BaseModelImpl<${entity.name}> imple
 			</#if>
 		</#list>
 
-		<#list cacheFields as cacheField>
-			<#assign methodName = serviceBuilder.getCacheFieldMethodName(cacheField) />
+		<#if cacheFields?size != 0>
+			try {
+				<#list cacheFields as cacheField>
+					<#assign
+						variableName = serviceBuilder.getVariableName(cacheField)
+						methodName = serviceBuilder.getCacheFieldMethodName(cacheField)
+						typeGenericsName = serviceBuilder.getTypeGenericsName(cacheField.getType())
+					/>
 
-			<#if !serviceBuilder.isCacheFieldPermanent(cacheField)>
-				set${methodName}(null);
-			</#if>
+					<#if !serviceBuilder.isCacheFieldPermanent(cacheField)>
+						set${methodName}(null);
+					</#if>
 
-			${entity.variableName}CacheModel.${cacheField.name} = get${methodName}();
-		</#list>
+					${entity.variableName}CacheModel.${variableName} = (${typeGenericsName})_${variableName}MethodHandle.invokeExact((${entity.name}Impl)this);
+				</#list>
+			}
+			catch (Throwable throwable) {
+				ReflectionUtil.throwException(throwable);
+			}
+		</#if>
 
 		return ${entity.variableName}CacheModel;
 	}
@@ -2114,6 +2132,52 @@ public class ${entity.name}ModelImpl extends BaseModelImpl<${entity.name}> imple
 		</#if>
 
 		private long _columnBitmask;
+	</#if>
+
+	<#list cacheFields as cacheField>
+		<#assign
+			variableName = serviceBuilder.getVariableName(cacheField)
+			typeWrapperName = serviceBuilder.getPrimitiveObj(serviceBuilder.getTypeGenericsName(cacheField.getType()))
+		/>
+
+		protected transient final Consumer<${typeWrapperName}> ${variableName}UpdateEntityCacheConsumer = ${variableName} -> {
+			${entity.name}CacheModel ${entity.variableName}CacheModel =
+				EntityCacheUtil.fetchCacheModel(
+					${entity.name}Impl.class,
+					_${entity.PKEntityColumns[0].name},
+					${entity.name}CacheModel.class);
+
+			if ((${entity.variableName}CacheModel != null)
+				<#if entity.isMvccEnabled()>
+				&& (${entity.variableName}CacheModel.getMvccVersion() == getMvccVersion())
+				</#if>
+				) {
+				${entity.variableName}CacheModel.${variableName} = ${variableName};
+			}
+		};
+
+		private static final MethodHandle _${variableName}MethodHandle;
+	</#list>
+
+	<#if cacheFields?size != 0>
+		static {
+			MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+			try {
+				<#list cacheFields as cacheField>
+					<#assign
+						variableName = serviceBuilder.getVariableName(cacheField)
+					/>
+
+					_${variableName}MethodHandle = lookup.findGetter(
+						${entity.name}Impl.class, "${cacheField.name}", ${cacheField.type.canonicalName}.class);
+				</#list>
+			}
+			catch (ReflectiveOperationException reflectiveOperationException) {
+				throw new ExceptionInInitializerError(
+					reflectiveOperationException);
+			}
+		}
 	</#if>
 
 	private ${entity.name} _escapedModel;

--- a/portal-impl/src/com/liferay/portal/model/impl/CompanyCacheModel.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/CompanyCacheModel.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.model.impl;
 
 import com.liferay.petra.lang.HashUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.CacheModel;
 import com.liferay.portal.kernel.model.Company;
@@ -15,6 +16,9 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 
 import java.util.Date;
 
@@ -253,9 +257,15 @@ public class CompanyCacheModel
 
 		companyImpl.resetOriginalValues();
 
-		companyImpl.setGroupId(_groupId);
+		try {
+			_groupIdMethodHandle.invokeExact(companyImpl, groupId);
 
-		companyImpl.setVirtualHostname(_virtualHostname);
+			_virtualHostnameMethodHandle.invokeExact(
+				companyImpl, virtualHostname);
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
 
 		return companyImpl;
 	}
@@ -293,8 +303,8 @@ public class CompanyCacheModel
 		indexNameCurrent = objectInput.readUTF();
 		indexNameNext = objectInput.readUTF();
 
-		_groupId = (long)objectInput.readObject();
-		_virtualHostname = (String)objectInput.readObject();
+		groupId = (long)objectInput.readObject();
+		virtualHostname = (String)objectInput.readObject();
 	}
 
 	@Override
@@ -419,8 +429,9 @@ public class CompanyCacheModel
 			objectOutput.writeUTF(indexNameNext);
 		}
 
-		objectOutput.writeObject(_groupId);
-		objectOutput.writeObject(_virtualHostname);
+		objectOutput.writeObject(groupId);
+
+		objectOutput.writeObject(virtualHostname);
 	}
 
 	public long mvccVersion;
@@ -446,7 +457,25 @@ public class CompanyCacheModel
 	public String size;
 	public String indexNameCurrent;
 	public String indexNameNext;
-	public long _groupId;
-	public String _virtualHostname;
+	public volatile long groupId;
+	public volatile String virtualHostname;
+
+	private static final MethodHandle _groupIdMethodHandle;
+	private static final MethodHandle _virtualHostnameMethodHandle;
+
+	static {
+		MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+		try {
+			_groupIdMethodHandle = lookup.findSetter(
+				CompanyImpl.class, "_groupId", long.class);
+
+			_virtualHostnameMethodHandle = lookup.findSetter(
+				CompanyImpl.class, "_virtualHostname", String.class);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ExceptionInInitializerError(reflectiveOperationException);
+		}
+	}
 
 }

--- a/portal-impl/src/com/liferay/portal/model/impl/CompanyImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/CompanyImpl.java
@@ -116,17 +116,7 @@ public class CompanyImpl extends CompanyBaseImpl {
 	public Group getGroup() throws PortalException {
 		if (getCompanyId() > CompanyConstants.SYSTEM) {
 			if (_group == null) {
-				if (_groupId == -1) {
-					_group = GroupLocalServiceUtil.fetchCompanyGroup(
-						getCompanyId());
-
-					if (_group != null) {
-						_groupId = _group.getGroupId();
-					}
-				}
-				else {
-					_group = GroupLocalServiceUtil.fetchGroup(_groupId);
-				}
+				_group = GroupLocalServiceUtil.fetchGroup(getGroupId());
 			}
 
 			return _group;
@@ -142,6 +132,8 @@ public class CompanyImpl extends CompanyBaseImpl {
 
 			if (_group != null) {
 				_groupId = _group.getGroupId();
+
+				groupIdUpdateEntityCacheConsumer.accept(_groupId);
 			}
 		}
 
@@ -281,6 +273,8 @@ public class CompanyImpl extends CompanyBaseImpl {
 		}
 
 		_virtualHostname = virtualHost.getHostname();
+
+		virtualHostnameUpdateEntityCacheConsumer.accept(_virtualHostname);
 
 		return _virtualHostname;
 	}

--- a/portal-impl/src/com/liferay/portal/model/impl/CompanyModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/CompanyModelImpl.java
@@ -7,8 +7,10 @@ package com.liferay.portal.model.impl;
 
 import com.liferay.expando.kernel.model.ExpandoBridge;
 import com.liferay.expando.kernel.util.ExpandoBridgeFactoryUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
+import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSON;
 import com.liferay.portal.kernel.model.CacheModel;
@@ -25,6 +27,8 @@ import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.Serializable;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationHandler;
 
 import java.sql.Blob;
@@ -37,6 +41,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -1193,11 +1198,19 @@ public class CompanyModelImpl
 			companyCacheModel.indexNameNext = null;
 		}
 
-		companyCacheModel._groupId = getGroupId();
+		try {
+			companyCacheModel.groupId = (long)_groupIdMethodHandle.invokeExact(
+				(CompanyImpl)this);
 
-		setVirtualHostname(null);
+			setVirtualHostname(null);
 
-		companyCacheModel._virtualHostname = getVirtualHostname();
+			companyCacheModel.virtualHostname =
+				(String)_virtualHostnameMethodHandle.invokeExact(
+					(CompanyImpl)this);
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
 
 		return companyCacheModel;
 	}
@@ -1413,6 +1426,52 @@ public class CompanyModelImpl
 	}
 
 	private long _columnBitmask;
+
+	protected final transient Consumer<Long> groupIdUpdateEntityCacheConsumer =
+		groupId -> {
+			CompanyCacheModel companyCacheModel =
+				EntityCacheUtil.fetchCacheModel(
+					CompanyImpl.class, _companyId, CompanyCacheModel.class);
+
+			if ((companyCacheModel != null) &&
+				(companyCacheModel.getMvccVersion() == getMvccVersion())) {
+
+				companyCacheModel.groupId = groupId;
+			}
+		};
+
+	private static final MethodHandle _groupIdMethodHandle;
+
+	protected final transient Consumer<String>
+		virtualHostnameUpdateEntityCacheConsumer = virtualHostname -> {
+			CompanyCacheModel companyCacheModel =
+				EntityCacheUtil.fetchCacheModel(
+					CompanyImpl.class, _companyId, CompanyCacheModel.class);
+
+			if ((companyCacheModel != null) &&
+				(companyCacheModel.getMvccVersion() == getMvccVersion())) {
+
+				companyCacheModel.virtualHostname = virtualHostname;
+			}
+		};
+
+	private static final MethodHandle _virtualHostnameMethodHandle;
+
+	static {
+		MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+		try {
+			_groupIdMethodHandle = lookup.findGetter(
+				CompanyImpl.class, "_groupId", long.class);
+
+			_virtualHostnameMethodHandle = lookup.findGetter(
+				CompanyImpl.class, "_virtualHostname", String.class);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ExceptionInInitializerError(reflectiveOperationException);
+		}
+	}
+
 	private Company _escapedModel;
 
 }

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutSetCacheModel.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutSetCacheModel.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.model.impl;
 
 import com.liferay.petra.lang.HashUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.CacheModel;
 import com.liferay.portal.kernel.model.LayoutSet;
@@ -15,6 +16,9 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 
 import java.util.Date;
 
@@ -175,10 +179,16 @@ public class LayoutSetCacheModel
 
 		layoutSetImpl.resetOriginalValues();
 
-		layoutSetImpl.setCompanyFallbackVirtualHostname(
-			_companyFallbackVirtualHostname);
+		try {
+			_companyFallbackVirtualHostnameMethodHandle.invokeExact(
+				layoutSetImpl, companyFallbackVirtualHostname);
 
-		layoutSetImpl.setVirtualHostnames(_virtualHostnames);
+			_virtualHostnamesMethodHandle.invokeExact(
+				layoutSetImpl, virtualHostnames);
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
 
 		return layoutSetImpl;
 	}
@@ -212,8 +222,8 @@ public class LayoutSetCacheModel
 
 		layoutSetPrototypeLinkEnabled = objectInput.readBoolean();
 
-		_companyFallbackVirtualHostname = (String)objectInput.readObject();
-		_virtualHostnames = (java.util.TreeMap)objectInput.readObject();
+		companyFallbackVirtualHostname = (String)objectInput.readObject();
+		virtualHostnames = (java.util.TreeMap)objectInput.readObject();
 	}
 
 	@Override
@@ -273,8 +283,9 @@ public class LayoutSetCacheModel
 
 		objectOutput.writeBoolean(layoutSetPrototypeLinkEnabled);
 
-		objectOutput.writeObject(_companyFallbackVirtualHostname);
-		objectOutput.writeObject(_virtualHostnames);
+		objectOutput.writeObject(companyFallbackVirtualHostname);
+
+		objectOutput.writeObject(virtualHostnames);
 	}
 
 	public long mvccVersion;
@@ -293,7 +304,28 @@ public class LayoutSetCacheModel
 	public String settings;
 	public String layoutSetPrototypeUuid;
 	public boolean layoutSetPrototypeLinkEnabled;
-	public String _companyFallbackVirtualHostname;
-	public java.util.TreeMap _virtualHostnames;
+	public volatile String companyFallbackVirtualHostname;
+	public volatile java.util.TreeMap virtualHostnames;
+
+	private static final MethodHandle
+		_companyFallbackVirtualHostnameMethodHandle;
+	private static final MethodHandle _virtualHostnamesMethodHandle;
+
+	static {
+		MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+		try {
+			_companyFallbackVirtualHostnameMethodHandle = lookup.findSetter(
+				LayoutSetImpl.class, "_companyFallbackVirtualHostname",
+				String.class);
+
+			_virtualHostnamesMethodHandle = lookup.findSetter(
+				LayoutSetImpl.class, "_virtualHostnames",
+				java.util.TreeMap.class);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ExceptionInInitializerError(reflectiveOperationException);
+		}
+	}
 
 }

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutSetImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutSetImpl.java
@@ -104,6 +104,9 @@ public class LayoutSetImpl extends LayoutSetBaseImpl {
 			}
 		}
 
+		companyFallbackVirtualHostnameUpdateEntityCacheConsumer.accept(
+			_companyFallbackVirtualHostname);
+
 		return _companyFallbackVirtualHostname;
 	}
 
@@ -350,6 +353,8 @@ public class LayoutSetImpl extends LayoutSetBaseImpl {
 
 			_virtualHostnames = virtualHostnames;
 		}
+
+		virtualHostnamesUpdateEntityCacheConsumer.accept(_virtualHostnames);
 
 		return new TreeMap<>(_virtualHostnames);
 	}

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutSetModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutSetModelImpl.java
@@ -7,8 +7,10 @@ package com.liferay.portal.model.impl;
 
 import com.liferay.expando.kernel.model.ExpandoBridge;
 import com.liferay.expando.kernel.util.ExpandoBridgeFactoryUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
+import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.json.JSON;
 import com.liferay.portal.kernel.model.CacheModel;
 import com.liferay.portal.kernel.model.LayoutSet;
@@ -22,6 +24,8 @@ import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.Serializable;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationHandler;
 
 import java.sql.Blob;
@@ -34,6 +38,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -981,14 +986,23 @@ public class LayoutSetModelImpl
 		layoutSetCacheModel.layoutSetPrototypeLinkEnabled =
 			isLayoutSetPrototypeLinkEnabled();
 
-		setCompanyFallbackVirtualHostname(null);
+		try {
+			setCompanyFallbackVirtualHostname(null);
 
-		layoutSetCacheModel._companyFallbackVirtualHostname =
-			getCompanyFallbackVirtualHostname();
+			layoutSetCacheModel.companyFallbackVirtualHostname =
+				(String)_companyFallbackVirtualHostnameMethodHandle.invokeExact(
+					(LayoutSetImpl)this);
 
-		setVirtualHostnames(null);
+			setVirtualHostnames(null);
 
-		layoutSetCacheModel._virtualHostnames = getVirtualHostnames();
+			layoutSetCacheModel.virtualHostnames =
+				(java.util.TreeMap<String, String>)
+					_virtualHostnamesMethodHandle.invokeExact(
+						(LayoutSetImpl)this);
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
 
 		return layoutSetCacheModel;
 	}
@@ -1176,6 +1190,60 @@ public class LayoutSetModelImpl
 	}
 
 	private long _columnBitmask;
+
+	protected final transient Consumer<String>
+		companyFallbackVirtualHostnameUpdateEntityCacheConsumer =
+			companyFallbackVirtualHostname -> {
+				LayoutSetCacheModel layoutSetCacheModel =
+					EntityCacheUtil.fetchCacheModel(
+						LayoutSetImpl.class, _layoutSetId,
+						LayoutSetCacheModel.class);
+
+				if ((layoutSetCacheModel != null) &&
+					(layoutSetCacheModel.getMvccVersion() ==
+						getMvccVersion())) {
+
+					layoutSetCacheModel.companyFallbackVirtualHostname =
+						companyFallbackVirtualHostname;
+				}
+			};
+
+	private static final MethodHandle
+		_companyFallbackVirtualHostnameMethodHandle;
+
+	protected final transient Consumer<java.util.TreeMap<String, String>>
+		virtualHostnamesUpdateEntityCacheConsumer = virtualHostnames -> {
+			LayoutSetCacheModel layoutSetCacheModel =
+				EntityCacheUtil.fetchCacheModel(
+					LayoutSetImpl.class, _layoutSetId,
+					LayoutSetCacheModel.class);
+
+			if ((layoutSetCacheModel != null) &&
+				(layoutSetCacheModel.getMvccVersion() == getMvccVersion())) {
+
+				layoutSetCacheModel.virtualHostnames = virtualHostnames;
+			}
+		};
+
+	private static final MethodHandle _virtualHostnamesMethodHandle;
+
+	static {
+		MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+		try {
+			_companyFallbackVirtualHostnameMethodHandle = lookup.findGetter(
+				LayoutSetImpl.class, "_companyFallbackVirtualHostname",
+				String.class);
+
+			_virtualHostnamesMethodHandle = lookup.findGetter(
+				LayoutSetImpl.class, "_virtualHostnames",
+				java.util.TreeMap.class);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ExceptionInInitializerError(reflectiveOperationException);
+		}
+	}
+
 	private LayoutSet _escapedModel;
 
 }

--- a/portal-impl/src/com/liferay/portal/model/impl/UserCacheModel.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/UserCacheModel.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.model.impl;
 
 import com.liferay.petra.lang.HashUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.CacheModel;
 import com.liferay.portal.kernel.model.MVCCModel;
@@ -15,6 +16,9 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 
 import java.util.Date;
 
@@ -384,7 +388,12 @@ public class UserCacheModel
 
 		userImpl.resetOriginalValues();
 
-		userImpl.setGroupId(_groupId);
+		try {
+			_groupIdMethodHandle.invokeExact(userImpl, groupId);
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
 
 		return userImpl;
 	}
@@ -454,7 +463,7 @@ public class UserCacheModel
 
 		status = objectInput.readInt();
 
-		_groupId = (long)objectInput.readObject();
+		groupId = (long)objectInput.readObject();
 	}
 
 	@Override
@@ -643,7 +652,7 @@ public class UserCacheModel
 
 		objectOutput.writeInt(status);
 
-		objectOutput.writeObject(_groupId);
+		objectOutput.writeObject(groupId);
 	}
 
 	public long mvccVersion;
@@ -690,6 +699,20 @@ public class UserCacheModel
 	public boolean emailAddressVerified;
 	public int type;
 	public int status;
-	public long _groupId;
+	public volatile long groupId;
+
+	private static final MethodHandle _groupIdMethodHandle;
+
+	static {
+		MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+		try {
+			_groupIdMethodHandle = lookup.findSetter(
+				UserImpl.class, "_groupId", long.class);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ExceptionInInitializerError(reflectiveOperationException);
+		}
+	}
 
 }

--- a/portal-impl/src/com/liferay/portal/model/impl/UserImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/UserImpl.java
@@ -381,17 +381,7 @@ public class UserImpl extends UserBaseImpl {
 	@Override
 	public Group getGroup() {
 		if (_group == null) {
-			if (_groupId == -1) {
-				_group = GroupLocalServiceUtil.fetchUserGroup(
-					getCompanyId(), getUserId());
-
-				if (_group != null) {
-					_groupId = _group.getGroupId();
-				}
-			}
-			else {
-				_group = GroupLocalServiceUtil.fetchGroup(_groupId);
-			}
+			_group = GroupLocalServiceUtil.fetchGroup(getGroupId());
 		}
 
 		return _group;
@@ -405,6 +395,8 @@ public class UserImpl extends UserBaseImpl {
 
 			if (_group != null) {
 				_groupId = _group.getGroupId();
+
+				groupIdUpdateEntityCacheConsumer.accept(_groupId);
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portal/model/impl/UserModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/UserModelImpl.java
@@ -8,8 +8,10 @@ package com.liferay.portal.model.impl;
 import com.liferay.expando.kernel.model.ExpandoBridge;
 import com.liferay.expando.kernel.util.ExpandoBridgeFactoryUtil;
 import com.liferay.exportimport.kernel.lar.StagedModelType;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
+import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSON;
 import com.liferay.portal.kernel.model.CacheModel;
@@ -26,6 +28,8 @@ import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.Serializable;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationHandler;
 
 import java.sql.Blob;
@@ -38,6 +42,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -2071,7 +2076,13 @@ public class UserModelImpl extends BaseModelImpl<User> implements UserModel {
 
 		userCacheModel.status = getStatus();
 
-		userCacheModel._groupId = getGroupId();
+		try {
+			userCacheModel.groupId = (long)_groupIdMethodHandle.invokeExact(
+				(UserImpl)this);
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
 
 		return userCacheModel;
 	}
@@ -2375,6 +2386,33 @@ public class UserModelImpl extends BaseModelImpl<User> implements UserModel {
 	}
 
 	private long _columnBitmask;
+
+	protected final transient Consumer<Long> groupIdUpdateEntityCacheConsumer =
+		groupId -> {
+			UserCacheModel userCacheModel = EntityCacheUtil.fetchCacheModel(
+				UserImpl.class, _userId, UserCacheModel.class);
+
+			if ((userCacheModel != null) &&
+				(userCacheModel.getMvccVersion() == getMvccVersion())) {
+
+				userCacheModel.groupId = groupId;
+			}
+		};
+
+	private static final MethodHandle _groupIdMethodHandle;
+
+	static {
+		MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+		try {
+			_groupIdMethodHandle = lookup.findGetter(
+				UserImpl.class, "_groupId", long.class);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ExceptionInInitializerError(reflectiveOperationException);
+		}
+	}
+
 	private User _escapedModel;
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/orm/EntityCache.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/orm/EntityCache.java
@@ -7,6 +7,7 @@ package com.liferay.portal.kernel.dao.orm;
 
 import com.liferay.portal.kernel.cache.PortalCache;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.CacheModel;
 
 import java.io.Serializable;
 
@@ -23,6 +24,9 @@ public interface EntityCache {
 	public void clearCache(Class<?> clazz);
 
 	public void clearLocalCache();
+
+	public <T extends CacheModel<?>> T fetchCacheModel(
+		Class<?> clazz, Serializable primaryKey, Class<T> cacheModelClass);
 
 	public Serializable getLocalCacheResult(
 		Class<?> clazz, Serializable primaryKey);

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/orm/EntityCacheUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/orm/EntityCacheUtil.java
@@ -7,6 +7,7 @@ package com.liferay.portal.kernel.dao.orm;
 
 import com.liferay.portal.kernel.cache.PortalCache;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.CacheModel;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.util.ProxyFactory;
 
@@ -33,6 +34,14 @@ public class EntityCacheUtil {
 		EntityCache entityCache = getEntityCache();
 
 		entityCache.clearLocalCache();
+	}
+
+	public static <T extends CacheModel<?>> T fetchCacheModel(
+		Class<?> clazz, Serializable primaryKey, Class<T> cacheModelClass) {
+
+		EntityCache entityCache = getEntityCache();
+
+		return entityCache.fetchCacheModel(clazz, primaryKey, cacheModelClass);
 	}
 
 	public static EntityCache getEntityCache() {

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/orm/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/orm/packageinfo
@@ -1,1 +1,1 @@
-version 14.1.0
+version 14.2.0


### PR DESCRIPTION
@brianchandotcom We have 11 real CacheField usage + 1 from test. Only the test and 3 usages from core are used correctly. Every usage from other teams are wrong. They practically always missed the cache, making this thing only an useless overhead to recalculate all the time without being read.

This change further optimized the CacheField integration to EntityCache, and also simplified the usage of it, making it possible to be checked by SF.

@ling-alan-huang please add a SF check for @CacheField usage. Here are the rules.

1) CacheField has a [methodName()](https://github.com/shuyangzhou/liferay-portal/blob/startup-optimization-reboot-10/portal-kernel/src/com/liferay/portal/kernel/model/cache/CacheField.java#L22) attribute , by default, it is the annotated field variable name with the [1st letter uppercased](https://github.com/shuyangzhou/liferay-portal/blob/startup-optimization-reboot-10/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java#L5658-L5661).
2) Each CacheField must override the getter method from XYZModelImpl.java [public ${typeGenericsName} get${methodName}() ](https://github.com/shuyangzhou/liferay-portal/blob/startup-optimization-reboot-10/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/model_impl.ftl#L1116)in its enclosing class XYZImpl.java, for example [CompanyImpl.getGroupId()](https://github.com/shuyangzhou/liferay-portal/blob/startup-optimization-reboot-10/portal-impl/src/com/liferay/portal/model/impl/CompanyImpl.java#L129) and [CompanyImpl.getVirtualhostName()](https://github.com/shuyangzhou/liferay-portal/blob/startup-optimization-reboot-10/portal-impl/src/com/liferay/portal/model/impl/CompanyImpl.java#L129)
3) Inside the override getter method, it must use its corresponding [${variableName}UpdateEntityCacheConsumer](https://github.com/shuyangzhou/liferay-portal/blob/startup-optimization-reboot-10/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/model_impl.ftl#L2143) from XYZModelImpl.java to call accept exactly once. For example, [groupIdUpdateEntityCacheConsumer.accept(_groupId)](https://github.com/shuyangzhou/liferay-portal/blob/startup-optimization-reboot-10/portal-impl/src/com/liferay/portal/model/impl/CompanyImpl.java#L136) and [virtualHostnameUpdateEntityCacheConsumer.accept(_virtualHostname)](https://github.com/shuyangzhou/liferay-portal/blob/startup-optimization-reboot-10/portal-impl/src/com/liferay/portal/model/impl/CompanyImpl.java#L277)
4) Each CacheField can have an optional override setter. If the override setter does exist, it must assign the setter arg to field. For example, [_groupId = groupId](https://github.com/shuyangzhou/liferay-portal/blob/startup-optimization-reboot-10/portal-impl/src/com/liferay/portal/model/impl/CompanyImpl.java#L362) and [_virtualHostname = virtualHostname](https://github.com/shuyangzhou/liferay-portal/blob/startup-optimization-reboot-10/portal-impl/src/com/liferay/portal/model/impl/CompanyImpl.java#L381) . The override setter can be absent, which is totally fine.

@tinatian @ericyanLr this is the CacheField refactor I mentioned a while ago, please make sure you understand the new impl logic, in order to cope with future cache issues related to this.

@brianchandotcom even with the new SF check, we can only ensure the structure of CacheField is used correctly. There are still many possible ways to make mistakes. Fortunately CacheField is only expected to be used in very limited locations, if you see a new usage added from other teams, please redirect it to me for logic checking.