### PR TITLE
LPD-57706 portal-web: Remove role='tabpanel' in panel taglib

### DIFF
--- a/portal-web/docroot/html/taglib/ui/panel/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/panel/start.jsp
@@ -60,5 +60,5 @@ if (persistState) {
 		</c:otherwise>
 	</c:choose>
 
-	<div aria-labelledby="<%= id %>Header" class="<%= collapsible ? "collapse panel-collapse" : StringPool.BLANK %> <%= !collapsed ? "show" : StringPool.BLANK %>" <%= accordion ? "data-parent='#" + parentId + "'" : StringPool.BLANK %> id="<%= id %>Content" role="tabpanel">
+	<div aria-labelledby="<%= id %>Header" class="<%= collapsible ? "collapse panel-collapse" : StringPool.BLANK %> <%= !collapsed ? "show" : StringPool.BLANK %>" <%= accordion ? "data-parent='#" + parentId + "'" : StringPool.BLANK %> id="<%= id %>Content" role="region">
 		<div class="panel-body">


### PR DESCRIPTION
Manually forwarded from https://github.com/liferay-frontend/liferay-portal/pull/4961
Test failures look unrelated.

https://liferay.atlassian.net/browse/LPD-57706 - Remove "tabpanel" role within panel liferay_ui taglib

For a11y. Customers have had some confusion with several of the search widgets, which is using the `liferay_ui` Panel taglib. The panel body has an element like this:

`<div aria-labelledby="_com_liferay_portal_search_web_type_facet_portlet_TypeFacetPortlet_INSTANCE_nmMA61PnQ1M2_facetAssetEntriesPanelHeader" class="panel-collapse collapse show" id="_com_liferay_portal_search_web_type_facet_portlet_TypeFacetPortlet_INSTANCE_nmMA61PnQ1M2_facetAssetEntriesPanelContent" role="tabpanel" style="">`

Since it has a role of “tabpanel”, it causes confusion as there are no other contents to switch tabs to.
In the React version, it uses `role="region"` ([reference](https://github.com/liferay/clay/blob/d4c905df8e07543543715c180b4d7ab42a72a4b4/packages/clay-panel/src/index.tsx#L207)) which indicates that the section is important in the page structure.

The role of "tabpanel" was then replaced with "region" to keep it consistent.

![Screenshot 2025-06-11 at 4 10 39 PM](https://github.com/user-attachments/assets/3c25e5fd-3602-4b8b-9781-3b6e890b76c6)


Let me know if this change sounds reasonable, thanks!