### PR TITLE
LPD-57904 Avoid the unnecessary db query during startup

### DIFF
--- a/modules/apps/analytics/analytics-settings-impl/src/main/java/com/liferay/analytics/settings/internal/configuration/AnalyticsConfigurationRegistryImpl.java
+++ b/modules/apps/analytics/analytics-settings-impl/src/main/java/com/liferay/analytics/settings/internal/configuration/AnalyticsConfigurationRegistryImpl.java
@@ -172,11 +172,7 @@ public class AnalyticsConfigurationRegistryImpl
 						PropsUtil.get(
 							PropsKeys.
 								ANALYTICS_CLOUD_CONFIGURATION_DELETE_ON_STARTUP)) ||
-					GetterUtil.getBoolean(
-						PropsUtil.get(
-							PropsKeys.
-								ANALYTICS_CLOUD_CONFIGURATION_DELETE_ON_STARTUP,
-							new Filter(company.getVirtualHostname())))) {
+					_isEnabled(company)) {
 
 					_activatedCompanyIds.put(company.getCompanyId(), true);
 				}
@@ -484,6 +480,31 @@ public class AnalyticsConfigurationRegistryImpl
 
 		return GetterUtil.getBoolean(
 			dictionary.get("contentRecommenderUserPersonalizationEnabled"));
+	}
+
+	private boolean _isEnabled(Company company) {
+		boolean hasEnabled = false;
+
+		for (String deleteOnStartup :
+				PropsUtil.getArray(
+					PropsKeys.
+						ANALYTICS_CLOUD_CONFIGURATION_DELETE_ON_STARTUP)) {
+
+			if (GetterUtil.getBoolean(deleteOnStartup)) {
+				hasEnabled = true;
+
+				break;
+			}
+		}
+
+		if (!hasEnabled) {
+			return false;
+		}
+
+		return GetterUtil.getBoolean(
+			PropsUtil.get(
+				PropsKeys.ANALYTICS_CLOUD_CONFIGURATION_DELETE_ON_STARTUP,
+				new Filter(company.getVirtualHostname())));
 	}
 
 	private boolean _isSyncedAccountFieldsChanged(


### PR DESCRIPTION
@JerryAdrianoo https://github.com/brianchandotcom/liferay-portal/pull/162592 caused a regression on DB query, this pull fixes it.

And after this fix, "Count of Prepared Statement Query" should go back to 96, which is exactly the baseline before objects startup regression from last year.

Please confirm, and turn to strict defense mode. It was not easy to reduce the query count from 1740 to 96, please do your best to prevent regressions.