### PR TITLE
LCD-47064 Fix "bad syntax for struct tag value"

### DIFF
--- a/cloud/operator/resources/main.go
+++ b/cloud/operator/resources/main.go
@@ -78,8 +78,8 @@ func main() {
 }
 
 type config struct {
-	MetricsAddress string `env: "METRICS_ADDRESS" envDefault: ":8080"`
-	ProbeAddress   string `env: "PROBE_ADDRESS" envDefault: ":8081"`
+	MetricsAddress string `env:"METRICS_ADDRESS" envDefault:":8080"`
+	ProbeAddress   string `env:"PROBE_ADDRESS" envDefault:":8081"`
 }
 
 var (


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LCD-47063
https://liferay.atlassian.net/browse/LCD-47064

---

Formatting struct tags with a space `key: "VALUE"` instead of `key:"VALUE"` causes a syntax error which fails go vet.