### PR TITLE
LPD-57471 Implement pagination for users and groups

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/package.json
+++ b/modules/apps/site/site-cms-site-initializer/package.json
@@ -1,7 +1,7 @@
 {
 	"dependencies": {
 		"@clayui/alert": "3.129.1",
-		"@clayui/autocomplete": "3.138.0",
+		"@clayui/autocomplete": "3.139.1",
 		"@clayui/breadcrumb": "3.136.0",
 		"@clayui/button": "3.136.0",
 		"@clayui/core": "3.139.1",

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/spaces/SpaceMembersWithList.scss
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/spaces/SpaceMembersWithList.scss
@@ -1,4 +1,4 @@
-.add-space-members {
+.space-members-with-list {
 	padding: 24px;
 
 	.members-list {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces/AddSpaceMembers.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces/AddSpaceMembers.tsx
@@ -93,7 +93,6 @@ export function AddSpaceMembers({
 			}
 
 			setIsFetchingMembers(true);
-			setUsersPage(newUsersPage);
 
 			try {
 				const spaceUsers = await SpaceService.getSpaceUsers({
@@ -106,6 +105,7 @@ export function AddSpaceMembers({
 					...currentSelectedUsers,
 					...spaceUsers.items,
 				]);
+				setUsersPage(newUsersPage);
 				setUsersLastPage(spaceUsers.lastPage);
 			}
 			catch (error) {
@@ -124,7 +124,6 @@ export function AddSpaceMembers({
 		}
 
 		setIsFetchingMembers(true);
-		setUserGroupsPage(newUserGroupsPage);
 
 		try {
 			const spaceUserGroups = await SpaceService.getSpaceUserGroups({
@@ -137,6 +136,7 @@ export function AddSpaceMembers({
 				...currentSelectedUserGroups,
 				...spaceUserGroups.items,
 			]);
+			setUserGroupsPage(newUserGroupsPage);
 			setUserGroupsLastPage(spaceUserGroups.lastPage);
 		}
 		catch (error) {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces/AddSpaceMembers.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces/AddSpaceMembers.tsx
@@ -7,6 +7,7 @@ import '../../../css/spaces/AddSpaceMembers.scss';
 
 import ClayButton from '@clayui/button';
 import ClayLayout from '@clayui/layout';
+import LoadingIndicator from '@clayui/loading-indicator';
 import {openToast} from 'frontend-js-components-web';
 import {navigate, sub} from 'frontend-js-web';
 import React, {useCallback, useEffect, useId, useRef, useState} from 'react';
@@ -20,7 +21,6 @@ import {
 	SelectOptions,
 	SpaceMembersInputWithSelect,
 } from './SpaceMembersInputWithSelect';
-import LoadingIndicator from '@clayui/loading-indicator';
 
 export interface AddSpaceMembersProps {
 	assetLibraryCreatorUserId: string;
@@ -38,7 +38,7 @@ export function AddSpaceMembers({
 	baseAssetLibraryURL,
 }: AddSpaceMembersProps) {
 	const currentUserId = Liferay.ThemeDisplay.getUserId();
-	const [isFetchingMoreMembers, setIsFetchingMoreMembers] = useState(false);
+	const [isFetchingMembers, setIsFetchingMembers] = useState(false);
 	const [selectedOption, setSelectedOption] = useState(SelectOptions.USERS);
 	const [selectedUsers, setSelectedUsers] = useState<UserAccount[]>([]);
 	const [selectedUserGroups, setSelectedUserGroups] = useState<UserGroup[]>(
@@ -71,7 +71,17 @@ export function AddSpaceMembers({
 			setUsersLastPage(spaceUsers.lastPage);
 		};
 
-		fetchMembers();
+		setIsFetchingMembers(true);
+
+		try {
+			fetchMembers();
+		}
+		catch (error) {
+			console.error(error);
+		}
+		finally {
+			setIsFetchingMembers(false);
+		}
 	}, [assetLibraryId]);
 
 	const loadMoreItems = useCallback(async () => {
@@ -82,7 +92,7 @@ export function AddSpaceMembers({
 				return;
 			}
 
-			setIsFetchingMoreMembers(true);
+			setIsFetchingMembers(true);
 			setUsersPage(newUsersPage);
 
 			try {
@@ -91,14 +101,18 @@ export function AddSpaceMembers({
 					pageSize: DEFAULT_PAGE_SIZE,
 					spaceId: assetLibraryId,
 				});
-	
+
 				setSelectedUsers((currentSelectedUsers) => [
 					...currentSelectedUsers,
 					...spaceUsers.items,
 				]);
 				setUsersLastPage(spaceUsers.lastPage);
-			} finally {
-				setIsFetchingMoreMembers(false);
+			}
+			catch (error) {
+				console.error(error);
+			}
+			finally {
+				setIsFetchingMembers(false);
 			}
 
 			return;
@@ -109,7 +123,7 @@ export function AddSpaceMembers({
 			return;
 		}
 
-		setIsFetchingMoreMembers(true);
+		setIsFetchingMembers(true);
 		setUserGroupsPage(newUserGroupsPage);
 
 		try {
@@ -118,16 +132,27 @@ export function AddSpaceMembers({
 				pageSize: DEFAULT_PAGE_SIZE,
 				spaceId: assetLibraryId,
 			});
-	
+
 			setSelectedUserGroups((currentSelectedUserGroups) => [
 				...currentSelectedUserGroups,
 				...spaceUserGroups.items,
 			]);
 			setUserGroupsLastPage(spaceUserGroups.lastPage);
-		} finally {
-			setIsFetchingMoreMembers(false);
 		}
-	}, [assetLibraryId, selectedOption, userGroupsPage, usersPage, userGroupsLastPage, usersLastPage]);
+		catch (error) {
+			console.error(error);
+		}
+		finally {
+			setIsFetchingMembers(false);
+		}
+	}, [
+		assetLibraryId,
+		selectedOption,
+		userGroupsPage,
+		usersPage,
+		userGroupsLastPage,
+		usersLastPage,
+	]);
 
 	useEffect(() => {
 		if (!sentinelRef.current) {
@@ -348,7 +373,15 @@ export function AddSpaceMembers({
 							/>
 						)}
 
-						{isFetchingMoreMembers && <li className="d-flex justify-content-center"><LoadingIndicator displayType="secondary" size="sm" /></li>}
+						{isFetchingMembers && (
+							<li className="d-flex justify-content-center">
+								<LoadingIndicator
+									displayType="secondary"
+									size="sm"
+								/>
+							</li>
+						)}
+
 						<div ref={sentinelRef} />
 					</ul>
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces/AddSpaceMembers.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces/AddSpaceMembers.tsx
@@ -9,7 +9,7 @@ import ClayButton from '@clayui/button';
 import ClayLayout from '@clayui/layout';
 import {openToast} from 'frontend-js-components-web';
 import {navigate, sub} from 'frontend-js-web';
-import React, {useEffect, useId, useState} from 'react';
+import React, {useCallback, useEffect, useId, useRef, useState} from 'react';
 
 import SpaceService from '../../services/SpaceService';
 import {UserAccount, UserGroup} from '../../types/UserAccount';
@@ -20,6 +20,7 @@ import {
 	SelectOptions,
 	SpaceMembersInputWithSelect,
 } from './SpaceMembersInputWithSelect';
+import LoadingIndicator from '@clayui/loading-indicator';
 
 export interface AddSpaceMembersProps {
 	assetLibraryCreatorUserId: string;
@@ -28,6 +29,8 @@ export interface AddSpaceMembersProps {
 	baseAssetLibraryURL: string;
 }
 
+const DEFAULT_PAGE_SIZE = 20;
+
 export function AddSpaceMembers({
 	assetLibraryCreatorUserId,
 	assetLibraryId,
@@ -35,29 +38,119 @@ export function AddSpaceMembers({
 	baseAssetLibraryURL,
 }: AddSpaceMembersProps) {
 	const currentUserId = Liferay.ThemeDisplay.getUserId();
+	const [isFetchingMoreMembers, setIsFetchingMoreMembers] = useState(false);
 	const [selectedOption, setSelectedOption] = useState(SelectOptions.USERS);
 	const [selectedUsers, setSelectedUsers] = useState<UserAccount[]>([]);
 	const [selectedUserGroups, setSelectedUserGroups] = useState<UserGroup[]>(
 		[]
 	);
+	const [usersLastPage, setUsersLastPage] = useState(0);
+	const [usersPage, setUsersPage] = useState(1);
+	const [userGroupsLastPage, setUserGroupsLastPage] = useState(0);
+	const [userGroupsPage, setUserGroupsPage] = useState(1);
+	const sentinelRef = useRef(null);
 
 	useEffect(() => {
 		const fetchMembers = async () => {
 			const [spaceUsers, spaceUserGroups] = await Promise.all([
 				SpaceService.getSpaceUsers({
+					page: 1,
+					pageSize: DEFAULT_PAGE_SIZE,
 					spaceId: assetLibraryId,
 				}),
 				SpaceService.getSpaceUserGroups({
+					page: 1,
+					pageSize: DEFAULT_PAGE_SIZE,
 					spaceId: assetLibraryId,
 				}),
 			]);
 
-			setSelectedUsers(spaceUsers);
-			setSelectedUserGroups(spaceUserGroups);
+			setSelectedUsers(spaceUsers.items);
+			setSelectedUserGroups(spaceUserGroups.items);
+			setUserGroupsLastPage(spaceUserGroups.lastPage);
+			setUsersLastPage(spaceUsers.lastPage);
 		};
 
 		fetchMembers();
 	}, [assetLibraryId]);
+
+	const loadMoreItems = useCallback(async () => {
+		if (selectedOption === SelectOptions.USERS) {
+			const newUsersPage = usersPage + 1;
+
+			if (newUsersPage > usersLastPage) {
+				return;
+			}
+
+			setIsFetchingMoreMembers(true);
+			setUsersPage(newUsersPage);
+
+			try {
+				const spaceUsers = await SpaceService.getSpaceUsers({
+					page: newUsersPage,
+					pageSize: DEFAULT_PAGE_SIZE,
+					spaceId: assetLibraryId,
+				});
+	
+				setSelectedUsers((currentSelectedUsers) => [
+					...currentSelectedUsers,
+					...spaceUsers.items,
+				]);
+				setUsersLastPage(spaceUsers.lastPage);
+			} finally {
+				setIsFetchingMoreMembers(false);
+			}
+
+			return;
+		}
+
+		const newUserGroupsPage = userGroupsPage + 1;
+		if (newUserGroupsPage > userGroupsLastPage) {
+			return;
+		}
+
+		setIsFetchingMoreMembers(true);
+		setUserGroupsPage(newUserGroupsPage);
+
+		try {
+			const spaceUserGroups = await SpaceService.getSpaceUserGroups({
+				page: newUserGroupsPage,
+				pageSize: DEFAULT_PAGE_SIZE,
+				spaceId: assetLibraryId,
+			});
+	
+			setSelectedUserGroups((currentSelectedUserGroups) => [
+				...currentSelectedUserGroups,
+				...spaceUserGroups.items,
+			]);
+			setUserGroupsLastPage(spaceUserGroups.lastPage);
+		} finally {
+			setIsFetchingMoreMembers(false);
+		}
+	}, [assetLibraryId, selectedOption, userGroupsPage, usersPage, userGroupsLastPage, usersLastPage]);
+
+	useEffect(() => {
+		if (!sentinelRef.current) {
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries[0].isIntersecting) {
+					loadMoreItems();
+				}
+			},
+			{
+				threshold: 1,
+			}
+		);
+
+		observer.observe(sentinelRef.current);
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [sentinelRef, loadMoreItems]);
 
 	const onAutocompleteItemSelected = async (
 		item: UserAccount | UserGroup
@@ -220,7 +313,9 @@ export function AddSpaceMembers({
 				>
 					<SpaceMembersInputWithSelect
 						onAutocompleteItemSelected={onAutocompleteItemSelected}
-						onSelectChange={setSelectedOption}
+						onSelectChange={(value) => {
+							setSelectedOption(value);
+						}}
 						selectValue={selectedOption}
 					/>
 
@@ -252,6 +347,9 @@ export function AddSpaceMembers({
 								onRemoveItem={onRemoveItem}
 							/>
 						)}
+
+						{isFetchingMoreMembers && <li className="d-flex justify-content-center"><LoadingIndicator displayType="secondary" size="sm" /></li>}
+						<div ref={sentinelRef} />
 					</ul>
 
 					<ClayButton.Group className="mb-0 w-100" spaced vertical>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces/AddSpaceMembers.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces/AddSpaceMembers.tsx
@@ -3,24 +3,14 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import '../../../css/spaces/AddSpaceMembers.scss';
-
 import ClayButton from '@clayui/button';
 import ClayLayout from '@clayui/layout';
-import LoadingIndicator from '@clayui/loading-indicator';
-import {openToast} from 'frontend-js-components-web';
 import {navigate, sub} from 'frontend-js-web';
-import React, {useCallback, useEffect, useId, useRef, useState} from 'react';
+import React, {useState} from 'react';
 
-import SpaceService from '../../services/SpaceService';
-import {UserAccount, UserGroup} from '../../types/UserAccount';
 import {getImage} from '../util/getImage';
-import {MembersListItem} from './MemberListItem';
 import {NewSpaceFormSection} from './NewSpaceFormSection';
-import {
-	SelectOptions,
-	SpaceMembersInputWithSelect,
-} from './SpaceMembersInputWithSelect';
+import {SpaceMembersWithList} from './SpaceMembersWithList';
 
 export interface AddSpaceMembersProps {
 	assetLibraryCreatorUserId: string;
@@ -29,298 +19,17 @@ export interface AddSpaceMembersProps {
 	baseAssetLibraryURL: string;
 }
 
-const DEFAULT_PAGE_SIZE = 20;
-
 export function AddSpaceMembers({
 	assetLibraryCreatorUserId,
 	assetLibraryId,
 	assetLibraryName,
 	baseAssetLibraryURL,
 }: AddSpaceMembersProps) {
-	const currentUserId = Liferay.ThemeDisplay.getUserId();
-	const [isFetchingMembers, setIsFetchingMembers] = useState(false);
-	const [selectedOption, setSelectedOption] = useState(SelectOptions.USERS);
-	const [selectedUsers, setSelectedUsers] = useState<UserAccount[]>([]);
-	const [selectedUserGroups, setSelectedUserGroups] = useState<UserGroup[]>(
-		[]
-	);
-	const [usersLastPage, setUsersLastPage] = useState(0);
-	const [usersPage, setUsersPage] = useState(1);
-	const [userGroupsLastPage, setUserGroupsLastPage] = useState(0);
-	const [userGroupsPage, setUserGroupsPage] = useState(1);
-	const sentinelRef = useRef(null);
-
-	useEffect(() => {
-		const fetchMembers = async () => {
-			const [spaceUsers, spaceUserGroups] = await Promise.all([
-				SpaceService.getSpaceUsers({
-					page: 1,
-					pageSize: DEFAULT_PAGE_SIZE,
-					spaceId: assetLibraryId,
-				}),
-				SpaceService.getSpaceUserGroups({
-					page: 1,
-					pageSize: DEFAULT_PAGE_SIZE,
-					spaceId: assetLibraryId,
-				}),
-			]);
-
-			setSelectedUsers(spaceUsers.items);
-			setSelectedUserGroups(spaceUserGroups.items);
-			setUserGroupsLastPage(spaceUserGroups.lastPage);
-			setUsersLastPage(spaceUsers.lastPage);
-		};
-
-		setIsFetchingMembers(true);
-
-		try {
-			fetchMembers();
-		}
-		catch (error) {
-			console.error(error);
-		}
-		finally {
-			setIsFetchingMembers(false);
-		}
-	}, [assetLibraryId]);
-
-	const loadMoreItems = useCallback(async () => {
-		if (selectedOption === SelectOptions.USERS) {
-			const newUsersPage = usersPage + 1;
-
-			if (newUsersPage > usersLastPage) {
-				return;
-			}
-
-			setIsFetchingMembers(true);
-
-			try {
-				const spaceUsers = await SpaceService.getSpaceUsers({
-					page: newUsersPage,
-					pageSize: DEFAULT_PAGE_SIZE,
-					spaceId: assetLibraryId,
-				});
-
-				setSelectedUsers((currentSelectedUsers) => [
-					...currentSelectedUsers,
-					...spaceUsers.items,
-				]);
-				setUsersPage(newUsersPage);
-				setUsersLastPage(spaceUsers.lastPage);
-			}
-			catch (error) {
-				console.error(error);
-			}
-			finally {
-				setIsFetchingMembers(false);
-			}
-
-			return;
-		}
-
-		const newUserGroupsPage = userGroupsPage + 1;
-		if (newUserGroupsPage > userGroupsLastPage) {
-			return;
-		}
-
-		setIsFetchingMembers(true);
-
-		try {
-			const spaceUserGroups = await SpaceService.getSpaceUserGroups({
-				page: newUserGroupsPage,
-				pageSize: DEFAULT_PAGE_SIZE,
-				spaceId: assetLibraryId,
-			});
-
-			setSelectedUserGroups((currentSelectedUserGroups) => [
-				...currentSelectedUserGroups,
-				...spaceUserGroups.items,
-			]);
-			setUserGroupsPage(newUserGroupsPage);
-			setUserGroupsLastPage(spaceUserGroups.lastPage);
-		}
-		catch (error) {
-			console.error(error);
-		}
-		finally {
-			setIsFetchingMembers(false);
-		}
-	}, [
-		assetLibraryId,
-		selectedOption,
-		userGroupsPage,
-		usersPage,
-		userGroupsLastPage,
-		usersLastPage,
-	]);
-
-	useEffect(() => {
-		if (!sentinelRef.current) {
-			return;
-		}
-
-		const observer = new IntersectionObserver(
-			(entries) => {
-				if (entries[0].isIntersecting) {
-					loadMoreItems();
-				}
-			},
-			{
-				threshold: 1,
-			}
-		);
-
-		observer.observe(sentinelRef.current);
-
-		return () => {
-			observer.disconnect();
-		};
-	}, [sentinelRef, loadMoreItems]);
-
-	const onAutocompleteItemSelected = async (
-		item: UserAccount | UserGroup
-	) => {
-		if (selectedOption === SelectOptions.USERS) {
-			if (selectedUsers.some((user) => user.id === item.id)) {
-				return;
-			}
-
-			setSelectedUsers([item as UserAccount, ...selectedUsers]);
-
-			const {error} = await SpaceService.linkUserToSpace({
-				spaceId: assetLibraryId,
-				userId: item.id,
-			});
-
-			if (error) {
-				openToast({
-					message: sub(
-						Liferay.Language.get('failed-to-add-user-x-to-space'),
-						[`<strong>${item.name}</strong>`]
-					),
-					type: 'danger',
-				});
-			}
-			else {
-				openToast({
-					message: sub(
-						Liferay.Language.get(
-							'user-x-successfully-added-to-space'
-						),
-						[`<strong>${item.name}</strong>`]
-					),
-					type: 'success',
-				});
-			}
-
-			return;
-		}
-
-		if (selectedUserGroups.some((group) => group.id === item.id)) {
-			return;
-		}
-
-		setSelectedUserGroups([item, ...selectedUserGroups]);
-
-		const {error} = await SpaceService.linkUserGroupToSpace({
-			spaceId: assetLibraryId,
-			userGroupId: item.id,
-		});
-
-		if (error) {
-			openToast({
-				message: sub(
-					Liferay.Language.get('failed-to-add-group-x-to-space'),
-					[`<strong>${item.name}</strong>`]
-				),
-				type: 'danger',
-			});
-		}
-		else {
-			openToast({
-				message: sub(
-					Liferay.Language.get('group-x-successfully-added-to-space'),
-					[`<strong>${item.name}</strong>`]
-				),
-				type: 'success',
-			});
-		}
-	};
-
-	const onRemoveItem = async (item: UserAccount | UserGroup) => {
-		if (selectedOption === SelectOptions.USERS) {
-			setSelectedUsers(selectedUsers.filter((u) => u.id !== item.id));
-
-			const {error} = await SpaceService.unlinkUserFromSpace({
-				spaceId: assetLibraryId,
-				userId: item.id,
-			});
-
-			if (error) {
-				openToast({
-					message: sub(
-						Liferay.Language.get(
-							'unable-to-remove-user-x-from-space'
-						),
-						[`<strong>${item.name}</strong>`]
-					),
-					type: 'danger',
-				});
-			}
-			else {
-				openToast({
-					message: sub(
-						Liferay.Language.get(
-							'user-x-successfully-removed-from-space'
-						),
-						[`<strong>${item.name}</strong>`]
-					),
-					type: 'success',
-				});
-			}
-
-			return;
-		}
-
-		setSelectedUserGroups(
-			selectedUserGroups.filter((u) => u.id !== item.id)
-		);
-
-		const {error} = await SpaceService.unlinkUserGroupFromSpace({
-			spaceId: assetLibraryId,
-			userGroupId: item.id,
-		});
-
-		if (error) {
-			openToast({
-				message: sub(
-					Liferay.Language.get(
-						'unable-to-remove-group-x-from-space-x'
-					),
-					[`<strong>${item.name}</strong>`]
-				),
-				type: 'success',
-			});
-		}
-		else {
-			openToast({
-				message: sub(
-					Liferay.Language.get(
-						'group-x-successfully-removed-from-space-x'
-					),
-					[`<strong>${item.name}</strong>`]
-				),
-				type: 'success',
-			});
-		}
-	};
+	const [hasSelectedMembers, setHasSelectedMembers] = useState(false);
 
 	const onContinueBtnClick = () => {
 		navigate(baseAssetLibraryURL + assetLibraryId);
 	};
-
-	const hasMembers = selectedUsers?.length > 1 || selectedUserGroups?.length;
-	const listLabelId = useId();
 
 	return (
 		<ClayLayout.Row className="add-space-members">
@@ -336,61 +45,18 @@ export function AddSpaceMembers({
 					)}
 					withForm={false}
 				>
-					<SpaceMembersInputWithSelect
-						onAutocompleteItemSelected={onAutocompleteItemSelected}
-						onSelectChange={(value) => {
-							setSelectedOption(value);
-						}}
-						selectValue={selectedOption}
+					<SpaceMembersWithList
+						assetLibraryCreatorUserId={assetLibraryCreatorUserId}
+						assetLibraryId={assetLibraryId}
+						onHasSelectedMembersChange={setHasSelectedMembers}
 					/>
-
-					<label className="d-block" id={listLabelId}>
-						{Liferay.Language.get('who-has-access')}
-					</label>
-
-					<ul aria-labelledby={listLabelId} className="members-list">
-						{selectedOption === SelectOptions.USERS ? (
-							<MembersListItem
-								assetLibraryCreatorUserId={
-									assetLibraryCreatorUserId
-								}
-								currentUserId={currentUserId}
-								emptyMessage={Liferay.Language.get(
-									'this-space-has-no-user-yet'
-								)}
-								itemType="user"
-								items={selectedUsers}
-								onRemoveItem={onRemoveItem}
-							/>
-						) : (
-							<MembersListItem
-								emptyMessage={Liferay.Language.get(
-									'this-space-has-no-group-yet'
-								)}
-								itemType="group"
-								items={selectedUserGroups}
-								onRemoveItem={onRemoveItem}
-							/>
-						)}
-
-						{isFetchingMembers && (
-							<li className="d-flex justify-content-center">
-								<LoadingIndicator
-									displayType="secondary"
-									size="sm"
-								/>
-							</li>
-						)}
-
-						<div ref={sentinelRef} />
-					</ul>
 
 					<ClayButton.Group className="mb-0 w-100" spaced vertical>
 						<ClayButton
 							className="mt-4"
 							onClick={onContinueBtnClick}
 						>
-							{hasMembers
+							{hasSelectedMembers
 								? Liferay.Language.get('continue')
 								: Liferay.Language.get(
 										'continue-without-members'

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces/SpaceMembersWithList.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces/SpaceMembersWithList.tsx
@@ -1,0 +1,372 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '../../../css/spaces/SpaceMembersWithList.scss';
+
+import LoadingIndicator from '@clayui/loading-indicator';
+import classNames from 'classnames';
+import {openToast} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
+import React, {useCallback, useEffect, useId, useRef, useState} from 'react';
+
+import SpaceService from '../../services/SpaceService';
+import {UserAccount, UserGroup} from '../../types/UserAccount';
+import {MembersListItem} from './MemberListItem';
+import {
+	SelectOptions,
+	SpaceMembersInputWithSelect,
+} from './SpaceMembersInputWithSelect';
+
+interface SpaceMembersWithListProps {
+	assetLibraryCreatorUserId: string;
+	assetLibraryId: string;
+	className?: string;
+	onHasSelectedMembersChange?: (hasSelectedMembers: boolean) => void;
+  pageSize?: number;
+}
+
+const DEFAULT_PAGE_SIZE = 20;
+
+export function SpaceMembersWithList({
+	assetLibraryCreatorUserId,
+	assetLibraryId,
+	className,
+	onHasSelectedMembersChange,
+  pageSize = DEFAULT_PAGE_SIZE,
+}: SpaceMembersWithListProps) {
+	const currentUserId = Liferay.ThemeDisplay.getUserId();
+	const [isFetchingMembers, setIsFetchingMembers] = useState(false);
+	const [selectedOption, setSelectedOption] = useState(SelectOptions.USERS);
+	const [selectedUsers, setSelectedUsers] = useState<UserAccount[]>([]);
+	const [selectedUserGroups, setSelectedUserGroups] = useState<UserGroup[]>(
+		[]
+	);
+	const [usersLastPage, setUsersLastPage] = useState(0);
+	const [usersPage, setUsersPage] = useState(1);
+	const [userGroupsLastPage, setUserGroupsLastPage] = useState(0);
+	const [userGroupsPage, setUserGroupsPage] = useState(1);
+	const sentinelRef = useRef(null);
+
+	useEffect(() => {
+		const fetchMembers = async () => {
+			const [spaceUsers, spaceUserGroups] = await Promise.all([
+				SpaceService.getSpaceUsers({
+					page: 1,
+					pageSize,
+					spaceId: assetLibraryId,
+				}),
+				SpaceService.getSpaceUserGroups({
+					page: 1,
+					pageSize,
+					spaceId: assetLibraryId,
+				}),
+			]);
+
+			setSelectedUsers(spaceUsers.items);
+			setSelectedUserGroups(spaceUserGroups.items);
+			setUserGroupsLastPage(spaceUserGroups.lastPage);
+			setUsersLastPage(spaceUsers.lastPage);
+		};
+
+		setIsFetchingMembers(true);
+
+		try {
+			fetchMembers();
+		}
+		catch (error) {
+			console.error(error);
+		}
+		finally {
+			setIsFetchingMembers(false);
+		}
+	}, [assetLibraryId]);
+
+	useEffect(() => {
+		const hasMembers =
+			selectedUsers?.length > 1 || selectedUserGroups?.length;
+		onHasSelectedMembersChange?.(Boolean(hasMembers));
+	}, [onHasSelectedMembersChange, selectedUsers, selectedUserGroups]);
+
+	const loadMoreItems = useCallback(async () => {
+		if (selectedOption === SelectOptions.USERS) {
+			const newUsersPage = usersPage + 1;
+
+			if (newUsersPage > usersLastPage) {
+				return;
+			}
+
+			setIsFetchingMembers(true);
+
+			try {
+				const spaceUsers = await SpaceService.getSpaceUsers({
+					page: newUsersPage,
+					pageSize,
+					spaceId: assetLibraryId,
+				});
+
+				setSelectedUsers((currentSelectedUsers) => [
+					...currentSelectedUsers,
+					...spaceUsers.items,
+				]);
+				setUsersPage(newUsersPage);
+				setUsersLastPage(spaceUsers.lastPage);
+			}
+			catch (error) {
+				console.error(error);
+			}
+			finally {
+				setIsFetchingMembers(false);
+			}
+
+			return;
+		}
+
+		const newUserGroupsPage = userGroupsPage + 1;
+		if (newUserGroupsPage > userGroupsLastPage) {
+			return;
+		}
+
+		setIsFetchingMembers(true);
+
+		try {
+			const spaceUserGroups = await SpaceService.getSpaceUserGroups({
+				page: newUserGroupsPage,
+				pageSize,
+				spaceId: assetLibraryId,
+			});
+
+			setSelectedUserGroups((currentSelectedUserGroups) => [
+				...currentSelectedUserGroups,
+				...spaceUserGroups.items,
+			]);
+			setUserGroupsPage(newUserGroupsPage);
+			setUserGroupsLastPage(spaceUserGroups.lastPage);
+		}
+		catch (error) {
+			console.error(error);
+		}
+		finally {
+			setIsFetchingMembers(false);
+		}
+	}, [
+		assetLibraryId,
+		selectedOption,
+		userGroupsPage,
+		usersPage,
+		userGroupsLastPage,
+		usersLastPage,
+	]);
+
+	useEffect(() => {
+		if (!sentinelRef.current) {
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries[0].isIntersecting) {
+					loadMoreItems();
+				}
+			},
+			{
+				threshold: 1,
+			}
+		);
+
+		observer.observe(sentinelRef.current);
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [sentinelRef, loadMoreItems]);
+
+	const onAutocompleteItemSelected = async (
+		item: UserAccount | UserGroup
+	) => {
+		if (selectedOption === SelectOptions.USERS) {
+			if (selectedUsers.some((user) => user.id === item.id)) {
+				return;
+			}
+
+			setSelectedUsers([item as UserAccount, ...selectedUsers]);
+
+			const {error} = await SpaceService.linkUserToSpace({
+				spaceId: assetLibraryId,
+				userId: item.id,
+			});
+
+			if (error) {
+				openToast({
+					message: sub(
+						Liferay.Language.get('failed-to-add-user-x-to-space'),
+						[`<strong>${item.name}</strong>`]
+					),
+					type: 'danger',
+				});
+			}
+			else {
+				openToast({
+					message: sub(
+						Liferay.Language.get(
+							'user-x-successfully-added-to-space'
+						),
+						[`<strong>${item.name}</strong>`]
+					),
+					type: 'success',
+				});
+			}
+
+			return;
+		}
+
+		if (selectedUserGroups.some((group) => group.id === item.id)) {
+			return;
+		}
+
+		setSelectedUserGroups([item, ...selectedUserGroups]);
+
+		const {error} = await SpaceService.linkUserGroupToSpace({
+			spaceId: assetLibraryId,
+			userGroupId: item.id,
+		});
+
+		if (error) {
+			openToast({
+				message: sub(
+					Liferay.Language.get('failed-to-add-group-x-to-space'),
+					[`<strong>${item.name}</strong>`]
+				),
+				type: 'danger',
+			});
+		}
+		else {
+			openToast({
+				message: sub(
+					Liferay.Language.get('group-x-successfully-added-to-space'),
+					[`<strong>${item.name}</strong>`]
+				),
+				type: 'success',
+			});
+		}
+	};
+
+	const onRemoveItem = async (item: UserAccount | UserGroup) => {
+		if (selectedOption === SelectOptions.USERS) {
+			setSelectedUsers(selectedUsers.filter((u) => u.id !== item.id));
+
+			const {error} = await SpaceService.unlinkUserFromSpace({
+				spaceId: assetLibraryId,
+				userId: item.id,
+			});
+
+			if (error) {
+				openToast({
+					message: sub(
+						Liferay.Language.get(
+							'unable-to-remove-user-x-from-space'
+						),
+						[`<strong>${item.name}</strong>`]
+					),
+					type: 'danger',
+				});
+			}
+			else {
+				openToast({
+					message: sub(
+						Liferay.Language.get(
+							'user-x-successfully-removed-from-space'
+						),
+						[`<strong>${item.name}</strong>`]
+					),
+					type: 'success',
+				});
+			}
+
+			return;
+		}
+
+		setSelectedUserGroups(
+			selectedUserGroups.filter((u) => u.id !== item.id)
+		);
+
+		const {error} = await SpaceService.unlinkUserGroupFromSpace({
+			spaceId: assetLibraryId,
+			userGroupId: item.id,
+		});
+
+		if (error) {
+			openToast({
+				message: sub(
+					Liferay.Language.get(
+						'unable-to-remove-group-x-from-space-x'
+					),
+					[`<strong>${item.name}</strong>`]
+				),
+				type: 'success',
+			});
+		}
+		else {
+			openToast({
+				message: sub(
+					Liferay.Language.get(
+						'group-x-successfully-removed-from-space-x'
+					),
+					[`<strong>${item.name}</strong>`]
+				),
+				type: 'success',
+			});
+		}
+	};
+
+	const listLabelId = useId();
+
+	return (
+		<div className={classNames('space-members-with-list', className)}>
+			<SpaceMembersInputWithSelect
+				onAutocompleteItemSelected={onAutocompleteItemSelected}
+				onSelectChange={(value) => {
+					setSelectedOption(value);
+				}}
+				selectValue={selectedOption}
+			/>
+
+			<label className="d-block" id={listLabelId}>
+				{Liferay.Language.get('who-has-access')}
+			</label>
+
+			<ul aria-labelledby={listLabelId} className="members-list">
+				{selectedOption === SelectOptions.USERS ? (
+					<MembersListItem
+						assetLibraryCreatorUserId={assetLibraryCreatorUserId}
+						currentUserId={currentUserId}
+						emptyMessage={Liferay.Language.get(
+							'this-space-has-no-user-yet'
+						)}
+						itemType="user"
+						items={selectedUsers}
+						onRemoveItem={onRemoveItem}
+					/>
+				) : (
+					<MembersListItem
+						emptyMessage={Liferay.Language.get(
+							'this-space-has-no-group-yet'
+						)}
+						itemType="group"
+						items={selectedUserGroups}
+						onRemoveItem={onRemoveItem}
+					/>
+				)}
+
+				{isFetchingMembers && (
+					<li className="d-flex justify-content-center">
+						<LoadingIndicator displayType="secondary" size="sm" />
+					</li>
+				)}
+
+				<div ref={sentinelRef} />
+			</ul>
+		</div>
+	);
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces/SpaceMembersWithList.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces/SpaceMembersWithList.tsx
@@ -24,7 +24,7 @@ interface SpaceMembersWithListProps {
 	assetLibraryId: string;
 	className?: string;
 	onHasSelectedMembersChange?: (hasSelectedMembers: boolean) => void;
-  pageSize?: number;
+	pageSize?: number;
 }
 
 const DEFAULT_PAGE_SIZE = 20;
@@ -34,7 +34,7 @@ export function SpaceMembersWithList({
 	assetLibraryId,
 	className,
 	onHasSelectedMembersChange,
-  pageSize = DEFAULT_PAGE_SIZE,
+	pageSize = DEFAULT_PAGE_SIZE,
 }: SpaceMembersWithListProps) {
 	const currentUserId = Liferay.ThemeDisplay.getUserId();
 	const [isFetchingMembers, setIsFetchingMembers] = useState(false);
@@ -81,7 +81,7 @@ export function SpaceMembersWithList({
 		finally {
 			setIsFetchingMembers(false);
 		}
-	}, [assetLibraryId]);
+	}, [assetLibraryId, pageSize]);
 
 	useEffect(() => {
 		const hasMembers =
@@ -152,6 +152,7 @@ export function SpaceMembersWithList({
 		}
 	}, [
 		assetLibraryId,
+		pageSize,
 		selectedOption,
 		userGroupsPage,
 		usersPage,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/services/SpaceService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/services/SpaceService.ts
@@ -55,7 +55,12 @@ async function getSpaceUserGroups({
 	page?: number;
 	pageSize?: number;
 	spaceId: string;
-}): Promise<{items: UserGroup[]; page: number; lastPage: number; totalCount: number;}> {
+}): Promise<{
+	items: UserGroup[];
+	lastPage: number;
+	page: number;
+	totalCount: number;
+}> {
 	const urlParams = new URLSearchParams();
 
 	if (page) {
@@ -66,7 +71,12 @@ async function getSpaceUserGroups({
 		urlParams.set('pageSize', String(pageSize));
 	}
 
-	const {data, error} = await ApiHelper.get<{items: UserGroup[]; page: number; lastPage: number; totalCount: number;}>(
+	const {data, error} = await ApiHelper.get<{
+		items: UserGroup[];
+		lastPage: number;
+		page: number;
+		totalCount: number;
+	}>(
 		`/o/headless-asset-library/v1.0/asset-libraries/${spaceId}/user-groups?${urlParams.toString()}`
 	);
 
@@ -85,7 +95,12 @@ async function getSpaceUsers({
 	page?: number;
 	pageSize?: number;
 	spaceId: string;
-}): Promise<{items: UserAccount[]; page: number; lastPage: number; totalCount: number;}> {
+}): Promise<{
+	items: UserAccount[];
+	lastPage: number;
+	page: number;
+	totalCount: number;
+}> {
 	const urlParams = new URLSearchParams();
 
 	if (page) {
@@ -96,7 +111,12 @@ async function getSpaceUsers({
 		urlParams.set('pageSize', String(pageSize));
 	}
 
-	const {data, error} = await ApiHelper.get<{items: UserAccount[]; page: number; lastPage: number; totalCount: number;}>(
+	const {data, error} = await ApiHelper.get<{
+		items: UserAccount[];
+		lastPage: number;
+		page: number;
+		totalCount: number;
+	}>(
 		`/o/headless-asset-library/v1.0/asset-libraries/${spaceId}/user-accounts?${urlParams.toString()}`
 	);
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/services/SpaceService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/services/SpaceService.ts
@@ -48,32 +48,60 @@ async function getSpace({
 }
 
 async function getSpaceUserGroups({
+	page,
+	pageSize,
 	spaceId,
 }: {
+	page?: number;
+	pageSize?: number;
 	spaceId: string;
-}): Promise<UserGroup[]> {
-	const {data, error} = await ApiHelper.get<{items: UserGroup[]}>(
-		`/o/headless-asset-library/v1.0/asset-libraries/${spaceId}/user-groups`
+}): Promise<{items: UserGroup[]; page: number; lastPage: number; totalCount: number;}> {
+	const urlParams = new URLSearchParams();
+
+	if (page) {
+		urlParams.set('page', String(page));
+	}
+
+	if (pageSize) {
+		urlParams.set('pageSize', String(pageSize));
+	}
+
+	const {data, error} = await ApiHelper.get<{items: UserGroup[]; page: number; lastPage: number; totalCount: number;}>(
+		`/o/headless-asset-library/v1.0/asset-libraries/${spaceId}/user-groups?${urlParams.toString()}`
 	);
 
 	if (data) {
-		return data.items;
+		return data;
 	}
 
 	throw new Error(error);
 }
 
 async function getSpaceUsers({
+	page,
+	pageSize,
 	spaceId,
 }: {
+	page?: number;
+	pageSize?: number;
 	spaceId: string;
-}): Promise<UserAccount[]> {
-	const {data, error} = await ApiHelper.get<{items: UserAccount[]}>(
-		`/o/headless-asset-library/v1.0/asset-libraries/${spaceId}/user-accounts`
+}): Promise<{items: UserAccount[]; page: number; lastPage: number; totalCount: number;}> {
+	const urlParams = new URLSearchParams();
+
+	if (page) {
+		urlParams.set('page', String(page));
+	}
+
+	if (pageSize) {
+		urlParams.set('pageSize', String(pageSize));
+	}
+
+	const {data, error} = await ApiHelper.get<{items: UserAccount[]; page: number; lastPage: number; totalCount: number;}>(
+		`/o/headless-asset-library/v1.0/asset-libraries/${spaceId}/user-accounts?${urlParams.toString()}`
 	);
 
 	if (data) {
-		return data.items;
+		return data;
 	}
 
 	throw new Error(error);

--- a/modules/apps/site/site-cms-site-initializer/test/js/main/spaces/AddSpaceMembers.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main/spaces/AddSpaceMembers.test.tsx
@@ -4,8 +4,7 @@
  */
 
 import '@testing-library/jest-dom/extend-expect';
-import {act, render, screen, waitFor, within} from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import {act, render, screen} from '@testing-library/react';
 import React from 'react';
 
 import {
@@ -14,10 +13,6 @@ import {
 } from '../../../../src/main/resources/META-INF/resources/js/main/spaces/AddSpaceMembers';
 import SpaceService from '../../../../src/main/resources/META-INF/resources/js/services/SpaceService';
 import {Space} from '../../../../src/main/resources/META-INF/resources/js/types/Space';
-import {
-	UserAccount,
-	UserGroup,
-} from '../../../../src/main/resources/META-INF/resources/js/types/UserAccount';
 
 describe('AddSpaceMembers', () => {
 	const testSpace = {
@@ -25,60 +20,31 @@ describe('AddSpaceMembers', () => {
 		name: 'Test Space',
 	};
 
-	const testUsers = [
-		{
-			emailAddress: 'john.doe@example.com',
-			id: '1',
-			image: '/image/user_portrait',
-			name: 'John Doe',
-		},
-		{
-			emailAddress: 'jane.smith@example.com',
-			id: '2',
-			image: '/image/user_portrait',
-			name: 'Jane Smith',
-		},
-	] as UserAccount[];
-
 	const testUsersResponse = {
-		items: testUsers,
+		items: [],
 		lastPage: 1,
 		page: 1,
-		totalCount: testUsers.length,
+		totalCount: 0,
 	};
 
-	const testUserGroups = [
-		{
-			id: '1',
-			name: 'Group 1',
-		},
-		{
-			id: '2',
-			name: 'Group 2',
-		},
-	] as UserGroup[];
-
 	const testUserGroupsResponse = {
-		items: testUserGroups,
+		items: [],
 		lastPage: 1,
 		page: 1,
-		totalCount: testUserGroups.length,
+		totalCount: 0,
 	};
 
 	const props: AddSpaceMembersProps = {
-		assetLibraryCreatorUserId: testUsers[0].id,
+		assetLibraryCreatorUserId: '0',
 		assetLibraryId: testSpace.id,
 		assetLibraryName: testSpace.name,
 		baseAssetLibraryURL: '/web/cms/e/space/28632',
 	};
 
 	const LiferayOriginal = global.Liferay;
-	const {ResizeObserver: ResizeObserverOriginal} = window;
-
 	let getSpaceSpy: jest.SpyInstance;
 	let getSpaceUsersSpy: jest.SpyInstance;
 	let getSpaceUserGroupsSpy: jest.SpyInstance;
-	let intersectionObserverMock: jest.Mock;
 
 	beforeEach(() => {
 		getSpaceSpy = jest
@@ -90,17 +56,6 @@ describe('AddSpaceMembers', () => {
 		getSpaceUserGroupsSpy = jest
 			.spyOn(SpaceService, 'getSpaceUserGroups')
 			.mockResolvedValue(testUserGroupsResponse);
-
-		intersectionObserverMock = jest.fn((callback) => {
-			(intersectionObserverMock as any).mockCallback = callback;
-
-			return {
-				disconnect: jest.fn(),
-				observe: jest.fn(),
-				unobserve: jest.fn(),
-			};
-		});
-		global.IntersectionObserver = intersectionObserverMock;
 	});
 
 	beforeAll(() => {
@@ -113,12 +68,6 @@ describe('AddSpaceMembers', () => {
 				getUserId: jest.fn(() => '1'),
 			},
 		} as any;
-
-		window.ResizeObserver = jest.fn().mockImplementation(() => ({
-			disconnect: jest.fn(),
-			observe: jest.fn(),
-			unobserve: jest.fn(),
-		}));
 	});
 
 	afterEach(() => {
@@ -130,8 +79,6 @@ describe('AddSpaceMembers', () => {
 	});
 
 	afterAll(() => {
-		window.ResizeObserver = ResizeObserverOriginal;
-		delete (global as any).IntersectionObserver;
 		jest.restoreAllMocks();
 	});
 
@@ -152,145 +99,5 @@ describe('AddSpaceMembers', () => {
 				name: 'continue',
 			})
 		).toBeInTheDocument();
-	});
-
-	it('lists users from a space', async () => {
-		await act(async () => render(<AddSpaceMembers {...props} />));
-
-		const usersList = screen.getByLabelText('who-has-access');
-		expect(usersList).toBeInTheDocument();
-
-		await waitFor(() => {
-			const usersListItems = within(usersList).getAllByRole('listitem');
-			expect(usersListItems).toHaveLength(testUsers.length);
-
-			usersListItems.forEach((item, index) => {
-				expect(item).toHaveTextContent(testUsers[index].name);
-			});
-		});
-	});
-
-	it('lists user groups from a space', async () => {
-		await act(async () => render(<AddSpaceMembers {...props} />));
-
-		await userEvent.click(
-			screen.getByRole('combobox', {name: 'add-people-to-collaborate'})
-		);
-
-		await userEvent.click(screen.getByRole('option', {name: 'groups'}));
-
-		const userGroupsList = screen.getByLabelText('who-has-access');
-		expect(userGroupsList).toBeInTheDocument();
-
-		await waitFor(() => {
-			const userGroupsListItems =
-				within(userGroupsList).getAllByRole('listitem');
-			expect(userGroupsListItems).toHaveLength(testUsers.length);
-
-			userGroupsListItems.forEach((item, index) => {
-				expect(item).toHaveTextContent(testUsers[index].name);
-			});
-		});
-	});
-
-	it('loads more users when scrolling down', async () => {
-		const moreUsers = [
-			{
-				emailAddress: 'user3@example.com',
-				id: '3',
-				name: 'User Three',
-			},
-		];
-		const moreUsersResponse = {
-			items: moreUsers,
-			lastPage: 2,
-			page: 2,
-			totalCount: 1,
-		};
-
-		getSpaceUsersSpy.mockResolvedValueOnce({
-			...testUsersResponse,
-			lastPage: 2,
-		});
-
-		await act(async () => render(<AddSpaceMembers {...props} />));
-
-		await waitFor(() => {
-			expect(
-				within(screen.getByLabelText('who-has-access')).getAllByRole(
-					'listitem'
-				)
-			).toHaveLength(testUsers.length);
-		});
-
-		getSpaceUsersSpy.mockResolvedValueOnce(moreUsersResponse);
-
-		act(() => {
-			(intersectionObserverMock as any).mockCallback([
-				{isIntersecting: true},
-			]);
-		});
-
-		await waitFor(() => {
-			expect(getSpaceUsersSpy).toHaveBeenCalledTimes(2);
-			expect(getSpaceUsersSpy).toHaveBeenLastCalledWith(
-				expect.objectContaining({page: 2})
-			);
-		});
-
-		await waitFor(() => {
-			expect(
-				within(screen.getByLabelText('who-has-access')).getAllByRole(
-					'listitem'
-				)
-			).toHaveLength(testUsers.length + moreUsers.length);
-		});
-
-		expect(screen.queryByRole('status')).not.toBeInTheDocument();
-	});
-
-	it('loads more user groups when scrolling down', async () => {
-		const moreGroups = [{id: '3', name: 'Group Three'}];
-		const moreGroupsResponse = {
-			items: moreGroups,
-			lastPage: 2,
-			page: 2,
-			totalCount: 1,
-		};
-
-		getSpaceUserGroupsSpy.mockResolvedValueOnce({
-			...testUserGroupsResponse,
-			lastPage: 2,
-		});
-
-		await act(async () => render(<AddSpaceMembers {...props} />));
-
-		await userEvent.selectOptions(
-			screen.getByRole('combobox', {name: 'add-people-to-collaborate'}),
-			'groups'
-		);
-
-		getSpaceUserGroupsSpy.mockResolvedValueOnce(moreGroupsResponse);
-
-		act(() => {
-			(intersectionObserverMock as any).mockCallback([
-				{isIntersecting: true},
-			]);
-		});
-
-		await waitFor(() => {
-			expect(getSpaceUserGroupsSpy).toHaveBeenCalledTimes(2);
-			expect(getSpaceUserGroupsSpy).toHaveBeenLastCalledWith(
-				expect.objectContaining({page: 2})
-			);
-		});
-
-		await waitFor(() => {
-			expect(
-				within(screen.getByLabelText('who-has-access')).getAllByRole(
-					'listitem'
-				)
-			).toHaveLength(testUserGroups.length + moreGroups.length);
-		});
 	});
 });

--- a/modules/apps/site/site-cms-site-initializer/test/js/main/spaces/AddSpaceMembers.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main/spaces/AddSpaceMembers.test.tsx
@@ -38,7 +38,14 @@ describe('AddSpaceMembers', () => {
 			image: '/image/user_portrait',
 			name: 'Jane Smith',
 		},
-	];
+	] as UserAccount[];
+
+	const testUsersResponse = {
+		items: testUsers,
+		lastPage: 1,
+		page: 1,
+		totalCount: testUsers.length,
+	};
 
 	const testUserGroups = [
 		{
@@ -49,13 +56,20 @@ describe('AddSpaceMembers', () => {
 			id: '2',
 			name: 'Group 2',
 		},
-	];
+	] as UserGroup[];
+
+	const testUserGroupsResponse = {
+		items: testUserGroups,
+		lastPage: 1,
+		page: 1,
+		totalCount: testUserGroups.length,
+	};
 
 	const props: AddSpaceMembersProps = {
 		assetLibraryCreatorUserId: testUsers[0].id,
 		assetLibraryId: testSpace.id,
 		assetLibraryName: testSpace.name,
-		baseAssetLibraryURL: '/web/cms/e/space/28632/',
+		baseAssetLibraryURL: '/web/cms/e/space/28632',
 	};
 
 	const LiferayOriginal = global.Liferay;
@@ -64,6 +78,7 @@ describe('AddSpaceMembers', () => {
 	let getSpaceSpy: jest.SpyInstance;
 	let getSpaceUsersSpy: jest.SpyInstance;
 	let getSpaceUserGroupsSpy: jest.SpyInstance;
+	let intersectionObserverMock: jest.Mock;
 
 	beforeEach(() => {
 		getSpaceSpy = jest
@@ -71,19 +86,24 @@ describe('AddSpaceMembers', () => {
 			.mockResolvedValue(testSpace as Space);
 		getSpaceUsersSpy = jest
 			.spyOn(SpaceService, 'getSpaceUsers')
-			.mockResolvedValue(testUsers as UserAccount[]);
+			.mockResolvedValue(testUsersResponse);
 		getSpaceUserGroupsSpy = jest
 			.spyOn(SpaceService, 'getSpaceUserGroups')
-			.mockResolvedValue(testUserGroups as UserGroup[]);
+			.mockResolvedValue(testUserGroupsResponse);
+
+		intersectionObserverMock = jest.fn((callback) => {
+			(intersectionObserverMock as any).mockCallback = callback;
+
+			return {
+				disconnect: jest.fn(),
+				observe: jest.fn(),
+				unobserve: jest.fn(),
+			};
+		});
+		global.IntersectionObserver = intersectionObserverMock;
 	});
 
 	beforeAll(() => {
-		window.ResizeObserver = jest.fn().mockImplementation(() => ({
-			disconnect: jest.fn(),
-			observe: jest.fn(),
-			unobserve: jest.fn(),
-		}));
-
 		global.Liferay = {
 			Language: {
 				get: jest.fn((key) => key),
@@ -93,6 +113,12 @@ describe('AddSpaceMembers', () => {
 				getUserId: jest.fn(() => '1'),
 			},
 		} as any;
+
+		window.ResizeObserver = jest.fn().mockImplementation(() => ({
+			disconnect: jest.fn(),
+			observe: jest.fn(),
+			unobserve: jest.fn(),
+		}));
 	});
 
 	afterEach(() => {
@@ -105,6 +131,7 @@ describe('AddSpaceMembers', () => {
 
 	afterAll(() => {
 		window.ResizeObserver = ResizeObserverOriginal;
+		delete (global as any).IntersectionObserver;
 		jest.restoreAllMocks();
 	});
 
@@ -163,6 +190,107 @@ describe('AddSpaceMembers', () => {
 			userGroupsListItems.forEach((item, index) => {
 				expect(item).toHaveTextContent(testUsers[index].name);
 			});
+		});
+	});
+
+	it('loads more users when scrolling down', async () => {
+		const moreUsers = [
+			{
+				emailAddress: 'user3@example.com',
+				id: '3',
+				name: 'User Three',
+			},
+		];
+		const moreUsersResponse = {
+			items: moreUsers,
+			lastPage: 2,
+			page: 2,
+			totalCount: 1,
+		};
+
+		getSpaceUsersSpy.mockResolvedValueOnce({
+			...testUsersResponse,
+			lastPage: 2,
+		});
+
+		await act(async () => render(<AddSpaceMembers {...props} />));
+
+		await waitFor(() => {
+			expect(
+				within(screen.getByLabelText('who-has-access')).getAllByRole(
+					'listitem'
+				)
+			).toHaveLength(testUsers.length);
+		});
+
+		getSpaceUsersSpy.mockResolvedValueOnce(moreUsersResponse);
+
+		act(() => {
+			(intersectionObserverMock as any).mockCallback([
+				{isIntersecting: true},
+			]);
+		});
+
+		await waitFor(() => {
+			expect(getSpaceUsersSpy).toHaveBeenCalledTimes(2);
+			expect(getSpaceUsersSpy).toHaveBeenLastCalledWith(
+				expect.objectContaining({page: 2})
+			);
+		});
+
+		await waitFor(() => {
+			expect(
+				within(screen.getByLabelText('who-has-access')).getAllByRole(
+					'listitem'
+				)
+			).toHaveLength(testUsers.length + moreUsers.length);
+		});
+
+		expect(screen.queryByRole('status')).not.toBeInTheDocument();
+	});
+
+	it('loads more user groups when scrolling down', async () => {
+		const moreGroups = [{id: '3', name: 'Group Three'}];
+		const moreGroupsResponse = {
+			items: moreGroups,
+			lastPage: 2,
+			page: 2,
+			totalCount: 1,
+		};
+
+		getSpaceUserGroupsSpy.mockResolvedValueOnce({
+			...testUserGroupsResponse,
+			lastPage: 2,
+		});
+
+		await act(async () => render(<AddSpaceMembers {...props} />));
+
+		await userEvent.selectOptions(
+			screen.getByRole('combobox', {name: 'add-people-to-collaborate'}),
+			'groups'
+		);
+
+		getSpaceUserGroupsSpy.mockResolvedValueOnce(moreGroupsResponse);
+
+		act(() => {
+			(intersectionObserverMock as any).mockCallback([
+				{isIntersecting: true},
+			]);
+		});
+
+		await waitFor(() => {
+			expect(getSpaceUserGroupsSpy).toHaveBeenCalledTimes(2);
+			expect(getSpaceUserGroupsSpy).toHaveBeenLastCalledWith(
+				expect.objectContaining({page: 2})
+			);
+		});
+
+		await waitFor(() => {
+			expect(
+				within(screen.getByLabelText('who-has-access')).getAllByRole(
+					'listitem'
+				)
+			).toHaveLength(testUserGroups.length + moreGroups.length);
 		});
 	});
 });

--- a/modules/apps/site/site-cms-site-initializer/test/js/main/spaces/AddSpaceMembers.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main/spaces/AddSpaceMembers.test.tsx
@@ -56,6 +56,12 @@ describe('AddSpaceMembers', () => {
 		getSpaceUserGroupsSpy = jest
 			.spyOn(SpaceService, 'getSpaceUserGroups')
 			.mockResolvedValue(testUserGroupsResponse);
+
+		global.IntersectionObserver = jest.fn().mockImplementation(() => ({
+			disconnect: jest.fn(),
+			observe: jest.fn(),
+			unobserve: jest.fn(),
+		}));
 	});
 
 	beforeAll(() => {
@@ -80,6 +86,7 @@ describe('AddSpaceMembers', () => {
 
 	afterAll(() => {
 		jest.restoreAllMocks();
+		delete (global as any).IntersectionObserver;
 	});
 
 	it('renders with correct title, description, buttons', async () => {
@@ -96,7 +103,7 @@ describe('AddSpaceMembers', () => {
 
 		expect(
 			screen.getByRole('button', {
-				name: 'continue',
+				name: 'continue-without-members',
 			})
 		).toBeInTheDocument();
 	});

--- a/modules/apps/site/site-cms-site-initializer/test/js/main/spaces/SpaceMembersWithList.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main/spaces/SpaceMembersWithList.test.tsx
@@ -1,0 +1,277 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom/extend-expect';
+import {act, render, screen, waitFor, within} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import {
+	AddSpaceMembers,
+	AddSpaceMembersProps,
+} from '../../../../src/main/resources/META-INF/resources/js/main/spaces/AddSpaceMembers';
+import SpaceService from '../../../../src/main/resources/META-INF/resources/js/services/SpaceService';
+import {Space} from '../../../../src/main/resources/META-INF/resources/js/types/Space';
+import {
+	UserAccount,
+	UserGroup,
+} from '../../../../src/main/resources/META-INF/resources/js/types/UserAccount';
+
+describe('SpaceMembersWithList', () => {
+	const testSpace = {
+		id: '123',
+		name: 'Test Space',
+	};
+
+	const testUsers = [
+		{
+			emailAddress: 'john.doe@example.com',
+			id: '1',
+			image: '/image/user_portrait',
+			name: 'John Doe',
+		},
+		{
+			emailAddress: 'jane.smith@example.com',
+			id: '2',
+			image: '/image/user_portrait',
+			name: 'Jane Smith',
+		},
+	] as UserAccount[];
+
+	const testUsersResponse = {
+		items: testUsers,
+		lastPage: 1,
+		page: 1,
+		totalCount: testUsers.length,
+	};
+
+	const testUserGroups = [
+		{
+			id: '1',
+			name: 'Group 1',
+		},
+		{
+			id: '2',
+			name: 'Group 2',
+		},
+	] as UserGroup[];
+
+	const testUserGroupsResponse = {
+		items: testUserGroups,
+		lastPage: 1,
+		page: 1,
+		totalCount: testUserGroups.length,
+	};
+
+	const props: AddSpaceMembersProps = {
+		assetLibraryCreatorUserId: testUsers[0].id,
+		assetLibraryId: testSpace.id,
+		assetLibraryName: testSpace.name,
+		baseAssetLibraryURL: '/web/cms/e/space/28632',
+	};
+
+	const LiferayOriginal = global.Liferay;
+	const {ResizeObserver: ResizeObserverOriginal} = window;
+
+	let getSpaceSpy: jest.SpyInstance;
+	let getSpaceUsersSpy: jest.SpyInstance;
+	let getSpaceUserGroupsSpy: jest.SpyInstance;
+	let intersectionObserverMock: jest.Mock;
+
+	beforeEach(() => {
+		getSpaceSpy = jest
+			.spyOn(SpaceService, 'getSpace')
+			.mockResolvedValue(testSpace as Space);
+		getSpaceUsersSpy = jest
+			.spyOn(SpaceService, 'getSpaceUsers')
+			.mockResolvedValue(testUsersResponse);
+		getSpaceUserGroupsSpy = jest
+			.spyOn(SpaceService, 'getSpaceUserGroups')
+			.mockResolvedValue(testUserGroupsResponse);
+
+		intersectionObserverMock = jest.fn((callback) => {
+			(intersectionObserverMock as any).mockCallback = callback;
+
+			return {
+				disconnect: jest.fn(),
+				observe: jest.fn(),
+				unobserve: jest.fn(),
+			};
+		});
+		global.IntersectionObserver = intersectionObserverMock;
+	});
+
+	beforeAll(() => {
+		global.Liferay = {
+			Language: {
+				get: jest.fn((key) => key),
+			},
+			ThemeDisplay: {
+				...LiferayOriginal.ThemeDisplay,
+				getUserId: jest.fn(() => '1'),
+			},
+		} as any;
+
+		window.ResizeObserver = jest.fn().mockImplementation(() => ({
+			disconnect: jest.fn(),
+			observe: jest.fn(),
+			unobserve: jest.fn(),
+		}));
+	});
+
+	afterEach(() => {
+		getSpaceSpy.mockClear();
+		getSpaceUsersSpy.mockClear();
+		getSpaceUserGroupsSpy.mockClear();
+
+		jest.clearAllMocks();
+	});
+
+	afterAll(() => {
+		window.ResizeObserver = ResizeObserverOriginal;
+		delete (global as any).IntersectionObserver;
+		jest.restoreAllMocks();
+	});
+
+	it('lists users from a space', async () => {
+		await act(async () => render(<AddSpaceMembers {...props} />));
+
+		const usersList = screen.getByLabelText('who-has-access');
+		expect(usersList).toBeInTheDocument();
+
+		await waitFor(() => {
+			const usersListItems = within(usersList).getAllByRole('listitem');
+			expect(usersListItems).toHaveLength(testUsers.length);
+
+			usersListItems.forEach((item, index) => {
+				expect(item).toHaveTextContent(testUsers[index].name);
+			});
+		});
+	});
+
+	it('lists user groups from a space', async () => {
+		await act(async () => render(<AddSpaceMembers {...props} />));
+
+		await userEvent.click(
+			screen.getByRole('combobox', {name: 'add-people-to-collaborate'})
+		);
+
+		await userEvent.click(screen.getByRole('option', {name: 'groups'}));
+
+		const userGroupsList = screen.getByLabelText('who-has-access');
+		expect(userGroupsList).toBeInTheDocument();
+
+		await waitFor(() => {
+			const userGroupsListItems =
+				within(userGroupsList).getAllByRole('listitem');
+			expect(userGroupsListItems).toHaveLength(testUsers.length);
+
+			userGroupsListItems.forEach((item, index) => {
+				expect(item).toHaveTextContent(testUsers[index].name);
+			});
+		});
+	});
+
+	it('loads more users when scrolling down', async () => {
+		const moreUsers = [
+			{
+				emailAddress: 'user3@example.com',
+				id: '3',
+				name: 'User Three',
+			},
+		];
+		const moreUsersResponse = {
+			items: moreUsers,
+			lastPage: 2,
+			page: 2,
+			totalCount: 1,
+		};
+
+		getSpaceUsersSpy.mockResolvedValueOnce({
+			...testUsersResponse,
+			lastPage: 2,
+		});
+
+		await act(async () => render(<AddSpaceMembers {...props} />));
+
+		await waitFor(() => {
+			expect(
+				within(screen.getByLabelText('who-has-access')).getAllByRole(
+					'listitem'
+				)
+			).toHaveLength(testUsers.length);
+		});
+
+		getSpaceUsersSpy.mockResolvedValueOnce(moreUsersResponse);
+
+		act(() => {
+			(intersectionObserverMock as any).mockCallback([
+				{isIntersecting: true},
+			]);
+		});
+
+		await waitFor(() => {
+			expect(getSpaceUsersSpy).toHaveBeenCalledTimes(2);
+			expect(getSpaceUsersSpy).toHaveBeenLastCalledWith(
+				expect.objectContaining({page: 2})
+			);
+		});
+
+		await waitFor(() => {
+			expect(
+				within(screen.getByLabelText('who-has-access')).getAllByRole(
+					'listitem'
+				)
+			).toHaveLength(testUsers.length + moreUsers.length);
+		});
+
+		expect(screen.queryByRole('status')).not.toBeInTheDocument();
+	});
+
+	it('loads more user groups when scrolling down', async () => {
+		const moreGroups = [{id: '3', name: 'Group Three'}];
+		const moreGroupsResponse = {
+			items: moreGroups,
+			lastPage: 2,
+			page: 2,
+			totalCount: 1,
+		};
+
+		getSpaceUserGroupsSpy.mockResolvedValueOnce({
+			...testUserGroupsResponse,
+			lastPage: 2,
+		});
+
+		await act(async () => render(<AddSpaceMembers {...props} />));
+
+		await userEvent.selectOptions(
+			screen.getByRole('combobox', {name: 'add-people-to-collaborate'}),
+			'groups'
+		);
+
+		getSpaceUserGroupsSpy.mockResolvedValueOnce(moreGroupsResponse);
+
+		act(() => {
+			(intersectionObserverMock as any).mockCallback([
+				{isIntersecting: true},
+			]);
+		});
+
+		await waitFor(() => {
+			expect(getSpaceUserGroupsSpy).toHaveBeenCalledTimes(2);
+			expect(getSpaceUserGroupsSpy).toHaveBeenLastCalledWith(
+				expect.objectContaining({page: 2})
+			);
+		});
+
+		await waitFor(() => {
+			expect(
+				within(screen.getByLabelText('who-has-access')).getAllByRole(
+					'listitem'
+				)
+			).toHaveLength(testUserGroups.length + moreGroups.length);
+		});
+	});
+});


### PR DESCRIPTION
[LPD-57471](https://liferay.atlassian.net/browse/LPD-57471)

# What is this trying to solve?
It avoids loading all the users/groups linked to a space when the page is loaded.

# How am I fixing it?
By implementing pagination when scrolling. Only 20 users/groups will be loaded at a time.

# How can you verify that it works?
1. Create more than 20 users.
2. Go to `/web/cms/new-space`
3. Add a name
4. Click "Continue"
5. Add more than 20 users and/or groups to the space
6. Reload the page
7. Open the network tab in the browser and monitor requests for `/o/headless-asset-library/v1.0/asset-libraries/<asset-library-id>/user-accounts`
8. Assert only 20 are loaded in the first time
9. Scroll to the end of the list
10. Assert a loading icon is displayed while the users are being loaded
11. Assert that more users were loaded (no more than 20 at each time)