### PR TITLE
LPD-57341 Fix embedded result for Layouts in Search Result REST API by implementing the VulcanCRUDItemDelegate interface

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageSpecificationDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageSpecificationDTOConverter.java
@@ -51,10 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Lourdes Fernández Besada
  */
-@Component(
-	property = "dto.class.name=com.liferay.portal.kernel.model.Layout",
-	service = DTOConverter.class
-)
+@Component(service = DTOConverter.class)
 public class PageSpecificationDTOConverter
 	implements DTOConverter<Layout, PageSpecification> {
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/SitePageDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/SitePageDTOConverter.java
@@ -24,10 +24,7 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Rubén Pulido
  */
-@Component(
-	property = "dto.class.name=com.liferay.portal.kernel.model.Layout",
-	service = DTOConverter.class
-)
+@Component(service = DTOConverter.class)
 public class SitePageDTOConverter implements DTOConverter<Layout, SitePage> {
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
@@ -86,6 +86,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.vulcan.aggregation.Aggregation;
+import com.liferay.portal.vulcan.crud.VulcanCRUDItemDelegate;
 import com.liferay.portal.vulcan.custom.field.CustomFieldsUtil;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
@@ -128,13 +129,26 @@ import org.osgi.service.component.annotations.ServiceScope;
  */
 @Component(
 	properties = "OSGI-INF/liferay/rest/v1_0/site-page.properties",
+	property = {
+		"crud.entity.class.name=com.liferay.headless.delivery.dto.v1_0.SitePage",
+		"crud.item.delegate=true"
+	},
 	scope = ServiceScope.PROTOTYPE, service = SitePageResource.class
 )
-public class SitePageResourceImpl extends BaseSitePageResourceImpl {
+public class SitePageResourceImpl
+	extends BaseSitePageResourceImpl
+	implements VulcanCRUDItemDelegate<SitePage> {
 
 	@Override
 	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
 		return _entityModel;
+	}
+
+	@Override
+	public SitePage getItem(Long id) throws Exception {
+		Layout layout = _layoutLocalService.getLayout(id);
+
+		return getSiteSitePage(layout.getGroupId(), layout.getFriendlyURL());
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/SitePageResourceTest.java
@@ -124,8 +124,6 @@ import com.liferay.segments.model.SegmentsExperience;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
 import com.liferay.segments.test.util.SegmentsTestUtil;
 
-import jakarta.servlet.http.HttpServletRequest;
-
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.PathSegment;
@@ -518,6 +516,171 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 					" does not contain " + taxonomyCategoryBrief1,
 				contains);
 		}
+	}
+
+	private VulcanCRUDItemDelegate _getVulcanCRUDItemDelegate(Locale locale)
+		throws Exception {
+
+		return _vulcanCRUDItemDelegateBuilderRegistry.builder(
+			testCompany, "com.liferay.headless.delivery.dto.v1_0.SitePage"
+		).acceptLanguage(
+			new AcceptLanguage() {
+
+				@Override
+				public List<Locale> getLocales() {
+					return Arrays.asList(locale);
+				}
+
+				@Override
+				public String getPreferredLanguageId() {
+					return LocaleUtil.toLanguageId(locale);
+				}
+
+				@Override
+				public Locale getPreferredLocale() {
+					return locale;
+				}
+
+			}
+		).groupLocalService(
+			_groupLocalService
+		).httpServletRequest(
+			new MockHttpServletRequest() {
+
+				@Override
+				public StringBuffer getRequestURL() {
+					return new StringBuffer(
+						StringBundler.concat(
+							"http://localhost:8080/o/v1.0/",
+							RandomTestUtil.randomString(), "/",
+							RandomTestUtil.randomString()));
+				}
+
+			}
+		).httpServletResponse(
+			new MockHttpServletResponse()
+		).resourceActionLocalService(
+			_resourceActionLocalService
+		).resourcePermissionLocalService(
+			_resourcePermissionLocalService
+		).roleLocalService(
+			_roleLocalService
+		).scopeChecker(
+			_scopeChecker
+		).uriInfo(
+			new UriInfo() {
+
+				@Override
+				public URI getAbsolutePath() {
+					return getRequestUri();
+				}
+
+				@Override
+				public UriBuilder getAbsolutePathBuilder() {
+					return getRequestUriBuilder();
+				}
+
+				@Override
+				public URI getBaseUri() {
+					return URI.create(
+						"http://localhost:8080/o/" + _applicationPath);
+				}
+
+				@Override
+				public UriBuilder getBaseUriBuilder() {
+					return UriBuilder.fromUri(getBaseUri());
+				}
+
+				@Override
+				public List<Object> getMatchedResources() {
+					return Collections.emptyList();
+				}
+
+				@Override
+				public List<String> getMatchedURIs() {
+					return Collections.emptyList();
+				}
+
+				@Override
+				public List<String> getMatchedURIs(boolean decode) {
+					return getMatchedURIs();
+				}
+
+				@Override
+				public String getPath() {
+					return _resourcePath;
+				}
+
+				@Override
+				public String getPath(boolean decode) {
+					return getPath();
+				}
+
+				@Override
+				public MultivaluedMap<String, String> getPathParameters() {
+					return new MultivaluedHashMap<>();
+				}
+
+				@Override
+				public MultivaluedMap<String, String> getPathParameters(
+					boolean decode) {
+
+					return getPathParameters();
+				}
+
+				@Override
+				public List<PathSegment> getPathSegments() {
+					return Collections.emptyList();
+				}
+
+				@Override
+				public List<PathSegment> getPathSegments(boolean decode) {
+					return getPathSegments();
+				}
+
+				@Override
+				public MultivaluedMap<String, String> getQueryParameters() {
+					return new MultivaluedHashMap<>();
+				}
+
+				@Override
+				public MultivaluedMap<String, String> getQueryParameters(
+					boolean decode) {
+
+					return getQueryParameters();
+				}
+
+				@Override
+				public URI getRequestUri() {
+					return URI.create(
+						"http://localhost:8080/o/" + _applicationPath +
+							_resourcePath);
+				}
+
+				@Override
+				public UriBuilder getRequestUriBuilder() {
+					return UriBuilder.fromUri(getRequestUri());
+				}
+
+				@Override
+				public URI relativize(URI uri) {
+					return getBaseUri().relativize(uri);
+				}
+
+				@Override
+				public URI resolve(URI requestURI) {
+					return getBaseUri().resolve(requestURI);
+				}
+
+				private final String _applicationPath =
+					RandomTestUtil.randomString() + "/";
+				private final String _resourcePath =
+					RandomTestUtil.randomString();
+
+			}
+		).user(
+			UserTestUtil.getAdminUser(testCompany.getCompanyId())
+		).build();
 	}
 
 	private void _testPostSiteSitePageFailureDuplicateFriendlyURL()
@@ -1871,133 +2034,6 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			expectedTaxonomyCategoryBriefs, inputTaxonomyCategoryBriefs);
 	}
 
-	private HttpServletRequest
-		_testVulcanCRUDItemDelegate_getHttpServletRequest() {
-
-		return new MockHttpServletRequest() {
-
-			@Override
-			public StringBuffer getRequestURL() {
-				return new StringBuffer(
-					StringBundler.concat(
-						"http://localhost:8080/o/v1.0/",
-						RandomTestUtil.randomString(), "/",
-						RandomTestUtil.randomString()));
-			}
-
-		};
-	}
-
-	private UriInfo _testVulcanCRUDItemDelegate_getUriInfo() {
-		String applicationPath = RandomTestUtil.randomString() + "/";
-		String resourcePath = RandomTestUtil.randomString();
-
-		return new UriInfo() {
-
-			@Override
-			public URI getAbsolutePath() {
-				return getRequestUri();
-			}
-
-			@Override
-			public UriBuilder getAbsolutePathBuilder() {
-				return getRequestUriBuilder();
-			}
-
-			@Override
-			public URI getBaseUri() {
-				return URI.create("http://localhost:8080/o/" + applicationPath);
-			}
-
-			@Override
-			public UriBuilder getBaseUriBuilder() {
-				return UriBuilder.fromUri(getBaseUri());
-			}
-
-			@Override
-			public List<Object> getMatchedResources() {
-				return Collections.emptyList();
-			}
-
-			@Override
-			public List<String> getMatchedURIs() {
-				return Collections.emptyList();
-			}
-
-			@Override
-			public List<String> getMatchedURIs(boolean decode) {
-				return getMatchedURIs();
-			}
-
-			@Override
-			public String getPath() {
-				return resourcePath;
-			}
-
-			@Override
-			public String getPath(boolean decode) {
-				return getPath();
-			}
-
-			@Override
-			public MultivaluedMap<String, String> getPathParameters() {
-				return new MultivaluedHashMap<>();
-			}
-
-			@Override
-			public MultivaluedMap<String, String> getPathParameters(
-				boolean decode) {
-
-				return getPathParameters();
-			}
-
-			@Override
-			public List<PathSegment> getPathSegments() {
-				return Collections.emptyList();
-			}
-
-			@Override
-			public List<PathSegment> getPathSegments(boolean decode) {
-				return getPathSegments();
-			}
-
-			@Override
-			public MultivaluedMap<String, String> getQueryParameters() {
-				return new MultivaluedHashMap<>();
-			}
-
-			@Override
-			public MultivaluedMap<String, String> getQueryParameters(
-				boolean decode) {
-
-				return getQueryParameters();
-			}
-
-			@Override
-			public URI getRequestUri() {
-				return URI.create(
-					"http://localhost:8080/o/" + applicationPath +
-						resourcePath);
-			}
-
-			@Override
-			public UriBuilder getRequestUriBuilder() {
-				return UriBuilder.fromUri(getRequestUri());
-			}
-
-			@Override
-			public URI relativize(URI uri) {
-				return getBaseUri().relativize(uri);
-			}
-
-			@Override
-			public URI resolve(URI requestURI) {
-				return getBaseUri().resolve(requestURI);
-			}
-
-		};
-	}
-
 	private void _testVulcanCRUDItemDelegateGetItem() throws Exception {
 
 		// Default locale
@@ -2006,46 +2042,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			randomSitePage());
 
 		VulcanCRUDItemDelegate vulcanCRUDItemDelegate =
-			_vulcanCRUDItemDelegateBuilderRegistry.builder(
-				testCompany, "com.liferay.headless.delivery.dto.v1_0.SitePage"
-			).acceptLanguage(
-				new AcceptLanguage() {
-
-					@Override
-					public List<Locale> getLocales() {
-						return Arrays.asList(LocaleUtil.getDefault());
-					}
-
-					@Override
-					public String getPreferredLanguageId() {
-						return LocaleUtil.toLanguageId(LocaleUtil.getDefault());
-					}
-
-					@Override
-					public Locale getPreferredLocale() {
-						return LocaleUtil.getDefault();
-					}
-
-				}
-			).groupLocalService(
-				_groupLocalService
-			).httpServletRequest(
-				_testVulcanCRUDItemDelegate_getHttpServletRequest()
-			).httpServletResponse(
-				new MockHttpServletResponse()
-			).resourceActionLocalService(
-				_resourceActionLocalService
-			).resourcePermissionLocalService(
-				_resourcePermissionLocalService
-			).roleLocalService(
-				_roleLocalService
-			).scopeChecker(
-				_scopeChecker
-			).uriInfo(
-				_testVulcanCRUDItemDelegate_getUriInfo()
-			).user(
-				UserTestUtil.getAdminUser(testCompany.getCompanyId())
-			).build();
+			_getVulcanCRUDItemDelegate(LocaleUtil.getDefault());
 
 		assertEquals(
 			sitePageResource.getSiteSitePage(
@@ -2069,47 +2066,6 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 		postSitePage = testPostSiteSitePage_addSitePage(randomSitePage);
 
-		vulcanCRUDItemDelegate = _vulcanCRUDItemDelegateBuilderRegistry.builder(
-			testCompany, "com.liferay.headless.delivery.dto.v1_0.SitePage"
-		).acceptLanguage(
-			new AcceptLanguage() {
-
-				@Override
-				public List<Locale> getLocales() {
-					return Arrays.asList(LocaleUtil.SPAIN);
-				}
-
-				@Override
-				public String getPreferredLanguageId() {
-					return LocaleUtil.toLanguageId(LocaleUtil.SPAIN);
-				}
-
-				@Override
-				public Locale getPreferredLocale() {
-					return LocaleUtil.SPAIN;
-				}
-
-			}
-		).groupLocalService(
-			_groupLocalService
-		).httpServletRequest(
-			_testVulcanCRUDItemDelegate_getHttpServletRequest()
-		).httpServletResponse(
-			new MockHttpServletResponse()
-		).resourceActionLocalService(
-			_resourceActionLocalService
-		).resourcePermissionLocalService(
-			_resourcePermissionLocalService
-		).roleLocalService(
-			_roleLocalService
-		).scopeChecker(
-			_scopeChecker
-		).uriInfo(
-			_testVulcanCRUDItemDelegate_getUriInfo()
-		).user(
-			UserTestUtil.getAdminUser(testCompany.getCompanyId())
-		).build();
-
 		SitePageResource spainSitePageResource = SitePageResource.builder(
 		).authentication(
 			"test@liferay.com", PropsValues.DEFAULT_ADMIN_PASSWORD
@@ -2118,6 +2074,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		).locale(
 			LocaleUtil.SPAIN
 		).build();
+
+		vulcanCRUDItemDelegate = _getVulcanCRUDItemDelegate(LocaleUtil.SPAIN);
 
 		assertEquals(
 			spainSitePageResource.getSiteSitePage(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/SitePageResourceTest.java
@@ -57,12 +57,15 @@ import com.liferay.headless.delivery.client.dto.v1_0.TaxonomyCategoryReference;
 import com.liferay.headless.delivery.client.pagination.Page;
 import com.liferay.headless.delivery.client.problem.Problem;
 import com.liferay.headless.delivery.client.resource.v1_0.SitePageResource;
+import com.liferay.headless.delivery.client.serdes.v1_0.SitePageSerDes;
 import com.liferay.layout.admin.kernel.model.LayoutTypePortletConstants;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelLocalService;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.oauth2.provider.scope.ScopeChecker;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -92,6 +95,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -111,14 +115,26 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.crud.VulcanCRUDItemDelegate;
+import com.liferay.portal.vulcan.crud.VulcanCRUDItemDelegateBuilderRegistry;
 import com.liferay.segments.constants.SegmentsEntryConstants;
 import com.liferay.segments.constants.SegmentsExperienceConstants;
 import com.liferay.segments.model.SegmentsExperience;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
 import com.liferay.segments.test.util.SegmentsTestUtil;
 
+import jakarta.servlet.http.HttpServletRequest;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.PathSegment;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.UriInfo;
+
 import java.io.Serializable;
 
+import java.net.URI;
 import java.net.URLEncoder;
 
 import java.util.Arrays;
@@ -126,6 +142,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -138,6 +155,9 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 /**
  * @author Javier Gamarra
@@ -204,6 +224,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		catch (Problem.ProblemException problemException) {
 			Assert.assertNotNull(problemException);
 		}
+
+		_testVulcanCRUDItemDelegateGetItem();
 	}
 
 	@Override
@@ -1849,6 +1871,187 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			expectedTaxonomyCategoryBriefs, inputTaxonomyCategoryBriefs);
 	}
 
+	private HttpServletRequest
+		_testVulcanCRUDItemDelegate_getHttpServletRequest() {
+
+		return new MockHttpServletRequest() {
+
+			@Override
+			public StringBuffer getRequestURL() {
+				return new StringBuffer(
+					StringBundler.concat(
+						"http://localhost:8080/o/v1.0/",
+						RandomTestUtil.randomString(), "/",
+						RandomTestUtil.randomString()));
+			}
+
+		};
+	}
+
+	private UriInfo _testVulcanCRUDItemDelegate_getUriInfo() {
+		String applicationPath = RandomTestUtil.randomString() + "/";
+		String resourcePath = RandomTestUtil.randomString();
+
+		return new UriInfo() {
+
+			@Override
+			public URI getAbsolutePath() {
+				return getRequestUri();
+			}
+
+			@Override
+			public UriBuilder getAbsolutePathBuilder() {
+				return getRequestUriBuilder();
+			}
+
+			@Override
+			public URI getBaseUri() {
+				return URI.create("http://localhost:8080/o/" + applicationPath);
+			}
+
+			@Override
+			public UriBuilder getBaseUriBuilder() {
+				return UriBuilder.fromUri(getBaseUri());
+			}
+
+			@Override
+			public List<Object> getMatchedResources() {
+				return Collections.emptyList();
+			}
+
+			@Override
+			public List<String> getMatchedURIs() {
+				return Collections.emptyList();
+			}
+
+			@Override
+			public List<String> getMatchedURIs(boolean decode) {
+				return getMatchedURIs();
+			}
+
+			@Override
+			public String getPath() {
+				return resourcePath;
+			}
+
+			@Override
+			public String getPath(boolean decode) {
+				return getPath();
+			}
+
+			@Override
+			public MultivaluedMap<String, String> getPathParameters() {
+				return new MultivaluedHashMap<>();
+			}
+
+			@Override
+			public MultivaluedMap<String, String> getPathParameters(
+				boolean decode) {
+
+				return getPathParameters();
+			}
+
+			@Override
+			public List<PathSegment> getPathSegments() {
+				return Collections.emptyList();
+			}
+
+			@Override
+			public List<PathSegment> getPathSegments(boolean decode) {
+				return getPathSegments();
+			}
+
+			@Override
+			public MultivaluedMap<String, String> getQueryParameters() {
+				return new MultivaluedHashMap<>();
+			}
+
+			@Override
+			public MultivaluedMap<String, String> getQueryParameters(
+				boolean decode) {
+
+				return getQueryParameters();
+			}
+
+			@Override
+			public URI getRequestUri() {
+				return URI.create(
+					"http://localhost:8080/o/" + applicationPath +
+						resourcePath);
+			}
+
+			@Override
+			public UriBuilder getRequestUriBuilder() {
+				return UriBuilder.fromUri(getRequestUri());
+			}
+
+			@Override
+			public URI relativize(URI uri) {
+				return getBaseUri().relativize(uri);
+			}
+
+			@Override
+			public URI resolve(URI requestURI) {
+				return getBaseUri().resolve(requestURI);
+			}
+
+		};
+	}
+
+	private void _testVulcanCRUDItemDelegateGetItem() throws Exception {
+		SitePage postSitePage = testPostSiteSitePage_addSitePage(
+			randomSitePage());
+
+		VulcanCRUDItemDelegate vulcanCRUDItemDelegate =
+			_vulcanCRUDItemDelegateBuilderRegistry.builder(
+				testCompany, "com.liferay.headless.delivery.dto.v1_0.SitePage"
+			).acceptLanguage(
+				new AcceptLanguage() {
+
+					@Override
+					public List<Locale> getLocales() {
+						return Arrays.asList(LocaleUtil.getDefault());
+					}
+
+					@Override
+					public String getPreferredLanguageId() {
+						return LocaleUtil.toLanguageId(LocaleUtil.getDefault());
+					}
+
+					@Override
+					public Locale getPreferredLocale() {
+						return LocaleUtil.getDefault();
+					}
+
+				}
+			).groupLocalService(
+				_groupLocalService
+			).httpServletRequest(
+				_testVulcanCRUDItemDelegate_getHttpServletRequest()
+			).httpServletResponse(
+				new MockHttpServletResponse()
+			).resourceActionLocalService(
+				_resourceActionLocalService
+			).resourcePermissionLocalService(
+				_resourcePermissionLocalService
+			).roleLocalService(
+				_roleLocalService
+			).scopeChecker(
+				_scopeChecker
+			).uriInfo(
+				_testVulcanCRUDItemDelegate_getUriInfo()
+			).user(
+				UserTestUtil.getAdminUser(testCompany.getCompanyId())
+			).build();
+
+		assertEquals(
+			sitePageResource.getSiteSitePage(
+				testGroup.getGroupId(), postSitePage.getFriendlyUrlPath()),
+			SitePageSerDes.toDTO(
+				String.valueOf(
+					vulcanCRUDItemDelegate.getItem(postSitePage.getId()))));
+	}
+
 	private static final String _CLASS_NAME_EXCEPTION_MAPPER =
 		"com.liferay.headless.delivery.internal.resource.v1_0." +
 			"SitePageResourceImpl";
@@ -1941,6 +2144,13 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 	private RoleLocalService _roleLocalService;
 
 	@Inject
+	private ScopeChecker _scopeChecker;
+
+	@Inject
 	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
+
+	@Inject
+	private VulcanCRUDItemDelegateBuilderRegistry
+		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/SitePageResourceTest.java
@@ -1999,6 +1999,9 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 	}
 
 	private void _testVulcanCRUDItemDelegateGetItem() throws Exception {
+
+		// Default locale
+
 		SitePage postSitePage = testPostSiteSitePage_addSitePage(
 			randomSitePage());
 
@@ -2046,6 +2049,78 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 		assertEquals(
 			sitePageResource.getSiteSitePage(
+				testGroup.getGroupId(), postSitePage.getFriendlyUrlPath()),
+			SitePageSerDes.toDTO(
+				String.valueOf(
+					vulcanCRUDItemDelegate.getItem(postSitePage.getId()))));
+
+		// Different locale
+
+		SitePage randomSitePage = randomSitePage();
+
+		randomSitePage.setFriendlyUrlPath_i18n(
+			HashMapBuilder.put(
+				"en-US", randomSitePage.getFriendlyUrlPath()
+			).put(
+				"es-ES",
+				StringPool.FORWARD_SLASH +
+					StringUtil.toLowerCase(RandomTestUtil.randomString())
+			).build());
+
+		postSitePage = testPostSiteSitePage_addSitePage(randomSitePage);
+
+		vulcanCRUDItemDelegate = _vulcanCRUDItemDelegateBuilderRegistry.builder(
+			testCompany, "com.liferay.headless.delivery.dto.v1_0.SitePage"
+		).acceptLanguage(
+			new AcceptLanguage() {
+
+				@Override
+				public List<Locale> getLocales() {
+					return Arrays.asList(LocaleUtil.SPAIN);
+				}
+
+				@Override
+				public String getPreferredLanguageId() {
+					return LocaleUtil.toLanguageId(LocaleUtil.SPAIN);
+				}
+
+				@Override
+				public Locale getPreferredLocale() {
+					return LocaleUtil.SPAIN;
+				}
+
+			}
+		).groupLocalService(
+			_groupLocalService
+		).httpServletRequest(
+			_testVulcanCRUDItemDelegate_getHttpServletRequest()
+		).httpServletResponse(
+			new MockHttpServletResponse()
+		).resourceActionLocalService(
+			_resourceActionLocalService
+		).resourcePermissionLocalService(
+			_resourcePermissionLocalService
+		).roleLocalService(
+			_roleLocalService
+		).scopeChecker(
+			_scopeChecker
+		).uriInfo(
+			_testVulcanCRUDItemDelegate_getUriInfo()
+		).user(
+			UserTestUtil.getAdminUser(testCompany.getCompanyId())
+		).build();
+
+		SitePageResource spainSitePageResource = SitePageResource.builder(
+		).authentication(
+			"test@liferay.com", PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(), 8080, "http"
+		).locale(
+			LocaleUtil.SPAIN
+		).build();
+
+		assertEquals(
+			spainSitePageResource.getSiteSitePage(
 				testGroup.getGroupId(), postSitePage.getFriendlyUrlPath()),
 			SitePageSerDes.toDTO(
 				String.valueOf(

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SearchResultResourceImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SearchResultResourceImpl.java
@@ -9,6 +9,8 @@ import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
 import com.liferay.asset.kernel.model.AssetRenderer;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.NoSuchModelException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -509,30 +511,47 @@ public class SearchResultResourceImpl extends BaseSearchResultResourceImpl {
 		if (vulcanCRUDItemDelegateBuilder != null) {
 			searchResult.setEmbedded(
 				() -> {
-					VulcanCRUDItemDelegate vulcanCRUDItemDelegate =
-						vulcanCRUDItemDelegateBuilder.acceptLanguage(
-							contextAcceptLanguage
-						).groupLocalService(
-							groupLocalService
-						).httpServletRequest(
-							contextHttpServletRequest
-						).httpServletResponse(
-							contextHttpServletResponse
-						).resourceActionLocalService(
-							resourceActionLocalService
-						).resourcePermissionLocalService(
-							resourcePermissionLocalService
-						).roleLocalService(
-							roleLocalService
-						).scopeChecker(
-							contextScopeChecker
-						).uriInfo(
-							contextUriInfo
-						).user(
-							contextUser
-						).build();
+					try {
+						VulcanCRUDItemDelegate vulcanCRUDItemDelegate =
+							vulcanCRUDItemDelegateBuilder.acceptLanguage(
+								contextAcceptLanguage
+							).groupLocalService(
+								groupLocalService
+							).httpServletRequest(
+								contextHttpServletRequest
+							).httpServletResponse(
+								contextHttpServletResponse
+							).resourceActionLocalService(
+								resourceActionLocalService
+							).resourcePermissionLocalService(
+								resourcePermissionLocalService
+							).roleLocalService(
+								roleLocalService
+							).scopeChecker(
+								contextScopeChecker
+							).uriInfo(
+								contextUriInfo
+							).user(
+								contextUser
+							).build();
 
-					return vulcanCRUDItemDelegate.getItem(entryClassPK);
+						return vulcanCRUDItemDelegate.getItem(entryClassPK);
+					}
+					catch (NoSuchModelException noSuchModelException) {
+						if (_log.isDebugEnabled()) {
+							_log.debug(
+								StringBundler.concat(
+									"Unable to find entity {entityClassName=",
+									entityClassName, ", entryClassPK=",
+									entryClassPK, "}"),
+								noSuchModelException);
+						}
+					}
+					catch (Exception exception) {
+						_log.error(exception);
+					}
+
+					return null;
 				});
 		}
 	}

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SearchResultResourceImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/SearchResultResourceImpl.java
@@ -9,8 +9,6 @@ import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
 import com.liferay.asset.kernel.model.AssetRenderer;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.petra.function.UnsafeConsumer;
-import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.exception.NoSuchModelException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -511,47 +509,30 @@ public class SearchResultResourceImpl extends BaseSearchResultResourceImpl {
 		if (vulcanCRUDItemDelegateBuilder != null) {
 			searchResult.setEmbedded(
 				() -> {
-					try {
-						VulcanCRUDItemDelegate vulcanCRUDItemDelegate =
-							vulcanCRUDItemDelegateBuilder.acceptLanguage(
-								contextAcceptLanguage
-							).groupLocalService(
-								groupLocalService
-							).httpServletRequest(
-								contextHttpServletRequest
-							).httpServletResponse(
-								contextHttpServletResponse
-							).resourceActionLocalService(
-								resourceActionLocalService
-							).resourcePermissionLocalService(
-								resourcePermissionLocalService
-							).roleLocalService(
-								roleLocalService
-							).scopeChecker(
-								contextScopeChecker
-							).uriInfo(
-								contextUriInfo
-							).user(
-								contextUser
-							).build();
+					VulcanCRUDItemDelegate vulcanCRUDItemDelegate =
+						vulcanCRUDItemDelegateBuilder.acceptLanguage(
+							contextAcceptLanguage
+						).groupLocalService(
+							groupLocalService
+						).httpServletRequest(
+							contextHttpServletRequest
+						).httpServletResponse(
+							contextHttpServletResponse
+						).resourceActionLocalService(
+							resourceActionLocalService
+						).resourcePermissionLocalService(
+							resourcePermissionLocalService
+						).roleLocalService(
+							roleLocalService
+						).scopeChecker(
+							contextScopeChecker
+						).uriInfo(
+							contextUriInfo
+						).user(
+							contextUser
+						).build();
 
-						return vulcanCRUDItemDelegate.getItem(entryClassPK);
-					}
-					catch (NoSuchModelException noSuchModelException) {
-						if (_log.isDebugEnabled()) {
-							_log.debug(
-								StringBundler.concat(
-									"Unable to find entity {entityClassName=",
-									entityClassName, ", entryClassPK=",
-									entryClassPK, "}"),
-								noSuchModelException);
-						}
-					}
-					catch (Exception exception) {
-						_log.error(exception);
-					}
-
-					return null;
+					return vulcanCRUDItemDelegate.fetchItem(entryClassPK);
 				});
 		}
 	}

--- a/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SearchResultResourceTest.java
+++ b/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SearchResultResourceTest.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.SearchEngine;
@@ -990,6 +991,13 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 			return;
 		}
 
+		_testPostSearchPageWithEmbeddedNestedFieldsInObjectEntry();
+		_testPostSearchPageWithEmbeddedNestedFieldsInSitePage();
+	}
+
+	private void _testPostSearchPageWithEmbeddedNestedFieldsInObjectEntry()
+		throws Exception {
+
 		DTOConverterContext dtoConverterContext =
 			new DefaultDTOConverterContext(
 				false, Collections.emptyMap(), _dtoConverterRegistry, null,
@@ -1048,6 +1056,28 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 
 		_objectDefinitionLocalService.deleteObjectDefinition(
 			objectDefinition.getObjectDefinitionId());
+	}
+
+	private void _testPostSearchPageWithEmbeddedNestedFieldsInSitePage()
+		throws Exception {
+
+		SearchPage<SearchResult> searchPage = _postSearchPage(
+			HashMapBuilder.put(
+				"entryClassNames", Layout.class.getName()
+			).put(
+				"nestedFields", "embedded"
+			).put(
+				"search", "home"
+			).build(),
+			new SearchRequestBody());
+
+		Collection<SearchResult> searchResults = searchPage.getItems();
+
+		Assert.assertFalse(searchResults.isEmpty());
+
+		for (SearchResult searchResult : searchResults) {
+			Assert.assertNotNull(searchResult.getEmbedded());
+		}
 	}
 
 	private void _testPostSearchPageWithEmptyScope() throws Exception {

--- a/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SearchResultResourceTest.java
+++ b/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SearchResultResourceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.kernel.search.SearchEngine;
 import com.liferay.portal.kernel.search.SearchEngineHelper;
 import com.liferay.portal.kernel.search.highlight.HighlightUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -368,6 +369,7 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 
 	@Override
 	@Test
+	@TestInfo("LPD-57341")
 	public void testPostSearchPage() throws Exception {
 		_testPostSearchPageAggregationNameAsFacetName();
 		_testPostSearchPageWithCategoryTreeFacetConfiguration();

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/crud/VulcanCRUDItemDelegate.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/crud/VulcanCRUDItemDelegate.java
@@ -5,6 +5,12 @@
 
 package com.liferay.portal.vulcan.crud;
 
+import com.liferay.portal.kernel.exception.NoSuchModelException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+
+import jakarta.ws.rs.NotFoundException;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -13,6 +19,25 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface VulcanCRUDItemDelegate<T> {
+
+	public static final Log log = LogFactoryUtil.getLog(
+		VulcanCRUDItemDelegate.class);
+
+	public default T fetchItem(Long id) {
+		try {
+			return getItem(id);
+		}
+		catch (NoSuchModelException | NotFoundException exception) {
+			if (log.isDebugEnabled()) {
+				log.debug("Unable to find item with id " + id, exception);
+			}
+		}
+		catch (Exception exception) {
+			log.error("Unable to find item with id " + id, exception);
+		}
+
+		return null;
+	}
 
 	public T getItem(Long id) throws Exception;
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/crud/VulcanCRUDItemDelegateTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/crud/VulcanCRUDItemDelegateTest.java
@@ -1,0 +1,202 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.vulcan.crud;
+
+import com.liferay.portal.kernel.exception.NoSuchModelException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogWrapper;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.ws.rs.NotFoundException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Carlos Correa
+ */
+public class VulcanCRUDItemDelegateTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_log = ReflectionTestUtil.getFieldValue(
+			VulcanCRUDItemDelegate.class, "log");
+
+		ReflectionTestUtil.setFieldValue(
+			VulcanCRUDItemDelegate.class, "log", new TestLogWrapper(_log));
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		ReflectionTestUtil.setFieldValue(
+			VulcanCRUDItemDelegate.class, "log", _log);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_debugMessages = new ArrayList<>();
+		_debugThrowables = new ArrayList<>();
+		_errorMessages = new ArrayList<>();
+		_errorThrowables = new ArrayList<>();
+	}
+
+	@Test
+	public void testFetchItem() {
+		Object object = Mockito.mock(Object.class);
+
+		VulcanCRUDItemDelegate<Object> vulcanCRUDItemDelegate =
+			new TestVulcanCRUDItemDelegate(object);
+
+		Assert.assertSame(
+			object,
+			vulcanCRUDItemDelegate.fetchItem(RandomTestUtil.randomLong()));
+
+		Assert.assertTrue(_debugMessages.isEmpty());
+		Assert.assertTrue(_debugThrowables.isEmpty());
+		Assert.assertTrue(_errorMessages.isEmpty());
+		Assert.assertTrue(_errorThrowables.isEmpty());
+	}
+
+	@Test
+	public void testFetchItemAnyOtherException() {
+		Exception exception = new Exception();
+		long id = RandomTestUtil.randomLong();
+
+		VulcanCRUDItemDelegate<Object> vulcanCRUDItemDelegate =
+			new TestVulcanCRUDItemDelegate(exception);
+
+		Assert.assertNull(vulcanCRUDItemDelegate.fetchItem(id));
+
+		Assert.assertTrue(_debugMessages.isEmpty());
+		Assert.assertTrue(_debugThrowables.isEmpty());
+		Assert.assertEquals(
+			_errorMessages.toString(), 1, _errorMessages.size());
+		Assert.assertEquals(
+			"Unable to find item with id " + id, _errorMessages.get(0));
+		Assert.assertEquals(
+			_errorThrowables.toString(), 1, _errorThrowables.size());
+		Assert.assertSame(exception, _errorThrowables.get(0));
+	}
+
+	@Test
+	public void testFetchItemNoSuchModelException() {
+		long id = RandomTestUtil.randomLong();
+
+		NoSuchModelException noSuchModelException = new NoSuchModelException();
+
+		VulcanCRUDItemDelegate<Object> vulcanCRUDItemDelegate =
+			new TestVulcanCRUDItemDelegate(noSuchModelException);
+
+		Assert.assertNull(vulcanCRUDItemDelegate.fetchItem(id));
+
+		Assert.assertEquals(
+			_debugMessages.toString(), 1, _debugMessages.size());
+		Assert.assertEquals(
+			"Unable to find item with id " + id, _debugMessages.get(0));
+		Assert.assertEquals(
+			_debugThrowables.toString(), 1, _debugThrowables.size());
+		Assert.assertSame(noSuchModelException, _debugThrowables.get(0));
+		Assert.assertTrue(_errorMessages.isEmpty());
+		Assert.assertTrue(_errorThrowables.isEmpty());
+	}
+
+	@Test
+	public void testFetchItemNotFoundException() {
+		long id = RandomTestUtil.randomLong();
+
+		NotFoundException notFoundException = new NotFoundException();
+
+		VulcanCRUDItemDelegate<Object> vulcanCRUDItemDelegate =
+			new TestVulcanCRUDItemDelegate(notFoundException);
+
+		Assert.assertNull(vulcanCRUDItemDelegate.fetchItem(id));
+
+		Assert.assertEquals(
+			_debugMessages.toString(), 1, _debugMessages.size());
+		Assert.assertEquals(
+			"Unable to find item with id " + id, _debugMessages.get(0));
+		Assert.assertEquals(
+			_debugThrowables.toString(), 1, _debugThrowables.size());
+		Assert.assertSame(notFoundException, _debugThrowables.get(0));
+		Assert.assertTrue(_errorMessages.isEmpty());
+		Assert.assertTrue(_errorThrowables.isEmpty());
+	}
+
+	private static Log _log;
+
+	private static List<Object> _debugMessages = new ArrayList<>();
+	private static List<Throwable> _debugThrowables = new ArrayList<>();
+	private static List<Object> _errorMessages = new ArrayList<>();
+	private static List<Throwable> _errorThrowables = new ArrayList<>();
+
+	private static class TestLogWrapper extends LogWrapper {
+
+		public TestLogWrapper(Log log) {
+			super(log);
+		}
+
+		@Override
+		public void debug(Object msg, Throwable throwable) {
+			_debugMessages.add((String)msg);
+			_debugThrowables.add(throwable);
+		}
+
+		@Override
+		public void error(Object msg, Throwable throwable) {
+			_errorMessages.add((String)msg);
+			_errorThrowables.add(throwable);
+		}
+
+		@Override
+		public boolean isDebugEnabled() {
+			return true;
+		}
+
+	}
+
+	private static class TestVulcanCRUDItemDelegate
+		implements VulcanCRUDItemDelegate<Object> {
+
+		public TestVulcanCRUDItemDelegate(Exception exception) {
+			_exception = exception;
+		}
+
+		public TestVulcanCRUDItemDelegate(Object item) {
+			_item = item;
+		}
+
+		@Override
+		public Object getItem(Long id) throws Exception {
+			if (_exception != null) {
+				throw _exception;
+			}
+
+			return _item;
+		}
+
+		private Exception _exception;
+		private Object _item;
+
+	}
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/dto/converter/test/DTOConverterRegistryTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/dto/converter/test/DTOConverterRegistryTest.java
@@ -1,0 +1,144 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.vulcan.dto.converter.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.dto.converter.DTOConverter;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
+
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Carlos Correa
+ */
+@RunWith(Arquillian.class)
+public class DTOConverterRegistryTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() {
+		Bundle bundle = FrameworkUtil.getBundle(DTOConverterRegistryTest.class);
+
+		_bundleContext = bundle.getBundleContext();
+	}
+
+	@Test
+	public void testGetDTOClassNames() throws Exception {
+		String dtoClassName = RandomTestUtil.randomString();
+
+		Set<String> dtoClassNames = _dtoConverterRegistry.getDTOClassNames();
+
+		Assert.assertFalse(dtoClassNames.contains(dtoClassName));
+
+		try (AutoCloseable autoCloseable = _registerDTOConverter(
+				null, dtoClassName, new TestDTOConverter(), null)) {
+
+			dtoClassNames = _dtoConverterRegistry.getDTOClassNames();
+
+			Assert.assertTrue(dtoClassNames.contains(dtoClassName));
+		}
+	}
+
+	@Test
+	public void testGetDTOConverterWithApplicationNameDTOClassNameAndVersionProperties()
+		throws Exception {
+
+		String applicationName = RandomTestUtil.randomString();
+		String dtoClassName = RandomTestUtil.randomString();
+		DTOConverter<?, ?> dtoConverter = new TestDTOConverter();
+		String version = RandomTestUtil.randomString();
+
+		Assert.assertNull(_dtoConverterRegistry.getDTOConverter(dtoClassName));
+		Assert.assertNull(
+			_dtoConverterRegistry.getDTOConverter(
+				applicationName, dtoClassName, version));
+
+		try (AutoCloseable autoCloseable = _registerDTOConverter(
+				applicationName, dtoClassName, dtoConverter, version)) {
+
+			Assert.assertSame(
+				dtoConverter,
+				_dtoConverterRegistry.getDTOConverter(dtoClassName));
+
+			Assert.assertSame(
+				dtoConverter,
+				_dtoConverterRegistry.getDTOConverter(
+					applicationName, dtoClassName, version));
+		}
+	}
+
+	@Test
+	public void testGetDTOConverterWithDTOClassNameProperty() throws Exception {
+		String dtoClassName = RandomTestUtil.randomString();
+
+		Assert.assertNull(_dtoConverterRegistry.getDTOConverter(dtoClassName));
+
+		DTOConverter<?, ?> dtoConverter = new TestDTOConverter();
+
+		try (AutoCloseable autoCloseable = _registerDTOConverter(
+				null, dtoClassName, dtoConverter, null)) {
+
+			Assert.assertSame(
+				dtoConverter,
+				_dtoConverterRegistry.getDTOConverter(dtoClassName));
+		}
+	}
+
+	private AutoCloseable _registerDTOConverter(
+		String applicationName, String dtoClassName,
+		DTOConverter<?, ?> dtoConverter, String version) {
+
+		ServiceRegistration<DTOConverter<?, ?>> serviceRegistration =
+			_bundleContext.registerService(
+				(Class<DTOConverter<?, ?>>)(Class<?>)DTOConverter.class,
+				dtoConverter,
+				HashMapDictionaryBuilder.put(
+					"application.name", () -> applicationName
+				).put(
+					"dto.class.name", dtoClassName
+				).put(
+					"version", () -> version
+				).build());
+
+		return serviceRegistration::unregister;
+	}
+
+	private static BundleContext _bundleContext;
+
+	@Inject
+	private DTOConverterRegistry _dtoConverterRegistry;
+
+	private static class TestDTOConverter
+		implements DTOConverter<Object, Object> {
+
+		@Override
+		public String getContentType() {
+			return "";
+		}
+
+	}
+
+}


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-57341

see: https://github.com/liferay-headless/liferay-portal/pull/2908

---

The purpose of this PR is to return the `Headless Delivery REST API` - `Layout` **DTO** from the `Search REST API` when performing the following request (NOTE: The development feature flag `LPD-11232` must be active):

```
curl -X 'GET' \
     -u 'test@liferay.com:test' \
     'http://localhost:8080/o/search/v1.0/search?fields=embedded&nestedFields=embedded&search=home' 
```
For that:
* We have implemented the `VulcanCRUDItemDelegate` interface manually, to get a Layout by Id, as the Search REST API uses it to return the DTO given its identifier.
* We have created a `fetchItem` method in the `VulcanCRUDItemDelegate` interface with a default implementation. The `getItem` method is called and if there is an exception thrown, then we log the message and return null
* As there are several `DTOConverter` implementation with `dto.class.name=com.liferay.portal.kernel.model.Layout`, we removed the `dto.class.name` property for all of them except `com.liferay.headless.delivery.internal.dto.v1_0.converter.SitePageDTOConverter`, so it will be the default one returned for the Layout class by the `DTOConverterRegistry` (several releases before, it was the only DTOConverter for Layouts). In the future, we will have to handle the different types of Layout (Site Pages, Widged Pages, etc), but for now, we are just calling the endpoint with the friendly URL, if the Headless Delivery REST API returns a result, the Search REST API will return it as the embedded field value.

After the Pull request, the response contains:

```json
{
  "items" : [ {
    "embedded" : {
      "actions" : {
        "get-experiences" : {
          "method" : "GET",
          "href" : "http://localhost:8080/o/headless-delivery/v1.0/sites/20124/site-pages/{friendlyUrlPath:.+}/experiences"
        },
        "get" : {
          "method" : "GET",
          "href" : "http://localhost:8080/o/headless-delivery/v1.0/sites/20124/site-pages/{friendlyUrlPath:.+}"
        },
        "get-rendered-page" : {
          "method" : "GET",
          "href" : "http://localhost:8080/o/headless-delivery/v1.0/sites/20124/site-pages/{friendlyUrlPath:.+}/rendered-page"
        }
      },
      "availableLanguages" : [ "en-US" ],
      "creator" : {
        "additionalName" : "",
        "contentType" : "UserAccount",
        "familyName" : "Test",
        "givenName" : "Test",
        "id" : 20130,
        "name" : "Test Test"
      },
      "customFields" : [ {
        "customValue" : {
          "data" : ""
        },
        "dataType" : "Text",
        "name" : "asdf"
      } ],
      "dateCreated" : "2025-06-09T09:36:25Z",
      "dateModified" : "2025-06-09T09:36:37Z",
      "datePublished" : "2025-06-09T09:36:25Z",
      "friendlyUrlPath" : "/home",
      "id" : 8,
      "keywords" : [ ],
      "pagePermissions" : [ {
        "actionKeys" : [ "UPDATE_DISCUSSION", "PERMISSIONS", "UPDATE_LAYOUT_ADVANCED_OPTIONS", "UPDATE_LAYOUT_CONTENT", "CUSTOMIZE", "LAYOUT_RULE_BUILDER", "ADD_LAYOUT", "VIEW", "DELETE", "PREVIEW_DRAFT", "UPDATE_LAYOUT_BASIC", "DELETE_DISCUSSION", "CONFIGURE_PORTLETS", "UPDATE", "UPDATE_LAYOUT_LIMITED", "ADD_DISCUSSION" ],
        "roleKey" : "Owner"
      }, {
        "actionKeys" : [ "CUSTOMIZE", "VIEW", "ADD_DISCUSSION" ],
        "roleKey" : "Site Member"
      }, {
        "actionKeys" : [ "VIEW" ],
        "roleKey" : "Guest"
      } ],
      "pageSettings" : {
        "hiddenFromNavigation" : false,
        "seoSettings" : {
          "description" : "",
          "htmlTitle" : "",
          "robots" : "",
          "seoKeywords" : ""
        }
      },
      "pageType" : "Content Page",
      "renderedPage" : {
        "renderedPageURL" : "http://localhost:8080/o/headless-delivery/v1.0/sites/20124/site-pages/home/rendered-page"
      },
      "siteId" : 20124,
      "taxonomyCategoryBriefs" : [ ],
      "title" : "Home",
      "uuid" : "27b4919a-fbfb-7a26-ad54-a6340dc0679c"
    }
  } ],
  "lastPage" : 1,
  "page" : 1,
  "pageSize" : 20,
  "totalCount" : 1
}
```

cc/ @ruben-pulido