### PR TITLE
LPD-44842 SF, name of variable with type "*ThreadLocal" should not end with "ThreadLocal"

### DIFF
--- a/modules/apps/portlet-preferences/portlet-preferences-test/src/testIntegration/java/com/liferay/portlet/preferences/test/PortalPreferencesImplTest.java
+++ b/modules/apps/portlet-preferences/portlet-preferences-test/src/testIntegration/java/com/liferay/portlet/preferences/test/PortalPreferencesImplTest.java
@@ -87,8 +87,8 @@ public class PortalPreferencesImplTest {
 		_platformTransactionManager = ReflectionTestUtil.getFieldValue(
 			_originalTransactionExecutor, "_platformTransactionManager");
 
-		_synchronizeThreadLocal = ReflectionTestUtil.getFieldValue(
-			SynchronousInvocationHandler.class, "_synchronizeThreadLocal");
+		_synchronized = ReflectionTestUtil.getFieldValue(
+			SynchronousInvocationHandler.class, "_synchronized");
 	}
 
 	@Before
@@ -444,7 +444,7 @@ public class PortalPreferencesImplTest {
 			TransactionAttributeAdapter transactionAttributeAdapter,
 			TransactionStatusAdapter transactionStatusAdapter) {
 
-			if (!_synchronizeThreadLocal.get()) {
+			if (!_synchronized.get()) {
 				_originalTransactionExecutor.commit(
 					transactionAttributeAdapter, transactionStatusAdapter);
 
@@ -509,7 +509,7 @@ public class PortalPreferencesImplTest {
 	@Inject
 	private static PortalPreferencesLocalService _portalPreferencesLocalService;
 
-	private static ThreadLocal<Boolean> _synchronizeThreadLocal;
+	private static ThreadLocal<Boolean> _synchronized;
 	private static TransactionInterceptor _transactionInterceptor;
 	private static Method _updatePreferencesMethod;
 

--- a/portal-test/src/com/liferay/portal/kernel/test/SynchronousInvocationHandler.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/SynchronousInvocationHandler.java
@@ -17,11 +17,11 @@ import java.util.concurrent.CyclicBarrier;
 public class SynchronousInvocationHandler implements InvocationHandler {
 
 	public static void disable() {
-		_synchronizeThreadLocal.remove();
+		_synchronized.remove();
 	}
 
 	public static void enable() {
-		_synchronizeThreadLocal.set(Boolean.TRUE);
+		_synchronized.set(Boolean.TRUE);
 	}
 
 	public SynchronousInvocationHandler(
@@ -38,7 +38,7 @@ public class SynchronousInvocationHandler implements InvocationHandler {
 	public Object invoke(Object proxy, Method method, Object[] args)
 		throws Throwable {
 
-		if ((_synchronizeThreadLocal.get() == Boolean.TRUE) &&
+		if ((_synchronized.get() == Boolean.TRUE) &&
 			_syncMethod.equals(method)) {
 
 			_cyclicBarrier.await();
@@ -47,7 +47,7 @@ public class SynchronousInvocationHandler implements InvocationHandler {
 		return method.invoke(_target, args);
 	}
 
-	private static final ThreadLocal<Boolean> _synchronizeThreadLocal =
+	private static final ThreadLocal<Boolean> _synchronized =
 		new InheritableThreadLocal<>();
 
 	private final CyclicBarrier _cyclicBarrier;


### PR DESCRIPTION
Tested [here](https://github.com/ling-alan-huang/liferay-portal/pull/3522), unrelated failures.