### PR TITLE
LPD-2664 Fix typo in the warn message of DataSourceFactoryImpl

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/jdbc/DataSourceFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/jdbc/DataSourceFactoryImpl.java
@@ -490,7 +490,7 @@ public class DataSourceFactoryImpl implements DataSourceFactory {
 					StringBundler.concat(
 						"At attempt ", maxRetries - count, " of ", maxRetries,
 						" in acquiring a JDBC connection after a ", delay,
-						" second ", delay));
+						" seconds delay"));
 			}
 
 			try {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-2664

Fix typo in the warn message changed in commit 14921189762e38efdca9dc56c4da0ac7ce0e0bf4, we are using the delay var instead of using the 'delay' string:

- wrong:
```
						"At attempt ", maxRetries - count, " of ", maxRetries,
						" in acquiring a JDBC connection after a ", delay,
						" second ", delay));
```
- correct:
```
						"At attempt ", maxRetries - count, " of ", maxRetries,
						" in acquiring a JDBC connection after a ", delay,
						" seconds delay"));
```

The tests are already executed in https://github.com/jorgediaz-lr/liferay-portal/pull/552