### PR TITLE
LPD-53149 - part 1

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -12303,6 +12303,8 @@ ${update.properties}</echo>
 
 liferay.home=${liferay.home}
 
+upgrade.database.dl.storage.check.disabled=true
+
 jdbc.default.jndi.name=
 jdbc.default.driverClassName=${database.driver}
 jdbc.default.url=${database.url}

--- a/modules/apps/portal/portal-verify-test/build.gradle
+++ b/modules/apps/portal/portal-verify-test/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
 	testIntegrationImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
+	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-verify-test-util")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDLStoreTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDLStoreTest.java
@@ -1,0 +1,148 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.verify.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringPool;
+import com.liferay.petra.string.StringUtil;
+import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.AssumeTestRule;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.verify.PreupgradeVerifyDLStore;
+import com.liferay.portal.verify.VerifyProcess;
+import com.liferay.portal.verify.test.util.BaseVerifyProcessTestCase;
+
+import java.io.FileNotFoundException;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+/**
+ * @author István András Dézsi
+ */
+@RunWith(Arquillian.class)
+public class PreupgradeVerifyDLStoreTest extends BaseVerifyProcessTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new AssumeTestRule("assume"), new LiferayIntegrationTestRule());
+
+	public static void assume() {
+		Assume.assumeTrue(
+			com.liferay.portal.kernel.util.StringUtil.equals(
+				PropsValues.DL_STORE_IMPL,
+				"com.liferay.portal.store.file.system." +
+					"AdvancedFileSystemStore") ||
+			com.liferay.portal.kernel.util.StringUtil.equals(
+				PropsValues.DL_STORE_IMPL,
+				"com.liferay.portal.store.file.system.FileSystemStore"));
+	}
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_rootDir =
+			_props.get(PropsKeys.LIFERAY_HOME) + "/test/store/file_system";
+
+		_configuration = _configurationAdmin.getConfiguration(
+			"com.liferay.portal.store.file.system.configuration." +
+				"FileSystemStoreConfiguration",
+			StringPool.QUESTION);
+
+		ConfigurationTestUtil.saveConfiguration(
+			_configuration,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"rootDir", _rootDir
+			).build());
+
+		_upgradeDatabaseDLStorageCheckDisabledSafeCloseable =
+			PropsValuesTestUtil.swapWithSafeCloseable(
+				"UPGRADE_DATABASE_DL_STORAGE_CHECK_DISABLED", false);
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		ConfigurationTestUtil.deleteConfiguration(_configuration);
+
+		FileUtil.deltree(_rootDir);
+
+		_upgradeDatabaseDLStorageCheckDisabledSafeCloseable.close();
+	}
+
+	@Test
+	public void testVerifyNonexistentRootDirectory() throws Exception {
+		Path originalRootDirPath = Paths.get(_rootDir);
+
+		Path renamedRootDirPath = Paths.get(
+			StringUtil.replace(_rootDir, "file_system", "file_system2"));
+
+		if (Files.exists(originalRootDirPath)) {
+			Files.move(originalRootDirPath, renamedRootDirPath);
+		}
+
+		Files.createFile(originalRootDirPath);
+
+		try {
+			testVerify();
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			String message = exception.getMessage();
+
+			Assert.assertTrue(
+				message.contains(FileNotFoundException.class.getName()));
+		}
+		finally {
+			Files.deleteIfExists(originalRootDirPath);
+
+			if (Files.exists(renamedRootDirPath)) {
+				Files.move(renamedRootDirPath, originalRootDirPath);
+			}
+		}
+	}
+
+	@Override
+	protected VerifyProcess getVerifyProcess() {
+		return new PreupgradeVerifyDLStore();
+	}
+
+	private static Configuration _configuration;
+
+	@Inject
+	private static ConfigurationAdmin _configurationAdmin;
+
+	@Inject
+	private static Props _props;
+
+	private static String _rootDir;
+	private static SafeCloseable
+		_upgradeDatabaseDLStorageCheckDisabledSafeCloseable;
+
+}

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -2396,6 +2396,11 @@ public class PropsValues {
 	public static final String UNICODE_TEXT_NORMALIZER_FORM = PropsUtil.get(
 		PropsKeys.UNICODE_TEXT_NORMALIZER_FORM);
 
+	public static final boolean UPGRADE_DATABASE_DL_STORAGE_CHECK_DISABLED =
+		GetterUtil.getBoolean(
+			PropsUtil.get(
+				PropsKeys.UPGRADE_DATABASE_DL_STORAGE_CHECK_DISABLED));
+
 	public static final boolean UPGRADE_DATABASE_PREUPGRADE_VERIFY_ENABLED =
 		GetterUtil.getBoolean(
 			PropsUtil.get(

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDLStore.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDLStore.java
@@ -28,7 +28,10 @@ public class PreupgradeVerifyDLStore extends PreupgradeVerifyProcess {
 	@Override
 	protected void doVerify() throws Exception {
 		if (PropsValues.UPGRADE_DATABASE_DL_STORAGE_CHECK_DISABLED ||
-			StartupHelperUtil.isDBNew()) {
+			StartupHelperUtil.isDBNew() ||
+			StringUtil.equals(
+				PropsValues.DL_STORE_IMPL,
+				"com.liferay.portal.store.db.DBStore")) {
 
 			return;
 		}

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDLStore.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDLStore.java
@@ -1,0 +1,100 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.verify;
+
+import com.liferay.document.library.kernel.store.Store;
+import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
+import com.liferay.portal.events.StartupHelperUtil;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.util.PropsValues;
+
+import java.util.Random;
+import java.util.Set;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+
+/**
+ * @author István András Dézsi
+ */
+public class PreupgradeVerifyDLStore extends PreupgradeVerifyProcess {
+
+	@Override
+	protected void doVerify() throws Exception {
+		if (PropsValues.UPGRADE_DATABASE_DL_STORAGE_CHECK_DISABLED ||
+			StartupHelperUtil.isDBNew()) {
+
+			return;
+		}
+
+		Store store = null;
+
+		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+
+		for (ServiceReference<Store> serviceReference :
+				bundleContext.getServiceReferences(
+					Store.class,
+					"(store.type=" + PropsValues.DL_STORE_IMPL + ")")) {
+
+			store = bundleContext.getService(serviceReference);
+
+			break;
+		}
+
+		if (store == null) {
+			throw new VerifyException(
+				PropsValues.DL_STORE_IMPL + " is not available");
+		}
+
+		long randomCompanyId = _getRandomCompanyId();
+		long randomRepositoryId = Math.abs(
+			new Random(
+			).nextLong(
+				1, Long.MAX_VALUE
+			));
+		String randomFileName = StringUtil.randomString();
+
+		store.addFile(
+			randomCompanyId, randomRepositoryId, randomFileName,
+			Store.VERSION_DEFAULT,
+			new UnsyncByteArrayInputStream(new byte[1024 * 65]));
+
+		if (!store.hasFile(
+				randomCompanyId, randomRepositoryId, randomFileName,
+				Store.VERSION_DEFAULT)) {
+
+			throw new VerifyException(
+				"Unable to create temporary file in store");
+		}
+
+		store.deleteFile(
+			randomCompanyId, randomRepositoryId, randomFileName,
+			Store.VERSION_DEFAULT);
+	}
+
+	@Override
+	protected boolean isSkipDBPartitions() {
+		return true;
+	}
+
+	private long _getRandomCompanyId() {
+		Set<Long> companyIds = SetUtil.fromArray(
+			PortalInstancePool.getCompanyIds());
+		Random random = new Random();
+
+		while (true) {
+			long randomCompanyId = random.nextLong(1, Long.MAX_VALUE);
+
+			if (!companyIds.contains(randomCompanyId)) {
+				return randomCompanyId;
+			}
+		}
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyProcessSuite.java
@@ -25,6 +25,7 @@ public class PreupgradeVerifyProcessSuite extends PreupgradeVerifyProcess {
 		_verify(new PreupgradeVerifyDatabaseCharacterSet());
 		_verify(new PreupgradeVerifyDatabasePrivileges());
 		_verify(new PreupgradeVerifyDatabaseState());
+		_verify(new PreupgradeVerifyDLStore());
 		_verify(new PreupgradeVerifyProperties());
 
 		if (ListUtil.isNotEmpty(_exceptionMessages)) {

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -153,6 +153,16 @@
     upgrade.database.auto.run=false
 
     #
+    # Set this to true to disable the document library storage file system
+    # verification before database upgrades. This check verifies that the
+    # expected file system store structure is present and has write permissions
+    # before making any database changes.
+    #
+    # Env: LIFERAY_UPGRADE_PERIOD_DATABASE_PERIOD_DL_PERIOD_STORAGE_PERIOD_CHECK_PERIOD_DISABLED
+    #
+    upgrade.database.dl.storage.check.disabled=false
+
+    #
     # Set this to true to enable preupgrade verification.
     #
     # Env: LIFERAY_UPGRADE_PERIOD_DATABASE_PERIOD_PREUPGRADE_PERIOD_VERIFY_PERIOD_ENABLED

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2736,6 +2736,9 @@ public interface PropsKeys {
 	public static final String UPGRADE_DATABASE_AUTO_RUN =
 		"upgrade.database.auto.run";
 
+	public static final String UPGRADE_DATABASE_DL_STORAGE_CHECK_DISABLED =
+		"upgrade.database.dl.storage.check.disabled";
+
 	public static final String UPGRADE_DATABASE_PREUPGRADE_VERIFY_ENABLED =
 		"upgrade.database.preupgrade.verify.enabled";
 


### PR DESCRIPTION
First part of LPD-53149. This includes the PreupgradeVerifyDLStore that tests a write/read/delete operation to verify the store is correctly configured and working before the upgrade