### PR TITLE
LPD-53149 Rename PreupgradeVerifyDLStore to PreupgradeVerifyStoreAccess to follow the same pattern than PreupgradeVerifyStoreFileSystemStructure

### DIFF
--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyStoreAccessTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyStoreAccessTest.java
@@ -20,7 +20,7 @@ import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsValues;
-import com.liferay.portal.verify.PreupgradeVerifyDLStore;
+import com.liferay.portal.verify.PreupgradeVerifyStoreAccess;
 import com.liferay.portal.verify.VerifyProcess;
 import com.liferay.portal.verify.test.util.BaseVerifyProcessTestCase;
 
@@ -46,7 +46,7 @@ import org.osgi.service.cm.ConfigurationAdmin;
  * @author István András Dézsi
  */
 @RunWith(Arquillian.class)
-public class PreupgradeVerifyDLStoreTest extends BaseVerifyProcessTestCase {
+public class PreupgradeVerifyStoreAccessTest extends BaseVerifyProcessTestCase {
 
 	@ClassRule
 	@Rule
@@ -130,7 +130,7 @@ public class PreupgradeVerifyDLStoreTest extends BaseVerifyProcessTestCase {
 
 	@Override
 	protected VerifyProcess getVerifyProcess() {
-		return new PreupgradeVerifyDLStore();
+		return new PreupgradeVerifyStoreAccess();
 	}
 
 	private static Configuration _configuration;

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyProcessSuite.java
@@ -25,8 +25,8 @@ public class PreupgradeVerifyProcessSuite extends PreupgradeVerifyProcess {
 		_verify(new PreupgradeVerifyDatabaseCharacterSet());
 		_verify(new PreupgradeVerifyDatabasePrivileges());
 		_verify(new PreupgradeVerifyDatabaseState());
-		_verify(new PreupgradeVerifyDLStore());
 		_verify(new PreupgradeVerifyProperties());
+		_verify(new PreupgradeVerifyStoreAccess());
 		_verify(new PreupgradeVerifyStoreFileSystemStructure());
 
 		if (ListUtil.isNotEmpty(_exceptionMessages)) {

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyStoreAccess.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyStoreAccess.java
@@ -23,7 +23,7 @@ import org.osgi.framework.ServiceReference;
 /**
  * @author István András Dézsi
  */
-public class PreupgradeVerifyDLStore extends PreupgradeVerifyProcess {
+public class PreupgradeVerifyStoreAccess extends PreupgradeVerifyProcess {
 
 	@Override
 	protected void doVerify() throws Exception {


### PR DESCRIPTION
In previous 164113a0ce6e70864bb00a56d0cd6f78de91833f commit PreupgradeVerifyFileSystemStoreStructure was renamed to PreupgradeVerifyStoreFileSystemStructure.

In this PR I am renaming PreupgradeVerifyDLStore to PreupgradeVerifyStoreAccess to follow the same pattern.