### PR TITLE
LPD-58961 Not render the control panel page for a group that is an organization but is not a site

### DIFF
--- a/modules/apps/layout/layout-type-controller/layout-type-controller-control-panel/src/main/java/com/liferay/layout/type/controller/control/panel/internal/model/ControlPanelLayoutTypeAccessPolicy.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-control-panel/src/main/java/com/liferay/layout/type/controller/control/panel/internal/model/ControlPanelLayoutTypeAccessPolicy.java
@@ -45,15 +45,17 @@ public class ControlPanelLayoutTypeAccessPolicy
 
 		Group scopeGroup = themeDisplay.getScopeGroup();
 
-		if ((scopeGroup != null) &&
-			(scopeGroup.isControlPanel() || scopeGroup.isDepot() ||
-			 scopeGroup.isSite()) &&
-			(PortletPermissionUtil.hasControlPanelAccessPermission(
+		if (scopeGroup.isOrganization() && !scopeGroup.isSite()) {
+			throw new PrincipalException(
+				"Unable to access an organization's site that is not enabled");
+		}
+
+		if (PortletPermissionUtil.hasControlPanelAccessPermission(
 				PermissionThreadLocal.getPermissionChecker(),
 				themeDisplay.getScopeGroupId(), portlet) ||
-			 isAccessGrantedByRuntimePortlet(httpServletRequest) ||
-			 isAccessGrantedByPortletAuthenticationToken(
-				 httpServletRequest, layout, portlet))) {
+			isAccessGrantedByRuntimePortlet(httpServletRequest) ||
+			isAccessGrantedByPortletAuthenticationToken(
+				httpServletRequest, layout, portlet)) {
 
 			return;
 		}

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-control-panel/src/test/java/com/liferay/layout/type/controller/control/panel/internal/model/ControlPanelLayoutTypeAccessPolicyTest.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-control-panel/src/test/java/com/liferay/layout/type/controller/control/panel/internal/model/ControlPanelLayoutTypeAccessPolicyTest.java
@@ -10,7 +10,6 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
-import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -51,15 +50,9 @@ public class ControlPanelLayoutTypeAccessPolicyTest {
 		);
 
 		Mockito.when(
-			group.isControlPanel()
+			group.isOrganization()
 		).thenReturn(
-			false
-		);
-
-		Mockito.when(
-			group.isDepot()
-		).thenReturn(
-			false
+			true
 		);
 
 		Mockito.when(
@@ -76,8 +69,6 @@ public class ControlPanelLayoutTypeAccessPolicyTest {
 
 		Portlet portlet = Mockito.mock(Portlet.class);
 
-		portlet.setPortletId(RandomTestUtil.randomString());
-
 		ControlPanelLayoutTypeAccessPolicy controlPanelLayoutTypeAccessPolicy =
 			new ControlPanelLayoutTypeAccessPolicy();
 
@@ -89,13 +80,12 @@ public class ControlPanelLayoutTypeAccessPolicyTest {
 		}
 		catch (PortalException portalException) {
 			Assert.assertEquals(
-				"User does not have permission to access Control Panel " +
-					"portlet " + portlet.getPortletId(),
+				"Unable to access an organization's site that is not enabled",
 				portalException.getMessage());
 		}
 
 		Mockito.when(
-			group.isControlPanel()
+			group.isSite()
 		).thenReturn(
 			true
 		);
@@ -115,13 +105,7 @@ public class ControlPanelLayoutTypeAccessPolicyTest {
 			httpServletRequest, null, portlet);
 
 		Mockito.when(
-			group.isControlPanel()
-		).thenReturn(
-			false
-		);
-
-		Mockito.when(
-			group.isDepot()
+			group.isSite()
 		).thenReturn(
 			true
 		);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-58961

Not render the control panel page for a group that is an organization but is not a site. _**That means an organization exists but its site is not enabled.**_

CI passed [here](https://github.com/liferay-platform-experience/liferay-portal/pull/1351), I am sending manually because master branch is taking way too long to sync.