### PR TITLE
LPD-58514 rename it back to siteExternalReferenceCode because we already use that name for the site initializer client extension

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationModelRetrieverImpl.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationModelRetrieverImpl.java
@@ -210,7 +210,7 @@ public class ConfigurationModelRetrieverImpl
 				ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
 				"=*))(!(dxp.lxc.liferay.com.virtualInstanceId=*))(!(",
 				ExtendedObjectClassDefinition.Scope.GROUP.getPropertyKey(),
-				"=*))(!(groupExternalReferenceCode=*)))");
+				"=*))(!(siteExternalReferenceCode=*)))");
 		}
 
 		String scopedFilterString = StringBundler.concat(
@@ -226,7 +226,7 @@ public class ConfigurationModelRetrieverImpl
 				ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
 				"=*)(dxp.lxc.liferay.com.virtualInstanceId=*))(!(",
 				ExtendedObjectClassDefinition.Scope.GROUP.getPropertyKey(),
-				"=*))(!(groupExternalReferenceCode=*))(!(",
+				"=*))(!(siteExternalReferenceCode=*))(!(",
 				ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE.
 					getPropertyKey(),
 				"=*)))");
@@ -237,7 +237,7 @@ public class ConfigurationModelRetrieverImpl
 				StringPool.OPEN_PARENTHESIS, StringPool.AMPERSAND,
 				scopedFilterString, "(|(",
 				ExtendedObjectClassDefinition.Scope.GROUP.getPropertyKey(),
-				"=*)(groupExternalReferenceCode=*))(!(",
+				"=*)(siteExternalReferenceCode=*))(!(",
 				ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE.
 					getPropertyKey(),
 				"=*)))");
@@ -247,7 +247,7 @@ public class ConfigurationModelRetrieverImpl
 			StringPool.OPEN_PARENTHESIS, StringPool.AMPERSAND,
 			scopedFilterString, "(|(",
 			ExtendedObjectClassDefinition.Scope.GROUP.getPropertyKey(),
-			"=*)(groupExternalReferenceCode=*))(",
+			"=*)(siteExternalReferenceCode=*))(",
 			ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE.
 				getPropertyKey(),
 			"=*))");

--- a/modules/apps/static/portal-configuration/portal-configuration-plugin-impl/src/main/java/com/liferay/portal/configuration/plugin/internal/SiteExternalReferenceCodeToGroupConfigurationPluginImpl.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-plugin-impl/src/main/java/com/liferay/portal/configuration/plugin/internal/SiteExternalReferenceCodeToGroupConfigurationPluginImpl.java
@@ -27,10 +27,10 @@ import org.osgi.service.cm.ConfigurationPlugin;
 /**
  * @author Raymond Augé
  */
-public class GroupExternalReferenceCodeToGroupConfigurationPluginImpl
+public class SiteExternalReferenceCodeToGroupConfigurationPluginImpl
 	implements ConfigurationPlugin {
 
-	public GroupExternalReferenceCodeToGroupConfigurationPluginImpl(
+	public SiteExternalReferenceCodeToGroupConfigurationPluginImpl(
 		BundleContext bundleContext) {
 
 		_bundleContext = bundleContext;
@@ -41,10 +41,10 @@ public class GroupExternalReferenceCodeToGroupConfigurationPluginImpl
 		ServiceReference<?> serviceReference,
 		Dictionary<String, Object> properties) {
 
-		String groupExternalReferenceCode = (String)properties.get(
-			"groupExternalReferenceCode");
+		String siteExternalReferenceCode = (String)properties.get(
+			"siteExternalReferenceCode");
 
-		if (Validator.isNull(groupExternalReferenceCode)) {
+		if (Validator.isNull(siteExternalReferenceCode)) {
 			return;
 		}
 
@@ -70,7 +70,7 @@ public class GroupExternalReferenceCodeToGroupConfigurationPluginImpl
 							"select groupId from Group_ where " +
 								"externalReferenceCode = ?"))) {
 
-				preparedStatement.setString(1, groupExternalReferenceCode);
+				preparedStatement.setString(1, siteExternalReferenceCode);
 
 				try (ResultSet resultSet = preparedStatement.executeQuery()) {
 					if (resultSet.next()) {
@@ -81,9 +81,9 @@ public class GroupExternalReferenceCodeToGroupConfigurationPluginImpl
 						if (_log.isInfoEnabled()) {
 							_log.info(
 								StringBundler.concat(
-									"Injected group ID ", groupId,
+									"Injected site ID ", groupId,
 									" for group external reference code ",
-									groupExternalReferenceCode));
+									siteExternalReferenceCode));
 						}
 					}
 				}
@@ -96,14 +96,14 @@ public class GroupExternalReferenceCodeToGroupConfigurationPluginImpl
 
 			if (_log.isWarnEnabled()) {
 				_log.warn(
-					"Skip group external reference code " +
-						groupExternalReferenceCode);
+					"Skip site external reference code " +
+					siteExternalReferenceCode);
 			}
 		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
-		GroupExternalReferenceCodeToGroupConfigurationPluginImpl.class);
+		SiteExternalReferenceCodeToGroupConfigurationPluginImpl.class);
 
 	private final BundleContext _bundleContext;
 	private final DB _db = DBManagerUtil.getDB();

--- a/modules/apps/static/portal-configuration/portal-configuration-plugin-impl/src/main/java/com/liferay/portal/configuration/plugin/internal/activator/ConfigurationPluginImplBundleActivator.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-plugin-impl/src/main/java/com/liferay/portal/configuration/plugin/internal/activator/ConfigurationPluginImplBundleActivator.java
@@ -5,7 +5,7 @@
 
 package com.liferay.portal.configuration.plugin.internal.activator;
 
-import com.liferay.portal.configuration.plugin.internal.GroupExternalReferenceCodeToGroupConfigurationPluginImpl;
+import com.liferay.portal.configuration.plugin.internal.SiteExternalReferenceCodeToGroupConfigurationPluginImpl;
 import com.liferay.portal.configuration.plugin.internal.WebIdToCompanyConfigurationPluginImpl;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 
@@ -27,13 +27,13 @@ public class ConfigurationPluginImplBundleActivator implements BundleActivator {
 		_serviceRegistrations.add(
 			bundleContext.registerService(
 				ConfigurationPlugin.class,
-				new GroupExternalReferenceCodeToGroupConfigurationPluginImpl(
+				new SiteExternalReferenceCodeToGroupConfigurationPluginImpl(
 					bundleContext),
 				HashMapDictionaryBuilder.<String, Object>put(
 					ConfigurationPlugin.CM_RANKING, 500
 				).put(
 					"config.plugin.id",
-					GroupExternalReferenceCodeToGroupConfigurationPluginImpl.
+					SiteExternalReferenceCodeToGroupConfigurationPluginImpl.
 						class.getName()
 				).build()));
 		_serviceRegistrations.add(

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -8324,7 +8324,7 @@
     # Env: LIFERAY_MODULE_PERIOD_FRAMEWORK_PERIOD_PROPERTIES_PERIOD_FELIX_PERIOD_CM_PERIOD_CONFIG_PERIOD_PLUGINS
     #
     module.framework.properties.felix.cm.config.plugins=\
-        com.liferay.portal.configuration.plugin.internal.GroupExternalReferenceCodeToGroupConfigurationPluginImpl,\
+        com.liferay.portal.configuration.plugin.internal.SiteExternalReferenceCodeToGroupConfigurationPluginImpl,\
         com.liferay.portal.configuration.plugin.internal.WebIdToCompanyConfigurationPluginImpl,\
         org.apache.felix.configadmin.plugin.interpolation
 


### PR DESCRIPTION
Reverse renaming made in https://github.com/brianchandotcom/liferay-portal/pull/163269/commits/a0517f3b40210d93f7c728917f711a2be00948e2