### PR TITLE
LPD-59117 | Revert "LPD-59117 Wordsmith" as we are asserting java's failure message

### DIFF
--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/TestEntityResourceTest.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/TestEntityResourceTest.java
@@ -231,8 +231,7 @@ public class TestEntityResourceTest extends BaseTestEntityResourceTestCase {
 			jsonObject.getString(
 				"title"
 			).contains(
-				"Unable to resolve type ID \"" + invalidTypeId +
-					"\" as a subtype"
+				"Could not resolve type id '" + invalidTypeId + "' as a subtype"
 			));
 
 		jsonObject = HTTPTestUtil.invokeToJSONObject(
@@ -246,7 +245,7 @@ public class TestEntityResourceTest extends BaseTestEntityResourceTestCase {
 			jsonObject.getString(
 				"title"
 			).contains(
-				"Missing type ID property \"type\""
+				"missing type id property 'type'"
 			));
 
 		// TODO Split after LPD-60141
@@ -410,8 +409,8 @@ public class TestEntityResourceTest extends BaseTestEntityResourceTestCase {
 				).getString(
 					"message"
 				).contains(
-					"Unable to resolve type ID \"" + invalidTypeId +
-						"\" as a subtype"
+					"Could not resolve type id '" + invalidTypeId +
+						"' as a subtype"
 				));
 			Assert.assertTrue(
 				failedItemsJSONArray.getJSONObject(
@@ -419,7 +418,7 @@ public class TestEntityResourceTest extends BaseTestEntityResourceTestCase {
 				).getString(
 					"message"
 				).contains(
-					"Missing type ID property \"type\""
+					"missing type id property 'type'"
 				));
 		}
 	}


### PR DESCRIPTION
Error messages are:

> Could not resolve type id 'bkev0ak7' as a subtype of `com.liferay.portal.tools.rest.builder.test.dto.v1_0.TestEntity`: known type ids = [ChildTestEntity1, ChildTestEntity2, ChildTestEntity3]


> Could not resolve subtype of [simple type, class com.liferay.portal.tools.rest.builder.test.dto.v1_0.TestEntity]: missing type id property 'type'

