### PR TITLE
Fixing more learn-resources

### DIFF
--- a/learn-resources/data/click-to-chat-web.json
+++ b/learn-resources/data/click-to-chat-web.json
@@ -2,67 +2,67 @@
 	"chat-provider-account-id-chatwoot": {
 		"en_US": {
 			"message": "Get my account token for Chatwoot.",
-			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
+			"url": "https://learn.liferay.com/w/dxp/personalization/experiences/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
 		}
 	},
 	"chat-provider-account-id-crisp": {
 		"en_US": {
 			"message": "Get my account token for Crisp.",
-			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
+			"url": "https://learn.liferay.com/w/dxp/personalization/experiences/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
 		}
 	},
 	"chat-provider-account-id-hubspot": {
 		"en_US": {
 			"message": "Get my account token for Hubspot.",
-			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
+			"url": "https://learn.liferay.com/w/dxp/personalization/experiences/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
 		}
 	},
 	"chat-provider-account-id-jivochat": {
 		"en_US": {
 			"message": "Get my account token for JivoChat.",
-			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
+			"url": "https://learn.liferay.com/w/dxp/personalization/experiences/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
 		}
 	},
 	"chat-provider-account-id-livechat": {
 		"en_US": {
 			"message": "Get my account token for LiveChat.",
-			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
+			"url": "https://learn.liferay.com/w/dxp/personalization/experiences/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
 		}
 	},
 	"chat-provider-account-id-liveperson": {
 		"en_US": {
 			"message": "Get my account token for LivePerson.",
-			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
+			"url": "https://learn.liferay.com/w/dxp/personalization/experiences/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
 		}
 	},
 	"chat-provider-account-id-smartsupp": {
 		"en_US": {
 			"message": "Get my account token for Smartsupp.",
-			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
+			"url": "https://learn.liferay.com/w/dxp/personalization/experiences/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
 		}
 	},
 	"chat-provider-account-id-tawkto": {
 		"en_US": {
 			"message": "Get my account token for tawk.to.",
-			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
+			"url": "https://learn.liferay.com/w/dxp/personalization/experiences/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
 		}
 	},
 	"chat-provider-account-id-tidio": {
 		"en_US": {
 			"message": "Get my account token for Tidio.",
-			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
+			"url": "https://learn.liferay.com/w/dxp/personalization/experiences/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
 		}
 	},
 	"chat-provider-account-id-zendesk_web_widget": {
 		"en_US": {
 			"message": "Get my account token for Zendesk.",
-			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
+			"url": "https://learn.liferay.com/w/dxp/personalization/experiences/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
 		}
 	},
 	"chat-provider-account-id-zendesk_web_widget_classic": {
 		"en_US": {
 			"message": "Get my account token for Zendesk.",
-			"url": "https://learn.liferay.com/w/dxp/site-building/personalizing-site-experience/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
+			"url": "https://learn.liferay.com/w/dxp/personalization/experiences/enabling-automated-live-chat-systems#getting-the-chat-provider-account-id-or-token"
 		}
 	}
 }


### PR DESCRIPTION
Because we're still in the process of reorganizing documentation and adding pattern redirects, this may not be the last PR fixing Liferay Learn links. Yesterday's batch was important because product team tests were breaking. By contrast, I am not sure if there are tests covering this click to chat link.

I don't know how publishing to AWS works, but in my opinion you can merge these and wait to publish until we're done breaking links, probably by the end of the week.

cc @sez11a