### PR TITLE
LPD-53149 Followup: Set upgrade.database.dl.storage.check.disabled=true in portal-developer.properties

### DIFF
--- a/portal-impl/src/portal-developer.properties
+++ b/portal-impl/src/portal-developer.properties
@@ -1,5 +1,6 @@
 schema.module.build.auto.upgrade=true
 upgrade.database.auto.run=true
+upgrade.database.dl.storage.check.disabled=true
 theme.css.fast.load=false
 theme.css.fast.load.check.request.parameter=true
 theme.images.fast.load=false


### PR DESCRIPTION
Set `upgrade.database.dl.storage.check.disabled=true` in portal-developer.properties to disable the PreupgradeVerifyStoreAccess and PreupgradeVerifyStoreFileSystemStructure checks in the developer mode. 

Most of developers when testing a customer upgrade doesn't copy the document_library directory as it can be very big and for testing is not so problematic.