### PR TITLE
LPD-59412 PortletTracker is not setting portlet target companyId when deploying portlets at startup time

### DIFF
--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PortletTrackerTest.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PortletTrackerTest.java
@@ -127,15 +127,18 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 	@Test
 	public void testLoadGetPortlets() throws Exception {
 		try {
+			String portletName = RandomTestUtil.randomString();
+
 			setUpPortlet(
 				_internalClassTestPortlet,
 				HashMapDictionaryBuilder.<String, Object>put(
-					"com.liferay.portlet.display-category", "company-scope"
+					"com.liferay.portlet.display-category",
+					RandomTestUtil.randomString()
 				).build(),
-				"companyPortlet", false);
+				portletName, false);
 
-			_assertPortletDeployed(_company1, "companyPortlet");
-			_assertPortletDeployed(_company2, "companyPortlet");
+			_assertPortletDeployed(_company1, portletName);
+			_assertPortletDeployed(_company2, portletName);
 		}
 		finally {
 			for (ServiceRegistration<?> serviceRegistration :
@@ -151,17 +154,20 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 	@Test
 	public void testLoadGetPortletsByCompany() throws Exception {
 		try {
+			String portletName = RandomTestUtil.randomString();
+
 			setUpPortlet(
 				_internalClassTestPortlet,
 				HashMapDictionaryBuilder.<String, Object>put(
 					"com.liferay.portlet.company", _company1.getCompanyId()
 				).put(
-					"com.liferay.portlet.display-category", "company-scope"
+					"com.liferay.portlet.display-category",
+					RandomTestUtil.randomString()
 				).build(),
-				"companyPortlet", false);
+				portletName, false);
 
-			_assertPortletDeployed(_company1, "companyPortlet");
-			_assertPortletNotDeployed(_company2, "companyPortlet");
+			_assertPortletDeployed(_company1, portletName);
+			_assertPortletNotDeployed(_company2, portletName);
 		}
 		finally {
 			for (ServiceRegistration<?> serviceRegistration :
@@ -179,21 +185,24 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 		Company company = null;
 
 		try {
+			String portletName = RandomTestUtil.randomString();
+
 			setUpPortlet(
 				_internalClassTestPortlet,
 				HashMapDictionaryBuilder.<String, Object>put(
 					"com.liferay.portlet.company", _company1.getCompanyId()
 				).put(
-					"com.liferay.portlet.display-category", "company-scope"
+					"com.liferay.portlet.display-category",
+					RandomTestUtil.randomString()
 				).build(),
-				"companyPortlet", false);
+				portletName, false);
 
 			company = CompanyTestUtil.addCompany();
 
 			PortalInstances.initCompany(company);
 
-			_assertPortletDeployed(_company1, "companyPortlet");
-			_assertPortletNotDeployed(company, "companyPortlet");
+			_assertPortletDeployed(_company1, portletName);
+			_assertPortletNotDeployed(company, portletName);
 		}
 		finally {
 			for (ServiceRegistration<?> serviceRegistration :
@@ -222,7 +231,7 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 				HashMapDictionaryBuilder.<String, Object>put(
 					"com.liferay.portlet.display-category", displayCategory
 				).build(),
-				"companyPortlet", false);
+				RandomTestUtil.randomString(), false);
 
 			PortletCategory portletCategory1 = (PortletCategory)WebAppPool.get(
 				_company1.getCompanyId(), WebKeys.PORTLET_CATEGORY);
@@ -275,7 +284,7 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 				).put(
 					"com.liferay.portlet.display-category", displayCategory
 				).build(),
-				"companyPortlet", false);
+				RandomTestUtil.randomString(), false);
 
 			PortletCategory portletCategory1 = (PortletCategory)WebAppPool.get(
 				_company1.getCompanyId(), WebKeys.PORTLET_CATEGORY);
@@ -345,32 +354,34 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 	@Test
 	public void testPortletTrackerRegistrationCompanyScope() throws Exception {
 		try {
+			String displayCategory = RandomTestUtil.randomString();
+			String portletName = RandomTestUtil.randomString();
+
 			setUpPortlet(
 				_internalClassTestPortlet,
 				HashMapDictionaryBuilder.<String, Object>put(
 					"com.liferay.portlet.company", _company1.getCompanyId()
 				).put(
-					"com.liferay.portlet.display-category", "company-scope"
+					"com.liferay.portlet.display-category", displayCategory
 				).build(),
-				"companyScopePortlet", false);
+				portletName, false);
 
 			PortletCategory portletCategory1 = (PortletCategory)WebAppPool.get(
 				_company1.getCompanyId(), WebKeys.PORTLET_CATEGORY);
 
 			PortletCategory companyScopePortletCategory =
-				portletCategory1.getCategory("company-scope");
+				portletCategory1.getCategory(displayCategory);
 
 			Set<String> portletIds =
 				companyScopePortletCategory.getPortletIds();
 
 			Assert.assertTrue(
-				portletIds.toString(),
-				portletIds.contains("companyScopePortlet"));
+				portletIds.toString(), portletIds.contains(portletName));
 
 			PortletCategory portletCategory2 = (PortletCategory)WebAppPool.get(
 				_company2.getCompanyId(), WebKeys.PORTLET_CATEGORY);
 
-			Assert.assertNull(portletCategory2.getCategory("company-scope"));
+			Assert.assertNull(portletCategory2.getCategory(displayCategory));
 		}
 		finally {
 			for (ServiceRegistration<?> serviceRegistration :

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PortletTrackerTest.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PortletTrackerTest.java
@@ -10,14 +10,17 @@ import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.io.StreamUtil;
 import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.db.partition.DBPartition;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.PortletCategory;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -47,9 +50,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.jar.Attributes;
@@ -58,8 +59,11 @@ import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -85,14 +89,43 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
 
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		if (DBPartition.isPartitionEnabled()) {
+			_safeCloseable = CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+				PortalInstancePool.getDefaultCompanyId());
+		}
+
+		_company1 = CompanyTestUtil.addCompany();
+		_company2 = CompanyTestUtil.addCompany();
+
+		PortalInstances.initCompany(_company1);
+		PortalInstances.initCompany(_company2);
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		CompanyLocalServiceUtil.deleteCompany(_company2);
+
+		CompanyLocalServiceUtil.deleteCompany(_company1);
+
+		PortalInstances.removeCompany(_company1.getCompanyId());
+		PortalInstances.removeCompany(_company2.getCompanyId());
+
+		if (_safeCloseable != null) {
+			_safeCloseable.close();
+		}
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		if (!DBPartition.isPartitionEnabled()) {
+			super.setUp();
+		}
+	}
+
 	@Test
 	public void testLoadGetPortlets() throws Exception {
-		Company company1 = CompanyTestUtil.addCompany();
-		Company company2 = CompanyTestUtil.addCompany();
-
-		PortalInstances.initCompany(company1);
-		PortalInstances.initCompany(company2);
-
 		try {
 			setUpPortlet(
 				_internalClassTestPortlet,
@@ -101,8 +134,8 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 				).build(),
 				"companyPortlet", false);
 
-			_assertPortletDeployed(company1, "companyPortlet");
-			_assertPortletDeployed(company2, "companyPortlet");
+			_assertPortletDeployed(_company1, "companyPortlet");
+			_assertPortletDeployed(_company2, "companyPortlet");
 		}
 		finally {
 			for (ServiceRegistration<?> serviceRegistration :
@@ -112,36 +145,23 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 			}
 
 			serviceRegistrations.clear();
-
-			_companyLocalService.deleteCompany(company2);
-
-			_companyLocalService.deleteCompany(company1);
-
-			PortalInstances.removeCompany(company1.getCompanyId());
-			PortalInstances.removeCompany(company2.getCompanyId());
 		}
 	}
 
 	@Test
 	public void testLoadGetPortletsByCompany() throws Exception {
-		Company company1 = CompanyTestUtil.addCompany();
-		Company company2 = CompanyTestUtil.addCompany();
-
-		PortalInstances.initCompany(company1);
-		PortalInstances.initCompany(company2);
-
 		try {
 			setUpPortlet(
 				_internalClassTestPortlet,
 				HashMapDictionaryBuilder.<String, Object>put(
-					"com.liferay.portlet.company", company1.getCompanyId()
+					"com.liferay.portlet.company", _company1.getCompanyId()
 				).put(
 					"com.liferay.portlet.display-category", "company-scope"
 				).build(),
 				"companyPortlet", false);
 
-			_assertPortletDeployed(company1, "companyPortlet");
-			_assertPortletNotDeployed(company2, "companyPortlet");
+			_assertPortletDeployed(_company1, "companyPortlet");
+			_assertPortletNotDeployed(_company2, "companyPortlet");
 		}
 		finally {
 			for (ServiceRegistration<?> serviceRegistration :
@@ -151,44 +171,29 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 			}
 
 			serviceRegistrations.clear();
-
-			_companyLocalService.deleteCompany(company2);
-
-			_companyLocalService.deleteCompany(company1);
-
-			PortalInstances.removeCompany(company1.getCompanyId());
-			PortalInstances.removeCompany(company2.getCompanyId());
 		}
 	}
 
 	@Test
 	public void testLoadGetPortletsByCompanyWithReload() throws Exception {
-		List<Company> companies = new ArrayList<>();
+		Company company = null;
 
 		try {
-			Company company1 = CompanyTestUtil.addCompany();
-
-			companies.add(company1);
-
-			PortalInstances.initCompany(company1);
-
 			setUpPortlet(
 				_internalClassTestPortlet,
 				HashMapDictionaryBuilder.<String, Object>put(
-					"com.liferay.portlet.company", company1.getCompanyId()
+					"com.liferay.portlet.company", _company1.getCompanyId()
 				).put(
 					"com.liferay.portlet.display-category", "company-scope"
 				).build(),
 				"companyPortlet", false);
 
-			Company company2 = CompanyTestUtil.addCompany();
+			company = CompanyTestUtil.addCompany();
 
-			companies.add(company2);
+			PortalInstances.initCompany(company);
 
-			PortalInstances.initCompany(company2);
-
-			_assertPortletDeployed(company1, "companyPortlet");
-			_assertPortletNotDeployed(company2, "companyPortlet");
+			_assertPortletDeployed(_company1, "companyPortlet");
+			_assertPortletNotDeployed(company, "companyPortlet");
 		}
 		finally {
 			for (ServiceRegistration<?> serviceRegistration :
@@ -199,24 +204,16 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 
 			serviceRegistrations.clear();
 
-			_companyLocalService.forEachCompany(
-				company -> {
-					_companyLocalService.deleteCompany(company);
+			if (company != null) {
+				_companyLocalService.deleteCompany(company);
 
-					PortalInstances.removeCompany(company.getCompanyId());
-				},
-				companies);
+				PortalInstances.removeCompany(company.getCompanyId());
+			}
 		}
 	}
 
 	@Test
 	public void testPortletDisplayCategory() throws Exception {
-		Company company1 = CompanyTestUtil.addCompany();
-		Company company2 = CompanyTestUtil.addCompany();
-
-		PortalInstances.initCompany(company1);
-		PortalInstances.initCompany(company2);
-
 		String displayCategory = RandomTestUtil.randomString();
 
 		try {
@@ -228,31 +225,31 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 				"companyPortlet", false);
 
 			PortletCategory portletCategory1 = (PortletCategory)WebAppPool.get(
-				company1.getCompanyId(), WebKeys.PORTLET_CATEGORY);
+				_company1.getCompanyId(), WebKeys.PORTLET_CATEGORY);
 
 			Assert.assertNotNull(portletCategory1.getCategory(displayCategory));
 
 			PortletCategory portletCategory2 = (PortletCategory)WebAppPool.get(
-				company2.getCompanyId(), WebKeys.PORTLET_CATEGORY);
+				_company2.getCompanyId(), WebKeys.PORTLET_CATEGORY);
 
 			Assert.assertNotNull(portletCategory2.getCategory(displayCategory));
 
-			Company company3 = CompanyTestUtil.addCompany();
+			Company company = CompanyTestUtil.addCompany();
 
-			PortalInstances.initCompany(company3);
+			PortalInstances.initCompany(company);
 
 			try {
 				PortletCategory portletCategory3 =
 					(PortletCategory)WebAppPool.get(
-						company3.getCompanyId(), WebKeys.PORTLET_CATEGORY);
+						company.getCompanyId(), WebKeys.PORTLET_CATEGORY);
 
 				Assert.assertNotNull(
 					portletCategory3.getCategory(displayCategory));
 			}
 			finally {
-				_companyLocalService.deleteCompany(company3);
+				_companyLocalService.deleteCompany(company);
 
-				PortalInstances.removeCompany(company3.getCompanyId());
+				PortalInstances.removeCompany(company.getCompanyId());
 			}
 		}
 		finally {
@@ -263,63 +260,49 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 			}
 
 			serviceRegistrations.clear();
-
-			_companyLocalService.deleteCompany(company1);
-
-			PortalInstances.removeCompany(company1.getCompanyId());
-
-			_companyLocalService.deleteCompany(company2);
-
-			PortalInstances.removeCompany(company2.getCompanyId());
 		}
 	}
 
 	@Test
 	public void testPortletDisplayCategoryByCompany() throws Exception {
-		Company company1 = CompanyTestUtil.addCompany();
-		Company company2 = CompanyTestUtil.addCompany();
-
-		PortalInstances.initCompany(company1);
-		PortalInstances.initCompany(company2);
-
 		String displayCategory = RandomTestUtil.randomString();
 
 		try {
 			setUpPortlet(
 				_internalClassTestPortlet,
 				HashMapDictionaryBuilder.<String, Object>put(
-					"com.liferay.portlet.company", company1.getCompanyId()
+					"com.liferay.portlet.company", _company1.getCompanyId()
 				).put(
 					"com.liferay.portlet.display-category", displayCategory
 				).build(),
 				"companyPortlet", false);
 
 			PortletCategory portletCategory1 = (PortletCategory)WebAppPool.get(
-				company1.getCompanyId(), WebKeys.PORTLET_CATEGORY);
+				_company1.getCompanyId(), WebKeys.PORTLET_CATEGORY);
 
 			Assert.assertNotNull(portletCategory1.getCategory(displayCategory));
 
 			PortletCategory portletCategory2 = (PortletCategory)WebAppPool.get(
-				company2.getCompanyId(), WebKeys.PORTLET_CATEGORY);
+				_company2.getCompanyId(), WebKeys.PORTLET_CATEGORY);
 
 			Assert.assertNull(portletCategory2.getCategory(displayCategory));
 
-			Company company3 = CompanyTestUtil.addCompany();
+			Company company = CompanyTestUtil.addCompany();
 
-			PortalInstances.initCompany(company3);
+			PortalInstances.initCompany(company);
 
 			try {
 				PortletCategory portletCategory3 =
 					(PortletCategory)WebAppPool.get(
-						company3.getCompanyId(), WebKeys.PORTLET_CATEGORY);
+						company.getCompanyId(), WebKeys.PORTLET_CATEGORY);
 
 				Assert.assertNull(
 					portletCategory3.getCategory(displayCategory));
 			}
 			finally {
-				_companyLocalService.deleteCompany(company3);
+				_companyLocalService.deleteCompany(company);
 
-				PortalInstances.removeCompany(company3.getCompanyId());
+				PortalInstances.removeCompany(company.getCompanyId());
 			}
 		}
 		finally {
@@ -330,13 +313,6 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 			}
 
 			serviceRegistrations.clear();
-
-			_companyLocalService.deleteCompany(company2);
-
-			_companyLocalService.deleteCompany(company1);
-
-			PortalInstances.removeCompany(company1.getCompanyId());
-			PortalInstances.removeCompany(company2.getCompanyId());
 		}
 	}
 
@@ -368,24 +344,18 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 
 	@Test
 	public void testPortletTrackerRegistrationCompanyScope() throws Exception {
-		Company company1 = CompanyTestUtil.addCompany();
-		Company company2 = CompanyTestUtil.addCompany();
-
-		PortalInstances.initCompany(company1);
-		PortalInstances.initCompany(company2);
-
 		try {
 			setUpPortlet(
 				_internalClassTestPortlet,
 				HashMapDictionaryBuilder.<String, Object>put(
-					"com.liferay.portlet.company", company1.getCompanyId()
+					"com.liferay.portlet.company", _company1.getCompanyId()
 				).put(
 					"com.liferay.portlet.display-category", "company-scope"
 				).build(),
 				"companyScopePortlet", false);
 
 			PortletCategory portletCategory1 = (PortletCategory)WebAppPool.get(
-				company1.getCompanyId(), WebKeys.PORTLET_CATEGORY);
+				_company1.getCompanyId(), WebKeys.PORTLET_CATEGORY);
 
 			PortletCategory companyScopePortletCategory =
 				portletCategory1.getCategory("company-scope");
@@ -398,7 +368,7 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 				portletIds.contains("companyScopePortlet"));
 
 			PortletCategory portletCategory2 = (PortletCategory)WebAppPool.get(
-				company2.getCompanyId(), WebKeys.PORTLET_CATEGORY);
+				_company2.getCompanyId(), WebKeys.PORTLET_CATEGORY);
 
 			Assert.assertNull(portletCategory2.getCategory("company-scope"));
 		}
@@ -410,13 +380,6 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 			}
 
 			serviceRegistrations.clear();
-
-			_companyLocalService.deleteCompany(company2);
-
-			_companyLocalService.deleteCompany(company1);
-
-			PortalInstances.removeCompany(company1.getCompanyId());
-			PortalInstances.removeCompany(company2.getCompanyId());
 		}
 	}
 
@@ -661,6 +624,10 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 
 		jarOutputStream.closeEntry();
 	}
+
+	private static Company _company1;
+	private static Company _company2;
+	private static SafeCloseable _safeCloseable;
 
 	@Inject
 	private CompanyLocalService _companyLocalService;

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PortletTrackerTest.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PortletTrackerTest.java
@@ -37,7 +37,6 @@ import com.liferay.portal.osgi.web.portlet.container.test.util.PortletContainerT
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
-import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.WebAppPool;
 
 import jakarta.portlet.PortletException;
@@ -98,9 +97,6 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 
 		_company1 = CompanyTestUtil.addCompany();
 		_company2 = CompanyTestUtil.addCompany();
-
-		PortalInstances.initCompany(_company1);
-		PortalInstances.initCompany(_company2);
 	}
 
 	@AfterClass
@@ -108,9 +104,6 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 		CompanyLocalServiceUtil.deleteCompany(_company2);
 
 		CompanyLocalServiceUtil.deleteCompany(_company1);
-
-		PortalInstances.removeCompany(_company1.getCompanyId());
-		PortalInstances.removeCompany(_company2.getCompanyId());
 
 		if (_safeCloseable != null) {
 			_safeCloseable.close();
@@ -199,8 +192,6 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 
 			company = CompanyTestUtil.addCompany();
 
-			PortalInstances.initCompany(company);
-
 			_assertPortletDeployed(_company1, portletName);
 			_assertPortletNotDeployed(company, portletName);
 		}
@@ -215,8 +206,6 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 
 			if (company != null) {
 				_companyLocalService.deleteCompany(company);
-
-				PortalInstances.removeCompany(company.getCompanyId());
 			}
 		}
 	}
@@ -245,8 +234,6 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 
 			Company company = CompanyTestUtil.addCompany();
 
-			PortalInstances.initCompany(company);
-
 			try {
 				PortletCategory portletCategory3 =
 					(PortletCategory)WebAppPool.get(
@@ -257,8 +244,6 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 			}
 			finally {
 				_companyLocalService.deleteCompany(company);
-
-				PortalInstances.removeCompany(company.getCompanyId());
 			}
 		}
 		finally {
@@ -298,8 +283,6 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 
 			Company company = CompanyTestUtil.addCompany();
 
-			PortalInstances.initCompany(company);
-
 			try {
 				PortletCategory portletCategory3 =
 					(PortletCategory)WebAppPool.get(
@@ -310,8 +293,6 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 			}
 			finally {
 				_companyLocalService.deleteCompany(company);
-
-				PortalInstances.removeCompany(company.getCompanyId());
 			}
 		}
 		finally {

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PortletTrackerTest.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PortletTrackerTest.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.PortletCategory;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
@@ -102,18 +103,8 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 				).build(),
 				"companyPortlet", false);
 
-			Map<String, Portlet> portlets =
-				_portletLocalService.loadGetPortletsMap(
-					company1.getCompanyId());
-
-			Assert.assertTrue(
-				portlets.toString(), portlets.containsKey("companyPortlet"));
-
-			portlets = _portletLocalService.loadGetPortletsMap(
-				company2.getCompanyId());
-
-			Assert.assertFalse(
-				portlets.toString(), portlets.containsKey("companyPortlet"));
+			_assertPortletDeployed(company1, "companyPortlet");
+			_assertPortletNotDeployed(company2, "companyPortlet");
 		}
 		finally {
 			for (ServiceRegistration<?> serviceRegistration :
@@ -159,18 +150,8 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 
 			PortalInstances.initCompany(company2);
 
-			Map<String, Portlet> portlets =
-				_portletLocalService.loadGetPortletsMap(
-					company1.getCompanyId());
-
-			Assert.assertTrue(
-				portlets.toString(), portlets.containsKey("companyPortlet"));
-
-			portlets = _portletLocalService.loadGetPortletsMap(
-				company2.getCompanyId());
-
-			Assert.assertFalse(
-				portlets.toString(), portlets.containsKey("companyPortlet"));
+			_assertPortletDeployed(company1, "companyPortlet");
+			_assertPortletNotDeployed(company2, "companyPortlet");
 		}
 		finally {
 			for (ServiceRegistration<?> serviceRegistration :
@@ -479,6 +460,37 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 		public void stop(BundleContext bundleContext) {
 		}
 
+	}
+
+	private void _assertPortletDeployed(Company company, String portletId) {
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					company.getCompanyId())) {
+
+			Map<String, Portlet> portlets =
+				_portletLocalService.loadGetPortletsMap(company.getCompanyId());
+
+			Assert.assertTrue(
+				portlets.toString(), portlets.containsKey(portletId));
+
+			Assert.assertNotNull(
+				_portletLocalService.getPortletById(portletId));
+		}
+	}
+
+	private void _assertPortletNotDeployed(Company company, String portletId) {
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					company.getCompanyId())) {
+
+			Map<String, Portlet> portlets =
+				_portletLocalService.loadGetPortletsMap(company.getCompanyId());
+
+			Assert.assertFalse(
+				portlets.toString(), portlets.containsKey(portletId));
+
+			Assert.assertNull(_portletLocalService.getPortletById(portletId));
+		}
 	}
 
 	private InputStream _createBundle(String bundleSymbolicName)

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PortletTrackerTest.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PortletTrackerTest.java
@@ -526,7 +526,14 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 			Assert.assertFalse(
 				portlets.toString(), portlets.containsKey(portletId));
 
-			Assert.assertNull(_portletLocalService.getPortletById(portletId));
+			if (DBPartition.isPartitionEnabled()) {
+				Assert.assertNull(
+					_portletLocalService.getPortletById(portletId));
+			}
+			else {
+				Assert.assertNotNull(
+					_portletLocalService.getPortletById(portletId));
+			}
 		}
 	}
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PortletTrackerTest.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PortletTrackerTest.java
@@ -86,6 +86,43 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Test
+	public void testLoadGetPortlets() throws Exception {
+		Company company1 = CompanyTestUtil.addCompany();
+		Company company2 = CompanyTestUtil.addCompany();
+
+		PortalInstances.initCompany(company1);
+		PortalInstances.initCompany(company2);
+
+		try {
+			setUpPortlet(
+				_internalClassTestPortlet,
+				HashMapDictionaryBuilder.<String, Object>put(
+					"com.liferay.portlet.display-category", "company-scope"
+				).build(),
+				"companyPortlet", false);
+
+			_assertPortletDeployed(company1, "companyPortlet");
+			_assertPortletDeployed(company2, "companyPortlet");
+		}
+		finally {
+			for (ServiceRegistration<?> serviceRegistration :
+					serviceRegistrations) {
+
+				serviceRegistration.unregister();
+			}
+
+			serviceRegistrations.clear();
+
+			_companyLocalService.deleteCompany(company2);
+
+			_companyLocalService.deleteCompany(company1);
+
+			PortalInstances.removeCompany(company1.getCompanyId());
+			PortalInstances.removeCompany(company2.getCompanyId());
+		}
+	}
+
+	@Test
 	public void testLoadGetPortletsByCompany() throws Exception {
 		Company company1 = CompanyTestUtil.addCompany();
 		Company company2 = CompanyTestUtil.addCompany();

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PortletTrackerTest.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PortletTrackerTest.java
@@ -11,6 +11,7 @@ import com.liferay.petra.io.StreamUtil;
 import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.petra.string.CharPool;
+import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.PortletCategory;
@@ -19,7 +20,6 @@ import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -58,6 +58,7 @@ import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -80,7 +81,7 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
-			new AssumeTestRule("assume"), new LiferayIntegrationTestRule(),
+			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Test
@@ -323,6 +324,8 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 
 	@Test
 	public void testPortletTrackerBundleStopCleanup() throws Exception {
+		Assume.assumeFalse(DBPartition.isPartitionEnabled());
+
 		Bundle bundle = FrameworkUtil.getBundle(PortletTrackerTest.class);
 
 		BundleContext bundleContext = bundle.getBundleContext();
@@ -403,6 +406,8 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 	public void testPortletTrackerRegistrationUsingPortletClassName()
 		throws Exception {
 
+		Assume.assumeFalse(DBPartition.isPartitionEnabled());
+
 		_testPortletTrackerRegistration(
 			"com_liferay_portal_osgi_web_portlet_container_test_" +
 				"PortletTrackerTest_InternalClassTestPortlet");
@@ -412,12 +417,16 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 	public void testPortletTrackerRegistrationUsingPortletNameWithDollar()
 		throws Exception {
 
+		Assume.assumeFalse(DBPartition.isPartitionEnabled());
+
 		_testPortletTrackerRegistration("dollar$portlet", "dollar_portlet");
 	}
 
 	@Test
 	public void testPortletTrackerRegistrationUsingPortletNameWithDot()
 		throws Exception {
+
+		Assume.assumeFalse(DBPartition.isPartitionEnabled());
 
 		_testPortletTrackerRegistration("dot.portlet", "dot_portlet");
 	}
@@ -426,6 +435,8 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 	public void testPortletTrackerRegistrationUsingPortletNameWithHyphen()
 		throws Exception {
 
+		Assume.assumeFalse(DBPartition.isPartitionEnabled());
+
 		_testPortletTrackerRegistration("hyphen-portlet", "hyphenportlet");
 	}
 
@@ -433,12 +444,16 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 	public void testPortletTrackerRegistrationUsingPortletNameWithSpace()
 		throws Exception {
 
+		Assume.assumeFalse(DBPartition.isPartitionEnabled());
+
 		_testPortletTrackerRegistration("space portlet", "spaceportlet");
 	}
 
 	@Test
 	public void testPortletTrackerRegistrationUsingSimpleName()
 		throws Exception {
+
+		Assume.assumeFalse(DBPartition.isPartitionEnabled());
 
 		_testPortletTrackerRegistration("simplename", "simplename");
 	}

--- a/portal-impl/src/com/liferay/portal/db/partition/util/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/util/DBPartitionUtil.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.module.framework.ThrowableCollector;
 import com.liferay.portal.kernel.scheduler.SchedulerEngine;
 import com.liferay.portal.kernel.scheduler.SchedulerEngineHelperUtil;
@@ -282,6 +283,16 @@ public class DBPartitionUtil {
 		}
 
 		return key + StringPool.AT + CompanyThreadLocal.getNonsystemCompanyId();
+	}
+
+	public static String getPartitionKey(
+		String key, ShardedModel shardedModel) {
+
+		if (!DBPartition.isPartitionEnabled()) {
+			return key;
+		}
+
+		return key + StringPool.AT + shardedModel.getCompanyId();
 	}
 
 	public static String getPartitionName(long companyId) {

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -3033,13 +3033,12 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 
 		@Override
 		public Portlet put(String key, Portlet value) {
-			if (!DBPartition.isPartitionEnabled() || (value == null) ||
-				(value.getCompanyId() == CompanyConstants.SYSTEM)) {
-
+			if (value.getCompanyId() == CompanyConstants.SYSTEM) {
 				return super.put(key, value);
 			}
 
-			return super.put(key + StringPool.AT + value.getCompanyId(), value);
+			return super.put(
+				DBPartitionUtil.getPartitionKey(key, value), value);
 		}
 
 		@Override

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -3039,7 +3039,7 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 				return super.put(key, value);
 			}
 
-			return super.put(DBPartitionUtil.getPartitionKey(key), value);
+			return super.put(key + StringPool.AT + value.getCompanyId(), value);
 		}
 
 		@Override

--- a/test.properties
+++ b/test.properties
@@ -3320,6 +3320,7 @@
         **/portal-tools-db-partition*/**/*Test.java,\
         **/testIntegration/**/UpgradeProcessDBPartitionTest.java,\
         **/testIntegration/**/company/service/test/*Test.java,\
+        **/testIntegration/**/container/test/PortletTrackerTest.java,\
         **/testIntegration/**/v1_0_1/test/QuartzUpgradeProcessTest.java,\
         **/testIntegration/**/v1_0_3/test/QuartzDBPartitionUpgradeProcessTest.java
 


### PR DESCRIPTION
Same pull than https://github.com/brianchandotcom/liferay-portal/pull/163760 but with an additional commit b9b52ed4a4802406c90e4cccbdb3d53e4daa7b68 with the requested  removal of the unnecessary calls to `PortalInstances.initCompany` and `PortalInstances.removeCompany` as they are done at CompanyLocalServiceImpl level.

cc @dantewang