### PR TITLE
LPD-57581 portal-search-web: Apply SPA navigation using Liferay util

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/CustomFilter.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/CustomFilter.js
@@ -25,7 +25,7 @@ export default function ({namespace: portletNamespace}) {
 			document.location.search
 		);
 
-		document.location.href = searchURL + queryString;
+		Liferay.Util.navigate(searchURL + queryString);
 	}
 
 	function _handleSubmit(event) {

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/CustomFilter.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/CustomFilter.js
@@ -22,7 +22,7 @@ export default function ({namespace: portletNamespace}) {
 		const queryString = FacetUtil.updateQueryString(
 			filterValueInput.getAttribute('name'),
 			[filterValueInput.value],
-			document.location.search
+			window.location.search
 		);
 
 		Liferay.Util.navigate(searchURL + queryString);

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/FacetUtil.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/FacetUtil.js
@@ -292,13 +292,11 @@ export const FacetUtil = {
 	},
 
 	selectTerms(form, selections) {
-		const search = document.location.search;
-
 		const url = new URL(window.location.href);
 
 		url.search = this.queryParameterAndUpdateValue(
 			form,
-			search,
+			window.location.search,
 			selections
 		);
 

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/FacetUtil.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/FacetUtil.js
@@ -292,11 +292,17 @@ export const FacetUtil = {
 	},
 
 	selectTerms(form, selections) {
-		let search = document.location.search;
+		const search = document.location.search;
 
-		search = this.queryParameterAndUpdateValue(form, search, selections);
+		const url = new URL(window.location.href);
 
-		document.location.search = search;
+		url.search = this.queryParameterAndUpdateValue(
+			form,
+			search,
+			selections
+		);
+
+		Liferay.Util.navigate(url.toString());
 	},
 
 	setURLParameter(url, name, value) {

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/SearchBar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/SearchBar.js
@@ -86,7 +86,7 @@ export default function ({formId, initialKeywords, retainFacetSelections}) {
 			const keywords = getKeywords();
 			const searchURL = form.action;
 
-			let queryString = updateQueryString(document.location.search);
+			let queryString = updateQueryString(window.location.search);
 
 			/*
 			 * Refer to LPD-19994 for acceptance criteria regarding

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/SearchBar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/SearchBar.js
@@ -102,7 +102,7 @@ export default function ({formId, initialKeywords, retainFacetSelections}) {
 				queryString = FacetUtil.removeAllFacetParameters(queryString);
 			}
 
-			document.location.href = searchURL + queryString;
+			Liferay.Util.navigate(searchURL + queryString);
 		}
 	}
 

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/Sort.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/Sort.js
@@ -20,11 +20,15 @@ export default function ({namespace: portletNamespace}) {
 		).value;
 
 		if (key) {
-			document.location.search = FacetUtil.updateQueryString(
+			const url = new URL(window.location.href);
+
+			url.search = FacetUtil.updateQueryString(
 				key,
 				[sortSelect],
 				document.location.search
 			);
+
+			Liferay.Util.navigate(url.toString());
 		}
 	}
 

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/Sort.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/Sort.js
@@ -25,7 +25,7 @@ export default function ({namespace: portletNamespace}) {
 			url.search = FacetUtil.updateQueryString(
 				key,
 				[sortSelect],
-				document.location.search
+				window.location.search
 			);
 
 			Liferay.Util.navigate(url.toString());

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBar.js
@@ -176,7 +176,7 @@ export default function SearchBar({
 
 		if (!!inputValue.trim().length || emptySearchEnabled) {
 			const keywords = inputValue.trim();
-			let queryString = _updateQueryString(document.location.search);
+			let queryString = _updateQueryString(window.location.search);
 
 			/*
 			 * Refer to LPD-19994 for acceptance criteria regarding

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/custom_range_facet.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/custom_range_facet.js
@@ -82,7 +82,11 @@ AUI.add(
 			},
 
 			submitSearch(parameterString) {
-				document.location.search = parameterString;
+				const url = new URL(window.location.href);
+
+				url.search = parameterString;
+
+				Liferay.Util.navigate(url.toString());
 			},
 
 			/**

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/custom_range_facet.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/custom_range_facet.js
@@ -275,7 +275,7 @@ AUI.add(
 				const paramFrom = param + 'From';
 				const paramTo = param + 'To';
 
-				let parameterArray = document.location.search
+				let parameterArray = window.location.search
 					.substr(1)
 					.split('&');
 

--- a/modules/test/playwright/pages/portal-search-web/SearchPage.ts
+++ b/modules/test/playwright/pages/portal-search-web/SearchPage.ts
@@ -286,6 +286,8 @@ export class SearchPage {
 
 			await expect(searchFacetCheckbox).not.toBeChecked();
 		}
+
+		await expect(searchFacetCheckbox).not.toBeDisabled();
 	}
 
 	async selectSearchFacetLink(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
@@ -2422,6 +2422,10 @@ definition {
 			facetName = "User Facet",
 			facetTerm = "userfn userln");
 
+		AssertChecked(
+			checkboxName = "userfn userln",
+			locator1 = "Checkbox#ANY_CHECKBOX");
+
 		var currentURL = selenium.getLocation();
 
 		if (!(contains(${currentURL}, "username"))) {


### PR DESCRIPTION
Manually forwarded from https://github.com/liferay-search/liferay-portal/pull/1677
Failures look unrelated

https://liferay.atlassian.net/browse/LPD-57581 - Use SPA navigation when changing search facets

This applies Liferay's `navigate` util in order to take advantage of SPA navigation. Applicable widgets are:
- facets
- custom filter's 'Apply' button
- search bar from widget templates
- sort widget if using an older template (before changes from [LPD-4507](https://liferay.atlassian.net/browse/LPD-4507))