### PR TITLE
LPD-61175 Follow up

### DIFF
--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalInstancesTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalInstancesTest.java
@@ -207,10 +207,11 @@ public class PortalInstancesTest {
 
 		Assert.assertEquals(
 			_company.getCompanyId(),
-			(long)CompanyThreadLocal.getCompanyId());
+			PortalInstances.getCompanyId(mockHttpServletRequest));
+
 		Assert.assertEquals(
 			_company.getCompanyId(),
-			PortalInstances.getCompanyId(mockHttpServletRequest));
+			(long)CompanyThreadLocal.getCompanyId());
 		Assert.assertEquals(
 			_company.getCompanyId(),
 			mockHttpServletRequest.getAttribute(WebKeys.COMPANY_ID));

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalInstancesTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalInstancesTest.java
@@ -198,9 +198,7 @@ public class PortalInstancesTest {
 		_testGetVirtualHostLanguageId(languageId, hostname);
 	}
 
-	private void _testGetCompanyId(
-		String hostname, LayoutSet layoutSet) {
-
+	private void _testGetCompanyId(String hostname, LayoutSet layoutSet) {
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest();
 
@@ -212,8 +210,7 @@ public class PortalInstancesTest {
 			PortalInstances.getCompanyId(mockHttpServletRequest));
 
 		Assert.assertEquals(
-			_company.getCompanyId(),
-			(long)CompanyThreadLocal.getCompanyId());
+			_company.getCompanyId(), (long)CompanyThreadLocal.getCompanyId());
 		Assert.assertEquals(
 			_company.getCompanyId(),
 			mockHttpServletRequest.getAttribute(WebKeys.COMPANY_ID));

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalInstancesTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalInstancesTest.java
@@ -141,22 +141,24 @@ public class PortalInstancesTest {
 
 			Assert.assertEquals(
 				_company.getCompanyId(),
-				(long)CompanyThreadLocal.getCompanyId());
+				PortalInstances.getCompanyId(mockHttpServletRequest));
+
 			Assert.assertEquals(
 				_company.getCompanyId(),
-				PortalInstances.getCompanyId(mockHttpServletRequest));
+				(long)CompanyThreadLocal.getCompanyId());
 		}
 
 		try (SafeCloseable safeCloseable =
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					RandomTestUtil.randomLong())) {
 
-			Assert.assertNotEquals(
-				_company.getCompanyId(),
-				(long)CompanyThreadLocal.getCompanyId());
 			Assert.assertEquals(
 				_company.getCompanyId(),
 				PortalInstances.getCompanyId(mockHttpServletRequest));
+
+			Assert.assertNotEquals(
+				_company.getCompanyId(),
+				(long)CompanyThreadLocal.getCompanyId());
 		}
 	}
 

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalInstancesTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalInstancesTest.java
@@ -139,6 +139,8 @@ public class PortalInstancesTest {
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					CompanyConstants.SYSTEM)) {
 
+			// PortalInstances.getCompanyId code sets the CompanyThreadLocal
+
 			Assert.assertEquals(
 				_company.getCompanyId(),
 				PortalInstances.getCompanyId(mockHttpServletRequest));
@@ -151,6 +153,8 @@ public class PortalInstancesTest {
 		try (SafeCloseable safeCloseable =
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					RandomTestUtil.randomLong())) {
+
+			// PortalInstances.getCompanyId code sets the CompanyThreadLocal
 
 			Assert.assertEquals(
 				_company.getCompanyId(),
@@ -204,6 +208,8 @@ public class PortalInstancesTest {
 
 		mockHttpServletRequest.addHeader("Host", hostname);
 		mockHttpServletRequest.setServerName(hostname);
+
+		// PortalInstances.getCompanyId code sets the CompanyThreadLocal
 
 		Assert.assertEquals(
 			_company.getCompanyId(),


### PR DESCRIPTION
This is a follow up of https://github.com/brianchandotcom/liferay-portal/pull/163922

I am reverting two SF commits because `PortalInstances.getCompanyId(mockHttpServletRequest)` must be executed before, as it does CompanyThreadLocal.setCompanyId on it, see https://github.com/brianchandotcom/liferay-portal/blob/9f0f034b7c5e55376cafb64d4f486193c52c42fb/portal-impl/src/com/liferay/portal/util/PortalInstances.java#L102-L104 and https://github.com/brianchandotcom/liferay-portal/blob/9f0f034b7c5e55376cafb64d4f486193c52c42fb/portal-impl/src/com/liferay/portal/util/PortalInstances.java#L164