### PR TITLE
LPD-55438 Client extensions

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
@@ -467,9 +467,6 @@ public class LayoutUtil {
 			ServiceContext serviceContext)
 		throws Exception {
 
-		_updateClientExtensions(
-			layout, contentPageSpecification.getSettings(), serviceContext);
-
 		updateLayout(
 			layout, nameMap, titleMap, descriptionMap, robotsMap,
 			friendlyURLMap, contentPageSpecification.getSettings(),
@@ -490,6 +487,8 @@ public class LayoutUtil {
 			Map<Locale, String> robotsMap, Map<Locale, String> friendlyURLMap,
 			Settings settings, ServiceContext serviceContext)
 		throws Exception {
+
+		_updateClientExtensions(layout, settings, serviceContext);
 
 		layout = _updateLookAndFeel(layout, settings);
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
@@ -653,7 +653,7 @@ public class LayoutUtil {
 		ClientExtensionEntryRelLocalServiceUtil.deleteClientExtensionEntryRels(
 			PortalUtil.getClassNameId(Layout.class), layout.getPlid(), type);
 
-		if (Validator.isNull(clientExtension.getExternalReferenceCode())) {
+		if (clientExtension == null) {
 			return;
 		}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
@@ -645,28 +645,6 @@ public class LayoutUtil {
 		return styleBookEntry.getStyleBookEntryId();
 	}
 
-	private static void _updateClientExtensionEntryRel(
-			ClientExtension clientExtension, Layout layout, String type,
-			ServiceContext serviceContext)
-		throws Exception {
-
-		ClientExtensionEntryRelLocalServiceUtil.deleteClientExtensionEntryRels(
-			PortalUtil.getClassNameId(Layout.class), layout.getPlid(), type);
-
-		if (clientExtension == null) {
-			return;
-		}
-
-		ClientExtensionEntryRelLocalServiceUtil.addClientExtensionEntryRel(
-			serviceContext.getUserId(), layout.getGroupId(),
-			PortalUtil.getClassNameId(Layout.class), layout.getPlid(),
-			clientExtension.getExternalReferenceCode(), type,
-			UnicodePropertiesBuilder.create(
-				clientExtension.getClientExtensionConfig(), true
-			).buildString(),
-			serviceContext);
-	}
-
 	private static void _updateClientExtensionEntryRels(
 			ClientExtension[] clientExtensions, Layout layout, String type,
 			ServiceContext serviceContext)
@@ -674,6 +652,10 @@ public class LayoutUtil {
 
 		ClientExtensionEntryRelLocalServiceUtil.deleteClientExtensionEntryRels(
 			PortalUtil.getClassNameId(Layout.class), layout.getPlid(), type);
+
+		if (clientExtensions == null) {
+			return;
+		}
 
 		for (ClientExtension clientExtension : clientExtensions) {
 			ClientExtensionEntryRelLocalServiceUtil.addClientExtensionEntryRel(
@@ -709,19 +691,23 @@ public class LayoutUtil {
 			return;
 		}
 
-		_updateClientExtensionEntryRel(
-			settings.getFavIcon() instanceof ClientExtension ?
-				(ClientExtension)settings.getFavIcon() : null,
+		_updateClientExtensionEntryRels(
+			new ClientExtension[] {
+				settings.getFavIcon() instanceof ClientExtension ?
+					(ClientExtension)settings.getFavIcon() : null
+			},
 			layout, ClientExtensionEntryConstants.TYPE_THEME_FAVICON,
 			serviceContext);
 
-		_updateClientExtensionEntryRel(
-			settings.getThemeCSSClientExtension(), layout,
-			ClientExtensionEntryConstants.TYPE_THEME_CSS, serviceContext);
+		_updateClientExtensionEntryRels(
+			new ClientExtension[] {settings.getThemeCSSClientExtension()},
+			layout, ClientExtensionEntryConstants.TYPE_THEME_CSS,
+			serviceContext);
 
-		_updateClientExtensionEntryRel(
-			settings.getThemeSpritemapClientExtension(), layout,
-			ClientExtensionEntryConstants.TYPE_THEME_SPRITEMAP, serviceContext);
+		_updateClientExtensionEntryRels(
+			new ClientExtension[] {settings.getThemeSpritemapClientExtension()},
+			layout, ClientExtensionEntryConstants.TYPE_THEME_SPRITEMAP,
+			serviceContext);
 
 		_updateClientExtensionEntryRels(
 			settings.getGlobalCSSClientExtensions(), layout,

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
@@ -22,7 +22,6 @@ import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeCon
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalServiceUtil;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryServiceUtil;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
@@ -36,7 +35,6 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
@@ -662,7 +660,10 @@ public class LayoutUtil {
 		ClientExtensionEntryRelLocalServiceUtil.addClientExtensionEntryRel(
 			serviceContext.getUserId(), layout.getGroupId(),
 			PortalUtil.getClassNameId(Layout.class), layout.getPlid(),
-			clientExtension.getExternalReferenceCode(), type, StringPool.BLANK,
+			clientExtension.getExternalReferenceCode(), type,
+			UnicodePropertiesBuilder.create(
+				clientExtension.getClientExtensionConfig(), true
+			).buildString(),
 			serviceContext);
 	}
 
@@ -675,29 +676,14 @@ public class LayoutUtil {
 			PortalUtil.getClassNameId(Layout.class), layout.getPlid(), type);
 
 		for (ClientExtension clientExtension : clientExtensions) {
-			String externalReferenceCode =
-				clientExtension.getExternalReferenceCode();
-			String typeSettings = StringPool.BLANK;
-
-			if (type.equals(ClientExtensionEntryConstants.TYPE_GLOBAL_JS)) {
-				String[] parts = StringUtil.split(
-					externalReferenceCode, StringPool.UNDERLINE);
-
-				externalReferenceCode = parts[0];
-				typeSettings = UnicodePropertiesBuilder.create(
-					true
-				).put(
-					"loadType", parts[1]
-				).put(
-					"scriptLocation", parts[2]
-				).build(
-				).toString();
-			}
-
 			ClientExtensionEntryRelLocalServiceUtil.addClientExtensionEntryRel(
 				serviceContext.getUserId(), layout.getGroupId(),
 				PortalUtil.getClassNameId(Layout.class), layout.getPlid(),
-				externalReferenceCode, type, typeSettings, serviceContext);
+				clientExtension.getExternalReferenceCode(), type,
+				UnicodePropertiesBuilder.create(
+					clientExtension.getClientExtensionConfig(), true
+				).buildString(),
+				serviceContext);
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
@@ -5,8 +5,12 @@
 
 package com.liferay.headless.admin.site.internal.resource.v1_0.util;
 
+import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
+import com.liferay.client.extension.model.ClientExtensionEntryRel;
+import com.liferay.client.extension.service.ClientExtensionEntryRelLocalServiceUtil;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLFileEntryServiceUtil;
+import com.liferay.headless.admin.site.dto.v1_0.ClientExtension;
 import com.liferay.headless.admin.site.dto.v1_0.ContentPageSpecification;
 import com.liferay.headless.admin.site.dto.v1_0.ItemExternalReference;
 import com.liferay.headless.admin.site.dto.v1_0.PageExperience;
@@ -19,6 +23,7 @@ import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeCon
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalServiceUtil;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryServiceUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
@@ -30,7 +35,10 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.segments.model.SegmentsExperience;
@@ -459,6 +467,9 @@ public class LayoutUtil {
 			ServiceContext serviceContext)
 		throws Exception {
 
+		_updateClientExtensionEntryRels(
+			layout, contentPageSpecification.getSettings(), serviceContext);
+
 		updateLayout(
 			layout, nameMap, titleMap, descriptionMap, robotsMap,
 			friendlyURLMap, contentPageSpecification.getSettings(),
@@ -521,6 +532,38 @@ public class LayoutUtil {
 		return LayoutServiceUtil.updateLayout(
 			layout.getGroupId(), layout.isPrivateLayout(), layout.getLayoutId(),
 			typeSettingsUnicodeProperties.toString());
+	}
+
+	private static void _addClientExtensionEntryRel(
+			String cetExternalReferenceCode, Layout layout, String type,
+			ServiceContext serviceContext)
+		throws Exception {
+
+		if (Validator.isNull(cetExternalReferenceCode)) {
+			ClientExtensionEntryRelLocalServiceUtil.
+				deleteClientExtensionEntryRels(
+					PortalUtil.getClassNameId(Layout.class), layout.getPlid(),
+					type);
+
+			return;
+		}
+
+		ClientExtensionEntryRel clientExtensionEntryRel =
+			ClientExtensionEntryRelLocalServiceUtil.
+				fetchClientExtensionEntryRelByExternalReferenceCode(
+					cetExternalReferenceCode, layout.getCompanyId());
+
+		if (clientExtensionEntryRel != null) {
+			return;
+		}
+
+		ClientExtensionEntryRelLocalServiceUtil.deleteClientExtensionEntryRels(
+			PortalUtil.getClassNameId(Layout.class), layout.getPlid(), type);
+
+		ClientExtensionEntryRelLocalServiceUtil.addClientExtensionEntryRel(
+			serviceContext.getUserId(), layout.getGroupId(),
+			PortalUtil.getClassNameId(Layout.class), layout.getPlid(),
+			cetExternalReferenceCode, type, StringPool.BLANK, serviceContext);
 	}
 
 	private static long _getFaviconFileEntryId(
@@ -635,6 +678,77 @@ public class LayoutUtil {
 				itemExternalReference.getExternalReferenceCode(), groupId);
 
 		return styleBookEntry.getStyleBookEntryId();
+	}
+
+	private static void _updateClientExtensionEntryRels(
+			Layout layout, Settings settings, ServiceContext serviceContext)
+		throws Exception {
+
+		if (settings.getFavIcon() instanceof ClientExtension) {
+			ClientExtension favIconClientExtension =
+				(ClientExtension)settings.getFavIcon();
+
+			_addClientExtensionEntryRel(
+				favIconClientExtension.getExternalReferenceCode(), layout,
+				ClientExtensionEntryConstants.TYPE_THEME_FAVICON,
+				serviceContext);
+		}
+
+		ClientExtensionEntryRelLocalServiceUtil.deleteClientExtensionEntryRels(
+			PortalUtil.getClassNameId(Layout.class), layout.getPlid(),
+			ClientExtensionEntryConstants.TYPE_GLOBAL_CSS);
+
+		for (ClientExtension globalCSSClientExtension :
+				settings.getGlobalCSSClientExtensions()) {
+
+			ClientExtensionEntryRelLocalServiceUtil.addClientExtensionEntryRel(
+				serviceContext.getUserId(), layout.getGroupId(),
+				PortalUtil.getClassNameId(Layout.class), layout.getPlid(),
+				globalCSSClientExtension.getExternalReferenceCode(),
+				ClientExtensionEntryConstants.TYPE_GLOBAL_CSS, StringPool.BLANK,
+				serviceContext);
+		}
+
+		ClientExtensionEntryRelLocalServiceUtil.deleteClientExtensionEntryRels(
+			PortalUtil.getClassNameId(Layout.class), layout.getPlid(),
+			ClientExtensionEntryConstants.TYPE_GLOBAL_JS);
+
+		for (ClientExtension globalJSClientExtension :
+				settings.getGlobalJSClientExtensions()) {
+
+			String[] typeSettings = StringUtil.split(
+				globalJSClientExtension.getExternalReferenceCode(),
+				StringPool.UNDERLINE);
+
+			UnicodeProperties typeSettingsUnicodeProperties =
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"loadType", typeSettings[1]
+				).put(
+					"scriptLocation", typeSettings[2]
+				).build();
+
+			ClientExtensionEntryRelLocalServiceUtil.addClientExtensionEntryRel(
+				serviceContext.getUserId(), layout.getGroupId(),
+				PortalUtil.getClassNameId(Layout.class), layout.getPlid(),
+				typeSettings[0], ClientExtensionEntryConstants.TYPE_GLOBAL_JS,
+				typeSettingsUnicodeProperties.toString(), serviceContext);
+		}
+
+		ClientExtension themeCSSClientExtension =
+			settings.getThemeCSSClientExtension();
+
+		_addClientExtensionEntryRel(
+			themeCSSClientExtension.getExternalReferenceCode(), layout,
+			ClientExtensionEntryConstants.TYPE_THEME_CSS, serviceContext);
+
+		ClientExtension themeSpritemapClientExtension =
+			settings.getThemeSpritemapClientExtension();
+
+		_addClientExtensionEntryRel(
+			themeSpritemapClientExtension.getExternalReferenceCode(), layout,
+			ClientExtensionEntryConstants.TYPE_THEME_SPRITEMAP, serviceContext);
 	}
 
 	private static Layout _updateLayout(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.service.LayoutServiceUtil;
 import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -709,6 +710,20 @@ public class LayoutUtil {
 	private static void _updateClientExtensions(
 			Layout layout, Settings settings, ServiceContext serviceContext)
 		throws Exception {
+
+		if (layout.isTypeUtility()) {
+			if ((settings.getFavIcon() instanceof ClientExtension) ||
+				ArrayUtil.isNotEmpty(settings.getGlobalCSSClientExtensions()) ||
+				ArrayUtil.isNotEmpty(settings.getGlobalJSClientExtensions()) ||
+				Validator.isNotNull(settings.getThemeCSSClientExtension()) ||
+				Validator.isNotNull(
+					settings.getThemeSpritemapClientExtension())) {
+
+				throw new UnsupportedOperationException();
+			}
+
+			return;
+		}
 
 		_updateClientExtensionEntryRel(
 			settings.getFavIcon() instanceof ClientExtension ?

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
@@ -534,11 +534,11 @@ public class LayoutUtil {
 	}
 
 	private static void _addClientExtensionEntryRel(
-			String cetExternalReferenceCode, Layout layout, String type,
+			ClientExtension clientExtension, Layout layout, String type,
 			ServiceContext serviceContext)
 		throws Exception {
 
-		if (Validator.isNull(cetExternalReferenceCode)) {
+		if (Validator.isNull(clientExtension.getExternalReferenceCode())) {
 			ClientExtensionEntryRelLocalServiceUtil.
 				deleteClientExtensionEntryRels(
 					PortalUtil.getClassNameId(Layout.class), layout.getPlid(),
@@ -553,7 +553,8 @@ public class LayoutUtil {
 		ClientExtensionEntryRelLocalServiceUtil.addClientExtensionEntryRel(
 			serviceContext.getUserId(), layout.getGroupId(),
 			PortalUtil.getClassNameId(Layout.class), layout.getPlid(),
-			cetExternalReferenceCode, type, StringPool.BLANK, serviceContext);
+			clientExtension.getExternalReferenceCode(), type, StringPool.BLANK,
+			serviceContext);
 	}
 
 	private static void _addClientExtensionEntryRels(
@@ -709,13 +710,19 @@ public class LayoutUtil {
 			Layout layout, Settings settings, ServiceContext serviceContext)
 		throws Exception {
 
-		ClientExtension favIconClientExtension =
+		_addClientExtensionEntryRel(
 			settings.getFavIcon() instanceof ClientExtension ?
-				(ClientExtension)settings.getFavIcon() : null;
+				(ClientExtension)settings.getFavIcon() : null,
+			layout, ClientExtensionEntryConstants.TYPE_THEME_FAVICON,
+			serviceContext);
 
 		_addClientExtensionEntryRel(
-			favIconClientExtension.getExternalReferenceCode(), layout,
-			ClientExtensionEntryConstants.TYPE_THEME_FAVICON, serviceContext);
+			settings.getThemeCSSClientExtension(), layout,
+			ClientExtensionEntryConstants.TYPE_THEME_CSS, serviceContext);
+
+		_addClientExtensionEntryRel(
+			settings.getThemeSpritemapClientExtension(), layout,
+			ClientExtensionEntryConstants.TYPE_THEME_SPRITEMAP, serviceContext);
 
 		_addClientExtensionEntryRels(
 			settings.getGlobalCSSClientExtensions(), layout,
@@ -724,20 +731,6 @@ public class LayoutUtil {
 		_addClientExtensionEntryRels(
 			settings.getGlobalJSClientExtensions(), layout,
 			ClientExtensionEntryConstants.TYPE_GLOBAL_JS, serviceContext);
-
-		ClientExtension themeCSSClientExtension =
-			settings.getThemeCSSClientExtension();
-
-		_addClientExtensionEntryRel(
-			themeCSSClientExtension.getExternalReferenceCode(), layout,
-			ClientExtensionEntryConstants.TYPE_THEME_CSS, serviceContext);
-
-		ClientExtension themeSpritemapClientExtension =
-			settings.getThemeSpritemapClientExtension();
-
-		_addClientExtensionEntryRel(
-			themeSpritemapClientExtension.getExternalReferenceCode(), layout,
-			ClientExtensionEntryConstants.TYPE_THEME_SPRITEMAP, serviceContext);
 	}
 
 	private static Layout _updateLayout(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
@@ -548,15 +548,6 @@ public class LayoutUtil {
 			return;
 		}
 
-		ClientExtensionEntryRel clientExtensionEntryRel =
-			ClientExtensionEntryRelLocalServiceUtil.
-				fetchClientExtensionEntryRelByExternalReferenceCode(
-					cetExternalReferenceCode, layout.getCompanyId());
-
-		if (clientExtensionEntryRel != null) {
-			return;
-		}
-
 		ClientExtensionEntryRelLocalServiceUtil.deleteClientExtensionEntryRels(
 			PortalUtil.getClassNameId(Layout.class), layout.getPlid(), type);
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
@@ -6,7 +6,6 @@
 package com.liferay.headless.admin.site.internal.resource.v1_0.util;
 
 import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
-import com.liferay.client.extension.model.ClientExtensionEntryRel;
 import com.liferay.client.extension.service.ClientExtensionEntryRelLocalServiceUtil;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLFileEntryServiceUtil;
@@ -557,6 +556,41 @@ public class LayoutUtil {
 			cetExternalReferenceCode, type, StringPool.BLANK, serviceContext);
 	}
 
+	private static void _addClientExtensionEntryRels(
+			ClientExtension[] clientExtensions, Layout layout, String type,
+			ServiceContext serviceContext)
+		throws Exception {
+
+		ClientExtensionEntryRelLocalServiceUtil.deleteClientExtensionEntryRels(
+			PortalUtil.getClassNameId(Layout.class), layout.getPlid(), type);
+
+		for (ClientExtension clientExtension : clientExtensions) {
+			String externalReferenceCode =
+				clientExtension.getExternalReferenceCode();
+			String typeSettings = StringPool.BLANK;
+
+			if (type.equals(ClientExtensionEntryConstants.TYPE_GLOBAL_JS)) {
+				String[] parts = StringUtil.split(
+					externalReferenceCode, StringPool.UNDERLINE);
+
+				externalReferenceCode = parts[0];
+				typeSettings = UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"loadType", parts[1]
+				).put(
+					"scriptLocation", parts[2]
+				).build(
+				).toString();
+			}
+
+			ClientExtensionEntryRelLocalServiceUtil.addClientExtensionEntryRel(
+				serviceContext.getUserId(), layout.getGroupId(),
+				PortalUtil.getClassNameId(Layout.class), layout.getPlid(),
+				externalReferenceCode, type, typeSettings, serviceContext);
+		}
+	}
+
 	private static long _getFaviconFileEntryId(
 			Settings settings, ServiceContext serviceContext)
 		throws Exception {
@@ -683,47 +717,13 @@ public class LayoutUtil {
 			favIconClientExtension.getExternalReferenceCode(), layout,
 			ClientExtensionEntryConstants.TYPE_THEME_FAVICON, serviceContext);
 
-		ClientExtensionEntryRelLocalServiceUtil.deleteClientExtensionEntryRels(
-			PortalUtil.getClassNameId(Layout.class), layout.getPlid(),
-			ClientExtensionEntryConstants.TYPE_GLOBAL_CSS);
+		_addClientExtensionEntryRels(
+			settings.getGlobalCSSClientExtensions(), layout,
+			ClientExtensionEntryConstants.TYPE_GLOBAL_CSS, serviceContext);
 
-		for (ClientExtension globalCSSClientExtension :
-				settings.getGlobalCSSClientExtensions()) {
-
-			ClientExtensionEntryRelLocalServiceUtil.addClientExtensionEntryRel(
-				serviceContext.getUserId(), layout.getGroupId(),
-				PortalUtil.getClassNameId(Layout.class), layout.getPlid(),
-				globalCSSClientExtension.getExternalReferenceCode(),
-				ClientExtensionEntryConstants.TYPE_GLOBAL_CSS, StringPool.BLANK,
-				serviceContext);
-		}
-
-		ClientExtensionEntryRelLocalServiceUtil.deleteClientExtensionEntryRels(
-			PortalUtil.getClassNameId(Layout.class), layout.getPlid(),
-			ClientExtensionEntryConstants.TYPE_GLOBAL_JS);
-
-		for (ClientExtension globalJSClientExtension :
-				settings.getGlobalJSClientExtensions()) {
-
-			String[] typeSettings = StringUtil.split(
-				globalJSClientExtension.getExternalReferenceCode(),
-				StringPool.UNDERLINE);
-
-			UnicodeProperties typeSettingsUnicodeProperties =
-				UnicodePropertiesBuilder.create(
-					true
-				).put(
-					"loadType", typeSettings[1]
-				).put(
-					"scriptLocation", typeSettings[2]
-				).build();
-
-			ClientExtensionEntryRelLocalServiceUtil.addClientExtensionEntryRel(
-				serviceContext.getUserId(), layout.getGroupId(),
-				PortalUtil.getClassNameId(Layout.class), layout.getPlid(),
-				typeSettings[0], ClientExtensionEntryConstants.TYPE_GLOBAL_JS,
-				typeSettingsUnicodeProperties.toString(), serviceContext);
-		}
+		_addClientExtensionEntryRels(
+			settings.getGlobalJSClientExtensions(), layout,
+			ClientExtensionEntryConstants.TYPE_GLOBAL_JS, serviceContext);
 
 		ClientExtension themeCSSClientExtension =
 			settings.getThemeCSSClientExtension();

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
@@ -684,15 +684,13 @@ public class LayoutUtil {
 			Layout layout, Settings settings, ServiceContext serviceContext)
 		throws Exception {
 
-		if (settings.getFavIcon() instanceof ClientExtension) {
-			ClientExtension favIconClientExtension =
-				(ClientExtension)settings.getFavIcon();
+		ClientExtension favIconClientExtension =
+			settings.getFavIcon() instanceof ClientExtension ?
+				(ClientExtension)settings.getFavIcon() : null;
 
-			_addClientExtensionEntryRel(
-				favIconClientExtension.getExternalReferenceCode(), layout,
-				ClientExtensionEntryConstants.TYPE_THEME_FAVICON,
-				serviceContext);
-		}
+		_addClientExtensionEntryRel(
+			favIconClientExtension.getExternalReferenceCode(), layout,
+			ClientExtensionEntryConstants.TYPE_THEME_FAVICON, serviceContext);
 
 		ClientExtensionEntryRelLocalServiceUtil.deleteClientExtensionEntryRels(
 			PortalUtil.getClassNameId(Layout.class), layout.getPlid(),

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
@@ -466,7 +466,7 @@ public class LayoutUtil {
 			ServiceContext serviceContext)
 		throws Exception {
 
-		_updateClientExtensionEntryRels(
+		_updateClientExtensions(
 			layout, contentPageSpecification.getSettings(), serviceContext);
 
 		updateLayout(
@@ -531,65 +531,6 @@ public class LayoutUtil {
 		return LayoutServiceUtil.updateLayout(
 			layout.getGroupId(), layout.isPrivateLayout(), layout.getLayoutId(),
 			typeSettingsUnicodeProperties.toString());
-	}
-
-	private static void _addClientExtensionEntryRel(
-			ClientExtension clientExtension, Layout layout, String type,
-			ServiceContext serviceContext)
-		throws Exception {
-
-		if (Validator.isNull(clientExtension.getExternalReferenceCode())) {
-			ClientExtensionEntryRelLocalServiceUtil.
-				deleteClientExtensionEntryRels(
-					PortalUtil.getClassNameId(Layout.class), layout.getPlid(),
-					type);
-
-			return;
-		}
-
-		ClientExtensionEntryRelLocalServiceUtil.deleteClientExtensionEntryRels(
-			PortalUtil.getClassNameId(Layout.class), layout.getPlid(), type);
-
-		ClientExtensionEntryRelLocalServiceUtil.addClientExtensionEntryRel(
-			serviceContext.getUserId(), layout.getGroupId(),
-			PortalUtil.getClassNameId(Layout.class), layout.getPlid(),
-			clientExtension.getExternalReferenceCode(), type, StringPool.BLANK,
-			serviceContext);
-	}
-
-	private static void _addClientExtensionEntryRels(
-			ClientExtension[] clientExtensions, Layout layout, String type,
-			ServiceContext serviceContext)
-		throws Exception {
-
-		ClientExtensionEntryRelLocalServiceUtil.deleteClientExtensionEntryRels(
-			PortalUtil.getClassNameId(Layout.class), layout.getPlid(), type);
-
-		for (ClientExtension clientExtension : clientExtensions) {
-			String externalReferenceCode =
-				clientExtension.getExternalReferenceCode();
-			String typeSettings = StringPool.BLANK;
-
-			if (type.equals(ClientExtensionEntryConstants.TYPE_GLOBAL_JS)) {
-				String[] parts = StringUtil.split(
-					externalReferenceCode, StringPool.UNDERLINE);
-
-				externalReferenceCode = parts[0];
-				typeSettings = UnicodePropertiesBuilder.create(
-					true
-				).put(
-					"loadType", parts[1]
-				).put(
-					"scriptLocation", parts[2]
-				).build(
-				).toString();
-			}
-
-			ClientExtensionEntryRelLocalServiceUtil.addClientExtensionEntryRel(
-				serviceContext.getUserId(), layout.getGroupId(),
-				PortalUtil.getClassNameId(Layout.class), layout.getPlid(),
-				externalReferenceCode, type, typeSettings, serviceContext);
-		}
 	}
 
 	private static long _getFaviconFileEntryId(
@@ -706,29 +647,88 @@ public class LayoutUtil {
 		return styleBookEntry.getStyleBookEntryId();
 	}
 
+	private static void _updateClientExtensionEntryRel(
+			ClientExtension clientExtension, Layout layout, String type,
+			ServiceContext serviceContext)
+		throws Exception {
+
+		if (Validator.isNull(clientExtension.getExternalReferenceCode())) {
+			ClientExtensionEntryRelLocalServiceUtil.
+				deleteClientExtensionEntryRels(
+					PortalUtil.getClassNameId(Layout.class), layout.getPlid(),
+					type);
+
+			return;
+		}
+
+		ClientExtensionEntryRelLocalServiceUtil.deleteClientExtensionEntryRels(
+			PortalUtil.getClassNameId(Layout.class), layout.getPlid(), type);
+
+		ClientExtensionEntryRelLocalServiceUtil.addClientExtensionEntryRel(
+			serviceContext.getUserId(), layout.getGroupId(),
+			PortalUtil.getClassNameId(Layout.class), layout.getPlid(),
+			clientExtension.getExternalReferenceCode(), type, StringPool.BLANK,
+			serviceContext);
+	}
+
 	private static void _updateClientExtensionEntryRels(
+			ClientExtension[] clientExtensions, Layout layout, String type,
+			ServiceContext serviceContext)
+		throws Exception {
+
+		ClientExtensionEntryRelLocalServiceUtil.deleteClientExtensionEntryRels(
+			PortalUtil.getClassNameId(Layout.class), layout.getPlid(), type);
+
+		for (ClientExtension clientExtension : clientExtensions) {
+			String externalReferenceCode =
+				clientExtension.getExternalReferenceCode();
+			String typeSettings = StringPool.BLANK;
+
+			if (type.equals(ClientExtensionEntryConstants.TYPE_GLOBAL_JS)) {
+				String[] parts = StringUtil.split(
+					externalReferenceCode, StringPool.UNDERLINE);
+
+				externalReferenceCode = parts[0];
+				typeSettings = UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"loadType", parts[1]
+				).put(
+					"scriptLocation", parts[2]
+				).build(
+				).toString();
+			}
+
+			ClientExtensionEntryRelLocalServiceUtil.addClientExtensionEntryRel(
+				serviceContext.getUserId(), layout.getGroupId(),
+				PortalUtil.getClassNameId(Layout.class), layout.getPlid(),
+				externalReferenceCode, type, typeSettings, serviceContext);
+		}
+	}
+
+	private static void _updateClientExtensions(
 			Layout layout, Settings settings, ServiceContext serviceContext)
 		throws Exception {
 
-		_addClientExtensionEntryRel(
+		_updateClientExtensionEntryRel(
 			settings.getFavIcon() instanceof ClientExtension ?
 				(ClientExtension)settings.getFavIcon() : null,
 			layout, ClientExtensionEntryConstants.TYPE_THEME_FAVICON,
 			serviceContext);
 
-		_addClientExtensionEntryRel(
+		_updateClientExtensionEntryRel(
 			settings.getThemeCSSClientExtension(), layout,
 			ClientExtensionEntryConstants.TYPE_THEME_CSS, serviceContext);
 
-		_addClientExtensionEntryRel(
+		_updateClientExtensionEntryRel(
 			settings.getThemeSpritemapClientExtension(), layout,
 			ClientExtensionEntryConstants.TYPE_THEME_SPRITEMAP, serviceContext);
 
-		_addClientExtensionEntryRels(
+		_updateClientExtensionEntryRels(
 			settings.getGlobalCSSClientExtensions(), layout,
 			ClientExtensionEntryConstants.TYPE_GLOBAL_CSS, serviceContext);
 
-		_addClientExtensionEntryRels(
+		_updateClientExtensionEntryRels(
 			settings.getGlobalJSClientExtensions(), layout,
 			ClientExtensionEntryConstants.TYPE_GLOBAL_JS, serviceContext);
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
@@ -7,6 +7,8 @@ package com.liferay.headless.admin.site.internal.resource.v1_0.util;
 
 import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
 import com.liferay.client.extension.service.ClientExtensionEntryRelLocalServiceUtil;
+import com.liferay.client.extension.type.CET;
+import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLFileEntryServiceUtil;
 import com.liferay.headless.admin.site.dto.v1_0.ClientExtension;
@@ -25,6 +27,7 @@ import com.liferay.layout.page.template.service.LayoutPageTemplateEntryServiceUt
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
+import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutServiceUtil;
 import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
@@ -657,6 +660,8 @@ public class LayoutUtil {
 			return;
 		}
 
+		CETManager cetManager = _cetManagerSnapshot.get();
+
 		for (ClientExtension clientExtension : clientExtensions) {
 			ClientExtensionEntryRelLocalServiceUtil.addClientExtensionEntryRel(
 				serviceContext.getUserId(), layout.getGroupId(),
@@ -666,6 +671,14 @@ public class LayoutUtil {
 					clientExtension.getClientExtensionConfig(), true
 				).buildString(),
 				serviceContext);
+
+			CET cet = cetManager.getCET(
+				layout.getCompanyId(),
+				clientExtension.getExternalReferenceCode());
+
+			if (cet == null) {
+				throw new UnsupportedOperationException();
+			}
 		}
 	}
 
@@ -826,5 +839,8 @@ public class LayoutUtil {
 				layout, pageExperience, segmentsExperience, serviceContext);
 		}
 	}
+
+	private static final Snapshot<CETManager> _cetManagerSnapshot =
+		new Snapshot<>(LayoutUtil.class, CETManager.class);
 
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
@@ -705,6 +705,10 @@ public class LayoutUtil {
 			Layout layout, Settings settings, ServiceContext serviceContext)
 		throws Exception {
 
+		if (settings == null) {
+			return;
+		}
+
 		if (layout.isTypeUtility()) {
 			if ((settings.getFavIcon() instanceof ClientExtension) ||
 				ArrayUtil.isNotEmpty(settings.getGlobalCSSClientExtensions()) ||

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
@@ -652,17 +652,12 @@ public class LayoutUtil {
 			ServiceContext serviceContext)
 		throws Exception {
 
-		if (Validator.isNull(clientExtension.getExternalReferenceCode())) {
-			ClientExtensionEntryRelLocalServiceUtil.
-				deleteClientExtensionEntryRels(
-					PortalUtil.getClassNameId(Layout.class), layout.getPlid(),
-					type);
-
-			return;
-		}
-
 		ClientExtensionEntryRelLocalServiceUtil.deleteClientExtensionEntryRels(
 			PortalUtil.getClassNameId(Layout.class), layout.getPlid(), type);
+
+		if (Validator.isNull(clientExtension.getExternalReferenceCode())) {
+			return;
+		}
 
 		ClientExtensionEntryRelLocalServiceUtil.addClientExtensionEntryRel(
 			serviceContext.getUserId(), layout.getGroupId(),

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageSpecificationsTestUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageSpecificationsTestUtil.java
@@ -265,6 +265,10 @@ public class PageSpecificationsTestUtil {
 				}
 			};
 
+		new Settings()
+
+		contentPageSpecification.setSettings();
+
 		contentPageSpecification.
 			setDraftContentPageSpecificationExternalReferenceCode(
 				draftContentPageSpecificationExternalReferenceCode);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/SettingsTestUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/SettingsTestUtil.java
@@ -5,12 +5,15 @@
 
 package com.liferay.headless.admin.site.resource.v1_0.test.util;
 
+import com.liferay.client.extension.type.manager.CETManager;
+import com.liferay.headless.admin.site.client.dto.v1_0.ClientExtension;
 import com.liferay.headless.admin.site.client.dto.v1_0.ItemExternalReference;
 import com.liferay.headless.admin.site.client.dto.v1_0.Settings;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalServiceUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -172,11 +175,24 @@ public class SettingsTestUtil {
 			{
 				setColorSchemeName(() -> "01");
 				setCss(RandomTestUtil::randomString);
+				setFavIcon(() -> _getClientExtension(serviceContext));
+				setGlobalCSSClientExtensions(
+					() -> new ClientExtension[] {
+						_getClientExtension(serviceContext),
+						_getClientExtension(serviceContext)
+					});
+				setGlobalJSClientExtensions(
+					() -> new ClientExtension[] {
+						_getClientExtension(serviceContext),
+						_getClientExtension(serviceContext)
+					});
 				setJavascript(RandomTestUtil::randomString);
 				setMasterPageItemExternalReference(
 					() -> _getMasterPageItemExternalReference(serviceContext));
 				setStyleBookItemExternalReference(
 					() -> _getStyleBookItemExternalReference(serviceContext));
+				setThemeCSSClientExtension(
+					() -> _getClientExtension(serviceContext));
 				setThemeName(() -> "classic_WAR_classictheme");
 				setThemeSettings(
 					() -> TreeMapBuilder.put(
@@ -186,6 +202,8 @@ public class SettingsTestUtil {
 						"lfr-theme:" + RandomTestUtil.randomString(),
 						RandomTestUtil.randomString()
 					).build());
+				setThemeSpritemapClientExtension(
+					() -> _getClientExtension(serviceContext));
 			}
 		};
 	}
@@ -264,6 +282,26 @@ public class SettingsTestUtil {
 		}
 	}
 
+	private static ClientExtension _getClientExtension(
+			ServiceContext serviceContext)
+		throws Exception {
+
+		CETManager cetManager = _cetManagerSnapshot.get();
+
+		String clientExtensionExternalReferenceCode =
+			RandomTestUtil.randomString();
+
+		cetManager.addCET(
+			null, serviceContext.getCompanyId(),
+			clientExtensionExternalReferenceCode);
+
+		return new ClientExtension() {
+			{
+				setExternalReferenceCode(clientExtensionExternalReferenceCode);
+			}
+		};
+	}
+
 	private static ItemExternalReference _getMasterPageItemExternalReference(
 			ServiceContext serviceContext)
 		throws Exception {
@@ -316,5 +354,8 @@ public class SettingsTestUtil {
 
 		return themeSettingsUnicodeProperties;
 	}
+
+	private static final Snapshot<CETManager> _cetManagerSnapshot =
+		new Snapshot<>(SettingsTestUtil.class, CETManager.class);
 
 }

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutDesignMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutDesignMVCActionCommand.java
@@ -87,7 +87,7 @@ public class EditLayoutDesignMVCActionCommand extends BaseMVCActionCommand {
 		ClientExtensionEntryRel clientExtensionEntryRel =
 			_clientExtensionEntryRelLocalService.
 				fetchClientExtensionEntryRelByExternalReferenceCode(
-					cetExternalReferenceCode, layout.getCompanyId());
+					cetExternalReferenceCode, layout.getGroupId());
 
 		if (clientExtensionEntryRel != null) {
 			return;


### PR DESCRIPTION
- **LPD-55438 Add methods to add/update client extensions for pages**
- **LPD-55438 We must remove the clientExtensionRel if the favIcon clientExtension is not provided in PUT**
- **LPD-55438 Support optional references**
- **LPD-55438 Extract**
- **LPD-55438 Manual SF**
- **LPD-55438 Consistent naming**
- **LPD-55438 UtilityPages does not allow client extensions**
- **LPD-55438 This is the right place to update client extensions so we also covered asset display and content pages**
- **LPD-55438 Simplify**
- **LPD-55438 Settings can be null**
- **LPD-55438 We must use the clientExtensionConfig to generate the typeSettings information**
- **LPD-55438 Incorrect check**
- **LPD-55438 Simplify**
- **LPD-55438 Fix old bug. Comes from LPS-156031, commit 88dff1483da1949a5664f6167096168938050d42**
- **LPD-55438 We must register a lazy reference here. Since the headless framework is not ready yet, we throw an exception. Replace when it is ready**
- **Temp**
