### PR TITLE
LPD-58597 | Send ERC as part of ratings

### DIFF
--- a/modules/apps/ratings/ratings-analytics/src/main/resources/META-INF/resources/dynamic_include/top_head.jsp
+++ b/modules/apps/ratings/ratings-analytics/src/main/resources/META-INF/resources/dynamic_include/top_head.jsp
@@ -25,6 +25,7 @@
 			Analytics.send('VOTE', 'Ratings', {
 				className: event.className,
 				classPK: event.classPK,
+				externalReferenceCode: event.externalReferenceCode,
 				ratingType: event.ratingType,
 				score: event.score,
 				title,

--- a/modules/apps/ratings/ratings-taglib/src/main/java/com/liferay/ratings/taglib/servlet/taglib/RatingsTag.java
+++ b/modules/apps/ratings/ratings-taglib/src/main/java/com/liferay/ratings/taglib/servlet/taglib/RatingsTag.java
@@ -7,12 +7,17 @@ package com.liferay.ratings.taglib.servlet.taglib;
 
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.PersistedModel;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.PersistedModelLocalService;
+import com.liferay.portal.kernel.service.PersistedResourcedModelLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.trash.TrashHandler;
 import com.liferay.portal.kernel.trash.TrashHandlerRegistryUtil;
@@ -24,6 +29,7 @@ import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
+import com.liferay.portal.service.PersistedModelLocalServiceRegistryUtil;
 import com.liferay.ratings.kernel.RatingsType;
 import com.liferay.ratings.kernel.definition.PortletRatingsDefinitionUtil;
 import com.liferay.ratings.kernel.model.RatingsEntry;
@@ -35,6 +41,8 @@ import com.liferay.taglib.util.IncludeTag;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.jsp.PageContext;
+
+import java.util.List;
 
 /**
  * @author Ambrín Chaudhary
@@ -138,6 +146,7 @@ public class RatingsTag extends IncludeTag {
 		_className = null;
 		_classPK = 0;
 		_contentTitle = null;
+		_externalReferenceCode = null;
 		_inTrash = null;
 		_numberOfStars = _NUMBER_OF_STARS;
 		_ratingsEntry = null;
@@ -160,6 +169,9 @@ public class RatingsTag extends IncludeTag {
 				"liferay-ratings:ratings:className", _className);
 			httpServletRequest.setAttribute(
 				"liferay-ratings:ratings:classPK", String.valueOf(_classPK));
+			httpServletRequest.setAttribute(
+				"liferay-ratings:ratings:externalReferenceCode",
+				_getExternalReferenceCode());
 
 			boolean inTrash = _isInTrash();
 
@@ -197,6 +209,8 @@ public class RatingsTag extends IncludeTag {
 					"contentTitle", _contentTitle
 				).put(
 					"enabled", _isEnabled(themeDisplay, inTrash)
+				).put(
+					"externalReferenceCode", _externalReferenceCode
 				).put(
 					"initialAverageScore", _getInitialAverageScore(ratingsStats)
 				).put(
@@ -242,6 +256,57 @@ public class RatingsTag extends IncludeTag {
 		catch (Exception exception) {
 			_log.error(exception);
 		}
+	}
+
+	private String _getExternalReferenceCode() {
+		if (Validator.isNotNull(_externalReferenceCode)) {
+			return _externalReferenceCode;
+		}
+
+		try {
+			PersistedModelLocalService persistedModelLocalService =
+				PersistedModelLocalServiceRegistryUtil.
+					getPersistedModelLocalService(_className);
+
+			PersistedModel model;
+
+			if (persistedModelLocalService instanceof
+					PersistedResourcedModelLocalService) {
+
+				PersistedResourcedModelLocalService
+					persistedResourcedModelLocalService =
+						(PersistedResourcedModelLocalService)
+							persistedModelLocalService;
+
+				List<? extends PersistedModel> persistedModels =
+					persistedResourcedModelLocalService.getPersistedModel(
+						_classPK);
+
+				model = persistedModels.get(0);
+			}
+			else {
+				model = persistedModelLocalService.getPersistedModel(_classPK);
+			}
+
+			if (model instanceof ExternalReferenceCodeModel) {
+				ExternalReferenceCodeModel externalReferenceCodeModel =
+					(ExternalReferenceCodeModel)model;
+
+				_externalReferenceCode =
+					externalReferenceCodeModel.getExternalReferenceCode();
+			}
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					StringBundler.concat(
+						"Unable to get external reference code for class name",
+						"\"", _className, "\" and class PK ", _classPK),
+					portalException);
+			}
+		}
+
+		return _externalReferenceCode;
 	}
 
 	private double _getInitialAverageScore(RatingsStats ratingsStats) {
@@ -399,6 +464,7 @@ public class RatingsTag extends IncludeTag {
 	private String _className;
 	private long _classPK;
 	private String _contentTitle;
+	private String _externalReferenceCode;
 	private Boolean _inTrash;
 	private int _numberOfStars = _NUMBER_OF_STARS;
 	private RatingsEntry _ratingsEntry;

--- a/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/BaseRatings.js
+++ b/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/BaseRatings.js
@@ -20,6 +20,7 @@ const BaseRatings = ({
 	classPK,
 	contentTitle,
 	enabled = false,
+	externalReferenceCode = '',
 	inTrash = false,
 	signedIn,
 	type,
@@ -55,6 +56,7 @@ const BaseRatings = ({
 				className,
 				classPK,
 				contentTitle: contentTitle || '',
+				externalReferenceCode,
 				ratingType: type,
 				score,
 			});
@@ -76,7 +78,7 @@ const BaseRatings = ({
 					errorToast();
 				});
 		},
-		[className, classPK, contentTitle, type, url]
+		[className, classPK, contentTitle, externalReferenceCode, type, url]
 	);
 
 	const RatingsTypes = {
@@ -103,6 +105,7 @@ BaseRatings.propTypes = {
 	className: PropTypes.string.isRequired,
 	classPK: PropTypes.string.isRequired,
 	enabled: PropTypes.bool,
+	externalReferenceCode: PropTypes.string,
 	inTrash: PropTypes.bool,
 	signedIn: PropTypes.bool.isRequired,
 	type: PropTypes.string.isRequired,

--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACUtils.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACUtils.macro
@@ -291,6 +291,20 @@ definition {
 	}
 
 	@summary = "Default summary"
+	macro assertEventPropertyValueIsPresent(eventId = null, property = null, applicationId = null) {
+		var postDataText = ProxyUtil.getHarRecording("$..request..postData..text");
+
+		var attributeValue = JSONUtil.getWithJSONPath("[${postDataText}]", "$..[?(@['applicationId'] == '${applicationId}' && @['eventId'] == '${eventId}')]..${property}");
+
+		if (${attributeValue} != "null") {
+			echo("PASSED");
+		}
+		else {
+			TestUtils.fail(message = "FAILED: Property '${property}' does not exists");
+		}
+	}
+
+	@summary = "Default summary"
 	macro assertIdentityRequestPropertiesValue(expectedDataSourceId = null) {
 		var actualDataSourceId = ACUtils.getPageRefRequestPropertyValue(
 			pageRef = "identity",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/RatingEvents.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/RatingEvents.testcase
@@ -114,6 +114,11 @@ definition {
 				property = "classPK",
 				value = ${entryId});
 
+			ACUtils.assertEventPropertyValueIsPresent(
+				applicationId = "Ratings",
+				eventId = "VOTE",
+				property = "externalReferenceCode");
+
 			ACUtils.assertEventPropertyValue(
 				applicationId = "Ratings",
 				eventId = "VOTE",
@@ -201,6 +206,11 @@ definition {
 				eventId = "VOTE",
 				property = "className",
 				value = "com.liferay.document.library.kernel.model.DLFileEntry");
+
+			ACUtils.assertEventPropertyValueIsPresent(
+				applicationId = "Ratings",
+				eventId = "VOTE",
+				property = "externalReferenceCode");
 
 			ACUtils.assertEventPropertyValue(
 				applicationId = "Ratings",


### PR DESCRIPTION
Coming from https://github.com/liferay-content-management/liferay-portal/pull/6912. CI is failing so I am sending directly after analyzing the results.

------
# Original description

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-58597

To send ERC for rateable assets (Blogs, Documents and Media and Web Content assets) to Analytics Cloud

# How am I doing it?

By finding the ERC when rendering the RatingsTag.

It can be found with the help of

- `PersistedModelLocalServiceRegistryUtil`: which retrieves a model entity based on its classPK;
- `PersistedResourcedModelLocalService`: which, AFAIK, handle models that are versioned. Versioned models have the same ERC, just a different UUID, version and fields edited by the user.

# How can you verify that it works?

You (liferay-content-management) won't be able to test it because you guys don't have access to Analytics Cloud. The automated test I changed requires additional setup that only will happen in CI.

## Examples
For journal article (versioned entity)
<img width="1103" height="596" alt="image" src="https://github.com/user-attachments/assets/bfdaab12-b5ea-4fb5-b05d-1a1660cdd59b" />

For blogs entry (non-versioned entry)
<img width="1167" height="607" alt="image" src="https://github.com/user-attachments/assets/123df253-d619-4401-a3da-caa34a142ed8" />
