### PR TITLE
LPD-61564 Add new type column to depot entry

### DIFF
--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/ConnectionInfoResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/ConnectionInfoResourceTest.java
@@ -8,6 +8,7 @@ package com.liferay.analytics.cms.rest.resource.v1_0.test;
 import com.liferay.analytics.cms.rest.client.dto.v1_0.ConnectionInfo;
 import com.liferay.analytics.settings.configuration.AnalyticsConfiguration;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
@@ -61,7 +62,7 @@ public class ConnectionInfoResourceTest
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
-			_serviceContext);
+			DepotConstants.TYPE_ASSET_LIBRARY, _serviceContext);
 		_depotEntry2 = _depotEntryLocalService.addDepotEntry(
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
@@ -69,7 +70,7 @@ public class ConnectionInfoResourceTest
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
-			_serviceContext);
+			DepotConstants.TYPE_ASSET_LIBRARY, _serviceContext);
 
 		_group = GroupTestUtil.addGroup();
 

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/InventoryAnalysisResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/InventoryAnalysisResourceTest.java
@@ -18,6 +18,7 @@ import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.batch.engine.unit.BatchEngineUnitProcessor;
 import com.liferay.batch.engine.unit.BatchEngineUnitReader;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.model.DLFileEntry;
@@ -103,7 +104,7 @@ public class InventoryAnalysisResourceTest
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
-			_serviceContext);
+			DepotConstants.TYPE_ASSET_LIBRARY, _serviceContext);
 
 		ObjectDefinition objectDefinition =
 			_objectDefinitionLocalService.

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/OverviewResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/OverviewResourceTest.java
@@ -18,6 +18,7 @@ import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.batch.engine.unit.BatchEngineUnitProcessor;
 import com.liferay.batch.engine.unit.BatchEngineUnitReader;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.model.DLFileEntry;
@@ -108,7 +109,7 @@ public class OverviewResourceTest extends BaseOverviewResourceTestCase {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
-			_serviceContext);
+			DepotConstants.TYPE_ASSET_LIBRARY, _serviceContext);
 	}
 
 	@Override

--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/display/context/AssetCategoriesDisplayContext.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/display/context/AssetCategoriesDisplayContext.java
@@ -27,6 +27,7 @@ import com.liferay.asset.kernel.service.AssetCategoryLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetCategoryServiceUtil;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetVocabularyServiceUtil;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryServiceUtil;
 import com.liferay.exportimport.kernel.staging.permission.StagingPermissionUtil;
@@ -516,8 +517,8 @@ public class AssetCategoriesDisplayContext {
 
 		List<DepotEntry> depotEntries =
 			DepotEntryServiceUtil.getGroupConnectedDepotEntries(
-				_themeDisplay.getScopeGroupId(), QueryUtil.ALL_POS,
-				QueryUtil.ALL_POS);
+				_themeDisplay.getScopeGroupId(), DepotConstants.TYPE_ANY,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		for (DepotEntry depotEntry : depotEntries) {
 			Group group = depotEntry.getGroup();

--- a/modules/apps/asset/asset-categories-item-selector-web/src/main/java/com/liferay/asset/categories/item/selector/web/internal/display/context/SelectAssetVocabularyDisplayContext.java
+++ b/modules/apps/asset/asset-categories-item-selector-web/src/main/java/com/liferay/asset/categories/item/selector/web/internal/display/context/SelectAssetVocabularyDisplayContext.java
@@ -9,6 +9,7 @@ import com.liferay.asset.categories.item.selector.web.internal.constants.AssetCa
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.model.AssetVocabularyConstants;
 import com.liferay.asset.kernel.service.AssetVocabularyServiceUtil;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryServiceUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -119,8 +120,8 @@ public class SelectAssetVocabularyDisplayContext {
 
 		List<DepotEntry> depotEntries =
 			DepotEntryServiceUtil.getCurrentAndGroupConnectedDepotEntries(
-				_themeDisplay.getScopeGroupId(), QueryUtil.ALL_POS,
-				QueryUtil.ALL_POS);
+				_themeDisplay.getScopeGroupId(), DepotConstants.TYPE_ANY,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		for (DepotEntry depotEntry : depotEntries) {
 			groupIds.add(depotEntry.getGroupId());

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/model/impl/test/AssetVocabularyImplTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/model/impl/test/AssetVocabularyImplTest.java
@@ -10,6 +10,7 @@ import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetCategoryConstants;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.test.util.AssetTestUtil;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
@@ -53,6 +54,7 @@ public class AssetVocabularyImplTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), "description"
 			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		_group = GroupTestUtil.addGroup();

--- a/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/info/item/provider/test/AssetEntryInfoItemFieldSetProviderTest.java
+++ b/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/info/item/provider/test/AssetEntryInfoItemFieldSetProviderTest.java
@@ -19,6 +19,7 @@ import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
 import com.liferay.asset.test.util.AssetTestUtil;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
@@ -79,6 +80,7 @@ public class AssetEntryInfoItemFieldSetProviderTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		_group = GroupTestUtil.addGroup();

--- a/modules/apps/depot/depot-api/bnd.bnd
+++ b/modules/apps/depot/depot-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Depot API
 Bundle-SymbolicName: com.liferay.depot.api
-Bundle-Version: 7.4.1
+Bundle-Version: 8.0.0
 Export-Package:\
 	com.liferay.depot.application,\
 	com.liferay.depot.configuration,\

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/constants/DepotConstants.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/constants/DepotConstants.java
@@ -14,4 +14,10 @@ public class DepotConstants {
 
 	public static final String SERVICE_NAME = "com.liferay.depot";
 
+	public static final int TYPE_ANY = -1;
+
+	public static final int TYPE_ASSET_LIBRARY = 0;
+
+	public static final int TYPE_SPACE = 1;
+
 }

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntryGroupRelModel.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntryGroupRelModel.java
@@ -301,6 +301,20 @@ public interface DepotEntryGroupRelModel
 	public void setToGroupId(long toGroupId);
 
 	/**
+	 * Returns the type of this depot entry group rel.
+	 *
+	 * @return the type of this depot entry group rel
+	 */
+	public long getType();
+
+	/**
+	 * Sets the type of this depot entry group rel.
+	 *
+	 * @param type the type of this depot entry group rel
+	 */
+	public void setType(long type);
+
+	/**
 	 * Returns the last publish date of this depot entry group rel.
 	 *
 	 * @return the last publish date of this depot entry group rel

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntryGroupRelTable.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntryGroupRelTable.java
@@ -64,6 +64,8 @@ public class DepotEntryGroupRelTable
 			"searchable", Boolean.class, Types.BOOLEAN, Column.FLAG_DEFAULT);
 	public final Column<DepotEntryGroupRelTable, Long> toGroupId = createColumn(
 		"toGroupId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
+	public final Column<DepotEntryGroupRelTable, Long> type = createColumn(
+		"type_", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
 	public final Column<DepotEntryGroupRelTable, Date> lastPublishDate =
 		createColumn(
 			"lastPublishDate", Date.class, Types.TIMESTAMP,

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntryGroupRelWrapper.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntryGroupRelWrapper.java
@@ -50,6 +50,7 @@ public class DepotEntryGroupRelWrapper
 		attributes.put("depotEntryId", getDepotEntryId());
 		attributes.put("searchable", isSearchable());
 		attributes.put("toGroupId", getToGroupId());
+		attributes.put("type", getType());
 		attributes.put("lastPublishDate", getLastPublishDate());
 
 		return attributes;
@@ -141,6 +142,12 @@ public class DepotEntryGroupRelWrapper
 
 		if (toGroupId != null) {
 			setToGroupId(toGroupId);
+		}
+
+		Long type = (Long)attributes.get("type");
+
+		if (type != null) {
+			setType(type);
 		}
 
 		Date lastPublishDate = (Date)attributes.get("lastPublishDate");
@@ -283,6 +290,16 @@ public class DepotEntryGroupRelWrapper
 	@Override
 	public long getToGroupId() {
 		return model.getToGroupId();
+	}
+
+	/**
+	 * Returns the type of this depot entry group rel.
+	 *
+	 * @return the type of this depot entry group rel
+	 */
+	@Override
+	public long getType() {
+		return model.getType();
 	}
 
 	/**
@@ -478,6 +495,16 @@ public class DepotEntryGroupRelWrapper
 	@Override
 	public void setToGroupId(long toGroupId) {
 		model.setToGroupId(toGroupId);
+	}
+
+	/**
+	 * Sets the type of this depot entry group rel.
+	 *
+	 * @param type the type of this depot entry group rel
+	 */
+	@Override
+	public void setType(long type) {
+		model.setType(type);
 	}
 
 	/**

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntryModel.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntryModel.java
@@ -231,6 +231,20 @@ public interface DepotEntryModel
 	@Override
 	public void setModifiedDate(Date modifiedDate);
 
+	/**
+	 * Returns the type of this depot entry.
+	 *
+	 * @return the type of this depot entry
+	 */
+	public int getType();
+
+	/**
+	 * Sets the type of this depot entry.
+	 *
+	 * @param type the type of this depot entry
+	 */
+	public void setType(int type);
+
 	@Override
 	public DepotEntry cloneWithOriginalValues();
 

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntryTable.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntryTable.java
@@ -43,6 +43,8 @@ public class DepotEntryTable extends BaseTable<DepotEntryTable> {
 		"createDate", Date.class, Types.TIMESTAMP, Column.FLAG_DEFAULT);
 	public final Column<DepotEntryTable, Date> modifiedDate = createColumn(
 		"modifiedDate", Date.class, Types.TIMESTAMP, Column.FLAG_DEFAULT);
+	public final Column<DepotEntryTable, Integer> type = createColumn(
+		"type_", Integer.class, Types.INTEGER, Column.FLAG_DEFAULT);
 
 	private DepotEntryTable() {
 		super("DepotEntry", DepotEntryTable::new);

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntryWrapper.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/model/DepotEntryWrapper.java
@@ -46,6 +46,7 @@ public class DepotEntryWrapper
 		attributes.put("userName", getUserName());
 		attributes.put("createDate", getCreateDate());
 		attributes.put("modifiedDate", getModifiedDate());
+		attributes.put("type", getType());
 
 		return attributes;
 	}
@@ -110,6 +111,12 @@ public class DepotEntryWrapper
 
 		if (modifiedDate != null) {
 			setModifiedDate(modifiedDate);
+		}
+
+		Integer type = (Integer)attributes.get("type");
+
+		if (type != null) {
+			setType(type);
 		}
 	}
 
@@ -203,6 +210,16 @@ public class DepotEntryWrapper
 	@Override
 	public long getPrimaryKey() {
 		return model.getPrimaryKey();
+	}
+
+	/**
+	 * Returns the type of this depot entry.
+	 *
+	 * @return the type of this depot entry
+	 */
+	@Override
+	public int getType() {
+		return model.getType();
 	}
 
 	/**
@@ -328,6 +345,16 @@ public class DepotEntryWrapper
 	@Override
 	public void setPrimaryKey(long primaryKey) {
 		model.setPrimaryKey(primaryKey);
+	}
+
+	/**
+	 * Sets the type of this depot entry.
+	 *
+	 * @param type the type of this depot entry
+	 */
+	@Override
+	public void setType(int type) {
+		model.setType(type);
 	}
 
 	/**

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryGroupRelLocalService.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryGroupRelLocalService.java
@@ -295,7 +295,7 @@ public interface DepotEntryGroupRelLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<DepotEntryGroupRel> getDepotEntryGroupRels(
-		long groupId, int start, int end);
+		long groupId, int type, int start, int end);
 
 	/**
 	 * Returns all the depot entry group rels matching the UUID and company.
@@ -335,7 +335,7 @@ public interface DepotEntryGroupRelLocalService
 	public int getDepotEntryGroupRelsCount(DepotEntry depotEntry);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public int getDepotEntryGroupRelsCount(long groupId);
+	public int getDepotEntryGroupRelsCount(long groupId, int type);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ExportActionableDynamicQuery getExportActionableDynamicQuery(

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryGroupRelLocalServiceUtil.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryGroupRelLocalServiceUtil.java
@@ -336,9 +336,9 @@ public class DepotEntryGroupRelLocalServiceUtil {
 	}
 
 	public static List<DepotEntryGroupRel> getDepotEntryGroupRels(
-		long groupId, int start, int end) {
+		long groupId, int type, int start, int end) {
 
-		return getService().getDepotEntryGroupRels(groupId, start, end);
+		return getService().getDepotEntryGroupRels(groupId, type, start, end);
 	}
 
 	/**
@@ -389,8 +389,8 @@ public class DepotEntryGroupRelLocalServiceUtil {
 		return getService().getDepotEntryGroupRelsCount(depotEntry);
 	}
 
-	public static int getDepotEntryGroupRelsCount(long groupId) {
-		return getService().getDepotEntryGroupRelsCount(groupId);
+	public static int getDepotEntryGroupRelsCount(long groupId, int type) {
+		return getService().getDepotEntryGroupRelsCount(groupId, type);
 	}
 
 	public static com.liferay.portal.kernel.dao.orm.ExportActionableDynamicQuery

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryGroupRelLocalServiceWrapper.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryGroupRelLocalServiceWrapper.java
@@ -383,10 +383,10 @@ public class DepotEntryGroupRelLocalServiceWrapper
 
 	@Override
 	public java.util.List<DepotEntryGroupRel> getDepotEntryGroupRels(
-		long groupId, int start, int end) {
+		long groupId, int type, int start, int end) {
 
 		return _depotEntryGroupRelLocalService.getDepotEntryGroupRels(
-			groupId, start, end);
+			groupId, type, start, end);
 	}
 
 	/**
@@ -445,9 +445,9 @@ public class DepotEntryGroupRelLocalServiceWrapper
 	}
 
 	@Override
-	public int getDepotEntryGroupRelsCount(long groupId) {
+	public int getDepotEntryGroupRelsCount(long groupId, int type) {
 		return _depotEntryGroupRelLocalService.getDepotEntryGroupRelsCount(
-			groupId);
+			groupId, type);
 	}
 
 	@Override

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryGroupRelService.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryGroupRelService.java
@@ -65,7 +65,7 @@ public interface DepotEntryGroupRelService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<DepotEntryGroupRel> getDepotEntryGroupRels(
-			long groupId, int start, int end)
+			long groupId, int type, int start, int end)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -73,7 +73,8 @@ public interface DepotEntryGroupRelService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public int getDepotEntryGroupRelsCount(long groupId) throws PortalException;
+	public int getDepotEntryGroupRelsCount(long groupId, int type)
+		throws PortalException;
 
 	/**
 	 * Returns the OSGi service identifier.

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryGroupRelServiceUtil.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryGroupRelServiceUtil.java
@@ -61,10 +61,10 @@ public class DepotEntryGroupRelServiceUtil {
 	}
 
 	public static List<DepotEntryGroupRel> getDepotEntryGroupRels(
-			long groupId, int start, int end)
+			long groupId, int type, int start, int end)
 		throws PortalException {
 
-		return getService().getDepotEntryGroupRels(groupId, start, end);
+		return getService().getDepotEntryGroupRels(groupId, type, start, end);
 	}
 
 	public static int getDepotEntryGroupRelsCount(
@@ -74,10 +74,10 @@ public class DepotEntryGroupRelServiceUtil {
 		return getService().getDepotEntryGroupRelsCount(depotEntry);
 	}
 
-	public static int getDepotEntryGroupRelsCount(long groupId)
+	public static int getDepotEntryGroupRelsCount(long groupId, int type)
 		throws PortalException {
 
-		return getService().getDepotEntryGroupRelsCount(groupId);
+		return getService().getDepotEntryGroupRelsCount(groupId, type);
 	}
 
 	/**

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryGroupRelServiceWrapper.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryGroupRelServiceWrapper.java
@@ -68,11 +68,11 @@ public class DepotEntryGroupRelServiceWrapper
 
 	@Override
 	public java.util.List<DepotEntryGroupRel> getDepotEntryGroupRels(
-			long groupId, int start, int end)
+			long groupId, int type, int start, int end)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _depotEntryGroupRelService.getDepotEntryGroupRels(
-			groupId, start, end);
+			groupId, type, start, end);
 	}
 
 	@Override
@@ -85,10 +85,11 @@ public class DepotEntryGroupRelServiceWrapper
 	}
 
 	@Override
-	public int getDepotEntryGroupRelsCount(long groupId)
+	public int getDepotEntryGroupRelsCount(long groupId, int type)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
-		return _depotEntryGroupRelService.getDepotEntryGroupRelsCount(groupId);
+		return _depotEntryGroupRelService.getDepotEntryGroupRelsCount(
+			groupId, type);
 	}
 
 	/**

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalService.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalService.java
@@ -84,7 +84,7 @@ public interface DepotEntryLocalService
 
 	public DepotEntry addDepotEntry(
 			Map<Locale, String> nameMap, Map<Locale, String> descriptionMap,
-			ServiceContext serviceContext)
+			int type, ServiceContext serviceContext)
 		throws PortalException;
 
 	/**
@@ -320,11 +320,11 @@ public interface DepotEntryLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<DepotEntry> getGroupConnectedDepotEntries(
-			long groupId, int start, int end)
+			long groupId, int type, int start, int end)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public int getGroupConnectedDepotEntriesCount(long groupId);
+	public int getGroupConnectedDepotEntriesCount(long groupId, int type);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public DepotEntry getGroupDepotEntry(long groupId) throws PortalException;

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalServiceUtil.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalServiceUtil.java
@@ -62,12 +62,12 @@ public class DepotEntryLocalServiceUtil {
 
 	public static DepotEntry addDepotEntry(
 			Map<java.util.Locale, String> nameMap,
-			Map<java.util.Locale, String> descriptionMap,
+			Map<java.util.Locale, String> descriptionMap, int type,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addDepotEntry(
-			nameMap, descriptionMap, serviceContext);
+			nameMap, descriptionMap, type, serviceContext);
 	}
 
 	/**
@@ -357,14 +357,17 @@ public class DepotEntryLocalServiceUtil {
 	}
 
 	public static List<DepotEntry> getGroupConnectedDepotEntries(
-			long groupId, int start, int end)
+			long groupId, int type, int start, int end)
 		throws PortalException {
 
-		return getService().getGroupConnectedDepotEntries(groupId, start, end);
+		return getService().getGroupConnectedDepotEntries(
+			groupId, type, start, end);
 	}
 
-	public static int getGroupConnectedDepotEntriesCount(long groupId) {
-		return getService().getGroupConnectedDepotEntriesCount(groupId);
+	public static int getGroupConnectedDepotEntriesCount(
+		long groupId, int type) {
+
+		return getService().getGroupConnectedDepotEntriesCount(groupId, type);
 	}
 
 	public static DepotEntry getGroupDepotEntry(long groupId)

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalServiceWrapper.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalServiceWrapper.java
@@ -58,12 +58,12 @@ public class DepotEntryLocalServiceWrapper
 	@Override
 	public DepotEntry addDepotEntry(
 			java.util.Map<java.util.Locale, String> nameMap,
-			java.util.Map<java.util.Locale, String> descriptionMap,
+			java.util.Map<java.util.Locale, String> descriptionMap, int type,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _depotEntryLocalService.addDepotEntry(
-			nameMap, descriptionMap, serviceContext);
+			nameMap, descriptionMap, type, serviceContext);
 	}
 
 	/**
@@ -393,17 +393,17 @@ public class DepotEntryLocalServiceWrapper
 
 	@Override
 	public java.util.List<DepotEntry> getGroupConnectedDepotEntries(
-			long groupId, int start, int end)
+			long groupId, int type, int start, int end)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _depotEntryLocalService.getGroupConnectedDepotEntries(
-			groupId, start, end);
+			groupId, type, start, end);
 	}
 
 	@Override
-	public int getGroupConnectedDepotEntriesCount(long groupId) {
+	public int getGroupConnectedDepotEntriesCount(long groupId, int type) {
 		return _depotEntryLocalService.getGroupConnectedDepotEntriesCount(
-			groupId);
+			groupId, type);
 	}
 
 	@Override

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryService.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryService.java
@@ -50,7 +50,7 @@ public interface DepotEntryService extends BaseService {
 	 */
 	public DepotEntry addDepotEntry(
 			Map<Locale, String> nameMap, Map<Locale, String> descriptionMap,
-			ServiceContext serviceContext)
+			int type, ServiceContext serviceContext)
 		throws PortalException;
 
 	public DepotEntry deleteDepotEntry(long depotEntryId)
@@ -58,7 +58,7 @@ public interface DepotEntryService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<DepotEntry> getCurrentAndGroupConnectedDepotEntries(
-			long groupId, int start, int end)
+			long groupId, int type, int start, int end)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -71,11 +71,11 @@ public interface DepotEntryService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<DepotEntry> getGroupConnectedDepotEntries(
-			long groupId, int start, int end)
+			long groupId, int type, int start, int end)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public int getGroupConnectedDepotEntriesCount(long groupId)
+	public int getGroupConnectedDepotEntriesCount(long groupId, int type)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryServiceUtil.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryServiceUtil.java
@@ -33,12 +33,12 @@ public class DepotEntryServiceUtil {
 	 */
 	public static DepotEntry addDepotEntry(
 			Map<java.util.Locale, String> nameMap,
-			Map<java.util.Locale, String> descriptionMap,
+			Map<java.util.Locale, String> descriptionMap, int type,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addDepotEntry(
-			nameMap, descriptionMap, serviceContext);
+			nameMap, descriptionMap, type, serviceContext);
 	}
 
 	public static DepotEntry deleteDepotEntry(long depotEntryId)
@@ -48,11 +48,11 @@ public class DepotEntryServiceUtil {
 	}
 
 	public static List<DepotEntry> getCurrentAndGroupConnectedDepotEntries(
-			long groupId, int start, int end)
+			long groupId, int type, int start, int end)
 		throws PortalException {
 
 		return getService().getCurrentAndGroupConnectedDepotEntries(
-			groupId, start, end);
+			groupId, type, start, end);
 	}
 
 	public static DepotEntry getDepotEntry(long depotEntryId)
@@ -70,16 +70,17 @@ public class DepotEntryServiceUtil {
 	}
 
 	public static List<DepotEntry> getGroupConnectedDepotEntries(
-			long groupId, int start, int end)
+			long groupId, int type, int start, int end)
 		throws PortalException {
 
-		return getService().getGroupConnectedDepotEntries(groupId, start, end);
+		return getService().getGroupConnectedDepotEntries(
+			groupId, type, start, end);
 	}
 
-	public static int getGroupConnectedDepotEntriesCount(long groupId)
+	public static int getGroupConnectedDepotEntriesCount(long groupId, int type)
 		throws PortalException {
 
-		return getService().getGroupConnectedDepotEntriesCount(groupId);
+		return getService().getGroupConnectedDepotEntriesCount(groupId, type);
 	}
 
 	public static DepotEntry getGroupDepotEntry(long groupId)

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryServiceWrapper.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryServiceWrapper.java
@@ -29,12 +29,12 @@ public class DepotEntryServiceWrapper
 	@Override
 	public DepotEntry addDepotEntry(
 			java.util.Map<java.util.Locale, String> nameMap,
-			java.util.Map<java.util.Locale, String> descriptionMap,
+			java.util.Map<java.util.Locale, String> descriptionMap, int type,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _depotEntryService.addDepotEntry(
-			nameMap, descriptionMap, serviceContext);
+			nameMap, descriptionMap, type, serviceContext);
 	}
 
 	@Override
@@ -46,11 +46,11 @@ public class DepotEntryServiceWrapper
 
 	@Override
 	public java.util.List<DepotEntry> getCurrentAndGroupConnectedDepotEntries(
-			long groupId, int start, int end)
+			long groupId, int type, int start, int end)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _depotEntryService.getCurrentAndGroupConnectedDepotEntries(
-			groupId, start, end);
+			groupId, type, start, end);
 	}
 
 	@Override
@@ -71,18 +71,19 @@ public class DepotEntryServiceWrapper
 
 	@Override
 	public java.util.List<DepotEntry> getGroupConnectedDepotEntries(
-			long groupId, int start, int end)
+			long groupId, int type, int start, int end)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _depotEntryService.getGroupConnectedDepotEntries(
-			groupId, start, end);
+			groupId, type, start, end);
 	}
 
 	@Override
-	public int getGroupConnectedDepotEntriesCount(long groupId)
+	public int getGroupConnectedDepotEntriesCount(long groupId, int type)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
-		return _depotEntryService.getGroupConnectedDepotEntriesCount(groupId);
+		return _depotEntryService.getGroupConnectedDepotEntriesCount(
+			groupId, type);
 	}
 
 	@Override

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/persistence/DepotEntryGroupRelPersistence.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/persistence/DepotEntryGroupRelPersistence.java
@@ -1032,6 +1032,161 @@ public interface DepotEntryGroupRelPersistence
 	public int countByS_TGI(boolean searchable, long toGroupId);
 
 	/**
+	 * Returns all the depot entry group rels where toGroupId = &#63; and type = &#63;.
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @return the matching depot entry group rels
+	 */
+	public java.util.List<DepotEntryGroupRel> findByTGI_T(
+		long toGroupId, long type);
+
+	/**
+	 * Returns a range of all the depot entry group rels where toGroupId = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DepotEntryGroupRelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @param start the lower bound of the range of depot entry group rels
+	 * @param end the upper bound of the range of depot entry group rels (not inclusive)
+	 * @return the range of matching depot entry group rels
+	 */
+	public java.util.List<DepotEntryGroupRel> findByTGI_T(
+		long toGroupId, long type, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the depot entry group rels where toGroupId = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DepotEntryGroupRelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @param start the lower bound of the range of depot entry group rels
+	 * @param end the upper bound of the range of depot entry group rels (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching depot entry group rels
+	 */
+	public java.util.List<DepotEntryGroupRel> findByTGI_T(
+		long toGroupId, long type, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<DepotEntryGroupRel>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the depot entry group rels where toGroupId = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DepotEntryGroupRelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @param start the lower bound of the range of depot entry group rels
+	 * @param end the upper bound of the range of depot entry group rels (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching depot entry group rels
+	 */
+	public java.util.List<DepotEntryGroupRel> findByTGI_T(
+		long toGroupId, long type, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<DepotEntryGroupRel>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first depot entry group rel in the ordered set where toGroupId = &#63; and type = &#63;.
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching depot entry group rel
+	 * @throws NoSuchEntryGroupRelException if a matching depot entry group rel could not be found
+	 */
+	public DepotEntryGroupRel findByTGI_T_First(
+			long toGroupId, long type,
+			com.liferay.portal.kernel.util.OrderByComparator<DepotEntryGroupRel>
+				orderByComparator)
+		throws NoSuchEntryGroupRelException;
+
+	/**
+	 * Returns the first depot entry group rel in the ordered set where toGroupId = &#63; and type = &#63;.
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching depot entry group rel, or <code>null</code> if a matching depot entry group rel could not be found
+	 */
+	public DepotEntryGroupRel fetchByTGI_T_First(
+		long toGroupId, long type,
+		com.liferay.portal.kernel.util.OrderByComparator<DepotEntryGroupRel>
+			orderByComparator);
+
+	/**
+	 * Returns the last depot entry group rel in the ordered set where toGroupId = &#63; and type = &#63;.
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching depot entry group rel
+	 * @throws NoSuchEntryGroupRelException if a matching depot entry group rel could not be found
+	 */
+	public DepotEntryGroupRel findByTGI_T_Last(
+			long toGroupId, long type,
+			com.liferay.portal.kernel.util.OrderByComparator<DepotEntryGroupRel>
+				orderByComparator)
+		throws NoSuchEntryGroupRelException;
+
+	/**
+	 * Returns the last depot entry group rel in the ordered set where toGroupId = &#63; and type = &#63;.
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching depot entry group rel, or <code>null</code> if a matching depot entry group rel could not be found
+	 */
+	public DepotEntryGroupRel fetchByTGI_T_Last(
+		long toGroupId, long type,
+		com.liferay.portal.kernel.util.OrderByComparator<DepotEntryGroupRel>
+			orderByComparator);
+
+	/**
+	 * Returns the depot entry group rels before and after the current depot entry group rel in the ordered set where toGroupId = &#63; and type = &#63;.
+	 *
+	 * @param depotEntryGroupRelId the primary key of the current depot entry group rel
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next depot entry group rel
+	 * @throws NoSuchEntryGroupRelException if a depot entry group rel with the primary key could not be found
+	 */
+	public DepotEntryGroupRel[] findByTGI_T_PrevAndNext(
+			long depotEntryGroupRelId, long toGroupId, long type,
+			com.liferay.portal.kernel.util.OrderByComparator<DepotEntryGroupRel>
+				orderByComparator)
+		throws NoSuchEntryGroupRelException;
+
+	/**
+	 * Removes all the depot entry group rels where toGroupId = &#63; and type = &#63; from the database.
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 */
+	public void removeByTGI_T(long toGroupId, long type);
+
+	/**
+	 * Returns the number of depot entry group rels where toGroupId = &#63; and type = &#63;.
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @return the number of matching depot entry group rels
+	 */
+	public int countByTGI_T(long toGroupId, long type);
+
+	/**
 	 * Caches the depot entry group rel in the entity cache if it is enabled.
 	 *
 	 * @param depotEntryGroupRel the depot entry group rel

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/persistence/DepotEntryGroupRelUtil.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/persistence/DepotEntryGroupRelUtil.java
@@ -1327,6 +1327,192 @@ public class DepotEntryGroupRelUtil {
 	}
 
 	/**
+	 * Returns all the depot entry group rels where toGroupId = &#63; and type = &#63;.
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @return the matching depot entry group rels
+	 */
+	public static List<DepotEntryGroupRel> findByTGI_T(
+		long toGroupId, long type) {
+
+		return getPersistence().findByTGI_T(toGroupId, type);
+	}
+
+	/**
+	 * Returns a range of all the depot entry group rels where toGroupId = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DepotEntryGroupRelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @param start the lower bound of the range of depot entry group rels
+	 * @param end the upper bound of the range of depot entry group rels (not inclusive)
+	 * @return the range of matching depot entry group rels
+	 */
+	public static List<DepotEntryGroupRel> findByTGI_T(
+		long toGroupId, long type, int start, int end) {
+
+		return getPersistence().findByTGI_T(toGroupId, type, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the depot entry group rels where toGroupId = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DepotEntryGroupRelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @param start the lower bound of the range of depot entry group rels
+	 * @param end the upper bound of the range of depot entry group rels (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching depot entry group rels
+	 */
+	public static List<DepotEntryGroupRel> findByTGI_T(
+		long toGroupId, long type, int start, int end,
+		OrderByComparator<DepotEntryGroupRel> orderByComparator) {
+
+		return getPersistence().findByTGI_T(
+			toGroupId, type, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the depot entry group rels where toGroupId = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DepotEntryGroupRelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @param start the lower bound of the range of depot entry group rels
+	 * @param end the upper bound of the range of depot entry group rels (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching depot entry group rels
+	 */
+	public static List<DepotEntryGroupRel> findByTGI_T(
+		long toGroupId, long type, int start, int end,
+		OrderByComparator<DepotEntryGroupRel> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByTGI_T(
+			toGroupId, type, start, end, orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first depot entry group rel in the ordered set where toGroupId = &#63; and type = &#63;.
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching depot entry group rel
+	 * @throws NoSuchEntryGroupRelException if a matching depot entry group rel could not be found
+	 */
+	public static DepotEntryGroupRel findByTGI_T_First(
+			long toGroupId, long type,
+			OrderByComparator<DepotEntryGroupRel> orderByComparator)
+		throws com.liferay.depot.exception.NoSuchEntryGroupRelException {
+
+		return getPersistence().findByTGI_T_First(
+			toGroupId, type, orderByComparator);
+	}
+
+	/**
+	 * Returns the first depot entry group rel in the ordered set where toGroupId = &#63; and type = &#63;.
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching depot entry group rel, or <code>null</code> if a matching depot entry group rel could not be found
+	 */
+	public static DepotEntryGroupRel fetchByTGI_T_First(
+		long toGroupId, long type,
+		OrderByComparator<DepotEntryGroupRel> orderByComparator) {
+
+		return getPersistence().fetchByTGI_T_First(
+			toGroupId, type, orderByComparator);
+	}
+
+	/**
+	 * Returns the last depot entry group rel in the ordered set where toGroupId = &#63; and type = &#63;.
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching depot entry group rel
+	 * @throws NoSuchEntryGroupRelException if a matching depot entry group rel could not be found
+	 */
+	public static DepotEntryGroupRel findByTGI_T_Last(
+			long toGroupId, long type,
+			OrderByComparator<DepotEntryGroupRel> orderByComparator)
+		throws com.liferay.depot.exception.NoSuchEntryGroupRelException {
+
+		return getPersistence().findByTGI_T_Last(
+			toGroupId, type, orderByComparator);
+	}
+
+	/**
+	 * Returns the last depot entry group rel in the ordered set where toGroupId = &#63; and type = &#63;.
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching depot entry group rel, or <code>null</code> if a matching depot entry group rel could not be found
+	 */
+	public static DepotEntryGroupRel fetchByTGI_T_Last(
+		long toGroupId, long type,
+		OrderByComparator<DepotEntryGroupRel> orderByComparator) {
+
+		return getPersistence().fetchByTGI_T_Last(
+			toGroupId, type, orderByComparator);
+	}
+
+	/**
+	 * Returns the depot entry group rels before and after the current depot entry group rel in the ordered set where toGroupId = &#63; and type = &#63;.
+	 *
+	 * @param depotEntryGroupRelId the primary key of the current depot entry group rel
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next depot entry group rel
+	 * @throws NoSuchEntryGroupRelException if a depot entry group rel with the primary key could not be found
+	 */
+	public static DepotEntryGroupRel[] findByTGI_T_PrevAndNext(
+			long depotEntryGroupRelId, long toGroupId, long type,
+			OrderByComparator<DepotEntryGroupRel> orderByComparator)
+		throws com.liferay.depot.exception.NoSuchEntryGroupRelException {
+
+		return getPersistence().findByTGI_T_PrevAndNext(
+			depotEntryGroupRelId, toGroupId, type, orderByComparator);
+	}
+
+	/**
+	 * Removes all the depot entry group rels where toGroupId = &#63; and type = &#63; from the database.
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 */
+	public static void removeByTGI_T(long toGroupId, long type) {
+		getPersistence().removeByTGI_T(toGroupId, type);
+	}
+
+	/**
+	 * Returns the number of depot entry group rels where toGroupId = &#63; and type = &#63;.
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @return the number of matching depot entry group rels
+	 */
+	public static int countByTGI_T(long toGroupId, long type) {
+		return getPersistence().countByTGI_T(toGroupId, type);
+	}
+
+	/**
 	 * Caches the depot entry group rel in the entity cache if it is enabled.
 	 *
 	 * @param depotEntryGroupRel the depot entry group rel

--- a/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/constants/packageinfo
+++ b/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 1.5.0

--- a/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/model/packageinfo
+++ b/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/model/packageinfo
@@ -1,1 +1,1 @@
-version 3.3.0
+version 3.4.0

--- a/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/service/packageinfo
+++ b/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/service/packageinfo
@@ -1,1 +1,1 @@
-version 2.3.0
+version 3.0.0

--- a/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/service/persistence/packageinfo
+++ b/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 1.6.0
+version 1.7.0

--- a/modules/apps/depot/depot-service/bnd.bnd
+++ b/modules/apps/depot/depot-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Depot Service
 Bundle-SymbolicName: com.liferay.depot.service
 Bundle-Version: 3.0.73
-Liferay-Require-SchemaVersion: 2.2.0
+Liferay-Require-SchemaVersion: 2.3.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/depot/depot-service/service.xml
+++ b/modules/apps/depot/depot-service/service.xml
@@ -85,6 +85,7 @@
 		<column name="depotEntryId" type="long" />
 		<column name="searchable" type="boolean" />
 		<column name="toGroupId" type="long" />
+		<column name="type" type="long" />
 		<column name="lastPublishDate" type="Date" />
 
 		<!-- Finder methods -->

--- a/modules/apps/depot/depot-service/service.xml
+++ b/modules/apps/depot/depot-service/service.xml
@@ -51,6 +51,10 @@
 		<column name="createDate" type="Date" />
 		<column name="modifiedDate" type="Date" />
 
+		<!-- Other fields -->
+
+		<column name="type" type="int" />
+
 		<!-- Finder methods -->
 
 		<finder name="GroupId" return-type="DepotEntry" unique="true">

--- a/modules/apps/depot/depot-service/service.xml
+++ b/modules/apps/depot/depot-service/service.xml
@@ -108,6 +108,10 @@
 			<finder-column name="searchable" />
 			<finder-column name="toGroupId" />
 		</finder>
+		<finder name="TGI_T" return-type="Collection">
+			<finder-column name="toGroupId" />
+			<finder-column name="type" />
+		</finder>
 	</entity>
 	<entity local-service="true" name="DepotEntryPin" remote-service="true" trash-enabled="false" uuid="true">
 

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/group/provider/SiteConnectedGroupGroupProviderImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/group/provider/SiteConnectedGroupGroupProviderImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.depot.internal.group.provider;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.group.provider.SiteConnectedGroupGroupProvider;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
@@ -35,7 +36,8 @@ public class SiteConnectedGroupGroupProviderImpl
 			_portal.getAncestorSiteGroupIds(groupId),
 			ListUtil.toLongArray(
 				_depotEntryLocalService.getGroupConnectedDepotEntries(
-					groupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+					groupId, DepotConstants.TYPE_ANY, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS),
 				DepotEntry::getGroupId));
 	}
 
@@ -70,7 +72,8 @@ public class SiteConnectedGroupGroupProviderImpl
 				groupId, checkContentSharingWithChildrenEnabled),
 			ListUtil.toLongArray(
 				_depotEntryLocalService.getGroupConnectedDepotEntries(
-					groupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+					groupId, DepotConstants.TYPE_ANY, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS),
 				DepotEntry::getGroupId));
 	}
 
@@ -107,7 +110,8 @@ public class SiteConnectedGroupGroupProviderImpl
 		for (long groupId : groupIds) {
 			depotEntries.addAll(
 				_depotEntryLocalService.getGroupConnectedDepotEntries(
-					groupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS));
+					groupId, DepotConstants.TYPE_ANY, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS));
 		}
 
 		return ArrayUtil.append(

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/registry/DepotServiceUpgradeStepRegistrator.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/registry/DepotServiceUpgradeStepRegistrator.java
@@ -5,6 +5,7 @@
 
 package com.liferay.depot.internal.upgrade.registry;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.internal.upgrade.v2_2_0.util.DepotEntryPinTable;
 import com.liferay.portal.kernel.upgrade.CTModelUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
@@ -43,6 +44,18 @@ public class DepotServiceUpgradeStepRegistrator
 				"DepotAppCustomization", "DepotEntry", "DepotEntryGroupRel"));
 
 		registry.register("2.1.0", "2.2.0", DepotEntryPinTable.create());
+
+		registry.register(
+			"2.2.0", "2.3.0",
+			UpgradeProcessFactory.addColumns(
+				"DepotEntry", "type_ INTEGER", "DepotEntryGroupRel",
+				"type_ INTEGER"),
+			UpgradeProcessFactory.runSQL(
+				"update DepotEntry set type_ = " +
+					DepotConstants.TYPE_ASSET_LIBRARY),
+			UpgradeProcessFactory.runSQL(
+				"update DepotEntryGroupRel set type_ = " +
+					DepotConstants.TYPE_ASSET_LIBRARY));
 	}
 
 }

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/model/impl/DepotEntryCacheModel.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/model/impl/DepotEntryCacheModel.java
@@ -68,7 +68,7 @@ public class DepotEntryCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(21);
+		StringBundler sb = new StringBundler(23);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -90,6 +90,8 @@ public class DepotEntryCacheModel
 		sb.append(createDate);
 		sb.append(", modifiedDate=");
 		sb.append(modifiedDate);
+		sb.append(", type=");
+		sb.append(type);
 		sb.append("}");
 
 		return sb.toString();
@@ -135,6 +137,8 @@ public class DepotEntryCacheModel
 			depotEntryImpl.setModifiedDate(new Date(modifiedDate));
 		}
 
+		depotEntryImpl.setType(type);
+
 		depotEntryImpl.resetOriginalValues();
 
 		return depotEntryImpl;
@@ -157,6 +161,8 @@ public class DepotEntryCacheModel
 		userName = objectInput.readUTF();
 		createDate = objectInput.readLong();
 		modifiedDate = objectInput.readLong();
+
+		type = objectInput.readInt();
 	}
 
 	@Override
@@ -189,6 +195,8 @@ public class DepotEntryCacheModel
 
 		objectOutput.writeLong(createDate);
 		objectOutput.writeLong(modifiedDate);
+
+		objectOutput.writeInt(type);
 	}
 
 	public long mvccVersion;
@@ -201,5 +209,6 @@ public class DepotEntryCacheModel
 	public String userName;
 	public long createDate;
 	public long modifiedDate;
+	public int type;
 
 }

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/model/impl/DepotEntryGroupRelCacheModel.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/model/impl/DepotEntryGroupRelCacheModel.java
@@ -69,7 +69,7 @@ public class DepotEntryGroupRelCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(31);
+		StringBundler sb = new StringBundler(33);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -99,6 +99,8 @@ public class DepotEntryGroupRelCacheModel
 		sb.append(searchable);
 		sb.append(", toGroupId=");
 		sb.append(toGroupId);
+		sb.append(", type=");
+		sb.append(type);
 		sb.append(", lastPublishDate=");
 		sb.append(lastPublishDate);
 		sb.append("}");
@@ -152,6 +154,7 @@ public class DepotEntryGroupRelCacheModel
 		depotEntryGroupRelImpl.setDepotEntryId(depotEntryId);
 		depotEntryGroupRelImpl.setSearchable(searchable);
 		depotEntryGroupRelImpl.setToGroupId(toGroupId);
+		depotEntryGroupRelImpl.setType(type);
 
 		if (lastPublishDate == Long.MIN_VALUE) {
 			depotEntryGroupRelImpl.setLastPublishDate(null);
@@ -191,6 +194,8 @@ public class DepotEntryGroupRelCacheModel
 		searchable = objectInput.readBoolean();
 
 		toGroupId = objectInput.readLong();
+
+		type = objectInput.readLong();
 		lastPublishDate = objectInput.readLong();
 	}
 
@@ -232,6 +237,8 @@ public class DepotEntryGroupRelCacheModel
 		objectOutput.writeBoolean(searchable);
 
 		objectOutput.writeLong(toGroupId);
+
+		objectOutput.writeLong(type);
 		objectOutput.writeLong(lastPublishDate);
 	}
 
@@ -249,6 +256,7 @@ public class DepotEntryGroupRelCacheModel
 	public long depotEntryId;
 	public boolean searchable;
 	public long toGroupId;
+	public long type;
 	public long lastPublishDate;
 
 }

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/model/impl/DepotEntryGroupRelModelImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/model/impl/DepotEntryGroupRelModelImpl.java
@@ -72,7 +72,8 @@ public class DepotEntryGroupRelModelImpl
 		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP},
 		{"ddmStructuresAvailable", Types.BOOLEAN},
 		{"depotEntryId", Types.BIGINT}, {"searchable", Types.BOOLEAN},
-		{"toGroupId", Types.BIGINT}, {"lastPublishDate", Types.TIMESTAMP}
+		{"toGroupId", Types.BIGINT}, {"type_", Types.BIGINT},
+		{"lastPublishDate", Types.TIMESTAMP}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -93,11 +94,12 @@ public class DepotEntryGroupRelModelImpl
 		TABLE_COLUMNS_MAP.put("depotEntryId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("searchable", Types.BOOLEAN);
 		TABLE_COLUMNS_MAP.put("toGroupId", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("type_", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table DepotEntryGroupRel (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,depotEntryGroupRelId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,ddmStructuresAvailable BOOLEAN,depotEntryId LONG,searchable BOOLEAN,toGroupId LONG,lastPublishDate DATE null,primary key (depotEntryGroupRelId, ctCollectionId))";
+		"create table DepotEntryGroupRel (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,depotEntryGroupRelId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,ddmStructuresAvailable BOOLEAN,depotEntryId LONG,searchable BOOLEAN,toGroupId LONG,type_ LONG,lastPublishDate DATE null,primary key (depotEntryGroupRelId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP = "drop table DepotEntryGroupRel";
 
@@ -153,14 +155,20 @@ public class DepotEntryGroupRelModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 64L;
+	public static final long TYPE_COLUMN_BITMASK = 64L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long UUID_COLUMN_BITMASK = 128L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *		#getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long DEPOTENTRYGROUPRELID_COLUMN_BITMASK = 128L;
+	public static final long DEPOTENTRYGROUPRELID_COLUMN_BITMASK = 256L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
@@ -301,6 +309,7 @@ public class DepotEntryGroupRelModelImpl
 				"searchable", DepotEntryGroupRel::getSearchable);
 			attributeGetterFunctions.put(
 				"toGroupId", DepotEntryGroupRel::getToGroupId);
+			attributeGetterFunctions.put("type", DepotEntryGroupRel::getType);
 			attributeGetterFunctions.put(
 				"lastPublishDate", DepotEntryGroupRel::getLastPublishDate);
 
@@ -377,6 +386,10 @@ public class DepotEntryGroupRelModelImpl
 				"toGroupId",
 				(BiConsumer<DepotEntryGroupRel, Long>)
 					DepotEntryGroupRel::setToGroupId);
+			attributeSetterBiConsumers.put(
+				"type",
+				(BiConsumer<DepotEntryGroupRel, Long>)
+					DepotEntryGroupRel::setType);
 			attributeSetterBiConsumers.put(
 				"lastPublishDate",
 				(BiConsumer<DepotEntryGroupRel, Date>)
@@ -712,6 +725,30 @@ public class DepotEntryGroupRelModelImpl
 
 	@JSON
 	@Override
+	public long getType() {
+		return _type;
+	}
+
+	@Override
+	public void setType(long type) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_type = type;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public long getOriginalType() {
+		return GetterUtil.getLong(this.<Long>getColumnOriginalValue("type_"));
+	}
+
+	@JSON
+	@Override
 	public Date getLastPublishDate() {
 		return _lastPublishDate;
 	}
@@ -805,6 +842,7 @@ public class DepotEntryGroupRelModelImpl
 		depotEntryGroupRelImpl.setDepotEntryId(getDepotEntryId());
 		depotEntryGroupRelImpl.setSearchable(isSearchable());
 		depotEntryGroupRelImpl.setToGroupId(getToGroupId());
+		depotEntryGroupRelImpl.setType(getType());
 		depotEntryGroupRelImpl.setLastPublishDate(getLastPublishDate());
 
 		depotEntryGroupRelImpl.resetOriginalValues();
@@ -845,6 +883,8 @@ public class DepotEntryGroupRelModelImpl
 			this.<Boolean>getColumnOriginalValue("searchable"));
 		depotEntryGroupRelImpl.setToGroupId(
 			this.<Long>getColumnOriginalValue("toGroupId"));
+		depotEntryGroupRelImpl.setType(
+			this.<Long>getColumnOriginalValue("type_"));
 		depotEntryGroupRelImpl.setLastPublishDate(
 			this.<Date>getColumnOriginalValue("lastPublishDate"));
 
@@ -981,6 +1021,8 @@ public class DepotEntryGroupRelModelImpl
 
 		depotEntryGroupRelCacheModel.toGroupId = getToGroupId();
 
+		depotEntryGroupRelCacheModel.type = getType();
+
 		Date lastPublishDate = getLastPublishDate();
 
 		if (lastPublishDate != null) {
@@ -1068,6 +1110,7 @@ public class DepotEntryGroupRelModelImpl
 	private long _depotEntryId;
 	private boolean _searchable;
 	private long _toGroupId;
+	private long _type;
 	private Date _lastPublishDate;
 
 	public <T> T getColumnValue(String columnName) {
@@ -1116,6 +1159,7 @@ public class DepotEntryGroupRelModelImpl
 		_columnOriginalValues.put("depotEntryId", _depotEntryId);
 		_columnOriginalValues.put("searchable", _searchable);
 		_columnOriginalValues.put("toGroupId", _toGroupId);
+		_columnOriginalValues.put("type_", _type);
 		_columnOriginalValues.put("lastPublishDate", _lastPublishDate);
 	}
 
@@ -1125,6 +1169,7 @@ public class DepotEntryGroupRelModelImpl
 		Map<String, String> attributeNames = new HashMap<>();
 
 		attributeNames.put("uuid_", "uuid");
+		attributeNames.put("type_", "type");
 
 		_attributeNames = Collections.unmodifiableMap(attributeNames);
 	}
@@ -1168,7 +1213,9 @@ public class DepotEntryGroupRelModelImpl
 
 		columnBitmasks.put("toGroupId", 8192L);
 
-		columnBitmasks.put("lastPublishDate", 16384L);
+		columnBitmasks.put("type_", 16384L);
+
+		columnBitmasks.put("lastPublishDate", 32768L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/model/impl/DepotEntryModelImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/model/impl/DepotEntryModelImpl.java
@@ -68,7 +68,8 @@ public class DepotEntryModelImpl
 		{"uuid_", Types.VARCHAR}, {"depotEntryId", Types.BIGINT},
 		{"groupId", Types.BIGINT}, {"companyId", Types.BIGINT},
 		{"userId", Types.BIGINT}, {"userName", Types.VARCHAR},
-		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP}
+		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP},
+		{"type_", Types.INTEGER}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -85,10 +86,11 @@ public class DepotEntryModelImpl
 		TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
 		TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+		TABLE_COLUMNS_MAP.put("type_", Types.INTEGER);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table DepotEntry (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,depotEntryId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,primary key (depotEntryId, ctCollectionId))";
+		"create table DepotEntry (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,depotEntryId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,type_ INTEGER,primary key (depotEntryId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP = "drop table DepotEntry";
 
@@ -251,6 +253,7 @@ public class DepotEntryModelImpl
 				"createDate", DepotEntry::getCreateDate);
 			attributeGetterFunctions.put(
 				"modifiedDate", DepotEntry::getModifiedDate);
+			attributeGetterFunctions.put("type", DepotEntry::getType);
 
 			_attributeGetterFunctions = Collections.unmodifiableMap(
 				attributeGetterFunctions);
@@ -295,6 +298,8 @@ public class DepotEntryModelImpl
 			attributeSetterBiConsumers.put(
 				"modifiedDate",
 				(BiConsumer<DepotEntry, Date>)DepotEntry::setModifiedDate);
+			attributeSetterBiConsumers.put(
+				"type", (BiConsumer<DepotEntry, Integer>)DepotEntry::setType);
 
 			_attributeSetterBiConsumers = Collections.unmodifiableMap(
 				(Map)attributeSetterBiConsumers);
@@ -512,6 +517,21 @@ public class DepotEntryModelImpl
 		_modifiedDate = modifiedDate;
 	}
 
+	@JSON
+	@Override
+	public int getType() {
+		return _type;
+	}
+
+	@Override
+	public void setType(int type) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_type = type;
+	}
+
 	@Override
 	public StagedModelType getStagedModelType() {
 		return new StagedModelType(
@@ -584,6 +604,7 @@ public class DepotEntryModelImpl
 		depotEntryImpl.setUserName(getUserName());
 		depotEntryImpl.setCreateDate(getCreateDate());
 		depotEntryImpl.setModifiedDate(getModifiedDate());
+		depotEntryImpl.setType(getType());
 
 		depotEntryImpl.resetOriginalValues();
 
@@ -611,6 +632,7 @@ public class DepotEntryModelImpl
 			this.<Date>getColumnOriginalValue("createDate"));
 		depotEntryImpl.setModifiedDate(
 			this.<Date>getColumnOriginalValue("modifiedDate"));
+		depotEntryImpl.setType(this.<Integer>getColumnOriginalValue("type_"));
 
 		return depotEntryImpl;
 	}
@@ -734,6 +756,8 @@ public class DepotEntryModelImpl
 			depotEntryCacheModel.modifiedDate = Long.MIN_VALUE;
 		}
 
+		depotEntryCacheModel.type = getType();
+
 		return depotEntryCacheModel;
 	}
 
@@ -806,6 +830,7 @@ public class DepotEntryModelImpl
 	private Date _createDate;
 	private Date _modifiedDate;
 	private boolean _setModifiedDate;
+	private int _type;
 
 	public <T> T getColumnValue(String columnName) {
 		columnName = _attributeNames.getOrDefault(columnName, columnName);
@@ -847,6 +872,7 @@ public class DepotEntryModelImpl
 		_columnOriginalValues.put("userName", _userName);
 		_columnOriginalValues.put("createDate", _createDate);
 		_columnOriginalValues.put("modifiedDate", _modifiedDate);
+		_columnOriginalValues.put("type_", _type);
 	}
 
 	private static final Map<String, String> _attributeNames;
@@ -855,6 +881,7 @@ public class DepotEntryModelImpl
 		Map<String, String> attributeNames = new HashMap<>();
 
 		attributeNames.put("uuid_", "uuid");
+		attributeNames.put("type_", "type");
 
 		_attributeNames = Collections.unmodifiableMap(attributeNames);
 	}
@@ -889,6 +916,8 @@ public class DepotEntryModelImpl
 		columnBitmasks.put("createDate", 256L);
 
 		columnBitmasks.put("modifiedDate", 512L);
+
+		columnBitmasks.put("type_", 1024L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/http/DepotEntryGroupRelServiceHttp.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/http/DepotEntryGroupRelServiceHttp.java
@@ -211,7 +211,8 @@ public class DepotEntryGroupRelServiceHttp {
 
 	public static java.util.List<com.liferay.depot.model.DepotEntryGroupRel>
 			getDepotEntryGroupRels(
-				HttpPrincipal httpPrincipal, long groupId, int start, int end)
+				HttpPrincipal httpPrincipal, long groupId, int type, int start,
+				int end)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
@@ -220,7 +221,7 @@ public class DepotEntryGroupRelServiceHttp {
 				_getDepotEntryGroupRelsParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, start, end);
+				methodKey, groupId, type, start, end);
 
 			Object returnObj = null;
 
@@ -294,7 +295,7 @@ public class DepotEntryGroupRelServiceHttp {
 	}
 
 	public static int getDepotEntryGroupRelsCount(
-			HttpPrincipal httpPrincipal, long groupId)
+			HttpPrincipal httpPrincipal, long groupId, int type)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
@@ -303,7 +304,8 @@ public class DepotEntryGroupRelServiceHttp {
 				"getDepotEntryGroupRelsCount",
 				_getDepotEntryGroupRelsCountParameterTypes6);
 
-			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, type);
 
 			Object returnObj = null;
 
@@ -432,13 +434,15 @@ public class DepotEntryGroupRelServiceHttp {
 			com.liferay.depot.model.DepotEntry.class, int.class, int.class
 		};
 	private static final Class<?>[] _getDepotEntryGroupRelsParameterTypes4 =
-		new Class[] {long.class, int.class, int.class};
+		new Class[] {long.class, int.class, int.class, int.class};
 	private static final Class<?>[]
 		_getDepotEntryGroupRelsCountParameterTypes5 = new Class[] {
 			com.liferay.depot.model.DepotEntry.class
 		};
 	private static final Class<?>[]
-		_getDepotEntryGroupRelsCountParameterTypes6 = new Class[] {long.class};
+		_getDepotEntryGroupRelsCountParameterTypes6 = new Class[] {
+			long.class, int.class
+		};
 	private static final Class<?>[]
 		_updateDDMStructuresAvailableParameterTypes7 = new Class[] {
 			long.class, boolean.class

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/http/DepotEntryServiceHttp.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/http/DepotEntryServiceHttp.java
@@ -44,7 +44,7 @@ public class DepotEntryServiceHttp {
 	public static com.liferay.depot.model.DepotEntry addDepotEntry(
 			HttpPrincipal httpPrincipal,
 			java.util.Map<java.util.Locale, String> nameMap,
-			java.util.Map<java.util.Locale, String> descriptionMap,
+			java.util.Map<java.util.Locale, String> descriptionMap, int type,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -54,7 +54,7 @@ public class DepotEntryServiceHttp {
 				_addDepotEntryParameterTypes0);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, nameMap, descriptionMap, serviceContext);
+				methodKey, nameMap, descriptionMap, type, serviceContext);
 
 			Object returnObj = null;
 
@@ -126,7 +126,8 @@ public class DepotEntryServiceHttp {
 
 	public static java.util.List<com.liferay.depot.model.DepotEntry>
 			getCurrentAndGroupConnectedDepotEntries(
-				HttpPrincipal httpPrincipal, long groupId, int start, int end)
+				HttpPrincipal httpPrincipal, long groupId, int type, int start,
+				int end)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
@@ -136,7 +137,7 @@ public class DepotEntryServiceHttp {
 				_getCurrentAndGroupConnectedDepotEntriesParameterTypes2);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, start, end);
+				methodKey, groupId, type, start, end);
 
 			Object returnObj = null;
 
@@ -252,7 +253,8 @@ public class DepotEntryServiceHttp {
 
 	public static java.util.List<com.liferay.depot.model.DepotEntry>
 			getGroupConnectedDepotEntries(
-				HttpPrincipal httpPrincipal, long groupId, int start, int end)
+				HttpPrincipal httpPrincipal, long groupId, int type, int start,
+				int end)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
@@ -261,7 +263,7 @@ public class DepotEntryServiceHttp {
 				_getGroupConnectedDepotEntriesParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, start, end);
+				methodKey, groupId, type, start, end);
 
 			Object returnObj = null;
 
@@ -293,7 +295,7 @@ public class DepotEntryServiceHttp {
 	}
 
 	public static int getGroupConnectedDepotEntriesCount(
-			HttpPrincipal httpPrincipal, long groupId)
+			HttpPrincipal httpPrincipal, long groupId, int type)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
@@ -302,7 +304,8 @@ public class DepotEntryServiceHttp {
 				"getGroupConnectedDepotEntriesCount",
 				_getGroupConnectedDepotEntriesCountParameterTypes6);
 
-			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, type);
 
 			Object returnObj = null;
 
@@ -424,14 +427,14 @@ public class DepotEntryServiceHttp {
 
 	private static final Class<?>[] _addDepotEntryParameterTypes0 =
 		new Class[] {
-			java.util.Map.class, java.util.Map.class,
+			java.util.Map.class, java.util.Map.class, int.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _deleteDepotEntryParameterTypes1 =
 		new Class[] {long.class};
 	private static final Class<?>[]
 		_getCurrentAndGroupConnectedDepotEntriesParameterTypes2 = new Class[] {
-			long.class, int.class, int.class
+			long.class, int.class, int.class, int.class
 		};
 	private static final Class<?>[] _getDepotEntryParameterTypes3 =
 		new Class[] {long.class};
@@ -441,11 +444,11 @@ public class DepotEntryServiceHttp {
 		};
 	private static final Class<?>[]
 		_getGroupConnectedDepotEntriesParameterTypes5 = new Class[] {
-			long.class, int.class, int.class
+			long.class, int.class, int.class, int.class
 		};
 	private static final Class<?>[]
 		_getGroupConnectedDepotEntriesCountParameterTypes6 = new Class[] {
-			long.class
+			long.class, int.class
 		};
 	private static final Class<?>[] _getGroupDepotEntryParameterTypes7 =
 		new Class[] {long.class};

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryGroupRelLocalServiceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryGroupRelLocalServiceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.depot.service.impl;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.model.DepotEntryGroupRel;
 import com.liferay.depot.service.base.DepotEntryGroupRelLocalServiceBaseImpl;
@@ -167,10 +168,14 @@ public class DepotEntryGroupRelLocalServiceImpl
 
 	@Override
 	public List<DepotEntryGroupRel> getDepotEntryGroupRels(
-		long groupId, int start, int end) {
+		long groupId, int type, int start, int end) {
 
-		return depotEntryGroupRelPersistence.findByToGroupId(
-			groupId, start, end);
+		if (type == DepotConstants.TYPE_ANY) {
+			return depotEntryGroupRelPersistence.findByToGroupId(groupId);
+		}
+
+		return depotEntryGroupRelPersistence.findByTGI_T(
+			groupId, type, start, end);
 	}
 
 	@Override
@@ -180,8 +185,12 @@ public class DepotEntryGroupRelLocalServiceImpl
 	}
 
 	@Override
-	public int getDepotEntryGroupRelsCount(long groupId) {
-		return depotEntryGroupRelPersistence.countByToGroupId(groupId);
+	public int getDepotEntryGroupRelsCount(long groupId, int type) {
+		if (type == DepotConstants.TYPE_ANY) {
+			return depotEntryGroupRelPersistence.countByToGroupId(groupId);
+		}
+
+		return depotEntryGroupRelPersistence.countByTGI_T(groupId, type);
 	}
 
 	@Override

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryGroupRelLocalServiceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryGroupRelLocalServiceImpl.java
@@ -8,6 +8,7 @@ package com.liferay.depot.service.impl;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.model.DepotEntryGroupRel;
 import com.liferay.depot.service.base.DepotEntryGroupRelLocalServiceBaseImpl;
+import com.liferay.depot.service.persistence.DepotEntryPersistence;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -67,6 +68,11 @@ public class DepotEntryGroupRelLocalServiceImpl
 		depotEntryGroupRel.setDepotEntryId(depotEntryId);
 		depotEntryGroupRel.setSearchable(searchable);
 		depotEntryGroupRel.setToGroupId(toGroupId);
+
+		DepotEntry depotEntry = _depotEntryPersistence.findByPrimaryKey(
+			depotEntryId);
+
+		depotEntryGroupRel.setType(depotEntry.getType());
 
 		ServiceContext serviceContext =
 			ServiceContextThreadLocal.getServiceContext();
@@ -292,6 +298,9 @@ public class DepotEntryGroupRelLocalServiceImpl
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DepotEntryGroupRelLocalServiceImpl.class);
+
+	@Reference
+	private DepotEntryPersistence _depotEntryPersistence;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryGroupRelServiceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryGroupRelServiceImpl.java
@@ -91,14 +91,14 @@ public class DepotEntryGroupRelServiceImpl
 
 	@Override
 	public List<DepotEntryGroupRel> getDepotEntryGroupRels(
-			long groupId, int start, int end)
+			long groupId, int type, int start, int end)
 		throws PortalException {
 
 		GroupPermissionUtil.check(
 			getPermissionChecker(), groupId, ActionKeys.VIEW);
 
 		return depotEntryGroupRelLocalService.getDepotEntryGroupRels(
-			groupId, start, end);
+			groupId, type, start, end);
 	}
 
 	@Override
@@ -114,14 +114,14 @@ public class DepotEntryGroupRelServiceImpl
 	}
 
 	@Override
-	public int getDepotEntryGroupRelsCount(long groupId)
+	public int getDepotEntryGroupRelsCount(long groupId, int type)
 		throws PortalException {
 
 		GroupPermissionUtil.check(
 			getPermissionChecker(), groupId, ActionKeys.VIEW);
 
 		return depotEntryGroupRelLocalService.getDepotEntryGroupRelsCount(
-			groupId);
+			groupId, type);
 	}
 
 	@Override

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryLocalServiceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryLocalServiceImpl.java
@@ -11,6 +11,7 @@ import com.liferay.depot.exception.DepotEntryGroupException;
 import com.liferay.depot.exception.DepotEntryNameException;
 import com.liferay.depot.exception.DepotEntryStagedException;
 import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.model.DepotEntryGroupRel;
 import com.liferay.depot.service.DepotAppCustomizationLocalService;
 import com.liferay.depot.service.DepotEntryPinLocalService;
 import com.liferay.depot.service.base.DepotEntryLocalServiceBaseImpl;
@@ -217,18 +218,22 @@ public class DepotEntryLocalServiceImpl extends DepotEntryLocalServiceBaseImpl {
 
 	@Override
 	public List<DepotEntry> getGroupConnectedDepotEntries(
-			long groupId, int start, int end)
+			long groupId, int type, int start, int end)
 		throws PortalException {
 
 		return TransformUtil.transform(
-			_depotEntryGroupRelPersistence.findByToGroupId(groupId, start, end),
+			_getGroupConnectedDepotEntries(groupId, type, start, end),
 			depotEntryGroupRel -> depotEntryLocalService.getDepotEntry(
 				depotEntryGroupRel.getDepotEntryId()));
 	}
 
 	@Override
-	public int getGroupConnectedDepotEntriesCount(long groupId) {
-		return _depotEntryGroupRelPersistence.countByToGroupId(groupId);
+	public int getGroupConnectedDepotEntriesCount(long groupId, int type) {
+		if (type == DepotConstants.TYPE_ANY) {
+			return _depotEntryGroupRelPersistence.countByToGroupId(groupId);
+		}
+
+		return _depotEntryGroupRelPersistence.countByTGI_T(groupId, type);
 	}
 
 	@Override
@@ -318,6 +323,18 @@ public class DepotEntryLocalServiceImpl extends DepotEntryLocalServiceBaseImpl {
 		}
 
 		return _language.get(defaultLocale, "unnamed-asset-library");
+	}
+
+	private List<DepotEntryGroupRel> _getGroupConnectedDepotEntries(
+		long groupId, int type, int start, int end) {
+
+		if (type == DepotConstants.TYPE_ANY) {
+			return _depotEntryGroupRelPersistence.findByToGroupId(
+				groupId, start, end);
+		}
+
+		return _depotEntryGroupRelPersistence.findByTGI_T(
+			groupId, type, start, end);
 	}
 
 	private boolean _isStaged(DepotEntry depotEntry) throws PortalException {

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryLocalServiceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryLocalServiceImpl.java
@@ -99,7 +99,7 @@ public class DepotEntryLocalServiceImpl extends DepotEntryLocalServiceBaseImpl {
 	@Override
 	public DepotEntry addDepotEntry(
 			Map<Locale, String> nameMap, Map<Locale, String> descriptionMap,
-			ServiceContext serviceContext)
+			int type, ServiceContext serviceContext)
 		throws PortalException {
 
 		_validateNameMap(nameMap, LocaleUtil.getDefault());
@@ -123,7 +123,7 @@ public class DepotEntryLocalServiceImpl extends DepotEntryLocalServiceBaseImpl {
 			UnicodePropertiesBuilder.create(
 				group.getTypeSettingsProperties(), true
 			).put(
-				"depotEntryType", DepotConstants.TYPE_ASSET_LIBRARY
+				"depotEntryType", type
 			).buildString());
 
 		_userLocalService.addGroupUsers(
@@ -146,7 +146,7 @@ public class DepotEntryLocalServiceImpl extends DepotEntryLocalServiceBaseImpl {
 		depotEntry.setGroupId(group.getGroupId());
 		depotEntry.setCompanyId(serviceContext.getCompanyId());
 		depotEntry.setUserId(serviceContext.getUserId());
-		depotEntry.setType(DepotConstants.TYPE_ASSET_LIBRARY);
+		depotEntry.setType(type);
 
 		depotEntry = depotEntryPersistence.update(depotEntry);
 

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryLocalServiceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryLocalServiceImpl.java
@@ -41,6 +41,7 @@ import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.List;
@@ -80,7 +81,10 @@ public class DepotEntryLocalServiceImpl extends DepotEntryLocalServiceBaseImpl {
 		depotEntry.setGroupId(group.getGroupId());
 		depotEntry.setCompanyId(serviceContext.getCompanyId());
 		depotEntry.setUserId(serviceContext.getUserId());
-		depotEntry.setType(DepotConstants.TYPE_ASSET_LIBRARY);
+		depotEntry.setType(
+			GetterUtil.getInteger(
+				group.getTypeSettingsProperty("depotEntryType"),
+				DepotConstants.TYPE_ASSET_LIBRARY));
 
 		depotEntry = depotEntryPersistence.update(depotEntry);
 
@@ -113,6 +117,14 @@ public class DepotEntryLocalServiceImpl extends DepotEntryLocalServiceBaseImpl {
 			GroupConstants.DEFAULT_MEMBERSHIP_RESTRICTION,
 			"/asset-library-" + depotEntry.getDepotEntryId(), false, false,
 			true, serviceContext);
+
+		_groupLocalService.updateGroup(
+			group.getGroupId(),
+			UnicodePropertiesBuilder.create(
+				group.getTypeSettingsProperties(), true
+			).put(
+				"depotEntryType", DepotConstants.TYPE_ASSET_LIBRARY
+			).buildString());
 
 		_userLocalService.addGroupUsers(
 			group.getGroupId(), new long[] {serviceContext.getUserId()});

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryLocalServiceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryLocalServiceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.depot.service.impl;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.exception.DepotEntryGroupException;
 import com.liferay.depot.exception.DepotEntryNameException;
@@ -79,6 +80,7 @@ public class DepotEntryLocalServiceImpl extends DepotEntryLocalServiceBaseImpl {
 		depotEntry.setGroupId(group.getGroupId());
 		depotEntry.setCompanyId(serviceContext.getCompanyId());
 		depotEntry.setUserId(serviceContext.getUserId());
+		depotEntry.setType(DepotConstants.TYPE_ASSET_LIBRARY);
 
 		depotEntry = depotEntryPersistence.update(depotEntry);
 
@@ -132,6 +134,7 @@ public class DepotEntryLocalServiceImpl extends DepotEntryLocalServiceBaseImpl {
 		depotEntry.setGroupId(group.getGroupId());
 		depotEntry.setCompanyId(serviceContext.getCompanyId());
 		depotEntry.setUserId(serviceContext.getUserId());
+		depotEntry.setType(DepotConstants.TYPE_ASSET_LIBRARY);
 
 		depotEntry = depotEntryPersistence.update(depotEntry);
 

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryServiceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryServiceImpl.java
@@ -69,11 +69,11 @@ public class DepotEntryServiceImpl extends DepotEntryServiceBaseImpl {
 
 	@Override
 	public List<DepotEntry> getCurrentAndGroupConnectedDepotEntries(
-			long groupId, int start, int end)
+			long groupId, int type, int start, int end)
 		throws PortalException {
 
 		List<DepotEntry> filteredDepotEntries = getGroupConnectedDepotEntries(
-			groupId, start, end);
+			groupId, type, start, end);
 
 		DepotEntry depotEntry = depotEntryLocalService.fetchGroupDepotEntry(
 			groupId);
@@ -117,7 +117,7 @@ public class DepotEntryServiceImpl extends DepotEntryServiceBaseImpl {
 
 	@Override
 	public List<DepotEntry> getGroupConnectedDepotEntries(
-			long groupId, int start, int end)
+			long groupId, int type, int start, int end)
 		throws PortalException {
 
 		PermissionChecker permissionChecker = getPermissionChecker();
@@ -132,7 +132,7 @@ public class DepotEntryServiceImpl extends DepotEntryServiceBaseImpl {
 
 		for (DepotEntry depotEntry :
 				depotEntryLocalService.getGroupConnectedDepotEntries(
-					groupId, start, end)) {
+					groupId, type, start, end)) {
 
 			Group group = depotEntry.getGroup();
 
@@ -149,7 +149,7 @@ public class DepotEntryServiceImpl extends DepotEntryServiceBaseImpl {
 	}
 
 	@Override
-	public int getGroupConnectedDepotEntriesCount(long groupId)
+	public int getGroupConnectedDepotEntriesCount(long groupId, int type)
 		throws PortalException {
 
 		if (!GroupPermissionUtil.contains(
@@ -159,7 +159,7 @@ public class DepotEntryServiceImpl extends DepotEntryServiceBaseImpl {
 		}
 
 		return depotEntryLocalService.getGroupConnectedDepotEntriesCount(
-			groupId);
+			groupId, type);
 	}
 
 	@Override

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryServiceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryServiceImpl.java
@@ -46,7 +46,7 @@ public class DepotEntryServiceImpl extends DepotEntryServiceBaseImpl {
 	@Override
 	public DepotEntry addDepotEntry(
 			Map<Locale, String> nameMap, Map<Locale, String> descriptionMap,
-			ServiceContext serviceContext)
+			int type, ServiceContext serviceContext)
 		throws PortalException {
 
 		_portletResourcePermission.check(
@@ -54,7 +54,7 @@ public class DepotEntryServiceImpl extends DepotEntryServiceBaseImpl {
 			DepotActionKeys.ADD_DEPOT_ENTRY);
 
 		return depotEntryLocalService.addDepotEntry(
-			nameMap, descriptionMap, serviceContext);
+			nameMap, descriptionMap, type, serviceContext);
 	}
 
 	@Override

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/persistence/impl/DepotEntryGroupRelPersistenceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/persistence/impl/DepotEntryGroupRelPersistenceImpl.java
@@ -3799,10 +3799,563 @@ public class DepotEntryGroupRelPersistenceImpl
 	private static final String _FINDER_COLUMN_S_TGI_TOGROUPID_2 =
 		"depotEntryGroupRel.toGroupId = ?";
 
+	private FinderPath _finderPathWithPaginationFindByTGI_T;
+	private FinderPath _finderPathWithoutPaginationFindByTGI_T;
+	private FinderPath _finderPathCountByTGI_T;
+
+	/**
+	 * Returns all the depot entry group rels where toGroupId = &#63; and type = &#63;.
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @return the matching depot entry group rels
+	 */
+	@Override
+	public List<DepotEntryGroupRel> findByTGI_T(long toGroupId, long type) {
+		return findByTGI_T(
+			toGroupId, type, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the depot entry group rels where toGroupId = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DepotEntryGroupRelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @param start the lower bound of the range of depot entry group rels
+	 * @param end the upper bound of the range of depot entry group rels (not inclusive)
+	 * @return the range of matching depot entry group rels
+	 */
+	@Override
+	public List<DepotEntryGroupRel> findByTGI_T(
+		long toGroupId, long type, int start, int end) {
+
+		return findByTGI_T(toGroupId, type, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the depot entry group rels where toGroupId = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DepotEntryGroupRelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @param start the lower bound of the range of depot entry group rels
+	 * @param end the upper bound of the range of depot entry group rels (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching depot entry group rels
+	 */
+	@Override
+	public List<DepotEntryGroupRel> findByTGI_T(
+		long toGroupId, long type, int start, int end,
+		OrderByComparator<DepotEntryGroupRel> orderByComparator) {
+
+		return findByTGI_T(
+			toGroupId, type, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the depot entry group rels where toGroupId = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DepotEntryGroupRelModelImpl</code>.
+	 * </p>
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @param start the lower bound of the range of depot entry group rels
+	 * @param end the upper bound of the range of depot entry group rels (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching depot entry group rels
+	 */
+	@Override
+	public List<DepotEntryGroupRel> findByTGI_T(
+		long toGroupId, long type, int start, int end,
+		OrderByComparator<DepotEntryGroupRel> orderByComparator,
+		boolean useFinderCache) {
+
+		try (SafeCloseable safeCloseable =
+				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
+					DepotEntryGroupRel.class)) {
+
+			FinderPath finderPath = null;
+			Object[] finderArgs = null;
+
+			if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+				(orderByComparator == null)) {
+
+				if (useFinderCache) {
+					finderPath = _finderPathWithoutPaginationFindByTGI_T;
+					finderArgs = new Object[] {toGroupId, type};
+				}
+			}
+			else if (useFinderCache) {
+				finderPath = _finderPathWithPaginationFindByTGI_T;
+				finderArgs = new Object[] {
+					toGroupId, type, start, end, orderByComparator
+				};
+			}
+
+			List<DepotEntryGroupRel> list = null;
+
+			if (useFinderCache) {
+				list = (List<DepotEntryGroupRel>)finderCache.getResult(
+					finderPath, finderArgs, this);
+
+				if ((list != null) && !list.isEmpty()) {
+					for (DepotEntryGroupRel depotEntryGroupRel : list) {
+						if ((toGroupId != depotEntryGroupRel.getToGroupId()) ||
+							(type != depotEntryGroupRel.getType())) {
+
+							list = null;
+
+							break;
+						}
+					}
+				}
+			}
+
+			if (list == null) {
+				StringBundler sb = null;
+
+				if (orderByComparator != null) {
+					sb = new StringBundler(
+						4 + (orderByComparator.getOrderByFields().length * 2));
+				}
+				else {
+					sb = new StringBundler(4);
+				}
+
+				sb.append(_SQL_SELECT_DEPOTENTRYGROUPREL_WHERE);
+
+				sb.append(_FINDER_COLUMN_TGI_T_TOGROUPID_2);
+
+				sb.append(_FINDER_COLUMN_TGI_T_TYPE_2);
+
+				if (orderByComparator != null) {
+					appendOrderByComparator(
+						sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+				}
+				else {
+					sb.append(DepotEntryGroupRelModelImpl.ORDER_BY_JPQL);
+				}
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(toGroupId);
+
+					queryPos.add(type);
+
+					list = (List<DepotEntryGroupRel>)QueryUtil.list(
+						query, getDialect(), start, end);
+
+					cacheResult(list);
+
+					if (useFinderCache) {
+						finderCache.putResult(finderPath, finderArgs, list);
+					}
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return list;
+		}
+	}
+
+	/**
+	 * Returns the first depot entry group rel in the ordered set where toGroupId = &#63; and type = &#63;.
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching depot entry group rel
+	 * @throws NoSuchEntryGroupRelException if a matching depot entry group rel could not be found
+	 */
+	@Override
+	public DepotEntryGroupRel findByTGI_T_First(
+			long toGroupId, long type,
+			OrderByComparator<DepotEntryGroupRel> orderByComparator)
+		throws NoSuchEntryGroupRelException {
+
+		DepotEntryGroupRel depotEntryGroupRel = fetchByTGI_T_First(
+			toGroupId, type, orderByComparator);
+
+		if (depotEntryGroupRel != null) {
+			return depotEntryGroupRel;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("toGroupId=");
+		sb.append(toGroupId);
+
+		sb.append(", type=");
+		sb.append(type);
+
+		sb.append("}");
+
+		throw new NoSuchEntryGroupRelException(sb.toString());
+	}
+
+	/**
+	 * Returns the first depot entry group rel in the ordered set where toGroupId = &#63; and type = &#63;.
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching depot entry group rel, or <code>null</code> if a matching depot entry group rel could not be found
+	 */
+	@Override
+	public DepotEntryGroupRel fetchByTGI_T_First(
+		long toGroupId, long type,
+		OrderByComparator<DepotEntryGroupRel> orderByComparator) {
+
+		List<DepotEntryGroupRel> list = findByTGI_T(
+			toGroupId, type, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last depot entry group rel in the ordered set where toGroupId = &#63; and type = &#63;.
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching depot entry group rel
+	 * @throws NoSuchEntryGroupRelException if a matching depot entry group rel could not be found
+	 */
+	@Override
+	public DepotEntryGroupRel findByTGI_T_Last(
+			long toGroupId, long type,
+			OrderByComparator<DepotEntryGroupRel> orderByComparator)
+		throws NoSuchEntryGroupRelException {
+
+		DepotEntryGroupRel depotEntryGroupRel = fetchByTGI_T_Last(
+			toGroupId, type, orderByComparator);
+
+		if (depotEntryGroupRel != null) {
+			return depotEntryGroupRel;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("toGroupId=");
+		sb.append(toGroupId);
+
+		sb.append(", type=");
+		sb.append(type);
+
+		sb.append("}");
+
+		throw new NoSuchEntryGroupRelException(sb.toString());
+	}
+
+	/**
+	 * Returns the last depot entry group rel in the ordered set where toGroupId = &#63; and type = &#63;.
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching depot entry group rel, or <code>null</code> if a matching depot entry group rel could not be found
+	 */
+	@Override
+	public DepotEntryGroupRel fetchByTGI_T_Last(
+		long toGroupId, long type,
+		OrderByComparator<DepotEntryGroupRel> orderByComparator) {
+
+		int count = countByTGI_T(toGroupId, type);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<DepotEntryGroupRel> list = findByTGI_T(
+			toGroupId, type, count - 1, count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the depot entry group rels before and after the current depot entry group rel in the ordered set where toGroupId = &#63; and type = &#63;.
+	 *
+	 * @param depotEntryGroupRelId the primary key of the current depot entry group rel
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next depot entry group rel
+	 * @throws NoSuchEntryGroupRelException if a depot entry group rel with the primary key could not be found
+	 */
+	@Override
+	public DepotEntryGroupRel[] findByTGI_T_PrevAndNext(
+			long depotEntryGroupRelId, long toGroupId, long type,
+			OrderByComparator<DepotEntryGroupRel> orderByComparator)
+		throws NoSuchEntryGroupRelException {
+
+		DepotEntryGroupRel depotEntryGroupRel = findByPrimaryKey(
+			depotEntryGroupRelId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			DepotEntryGroupRel[] array = new DepotEntryGroupRelImpl[3];
+
+			array[0] = getByTGI_T_PrevAndNext(
+				session, depotEntryGroupRel, toGroupId, type, orderByComparator,
+				true);
+
+			array[1] = depotEntryGroupRel;
+
+			array[2] = getByTGI_T_PrevAndNext(
+				session, depotEntryGroupRel, toGroupId, type, orderByComparator,
+				false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected DepotEntryGroupRel getByTGI_T_PrevAndNext(
+		Session session, DepotEntryGroupRel depotEntryGroupRel, long toGroupId,
+		long type, OrderByComparator<DepotEntryGroupRel> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				5 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(4);
+		}
+
+		sb.append(_SQL_SELECT_DEPOTENTRYGROUPREL_WHERE);
+
+		sb.append(_FINDER_COLUMN_TGI_T_TOGROUPID_2);
+
+		sb.append(_FINDER_COLUMN_TGI_T_TYPE_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(DepotEntryGroupRelModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(toGroupId);
+
+		queryPos.add(type);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						depotEntryGroupRel)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<DepotEntryGroupRel> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the depot entry group rels where toGroupId = &#63; and type = &#63; from the database.
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 */
+	@Override
+	public void removeByTGI_T(long toGroupId, long type) {
+		for (DepotEntryGroupRel depotEntryGroupRel :
+				findByTGI_T(
+					toGroupId, type, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+					null)) {
+
+			remove(depotEntryGroupRel);
+		}
+	}
+
+	/**
+	 * Returns the number of depot entry group rels where toGroupId = &#63; and type = &#63;.
+	 *
+	 * @param toGroupId the to group ID
+	 * @param type the type
+	 * @return the number of matching depot entry group rels
+	 */
+	@Override
+	public int countByTGI_T(long toGroupId, long type) {
+		try (SafeCloseable safeCloseable =
+				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
+					DepotEntryGroupRel.class)) {
+
+			FinderPath finderPath = _finderPathCountByTGI_T;
+
+			Object[] finderArgs = new Object[] {toGroupId, type};
+
+			Long count = (Long)finderCache.getResult(
+				finderPath, finderArgs, this);
+
+			if (count == null) {
+				StringBundler sb = new StringBundler(3);
+
+				sb.append(_SQL_COUNT_DEPOTENTRYGROUPREL_WHERE);
+
+				sb.append(_FINDER_COLUMN_TGI_T_TOGROUPID_2);
+
+				sb.append(_FINDER_COLUMN_TGI_T_TYPE_2);
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(toGroupId);
+
+					queryPos.add(type);
+
+					count = (Long)query.uniqueResult();
+
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return count.intValue();
+		}
+	}
+
+	private static final String _FINDER_COLUMN_TGI_T_TOGROUPID_2 =
+		"depotEntryGroupRel.toGroupId = ? AND ";
+
+	private static final String _FINDER_COLUMN_TGI_T_TYPE_2 =
+		"depotEntryGroupRel.type = ?";
+
 	public DepotEntryGroupRelPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
 
 		dbColumnNames.put("uuid", "uuid_");
+		dbColumnNames.put("type", "type_");
 
 		setDBColumnNames(dbColumnNames);
 
@@ -4653,6 +5206,7 @@ public class DepotEntryGroupRelPersistenceImpl
 		ctMergeColumnNames.add("depotEntryId");
 		ctMergeColumnNames.add("searchable");
 		ctMergeColumnNames.add("toGroupId");
+		ctMergeColumnNames.add("type_");
 		ctMergeColumnNames.add("lastPublishDate");
 
 		_ctColumnNamesMap.put(
@@ -4812,6 +5366,25 @@ public class DepotEntryGroupRelPersistenceImpl
 			new String[] {Boolean.class.getName(), Long.class.getName()},
 			new String[] {"searchable", "toGroupId"}, false);
 
+		_finderPathWithPaginationFindByTGI_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByTGI_T",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"toGroupId", "type_"}, true);
+
+		_finderPathWithoutPaginationFindByTGI_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByTGI_T",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"toGroupId", "type_"}, true);
+
+		_finderPathCountByTGI_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByTGI_T",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"toGroupId", "type_"}, false);
+
 		DepotEntryGroupRelUtil.setPersistence(this);
 	}
 
@@ -4881,7 +5454,7 @@ public class DepotEntryGroupRelPersistenceImpl
 		DepotEntryGroupRelPersistenceImpl.class);
 
 	private static final Set<String> _badColumnNames = SetUtil.fromArray(
-		new String[] {"uuid"});
+		new String[] {"uuid", "type"});
 
 	@Override
 	protected FinderCache getFinderCache() {

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/persistence/impl/DepotEntryPersistenceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/persistence/impl/DepotEntryPersistenceImpl.java
@@ -1598,6 +1598,7 @@ public class DepotEntryPersistenceImpl
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
 
 		dbColumnNames.put("uuid", "uuid_");
+		dbColumnNames.put("type", "type_");
 
 		setDBColumnNames(dbColumnNames);
 
@@ -2395,6 +2396,7 @@ public class DepotEntryPersistenceImpl
 	static {
 		Set<String> ctControlColumnNames = new HashSet<String>();
 		Set<String> ctIgnoreColumnNames = new HashSet<String>();
+		Set<String> ctMergeColumnNames = new HashSet<String>();
 		Set<String> ctStrictColumnNames = new HashSet<String>();
 
 		ctControlColumnNames.add("mvccVersion");
@@ -2406,11 +2408,13 @@ public class DepotEntryPersistenceImpl
 		ctStrictColumnNames.add("userName");
 		ctStrictColumnNames.add("createDate");
 		ctIgnoreColumnNames.add("modifiedDate");
+		ctMergeColumnNames.add("type_");
 
 		_ctColumnNamesMap.put(
 			CTColumnResolutionType.CONTROL, ctControlColumnNames);
 		_ctColumnNamesMap.put(
 			CTColumnResolutionType.IGNORE, ctIgnoreColumnNames);
+		_ctColumnNamesMap.put(CTColumnResolutionType.MERGE, ctMergeColumnNames);
 		_ctColumnNamesMap.put(
 			CTColumnResolutionType.PK, Collections.singleton("depotEntryId"));
 		_ctColumnNamesMap.put(
@@ -2557,7 +2561,7 @@ public class DepotEntryPersistenceImpl
 		DepotEntryPersistenceImpl.class);
 
 	private static final Set<String> _badColumnNames = SetUtil.fromArray(
-		new String[] {"uuid"});
+		new String[] {"uuid", "type"});
 
 	@Override
 	protected FinderCache getFinderCache() {

--- a/modules/apps/depot/depot-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/depot/depot-service/src/main/resources/META-INF/module-hbm.xml
@@ -30,6 +30,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="userName" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="createDate" type="org.hibernate.type.TimestampType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="modifiedDate" type="org.hibernate.type.TimestampType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="type_" name="type" type="com.liferay.portal.dao.orm.hibernate.IntegerType" />
 	</class>
 	<class dynamic-update="true" name="com.liferay.depot.model.impl.DepotEntryGroupRelImpl" table="DepotEntryGroupRel">
 		<id access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="depotEntryGroupRelId" type="long">
@@ -48,6 +49,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="depotEntryId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="searchable" type="com.liferay.portal.dao.orm.hibernate.BooleanType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="toGroupId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="type_" name="type" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="lastPublishDate" type="org.hibernate.type.TimestampType" />
 	</class>
 	<class dynamic-update="true" name="com.liferay.depot.model.impl.DepotEntryPinImpl" table="DepotEntryPin">

--- a/modules/apps/depot/depot-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/depot/depot-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -21,6 +21,7 @@
 		<field name="userName" type="String" />
 		<field name="createDate" type="Date" />
 		<field name="modifiedDate" type="Date" />
+		<field name="type" type="int" />
 	</model>
 	<model name="com.liferay.depot.model.DepotEntryGroupRel">
 		<field name="mvccVersion" type="long" />
@@ -37,6 +38,7 @@
 		<field name="depotEntryId" type="long" />
 		<field name="searchable" type="boolean" />
 		<field name="toGroupId" type="long" />
+		<field name="type" type="long" />
 		<field name="lastPublishDate" type="Date" />
 	</model>
 	<model name="com.liferay.depot.model.DepotEntryPin">

--- a/modules/apps/depot/depot-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/depot/depot-service/src/main/resources/META-INF/sql/indexes.sql
@@ -7,6 +7,7 @@ create index IX_146497CB on DepotEntryGroupRel (depotEntryId);
 create index IX_7CA33F81 on DepotEntryGroupRel (toGroupId, ddmStructuresAvailable);
 create unique index IX_1DD0EA9C on DepotEntryGroupRel (toGroupId, depotEntryId, ctCollectionId);
 create index IX_BA106967 on DepotEntryGroupRel (toGroupId, searchable);
+create index IX_98F19EC4 on DepotEntryGroupRel (toGroupId, type_);
 create unique index IX_A83D9516 on DepotEntryGroupRel (uuid_[$COLUMN_LENGTH:75$], ctCollectionId, groupId);
 
 create index IX_B423314A on DepotEntryPin (depotEntryId);

--- a/modules/apps/depot/depot-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/depot/depot-service/src/main/resources/META-INF/sql/tables.sql
@@ -20,6 +20,7 @@ create table DepotEntry (
 	userName VARCHAR(75) null,
 	createDate DATE null,
 	modifiedDate DATE null,
+	type_ INTEGER,
 	primary key (depotEntryId, ctCollectionId)
 );
 
@@ -38,6 +39,7 @@ create table DepotEntryGroupRel (
 	depotEntryId LONG,
 	searchable BOOLEAN,
 	toGroupId LONG,
+	type_ LONG,
 	lastPublishDate DATE null,
 	primary key (depotEntryGroupRelId, ctCollectionId)
 );

--- a/modules/apps/depot/depot-service/src/main/resources/service.properties
+++ b/modules/apps/depot/depot-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.depot.service
-    build.number=1
-    build.date=1570784699702
+    build.number=6
+    build.date=1753790980779

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/change/tracking/spi/reference/test/DepotAppCustomizationTableReferenceDefinitionTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/change/tracking/spi/reference/test/DepotAppCustomizationTableReferenceDefinitionTest.java
@@ -7,6 +7,7 @@ package com.liferay.depot.internal.change.tracking.spi.reference.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.change.tracking.test.util.BaseTableReferenceDefinitionTestCase;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotAppCustomizationLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
@@ -51,7 +52,8 @@ public class DepotAppCustomizationTableReferenceDefinitionTest
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
-			new HashMap<>(), ServiceContextTestUtil.getServiceContext());
+			new HashMap<>(), DepotConstants.TYPE_ASSET_LIBRARY,
+			ServiceContextTestUtil.getServiceContext());
 	}
 
 	@Override

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/change/tracking/spi/reference/test/DepotEntryGroupRelTableReferenceDefinitionTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/change/tracking/spi/reference/test/DepotEntryGroupRelTableReferenceDefinitionTest.java
@@ -7,6 +7,7 @@ package com.liferay.depot.internal.change.tracking.spi.reference.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.change.tracking.test.util.BaseTableReferenceDefinitionTestCase;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
@@ -50,7 +51,8 @@ public class DepotEntryGroupRelTableReferenceDefinitionTest
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
-			new HashMap<>(), ServiceContextTestUtil.getServiceContext());
+			new HashMap<>(), DepotConstants.TYPE_ASSET_LIBRARY,
+			ServiceContextTestUtil.getServiceContext());
 	}
 
 	@Override

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/change/tracking/spi/reference/test/DepotEntryPinTableReferenceDefinitionTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/change/tracking/spi/reference/test/DepotEntryPinTableReferenceDefinitionTest.java
@@ -7,6 +7,7 @@ package com.liferay.depot.internal.change.tracking.spi.reference.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.change.tracking.test.util.BaseTableReferenceDefinitionTestCase;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.depot.service.DepotEntryPinLocalService;
@@ -51,7 +52,8 @@ public class DepotEntryPinTableReferenceDefinitionTest
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
-			new HashMap<>(), ServiceContextTestUtil.getServiceContext());
+			new HashMap<>(), DepotConstants.TYPE_ASSET_LIBRARY,
+			ServiceContextTestUtil.getServiceContext());
 	}
 
 	@Override

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/change/tracking/spi/reference/test/DepotEntryTableReferenceDefinitionTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/change/tracking/spi/reference/test/DepotEntryTableReferenceDefinitionTest.java
@@ -7,6 +7,7 @@ package com.liferay.depot.internal.change.tracking.spi.reference.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.change.tracking.test.util.BaseTableReferenceDefinitionTestCase;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.portal.kernel.model.change.tracking.CTModel;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -44,7 +45,8 @@ public class DepotEntryTableReferenceDefinitionTest
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
-			new HashMap<>(), ServiceContextTestUtil.getServiceContext());
+			new HashMap<>(), DepotConstants.TYPE_ASSET_LIBRARY,
+			ServiceContextTestUtil.getServiceContext());
 	}
 
 	@Inject

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/info/item/provider/test/DepotEntryInfoItemPermissionProviderTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/info/item/provider/test/DepotEntryInfoItemPermissionProviderTest.java
@@ -6,6 +6,7 @@
 package com.liferay.depot.internal.info.item.provider.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.info.item.InfoItemServiceRegistry;
@@ -63,6 +64,7 @@ public class DepotEntryInfoItemPermissionProviderTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), StringUtil.randomString()
 			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		RoleTestUtil.removeResourcePermission(

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/search/test/DepotEntrySearchTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/search/test/DepotEntrySearchTest.java
@@ -6,6 +6,7 @@
 package com.liferay.depot.internal.search.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryService;
 import com.liferay.depot.test.util.DepotTestUtil;
@@ -230,6 +231,7 @@ public class DepotEntrySearchTest {
 			Collections.singletonMap(LocaleUtil.getDefault(), name),
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext(
 				TestPropsValues.getGroupId(), user.getUserId()));
 

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/contributor/test/DepotRoleContributorTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/contributor/test/DepotRoleContributorTest.java
@@ -6,6 +6,7 @@
 package com.liferay.depot.internal.security.permission.contributor.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
@@ -132,7 +133,8 @@ public class DepotRoleContributorTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
-			Collections.emptyMap(), ServiceContextTestUtil.getServiceContext());
+			Collections.emptyMap(), DepotConstants.TYPE_ASSET_LIBRARY,
+			ServiceContextTestUtil.getServiceContext());
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/wrapper/test/DepotPermissionCheckerWrapperTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/wrapper/test/DepotPermissionCheckerWrapperTest.java
@@ -6,6 +6,7 @@
 package com.liferay.depot.internal.security.permission.wrapper.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
@@ -701,7 +702,7 @@ public class DepotPermissionCheckerWrapperTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
-			Collections.emptyMap(),
+			Collections.emptyMap(), DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext(
 				TestPropsValues.getGroupId(), userId));
 

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/servlet/taglib/test/DepotBreadcrumbEntryContributorTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/servlet/taglib/test/DepotBreadcrumbEntryContributorTest.java
@@ -6,6 +6,7 @@
 package com.liferay.depot.internal.servlet.taglib.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.portal.kernel.language.Language;
@@ -173,6 +174,7 @@ public class DepotBreadcrumbEntryContributorTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), description
 			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		_depotEntries.add(depotEntry);

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/roles/service/test/DepotRoleLocalServiceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/roles/service/test/DepotRoleLocalServiceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.depot.roles.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.depot.test.util.DepotTestUtil;
@@ -95,6 +96,7 @@ public class DepotRoleLocalServiceTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), description
 			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		_depotEntries.add(depotEntry);

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotEntryGroupRelPersistenceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotEntryGroupRelPersistenceTest.java
@@ -143,6 +143,8 @@ public class DepotEntryGroupRelPersistenceTest {
 
 		newDepotEntryGroupRel.setToGroupId(RandomTestUtil.nextLong());
 
+		newDepotEntryGroupRel.setType(RandomTestUtil.nextLong());
+
 		newDepotEntryGroupRel.setLastPublishDate(RandomTestUtil.nextDate());
 
 		_depotEntryGroupRels.add(_persistence.update(newDepotEntryGroupRel));
@@ -194,6 +196,9 @@ public class DepotEntryGroupRelPersistenceTest {
 		Assert.assertEquals(
 			existingDepotEntryGroupRel.getToGroupId(),
 			newDepotEntryGroupRel.getToGroupId());
+		Assert.assertEquals(
+			existingDepotEntryGroupRel.getType(),
+			newDepotEntryGroupRel.getType());
 		Assert.assertEquals(
 			Time.getShortTimestamp(
 				existingDepotEntryGroupRel.getLastPublishDate()),
@@ -266,6 +271,14 @@ public class DepotEntryGroupRelPersistenceTest {
 	}
 
 	@Test
+	public void testCountByTGI_T() throws Exception {
+		_persistence.countByTGI_T(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextLong());
+
+		_persistence.countByTGI_T(0L, 0L);
+	}
+
+	@Test
 	public void testFindByPrimaryKeyExisting() throws Exception {
 		DepotEntryGroupRel newDepotEntryGroupRel = addDepotEntryGroupRel();
 
@@ -295,8 +308,8 @@ public class DepotEntryGroupRelPersistenceTest {
 			"uuid", true, "depotEntryGroupRelId", true, "groupId", true,
 			"companyId", true, "userId", true, "userName", true, "createDate",
 			true, "modifiedDate", true, "ddmStructuresAvailable", true,
-			"depotEntryId", true, "searchable", true, "toGroupId", true,
-			"lastPublishDate", true);
+			"depotEntryId", true, "searchable", true, "toGroupId", true, "type",
+			true, "lastPublishDate", true);
 	}
 
 	@Test
@@ -629,6 +642,8 @@ public class DepotEntryGroupRelPersistenceTest {
 		depotEntryGroupRel.setSearchable(RandomTestUtil.randomBoolean());
 
 		depotEntryGroupRel.setToGroupId(RandomTestUtil.nextLong());
+
+		depotEntryGroupRel.setType(RandomTestUtil.nextLong());
 
 		depotEntryGroupRel.setLastPublishDate(RandomTestUtil.nextDate());
 

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotEntryPersistenceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotEntryPersistenceTest.java
@@ -133,6 +133,8 @@ public class DepotEntryPersistenceTest {
 
 		newDepotEntry.setModifiedDate(RandomTestUtil.nextDate());
 
+		newDepotEntry.setType(RandomTestUtil.nextInt());
+
 		_depotEntries.add(_persistence.update(newDepotEntry));
 
 		DepotEntry existingDepotEntry = _persistence.findByPrimaryKey(
@@ -163,6 +165,8 @@ public class DepotEntryPersistenceTest {
 		Assert.assertEquals(
 			Time.getShortTimestamp(existingDepotEntry.getModifiedDate()),
 			Time.getShortTimestamp(newDepotEntry.getModifiedDate()));
+		Assert.assertEquals(
+			existingDepotEntry.getType(), newDepotEntry.getType());
 	}
 
 	@Test
@@ -227,7 +231,7 @@ public class DepotEntryPersistenceTest {
 			"DepotEntry", "mvccVersion", true, "ctCollectionId", true, "uuid",
 			true, "depotEntryId", true, "groupId", true, "companyId", true,
 			"userId", true, "userName", true, "createDate", true,
-			"modifiedDate", true);
+			"modifiedDate", true, "type", true);
 	}
 
 	@Test
@@ -530,6 +534,8 @@ public class DepotEntryPersistenceTest {
 		depotEntry.setCreateDate(RandomTestUtil.nextDate());
 
 		depotEntry.setModifiedDate(RandomTestUtil.nextDate());
+
+		depotEntry.setType(RandomTestUtil.nextInt());
 
 		_depotEntries.add(_persistence.update(depotEntry));
 

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryDLAppServiceWhenCopyingWithAssetCategoriesAndAssetTagsTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryDLAppServiceWhenCopyingWithAssetCategoriesAndAssetTagsTest.java
@@ -11,6 +11,7 @@ import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.group.provider.SiteConnectedGroupGroupProvider;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
@@ -398,6 +399,7 @@ public class
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), "description"
 			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		_depotEntries.add(depotEntry);

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryDLAppServiceWhenCopyingWithDLFileEntryTypeTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryDLAppServiceWhenCopyingWithDLFileEntryTypeTest.java
@@ -6,6 +6,7 @@
 package com.liferay.depot.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.group.provider.SiteConnectedGroupGroupProvider;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
@@ -71,6 +72,7 @@ public class DepotEntryDLAppServiceWhenCopyingWithDLFileEntryTypeTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), "description"
 			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		_depotGroup = _groupLocalService.getGroup(_depotEntry.getGroupId());

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryGroupRelLocalServiceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryGroupRelLocalServiceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.depot.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.exception.NoSuchEntryGroupRelException;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.model.DepotEntryGroupRel;
@@ -474,6 +475,7 @@ public class DepotEntryGroupRelLocalServiceTest {
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		_depotEntries.add(depotEntry);

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryGroupRelLocalServiceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryGroupRelLocalServiceTest.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -34,7 +35,9 @@ import com.liferay.sites.kernel.util.Sites;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -64,17 +67,29 @@ public class DepotEntryGroupRelLocalServiceTest {
 
 	@Test
 	public void testAddDepotEntryGroupRel() throws Exception {
-		DepotEntry depotEntry = _addDepotEntry(
+		DepotEntry depotEntry1 = _addDepotEntry(
 			DepotConstants.TYPE_ASSET_LIBRARY);
 
-		DepotEntryGroupRel depotEntryGroupRel =
+		DepotEntryGroupRel depotEntryGroupRel1 =
 			_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
-				depotEntry.getDepotEntryId(), _group1.getGroupId());
+				depotEntry1.getDepotEntryId(), _group1.getGroupId());
 
 		Assert.assertEquals(
-			depotEntry.getDepotEntryId(), depotEntryGroupRel.getDepotEntryId());
+			depotEntry1.getDepotEntryId(),
+			depotEntryGroupRel1.getDepotEntryId());
 		Assert.assertEquals(
-			_group1.getGroupId(), depotEntryGroupRel.getToGroupId());
+			_group1.getGroupId(), depotEntryGroupRel1.getToGroupId());
+		Assert.assertEquals(
+			depotEntry1.getType(), depotEntryGroupRel1.getType());
+
+		DepotEntry depotEntry2 = _addDepotEntry(DepotConstants.TYPE_SPACE);
+
+		DepotEntryGroupRel depotEntryGroupRel2 =
+			_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+				depotEntry2.getDepotEntryId(), _group1.getGroupId());
+
+		Assert.assertEquals(
+			depotEntry2.getType(), depotEntryGroupRel2.getType());
 	}
 
 	@Test
@@ -359,25 +374,55 @@ public class DepotEntryGroupRelLocalServiceTest {
 
 	@Test
 	public void testGetDepotEntryGroupRels() throws Exception {
-		DepotEntry depotEntry = _addDepotEntry(
+		DepotEntry depotEntry1 = _addDepotEntry(
 			DepotConstants.TYPE_ASSET_LIBRARY);
+		DepotEntry depotEntry2 = _addDepotEntry(DepotConstants.TYPE_SPACE);
 
 		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
-			depotEntry.getDepotEntryId(), _group1.getGroupId());
+			depotEntry1.getDepotEntryId(), _group1.getGroupId());
+		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+			depotEntry2.getDepotEntryId(), _group1.getGroupId());
 
-		List<DepotEntryGroupRel> depotEntryGroupRels =
+		List<DepotEntryGroupRel> depotEntryGroupRels1 =
 			_depotEntryGroupRelLocalService.getDepotEntryGroupRels(
 				_group1.getGroupId(), DepotConstants.TYPE_ASSET_LIBRARY, 0, 20);
 
 		Assert.assertEquals(
-			depotEntryGroupRels.toString(), 1, depotEntryGroupRels.size());
+			depotEntryGroupRels1.toString(), 1, depotEntryGroupRels1.size());
 
-		DepotEntryGroupRel depotEntryGroupRel = depotEntryGroupRels.get(0);
+		DepotEntryGroupRel depotEntryGroupRel1 = depotEntryGroupRels1.get(0);
 
 		Assert.assertEquals(
-			depotEntry.getDepotEntryId(), depotEntryGroupRel.getDepotEntryId());
+			depotEntry1.getDepotEntryId(),
+			depotEntryGroupRel1.getDepotEntryId());
 		Assert.assertEquals(
-			_group1.getGroupId(), depotEntryGroupRel.getToGroupId());
+			_group1.getGroupId(), depotEntryGroupRel1.getToGroupId());
+
+		List<DepotEntryGroupRel> depotEntryGroupRels2 =
+			_depotEntryGroupRelLocalService.getDepotEntryGroupRels(
+				_group1.getGroupId(), DepotConstants.TYPE_SPACE, 0, 20);
+
+		Assert.assertEquals(
+			depotEntryGroupRels2.toString(), 1, depotEntryGroupRels2.size());
+
+		DepotEntryGroupRel depotEntryGroupRel2 = depotEntryGroupRels2.get(0);
+
+		Assert.assertEquals(
+			depotEntry2.getDepotEntryId(),
+			depotEntryGroupRel2.getDepotEntryId());
+		Assert.assertEquals(
+			_group1.getGroupId(), depotEntryGroupRel2.getToGroupId());
+
+		Set<DepotEntryGroupRel> expectedDepotEntryGroupRels = new HashSet<>();
+
+		expectedDepotEntryGroupRels.addAll(depotEntryGroupRels1);
+		expectedDepotEntryGroupRels.addAll(depotEntryGroupRels2);
+
+		Assert.assertEquals(
+			expectedDepotEntryGroupRels,
+			SetUtil.fromCollection(
+				_depotEntryGroupRelLocalService.getDepotEntryGroupRels(
+					_group1.getGroupId(), DepotConstants.TYPE_ANY, 0, 20)));
 	}
 
 	@Test

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryGroupRelLocalServiceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryGroupRelLocalServiceTest.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.model.LayoutSetPrototype;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
 import com.liferay.portal.kernel.service.SystemEventLocalService;
+import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -34,8 +35,6 @@ import com.liferay.sites.kernel.util.Sites;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -65,13 +64,13 @@ public class DepotEntryGroupRelLocalServiceTest {
 
 	@Test
 	public void testAddDepotEntryGroupRel() throws Exception {
-		DepotEntry depotEntry = _addDepotEntry();
+		DepotEntry depotEntry = _addDepotEntry(
+			DepotConstants.TYPE_ASSET_LIBRARY);
 
 		DepotEntryGroupRel depotEntryGroupRel =
 			_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
 				depotEntry.getDepotEntryId(), _group1.getGroupId());
 
-		Assert.assertNotNull(depotEntryGroupRel.getDepotEntryId());
 		Assert.assertEquals(
 			depotEntry.getDepotEntryId(), depotEntryGroupRel.getDepotEntryId());
 		Assert.assertEquals(
@@ -82,7 +81,8 @@ public class DepotEntryGroupRelLocalServiceTest {
 	public void testAddDepotEntryGroupRelWithARepeatedDepotEntryGroupRel()
 		throws Exception {
 
-		DepotEntry depotEntry = _addDepotEntry();
+		DepotEntry depotEntry = _addDepotEntry(
+			DepotConstants.TYPE_ASSET_LIBRARY);
 
 		DepotEntryGroupRel originalDepotEntryGroupRel =
 			_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
@@ -107,7 +107,8 @@ public class DepotEntryGroupRelLocalServiceTest {
 	public void testAddDepotEntryGroupRelWithLayoutSetPrototypeWithoutPropagation()
 		throws Exception {
 
-		DepotEntry depotEntry = _addDepotEntry();
+		DepotEntry depotEntry = _addDepotEntry(
+			DepotConstants.TYPE_ASSET_LIBRARY);
 
 		LayoutSetPrototype layoutSetPrototype =
 			_layoutSetPrototypeLocalService.addLayoutSetPrototype(
@@ -115,7 +116,7 @@ public class DepotEntryGroupRelLocalServiceTest {
 				HashMapBuilder.put(
 					LocaleUtil.getDefault(), RandomTestUtil.randomString()
 				).build(),
-				(Map<Locale, String>)null, true, true, false,
+				null, true, true, false,
 				ServiceContextTestUtil.getServiceContext());
 
 		Group group = _setUpLayoutSetPrototypeGroup(layoutSetPrototype);
@@ -140,7 +141,8 @@ public class DepotEntryGroupRelLocalServiceTest {
 	public void testAddDepotEntryGroupRelWithLayoutSetPrototypeWithPropagation()
 		throws Exception {
 
-		DepotEntry depotEntry = _addDepotEntry();
+		DepotEntry depotEntry = _addDepotEntry(
+			DepotConstants.TYPE_ASSET_LIBRARY);
 
 		LayoutSetPrototype layoutSetPrototype =
 			_layoutSetPrototypeLocalService.addLayoutSetPrototype(
@@ -148,8 +150,7 @@ public class DepotEntryGroupRelLocalServiceTest {
 				HashMapBuilder.put(
 					LocaleUtil.getDefault(), RandomTestUtil.randomString()
 				).build(),
-				(Map<Locale, String>)null, true, true,
-				ServiceContextTestUtil.getServiceContext());
+				null, true, true, ServiceContextTestUtil.getServiceContext());
 
 		Group group = _setUpLayoutSetPrototypeGroup(layoutSetPrototype);
 
@@ -171,7 +172,8 @@ public class DepotEntryGroupRelLocalServiceTest {
 
 	@Test
 	public void testDeleteDepotEntryGroupRel() throws Exception {
-		DepotEntry depotEntry = _addDepotEntry();
+		DepotEntry depotEntry = _addDepotEntry(
+			DepotConstants.TYPE_ASSET_LIBRARY);
 
 		DepotEntryGroupRel depotEntryGroupRel =
 			_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
@@ -180,21 +182,20 @@ public class DepotEntryGroupRelLocalServiceTest {
 		_depotEntryGroupRelLocalService.deleteDepotEntryGroupRel(
 			depotEntryGroupRel.getDepotEntryGroupRelId());
 
-		try {
-			_depotEntryGroupRelLocalService.getDepotEntryGroupRel(
-				depotEntryGroupRel.getDepotEntryGroupRelId());
-
-			Assert.fail();
-		}
-		catch (NoSuchEntryGroupRelException noSuchEntryGroupRelException) {
-		}
+		AssertUtils.assertFailure(
+			NoSuchEntryGroupRelException.class,
+			"No DepotEntryGroupRel exists with the primary key " +
+				depotEntryGroupRel.getDepotEntryGroupRelId(),
+			() -> _depotEntryGroupRelLocalService.getDepotEntryGroupRel(
+				depotEntryGroupRel.getDepotEntryGroupRelId()));
 	}
 
 	@Test
 	public void testDeleteDepotEntryGroupRelWithLayoutSetPrototypeWithoutPropagation()
 		throws Exception {
 
-		DepotEntry depotEntry = _addDepotEntry();
+		DepotEntry depotEntry = _addDepotEntry(
+			DepotConstants.TYPE_ASSET_LIBRARY);
 
 		LayoutSetPrototype layoutSetPrototype =
 			_layoutSetPrototypeLocalService.addLayoutSetPrototype(
@@ -202,8 +203,7 @@ public class DepotEntryGroupRelLocalServiceTest {
 				HashMapBuilder.put(
 					LocaleUtil.getDefault(), RandomTestUtil.randomString()
 				).build(),
-				(Map<Locale, String>)null, true, true,
-				ServiceContextTestUtil.getServiceContext());
+				null, true, true, ServiceContextTestUtil.getServiceContext());
 
 		Group group = _setUpLayoutSetPrototypeGroup(layoutSetPrototype);
 
@@ -221,7 +221,7 @@ public class DepotEntryGroupRelLocalServiceTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
-			(Map<Locale, String>)null, true, true, false,
+			null, true, true, false,
 			ServiceContextTestUtil.getServiceContext());
 
 		int systemEventsCount = _systemEventLocalService.getSystemEventsCount();
@@ -253,7 +253,8 @@ public class DepotEntryGroupRelLocalServiceTest {
 	public void testDeleteDepotEntryGroupRelWithLayoutSetPrototypeWithPropagation()
 		throws Exception {
 
-		DepotEntry depotEntry = _addDepotEntry();
+		DepotEntry depotEntry = _addDepotEntry(
+			DepotConstants.TYPE_ASSET_LIBRARY);
 
 		LayoutSetPrototype layoutSetPrototype =
 			_layoutSetPrototypeLocalService.addLayoutSetPrototype(
@@ -261,8 +262,7 @@ public class DepotEntryGroupRelLocalServiceTest {
 				HashMapBuilder.put(
 					LocaleUtil.getDefault(), RandomTestUtil.randomString()
 				).build(),
-				(Map<Locale, String>)null, true, true,
-				ServiceContextTestUtil.getServiceContext());
+				null, true, true, ServiceContextTestUtil.getServiceContext());
 
 		Group group = _setUpLayoutSetPrototypeGroup(layoutSetPrototype);
 
@@ -302,7 +302,8 @@ public class DepotEntryGroupRelLocalServiceTest {
 
 	@Test
 	public void testDeleteGroup() throws Exception {
-		DepotEntry depotEntry = _addDepotEntry();
+		DepotEntry depotEntry = _addDepotEntry(
+			DepotConstants.TYPE_ASSET_LIBRARY);
 
 		Group group = _groupLocalService.addGroup(
 			TestPropsValues.getUserId(), GroupConstants.DEFAULT_PARENT_GROUP_ID,
@@ -334,7 +335,8 @@ public class DepotEntryGroupRelLocalServiceTest {
 
 	@Test
 	public void testGetDepotEntryGroupRel() throws Exception {
-		DepotEntry depotEntry = _addDepotEntry();
+		DepotEntry depotEntry = _addDepotEntry(
+			DepotConstants.TYPE_ASSET_LIBRARY);
 
 		DepotEntryGroupRel originalDepotEntryGroupRel =
 			_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
@@ -357,7 +359,8 @@ public class DepotEntryGroupRelLocalServiceTest {
 
 	@Test
 	public void testGetDepotEntryGroupRels() throws Exception {
-		DepotEntry depotEntry = _addDepotEntry();
+		DepotEntry depotEntry = _addDepotEntry(
+			DepotConstants.TYPE_ASSET_LIBRARY);
 
 		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
 			depotEntry.getDepotEntryId(), _group1.getGroupId());
@@ -367,7 +370,7 @@ public class DepotEntryGroupRelLocalServiceTest {
 				_group1.getGroupId(), DepotConstants.TYPE_ASSET_LIBRARY, 0, 20);
 
 		Assert.assertEquals(
-			depotEntryGroupRels.toString(), depotEntryGroupRels.size(), 1);
+			depotEntryGroupRels.toString(), 1, depotEntryGroupRels.size());
 
 		DepotEntryGroupRel depotEntryGroupRel = depotEntryGroupRels.get(0);
 
@@ -379,12 +382,14 @@ public class DepotEntryGroupRelLocalServiceTest {
 
 	@Test
 	public void testGetDepotEntryGroupRelsCount() throws Exception {
-		DepotEntry depotEntry1 = _addDepotEntry();
+		DepotEntry depotEntry1 = _addDepotEntry(
+			DepotConstants.TYPE_ASSET_LIBRARY);
 
 		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
 			depotEntry1.getDepotEntryId(), _group1.getGroupId());
 
-		DepotEntry depotEntry2 = _addDepotEntry();
+		DepotEntry depotEntry2 = _addDepotEntry(
+			DepotConstants.TYPE_ASSET_LIBRARY);
 
 		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
 			depotEntry2.getDepotEntryId(), _group1.getGroupId());
@@ -401,7 +406,8 @@ public class DepotEntryGroupRelLocalServiceTest {
 
 	@Test
 	public void testGetSearchableDepotEntryGroupRels() throws Exception {
-		DepotEntry depotEntry = _addDepotEntry();
+		DepotEntry depotEntry = _addDepotEntry(
+			DepotConstants.TYPE_ASSET_LIBRARY);
 
 		DepotEntryGroupRel depotEntryGroupRel =
 			_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
@@ -428,7 +434,8 @@ public class DepotEntryGroupRelLocalServiceTest {
 	public void testGetSearchableDepotEntryGroupRelsWithAnUnsearchableDepotEntryGroupRel()
 		throws Exception {
 
-		DepotEntry depotEntry = _addDepotEntry();
+		DepotEntry depotEntry = _addDepotEntry(
+			DepotConstants.TYPE_ASSET_LIBRARY);
 
 		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
 			depotEntry.getDepotEntryId(), _group1.getGroupId(), false);
@@ -450,7 +457,8 @@ public class DepotEntryGroupRelLocalServiceTest {
 
 	@Test
 	public void testUpdateSearchable() throws Exception {
-		DepotEntry depotEntry1 = _addDepotEntry();
+		DepotEntry depotEntry1 = _addDepotEntry(
+			DepotConstants.TYPE_ASSET_LIBRARY);
 
 		DepotEntryGroupRel depotEntryGroupRel =
 			_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
@@ -469,14 +477,13 @@ public class DepotEntryGroupRelLocalServiceTest {
 		Assert.assertTrue(depotEntryGroupRel.isSearchable());
 	}
 
-	private DepotEntry _addDepotEntry() throws Exception {
+	private DepotEntry _addDepotEntry(int type) throws Exception {
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			DepotConstants.TYPE_ASSET_LIBRARY,
-			ServiceContextTestUtil.getServiceContext());
+			type, ServiceContextTestUtil.getServiceContext());
 
 		_depotEntries.add(depotEntry);
 

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryGroupRelLocalServiceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryGroupRelLocalServiceTest.java
@@ -364,7 +364,7 @@ public class DepotEntryGroupRelLocalServiceTest {
 
 		List<DepotEntryGroupRel> depotEntryGroupRels =
 			_depotEntryGroupRelLocalService.getDepotEntryGroupRels(
-				_group1.getGroupId(), 0, 20);
+				_group1.getGroupId(), DepotConstants.TYPE_ASSET_LIBRARY, 0, 20);
 
 		Assert.assertEquals(
 			depotEntryGroupRels.toString(), depotEntryGroupRels.size(), 1);
@@ -392,11 +392,11 @@ public class DepotEntryGroupRelLocalServiceTest {
 		Assert.assertEquals(
 			2,
 			_depotEntryGroupRelLocalService.getDepotEntryGroupRelsCount(
-				_group1.getGroupId()));
+				_group1.getGroupId(), DepotConstants.TYPE_ASSET_LIBRARY));
 		Assert.assertEquals(
 			0,
 			_depotEntryGroupRelLocalService.getDepotEntryGroupRelsCount(
-				RandomTestUtil.randomInt()));
+				RandomTestUtil.randomInt(), DepotConstants.TYPE_ASSET_LIBRARY));
 	}
 
 	@Test

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryGroupRelServiceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryGroupRelServiceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.depot.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.model.DepotEntryGroupRel;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
@@ -149,6 +150,7 @@ public class DepotEntryGroupRelServiceTest {
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		_depotEntries.add(depotEntry);

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryGroupRelServiceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryGroupRelServiceTest.java
@@ -87,7 +87,7 @@ public class DepotEntryGroupRelServiceTest {
 				_permissionCheckerFactory.create(user));
 
 			_depotEntryGroupRelService.getDepotEntryGroupRels(
-				group.getGroupId(), 0, 20);
+				group.getGroupId(), DepotConstants.TYPE_ASSET_LIBRARY, 0, 20);
 		}
 		catch (PrincipalException.MustHavePermission principalException) {
 			String message = principalException.getMessage();
@@ -126,7 +126,8 @@ public class DepotEntryGroupRelServiceTest {
 		try {
 			List<DepotEntryGroupRel> depotEntryGroupRels =
 				_depotEntryGroupRelService.getDepotEntryGroupRels(
-					group.getGroupId(), 0, 20);
+					group.getGroupId(), DepotConstants.TYPE_ASSET_LIBRARY, 0,
+					20);
 
 			Assert.assertEquals(
 				depotEntryGroupRels.toString(), 1, depotEntryGroupRels.size());

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryLocalServiceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryLocalServiceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.depot.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.exception.DepotEntryNameException;
 import com.liferay.depot.model.DepotEntry;
@@ -125,7 +126,7 @@ public class DepotEntryLocalServiceTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), "description"
 			).build(),
-			_getServiceContext(user));
+			DepotConstants.TYPE_ASSET_LIBRARY, _getServiceContext(user));
 
 		Assert.assertEquals(company.getCompanyId(), depotEntry.getCompanyId());
 

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryLocalServiceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryLocalServiceTest.java
@@ -345,6 +345,7 @@ public class DepotEntryLocalServiceTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), description
 			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		_depotEntries.add(depotEntry);

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryServiceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryServiceTest.java
@@ -183,6 +183,7 @@ public class DepotEntryServiceTest {
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext(
 				TestPropsValues.getGroupId(), user.getUserId()));
 

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotUserServiceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotUserServiceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.depot.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
@@ -172,7 +173,7 @@ public class DepotUserServiceTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
-			Collections.emptyMap(),
+			Collections.emptyMap(), DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext(
 				TestPropsValues.getGroupId(), userId));
 

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/staging/test/DepotEntryFileEntryFriendlyURLTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/staging/test/DepotEntryFileEntryFriendlyURLTest.java
@@ -6,6 +6,7 @@
 package com.liferay.depot.staging.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.depot.test.util.DepotStagingTestUtil;
@@ -347,6 +348,7 @@ public class DepotEntryFileEntryFriendlyURLTest {
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 	}
 

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/staging/test/DepotEntryGroupRelStagingTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/staging/test/DepotEntryGroupRelStagingTest.java
@@ -6,6 +6,7 @@
 package com.liferay.depot.staging.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.model.DepotEntryGroupRel;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
@@ -383,6 +384,7 @@ public class DepotEntryGroupRelStagingTest {
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 	}
 

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/staging/test/DepotEntryStagingTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/staging/test/DepotEntryStagingTest.java
@@ -6,6 +6,7 @@
 package com.liferay.depot.staging.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.depot.test.util.DepotStagingTestUtil;
@@ -71,6 +72,7 @@ public class DepotEntryStagingTest {
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 	}
 

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/application/list/test/DepotPanelAppControllerTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/application/list/test/DepotPanelAppControllerTest.java
@@ -10,6 +10,7 @@ import com.liferay.application.list.PanelAppRegistry;
 import com.liferay.application.list.constants.PanelCategoryKeys;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.list.constants.AssetListPortletKeys;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.constants.DLPortletKeys;
@@ -60,7 +61,8 @@ public class DepotPanelAppControllerTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), "name"
 			).build(),
-			new HashMap<>(), ServiceContextTestUtil.getServiceContext());
+			new HashMap<>(), DepotConstants.TYPE_ASSET_LIBRARY,
+			ServiceContextTestUtil.getServiceContext());
 	}
 
 	@Test

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/asset/display/page/portlet/test/DepotEntryAssetDisplayPageFriendlyURLResolverTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/asset/display/page/portlet/test/DepotEntryAssetDisplayPageFriendlyURLResolverTest.java
@@ -6,6 +6,7 @@
 package com.liferay.depot.web.internal.asset.display.page.portlet.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.layout.display.page.LayoutDisplayPageProvider;
@@ -53,6 +54,7 @@ public class DepotEntryAssetDisplayPageFriendlyURLResolverTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), StringUtil.randomString()
 			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		ServiceContextThreadLocal.pushServiceContext(

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/asset/model/test/DepotAssetRendererFactoryTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/asset/model/test/DepotAssetRendererFactoryTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
 import com.liferay.asset.kernel.model.AssetRenderer;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.model.DepotEntryGroupRel;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
@@ -76,6 +77,7 @@ public class DepotAssetRendererFactoryTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), "description"
 			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 		_group = GroupTestUtil.addGroup();
 	}

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/asset/model/test/DepotAssetRendererFactoryTrackerTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/asset/model/test/DepotAssetRendererFactoryTrackerTest.java
@@ -8,6 +8,7 @@ package com.liferay.depot.web.internal.asset.model.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.model.DLFileEntry;
@@ -68,7 +69,8 @@ public class DepotAssetRendererFactoryTrackerTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), "name"
 			).build(),
-			new HashMap<>(), ServiceContextTestUtil.getServiceContext());
+			new HashMap<>(), DepotConstants.TYPE_ASSET_LIBRARY,
+			ServiceContextTestUtil.getServiceContext());
 	}
 
 	@Test

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/info/item/provider/test/DepotEntryInfoItemObjectProviderTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/info/item/provider/test/DepotEntryInfoItemObjectProviderTest.java
@@ -6,6 +6,7 @@
 package com.liferay.depot.web.internal.info.item.provider.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
@@ -50,6 +51,7 @@ public class DepotEntryInfoItemObjectProviderTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), StringUtil.randomString()
 			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		ServiceContextThreadLocal.pushServiceContext(

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/item/selector/provider/test/GroupItemSelectorProviderImplTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/item/selector/provider/test/GroupItemSelectorProviderImplTest.java
@@ -6,6 +6,7 @@
 package com.liferay.depot.web.internal.item.selector.provider.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
@@ -129,6 +130,7 @@ public class GroupItemSelectorProviderImplTest {
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		_depotEntries.add(depotEntry);

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/layout/display/page/test/DepotEntryLayoutDisplayPageProviderTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/layout/display/page/test/DepotEntryLayoutDisplayPageProviderTest.java
@@ -6,6 +6,7 @@
 package com.liferay.depot.web.internal.layout.display.page.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.info.item.InfoItemReference;
@@ -49,6 +50,7 @@ public class DepotEntryLayoutDisplayPageProviderTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), StringUtil.randomString()
 			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 	}
 

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/portlet/action/test/UpdateMembershipsMVCActionCommandTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/portlet/action/test/UpdateMembershipsMVCActionCommandTest.java
@@ -6,6 +6,7 @@
 package com.liferay.depot.web.internal.portlet.action.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
@@ -90,7 +91,7 @@ public class UpdateMembershipsMVCActionCommandTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
-			Collections.emptyMap(),
+			Collections.emptyMap(), DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext(
 				TestPropsValues.getGroupId(), TestPropsValues.getUserId()));
 		_user = UserTestUtil.addUser();

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/search/spi/searcher/test/DepotSearchRequestContributorTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/search/spi/searcher/test/DepotSearchRequestContributorTest.java
@@ -6,6 +6,7 @@
 package com.liferay.depot.web.internal.search.spi.searcher.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
@@ -239,6 +240,7 @@ public class DepotSearchRequestContributorTest {
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		_depotEntries.add(depotEntry);

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/util/test/DepotAdminGroupSearchProviderTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/util/test/DepotAdminGroupSearchProviderTest.java
@@ -6,6 +6,7 @@
 package com.liferay.depot.web.internal.util.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
@@ -140,6 +141,7 @@ public class DepotAdminGroupSearchProviderTest {
 			Collections.singletonMap(LocaleUtil.getDefault(), depotEntryName),
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		_depotEntries.add(depotEntry);

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotClassTypeReader.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotClassTypeReader.java
@@ -7,6 +7,7 @@ package com.liferay.depot.web.internal.asset.model;
 
 import com.liferay.asset.kernel.model.ClassType;
 import com.liferay.asset.kernel.model.ClassTypeReader;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -58,13 +59,13 @@ public class DepotClassTypeReader implements ClassTypeReader {
 			IntervalActionProcessor<Void> intervalActionProcessor =
 				new IntervalActionProcessor<>(
 					_depotEntryLocalService.getGroupConnectedDepotEntriesCount(
-						siteGroupId));
+						siteGroupId, DepotConstants.TYPE_ANY));
 
 			intervalActionProcessor.setPerformIntervalActionMethod(
 				(start, end) -> {
 					List<DepotEntry> depotEntries =
 						_depotEntryLocalService.getGroupConnectedDepotEntries(
-							siteGroupId, start, end);
+							siteGroupId, DepotConstants.TYPE_ANY, start, end);
 
 					for (DepotEntry depotEntry : depotEntries) {
 						groupIds.add(depotEntry.getGroupId());

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/item/selector/provider/DepotGroupItemSelectorProvider.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/item/selector/provider/DepotGroupItemSelectorProvider.java
@@ -5,6 +5,7 @@
 
 package com.liferay.depot.web.internal.item.selector.provider;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryService;
 import com.liferay.item.selector.provider.GroupItemSelectorProvider;
@@ -60,7 +61,8 @@ public class DepotGroupItemSelectorProvider
 
 			for (DepotEntry depotEntry :
 					_depotEntryService.getCurrentAndGroupConnectedDepotEntries(
-						_getGroupId(groupId), start, end)) {
+						_getGroupId(groupId), DepotConstants.TYPE_ANY, start,
+						end)) {
 
 				groups.add(depotEntry.getGroup());
 			}
@@ -78,7 +80,7 @@ public class DepotGroupItemSelectorProvider
 	public int getGroupsCount(long companyId, long groupId, String keywords) {
 		try {
 			return _depotEntryService.getGroupConnectedDepotEntriesCount(
-				_getGroupId(groupId));
+				_getGroupId(groupId), DepotConstants.TYPE_ANY);
 		}
 		catch (PortalException portalException) {
 			_log.error(portalException);

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/portlet/action/AddDepotEntryMVCActionCommand.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/portlet/action/AddDepotEntryMVCActionCommand.java
@@ -5,6 +5,7 @@
 
 package com.liferay.depot.web.internal.portlet.action;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.constants.DepotPortletKeys;
 import com.liferay.depot.exception.DepotEntryNameException;
 import com.liferay.depot.model.DepotEntry;
@@ -82,6 +83,7 @@ public class AddDepotEntryMVCActionCommand extends BaseMVCActionCommand {
 						DepotEntry depotEntry =
 							_depotEntryService.addDepotEntry(
 								nameMap, descriptionMap,
+								DepotConstants.TYPE_ASSET_LIBRARY,
 								ServiceContextFactory.getInstance(
 									DepotEntry.class.getName(), actionRequest));
 

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/util/DepotAdminGroupSearchProvider.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/util/DepotAdminGroupSearchProvider.java
@@ -5,6 +5,7 @@
 
 package com.liferay.depot.web.internal.util;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryService;
 import com.liferay.item.selector.criteria.group.criterion.GroupItemSelectorCriterion;
@@ -80,14 +81,14 @@ public class DepotAdminGroupSearchProvider {
 			() -> {
 				List<DepotEntry> depotEntries =
 					_depotEntryService.getGroupConnectedDepotEntries(
-						themeDisplay.getScopeGroupId(), groupSearch.getStart(),
-						groupSearch.getEnd());
+						themeDisplay.getScopeGroupId(), DepotConstants.TYPE_ANY,
+						groupSearch.getStart(), groupSearch.getEnd());
 
 				return TransformUtil.transform(
 					depotEntries, depotEntry -> depotEntry.getGroup());
 			},
 			_depotEntryService.getGroupConnectedDepotEntriesCount(
-				themeDisplay.getScopeGroupId()));
+				themeDisplay.getScopeGroupId(), DepotConstants.TYPE_ANY));
 
 		return groupSearch;
 	}

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/folder/DLFolderItemSelectorView.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/folder/DLFolderItemSelectorView.java
@@ -5,6 +5,7 @@
 
 package com.liferay.document.library.item.selector.web.internal.folder;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryService;
 import com.liferay.document.library.constants.DLPortletKeys;
@@ -201,8 +202,8 @@ public class DLFolderItemSelectorView
 		try {
 			return ListUtil.toList(
 				_depotEntryService.getCurrentAndGroupConnectedDepotEntries(
-					themeDisplay.getRefererGroupId(), QueryUtil.ALL_POS,
-					QueryUtil.ALL_POS),
+					themeDisplay.getRefererGroupId(), DepotConstants.TYPE_ANY,
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS),
 				DepotEntry::getGroupId);
 		}
 		catch (Exception exception) {

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/info/display/contributor/test/FileEntryInfoDisplayContributorTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/info/display/contributor/test/FileEntryInfoDisplayContributorTest.java
@@ -10,6 +10,7 @@ import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
 import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.asset.display.page.service.AssetDisplayPageEntryLocalService;
 import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.model.DLFileEntry;
@@ -255,6 +256,7 @@ public class FileEntryInfoDisplayContributorTest {
 					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
 				Collections.singletonMap(
 					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+				DepotConstants.TYPE_ASSET_LIBRARY,
 				ServiceContextTestUtil.getServiceContext());
 
 			DLFolder dlFolder = DLTestUtil.addDLFolder(

--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/test/DLExportImportPortletPreferencesProcessorTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/test/DLExportImportPortletPreferencesProcessorTest.java
@@ -6,6 +6,7 @@
 package com.liferay.document.library.web.internal.exportimport.portlet.preferences.processor.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.constants.DLPortletKeys;
@@ -524,6 +525,7 @@ public class DLExportImportPortletPreferencesProcessorTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		_depotEntries.add(depotEntry);

--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/test/IGExportImportPortletPreferencesProcessorTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/test/IGExportImportPortletPreferencesProcessorTest.java
@@ -6,6 +6,7 @@
 package com.liferay.document.library.web.internal.exportimport.portlet.preferences.processor.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.constants.DLPortletKeys;
@@ -526,6 +527,7 @@ public class IGExportImportPortletPreferencesProcessorTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		_depotEntries.add(depotEntry);

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/DLFolderUtil.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/DLFolderUtil.java
@@ -5,6 +5,7 @@
 
 package com.liferay.document.library.web.internal.util;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.document.library.kernel.exception.NoSuchFolderException;
@@ -50,7 +51,8 @@ public class DLFolderUtil {
 
 		List<Long> groupConnectedDepotEntries = ListUtil.toList(
 			DepotEntryLocalServiceUtil.getGroupConnectedDepotEntries(
-				scopeGroupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+				scopeGroupId, DepotConstants.TYPE_ANY, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS),
 			DepotEntry::getGroupId);
 
 		if (!groupConnectedDepotEntries.contains(groupId)) {

--- a/modules/apps/document-library/document-library-web/src/test/java/com/liferay/document/library/web/internal/util/DLFolderUtilTest.java
+++ b/modules/apps/document-library/document-library-web/src/test/java/com/liferay/document/library/web/internal/util/DLFolderUtilTest.java
@@ -76,7 +76,8 @@ public class DLFolderUtilTest {
 
 		Mockito.when(
 			depotEntryLocalService.getGroupConnectedDepotEntries(
-				Mockito.anyLong(), Mockito.anyInt(), Mockito.anyInt())
+				Mockito.anyLong(), Mockito.anyInt(), Mockito.anyInt(),
+				Mockito.anyInt())
 		).thenReturn(
 			depotEntries
 		);
@@ -112,7 +113,8 @@ public class DLFolderUtilTest {
 
 		Mockito.when(
 			depotEntryLocalService.getGroupConnectedDepotEntries(
-				Mockito.anyLong(), Mockito.anyInt(), Mockito.anyInt())
+				Mockito.anyLong(), Mockito.anyInt(), Mockito.anyInt(),
+				Mockito.anyInt())
 		).thenReturn(
 			depotEntries
 		);

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/StructuredContentResourceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.admin.content.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.dynamic.data.mapping.constants.DDMStructureConstants;
@@ -91,7 +92,7 @@ public class StructuredContentResourceTest
 		_depotEntry = _depotEntryLocalService.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testGroup.getCompanyId());

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateResourceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.admin.site.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.exportimport.kernel.service.StagingLocalService;
@@ -1667,7 +1668,8 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
-			new HashMap<>(), ServiceContextTestUtil.getServiceContext());
+			new HashMap<>(), DepotConstants.TYPE_ASSET_LIBRARY,
+			ServiceContextTestUtil.getServiceContext());
 
 		try {
 			unsafeConsumer.accept(depotEntry.getGroup());

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.headless.admin.taxonomy.client.dto.v1_0.Keyword;
@@ -138,7 +139,7 @@ public abstract class BaseKeywordResourceTestCase {
 		irrelevantDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());
@@ -149,7 +150,7 @@ public abstract class BaseKeywordResourceTestCase {
 		testDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.headless.admin.taxonomy.client.dto.v1_0.TaxonomyCategory;
@@ -113,7 +114,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		irrelevantDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());
@@ -124,7 +125,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		testDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.headless.admin.taxonomy.client.dto.v1_0.TaxonomyVocabulary;
@@ -138,7 +139,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		irrelevantDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());
@@ -149,7 +150,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		testDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/KeywordResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/KeywordResourceTest.java
@@ -11,6 +11,7 @@ import com.liferay.asset.kernel.model.AssetTagGroupRel;
 import com.liferay.asset.kernel.service.AssetTagGroupRelLocalService;
 import com.liferay.asset.kernel.service.AssetTagLocalServiceUtil;
 import com.liferay.asset.test.util.AssetTestUtil;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
@@ -718,6 +719,7 @@ public class KeywordResourceTest extends BaseKeywordResourceTestCase {
 	private AssetLibrary _randomAssetLibrary() throws Exception {
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			RandomTestUtil.randomLocaleStringMap(), null,
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		Group depotEntryGroup = depotEntry.getGroup();

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -8,6 +8,7 @@ package com.liferay.headless.admin.taxonomy.resource.v1_0.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.kernel.model.AssetVocabularyGroupRel;
 import com.liferay.asset.kernel.service.AssetVocabularyGroupRelLocalService;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
@@ -670,6 +671,7 @@ public class TaxonomyVocabularyResourceTest
 	private AssetLibrary _randomAssetLibrary() throws Exception {
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			RandomTestUtil.randomLocaleStringMap(), null,
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		Group depotEntryGroup = depotEntry.getGroup();

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserAccountResourceTest.java
@@ -21,6 +21,7 @@ import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.captcha.rest.client.dto.v1_0.Captcha;
 import com.liferay.captcha.rest.client.resource.v1_0.CaptchaResource;
 import com.liferay.captcha.simplecaptcha.SimpleCaptchaImpl;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
@@ -2221,7 +2222,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
-			new HashMap<>(),
+			new HashMap<>(), DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext(
 				TestPropsValues.getGroupId(), user.getUserId()));
 

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.asset.library.internal.resource.v1_0;
 
 import com.liferay.depot.constants.DepotActionKeys;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotAppCustomization;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.model.DepotEntryPin;
@@ -380,7 +381,8 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 		}
 
 		DepotEntry depotEntry = _depotEntryService.addDepotEntry(
-			nameMap, descriptionMap, serviceContext);
+			nameMap, descriptionMap, DepotConstants.TYPE_ASSET_LIBRARY,
+			serviceContext);
 
 		group = depotEntry.getGroup();
 

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseAssetLibraryResourceTestCase.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseAssetLibraryResourceTestCase.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.headless.asset.library.client.dto.v1_0.AssetLibrary;
@@ -105,7 +106,7 @@ public abstract class BaseAssetLibraryResourceTestCase {
 		irrelevantDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());
@@ -116,7 +117,7 @@ public abstract class BaseAssetLibraryResourceTestCase {
 		testDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseSiteResourceTestCase.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseSiteResourceTestCase.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.headless.asset.library.client.dto.v1_0.Site;
@@ -102,7 +103,7 @@ public abstract class BaseSiteResourceTestCase {
 		irrelevantDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());
@@ -113,7 +114,7 @@ public abstract class BaseSiteResourceTestCase {
 		testDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.headless.asset.library.client.dto.v1_0.UserAccount;
@@ -104,7 +105,7 @@ public abstract class BaseUserAccountResourceTestCase {
 		irrelevantDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());
@@ -115,7 +116,7 @@ public abstract class BaseUserAccountResourceTestCase {
 		testDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseUserGroupResourceTestCase.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseUserGroupResourceTestCase.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.headless.asset.library.client.dto.v1_0.UserGroup;
@@ -104,7 +105,7 @@ public abstract class BaseUserGroupResourceTestCase {
 		irrelevantDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());
@@ -115,7 +116,7 @@ public abstract class BaseUserGroupResourceTestCase {
 		testDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentElementResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentElementResourceTestCase.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.headless.delivery.client.dto.v1_0.ContentElement;
@@ -106,7 +107,7 @@ public abstract class BaseContentElementResourceTestCase {
 		irrelevantDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());
@@ -117,7 +118,7 @@ public abstract class BaseContentElementResourceTestCase {
 		testDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentSetElementResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentSetElementResourceTestCase.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.headless.delivery.client.dto.v1_0.ContentSetElement;
@@ -103,7 +104,7 @@ public abstract class BaseContentSetElementResourceTestCase {
 		irrelevantDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());
@@ -114,7 +115,7 @@ public abstract class BaseContentSetElementResourceTestCase {
 		testDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.headless.delivery.client.dto.v1_0.ContentStructure;
@@ -134,7 +135,7 @@ public abstract class BaseContentStructureResourceTestCase {
 		irrelevantDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());
@@ -145,7 +146,7 @@ public abstract class BaseContentStructureResourceTestCase {
 		testDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentTemplateResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentTemplateResourceTestCase.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.headless.delivery.client.dto.v1_0.ContentTemplate;
@@ -106,7 +107,7 @@ public abstract class BaseContentTemplateResourceTestCase {
 		irrelevantDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());
@@ -117,7 +118,7 @@ public abstract class BaseContentTemplateResourceTestCase {
 		testDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentDataDefinitionTypeResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentDataDefinitionTypeResourceTestCase.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.headless.batch.engine.client.dto.v1_0.ImportTask;
@@ -136,7 +137,7 @@ public abstract class BaseDocumentDataDefinitionTypeResourceTestCase {
 		irrelevantDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());
@@ -147,7 +148,7 @@ public abstract class BaseDocumentDataDefinitionTypeResourceTestCase {
 		testDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.headless.batch.engine.client.dto.v1_0.ImportTask;
@@ -140,7 +141,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		irrelevantDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());
@@ -151,7 +152,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		testDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentMetadataSetResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentMetadataSetResourceTestCase.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.headless.batch.engine.client.dto.v1_0.ImportTask;
@@ -134,7 +135,7 @@ public abstract class BaseDocumentMetadataSetResourceTestCase {
 		irrelevantDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());
@@ -145,7 +146,7 @@ public abstract class BaseDocumentMetadataSetResourceTestCase {
 		testDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.headless.batch.engine.client.dto.v1_0.ImportTask;
@@ -142,7 +143,7 @@ public abstract class BaseDocumentResourceTestCase {
 		irrelevantDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());
@@ -153,7 +154,7 @@ public abstract class BaseDocumentResourceTestCase {
 		testDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentShortcutResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentShortcutResourceTestCase.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.headless.batch.engine.client.dto.v1_0.ImportTask;
@@ -134,7 +135,7 @@ public abstract class BaseDocumentShortcutResourceTestCase {
 		irrelevantDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());
@@ -145,7 +146,7 @@ public abstract class BaseDocumentShortcutResourceTestCase {
 		testDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseLanguageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseLanguageResourceTestCase.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.headless.delivery.client.dto.v1_0.Field;
@@ -101,7 +102,7 @@ public abstract class BaseLanguageResourceTestCase {
 		irrelevantDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());
@@ -112,7 +113,7 @@ public abstract class BaseLanguageResourceTestCase {
 		testDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.headless.batch.engine.client.dto.v1_0.ImportTask;
@@ -139,7 +140,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		irrelevantDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());
@@ -150,7 +151,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		testDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.headless.batch.engine.client.dto.v1_0.ImportTask;
@@ -140,7 +141,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		irrelevantDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());
@@ -151,7 +152,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		testDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/ContentElementResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/ContentElementResourceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.delivery.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.document.library.test.util.DLAppTestUtil;
@@ -55,6 +56,7 @@ public class ContentElementResourceTest
 
 		DepotEntry depotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(LocaleUtil.getDefault(), name), null,
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext(testGroup.getGroupId()));
 
 		testGetAssetLibraryContentElementsPage_addContentElement(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/NavigationMenuResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/NavigationMenuResourceTest.java
@@ -8,6 +8,7 @@ package com.liferay.headless.delivery.resource.v1_0.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.blogs.service.BlogsEntryLocalService;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
@@ -160,7 +161,7 @@ public class NavigationMenuResourceTest
 		_depotEntry = _depotEntryLocalService.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testGroup.getCompanyId());

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/ObjectEntryFolderResourceTest.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/ObjectEntryFolderResourceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.object.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.headless.object.client.dto.v1_0.ObjectEntryFolder;
@@ -82,7 +83,7 @@ public class ObjectEntryFolderResourceTest
 		_testDepotEntry = _depotEntryLocalService.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testGroup.getCompanyId());

--- a/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.site.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.headless.site.client.dto.v1_0.Site;
@@ -322,7 +323,8 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		_depotEntry = _depotEntryLocalService.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null, ServiceContextTestUtil.getServiceContext());
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
+			ServiceContextTestUtil.getServiceContext());
 
 		sitesPage = siteResource.getSitesPage(null, Pagination.of(1, 100));
 

--- a/modules/apps/item-selector/item-selector-test/src/testIntegration/java/com/liferay/item/selector/test/taglib/test/GroupSelectorTagTest.java
+++ b/modules/apps/item-selector/item-selector-test/src/testIntegration/java/com/liferay/item/selector/test/taglib/test/GroupSelectorTagTest.java
@@ -6,6 +6,7 @@
 package com.liferay.item.selector.test.taglib.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
@@ -270,6 +271,7 @@ public class GroupSelectorTagTest {
 					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
 				Collections.singletonMap(
 					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+				DepotConstants.TYPE_ASSET_LIBRARY,
 				ServiceContextTestUtil.getServiceContext());
 
 			_depotEntries.add(depotEntry);

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/provider/test/JournalArticleSitemapURLProviderTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/provider/test/JournalArticleSitemapURLProviderTest.java
@@ -6,6 +6,7 @@
 package com.liferay.journal.internal.provider.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
@@ -208,6 +209,7 @@ public class JournalArticleSitemapURLProviderTest {
 				HashMapBuilder.put(
 					LocaleUtil.getDefault(), RandomTestUtil.randomString()
 				).build(),
+				DepotConstants.TYPE_ASSET_LIBRARY,
 				ServiceContextTestUtil.getServiceContext());
 
 			JournalArticle article = JournalTestUtil.addArticleWithWorkflow(

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/LayoutPageTemplateEntryLocalServiceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/LayoutPageTemplateEntryLocalServiceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.layout.page.template.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateCollectionTypeConstants;
@@ -247,7 +248,8 @@ public class LayoutPageTemplateEntryLocalServiceTest {
 
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			RandomTestUtil.randomLocaleStringMap(),
-			RandomTestUtil.randomLocaleStringMap(), _serviceContext);
+			RandomTestUtil.randomLocaleStringMap(),
+			DepotConstants.TYPE_ASSET_LIBRARY, _serviceContext);
 
 		Group depotGroup = depotEntry.getGroup();
 

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -7,6 +7,7 @@ package com.liferay.object.admin.rest.resource.v1_0.test;
 
 import com.liferay.account.model.AccountEntry;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.list.type.model.ListTypeDefinition;
@@ -1053,7 +1054,8 @@ public class ObjectDefinitionResourceTest
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
-			Collections.emptyMap(), ServiceContextTestUtil.getServiceContext());
+			Collections.emptyMap(), DepotConstants.TYPE_ASSET_LIBRARY,
+			ServiceContextTestUtil.getServiceContext());
 
 		Group group1 = depotEntry1.getGroup();
 
@@ -1089,7 +1091,8 @@ public class ObjectDefinitionResourceTest
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
-			Collections.emptyMap(), ServiceContextTestUtil.getServiceContext());
+			Collections.emptyMap(), DepotConstants.TYPE_ASSET_LIBRARY,
+			ServiceContextTestUtil.getServiceContext());
 
 		Group group2 = depotEntry2.getGroup();
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -7,6 +7,7 @@ package com.liferay.object.rest.internal.manager.v1_0;
 
 import com.liferay.account.exception.NoSuchGroupException;
 import com.liferay.batch.engine.attachment.BatchEngineAttachmentManager;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.object.action.engine.ObjectActionEngine;
@@ -627,7 +628,8 @@ public class DefaultObjectEntryManagerImpl
 
 			groupIds = TransformUtil.transformToArray(
 				_depotEntryLocalService.getGroupConnectedDepotEntries(
-					groupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+					groupId, DepotConstants.TYPE_ANY, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS),
 				depotEntry -> depotEntry.getGroupId(), Long.class);
 		}
 		else {

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -20,6 +20,7 @@ import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
@@ -5687,6 +5688,7 @@ public class DefaultObjectEntryManagerImplTest
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		Group group = _groupLocalService.getGroup(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -14,6 +14,7 @@ import com.liferay.asset.kernel.service.AssetCategoryLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetTagLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.model.DLFileEntry;
@@ -7709,6 +7710,7 @@ public class ObjectEntryResourceTest {
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			RandomTestUtil.randomLocaleStringMap(),
 			RandomTestUtil.randomLocaleStringMap(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		ObjectEntry depotScopedObjectEntry = ObjectEntryTestUtil.addObjectEntry(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/model/listener/test/GroupModelListenerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/model/listener/test/GroupModelListenerTest.java
@@ -6,6 +6,7 @@
 package com.liferay.object.internal.model.listener.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.object.constants.ObjectDefinitionConstants;
@@ -76,6 +77,7 @@ public class GroupModelListenerTest {
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			RandomTestUtil.randomLocaleStringMap(),
 			RandomTestUtil.randomLocaleStringMap(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		_testOnBeforeRemove(depotEntry.getGroup());
@@ -113,6 +115,7 @@ public class GroupModelListenerTest {
 			DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 				RandomTestUtil.randomLocaleStringMap(),
 				RandomTestUtil.randomLocaleStringMap(),
+				DepotConstants.TYPE_ASSET_LIBRARY,
 				ServiceContextTestUtil.getServiceContext());
 
 			_objectDefinitionSettingLocalService.addObjectDefinitionSetting(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.object.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.object.constants.ObjectActionExecutorConstants;
@@ -791,6 +792,7 @@ public class ObjectDefinitionLocalServiceTest {
 
 		DepotEntry depotEntry1 = _depotEntryLocalService.addDepotEntry(
 			RandomTestUtil.randomLocaleStringMap(), Collections.emptyMap(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		AssertUtils.assertFailure(
@@ -869,6 +871,7 @@ public class ObjectDefinitionLocalServiceTest {
 
 		DepotEntry depotEntry2 = _depotEntryLocalService.addDepotEntry(
 			RandomTestUtil.randomLocaleStringMap(), Collections.emptyMap(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		ObjectEntry objectEntry3 = ObjectEntryTestUtil.addObjectEntry(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -20,6 +20,7 @@ import com.liferay.commerce.product.model.CommerceChannel;
 import com.liferay.commerce.service.CommerceOrderLocalServiceUtil;
 import com.liferay.commerce.test.util.CommerceTestUtil;
 import com.liferay.counter.kernel.service.CounterLocalService;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
@@ -2645,6 +2646,7 @@ public class ObjectEntryLocalServiceTest {
 		DepotEntry depotEntry1 = _depotEntryLocalService.addDepotEntry(
 			RandomTestUtil.randomLocaleStringMap(),
 			RandomTestUtil.randomLocaleStringMap(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		ObjectEntry objectEntry1 = _addObjectEntry(
@@ -2670,6 +2672,7 @@ public class ObjectEntryLocalServiceTest {
 		DepotEntry depotEntry2 = _depotEntryLocalService.addDepotEntry(
 			RandomTestUtil.randomLocaleStringMap(),
 			RandomTestUtil.randomLocaleStringMap(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		AssertUtils.assertFailure(
@@ -5130,6 +5133,7 @@ public class ObjectEntryLocalServiceTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		_testScope(0, ObjectDefinitionConstants.SCOPE_COMPANY, true);
@@ -5190,6 +5194,7 @@ public class ObjectEntryLocalServiceTest {
 		DepotEntry depotEntry2 = _depotEntryLocalService.addDepotEntry(
 			RandomTestUtil.randomLocaleStringMap(),
 			RandomTestUtil.randomLocaleStringMap(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		AssertUtils.assertFailure(

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/util/test/GroupUtilTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/util/test/GroupUtilTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.vulcan.util.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -53,6 +54,7 @@ public class GroupUtilTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), StringUtil.randomString()
 			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 	}
 

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
@@ -49,6 +49,7 @@ import com.liferay.commerce.product.service.CommerceCatalogLocalService;
 import com.liferay.commerce.product.service.CommerceChannelLocalService;
 import com.liferay.data.engine.rest.dto.v2_0.DataDefinition;
 import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotAppCustomization;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotAppCustomizationLocalService;
@@ -1483,7 +1484,8 @@ public class BundleSiteInitializerTest {
 	private void _assertDepotEntries1() throws Exception {
 		List<DepotEntry> depotEntries =
 			_depotEntryLocalService.getGroupConnectedDepotEntries(
-				_group.getGroupId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+				_group.getGroupId(), DepotConstants.TYPE_ANY, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS);
 
 		Assert.assertEquals(depotEntries.toString(), 2, depotEntries.size());
 
@@ -1513,7 +1515,7 @@ public class BundleSiteInitializerTest {
 	private void _assertDepotEntries2() throws Exception {
 		List<DepotEntry> depotEntries =
 			_depotEntryLocalService.getGroupConnectedDepotEntries(
-				_group.getGroupId(), -1, -1);
+				_group.getGroupId(), DepotConstants.TYPE_ANY, -1, -1);
 
 		Assert.assertEquals(depotEntries.toString(), 3, depotEntries.size());
 

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -36,6 +36,7 @@ import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.client.extension.util.CETUtil;
 import com.liferay.data.engine.rest.dto.v2_0.DataDefinition;
 import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
@@ -1947,7 +1948,7 @@ public class BundleSiteInitializer implements SiteInitializer {
 						jsonObject.getString("name_i18n")),
 					SiteInitializerUtil.toMap(
 						jsonObject.getString("description_i18n")),
-					serviceContext);
+					DepotConstants.TYPE_ASSET_LIBRARY, serviceContext);
 			}
 
 			UnicodeProperties unicodeProperties = new UnicodeProperties(true);

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
@@ -5,6 +5,7 @@
 
 package com.liferay.site.cms.site.initializer.internal.display.context.test;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
@@ -374,6 +375,7 @@ public abstract class BaseSectionDisplayContextTestCase
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), StringUtil.randomString()
 			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 	}
 

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/SpaceStickerDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/SpaceStickerDisplayContextTest.java
@@ -6,6 +6,7 @@
 package com.liferay.site.cms.site.initializer.internal.display.context.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.fragment.constants.FragmentConstants;
@@ -119,6 +120,7 @@ public class SpaceStickerDisplayContextTest extends BaseDisplayContextTestCase {
 
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			Collections.singletonMap(LocaleUtil.getDefault(), name), null,
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(group.getCompanyId());

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewSpacesSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewSpacesSectionDisplayContextTest.java
@@ -6,6 +6,7 @@
 package com.liferay.site.cms.site.initializer.internal.display.context.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.fragment.renderer.FragmentRenderer;
@@ -208,7 +209,7 @@ public class ViewSpacesSectionDisplayContextTest
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(group.getCompanyId());
@@ -235,7 +236,7 @@ public class ViewSpacesSectionDisplayContextTest
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(group.getCompanyId());

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/GroupModelListenerTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/GroupModelListenerTest.java
@@ -6,6 +6,7 @@
 package com.liferay.site.cms.site.initializer.internal.model.listener.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
@@ -46,6 +47,7 @@ public class GroupModelListenerTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), StringUtil.randomString()
 			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		_depotEntryLocalService.deleteDepotEntry(depotEntry.getDepotEntryId());

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/notifications/test/DepotEntryUserNotificationTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/notifications/test/DepotEntryUserNotificationTest.java
@@ -6,6 +6,7 @@
 package com.liferay.site.cms.site.initializer.internal.notifications.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.constants.DepotPortletKeys;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
@@ -60,6 +61,7 @@ public class DepotEntryUserNotificationTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), StringUtil.randomString()
 			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 	}
 

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/DepotEntryLocalServiceTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/DepotEntryLocalServiceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.site.cms.site.initializer.internal.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
@@ -61,6 +62,7 @@ public class DepotEntryLocalServiceTest {
 				HashMapBuilder.put(
 					LocaleUtil.getDefault(), StringUtil.randomString()
 				).build(),
+				DepotConstants.TYPE_ASSET_LIBRARY,
 				ServiceContextTestUtil.getServiceContext()));
 
 		Group group = GroupTestUtil.addGroup();

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/servlet/test/DownloadObjectEntryFolderServletTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/servlet/test/DownloadObjectEntryFolderServletTest.java
@@ -6,6 +6,7 @@
 package com.liferay.site.cms.site.initializer.internal.servlet.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
@@ -95,7 +96,7 @@ public class DownloadObjectEntryFolderServletTest {
 		return _depotEntryLocalService.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(_group.getCompanyId());

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/AddStructuredContentItemStrutsActionTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/AddStructuredContentItemStrutsActionTest.java
@@ -6,6 +6,7 @@
 package com.liferay.site.cms.site.initializer.internal.struts.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.layout.constants.LayoutTypeSettingsConstants;
@@ -108,6 +109,7 @@ public class AddStructuredContentItemStrutsActionTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		_group = GroupLocalServiceUtil.getGroup(

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/EditStructureDisplayPageStrutsActionTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/EditStructureDisplayPageStrutsActionTest.java
@@ -6,6 +6,7 @@
 package com.liferay.site.cms.site.initializer.internal.struts.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
@@ -108,6 +109,7 @@ public class EditStructureDisplayPageStrutsActionTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		_group = _groupLocalService.getGroup(

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/ResetStructureDisplayPageStrutsActionTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/ResetStructureDisplayPageStrutsActionTest.java
@@ -6,6 +6,7 @@
 package com.liferay.site.cms.site.initializer.internal.struts.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.layout.constants.LayoutTypeSettingsConstants;
@@ -99,6 +100,7 @@ public class ResetStructureDisplayPageStrutsActionTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
 		_group = _groupLocalService.getGroup(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/service/CMSObjectEntryFolderDepotEntryLocalServiceWrapper.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/service/CMSObjectEntryFolderDepotEntryLocalServiceWrapper.java
@@ -45,11 +45,11 @@ public class CMSObjectEntryFolderDepotEntryLocalServiceWrapper
 	@Override
 	public DepotEntry addDepotEntry(
 			Map<Locale, String> nameMap, Map<Locale, String> descriptionMap,
-			ServiceContext serviceContext)
+			int type, ServiceContext serviceContext)
 		throws PortalException {
 
 		DepotEntry depotEntry = super.addDepotEntry(
-			nameMap, descriptionMap, serviceContext);
+			nameMap, descriptionMap, type, serviceContext);
 
 		_addObjectEntryFolders(depotEntry);
 

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseAssetLibraryTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseAssetLibraryTestEntityResourceTestCase.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.petra.function.transform.TransformUtil;
@@ -101,7 +102,7 @@ public abstract class BaseAssetLibraryTestEntityResourceTestCase {
 		irrelevantDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());
@@ -112,7 +113,7 @@ public abstract class BaseAssetLibraryTestEntityResourceTestCase {
 		testDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCAssetLibraryTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCAssetLibraryTestEntityResourceTestCase.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.headless.batch.engine.client.dto.v1_0.ImportTask;
@@ -104,7 +105,7 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 		irrelevantDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());
@@ -115,7 +116,7 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 		testDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCScopedTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCScopedTestEntityResourceTestCase.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.headless.batch.engine.client.dto.v1_0.ImportTask;
@@ -106,7 +107,7 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 		irrelevantDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());
@@ -117,7 +118,7 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 		testDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseScopedTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseScopedTestEntityResourceTestCase.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.headless.batch.engine.client.dto.v1_0.ImportTask;
@@ -104,7 +105,7 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 		irrelevantDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());
@@ -115,7 +116,7 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 		testDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null,
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
 			new ServiceContext() {
 				{
 					setCompanyId(testCompany.getCompanyId());

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -60,6 +60,7 @@ import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 </#list>
 
 <#if generateDepotEntry>
+	import com.liferay.depot.constants.DepotConstants;
 	import com.liferay.depot.model.DepotEntry;
 	import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 </#if>
@@ -192,6 +193,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 		<#if generateDepotEntry>
 			irrelevantDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 				Collections.singletonMap(LocaleUtil.getDefault(), RandomTestUtil.randomString()), null,
+				DepotConstants.TYPE_ASSET_LIBRARY,
 				new ServiceContext() {
 					{
 						setCompanyId(testCompany.getCompanyId());
@@ -201,6 +203,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 			irrelevantDepotEntryGroup = irrelevantDepotEntry.getGroup();
 			testDepotEntry = DepotEntryLocalServiceUtil.addDepotEntry(
 				Collections.singletonMap(LocaleUtil.getDefault(), RandomTestUtil.randomString()), null,
+				DepotConstants.TYPE_ASSET_LIBRARY,
 				new ServiceContext() {
 					{
 						setCompanyId(testCompany.getCompanyId());


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-61564

We need to differentiate between asset libraries and spaces, so that the CMS only works with the new subtype "space".

Manually forwarded from https://github.com/liferay-content-management/liferay-portal/pull/6916

# How am I fixing it?

By adding a new column to the depot entry and group rel tables.

# How can you verify that it works?

Run the new integration test. To verify for regressions, run the existing asset libraries functional tests.