### PR TITLE
LPD-61662 Page menu item is not published correctly when its parent item's page is excluded from the export

### DIFF
--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java
@@ -35,7 +35,6 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -110,12 +109,6 @@ public class LayoutSiteNavigationMenuItemType
 						privateLayout ? "private" : "public",
 						" layout is exported."));
 			}
-
-			return false;
-		}
-
-		if (!ArrayUtil.contains(
-				portletDataContext.getLayoutIds(), layout.getLayoutId())) {
 
 			return false;
 		}

--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java
@@ -128,7 +128,7 @@ public class LayoutSiteNavigationMenuItemType
 
 		portletDataContext.addReferenceElement(
 			siteNavigationMenuItem, siteNavigationMenuItemElement, layout,
-			PortletDataContext.REFERENCE_TYPE_DEPENDENCY, true);
+			PortletDataContext.REFERENCE_TYPE_DEPENDENCY_DISPOSABLE, true);
 
 		return true;
 	}

--- a/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/menu/web/internal/exportimport/test/SiteNavigationMenuExportImportTest.java
+++ b/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/menu/web/internal/exportimport/test/SiteNavigationMenuExportImportTest.java
@@ -28,6 +28,7 @@ import com.liferay.portlet.display.template.test.util.BaseExportImportTestCase;
 import com.liferay.site.navigation.constants.SiteNavigationMenuPortletKeys;
 import com.liferay.site.navigation.model.SiteNavigationMenu;
 import com.liferay.site.navigation.model.SiteNavigationMenuItem;
+import com.liferay.site.navigation.service.SiteNavigationMenuItemLocalService;
 import com.liferay.site.navigation.service.SiteNavigationMenuLocalService;
 import com.liferay.site.navigation.test.util.SiteNavigationMenuItemTestUtil;
 import com.liferay.site.navigation.test.util.SiteNavigationMenuTestUtil;
@@ -108,6 +109,58 @@ public class SiteNavigationMenuExportImportTest
 	@Override
 	@Test
 	public void testExportImportAssetLinks() throws Exception {
+	}
+
+	@Test
+	public void testExportImportChildLayoutSiteNavigationMenuItems()
+		throws Exception {
+
+		_setUpLocalStaging();
+
+		_setUpSiteNavigationMenu(_stagingGroup);
+
+		Layout parentLayout = LayoutTestUtil.addTypePortletLayout(
+			_stagingGroup);
+
+		SiteNavigationMenuItem parentSiteNavigationMenuItem =
+			SiteNavigationMenuItemTestUtil.addLayoutTypeSiteNavigationMenuItem(
+				_siteNavigationMenu, parentLayout, 0L);
+
+		Layout childLayout1 = LayoutTestUtil.addTypePortletLayout(
+			_stagingGroup);
+
+		SiteNavigationMenuItem childSiteNavigationMenuItem1 =
+			SiteNavigationMenuItemTestUtil.addLayoutTypeSiteNavigationMenuItem(
+				_siteNavigationMenu, childLayout1,
+				parentSiteNavigationMenuItem.getSiteNavigationMenuItemId());
+
+		_publishLayouts();
+
+		Layout childLayout2 = LayoutTestUtil.addTypePortletLayout(
+			_stagingGroup);
+
+		SiteNavigationMenuItem childSiteNavigationMenuItem2 =
+			SiteNavigationMenuItemTestUtil.addLayoutTypeSiteNavigationMenuItem(
+				_siteNavigationMenu, childLayout2,
+				childSiteNavigationMenuItem1.getSiteNavigationMenuItemId());
+
+		_publishLayouts(new long[] {childLayout2.getLayoutId()});
+
+		childSiteNavigationMenuItem2 =
+			_siteNavigationMenuItemLocalService.
+				getSiteNavigationMenuItemByUuidAndGroupId(
+					childSiteNavigationMenuItem2.getUuid(),
+					_liveGroup.getGroupId());
+
+		childSiteNavigationMenuItem1 =
+			_siteNavigationMenuItemLocalService.fetchSiteNavigationMenuItem(
+				childSiteNavigationMenuItem2.
+					getParentSiteNavigationMenuItemId());
+
+		Assert.assertNotNull(childSiteNavigationMenuItem1);
+
+		Assert.assertEquals(
+			_liveGroup.getGroupId(), childSiteNavigationMenuItem1.getGroupId());
 	}
 
 	@Test
@@ -202,20 +255,31 @@ public class SiteNavigationMenuExportImportTest
 	}
 
 	private void _publishLayouts() throws Exception {
+		_publishLayouts(null);
+	}
+
+	private void _publishLayouts(long[] layoutIds) throws Exception {
 		Map<String, String[]> parameterMap =
 			ExportImportConfigurationParameterMapFactoryUtil.
 				buildParameterMap();
 
 		parameterMap.put(
 			PortletDataHandlerKeys.PORTLET_DATA,
-			new String[] {Boolean.FALSE.toString()});
+			new String[] {Boolean.TRUE.toString()});
 		parameterMap.put(
 			PortletDataHandlerKeys.PORTLET_DATA_ALL,
 			new String[] {Boolean.FALSE.toString()});
 
-		StagingUtil.publishLayouts(
-			TestPropsValues.getUserId(), _stagingGroup.getGroupId(),
-			_liveGroup.getGroupId(), false, parameterMap);
+		if (layoutIds != null) {
+			StagingUtil.publishLayouts(
+				TestPropsValues.getUserId(), _stagingGroup.getGroupId(),
+				_liveGroup.getGroupId(), false, layoutIds, parameterMap);
+		}
+		else {
+			StagingUtil.publishLayouts(
+				TestPropsValues.getUserId(), _stagingGroup.getGroupId(),
+				_liveGroup.getGroupId(), false, parameterMap);
+		}
 	}
 
 	private void _setUpLocalStaging() throws Exception {
@@ -249,6 +313,10 @@ public class SiteNavigationMenuExportImportTest
 
 	private SiteNavigationMenu _siteNavigationMenu;
 	private SiteNavigationMenuItem _siteNavigationMenuItem;
+
+	@Inject
+	private SiteNavigationMenuItemLocalService
+		_siteNavigationMenuItemLocalService;
 
 	@Inject
 	private SiteNavigationMenuLocalService _siteNavigationMenuLocalService;

--- a/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/menu/web/internal/exportimport/test/SiteNavigationMenuExportImportTest.java
+++ b/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/menu/web/internal/exportimport/test/SiteNavigationMenuExportImportTest.java
@@ -76,7 +76,7 @@ public class SiteNavigationMenuExportImportTest
 				new String[] {_siteNavigationMenu.getExternalReferenceCode()}
 			).build());
 
-		_publishLayouts();
+		_publishAllLayouts();
 
 		_siteNavigationMenuLocalService.
 			getSiteNavigationMenuByExternalReferenceCode(
@@ -134,7 +134,7 @@ public class SiteNavigationMenuExportImportTest
 				_siteNavigationMenu, childLayout1,
 				parentSiteNavigationMenuItem.getSiteNavigationMenuItemId());
 
-		_publishLayouts();
+		_publishAllLayouts();
 
 		Layout childLayout2 = LayoutTestUtil.addTypePortletLayout(
 			_stagingGroup);
@@ -175,7 +175,7 @@ public class SiteNavigationMenuExportImportTest
 				"siteNavigationMenuType", new String[] {"1"}
 			).build());
 
-		_publishLayouts();
+		_publishAllLayouts();
 
 		Layout layout = _layoutLocalService.getLayoutByUuidAndGroupId(
 			_layout.getUuid(), _liveGroup.getGroupId(),
@@ -221,7 +221,7 @@ public class SiteNavigationMenuExportImportTest
 				new String[] {curGroup.getExternalReferenceCode()}
 			).build());
 
-		_publishLayouts();
+		_publishAllLayouts();
 
 		Assert.assertNull(
 			_siteNavigationMenuLocalService.
@@ -254,8 +254,21 @@ public class SiteNavigationMenuExportImportTest
 				"rootMenuItemExternalReferenceCode", StringPool.BLANK));
 	}
 
-	private void _publishLayouts() throws Exception {
-		_publishLayouts(null);
+	private void _publishAllLayouts() throws Exception {
+		Map<String, String[]> parameterMap =
+			ExportImportConfigurationParameterMapFactoryUtil.
+				buildParameterMap();
+
+		parameterMap.put(
+			PortletDataHandlerKeys.PORTLET_DATA,
+			new String[] {Boolean.TRUE.toString()});
+		parameterMap.put(
+			PortletDataHandlerKeys.PORTLET_DATA_ALL,
+			new String[] {Boolean.FALSE.toString()});
+
+		StagingUtil.publishLayouts(
+			TestPropsValues.getUserId(), _stagingGroup.getGroupId(),
+			_liveGroup.getGroupId(), false, parameterMap);
 	}
 
 	private void _publishLayouts(long[] layoutIds) throws Exception {
@@ -270,16 +283,9 @@ public class SiteNavigationMenuExportImportTest
 			PortletDataHandlerKeys.PORTLET_DATA_ALL,
 			new String[] {Boolean.FALSE.toString()});
 
-		if (layoutIds != null) {
-			StagingUtil.publishLayouts(
-				TestPropsValues.getUserId(), _stagingGroup.getGroupId(),
-				_liveGroup.getGroupId(), false, layoutIds, parameterMap);
-		}
-		else {
-			StagingUtil.publishLayouts(
-				TestPropsValues.getUserId(), _stagingGroup.getGroupId(),
-				_liveGroup.getGroupId(), false, parameterMap);
-		}
+		StagingUtil.publishLayouts(
+			TestPropsValues.getUserId(), _stagingGroup.getGroupId(),
+			_liveGroup.getGroupId(), false, layoutIds, parameterMap);
 	}
 
 	private void _setUpLocalStaging() throws Exception {

--- a/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/test/util/SiteNavigationMenuItemTestUtil.java
+++ b/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/test/util/SiteNavigationMenuItemTestUtil.java
@@ -7,8 +7,11 @@ package com.liferay.site.navigation.test.util;
 
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.site.navigation.menu.item.layout.constants.SiteNavigationMenuItemTypeConstants;
 import com.liferay.site.navigation.model.SiteNavigationMenu;
 import com.liferay.site.navigation.model.SiteNavigationMenuItem;
@@ -18,6 +21,33 @@ import com.liferay.site.navigation.service.SiteNavigationMenuItemLocalServiceUti
  * @author Kyle Miho
  */
 public class SiteNavigationMenuItemTestUtil {
+
+	public static SiteNavigationMenuItem addLayoutTypeSiteNavigationMenuItem(
+			SiteNavigationMenu siteNavigationMenu, Layout layout,
+			long parentSiteNavigationMenuItemId)
+		throws PortalException {
+
+		return SiteNavigationMenuItemLocalServiceUtil.addSiteNavigationMenuItem(
+			null, TestPropsValues.getUserId(), siteNavigationMenu.getGroupId(),
+			siteNavigationMenu.getSiteNavigationMenuId(),
+			parentSiteNavigationMenuItemId,
+			SiteNavigationMenuItemTypeConstants.LAYOUT,
+			UnicodePropertiesBuilder.create(
+				true
+			).put(
+				"externalReferenceCode", layout.getExternalReferenceCode()
+			).put(
+				"groupId", String.valueOf(layout.getGroupId())
+			).put(
+				"layoutUuid", layout.getUuid()
+			).put(
+				"privateLayout", String.valueOf(layout.isPrivateLayout())
+			).put(
+				"title", layout.getName(LocaleUtil.getDefault())
+			).buildString(),
+			ServiceContextTestUtil.getServiceContext(
+				siteNavigationMenu.getGroupId()));
+	}
 
 	public static SiteNavigationMenuItem addSiteNavigationMenuItem(
 			SiteNavigationMenu siteNavigationMenu)


### PR DESCRIPTION
Resending: https://github.com/brianchandotcom/liferay-portal/pull/164182#issuecomment-3150506732

@brianchandotcom ,
Yes, the order of `_setUpLocalStaging();` and `_setUpSiteNavigationMenu(_stagingGroup);` matters:
* Without `_setUpLocalStaging();`, we have no `_liveGroup` and `_stagingGroup` set up in the test.
* The scenario we want to test first involves activating staging, and then create the MenuItems, to check how we publish them the first time, when they did not exist in live. If it was the other way around, then they would already exist in live.