### PR TITLE
LPD-62507 source-formatter: do not require a breaking changes message if there was no previous version

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/YMLRESTConfigFileBreakingChangeCommitMessageCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/YMLRESTConfigFileBreakingChangeCommitMessageCheck.java
@@ -77,6 +77,10 @@ public class YMLRESTConfigFileBreakingChangeCommitMessageCheck
 				}
 			}
 
+			if (oldCompatibilityVersion == null) {
+				continue;
+			}
+
 			return !StringUtil.equals(
 				newCompatibilityVersion, oldCompatibilityVersion);
 		}


### PR DESCRIPTION
Tested [here](https://github.com/liferay-devtools/liferay-portal/pull/550), unrelated failures.