### PR TITLE
LPD-63018 Make CETEditorConfigContributor virtual instance aware

### DIFF
--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/portlet/editor/config/contributor/CETEditorConfigContributor.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/portlet/editor/config/contributor/CETEditorConfigContributor.java
@@ -26,9 +26,10 @@ public class CETEditorConfigContributor
 	implements EditorConfigContributor, Registrable {
 
 	public CETEditorConfigContributor(
-		String editorConfigKeys, String editorNames, String portletNames,
-		String url) {
+		long companyId, String editorConfigKeys, String editorNames,
+		String portletNames, String url) {
 
+		_companyId = companyId;
 		_editorConfigKeys = editorConfigKeys;
 		_editorNames = editorNames;
 		_portletNames = portletNames;
@@ -73,6 +74,10 @@ public class CETEditorConfigContributor
 		ThemeDisplay themeDisplay,
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
 
+		if (themeDisplay.getCompanyId() != _companyId) {
+			return;
+		}
+
 		JSONArray jsonArray = jsonObject.getJSONArray("editorTransformerURLs");
 
 		if (jsonArray == null) {
@@ -84,6 +89,7 @@ public class CETEditorConfigContributor
 		jsonArray.put(_url);
 	}
 
+	private final long _companyId;
 	private final String _editorConfigKeys;
 	private final String _editorNames;
 	private final String _portletNames;

--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/type/deployer/CETDeployerImpl.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/type/deployer/CETDeployerImpl.java
@@ -177,6 +177,7 @@ public class CETDeployerImpl implements CETDeployer {
 			_register(
 				EditorConfigContributor.class,
 				new CETEditorConfigContributor(
+					editorConfigContributorCET.getCompanyId(),
 					editorConfigContributorCET.getEditorConfigKeys(),
 					editorConfigContributorCET.getEditorNames(),
 					editorConfigContributorCET.getPortletNames(),

--- a/modules/test/playwright/tests/client-extension-web/main/editorConfigContributor.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/main/editorConfigContributor.spec.ts
@@ -7,7 +7,9 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../fixtures/loginTest';
+import {virtualInstancesPagesTest} from '../../../fixtures/virtualInstancesPagesTest';
 import getRandomString from '../../../utils/getRandomString';
+import performLogin from '../../../utils/performLogin';
 import {journalPagesTest} from '../../journal-web/main/fixtures/journalPagesTest';
 import {clientExtensionsPageTest} from './fixtures/clientExtensionsPageTest';
 import {editEditorConfigContributorPageTest} from './fixtures/editEditorConfigContributorPageTest';
@@ -23,7 +25,8 @@ const test = mergeTests(
 		'LPS-178052': {enabled: true},
 	}),
 	loginTest(),
-	journalPagesTest
+	journalPagesTest,
+	virtualInstancesPagesTest
 );
 
 test('Create, edit and delete editor config contributor client extension @LPS-186870', async ({
@@ -167,5 +170,73 @@ test('CKEditor is still usable after deploying Client Extension @LPD-31017', asy
 		await editorTextBox.fill('LPD-31017');
 
 		await expect(editorTextBox).toHaveText('LPD-31017');
+	});
+});
+
+test('Check client extension does not apply to new instances @LPD-63018', async ({
+	browser,
+	virtualInstancesPage,
+}) => {
+	const DEFAULT_VIRTUAL_INSTANCE_NAME = 'www.able.com';
+	const virtualInstancePage = await browser.newPage({
+		baseURL: `http://${DEFAULT_VIRTUAL_INSTANCE_NAME}:8080`,
+	});
+	await test.step('Create virtual instance', async () => {
+		test.slow();
+
+		await virtualInstancesPage.addNewVirtualInstance(
+			DEFAULT_VIRTUAL_INSTANCE_NAME
+		);
+
+		await performLogin(
+			virtualInstancePage,
+			'test',
+			'?p_p_id=com_liferay_login_web_portlet_LoginPortlet&' +
+				'p_p_state=maximized',
+			`@${DEFAULT_VIRTUAL_INSTANCE_NAME}.com`
+		);
+	});
+
+	await test.step('Check toolbar does not appear', async () => {
+		await virtualInstancePage.getByRole('link', {name: 'Edit'}).click();
+
+		await virtualInstancePage
+			.getByLabel('Search Fragments and Widgets')
+			.fill('ckeditor');
+
+		await virtualInstancePage
+			.getByRole('menuitem', {name: 'CKEditor Sample Add CKEditor'})
+			.locator('div')
+			.first()
+			.click();
+
+		await virtualInstancePage.keyboard.press('ArrowLeft');
+
+		await virtualInstancePage.keyboard.press('Enter');
+
+		await virtualInstancePage.keyboard.press('Enter');
+
+		await virtualInstancePage
+			.locator('header')
+			.filter({hasText: 'CKEditor Sample'})
+			.first()
+			.waitFor({state: 'visible'});
+
+		await virtualInstancePage.getByLabel('Publish').click();
+
+		await virtualInstancePage
+			.getByRole('link', {name: 'CKEditor 4'})
+			.first()
+			.click();
+
+		await virtualInstancePage.getByRole('link', {name: 'Alloy'}).click();
+
+		await expect(
+			virtualInstancePage.getByText('Alloy Editor')
+		).toBeVisible();
+
+		await expect(
+			virtualInstancePage.getByTitle('Insert Video')
+		).not.toBeInViewport();
 	});
 });

--- a/modules/test/playwright/tests/client-extension-web/main/env/portal-ext.properties
+++ b/modules/test/playwright/tests/client-extension-web/main/env/portal-ext.properties
@@ -1,2 +1,5 @@
+terms.of.use.required=false
+passwords.default.policy.change.required=false
+setup.wizard.enabled=false
 feature.flag.LPD-34594=true
 feature.flag.LPS-164563=true


### PR DESCRIPTION
FWD: https://github.com/liferay-frontend/liferay-portal/pull/5046

https://liferay.atlassian.net/browse/LPD-63018
https://liferay.atlassian.net/browse/LPP-60124

Client Extensions would be added to every instance and causing issues in the editor.
The current solution is to check the companyId matches for the client extension.

Please let me know if there are any questions or comments about this.
Thank you!