### PR TITLE
LPD-63742 Improve UserGroupRole cacheability, during login one user i…

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -454,18 +454,19 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 		Set<Long> roleIdsSet = SetUtil.fromArray(userBag.getRoleIds());
 
 		List<UserGroupRole> userGroupRoles =
-			UserGroupRoleLocalServiceUtil.getUserGroupRoles(userId, groupId);
+			UserGroupRoleLocalServiceUtil.getUserGroupRoles(userId);
 
 		for (UserGroupRole userGroupRole : userGroupRoles) {
-			roleIdsSet.add(userGroupRole.getRoleId());
+			if (userGroupRole.getGroupId() == groupId) {
+				roleIdsSet.add(userGroupRole.getRoleId());
+			}
 		}
 
 		if (parentGroupId > 0) {
-			userGroupRoles = UserGroupRoleLocalServiceUtil.getUserGroupRoles(
-				userId, parentGroupId);
-
 			for (UserGroupRole userGroupRole : userGroupRoles) {
-				roleIdsSet.add(userGroupRole.getRoleId());
+				if (userGroupRole.getGroupId() == parentGroupId) {
+					roleIdsSet.add(userGroupRole.getRoleId());
+				}
 			}
 		}
 


### PR DESCRIPTION
…s checked for multiple groups to collect roles, rather than pulling the data mapping one by one, a bulk fetching will reduce the db accessing and make the data more cacheable.