### PR TITLE
LPD-58688 Follow-up: Add missing 'collation' word

### DIFF
--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseCharacterSet.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseCharacterSet.java
@@ -89,8 +89,9 @@ public class PreupgradeVerifyDatabaseCharacterSet
 							resultSet.getString("default_character_set_name"),
 							" character set and ",
 							resultSet.getString("default_collation_name"),
-							". Recommended character set is utf8mb4 and ",
-							"recommended collation is utf8mb4_unicode_ci."));
+							" collation. Recommended character set is utf8mb4 ",
+							"and recommended collation is ",
+							"utf8mb4_unicode_ci."));
 				}
 			}
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-58688

There is a missing 'collation' word in the warn trace.