### PR TITLE
LPD-63797 Adding necessary MIME types for serving static content from…

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -5328,7 +5328,10 @@
         jpg,\
         pdf,\
         png,\
-        wmv
+        wmv,\
+        html,\
+        css,\
+        js
 
     #
     # Input a list of comma delimited MIME types that are optimized for


### PR DESCRIPTION
… Document and Media

Currently, when uploading HTML files to Documents and Media in Liferay, they are treated as attachments and downloaded instead of being rendered inline. MIME types need to be adjusted to allow inline rendering, any linked assets (CSS, JS, images) must be referenced using their individual document URLs. We should allow HTML files uploaded in Documents and Media to be rendered inline by default.