### PR TITLE
LPD-62552 - fds-web - make sure that the main filter and filter resume are synced up

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/FiltersDropdown.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/FiltersDropdown.js
@@ -42,7 +42,7 @@ const FiltersDropdown = () => {
 			onActiveChange={(active) => {
 				setActive(active);
 
-				if (active) {
+				if(active) {					
 					setActiveFilter(null);
 				}
 			}}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/FiltersDropdown.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/FiltersDropdown.js
@@ -33,7 +33,19 @@ const FiltersDropdown = () => {
 
 	useEffect(() => {
 		setFilters(initialFilters);
-	}, [initialFilters]);
+
+		setActiveFilter((currentActiveFilter) => {
+			if (!currentActiveFilter) {
+				return currentActiveFilter;
+			}
+
+			return (
+				initialFilters.find(
+					(filter) => filter.id === currentActiveFilter.id
+				) || null
+			);
+		});
+	}, [initialFilters, setActiveFilter, setFilters]);
 
 	return (
 		<ClayDropDown

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/FiltersDropdown.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/FiltersDropdown.js
@@ -36,7 +36,7 @@ const FiltersDropdown = () => {
 
 		setActiveFilter((currentActiveFilter) => {
 			if (!currentActiveFilter) {
-				return currentActiveFilter;
+				return null;
 			}
 
 			return (

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/FiltersDropdown.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/FiltersDropdown.js
@@ -39,13 +39,7 @@ const FiltersDropdown = () => {
 		<ClayDropDown
 			active={active}
 			className="filters-dropdown"
-			onActiveChange={(active) => {
-				setActive(active);
-
-				if(active) {					
-					setActiveFilter(null);
-				}
-			}}
+			onActiveChange={setActive}
 			trigger={
 				<Button
 					aria-expanded={active}

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/filters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/filters.spec.ts
@@ -371,10 +371,8 @@ test(
 
 				expect(page.getByRole('checkbox', {name: 'Blue'})).toBeChecked;
 				expect(page.getByRole('checkbox', {name: 'Green'})).toBeChecked;
-				expect(page.getByRole('checkbox', {name: 'Red'})).not
-					.toBeChecked;
-				expect(page.getByRole('checkbox', {name: 'Yellow'}))
-					.toBeChecked;
+				expect(page.getByRole('checkbox', {name: 'Red'})).not.toBeChecked;
+				expect(page.getByRole('checkbox', {name: 'Yellow'})).toBeChecked;
 			});
 
 			await test.step('Click on clear filters button', async () => {
@@ -401,14 +399,10 @@ test(
 					.getByRole('menuitem', {name: 'Color'})
 					.click();
 
-				expect(page.getByRole('checkbox', {name: 'Blue'})).not
-					.toBeChecked;
-				expect(page.getByRole('checkbox', {name: 'Green'})).not
-					.toBeChecked;
-				expect(page.getByRole('checkbox', {name: 'Red'})).not
-					.toBeChecked;
-				expect(page.getByRole('checkbox', {name: 'Yellow'})).not
-					.toBeChecked;
+				expect(page.getByRole('checkbox', {name: 'Blue'})).not.toBeChecked;
+				expect(page.getByRole('checkbox', {name: 'Green'})).not.toBeChecked;
+				expect(page.getByRole('checkbox', {name: 'Red'})).not.toBeChecked;
+				expect(page.getByRole('checkbox', {name: 'Yellow'})).not.toBeChecked;
 			});
 		});
 	}

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/filters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/filters.spec.ts
@@ -34,7 +34,7 @@ test.beforeEach(async ({fdsSamplePage, page, site}) => {
 test(
 	'Behavior of filters',
 	{
-		tag: ['@LPS-150047', '@LPD-62552'],
+		tag: ['@LPS-150047'],
 	},
 	async ({fdsSamplePage, page}) => {
 		const blueCells = page.getByRole('cell', {name: 'Blue'});
@@ -347,62 +347,6 @@ test(
 				expect.soft(await greenCells.count()).toBeGreaterThan(0);
 				expect.soft(await yellowCells.count()).toBeGreaterThan(0);
 				expect.soft(await redCells.count()).toBeGreaterThan(0);
-			});
-		});
-
-		await test.step('Check filter dropdown is updated after clearing results', async () => {
-			await test.step('Refresh the page', async () => {
-				await page.reload();
-
-				await page
-					.getByText('This is a description for sample 1.')
-					.waitFor();
-			});
-
-			await test.step('Open filter dropdown and check "Blue", "Green" and "Yellow" are selected', async () => {
-				await fdsSamplePage.managementToolbar.container
-					.getByRole('button', {name: 'Filter'})
-					.click();
-
-				await page
-					.locator('.dropdown-menu')
-					.getByRole('menuitem', {name: 'Color'})
-					.click();
-
-				expect(page.getByRole('checkbox', {name: 'Blue'})).toBeChecked;
-				expect(page.getByRole('checkbox', {name: 'Green'})).toBeChecked;
-				expect(page.getByRole('checkbox', {name: 'Red'})).not.toBeChecked;
-				expect(page.getByRole('checkbox', {name: 'Yellow'})).toBeChecked;
-			});
-
-			await test.step('Click on clear filters button', async () => {
-				await fdsSamplePage.managementToolbar.container
-					.getByRole('button', {name: 'Filter'})
-					.click();
-
-				await fdsSamplePage.activeFiltersToolbar
-					.getByRole('button', {name: 'Clear'})
-					.click();
-
-				await page
-					.getByText('This is a description for sample 1.')
-					.waitFor();
-			});
-
-			await test.step('Open filter dropdown again and check nothing is selected', async () => {
-				await fdsSamplePage.managementToolbar.container
-					.getByRole('button', {name: 'Filter'})
-					.click();
-
-				await page
-					.locator('.dropdown-menu')
-					.getByRole('menuitem', {name: 'Color'})
-					.click();
-
-				expect(page.getByRole('checkbox', {name: 'Blue'})).not.toBeChecked;
-				expect(page.getByRole('checkbox', {name: 'Green'})).not.toBeChecked;
-				expect(page.getByRole('checkbox', {name: 'Red'})).not.toBeChecked;
-				expect(page.getByRole('checkbox', {name: 'Yellow'})).not.toBeChecked;
 			});
 		});
 	}


### PR DESCRIPTION
## Manual forward of https://github.com/liferay-frontend/liferay-portal/pull/5053

`ci:test:relevant` failing on unrelated code
`ci:test:frontend-data-set` also failing on unrelated code

# Original description 

[LPP ticket](https://liferay.atlassian.net/browse/LPP-59921)

[LPD ticket](https://liferay.atlassian.net/browse/LPD-63677)

This PR reverts #5036 as the solution wasn't what we wanted, and it added tests that are failing on auto-backport

This PR doesn't include any tests in order to have the hotfix ready for the customer sooner, they will come in a follow-up PR.

