### PR TITLE
LPD-64139 Add liferay-aws-backup-restore-workflow-dependencies helm chart

### DIFF
--- a/cloud/helm/aws-backup-restore-workflow-dependencies/Chart.yaml
+++ b/cloud/helm/aws-backup-restore-workflow-dependencies/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+appVersion: latest
+description:
+    This chart contains the dependencies needed in order to run a Liferay AWS backup restore workflow in a namespace.
+icon: https://www-cdn.liferay.com/documents/d/guest/liferay-logo
+name: liferay-aws-backup-restore-workflow-dependencies
+type: application
+version: 0.1.0

--- a/cloud/helm/aws-backup-restore-workflow-dependencies/templates/_helpers.tpl
+++ b/cloud/helm/aws-backup-restore-workflow-dependencies/templates/_helpers.tpl
@@ -1,0 +1,19 @@
+{{- define "liferayBackupRestoreWorkflow.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.labels" -}}
+helm.sh/chart: {{ include "liferayBackupRestoreWorkflow.chart" . }}
+{{ include "liferayBackupRestoreWorkflow.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "liferayBackupRestoreWorkflow.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/cloud/helm/aws-backup-restore-workflow-dependencies/templates/clusterrolebinding.yaml
+++ b/cloud/helm/aws-backup-restore-workflow-dependencies/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    labels:
+    {{- include "liferayBackupRestoreWorkflow.labels" . | nindent 8 }}
+    name: {{ include "liferayBackupRestoreWorkflow.name" . }}
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: {{ .Values.clusterRoleName }}
+subjects:
+    -   kind: ServiceAccount
+        name: {{ include "liferayBackupRestoreWorkflow.name" . }}
+        namespace: {{ .Release.Namespace }}

--- a/cloud/helm/aws-backup-restore-workflow-dependencies/templates/secret-git-credentials.yaml
+++ b/cloud/helm/aws-backup-restore-workflow-dependencies/templates/secret-git-credentials.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.git.credentials.username .Values.git.credentials.token -}}
+{{- $url := .Values.terraformRepo.httpsUrl -}}
+
+{{- $hostname := $url | trimPrefix "https://" | splitList "/" | first -}}
+apiVersion: v1
+kind: Secret
+metadata:
+    labels:
+    {{- include "liferayBackupRestoreWorkflow.labels" . | nindent 8 }}
+    name: {{ .Values.kubernetesSecretName.gitCredentials }}
+stringData:
+    .git-credentials: |-
+        https://{{ .Values.git.credentials.username }}:{{ .Values.git.credentials.token }}@{{ $hostname }}
+type: Opaque
+{{- end -}}

--- a/cloud/helm/aws-backup-restore-workflow-dependencies/templates/serviceaccount.yaml
+++ b/cloud/helm/aws-backup-restore-workflow-dependencies/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+    annotations:
+        {{- toYaml .Values.serviceAccount.annotations | nindent 8 }}
+    name: {{ include "liferayBackupRestoreWorkflow.name" . }}
+    labels:
+    {{- include "liferayBackupRestoreWorkflow.labels" . | nindent 8 }}

--- a/cloud/helm/aws-backup-restore-workflow-dependencies/values.yaml
+++ b/cloud/helm/aws-backup-restore-workflow-dependencies/values.yaml
@@ -1,0 +1,11 @@
+clusterRoleName: ""
+git:
+    credentials:
+        token: ""
+        username: ""
+kubernetesSecretName:
+    gitCredentials: liferay-aws-backup-restore-workflow-git-credentials
+serviceAccount:
+    annotations: {}
+terraformRepo:
+    httpsUrl: https://github.com/liferay/liferay-portal.git


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-64139

@brianchandotcom I wasn't sure exactly what you were looking for in your comment [here](https://github.com/brianchandotcom/liferay-portal/pull/165025#issuecomment-3239037253), but I've adjusted both the name of the helm chart and the directory its in to try and provide more clarity.

As you saw from the multiple pull requests, there are two charts. One contains a cluster-wide workflowtemplate, which is why that helm chart is suffixed with "template". This has nothing to do with helm or helm templates.

Meanwhile, this particular chart contains a number of resources or dependencies needed in order for individual workflows to be instantiated in each kubernetes namespace.

Those resources include a clusterrolebinding, a secret, and a service account. I wanted to keep the specific resource names out of both the description and the directory name, so I went with the word "dependencies".

I also need to capture in the description that this chart needs to be deployed per namespace, whereas the other chart is installed once per cluster.

Hopefully that helps give more context.