### PR TITLE
LPD-63870 Add liferay-aws-backup-restore-workflow-template helm chart

### DIFF
--- a/cloud/helm/aws-backup-restore-workflow-template/Chart.yaml
+++ b/cloud/helm/aws-backup-restore-workflow-template/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+appVersion: latest
+description:
+    Provides Argo clusterworkflowtemplate to perform backup restores for Liferay on AWS
+icon: https://www-cdn.liferay.com/documents/d/guest/liferay-logo
+name: liferay-aws-backup-restore-workflow-template
+type: application
+version: 0.1.0

--- a/cloud/helm/aws-backup-restore-workflow-template/Chart.yaml
+++ b/cloud/helm/aws-backup-restore-workflow-template/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: latest
 description:
-    Provides Argo clusterworkflowtemplate to perform backup restores for Liferay on AWS
+    This chart contains a cluster workflow template which enables a Liferay AWS backup restore.
 icon: https://www-cdn.liferay.com/documents/d/guest/liferay-logo
 name: liferay-aws-backup-restore-workflow-template
 type: application

--- a/cloud/helm/aws-backup-restore-workflow-template/templates/_helpers.tpl
+++ b/cloud/helm/aws-backup-restore-workflow-template/templates/_helpers.tpl
@@ -1,0 +1,153 @@
+{{- define "liferayBackupRestoreWorkflow.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.configmap.artifactRepositories.name" -}}
+{{- printf "%s-art-repo" (include "liferayBackupRestoreWorkflow.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.constant.gitCredentialsFileName" -}}
+.git-credentials
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.constant.gitCredentialsMountPath" -}}
+{{- printf "/root/%s" (include "liferayBackupRestoreWorkflow.constant.gitCredentialsFileName" .) -}}
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.constant.gitCredentialsTempPath" -}}
+{{- printf "/tmp/%s" (include "liferayBackupRestoreWorkflow.constant.gitCredentialsFileName" .) -}}
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.constant.gitCredentialsVolumeName" -}}
+git-credentials
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.constant.outputPathDataActive" -}}
+/tmp/data_active.txt
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.constant.outputPathDataInactive" -}}
+/tmp/data_inactive.txt
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.constant.outputPathRdsSnapshotId" -}}
+/tmp/rds_snapshot_id.txt
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.constant.outputPathS3BucketIdActive" -}}
+/tmp/s3_bucket_id_active.txt
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.constant.outputPathS3BucketIdInactive" -}}
+/tmp/s3_bucket_id_inactive.txt
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.constant.outputPathS3RecoveryPointArn" -}}
+/tmp/s3_recovery_point_arn.txt
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.constant.workingDir" -}}
+/src
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.labels" -}}
+helm.sh/chart: {{ include "liferayBackupRestoreWorkflow.chart" . }}
+{{ include "liferayBackupRestoreWorkflow.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.param.commitMessage" -}}
+commit-message
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.param.dataActive" -}}
+data-active
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.param.dataInactive" -}}
+data-inactive
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.param.dbRestoreSnapshotIdentifier" -}}
+db-restore-snapshot-identifier
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.param.isRestoring" -}}
+is-restoring
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.param.recoveryPointArn" -}}
+recovery-point-arn
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.param.rdsSnapshotId" -}}
+rds-snapshot-id
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.param.s3BucketId" -}}
+s3-bucket-id
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.param.s3BucketIdActive" -}}
+s3-bucket-id-active
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.param.s3BucketIdInactive" -}}
+s3-bucket-id-inactive
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.param.s3RecoveryPointArn" -}}
+s3-recovery-point-arn
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.param.tfvarsContent" -}}
+tfvars-content
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "liferayBackupRestoreWorkflow.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.task.input.parameter" -}}
+{{- "{{" }}inputs.parameters.{{ . }}}}
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.task.output.artifact" -}}
+{{- "{{" }}tasks.{{ .task }}.outputs.artifacts.{{ .artifact }}}}
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.task.output.parameter" -}}
+{{- "{{" }}tasks.{{ .task }}.outputs.parameters.{{ .parameter }}}}
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.volumeMount.gitCredentials" -}}
+{{- if and .Values.git.credentials.username .Values.git.credentials.token -}}
+volumeMounts:
+    -   mountPath: {{ include "liferayBackupRestoreWorkflow.constant.gitCredentialsMountPath" . }}
+        name: {{ include "liferayBackupRestoreWorkflow.constant.gitCredentialsVolumeName" . }}
+        subPath: {{ include "liferayBackupRestoreWorkflow.constant.gitCredentialsFileName" . }}
+{{- end -}}
+{{- end -}}
+
+{{- define "liferayBackupRestoreWorkflow.workflow.parameter" -}}
+{{- "{{" }}workflow.parameters.{{ . }}}}
+{{- end -}}

--- a/cloud/helm/aws-backup-restore-workflow-template/templates/clusterrole.yaml
+++ b/cloud/helm/aws-backup-restore-workflow-template/templates/clusterrole.yaml
@@ -1,0 +1,33 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    labels:
+    {{- include "liferayBackupRestoreWorkflow.labels" . | nindent 8 }}
+    name: {{ include "liferayBackupRestoreWorkflow.fullname" . }}
+rules:
+    -   apiGroups: [ "argoproj.io" ]
+        resources: [ "workflowtaskresults" ]
+        verbs:
+            - create
+            - patch
+    -   apiGroups: [ "" ]
+        resources: [ "namespaces" ]
+        verbs:
+            - get
+            - list
+    -   apiGroups: [ "" ]
+        resourceNames: [ {{ .Values.liferayWorkload.managedSecretName }} ]
+        resources: [ "secrets" ]
+        verbs:
+            - create
+            - get
+            - patch
+            - update
+    -   apiGroups: [ "apps" ]
+        resourceNames: [ {{ .Values.liferayWorkload.name }} ]
+        resources: [ "statefulsets" ]
+        verbs:
+            - get
+            - list
+            - patch
+            - watch

--- a/cloud/helm/aws-backup-restore-workflow-template/templates/clusterworkflowtemplate.yaml
+++ b/cloud/helm/aws-backup-restore-workflow-template/templates/clusterworkflowtemplate.yaml
@@ -1,0 +1,264 @@
+{{- $artifactTerraformRepo := "terraform-repo" -}}
+{{- $containerCommandSh := "sh" -}}
+{{- $paramCommitMessage := include "liferayBackupRestoreWorkflow.param.commitMessage" . -}}
+{{- $paramDataActive := include "liferayBackupRestoreWorkflow.param.dataActive" . -}}
+{{- $paramDataInactive := include "liferayBackupRestoreWorkflow.param.dataInactive" . -}}
+{{- $paramDbRestoreSnapshotIdentifier := include "liferayBackupRestoreWorkflow.param.dbRestoreSnapshotIdentifier" . -}}
+{{- $paramIsRestoring := include "liferayBackupRestoreWorkflow.param.isRestoring" . -}}
+{{- $paramRdsSnapshotId := include "liferayBackupRestoreWorkflow.param.rdsSnapshotId" . -}}
+{{- $paramS3BucketId := include "liferayBackupRestoreWorkflow.param.s3BucketId" . -}}
+{{- $paramS3BucketIdActive := include "liferayBackupRestoreWorkflow.param.s3BucketIdActive" . -}}
+{{- $paramS3BucketIdInactive := include "liferayBackupRestoreWorkflow.param.s3BucketIdInactive" . -}}
+{{- $paramS3RecoveryPointArn := include "liferayBackupRestoreWorkflow.param.s3RecoveryPointArn" . -}}
+{{- $paramTfvarsContent := include "liferayBackupRestoreWorkflow.param.tfvarsContent" . -}}
+{{- $taskCheckoutTerraformRepo := "checkout-terraform-repo" -}}
+{{- $taskCleanupRdsInstance := "cleanup-rds-instance" -}}
+{{- $taskCleanupS3Bucket := "cleanup-s3-bucket" -}}
+{{- $taskFindPeerRecoveryPoints := "find-peer-recovery-points" -}}
+{{- $taskGetDependenciesModuleOutputs := "get-dependencies-module-outputs" -}}
+{{- $taskKubectlRolloutRestart := "kubectl-rollout-restart" -}}
+{{- $taskKubectlRolloutStatus := "kubectl-rollout-status" -}}
+{{- $taskRestartLiferay := "restart-liferay" -}}
+{{- $taskRestoreRdsInstance := "restore-rds-instance" -}}
+{{- $taskRestoreS3Bucket := "restore-s3-bucket" -}}
+{{- $taskRollbackFailedRestore := "rollback-failed-restore" -}}
+{{- $taskUpdateKubernetesSecret := "update-kubernetes-secret" -}}
+{{- $templateMain := "main" -}}
+{{- $templateTerraformApply := "terraform-apply" -}}
+{{- $tfvarDataActive := "data_active" -}}
+{{- $tfvarIsRestoring := "is_restoring" -}}
+{{- $tfvarDbRestoreSnapshotIdentifier := "db_restore_snapshot_identifier" -}}
+{{- $workflowName := include "liferayBackupRestoreWorkflow.fullname" . -}}
+{{- $workingDir := include "liferayBackupRestoreWorkflow.constant.workingDir" . -}}
+
+{{- $outputArtifactTerraformRepo := include "liferayBackupRestoreWorkflow.task.output.artifact" (dict "artifact" $artifactTerraformRepo "task" $taskCheckoutTerraformRepo) | quote -}}
+{{- $outputParamDataActive := include "liferayBackupRestoreWorkflow.task.output.parameter" (dict "parameter" $paramDataActive "task" $taskGetDependenciesModuleOutputs) | quote -}}
+{{- $outputParamDataInactive := include "liferayBackupRestoreWorkflow.task.output.parameter" (dict "parameter" $paramDataInactive "task" $taskGetDependenciesModuleOutputs) | quote -}}
+{{- $outputParamRdsSnapshotId := include "liferayBackupRestoreWorkflow.task.output.parameter" (dict "parameter" $paramRdsSnapshotId "task" $taskFindPeerRecoveryPoints) | quote -}}
+{{- $outputParamS3BucketIdActive := include "liferayBackupRestoreWorkflow.task.output.parameter" (dict "parameter" $paramS3BucketIdActive "task" $taskGetDependenciesModuleOutputs) | quote -}}
+{{- $outputParamS3BucketIdInactive := include "liferayBackupRestoreWorkflow.task.output.parameter" (dict "parameter" $paramS3BucketIdInactive "task" $taskGetDependenciesModuleOutputs) | quote -}}
+{{- $outputParamS3RecoveryPointArn := include "liferayBackupRestoreWorkflow.task.output.parameter" (dict "parameter" $paramS3RecoveryPointArn "task" $taskFindPeerRecoveryPoints) | quote -}}
+{{- $workingDirTerraform := printf "%s/%s/%s" $workingDir .Values.terraformRepo.sparseCheckoutRelativePath .Values.terraformRepo.dependenciesModuleRelativePath -}}
+
+apiVersion: argoproj.io/v1alpha1
+kind: ClusterWorkflowTemplate
+metadata:
+    labels:
+        {{- include "liferayBackupRestoreWorkflow.labels" . | nindent 8 }}
+    name: {{ $workflowName }}
+spec:
+    arguments:
+        parameters:
+            -   description: "The RDS or S3 recovery point arn of a single backup job run"
+                name: {{ include "liferayBackupRestoreWorkflow.param.recoveryPointArn" . }}
+    artifactRepositoryRef:
+        configMap: {{ include "liferayBackupRestoreWorkflow.configmap.artifactRepositories.name" . }}
+    entrypoint: {{ $templateMain }}
+    templates:
+        -   dag:
+                tasks:
+                    -   name: {{ $taskCheckoutTerraformRepo }}
+                        template: {{ $taskCheckoutTerraformRepo }}
+                    -   name: {{ $taskFindPeerRecoveryPoints }}
+                        template: {{ $taskFindPeerRecoveryPoints }}
+                    -   arguments:
+                            artifacts:
+                                -   from: {{ $outputArtifactTerraformRepo }}
+                                    name: {{ $artifactTerraformRepo }}
+                        depends: {{ $taskCheckoutTerraformRepo }}
+                        name: {{ $taskGetDependenciesModuleOutputs }}
+                        template: {{ $taskGetDependenciesModuleOutputs }}
+                    -   arguments:
+                            artifacts:
+                                -   from: {{ $outputArtifactTerraformRepo }}
+                                    name: {{ $artifactTerraformRepo }}
+                            parameters:
+                                -   name: {{ $paramCommitMessage }}
+                                    value: "chore(restore): provision inactive RDS instance from snapshot"
+                                -   name: {{ $paramTfvarsContent }}
+                                    value: |-
+                                        {{ $tfvarDataActive }} = {{ $outputParamDataActive }}
+                                        {{ $tfvarDbRestoreSnapshotIdentifier }} = {{ $outputParamRdsSnapshotId }}
+                                        {{ $tfvarIsRestoring }} = true
+                        depends: "{{ $taskFindPeerRecoveryPoints }} && {{ $taskGetDependenciesModuleOutputs }}"
+                        name: {{ $taskRestoreRdsInstance }}
+                        template: {{ $templateTerraformApply }}
+                    -   arguments:
+                            parameters:
+                                -   name: {{ $paramS3RecoveryPointArn }}
+                                    value: {{ $outputParamS3RecoveryPointArn }}
+                                -   name: {{ $paramS3BucketId }}
+                                    value: {{ $outputParamS3BucketIdInactive }}
+                        depends: "{{ $taskFindPeerRecoveryPoints }} && {{ $taskGetDependenciesModuleOutputs }}"
+                        name: {{ $taskRestoreS3Bucket }}
+                        template: {{ $taskRestoreS3Bucket }}
+                    -   arguments:
+                            artifacts:
+                                -   from: {{ $outputArtifactTerraformRepo }}
+                                    name: {{ $artifactTerraformRepo }}
+                            parameters:
+                                -   name: {{ $paramCommitMessage }}
+                                    value: "feat(restore): update liferay configuration to restored data plane"
+                                -   name: {{ $paramTfvarsContent }}
+                                    value: |-
+                                        {{ $tfvarDataActive }} = {{ $outputParamDataInactive }}
+                                        {{ $tfvarDbRestoreSnapshotIdentifier }} = null
+                                        {{ $tfvarIsRestoring }} = true
+                        depends: "{{ $taskRestoreRdsInstance }} && {{ $taskRestoreS3Bucket }}"
+                        name: {{ $taskUpdateKubernetesSecret }}
+                        template: {{ $templateTerraformApply }}
+                    -   depends: {{ $taskUpdateKubernetesSecret }}
+                        name: {{ $taskRestartLiferay }}
+                        template: {{ $taskRestartLiferay }}
+                    -   arguments:
+                            artifacts:
+                                -   name: {{ $artifactTerraformRepo }}
+                                    from: {{ $outputArtifactTerraformRepo }}
+                            parameters:
+                                -   name: {{ $paramCommitMessage }}
+                                    value: "chore(restore): clean up rds instance"
+                                -   name: {{ $paramTfvarsContent }}
+                                    value: |-
+                                        {{ $tfvarDataActive }} = {{ $outputParamDataInactive }}
+                                        {{ $tfvarIsRestoring }} = false
+                        depends: {{ $taskRestartLiferay }}
+                        name: {{ $taskCleanupRdsInstance }}
+                        template: {{ $templateTerraformApply }}
+                    -   arguments:
+                            parameters:
+                                -   name: {{ $paramS3BucketId }}
+                                    value: {{ $outputParamS3BucketIdActive }}
+                        depends: {{ $taskRestartLiferay }}
+                        name: {{ $taskCleanupS3Bucket }}
+                        template: {{ $taskCleanupS3Bucket }}
+                    -   arguments:
+                            artifacts:
+                                -   from: {{ $outputArtifactTerraformRepo }}
+                                    name: {{ $artifactTerraformRepo }}
+                            parameters:
+                                -   name: {{ $paramCommitMessage }}
+                                    value: "chore(restore): reset failed restore"
+                                -   name: {{ $paramTfvarsContent }}
+                                    value: |-
+                                        {{ $tfvarDataActive }} = {{ $outputParamDataActive }}
+                                        {{ $tfvarIsRestoring }} = false
+                        depends: "{{ $taskRestoreRdsInstance }}.Succeeded && !{{ $taskRestartLiferay }}.Succeeded"
+                        name: {{ $taskRollbackFailedRestore }}
+                        template: {{ $templateTerraformApply }}
+            name: {{ $templateMain }}
+        -   name: {{ $taskCheckoutTerraformRepo }}
+            outputs:
+                artifacts:
+                    -   name: {{ $artifactTerraformRepo }}
+                        path: {{ $workingDir }}
+            script:
+                command: [ {{ $containerCommandSh }} ]
+                image: "{{ .Values.terraformImage.repository }}:{{ .Values.terraformImage.tag }}"
+                source: |-
+                    {{- include "liferayBackupRestoreWorkflow.script.checkoutTerraformRepo" . | nindent 20 }}
+                {{- include "liferayBackupRestoreWorkflow.volumeMount.gitCredentials" . | nindent 16 }}
+        -   name: {{ $taskFindPeerRecoveryPoints }}
+            outputs:
+                parameters:
+                    -   name: {{ $paramRdsSnapshotId }}
+                        valueFrom:
+                            path: {{ include "liferayBackupRestoreWorkflow.constant.outputPathRdsSnapshotId" . }}
+                    -   name: {{ $paramS3RecoveryPointArn }}
+                        valueFrom:
+                            path: {{ include "liferayBackupRestoreWorkflow.constant.outputPathS3RecoveryPointArn" . }}
+            script:
+                command: [ {{ $containerCommandSh }} ]
+                image: "{{ .Values.awsCliImage.repository }}:{{ .Values.awsCliImage.tag }}"
+                source: |-
+                    {{- include "liferayBackupRestoreWorkflow.script.findPeerRecoveryPoints" . | nindent 20 }}
+        -   inputs:
+                artifacts:
+                    -   name: {{ $artifactTerraformRepo }}
+                        path: {{ $workingDir }}
+            name: {{ $taskGetDependenciesModuleOutputs }}
+            outputs:
+                parameters:
+                    -   name: {{ $paramDataActive }}
+                        valueFrom:
+                            path: {{ include "liferayBackupRestoreWorkflow.constant.outputPathDataActive" . }}
+                    -   name: {{ $paramDataInactive }}
+                        valueFrom:
+                            path: {{ include "liferayBackupRestoreWorkflow.constant.outputPathDataInactive" . }}
+                    -   name: {{ $paramS3BucketIdActive }}
+                        valueFrom:
+                            path: {{ include "liferayBackupRestoreWorkflow.constant.outputPathS3BucketIdActive" . }}
+                    -   name: {{ $paramS3BucketIdInactive }}
+                        valueFrom:
+                            path: {{ include "liferayBackupRestoreWorkflow.constant.outputPathS3BucketIdInactive" . }}
+            script:
+                command: [ {{ $containerCommandSh }} ]
+                image: "{{ .Values.terraformImage.repository }}:{{ .Values.terraformImage.tag }}"
+                source: |-
+                    {{- include "liferayBackupRestoreWorkflow.script.getDependenciesModuleOutputs" . | nindent 20 }}
+                workingDir: {{ $workingDirTerraform }}
+        -   name: {{ $taskCleanupS3Bucket }}
+            inputs:
+                parameters:
+                    -   name: {{ $paramS3BucketId }}
+            container:
+                args:
+                    - "s3"
+                    - "rm"
+                    - "s3://{{ include "liferayBackupRestoreWorkflow.task.input.parameter" $paramS3BucketId }}/"
+                    - "--recursive"
+                command: [ "aws" ]
+                image: "{{ .Values.awsCliImage.repository }}:{{ .Values.awsCliImage.tag }}"
+        -   name: {{ $taskRestoreS3Bucket }}
+            inputs:
+                parameters:
+                    -   name: {{ $paramS3BucketId }}
+                    -   name: {{ $paramS3RecoveryPointArn }}
+            script:
+                command: [ {{ $containerCommandSh }} ]
+                image: "{{ .Values.awsCliImage.repository }}:{{ .Values.awsCliImage.tag }}"
+                source: |-
+                    {{- include "liferayBackupRestoreWorkflow.script.restoreS3Bucket" . | nindent 20 }}
+        -   name: {{ $templateTerraformApply }}
+            inputs:
+                artifacts:
+                    -   name: {{ $artifactTerraformRepo }}
+                        path: {{ $workingDir }}
+                parameters:
+                    -   name: {{ $paramCommitMessage }}
+                    -   name: {{ $paramTfvarsContent }}
+            script:
+                command: [ {{ $containerCommandSh }} ]
+                image: "{{ .Values.terraformImage.repository }}:{{ .Values.terraformImage.tag }}"
+                source: |-
+                    {{- include "liferayBackupRestoreWorkflow.script.terraform-apply" . | nindent 20 }}
+                {{- include "liferayBackupRestoreWorkflow.volumeMount.gitCredentials" . | nindent 16 }}
+                workingDir: {{ $workingDirTerraform }}
+        -   name: {{ $taskRestartLiferay }}
+            steps:
+                -   -   name: {{ $taskKubectlRolloutRestart }}
+                        template: {{ $taskKubectlRolloutRestart }}
+                -   -   name: {{ $taskKubectlRolloutStatus }}
+                        template: {{ $taskKubectlRolloutStatus }}
+        -   container:
+                args:
+                    - rollout
+                    - restart
+                    - statefulset
+                    - "{{ .Values.liferayWorkload.name }}"
+                image: "{{ .Values.kubectlImage.repository }}:{{ .Values.kubectlImage.tag }}"
+            name: {{ $taskKubectlRolloutRestart }}
+        -   container:
+                args:
+                    - rollout
+                    - status
+                    - statefulset
+                    - "{{ .Values.liferayWorkload.name }}"
+                    - --timeout=15m
+                image: "{{ .Values.kubectlImage.repository }}:{{ .Values.kubectlImage.tag }}"
+            name: {{ $taskKubectlRolloutStatus }}
+    {{- if and .Values.git.credentials.username .Values.git.credentials.token }}
+    volumes:
+        -   name: {{ include "liferayBackupRestoreWorkflow.constant.gitCredentialsVolumeName" . }}
+            secret:
+                secretName: {{ .Values.kubernetesSecretName.gitCredentials }}
+    {{- end }}

--- a/cloud/helm/aws-backup-restore-workflow-template/templates/configmap-artifact-repository.yaml
+++ b/cloud/helm/aws-backup-restore-workflow-template/templates/configmap-artifact-repository.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    annotations:
+        workflows.argoproj.io/default-artifact-repository: artifact-repository
+    name: {{ include "liferayBackupRestoreWorkflow.configmap.artifactRepositories.name" . }}
+    namespace: {{ .Values.argoNamespace }}
+data:
+    artifact-repository: |-
+        s3:
+          endpoint: s3.amazonaws.com
+          bucket: {{ .Values.artifactRepositoryBucketId }}

--- a/cloud/helm/aws-backup-restore-workflow-template/values.yaml
+++ b/cloud/helm/aws-backup-restore-workflow-template/values.yaml
@@ -1,0 +1,31 @@
+argoNamespace: argo
+artifactRepositoryBucketId: ""
+awsBackupServiceAssumedIamRoleArn: ""
+awsBackupVaultName: "liferay-backup"
+awsCliImage:
+    repository: amazon/aws-cli
+    tag: "2.27.63"
+git:
+    credentials:
+        token: ""
+        username: ""
+    user:
+        email: ""
+        name: ""
+kubectlImage:
+    repository: registry.k8s.io/kubectl
+    tag: v1.34.0
+kubernetesSecretName:
+    gitCredentials: liferay-aws-backup-restore-workflow-git-credentials
+liferayWorkload:
+    managedSecretName: managed-service-details
+    name: liferay-default
+s3RestoreWaitTimeoutSeconds: 7200
+terraformImage:
+    repository: hashicorp/terraform
+    tag: "1.12.2"
+terraformRepo:
+    branch: master
+    dependenciesModuleRelativePath: dependencies
+    httpsUrl: https://github.com/liferay/liferay-portal.git
+    sparseCheckoutRelativePath: cloud/terraform/aws

--- a/cloud/terraform/aws/backup/backup-restore-workflow/variables.tf
+++ b/cloud/terraform/aws/backup/backup-restore-workflow/variables.tf
@@ -11,7 +11,7 @@ variable "kubernetes_namespace" {
 	default="liferay-system"
 }
 variable "kubernetes_service_account_name" {
-	default="liferay-backup-restore"
+	default="liferay-aws-backup-restore-workflow"
 }
 variable "region" {
 	type=string


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-63870

@brianchandotcom , regarding your comment [here](https://github.com/brianchandotcom/liferay-portal/pull/165029#issuecomment-3239034628),  there is confusion between a `workflowtemplate` and a helm template. This chart is named as it is because the main resource it contains is a `kind: ClusterWorkflowTemplate`, which has nothing to do with helm templates.

I still think "workflow-template" is the best name for the chart because this is exactly what it deploys -- a cluster-wide workflow template which enables individual workflows to be instantiated in each namespace.

I also updated the description per your request. The word `cluster` in the description is very important because this chart is meant to be installed once per cluster, whereas the other chart is to be deployed once in each namespace where backup restores will be performed.
