### PR TITLE
LPD-63870 Add backup-restore subchart

### DIFF
--- a/cloud/helm/aws/Chart.yaml
+++ b/cloud/helm/aws/Chart.yaml
@@ -1,6 +1,10 @@
 apiVersion: v2
 appVersion: latest
 dependencies:
+    -   condition: liferay-aws-backup-restore.enabled
+        name: liferay-aws-backup-restore
+        repository: file://./charts/backup-restore
+        version: 0.1.0
     -   name: liferay-default
         repository: file://../default
         version: 0.0.0

--- a/cloud/helm/aws/charts/backup-restore/Chart.yaml
+++ b/cloud/helm/aws/charts/backup-restore/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: liferay-aws-backup-restore
+version: 0.1.0

--- a/cloud/helm/aws/charts/backup-restore/templates/_helpers.tpl
+++ b/cloud/helm/aws/charts/backup-restore/templates/_helpers.tpl
@@ -1,0 +1,157 @@
+{{- define "liferayAwsBackupRestore.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.configmap.artifactRepository.name" -}}
+{{- printf "%s-art-repo" (include "liferayAwsBackupRestore.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.constant.gitCredentialsFileName" -}}
+.git-credentials
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.constant.gitCredentialsMountPath" -}}
+{{- printf "/root/%s" (include "liferayAwsBackupRestore.constant.gitCredentialsFileName" .) -}}
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.constant.gitCredentialsTempPath" -}}
+{{- printf "/tmp/%s" (include "liferayAwsBackupRestore.constant.gitCredentialsFileName" .) -}}
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.constant.gitCredentialsVolumeName" -}}
+git-credentials
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.constant.outputPathDataActive" -}}
+/tmp/data_active.txt
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.constant.outputPathDataInactive" -}}
+/tmp/data_inactive.txt
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.constant.outputPathRdsSnapshotId" -}}
+/tmp/rds_snapshot_id.txt
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.constant.outputPathS3BucketIdActive" -}}
+/tmp/s3_bucket_id_active.txt
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.constant.outputPathS3BucketIdInactive" -}}
+/tmp/s3_bucket_id_inactive.txt
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.constant.outputPathS3RecoveryPointArn" -}}
+/tmp/s3_recovery_point_arn.txt
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.constant.workingDir" -}}
+/src
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.labels" -}}
+helm.sh/chart: {{ include "liferayAwsBackupRestore.chart" . }}
+{{ include "liferayAwsBackupRestore.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.param.commitMessage" -}}
+commit-message
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.param.dataActive" -}}
+data-active
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.param.dataInactive" -}}
+data-inactive
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.param.dbRestoreSnapshotIdentifier" -}}
+db-restore-snapshot-identifier
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.param.isRestoring" -}}
+is-restoring
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.param.recoveryPointArn" -}}
+recovery-point-arn
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.param.rdsSnapshotId" -}}
+rds-snapshot-id
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.param.s3BucketId" -}}
+s3-bucket-id
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.param.s3BucketIdActive" -}}
+s3-bucket-id-active
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.param.s3BucketIdInactive" -}}
+s3-bucket-id-inactive
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.param.s3RecoveryPointArn" -}}
+s3-recovery-point-arn
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.param.tfvarsContent" -}}
+tfvars-content
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.secret.gitCredentials.name" -}}
+{{- printf "%s-git-creds" (include "liferayAwsBackupRestore.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "liferayAwsBackupRestore.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.task.input.parameter" -}}
+{{- "{{" }}inputs.parameters.{{ . }}}}
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.task.output.artifact" -}}
+{{- "{{" }}tasks.{{ .task }}.outputs.artifacts.{{ .artifact }}}}
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.task.output.parameter" -}}
+{{- "{{" }}tasks.{{ .task }}.outputs.parameters.{{ .parameter }}}}
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.volumeMount.gitCredentials" -}}
+{{- if and .Values.git.credentials.username .Values.git.credentials.token -}}
+volumeMounts:
+    -   mountPath: {{ include "liferayAwsBackupRestore.constant.gitCredentialsMountPath" . }}
+        name: {{ include "liferayAwsBackupRestore.constant.gitCredentialsVolumeName" . }}
+        subPath: {{ include "liferayAwsBackupRestore.constant.gitCredentialsFileName" . }}
+{{- end -}}
+{{- end -}}
+
+{{- define "liferayAwsBackupRestore.workflow.parameter" -}}
+{{- "{{" }}workflow.parameters.{{ . }}}}
+{{- end -}}

--- a/cloud/helm/aws/charts/backup-restore/templates/clusterrole.yaml
+++ b/cloud/helm/aws/charts/backup-restore/templates/clusterrole.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.createClusterResources -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    labels:
+    {{- include "liferayAwsBackupRestore.labels" . | nindent 8 }}
+    name: {{ include "liferayAwsBackupRestore.name" . }}
+rules:
+    -   apiGroups: [ "argoproj.io" ]
+        resources: [ "workflowtaskresults" ]
+        verbs:
+            - create
+            - patch
+    -   apiGroups: [ "" ]
+        resources: [ "namespaces" ]
+        verbs:
+            - get
+            - list
+    -   apiGroups: [ "" ]
+        resourceNames: [ {{ .Values.liferayWorkload.managedSecretName }} ]
+        resources: [ "secrets" ]
+        verbs:
+            - create
+            - get
+            - patch
+            - update
+    -   apiGroups: [ "apps" ]
+        resourceNames: [ {{ .Values.liferayWorkload.name }} ]
+        resources: [ "statefulsets" ]
+        verbs:
+            - get
+            - list
+            - patch
+            - watch
+{{- end }}

--- a/cloud/helm/aws/charts/backup-restore/templates/clusterrolebinding.yaml
+++ b/cloud/helm/aws/charts/backup-restore/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    labels:
+    {{- include "liferayAwsBackupRestore.labels" . | nindent 8 }}
+    name: {{ include "liferayAwsBackupRestore.name" . }}
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: {{ include "liferayAwsBackupRestore.fullname" . }}
+subjects:
+    -   kind: ServiceAccount
+        name: {{ include "liferayAwsBackupRestore.name" . }}
+        namespace: {{ .Release.Namespace }}

--- a/cloud/helm/aws/charts/backup-restore/templates/clusterworkflowtemplate.yaml
+++ b/cloud/helm/aws/charts/backup-restore/templates/clusterworkflowtemplate.yaml
@@ -1,0 +1,265 @@
+{{- if .Values.createClusterResources -}}
+{{- $artifactTerraformRepo := "terraform-repo" -}}
+{{- $containerCommandSh := "sh" -}}
+{{- $paramCommitMessage := include "liferayAwsBackupRestore.param.commitMessage" . -}}
+{{- $paramDataActive := include "liferayAwsBackupRestore.param.dataActive" . -}}
+{{- $paramDataInactive := include "liferayAwsBackupRestore.param.dataInactive" . -}}
+{{- $paramDbRestoreSnapshotIdentifier := include "liferayAwsBackupRestore.param.dbRestoreSnapshotIdentifier" . -}}
+{{- $paramIsRestoring := include "liferayAwsBackupRestore.param.isRestoring" . -}}
+{{- $paramRdsSnapshotId := include "liferayAwsBackupRestore.param.rdsSnapshotId" . -}}
+{{- $paramS3BucketId := include "liferayAwsBackupRestore.param.s3BucketId" . -}}
+{{- $paramS3BucketIdActive := include "liferayAwsBackupRestore.param.s3BucketIdActive" . -}}
+{{- $paramS3BucketIdInactive := include "liferayAwsBackupRestore.param.s3BucketIdInactive" . -}}
+{{- $paramS3RecoveryPointArn := include "liferayAwsBackupRestore.param.s3RecoveryPointArn" . -}}
+{{- $paramTfvarsContent := include "liferayAwsBackupRestore.param.tfvarsContent" . -}}
+{{- $taskCheckoutTerraformRepo := "checkout-terraform-repo" -}}
+{{- $taskCleanupRdsInstance := "cleanup-rds-instance" -}}
+{{- $taskCleanupS3Bucket := "cleanup-s3-bucket" -}}
+{{- $taskFindPeerRecoveryPoints := "find-peer-recovery-points" -}}
+{{- $taskGetDependenciesModuleOutputs := "get-dependencies-module-outputs" -}}
+{{- $taskKubectlRolloutRestart := "kubectl-rollout-restart" -}}
+{{- $taskKubectlRolloutStatus := "kubectl-rollout-status" -}}
+{{- $taskRestartLiferay := "restart-liferay" -}}
+{{- $taskRestoreRdsInstance := "restore-rds-instance" -}}
+{{- $taskRestoreS3Bucket := "restore-s3-bucket" -}}
+{{- $taskRollbackFailedRestore := "rollback-failed-restore" -}}
+{{- $taskUpdateKubernetesSecret := "update-kubernetes-secret" -}}
+{{- $templateMain := "main" -}}
+{{- $templateTerraformApply := "terraform-apply" -}}
+{{- $tfvarDataActive := "data_active" -}}
+{{- $tfvarIsRestoring := "is_restoring" -}}
+{{- $tfvarDbRestoreSnapshotIdentifier := "db_restore_snapshot_identifier" -}}
+{{- $workingDir := include "liferayAwsBackupRestore.constant.workingDir" . -}}
+
+{{- $outputArtifactTerraformRepo := include "liferayAwsBackupRestore.task.output.artifact" (dict "artifact" $artifactTerraformRepo "task" $taskCheckoutTerraformRepo) | quote -}}
+{{- $outputParamDataActive := include "liferayAwsBackupRestore.task.output.parameter" (dict "parameter" $paramDataActive "task" $taskGetDependenciesModuleOutputs) | quote -}}
+{{- $outputParamDataInactive := include "liferayAwsBackupRestore.task.output.parameter" (dict "parameter" $paramDataInactive "task" $taskGetDependenciesModuleOutputs) | quote -}}
+{{- $outputParamRdsSnapshotId := include "liferayAwsBackupRestore.task.output.parameter" (dict "parameter" $paramRdsSnapshotId "task" $taskFindPeerRecoveryPoints) | quote -}}
+{{- $outputParamS3BucketIdActive := include "liferayAwsBackupRestore.task.output.parameter" (dict "parameter" $paramS3BucketIdActive "task" $taskGetDependenciesModuleOutputs) | quote -}}
+{{- $outputParamS3BucketIdInactive := include "liferayAwsBackupRestore.task.output.parameter" (dict "parameter" $paramS3BucketIdInactive "task" $taskGetDependenciesModuleOutputs) | quote -}}
+{{- $outputParamS3RecoveryPointArn := include "liferayAwsBackupRestore.task.output.parameter" (dict "parameter" $paramS3RecoveryPointArn "task" $taskFindPeerRecoveryPoints) | quote -}}
+{{- $workingDirTerraform := printf "%s/%s/%s" $workingDir .Values.terraformRepo.sparseCheckoutRelativePath .Values.terraformRepo.dependenciesModuleRelativePath -}}
+
+apiVersion: argoproj.io/v1alpha1
+kind: ClusterWorkflowTemplate
+metadata:
+    labels:
+        {{- include "liferayAwsBackupRestore.labels" . | nindent 8 }}
+    name: {{ include "liferayAwsBackupRestore.name" . }}
+spec:
+    arguments:
+        parameters:
+            -   description: "The RDS or S3 recovery point arn of a single backup job run"
+                name: {{ include "liferayAwsBackupRestore.param.recoveryPointArn" . }}
+    artifactRepositoryRef:
+        configMap: {{ include "liferayAwsBackupRestore.configmap.artifactRepository.name" . }}
+    entrypoint: {{ $templateMain }}
+    templates:
+        -   dag:
+                tasks:
+                    -   name: {{ $taskCheckoutTerraformRepo }}
+                        template: {{ $taskCheckoutTerraformRepo }}
+                    -   name: {{ $taskFindPeerRecoveryPoints }}
+                        template: {{ $taskFindPeerRecoveryPoints }}
+                    -   arguments:
+                            artifacts:
+                                -   from: {{ $outputArtifactTerraformRepo }}
+                                    name: {{ $artifactTerraformRepo }}
+                        depends: {{ $taskCheckoutTerraformRepo }}
+                        name: {{ $taskGetDependenciesModuleOutputs }}
+                        template: {{ $taskGetDependenciesModuleOutputs }}
+                    -   arguments:
+                            artifacts:
+                                -   from: {{ $outputArtifactTerraformRepo }}
+                                    name: {{ $artifactTerraformRepo }}
+                            parameters:
+                                -   name: {{ $paramCommitMessage }}
+                                    value: "chore(restore): provision inactive RDS instance from snapshot"
+                                -   name: {{ $paramTfvarsContent }}
+                                    value: |-
+                                        {{ $tfvarDataActive }} = {{ $outputParamDataActive }}
+                                        {{ $tfvarDbRestoreSnapshotIdentifier }} = {{ $outputParamRdsSnapshotId }}
+                                        {{ $tfvarIsRestoring }} = true
+                        depends: "{{ $taskFindPeerRecoveryPoints }} && {{ $taskGetDependenciesModuleOutputs }}"
+                        name: {{ $taskRestoreRdsInstance }}
+                        template: {{ $templateTerraformApply }}
+                    -   arguments:
+                            parameters:
+                                -   name: {{ $paramS3RecoveryPointArn }}
+                                    value: {{ $outputParamS3RecoveryPointArn }}
+                                -   name: {{ $paramS3BucketId }}
+                                    value: {{ $outputParamS3BucketIdInactive }}
+                        depends: "{{ $taskFindPeerRecoveryPoints }} && {{ $taskGetDependenciesModuleOutputs }}"
+                        name: {{ $taskRestoreS3Bucket }}
+                        template: {{ $taskRestoreS3Bucket }}
+                    -   arguments:
+                            artifacts:
+                                -   from: {{ $outputArtifactTerraformRepo }}
+                                    name: {{ $artifactTerraformRepo }}
+                            parameters:
+                                -   name: {{ $paramCommitMessage }}
+                                    value: "feat(restore): update liferay configuration to restored data plane"
+                                -   name: {{ $paramTfvarsContent }}
+                                    value: |-
+                                        {{ $tfvarDataActive }} = {{ $outputParamDataInactive }}
+                                        {{ $tfvarDbRestoreSnapshotIdentifier }} = null
+                                        {{ $tfvarIsRestoring }} = true
+                        depends: "{{ $taskRestoreRdsInstance }} && {{ $taskRestoreS3Bucket }}"
+                        name: {{ $taskUpdateKubernetesSecret }}
+                        template: {{ $templateTerraformApply }}
+                    -   depends: {{ $taskUpdateKubernetesSecret }}
+                        name: {{ $taskRestartLiferay }}
+                        template: {{ $taskRestartLiferay }}
+                    -   arguments:
+                            artifacts:
+                                -   name: {{ $artifactTerraformRepo }}
+                                    from: {{ $outputArtifactTerraformRepo }}
+                            parameters:
+                                -   name: {{ $paramCommitMessage }}
+                                    value: "chore(restore): clean up rds instance"
+                                -   name: {{ $paramTfvarsContent }}
+                                    value: |-
+                                        {{ $tfvarDataActive }} = {{ $outputParamDataInactive }}
+                                        {{ $tfvarIsRestoring }} = false
+                        depends: {{ $taskRestartLiferay }}
+                        name: {{ $taskCleanupRdsInstance }}
+                        template: {{ $templateTerraformApply }}
+                    -   arguments:
+                            parameters:
+                                -   name: {{ $paramS3BucketId }}
+                                    value: {{ $outputParamS3BucketIdActive }}
+                        depends: {{ $taskRestartLiferay }}
+                        name: {{ $taskCleanupS3Bucket }}
+                        template: {{ $taskCleanupS3Bucket }}
+                    -   arguments:
+                            artifacts:
+                                -   from: {{ $outputArtifactTerraformRepo }}
+                                    name: {{ $artifactTerraformRepo }}
+                            parameters:
+                                -   name: {{ $paramCommitMessage }}
+                                    value: "chore(restore): reset failed restore"
+                                -   name: {{ $paramTfvarsContent }}
+                                    value: |-
+                                        {{ $tfvarDataActive }} = {{ $outputParamDataActive }}
+                                        {{ $tfvarIsRestoring }} = false
+                        depends: "{{ $taskRestoreRdsInstance }}.Succeeded && !{{ $taskRestartLiferay }}.Succeeded"
+                        name: {{ $taskRollbackFailedRestore }}
+                        template: {{ $templateTerraformApply }}
+            name: {{ $templateMain }}
+        -   name: {{ $taskCheckoutTerraformRepo }}
+            outputs:
+                artifacts:
+                    -   name: {{ $artifactTerraformRepo }}
+                        path: {{ $workingDir }}
+            script:
+                command: [ {{ $containerCommandSh }} ]
+                image: "{{ .Values.terraformImage.repository }}:{{ .Values.terraformImage.tag }}"
+                source: |-
+                    {{- include "liferayAwsBackupRestore.script.checkoutTerraformRepo" . | nindent 20 }}
+                {{- include "liferayAwsBackupRestore.volumeMount.gitCredentials" . | nindent 16 }}
+        -   name: {{ $taskFindPeerRecoveryPoints }}
+            outputs:
+                parameters:
+                    -   name: {{ $paramRdsSnapshotId }}
+                        valueFrom:
+                            path: {{ include "liferayAwsBackupRestore.constant.outputPathRdsSnapshotId" . }}
+                    -   name: {{ $paramS3RecoveryPointArn }}
+                        valueFrom:
+                            path: {{ include "liferayAwsBackupRestore.constant.outputPathS3RecoveryPointArn" . }}
+            script:
+                command: [ {{ $containerCommandSh }} ]
+                image: "{{ .Values.awsCliImage.repository }}:{{ .Values.awsCliImage.tag }}"
+                source: |-
+                    {{- include "liferayAwsBackupRestore.script.findPeerRecoveryPoints" . | nindent 20 }}
+        -   inputs:
+                artifacts:
+                    -   name: {{ $artifactTerraformRepo }}
+                        path: {{ $workingDir }}
+            name: {{ $taskGetDependenciesModuleOutputs }}
+            outputs:
+                parameters:
+                    -   name: {{ $paramDataActive }}
+                        valueFrom:
+                            path: {{ include "liferayAwsBackupRestore.constant.outputPathDataActive" . }}
+                    -   name: {{ $paramDataInactive }}
+                        valueFrom:
+                            path: {{ include "liferayAwsBackupRestore.constant.outputPathDataInactive" . }}
+                    -   name: {{ $paramS3BucketIdActive }}
+                        valueFrom:
+                            path: {{ include "liferayAwsBackupRestore.constant.outputPathS3BucketIdActive" . }}
+                    -   name: {{ $paramS3BucketIdInactive }}
+                        valueFrom:
+                            path: {{ include "liferayAwsBackupRestore.constant.outputPathS3BucketIdInactive" . }}
+            script:
+                command: [ {{ $containerCommandSh }} ]
+                image: "{{ .Values.terraformImage.repository }}:{{ .Values.terraformImage.tag }}"
+                source: |-
+                    {{- include "liferayAwsBackupRestore.script.getDependenciesModuleOutputs" . | nindent 20 }}
+                workingDir: {{ $workingDirTerraform }}
+        -   name: {{ $taskCleanupS3Bucket }}
+            inputs:
+                parameters:
+                    -   name: {{ $paramS3BucketId }}
+            container:
+                args:
+                    - "s3"
+                    - "rm"
+                    - "s3://{{ include "liferayAwsBackupRestore.task.input.parameter" $paramS3BucketId }}/"
+                    - "--recursive"
+                command: [ "aws" ]
+                image: "{{ .Values.awsCliImage.repository }}:{{ .Values.awsCliImage.tag }}"
+        -   name: {{ $taskRestoreS3Bucket }}
+            inputs:
+                parameters:
+                    -   name: {{ $paramS3BucketId }}
+                    -   name: {{ $paramS3RecoveryPointArn }}
+            script:
+                command: [ {{ $containerCommandSh }} ]
+                image: "{{ .Values.awsCliImage.repository }}:{{ .Values.awsCliImage.tag }}"
+                source: |-
+                    {{- include "liferayAwsBackupRestore.script.restoreS3Bucket" . | nindent 20 }}
+        -   name: {{ $templateTerraformApply }}
+            inputs:
+                artifacts:
+                    -   name: {{ $artifactTerraformRepo }}
+                        path: {{ $workingDir }}
+                parameters:
+                    -   name: {{ $paramCommitMessage }}
+                    -   name: {{ $paramTfvarsContent }}
+            script:
+                command: [ {{ $containerCommandSh }} ]
+                image: "{{ .Values.terraformImage.repository }}:{{ .Values.terraformImage.tag }}"
+                source: |-
+                    {{- include "liferayAwsBackupRestore.script.terraform-apply" . | nindent 20 }}
+                {{- include "liferayAwsBackupRestore.volumeMount.gitCredentials" . | nindent 16 }}
+                workingDir: {{ $workingDirTerraform }}
+        -   name: {{ $taskRestartLiferay }}
+            steps:
+                -   -   name: {{ $taskKubectlRolloutRestart }}
+                        template: {{ $taskKubectlRolloutRestart }}
+                -   -   name: {{ $taskKubectlRolloutStatus }}
+                        template: {{ $taskKubectlRolloutStatus }}
+        -   container:
+                args:
+                    - rollout
+                    - restart
+                    - statefulset
+                    - "{{ .Values.liferayWorkload.name }}"
+                image: "{{ .Values.kubectlImage.repository }}:{{ .Values.kubectlImage.tag }}"
+            name: {{ $taskKubectlRolloutRestart }}
+        -   container:
+                args:
+                    - rollout
+                    - status
+                    - statefulset
+                    - "{{ .Values.liferayWorkload.name }}"
+                    - --timeout=15m
+                image: "{{ .Values.kubectlImage.repository }}:{{ .Values.kubectlImage.tag }}"
+            name: {{ $taskKubectlRolloutStatus }}
+    {{- if and .Values.git.credentials.username .Values.git.credentials.token }}
+    volumes:
+        -   name: {{ include "liferayAwsBackupRestore.constant.gitCredentialsVolumeName" . }}
+            secret:
+                secretName: {{ include "liferayAwsBackupRestore.secret.gitCredentials.name" . }}
+    {{- end }}
+{{- end }}

--- a/cloud/helm/aws/charts/backup-restore/templates/configmap-artifact-repository.yaml
+++ b/cloud/helm/aws/charts/backup-restore/templates/configmap-artifact-repository.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    annotations:
+        workflows.argoproj.io/default-artifact-repository: artifact-repository
+    name: {{ include "liferayAwsBackupRestore.configmap.artifactRepository.name" . }}
+    namespace: {{ .Values.argoNamespace }}
+data:
+    artifact-repository: |-
+        s3:
+          endpoint: s3.amazonaws.com
+          bucket: {{ .Values.artifactRepositoryBucketId }}

--- a/cloud/helm/aws/charts/backup-restore/templates/secret-git-credentials.yaml
+++ b/cloud/helm/aws/charts/backup-restore/templates/secret-git-credentials.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.git.credentials.username .Values.git.credentials.token -}}
+{{- $url := .Values.terraformRepo.httpsUrl -}}
+
+{{- $hostname := $url | trimPrefix "https://" | splitList "/" | first -}}
+apiVersion: v1
+kind: Secret
+metadata:
+    labels:
+    {{- include "liferayAwsBackupRestore.labels" . | nindent 8 }}
+    name: {{ include "liferayAwsBackupRestore.secret.gitCredentials.name" . }}
+stringData:
+    .git-credentials: |-
+        https://{{ .Values.git.credentials.username }}:{{ .Values.git.credentials.token }}@{{ $hostname }}
+type: Opaque
+{{- end -}}

--- a/cloud/helm/aws/charts/backup-restore/templates/serviceaccount.yaml
+++ b/cloud/helm/aws/charts/backup-restore/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+    annotations:
+        {{- toYaml .Values.serviceAccount.annotations | nindent 8 }}
+    name: {{ include "liferayAwsBackupRestore.name" . }}
+    labels:
+    {{- include "liferayAwsBackupRestore.labels" . | nindent 8 }}

--- a/cloud/helm/aws/charts/backup-restore/values.yaml
+++ b/cloud/helm/aws/charts/backup-restore/values.yaml
@@ -1,0 +1,34 @@
+argoNamespace: argo
+artifactRepositoryBucketId: ""
+awsBackupServiceAssumedIamRoleArn: ""
+awsBackupVaultName: "liferay-backup"
+awsCliImage:
+    repository: amazon/aws-cli
+    tag: "2.27.63"
+createClusterResources: true
+fullnameOverride: ""
+git:
+    credentials:
+        token: ""
+        username: ""
+    user:
+        email: ""
+        name: ""
+kubectlImage:
+    repository: registry.k8s.io/kubectl
+    tag: v1.34.0
+liferayWorkload:
+    managedSecretName: managed-service-details
+    name: liferay-default
+nameOverride: ""
+s3RestoreWaitTimeoutSeconds: 7200
+serviceAccount:
+    annotations: {}
+terraformImage:
+    repository: hashicorp/terraform
+    tag: "1.12.2"
+terraformRepo:
+    branch: master
+    dependenciesModuleRelativePath: dependencies
+    httpsUrl: https://github.com/liferay/liferay-portal.git
+    sparseCheckoutRelativePath: cloud/terraform/aws

--- a/cloud/helm/aws/values.yaml
+++ b/cloud/helm/aws/values.yaml
@@ -1,3 +1,5 @@
+liferay-aws-backup-restore:
+    enabled: true
 liferay-default:
     configmap:
         data:

--- a/cloud/terraform/aws/backup/backup-restore-workflow/variables.tf
+++ b/cloud/terraform/aws/backup/backup-restore-workflow/variables.tf
@@ -11,7 +11,7 @@ variable "kubernetes_namespace" {
 	default="liferay-system"
 }
 variable "kubernetes_service_account_name" {
-	default="liferay-backup-restore"
+	default="liferay-aws-backup-restore"
 }
 variable "region" {
 	type=string


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-63870

After discussion with Ray and Jared, we agreed that the Liferay backup should not be installable as a standalone chart, but embedded in our current `liferay-aws` chart. This is because it is of no use when installed by itself. It will be enabled by a feature flag in our current aws chart, which the `liferay-aws-marketplace` chart extends.

I am following the pattern of an umbrella chart referenced here: https://helm.sh/docs/howto/charts_tips_and_tricks/#complex-charts-with-many-dependencies. The pattern is to put such code in a `charts` sub-directory.

This also has the side-effect that the subchart `backup-restore` will not be searchable or installable via a command such as `helm search repo`.