### PR TITLE
Revert "LPD-56780 portal-web: Remove redundant sr-only text"

### DIFF
--- a/portal-web/docroot/html/taglib/ui/icon/link_content.jspf
+++ b/portal-web/docroot/html/taglib/ui/icon/link_content.jspf
@@ -38,7 +38,7 @@
 		<span class="taglib-text-icon"><%= localizeMessage ? LanguageUtil.get(resourceBundle, message) : message %></span>
 	</c:when>
 	<c:otherwise>
-		<c:if test="<%= !toolTip && Validator.isNotNull(message) %>">
+		<c:if test="<%= Validator.isNotNull(message) %>">
 			<span class="taglib-text <%= label ? StringPool.BLANK : "hide-accessible sr-only" %>"><%= localizeMessage ? LanguageUtil.get(resourceBundle, message) : message %></span>
 		</c:if>
 	</c:otherwise>


### PR DESCRIPTION
This reverts commit ca743dcd8586b4138df5bba8948029a9df1729b4.

Reverting to avoid regressions, as teams are experiencing issues with playwright tests being unable to assert the `sr-only` text anymore: https://liferay.slack.com/archives/CNBG06JS3/p1756298554624939 

🫠 