### PR TITLE
LPD-64748 Enable ReleasePublisherTest.testPublishOnActivation test as it is not longer failing

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/ReleasePublisherTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/ReleasePublisherTest.java
@@ -27,7 +27,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -82,7 +81,6 @@ public class ReleasePublisherTest {
 		Assert.assertEquals(0, _getReleaseServiceReferences().size());
 	}
 
-	@Ignore
 	@Test
 	public void testPublishOnActivation() throws Exception {
 		_addReleaseBeforeActivation(ReleaseConstants.STATE_GOOD);


### PR DESCRIPTION
This reverts commit bf9976bfb6bfb673d7d66ec40f1056e7234ad8f5.

Tests were executed here: https://github.com/jorgediaz-lr/liferay-portal/pull/569