### PR TITLE
LPD-65098 Error in console while trying to export site data

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
@@ -362,7 +362,7 @@ public class BatchEnginePortletDataHandler extends BasePortletDataHandler {
 		batchEngineTaskItemDelegate.setLanguageId(user.getLanguageId());
 
 		Page<?> page = batchEngineTaskItemDelegate.read(
-			null, Pagination.of(0, 0), null, parameters, null);
+			null, Pagination.of(1, 1), null, parameters, null);
 
 		ManifestSummary manifestSummary =
 			portletDataContext.getManifestSummary();


### PR DESCRIPTION
Manually forwarding from: https://github.com/liferay-headless/liferay-portal/pull/3105

[LPD-65098](https://liferay.atlassian.net/browse/LPD-65098)

Fixes a major issue with site level export. Also, fixes some test cases, like `export-import-web/main/site.import.spec.ts > can export and import custom object entries at site level`.

cc: @4lejandrito 