### PR TITLE
LPD-64801 Add shell script to get peer recovery points

### DIFF
--- a/cloud/helm/aws/charts/backup-restore/templates/_scripts.tpl
+++ b/cloud/helm/aws/charts/backup-restore/templates/_scripts.tpl
@@ -39,6 +39,105 @@ function main {
 main
 {{- end -}}
 
+{{- define "liferayAWSBackupRestore.script.getPeerRecoveryPoints" -}}
+#!/bin/sh
+
+set -eu
+
+function get_recovery_point_arn_by_type {
+    local recovery_points_json="${2}"
+    local resource_type="${1}"
+
+    local filtered_recovery_points_json
+
+    filtered_recovery_points_json=$( \
+    	echo \
+			"${recovery_points_json}" \
+			| jq --arg resource_type "${resource_type}" '[.[] | select(.ResourceType == $resource_type)]')
+
+    local filtered_recovery_points_length
+
+    filtered_recovery_points_length=$(echo "${filtered_recovery_points_json}" | jq 'length')
+
+    if [ "${filtered_recovery_points_length}" -ne 1 ]
+    then
+        echo "A single recovery point of type \"${resource_type}\" was expected, but ${filtered_recovery_points_length} were found." >&2
+
+        return 1
+    fi
+
+    echo "${filtered_recovery_points_json}" | jq --raw-output '.[0].RecoveryPointArn'
+}
+
+function main {
+    local recovery_point_details
+
+    recovery_point_details=$( \
+    	aws \
+			backup \
+			describe-recovery-point \
+			--backup-vault-name "{{ .Values.awsBackupService.vaultName }}" \
+			--recovery-point-arn "{{ "{{" }}workflow.parameters.recovery-point-arn}}")
+
+    local creation_date
+
+    creation_date=$(echo "${recovery_point_details}" | jq --raw-output '.CreationDate')
+
+    if [ -z "${creation_date}" ] || [ "${creation_date}" = "null" ]
+    then
+        echo "The provided recovery point ARN has no CreationDate." >&2
+
+        return 1
+    fi
+
+    local creation_date_timestamp
+
+    creation_date_timestamp=$(date --date "${creation_date}" +%s)
+
+    local by_created_after
+    local by_created_before
+
+    by_created_after=$(date --date @$((creation_date_timestamp - 1)) --iso-8601=seconds)
+    by_created_before=$(date --date @$((creation_date_timestamp + 1)) --iso-8601=seconds)
+
+    local peer_recovery_points
+
+    peer_recovery_points=$( \
+    	aws \
+			backup \
+			list-recovery-points-by-backup-vault \
+			--backup-vault-name "{{ .Values.awsBackupService.vaultName }}" \
+			--by-created-after "${by_created_after}" \
+			--by-created-before "${by_created_before}" \
+			| jq --arg creation_date "${creation_date}" '[.RecoveryPoints[] | select(.CreationDate == $creation_date)]')
+
+    local rds_recovery_point_arn
+    local s3_recovery_point_arn
+
+    rds_recovery_point_arn=$(get_recovery_point_arn_by_type "RDS" "${peer_recovery_points}")
+    s3_recovery_point_arn=$(get_recovery_point_arn_by_type "S3" "${peer_recovery_points}")
+
+    local rds_snapshot_id
+
+    rds_snapshot_id=$( \
+    	echo \
+			"${rds_recovery_point_arn}" \
+			| awk --field-separator "snapshot:" '{print $2}')
+
+    if [ -z "${rds_snapshot_id}" ]
+    then
+        echo "The RDS snapshot id could not be parsed from ${rds_recovery_point_arn}." >&2
+
+        exit 1
+    fi
+
+    echo "${rds_snapshot_id}" > /tmp/rds-snapshot-id.txt
+    echo "${s3_recovery_point_arn}" > /tmp/s3-recovery-point-arn.txt
+}
+
+main
+{{- end -}}
+
 {{- define "liferayAWSBackupRestore.script.restoreS3Bucket" -}}
 #!/bin/sh
 

--- a/cloud/helm/aws/charts/backup-restore/templates/clusterworkflowtemplate.yaml
+++ b/cloud/helm/aws/charts/backup-restore/templates/clusterworkflowtemplate.yaml
@@ -36,20 +36,6 @@ spec:
                 parameters:
                     -   name: s3-bucket-id
             name: clean-up-s3-bucket
-        -   name: find-peer-recovery-points
-            outputs:
-                parameters:
-                    -   name: rds-snapshot-id
-                        valueFrom:
-                            path: /tmp/rds-snapshot-id.txt
-                    -   name: s3-recovery-point-arn
-                        valueFrom:
-                            path: /tmp/s3-recovery-point-arn.txt
-            script:
-                command: [sh]
-                image: "{{ .Values.images.awsCli.repository }}:{{ .Values.images.awsCli.tag }}"
-                source: |-
-                    {{- include "liferayAWSBackupRestore.script.findPeerRecoveryPoints" . | nindent 20 }}
         -   inputs:
                 artifacts:
                     -   name: git-repository
@@ -75,6 +61,20 @@ spec:
                 source: |-
                     {{- include "liferayAWSBackupRestore.script.getDependenciesModuleOutputs" . | nindent 20 }}
                 workingDir: {{ printf "/src/%s" .Values.git.repository.paths.dependenciesModule }}
+        -   name: get-peer-recovery-points
+            outputs:
+                parameters:
+                    -   name: rds-snapshot-id
+                        valueFrom:
+                            path: /tmp/rds-snapshot-id.txt
+                    -   name: s3-recovery-point-arn
+                        valueFrom:
+                            path: /tmp/s3-recovery-point-arn.txt
+            script:
+                command: [sh]
+                image: "{{ .Values.images.awsCli.repository }}:{{ .Values.images.awsCli.tag }}"
+                source: |-
+                    {{- include "liferayAWSBackupRestore.script.getPeerRecoveryPoints" . | nindent 20 }}
         -   container:
                 args:
                     -   rollout
@@ -117,8 +117,6 @@ spec:
                         depends: restart-liferay
                         name: clean-up-s3-bucket
                         template: clean-up-s3-bucket
-                    -   name: find-peer-recovery-points
-                        template: find-peer-recovery-points
                     -   arguments:
                             artifacts:
                                 -   from: {{ "{{" }}tasks.checkout-git-repository.outputs.artifacts.git-repository}}
@@ -126,6 +124,8 @@ spec:
                         depends: checkout-git-repository
                         name: get-dependencies-module-outputs
                         template: get-dependencies-module-outputs
+                    -   name: get-peer-recovery-points
+                        template: get-peer-recovery-points
                     -   depends: update-kubernetes-secret
                         name: restart-liferay
                         template: restart-liferay
@@ -139,18 +139,18 @@ spec:
                                 -   name: tfvars-content
                                     value: |-
                                         data_active = "{{ "{{" }}tasks.get-dependencies-module-outputs.outputs.parameters.data-active}}"
-                                        db_restore_snapshot_identifier = "{{ "{{" }}tasks.find-peer-recovery-points.outputs.parameters.rds-snapshot-id}}"
+                                        db_restore_snapshot_identifier = "{{ "{{" }}tasks.get-peer-recovery-points.outputs.parameters.rds-snapshot-id}}"
                                         is_restoring = true
-                        depends: find-peer-recovery-points && get-dependencies-module-outputs
+                        depends: get-dependencies-module-outputs && get-peer-recovery-points
                         name: restore-rds-instance
                         template: terraform-apply
                     -   arguments:
                             parameters:
                                 -   name: s3-recovery-point-arn
-                                    value: {{ "{{" }}tasks.find-peer-recovery-points.outputs.parameters.s3-recovery-point-arn}}
+                                    value: {{ "{{" }}tasks.get-peer-recovery-points.outputs.parameters.s3-recovery-point-arn}}
                                 -   name: s3-bucket-id
                                     value: {{ "{{" }}tasks.get-dependencies-module-outputs.outputs.parameters.s3-bucket-id-inactive}}
-                        depends: find-peer-recovery-points && get-dependencies-module-outputs
+                        depends: get-dependencies-module-outputs && get-peer-recovery-points
                         name: restore-s3-bucket
                         template: restore-s3-bucket
                     -   arguments:


### PR DESCRIPTION
Originally the term "find" was used to indicate the idea of searching. But it wasn't consistent with `get_recovery_point_arn_by_type`.

I'm aware of the concept in liferay-portal of `find` returning null and `get` throwing an error if something couldn't be found.

Since we fail when we cannot get the recovery points, I decided to use the word "get."