### PR TITLE
LPD-62088 Strict virtual host access functionality doesn't work

### DIFF
--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/build.gradle
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/build.gradle
@@ -12,5 +12,6 @@ dependencies {
 	compileOnly project(":apps:layout:layout-taglib")
 	compileOnly project(":apps:layout:layout-utility-page-api")
 	compileOnly project(":core:petra:petra-io")
+	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/request/contributor/CommonStatusLayoutUtilityPageEntryRequestContributor.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/request/contributor/CommonStatusLayoutUtilityPageEntryRequestContributor.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
@@ -28,7 +29,6 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.servlet.I18nServlet;
-import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsValues;
 
 import java.util.Set;
@@ -53,7 +53,7 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 	public void addAttributesAndParameters(
 		DynamicServletRequest dynamicServletRequest) {
 
-		long companyId = PortalInstances.getCompanyId(dynamicServletRequest);
+		long companyId = CompanyThreadLocal.getCompanyId();
 
 		PermissionChecker permissionChecker = _getPermissionChecker(
 			companyId, dynamicServletRequest);

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/test/java/com/liferay/layout/utility/page/status/internal/request/contributor/CommonStatusLayoutUtilityPageEntryRequestContributorTest.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/test/java/com/liferay/layout/utility/page/status/internal/request/contributor/CommonStatusLayoutUtilityPageEntryRequestContributorTest.java
@@ -28,10 +28,7 @@ import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.servlet.I18nServlet;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
-import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsValues;
-
-import jakarta.servlet.http.HttpServletRequest;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -79,7 +76,6 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributorTest {
 	public static void tearDownClass() {
 		_i18nServletMockedStatic.close();
 		_permissionThreadLocalMockedStatic.close();
-		_portalInstancesMockedStatic.close();
 	}
 
 	@Before
@@ -87,7 +83,6 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributorTest {
 		_setUpCommonStatusLayoutUtilityPageEntryRequestContributor();
 
 		_permissionThreadLocalMockedStatic.clearInvocations();
-		_portalInstancesMockedStatic.reset();
 	}
 
 	@Test
@@ -97,7 +92,8 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributorTest {
 		_testAddAttributesAndParameters(
 			null,
 			_getDynamicServletRequest(
-				RandomTestUtil.randomString(), RandomTestUtil.randomLong()),
+				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
+				null),
 			null, null, null, null, null, 0);
 	}
 
@@ -106,7 +102,8 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributorTest {
 		throws PortalException {
 
 		_testAddAttributesAndParameters(
-			null, _getDynamicServletRequest(RandomTestUtil.randomString(), 0L),
+			null,
+			_getDynamicServletRequest(RandomTestUtil.randomString(), 0L, null),
 			null, null, null, null, null, 0);
 	}
 
@@ -117,13 +114,15 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributorTest {
 		Layout layout = _mockLayout(
 			RandomTestUtil.randomLong(), RandomTestUtil.randomLong());
 
+		LayoutSet layoutSet = _getLayoutSet(
+			layout.getCompanyId(), layout.getGroupId(), layout, null);
+
 		_testAddAttributesAndParameters(
 			null,
-			_getDynamicServletRequest(_PATH_CONTEXT, layout.getCompanyId()),
+			_getDynamicServletRequest(
+				_PATH_CONTEXT, layout.getCompanyId(), layoutSet),
 			String.valueOf(layout.getGroupId()), null,
-			String.valueOf(layout.getLayoutId()),
-			_getLayoutSet(
-				layout.getCompanyId(), layout.getGroupId(), layout, null),
+			String.valueOf(layout.getLayoutId()), layoutSet,
 			RandomTestUtil.randomString(), 1);
 	}
 
@@ -147,17 +146,18 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributorTest {
 				groupFriendlyURL),
 			groupFriendlyURL);
 
+		LayoutSet layoutSet = _getLayoutSet(
+			layout.getCompanyId(), layout.getGroupId(), layout, null);
+
 		_testAddAttributesAndParameters(
 			StringBundler.concat(
 				_PATH_PROXY, _PATH_CONTEXT, StringPool.SLASH, languageId,
 				PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
 				StringPool.SLASH, RandomTestUtil.randomString(), "/test/test"),
-			_getDynamicServletRequest(_PATH_CONTEXT, layout.getCompanyId()),
+			_getDynamicServletRequest(
+				_PATH_CONTEXT, layout.getCompanyId(), layoutSet),
 			String.valueOf(layout.getGroupId()), languageId,
-			String.valueOf(layout.getLayoutId()),
-			_getLayoutSet(
-				layout.getCompanyId(), layout.getGroupId(), layout, null),
-			_PATH_PROXY, 1);
+			String.valueOf(layout.getLayoutId()), layoutSet, _PATH_PROXY, 1);
 	}
 
 	@Test
@@ -174,17 +174,18 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributorTest {
 
 		_mockGroupLocalService(layout.getCompanyId(), null, groupFriendlyURL);
 
+		LayoutSet layoutSet = _getLayoutSet(
+			layout.getCompanyId(), layout.getGroupId(), layout, null);
+
 		_testAddAttributesAndParameters(
 			StringBundler.concat(
 				_PATH_PROXY, _PATH_CONTEXT, StringPool.SLASH, languageId,
 				PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
 				StringPool.SLASH, RandomTestUtil.randomString(), "/test/test"),
-			_getDynamicServletRequest(_PATH_CONTEXT, layout.getCompanyId()),
+			_getDynamicServletRequest(
+				_PATH_CONTEXT, layout.getCompanyId(), layoutSet),
 			String.valueOf(layout.getGroupId()), languageId,
-			String.valueOf(layout.getLayoutId()),
-			_getLayoutSet(
-				layout.getCompanyId(), layout.getGroupId(), layout, null),
-			_PATH_PROXY, 1);
+			String.valueOf(layout.getLayoutId()), layoutSet, _PATH_PROXY, 1);
 	}
 
 	@Test
@@ -207,18 +208,18 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributorTest {
 
 		_mockLayoutLocalService(groupId, layout, null);
 
+		LayoutSet layoutSet = _getLayoutSet(
+			companyId, virtualHostGroupLayout.getGroupId(),
+			virtualHostGroupLayout, null);
+
 		_testAddAttributesAndParameters(
 			StringBundler.concat(
 				_PATH_PROXY, _PATH_CONTEXT, StringPool.SLASH, languageId,
 				PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
 				groupFriendlyURL, "/test/test"),
-			_getDynamicServletRequest(_PATH_CONTEXT, companyId),
+			_getDynamicServletRequest(_PATH_CONTEXT, companyId, layoutSet),
 			String.valueOf(group.getGroupId()), languageId,
-			String.valueOf(layout.getLayoutId()),
-			_getLayoutSet(
-				companyId, virtualHostGroupLayout.getGroupId(),
-				virtualHostGroupLayout, null),
-			_PATH_PROXY, 1);
+			String.valueOf(layout.getLayoutId()), layoutSet, _PATH_PROXY, 1);
 	}
 
 	@Test
@@ -242,19 +243,20 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributorTest {
 
 		_mockLayoutLocalService(group.getGroupId(), null, null);
 
+		LayoutSet layoutSet = _getLayoutSet(
+			virtualHostGroupLayout.getCompanyId(),
+			virtualHostGroupLayout.getGroupId(), virtualHostGroupLayout, null);
+
 		_testAddAttributesAndParameters(
 			StringBundler.concat(
 				_PATH_PROXY, _PATH_CONTEXT, StringPool.SLASH, languageId,
 				PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
 				groupFriendlyURL, "/test/test"),
 			_getDynamicServletRequest(
-				_PATH_CONTEXT, virtualHostGroupLayout.getCompanyId()),
+				_PATH_CONTEXT, virtualHostGroupLayout.getCompanyId(),
+				layoutSet),
 			String.valueOf(virtualHostGroupLayout.getGroupId()), languageId,
-			String.valueOf(virtualHostGroupLayout.getLayoutId()),
-			_getLayoutSet(
-				virtualHostGroupLayout.getCompanyId(),
-				virtualHostGroupLayout.getGroupId(), virtualHostGroupLayout,
-				null),
+			String.valueOf(virtualHostGroupLayout.getLayoutId()), layoutSet,
 			_PATH_PROXY, 2);
 	}
 
@@ -276,17 +278,18 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributorTest {
 
 		_mockGroupLocalService(layout.getCompanyId(), group, groupFriendlyURL);
 
+		LayoutSet layoutSet = _getLayoutSet(
+			layout.getCompanyId(), layout.getGroupId(), layout, null);
+
 		_testAddAttributesAndParameters(
 			StringBundler.concat(
 				_PATH_PROXY, _PATH_CONTEXT, StringPool.SLASH, languageId,
 				PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
 				groupFriendlyURL, "/test/test"),
-			_getDynamicServletRequest(_PATH_CONTEXT, layout.getCompanyId()),
+			_getDynamicServletRequest(
+				_PATH_CONTEXT, layout.getCompanyId(), layoutSet),
 			String.valueOf(layout.getGroupId()), languageId,
-			String.valueOf(layout.getLayoutId()),
-			_getLayoutSet(
-				layout.getCompanyId(), layout.getGroupId(), layout, null),
-			_PATH_PROXY, 2);
+			String.valueOf(layout.getLayoutId()), layoutSet, _PATH_PROXY, 2);
 	}
 
 	@Test
@@ -298,16 +301,17 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributorTest {
 		Layout layout = _mockLayout(
 			RandomTestUtil.randomLong(), RandomTestUtil.randomLong());
 
+		LayoutSet layoutSet = _getLayoutSet(
+			layout.getCompanyId(), layout.getGroupId(), layout, null);
+
 		_testAddAttributesAndParameters(
 			StringBundler.concat(
 				_PATH_PROXY, _PATH_CONTEXT, StringPool.SLASH, languageId,
 				StringPool.SLASH + RandomTestUtil.randomString()),
-			_getDynamicServletRequest(_PATH_CONTEXT, layout.getCompanyId()),
+			_getDynamicServletRequest(
+				_PATH_CONTEXT, layout.getCompanyId(), layoutSet),
 			String.valueOf(layout.getGroupId()), languageId,
-			String.valueOf(layout.getLayoutId()),
-			_getLayoutSet(
-				layout.getCompanyId(), layout.getGroupId(), layout, null),
-			_PATH_PROXY, 1);
+			String.valueOf(layout.getLayoutId()), layoutSet, _PATH_PROXY, 1);
 	}
 
 	@Test
@@ -319,16 +323,17 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributorTest {
 		Layout layout = _mockLayout(
 			RandomTestUtil.randomLong(), RandomTestUtil.randomLong());
 
+		LayoutSet layoutSet = _getLayoutSet(
+			layout.getCompanyId(), layout.getGroupId(), layout, null);
+
 		_testAddAttributesAndParameters(
 			StringBundler.concat(
 				_PATH_PROXY, _PATH_CONTEXT, StringPool.SLASH, languageId,
 				StringPool.SLASH),
-			_getDynamicServletRequest(_PATH_CONTEXT, layout.getCompanyId()),
+			_getDynamicServletRequest(
+				_PATH_CONTEXT, layout.getCompanyId(), layoutSet),
 			String.valueOf(layout.getGroupId()), languageId,
-			String.valueOf(layout.getLayoutId()),
-			_getLayoutSet(
-				layout.getCompanyId(), layout.getGroupId(), layout, null),
-			_PATH_PROXY, 1);
+			String.valueOf(layout.getLayoutId()), layoutSet, _PATH_PROXY, 1);
 	}
 
 	@Test
@@ -346,17 +351,18 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributorTest {
 
 		_mockGroupLocalService(group.getCompanyId(), group, groupFriendlyURL);
 
+		LayoutSet layoutSet = _getLayoutSet(
+			RandomTestUtil.randomLong(), RandomTestUtil.randomLong(), null,
+			null);
+
 		_testAddAttributesAndParameters(
 			StringBundler.concat(
 				_PATH_PROXY, _PATH_CONTEXT, StringPool.SLASH, languageId,
 				PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
 				groupFriendlyURL, "/test/test"),
-			_getDynamicServletRequest(_PATH_CONTEXT, group.getCompanyId()),
-			null, null, null,
-			_getLayoutSet(
-				RandomTestUtil.randomLong(), RandomTestUtil.randomLong(), null,
-				null),
-			_PATH_PROXY, 2);
+			_getDynamicServletRequest(
+				_PATH_CONTEXT, group.getCompanyId(), layoutSet),
+			null, null, null, layoutSet, _PATH_PROXY, 2);
 	}
 
 	@Test
@@ -366,7 +372,8 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributorTest {
 		_testAddAttributesAndParameters(
 			null,
 			_getDynamicServletRequest(
-				RandomTestUtil.randomString(), RandomTestUtil.randomLong()),
+				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
+				null),
 			null, null, null, null, null, 0);
 	}
 
@@ -377,12 +384,14 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributorTest {
 		Layout layout = _mockLayout(
 			RandomTestUtil.randomLong(), RandomTestUtil.randomLong());
 
+		LayoutSet layoutSet = _getLayoutSet(
+			layout.getCompanyId(), layout.getGroupId(), layout, null);
+
 		_testAddAttributesAndParameters(
-			null, _getDynamicServletRequest(null, layout.getCompanyId()),
+			null,
+			_getDynamicServletRequest(null, layout.getCompanyId(), layoutSet),
 			String.valueOf(layout.getGroupId()), null,
-			String.valueOf(layout.getLayoutId()),
-			_getLayoutSet(
-				layout.getCompanyId(), layout.getGroupId(), layout, null),
+			String.valueOf(layout.getLayoutId()), layoutSet,
 			RandomTestUtil.randomString(), 1);
 	}
 
@@ -393,15 +402,16 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributorTest {
 		Layout layout = _mockLayout(
 			RandomTestUtil.randomLong(), RandomTestUtil.randomLong());
 
+		LayoutSet layoutSet = _getLayoutSet(
+			layout.getCompanyId(), layout.getGroupId(), null, layout);
+
 		_testAddAttributesAndParameters(
 			null,
 			_getDynamicServletRequest(
-				RandomTestUtil.randomString(), layout.getCompanyId()),
+				RandomTestUtil.randomString(), layout.getCompanyId(),
+				layoutSet),
 			String.valueOf(layout.getGroupId()), null,
-			String.valueOf(layout.getLayoutId()),
-			_getLayoutSet(
-				layout.getCompanyId(), layout.getGroupId(), null, layout),
-			null, 1);
+			String.valueOf(layout.getLayoutId()), layoutSet, null, 1);
 	}
 
 	@Test
@@ -411,19 +421,20 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributorTest {
 		Layout layout = _mockLayout(
 			RandomTestUtil.randomLong(), RandomTestUtil.randomLong());
 
+		LayoutSet layoutSet = _getLayoutSet(
+			layout.getCompanyId(), layout.getGroupId(), layout, null);
+
 		_testAddAttributesAndParameters(
 			null,
 			_getDynamicServletRequest(
-				RandomTestUtil.randomString(), layout.getCompanyId()),
+				RandomTestUtil.randomString(), layout.getCompanyId(),
+				layoutSet),
 			String.valueOf(layout.getGroupId()), null,
-			String.valueOf(layout.getLayoutId()),
-			_getLayoutSet(
-				layout.getCompanyId(), layout.getGroupId(), layout, null),
-			null, 1);
+			String.valueOf(layout.getLayoutId()), layoutSet, null, 1);
 	}
 
 	private DynamicServletRequest _getDynamicServletRequest(
-		String contextPath, Long companyId) {
+		String contextPath, Long companyId, LayoutSet layoutSet) {
 
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest();
@@ -431,6 +442,9 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributorTest {
 		mockHttpServletRequest.setContextPath(contextPath);
 
 		mockHttpServletRequest.setAttribute(WebKeys.COMPANY_ID, companyId);
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.VIRTUAL_HOST_LAYOUT_SET, layoutSet);
 
 		return new DynamicServletRequest(mockHttpServletRequest);
 	}
@@ -463,8 +477,6 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributorTest {
 		).thenReturn(
 			group
 		);
-
-		_setUpPortalInstancesMockedStatic(layoutSet);
 
 		return layoutSet;
 	}
@@ -624,23 +636,6 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributorTest {
 		);
 	}
 
-	private void _setUpPortalInstancesMockedStatic(LayoutSet layoutSet) {
-		_portalInstancesMockedStatic.when(
-			() -> PortalInstances.getCompanyId(
-				Mockito.any(HttpServletRequest.class))
-		).thenAnswer(
-			invocationOnMock -> {
-				HttpServletRequest httpServletRequest =
-					invocationOnMock.getArgument(0, HttpServletRequest.class);
-
-				httpServletRequest.setAttribute(
-					WebKeys.VIRTUAL_HOST_LAYOUT_SET, layoutSet);
-
-				return httpServletRequest.getAttribute(WebKeys.COMPANY_ID);
-			}
-		);
-	}
-
 	private void _testAddAttributesAndParameters(
 			String currentURL, DynamicServletRequest dynamicServletRequest,
 			String groupId, String languageId, String layoutId,
@@ -674,9 +669,6 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributorTest {
 			() -> PermissionThreadLocal.setPermissionChecker(
 				_originalPermissionChecker),
 			Mockito.times(wantedNumberOfInvocations));
-
-		_portalInstancesMockedStatic.verify(
-			() -> PortalInstances.getCompanyId(dynamicServletRequest));
 	}
 
 	private static final String _PATH_CONTEXT = "/context";
@@ -689,9 +681,6 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributorTest {
 	private static final MockedStatic<PermissionThreadLocal>
 		_permissionThreadLocalMockedStatic = Mockito.mockStatic(
 			PermissionThreadLocal.class);
-	private static final MockedStatic<PortalInstances>
-		_portalInstancesMockedStatic = Mockito.mockStatic(
-			PortalInstances.class);
 
 	private CommonStatusLayoutUtilityPageEntryRequestContributor
 		_commonStatusLayoutUtilityPageEntryRequestContributor;

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/test/java/com/liferay/layout/utility/page/status/internal/request/contributor/CommonStatusLayoutUtilityPageEntryRequestContributorTest.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/test/java/com/liferay/layout/utility/page/status/internal/request/contributor/CommonStatusLayoutUtilityPageEntryRequestContributorTest.java
@@ -5,6 +5,7 @@
 
 package com.liferay.layout.utility.page.status.internal.request.contributor;
 
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -12,6 +13,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
@@ -645,8 +647,15 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributorTest {
 
 		_mockPortal(currentURL, pathProxy);
 
-		_commonStatusLayoutUtilityPageEntryRequestContributor.
-			addAttributesAndParameters(dynamicServletRequest);
+		long companyId = (Long)dynamicServletRequest.getAttribute(
+			WebKeys.COMPANY_ID);
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId)) {
+
+			_commonStatusLayoutUtilityPageEntryRequestContributor.
+				addAttributesAndParameters(dynamicServletRequest);
+		}
 
 		Assert.assertEquals(
 			groupId, dynamicServletRequest.getParameter("groupId"));

--- a/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/portal/instances/test/PortalInstancesFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/portal/instances/test/PortalInstancesFilterTest.java
@@ -26,6 +26,9 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TreeMapBuilder;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.servlet.filters.portal.instances.PortalInstancesFilter;
+import com.liferay.portal.test.rule.ExpectedLog;
+import com.liferay.portal.test.rule.ExpectedLogs;
+import com.liferay.portal.test.rule.ExpectedType;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsValues;
@@ -102,6 +105,15 @@ public class PortalInstancesFilterTest {
 		}
 	}
 
+	@ExpectedLogs(
+		expectedLogs = {
+			@ExpectedLog(
+				expectedLog = "Unknown Virtual Hostname:",
+				expectedType = ExpectedType.CONTAINS
+			)
+		},
+		level = "ERROR", loggerClass = PortalInstancesFilter.class
+	)
 	@Test
 	public void testNonexistingVirtualHostWithStrictAccessEnabled()
 		throws Exception {

--- a/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/portal/instances/test/PortalInstancesFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/portal/instances/test/PortalInstancesFilterTest.java
@@ -69,9 +69,12 @@ public class PortalInstancesFilterTest {
 		LayoutSet layoutSet = _layoutSetLocalService.fetchLayoutSet(
 			virtualHost.getLayoutSetId());
 
-		_test(virtualHost.getCompanyId(), hostName, layoutSet, null);
-
-		_virtualHostLocalService.deleteVirtualHost(virtualHost);
+		try {
+			_test(virtualHost.getCompanyId(), hostName, layoutSet, null);
+		}
+		finally {
+			_virtualHostLocalService.deleteVirtualHost(virtualHost);
+		}
 	}
 
 	@Test

--- a/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/portal/instances/test/PortalInstancesFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/portal/instances/test/PortalInstancesFilterTest.java
@@ -1,0 +1,171 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.servlet.filters.portal.instances.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.model.VirtualHost;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.LayoutSetLocalService;
+import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
+import com.liferay.portal.kernel.service.VirtualHostLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.TreeMapBuilder;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.servlet.filters.portal.instances.PortalInstancesFilter;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PropsValues;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Jorge Díaz
+ */
+@RunWith(Arquillian.class)
+public class PortalInstancesFilterTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testExistingVirtualHost() throws Exception {
+		String hostName = StringUtil.toLowerCase(RandomTestUtil.randomString());
+
+		_layoutSetLocalService.updateVirtualHosts(
+			TestPropsValues.getGroupId(), false,
+			TreeMapBuilder.put(
+				hostName, StringPool.BLANK
+			).build());
+
+		VirtualHost virtualHost = _virtualHostLocalService.getVirtualHost(
+			hostName);
+
+		LayoutSet layoutSet = _layoutSetLocalService.fetchLayoutSet(
+			virtualHost.getLayoutSetId());
+
+		_test(virtualHost.getCompanyId(), hostName, layoutSet, null);
+
+		_virtualHostLocalService.deleteVirtualHost(virtualHost);
+	}
+
+	@Test
+	public void testNonexistingVirtualHostWithStrictAccessDisabled()
+		throws Exception {
+
+		long companyId = PortalInstancePool.getDefaultCompanyId();
+
+		LayoutSet layoutSet = null;
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId)) {
+
+			Group group = GroupLocalServiceUtil.fetchGroup(
+				companyId, PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME);
+
+			if (group != null) {
+				layoutSet = LayoutSetLocalServiceUtil.getLayoutSet(
+					group.getGroupId(), false);
+			}
+		}
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"VIRTUAL_HOSTS_STRICT_ACCESS", false)) {
+
+			_test(
+				companyId,
+				StringUtil.toLowerCase(RandomTestUtil.randomString()),
+				layoutSet, null);
+		}
+	}
+
+	@Test
+	public void testNonexistingVirtualHostWithStrictAccessEnabled()
+		throws Exception {
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"VIRTUAL_HOSTS_STRICT_ACCESS", true)) {
+
+			_test(
+				null, StringUtil.toLowerCase(RandomTestUtil.randomString()),
+				null, true);
+		}
+	}
+
+	private void _test(
+			Long companyId, String hostname, LayoutSet layoutSet,
+			Boolean unknownVirtualHost)
+		throws Exception {
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					CompanyConstants.SYSTEM)) {
+
+			MockHttpServletRequest mockHttpServletRequest =
+				new MockHttpServletRequest();
+
+			mockHttpServletRequest.addHeader("Host", hostname);
+
+			_portalInstancesFilter.doFilterTry(
+				mockHttpServletRequest, new MockHttpServletResponse());
+
+			Assert.assertEquals(
+				companyId,
+				mockHttpServletRequest.getAttribute(WebKeys.COMPANY_ID));
+
+			if (companyId == null) {
+				Assert.assertEquals(
+					CompanyConstants.SYSTEM,
+					(long)CompanyThreadLocal.getCompanyId());
+			}
+			else {
+				Assert.assertEquals(
+					companyId, CompanyThreadLocal.getCompanyId());
+			}
+
+			Assert.assertEquals(
+				layoutSet,
+				mockHttpServletRequest.getAttribute(
+					WebKeys.VIRTUAL_HOST_LAYOUT_SET));
+
+			Assert.assertEquals(
+				unknownVirtualHost,
+				mockHttpServletRequest.getAttribute(
+					WebKeys.UNKNOWN_VIRTUAL_HOST));
+		}
+	}
+
+	@Inject
+	private static LayoutSetLocalService _layoutSetLocalService;
+
+	@Inject
+	private static VirtualHostLocalService _virtualHostLocalService;
+
+	private final PortalInstancesFilter _portalInstancesFilter =
+		new PortalInstancesFilter();
+
+}

--- a/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SpSessionTerminationSamlPortalFilter.java
+++ b/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SpSessionTerminationSamlPortalFilter.java
@@ -8,8 +8,6 @@ package com.liferay.saml.internal.servlet.filter;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.util.PortalInstances;
 import com.liferay.saml.helper.SamlHttpRequestHelper;
 import com.liferay.saml.persistence.model.SamlSpSession;
 import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
@@ -52,10 +50,6 @@ public class SpSessionTerminationSamlPortalFilter extends BaseSamlPortalFilter {
 	public boolean isFilterEnabled(
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse) {
-
-		if (httpServletRequest.getAttribute(WebKeys.COMPANY_ID) == null) {
-			PortalInstances.getCompanyId(httpServletRequest);
-		}
 
 		if (_samlProviderConfigurationHelper.isEnabled() &&
 			(httpServletRequest.getSession(false) != null)) {

--- a/portal-impl/src/com/liferay/portal/servlet/filters/absoluteredirects/AbsoluteRedirectsFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/absoluteredirects/AbsoluteRedirectsFilter.java
@@ -6,7 +6,6 @@
 package com.liferay.portal.servlet.filters.absoluteredirects;
 
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.exception.NoSuchVirtualHostException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -17,8 +16,6 @@ import com.liferay.portal.kernel.servlet.WrapHttpServletResponseFilter;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.servlet.filters.BasePortalFilter;
-import com.liferay.portal.util.PortalInstances;
-import com.liferay.portal.util.PropsValues;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -27,9 +24,7 @@ import jakarta.servlet.http.HttpSession;
 /**
  * <p>
  * This filter is used to ensure that all redirects are absolute. It should not
- * be disabled because it also sets the company ID in the request so that
- * subsequent calls in the thread have the company ID properly set. This filter
- * should also always be the first filter in the list of filters.
+ * be disabled.
  * </p>
  *
  * @author Minhchau Dang
@@ -50,24 +45,6 @@ public class AbsoluteRedirectsFilter
 		}
 
 		//response.setContentType(ContentTypes.TEXT_HTML_UTF8);
-
-		// Company ID needs to always be called here so that it is properly set
-		// in subsequent calls
-
-		try {
-			PortalInstances.getCompanyId(
-				httpServletRequest, PropsValues.VIRTUAL_HOSTS_STRICT_ACCESS);
-		}
-		catch (NoSuchVirtualHostException noSuchVirtualHostException) {
-			_log.error(noSuchVirtualHostException);
-
-			httpServletRequest.setAttribute(
-				WebKeys.UNKNOWN_VIRTUAL_HOST, Boolean.TRUE);
-
-			httpServletResponse.sendError(HttpServletResponse.SC_NOT_FOUND);
-
-			return null;
-		}
 
 		PortalUtil.getCurrentCompleteURL(httpServletRequest);
 		PortalUtil.getCurrentURL(httpServletRequest);

--- a/portal-impl/src/com/liferay/portal/servlet/filters/portal/instances/PortalInstancesFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/portal/instances/PortalInstancesFilter.java
@@ -1,0 +1,69 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.servlet.filters.portal.instances;
+
+import com.liferay.portal.kernel.exception.NoSuchVirtualHostException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.servlet.TryFilter;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.servlet.filters.BasePortalFilter;
+import com.liferay.portal.util.PortalInstances;
+import com.liferay.portal.util.PropsValues;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * <p>
+ * This filter is used to set the company ID in the request so that subsequent
+ * calls in the thread have the company ID properly set. This filter should
+ * also always be the first filter in the list of filters.
+ * </p>
+ *
+ * @author Jorge Díaz
+ */
+public class PortalInstancesFilter
+	extends BasePortalFilter implements TryFilter {
+
+	@Override
+	public Object doFilterTry(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws Exception {
+
+		// Company ID needs to always be called here so that it is properly set
+		// in subsequent calls
+
+		try {
+			PortalInstances.getCompanyId(
+				httpServletRequest, PropsValues.VIRTUAL_HOSTS_STRICT_ACCESS);
+		}
+		catch (NoSuchVirtualHostException noSuchVirtualHostException) {
+			_log.error(noSuchVirtualHostException);
+
+			httpServletRequest.setAttribute(
+				WebKeys.UNKNOWN_VIRTUAL_HOST, Boolean.TRUE);
+
+			httpServletResponse.sendError(HttpServletResponse.SC_NOT_FOUND);
+
+			return null;
+		}
+
+		return null;
+	}
+
+	@Override
+	public boolean isFilterEnabled() {
+		return _FILTER_ENABLED;
+	}
+
+	private static final boolean _FILTER_ENABLED = true;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		PortalInstancesFilter.class);
+
+}

--- a/portal-impl/src/com/liferay/portal/servlet/filters/portal/instances/PortalInstancesFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/portal/instances/PortalInstancesFilter.java
@@ -9,11 +9,13 @@ import com.liferay.portal.kernel.exception.NoSuchVirtualHostException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.servlet.TryFilter;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.servlet.filters.BasePortalFilter;
 import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsValues;
 
+import jakarta.servlet.DispatcherType;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -40,7 +42,8 @@ public class PortalInstancesFilter
 
 		try {
 			PortalInstances.getCompanyId(
-				httpServletRequest, PropsValues.VIRTUAL_HOSTS_STRICT_ACCESS);
+				httpServletRequest,
+				_isVirtualHostsStrictAccess(httpServletRequest));
 		}
 		catch (NoSuchVirtualHostException noSuchVirtualHostException) {
 			_log.error(noSuchVirtualHostException);
@@ -59,6 +62,21 @@ public class PortalInstancesFilter
 	@Override
 	public boolean isFilterEnabled() {
 		return _FILTER_ENABLED;
+	}
+
+	private boolean _isVirtualHostsStrictAccess(
+		HttpServletRequest httpServletRequest) {
+
+		if (!PropsValues.VIRTUAL_HOSTS_STRICT_ACCESS ||
+			((httpServletRequest.getDispatcherType() == DispatcherType.ERROR) &&
+			 GetterUtil.getBoolean(
+				 httpServletRequest.getAttribute(
+					 WebKeys.UNKNOWN_VIRTUAL_HOST)))) {
+
+			return false;
+		}
+
+		return true;
 	}
 
 	private static final boolean _FILTER_ENABLED = true;

--- a/portal-impl/src/com/liferay/portal/servlet/filters/virtualhost/VirtualHostFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/virtualhost/VirtualHostFilter.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.struts.LastPath;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
@@ -269,7 +270,7 @@ public class VirtualHostFilter extends BasePortalFilter {
 			return;
 		}
 
-		long companyId = PortalInstances.getCompanyId(httpServletRequest);
+		long companyId = CompanyThreadLocal.getCompanyId();
 
 		try {
 			Map<String, String[]> parameterMap =

--- a/portal-impl/src/com/liferay/portal/util/PortalInstances.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalInstances.java
@@ -484,7 +484,8 @@ public class PortalInstances {
 		long companyId = _getCompanyIdByHost(host, httpServletRequest);
 
 		if (strict && (companyId == 0)) {
-			throw new NoSuchVirtualHostException(host);
+			throw new NoSuchVirtualHostException(
+				"Unknown Virtual Hostname: " + host);
 		}
 
 		return companyId;

--- a/portal-web/docroot/WEB-INF/liferay-web.xml
+++ b/portal-web/docroot/WEB-INF/liferay-web.xml
@@ -202,6 +202,10 @@
 		<filter-class>com.liferay.portal.servlet.filters.password.modified.PasswordModifiedFilter</filter-class>
 	</filter>
 	<filter>
+		<filter-name>Portal Instances Filter</filter-name>
+		<filter-class>com.liferay.portal.servlet.filters.portal.instances.PortalInstancesFilter</filter-class>
+	</filter>
+	<filter>
 		<filter-name>Secure Friendly URL Servlet Filter</filter-name>
 		<filter-class>com.liferay.portal.servlet.filters.secure.SecureFilter</filter-class>
 		<init-param>
@@ -329,6 +333,10 @@
 		<filter-name>WebLogic Include Filter</filter-name>
 		<filter-class>com.liferay.portal.servlet.filters.weblogic.WebLogicIncludeFilter</filter-class>
 	</filter>
+	<filter-mapping>
+		<filter-name>Portal Instances Filter</filter-name>
+		<url-pattern>/*</url-pattern>
+	</filter-mapping>
 	<filter-mapping>
 		<filter-name>Ignore Filter - FTL</filter-name>
 		<url-pattern>*.ftl</url-pattern>

--- a/portal-web/docroot/WEB-INF/liferay-web.xml
+++ b/portal-web/docroot/WEB-INF/liferay-web.xml
@@ -336,6 +336,8 @@
 	<filter-mapping>
 		<filter-name>Portal Instances Filter</filter-name>
 		<url-pattern>/*</url-pattern>
+		<dispatcher>ERROR</dispatcher>
+		<dispatcher>REQUEST</dispatcher>
 	</filter-mapping>
 	<filter-mapping>
 		<filter-name>Ignore Filter - FTL</filter-name>

--- a/test.properties
+++ b/test.properties
@@ -3283,6 +3283,7 @@
         **/testIntegration/**/UpgradeProcessDBPartitionTest.java,\
         **/testIntegration/**/company/service/test/*Test.java,\
         **/testIntegration/**/container/test/PortletTrackerTest.java,\
+        **/testIntegration/**/instances/test/PortalInstancesFilterTest.java,\
         **/testIntegration/**/v1_0_1/test/QuartzUpgradeProcessTest.java,\
         **/testIntegration/**/v1_0_3/test/QuartzDBPartitionUpgradeProcessTest.java
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-62088

Tests executed here: https://github.com/liferay-database-infra/liferay-portal/pull/3005

**Root cause**
The root cause of this issue is LPD-26723 because it added an additional call to `PortalInstances.getCompanyId(httpServletRequest);` in **SpSessionTerminationSamlPortalFilter** so the code that validates the valid virtual host at AbsoluteRedirectsFilter is no longer executed because once `PortalInstances.getCompanyId(httpServletRequest);` sets the request attributes and the validations are no longer executed in the following executions

**Solution**
To avoid this problem, I have moved the `PortalInstances.getCompanyId` call from AbsoluteRedirectsFilter  to a new **PortalInstancesFilter** filter that is always executed in first place.

This change also allows us to fix the https://liferay.atlassian.net/browse/LPD-60239 that was solved with a workaround: 
  - When an error page is rendered, the contributors need to execute `PortalInstances.getCompanyId` because CompanyThreadLocal is not set.
  - The new **PortalInstancesFilter** is configured in liferay-web.xml file with both ERROR and REQUEST dispatchers, so the CompanyThreadLocal will be set for the error pages.

cc @marianoalvarosaiz @javalosjr96 @achaparro