### PR TITLE
LPD-64072 Add show to dropdown menu

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
@@ -22,6 +22,8 @@ AUI.add(
 
 		const CSS_PORTLET = '.portlet';
 
+		const CSS_SHOW = 'show';
+
 		const DEFAULT_ALIGN_POINTS = ['tl', 'bl'];
 
 		const EVENT_CLICK = 'click';
@@ -280,6 +282,8 @@ AUI.add(
 					listItems = listContainer.all(SELECTOR_LIST_ITEM);
 
 					menu = A.Node.create(TPL_MENU);
+
+					menu.addClass(CSS_SHOW);
 
 					listContainer.placeBefore(menu);
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/test.properties
+++ b/modules/apps/frontend-js/frontend-js-aui-web/test.properties
@@ -1,1 +1,11 @@
+modified.files.includes[relevant][frontend-js-aui-web-playwright-rule]=**
+
+playwright.projects.includes[playwright-js-tomcat90-mysql57][relevant][frontend-js-aui-web-playwright-rule]=\
+    frontend-js-aui-web.main
+
+relevant.rule.names=frontend-js-aui-web-playwright-rule
+
+test.batch.names[relevant][frontend-js-aui-web-playwright-rule]=\
+    playwright-js-tomcat90-mysql57
+
 testray.main.component.name=Frontend JS

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -64,6 +64,7 @@ import {config as frontendDataSetAdminWebConfig} from './tests/frontend-data-set
 import {config as frontendDataSetWebConfig} from './tests/frontend-data-set-web/main/config';
 import {config as frontendEditorAlloyEditorWebConfig} from './tests/frontend-editor-alloyeditor-web/main/config';
 import {config as frontendEditorCKEditorWebConfig} from './tests/frontend-editor-ckeditor-web/main/config';
+import {config as frontendJsAuiWebConfig} from './tests/frontend-js-aui-web/main/config';
 import {config as frontendJsBootstrapSupportWebConfig} from './tests/frontend-js-bootstrap-support-web/main/config';
 import {config as frontendJsComponentsWebConfig} from './tests/frontend-js-components-web/main/config';
 import {config as frontendJsItemSelectorWebConfig} from './tests/frontend-js-item-selector-web/main/config';
@@ -231,6 +232,7 @@ export default defineConfig({
 		frontendDataSetWebConfig,
 		frontendEditorAlloyEditorWebConfig,
 		frontendEditorCKEditorWebConfig,
+		frontendJsAuiWebConfig,
 		frontendJsBootstrapSupportWebConfig,
 		frontendJsComponentsWebConfig,
 		frontendJsItemSelectorWebConfig,

--- a/modules/test/playwright/tests/frontend-js-aui-web/main/config.ts
+++ b/modules/test/playwright/tests/frontend-js-aui-web/main/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'frontend-js-aui-web.main',
+	testDir: 'tests/frontend-js-aui-web/main',
+};

--- a/modules/test/playwright/tests/frontend-js-aui-web/main/menu.spec.ts
+++ b/modules/test/playwright/tests/frontend-js-aui-web/main/menu.spec.ts
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {loginTest} from '../../../fixtures/loginTest';
+
+export const test = mergeTests(loginTest());
+
+test('Check dropdown menu has show', {tag: '@LPD-64072'}, async ({page}) => {
+	await page.getByLabel('Open Applications MenuCtrl+').click();
+
+	await page.getByRole('tab', {name: 'Control Panel'}).click();
+
+	await page.getByRole('menuitem', {name: 'Countries Management'}).click();
+
+	const countryEllipses = page.locator(
+		'[id="_com_liferay_address_web_internal_portlet_CountriesManagementAdminPortlet_countrySearchContainer_1_menu"]'
+	);
+
+	await countryEllipses.waitFor({state: 'visible'});
+
+	await countryEllipses.click();
+
+	await expect(
+		page.locator('div.open.show.lfr-icon-menu-open')
+	).toBeVisible();
+
+	await expect(page.locator('.dropdown.lfr-icon-menu.open')).toBeVisible();
+});

--- a/modules/test/playwright/tests/frontend-js-aui-web/main/test.properties
+++ b/modules/test/playwright/tests/frontend-js-aui-web/main/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Frontend JS


### PR DESCRIPTION
FWD: https://github.com/liferay-frontend/liferay-portal/pull/5058

https://liferay.atlassian.net/browse/LPP-60311
https://liferay.atlassian.net/browse/LPD-64072

Using 2025.q1.14, enabling JQuery in liferay, using liferay-ui:icon-menu and liferay-ui:icon, we see that the arrow buttons are not functioning correctly in the dropdown menu.

[Screencast from 08-28-2025 02:38:38 PM.webm](https://github.com/user-attachments/assets/79766d63-8b12-490c-afbe-e3139b631c0c)

I found this was due to JQuery dropdown.js file, that looks for `show` in the dropdown menu. 
Since [menu.js ](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js)is responsible for the dropdown menu creation, we are using open instead, the dropdown menu is then closed.

To make sure this functions in all situations, I include `show` to the dropdown menu.

Please let me know if there are any questions or comments about this.
Thank you!