### PR TITLE
LPD-65256 Make probes less aggressive

### DIFF
--- a/cloud/helm/default/values.yaml
+++ b/cloud/helm/default/values.yaml
@@ -164,12 +164,13 @@ initContainers:
                 imagePullPolicy: IfNotPresent
                 name: liferay-wait-on-services
 livenessProbe:
-    failureThreshold: 2
+    failureThreshold: 3
     httpGet:
         path: /c/portal/robots
         port: http
-    initialDelaySeconds: 10
-    periodSeconds: 5
+    initialDelaySeconds: 60
+    periodSeconds: 30
+    timeoutSeconds: 5
 nameOverride: ""
 nodeSelector: {}
 podAnnotations: {}
@@ -200,8 +201,9 @@ readinessProbe:
     httpGet:
         path: /c/portal/robots
         port: http
-    initialDelaySeconds: 10
-    periodSeconds: 5
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 5
 replicaCount: 1
 resources: {}
 schedulingGates: []
@@ -237,12 +239,13 @@ serviceAccount:
                 verbs:
                     -   "*"
 startupProbe:
-    failureThreshold: 30
+    failureThreshold: 90
     httpGet:
         path: /c/portal/robots
         port: http
-    initialDelaySeconds: 20
-    periodSeconds: 5
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    timeoutSeconds: 5
 tolerations: []
 updateStrategy:
     type: RollingUpdate


### PR DESCRIPTION
@brianchandotcom , we decided not to release the new helm chart yet, because the backup subchart is still in testing and needs a few fixes.

When we do bump the version, just a couple points of clarification.

When bumping any version in semantic versioning, if we bump patch it would go from `x.x.9` to `x.x.10`, not `x.1.0`.

Since we're in development phase, the version doesn't matter _too_ much. But we should still be consistent.

I suggested we should use `minor` instead of `patch` though since most of these releases are releasing new features and not bug fixes (see https://semver.org/). This is what I did with the backup-restore subchart at `0.1.0`. `0.2.0` and so on. If there's a release with only a bug fix, something like `0.2.1` -- this follows SemVer.

Unrelated to this current PR but just following up from your comment for when we do send the next version bump.

