### PR TITLE
LPD-65260 Single quotes are still needed

### DIFF
--- a/cloud/helm/aws/charts/backup-restore/templates/_scripts.tpl
+++ b/cloud/helm/aws/charts/backup-restore/templates/_scripts.tpl
@@ -12,7 +12,7 @@ function main {
 
     git pull origin {{ .Values.git.repository.branch }}
 
-    echo "{{ '{{' }}inputs.parameters.tfvars-content}}" > {{ .Values.tfvarsOverrideFileName }}
+    echo '{{ "{{" }}inputs.parameters.tfvars-content}}' > {{ .Values.tfvarsOverrideFileName }}
 
     git add {{ .Values.tfvarsOverrideFileName }}
 


### PR DESCRIPTION
@brianchandotcom responding to https://github.com/brianchandotcom/liferay-portal/pull/165479#issuecomment-3282659278, let me do my best to explain it:
1.     
`echo '{{ "{{" }}inputs.parameters.tfvars-content}}' > {{ .Values.tfvarsOverrideFileName }}`
`{{ "{{" }}` is how you escape a `{{` so that helm does not interpret it. It will become `'{{inputs.parameters.tfvars-content}}'` after the helm template is rendered.
2. `'{{inputs.parameters.tfvars-content}}'` is an argo workflow ref which will get replaced with 
```
'data_active = "blue"
is_restoring = false'
```
e.g. https://github.com/brianchandotcom/liferay-portal/blob/master/cloud/helm/aws/charts/backup-restore/templates/clusterworkflowtemplate.yaml#L122-L124. 

Single quotes are needed because in this case `blue` has double quotes around it.

Terraform vars like `data_active` must use double quotes, not single quotes.

Regarding your example:
```
git commit --message "{{ "{{" }}inputs.parameters.commit-message}}"
```

This is OK because `{{ "{{" }}` is interpreted by the helm templating engine first as described above, way before the shell script is ever interpreted by `sh`.

There are therefore two options that I can see:
1. Use single quotes as I have done. It's the safest options in shell scripts when working with strings when you want a string literal and nothing to be interpreted.
2. You could escape the double-quotes in clusterworkflowtemplate, but to me it makes a hidden assumption that the variable is going to be parsed by a shell script, and I don't think this assumption would be obvious to readers of the file.
