### PR TITLE
LPD-61435 Support ERC in InfoFramework Implementation

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/info/item/provider/AssetCategoryInfoItemDetailsProvider.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/info/item/provider/AssetCategoryInfoItemDetailsProvider.java
@@ -6,12 +6,24 @@
 package com.liferay.asset.categories.admin.web.internal.info.item.provider;
 
 import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.info.item.ClassPKInfoItemIdentifier;
+import com.liferay.info.item.ERCInfoItemIdentifier;
 import com.liferay.info.item.InfoItemClassDetails;
 import com.liferay.info.item.InfoItemDetails;
+import com.liferay.info.item.InfoItemIdentifier;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.info.item.provider.InfoItemDetailsProvider;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
+
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Jürgen Kappler
@@ -27,10 +39,78 @@ public class AssetCategoryInfoItemDetailsProvider
 
 	@Override
 	public InfoItemDetails getInfoItemDetails(AssetCategory assetCategory) {
-		return new InfoItemDetails(
-			getInfoItemClassDetails(),
-			new InfoItemReference(
-				AssetCategory.class.getName(), assetCategory.getCategoryId()));
+		return getInfoItemDetails(
+			_getGroupId(), ClassPKInfoItemIdentifier.class, assetCategory);
 	}
+
+	@Override
+	public InfoItemDetails getInfoItemDetails(
+		long groupId,
+		Class<? extends InfoItemIdentifier> infoItemIdentifierClass,
+		AssetCategory assetCategory) {
+
+		if (Objects.equals(
+				infoItemIdentifierClass, ClassPKInfoItemIdentifier.class)) {
+
+			return new InfoItemDetails(
+				getInfoItemClassDetails(),
+				new InfoItemReference(
+					AssetCategory.class.getName(),
+					assetCategory.getCategoryId()));
+		}
+
+		if (Objects.equals(
+				infoItemIdentifierClass, ERCInfoItemIdentifier.class)) {
+
+			return new InfoItemDetails(
+				getInfoItemClassDetails(),
+				new InfoItemReference(
+					AssetCategory.class.getName(),
+					new ERCInfoItemIdentifier(
+						assetCategory.getExternalReferenceCode(),
+						_getScopeExternalReferenceCode(
+							groupId, assetCategory))));
+		}
+
+		return null;
+	}
+
+	private long _getGroupId() {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext != null) {
+			return serviceContext.getScopeGroupId();
+		}
+
+		Long groupId = GroupThreadLocal.getGroupId();
+
+		if (groupId != null) {
+			return groupId;
+		}
+
+		throw new IllegalStateException(
+			"Neither service context thread local nor group thread local are " +
+				"initialized");
+	}
+
+	private String _getScopeExternalReferenceCode(
+		long groupId, GroupedModel groupedModel) {
+
+		if (groupId == groupedModel.getGroupId()) {
+			return null;
+		}
+
+		Group group = _groupLocalService.fetchGroup(groupedModel.getGroupId());
+
+		if (group == null) {
+			return null;
+		}
+
+		return group.getExternalReferenceCode();
+	}
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/info/item/provider/AssetCategoryInfoItemDetailsProvider.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/info/item/provider/AssetCategoryInfoItemDetailsProvider.java
@@ -9,28 +9,20 @@ import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.ERCInfoItemIdentifier;
 import com.liferay.info.item.InfoItemClassDetails;
-import com.liferay.info.item.InfoItemDetails;
-import com.liferay.info.item.InfoItemIdentifier;
-import com.liferay.info.item.InfoItemReference;
+import com.liferay.info.item.provider.BaseInfoItemDetailsProvider;
 import com.liferay.info.item.provider.InfoItemDetailsProvider;
-import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupedModel;
-import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.util.GroupThreadLocal;
-
-import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Jürgen Kappler
  */
-@Component(service = InfoItemDetailsProvider.class)
+@Component(
+	property = "item.class.name=com.liferay.asset.kernel.model.AssetCategory",
+	service = InfoItemDetailsProvider.class
+)
 public class AssetCategoryInfoItemDetailsProvider
-	implements InfoItemDetailsProvider<AssetCategory> {
+	extends BaseInfoItemDetailsProvider<AssetCategory> {
 
 	@Override
 	public InfoItemClassDetails getInfoItemClassDetails() {
@@ -38,79 +30,29 @@ public class AssetCategoryInfoItemDetailsProvider
 	}
 
 	@Override
-	public InfoItemDetails getInfoItemDetails(AssetCategory assetCategory) {
-		return getInfoItemDetails(
-			_getGroupId(), ClassPKInfoItemIdentifier.class, assetCategory);
+	protected InfoItemIdentifierFactory<AssetCategory>
+		getInfoItemIdentifierFactory() {
+
+		return new InfoItemIdentifierFactory<>() {
+
+			@Override
+			public ClassPKInfoItemIdentifier createClassPKInfoItemIdentifier(
+				AssetCategory assetCategory) {
+
+				return new ClassPKInfoItemIdentifier(
+					assetCategory.getCategoryId());
+			}
+
+			@Override
+			public ERCInfoItemIdentifier createERCInfoItemIdentifier(
+				String externalReferenceCode,
+				String scopeExternalReferenceCode) {
+
+				return new ERCInfoItemIdentifier(
+					externalReferenceCode, scopeExternalReferenceCode);
+			}
+
+		};
 	}
-
-	@Override
-	public InfoItemDetails getInfoItemDetails(
-		long groupId,
-		Class<? extends InfoItemIdentifier> infoItemIdentifierClass,
-		AssetCategory assetCategory) {
-
-		if (Objects.equals(
-				infoItemIdentifierClass, ClassPKInfoItemIdentifier.class)) {
-
-			return new InfoItemDetails(
-				getInfoItemClassDetails(),
-				new InfoItemReference(
-					AssetCategory.class.getName(),
-					assetCategory.getCategoryId()));
-		}
-
-		if (Objects.equals(
-				infoItemIdentifierClass, ERCInfoItemIdentifier.class)) {
-
-			return new InfoItemDetails(
-				getInfoItemClassDetails(),
-				new InfoItemReference(
-					AssetCategory.class.getName(),
-					new ERCInfoItemIdentifier(
-						assetCategory.getExternalReferenceCode(),
-						_getScopeExternalReferenceCode(
-							groupId, assetCategory))));
-		}
-
-		return null;
-	}
-
-	private long _getGroupId() {
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		if (serviceContext != null) {
-			return serviceContext.getScopeGroupId();
-		}
-
-		Long groupId = GroupThreadLocal.getGroupId();
-
-		if (groupId != null) {
-			return groupId;
-		}
-
-		throw new IllegalStateException(
-			"Neither service context thread local nor group thread local are " +
-				"initialized");
-	}
-
-	private String _getScopeExternalReferenceCode(
-		long groupId, GroupedModel groupedModel) {
-
-		if (groupId == groupedModel.getGroupId()) {
-			return null;
-		}
-
-		Group group = _groupLocalService.fetchGroup(groupedModel.getGroupId());
-
-		if (group == null) {
-			return null;
-		}
-
-		return group.getExternalReferenceCode();
-	}
-
-	@Reference
-	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/info/item/provider/AssetCategoryInfoItemObjectProvider.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/info/item/provider/AssetCategoryInfoItemObjectProvider.java
@@ -9,8 +9,17 @@ import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.info.exception.NoSuchInfoItemException;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
+import com.liferay.info.item.ERCInfoItemIdentifier;
 import com.liferay.info.item.InfoItemIdentifier;
 import com.liferay.info.item.provider.InfoItemObjectProvider;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
+import com.liferay.portal.kernel.util.Validator;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -21,6 +30,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = {
 		"info.item.identifier=com.liferay.info.item.ClassPKInfoItemIdentifier",
+		"info.item.identifier=com.liferay.info.item.ERCInfoItemIdentifier",
 		"service.ranking:Integer=100"
 	},
 	service = InfoItemObjectProvider.class
@@ -32,17 +42,114 @@ public class AssetCategoryInfoItemObjectProvider
 	public AssetCategory getInfoItem(InfoItemIdentifier infoItemIdentifier)
 		throws NoSuchInfoItemException {
 
-		if (!(infoItemIdentifier instanceof ClassPKInfoItemIdentifier)) {
+		return getInfoItem(_getGroupId(), infoItemIdentifier);
+	}
+
+	@Override
+	public AssetCategory getInfoItem(
+			long groupId, InfoItemIdentifier infoItemIdentifier)
+		throws NoSuchInfoItemException {
+
+		return _getInfoItem(_getCompanyId(), groupId, infoItemIdentifier);
+	}
+
+	private long _getCompanyId() {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext != null) {
+			return serviceContext.getCompanyId();
+		}
+
+		Long companyId = CompanyThreadLocal.getCompanyId();
+
+		if (companyId != null) {
+			return companyId;
+		}
+
+		throw new IllegalStateException(
+			"Neither service context thread local nor company thread local " +
+				"are initialized");
+	}
+
+	private long _getGroupId() {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext != null) {
+			return serviceContext.getScopeGroupId();
+		}
+
+		Long groupId = GroupThreadLocal.getGroupId();
+
+		if (groupId != null) {
+			return groupId;
+		}
+
+		throw new IllegalStateException(
+			"Neither service context thread local nor group thread local are " +
+				"initialized");
+	}
+
+	private long _getGroupId(
+			long companyId, ERCInfoItemIdentifier ercInfoItemIdentifier,
+			long groupId)
+		throws NoSuchInfoItemException {
+
+		try {
+			if (Validator.isNull(
+					ercInfoItemIdentifier.getScopeExternalReferenceCode())) {
+
+				return groupId;
+			}
+
+			Group group = _groupLocalService.getGroupByExternalReferenceCode(
+				ercInfoItemIdentifier.getScopeExternalReferenceCode(),
+				companyId);
+
+			return group.getGroupId();
+		}
+		catch (PortalException portalException) {
+			throw new NoSuchInfoItemException(portalException);
+		}
+	}
+
+	private AssetCategory _getInfoItem(
+			long companyId, long groupId, InfoItemIdentifier infoItemIdentifier)
+		throws NoSuchInfoItemException {
+
+		if (!(infoItemIdentifier instanceof ClassPKInfoItemIdentifier) &&
+			!(infoItemIdentifier instanceof ERCInfoItemIdentifier)) {
+
 			throw new NoSuchInfoItemException(
 				"Unsupported info item identifier " + infoItemIdentifier);
 		}
 
-		ClassPKInfoItemIdentifier classPKInfoItemIdentifier =
-			(ClassPKInfoItemIdentifier)infoItemIdentifier;
+		if (infoItemIdentifier instanceof ClassPKInfoItemIdentifier) {
+			ClassPKInfoItemIdentifier classPKInfoItemIdentifier =
+				(ClassPKInfoItemIdentifier)infoItemIdentifier;
+
+			AssetCategory assetCategory =
+				_assetCategoryLocalService.fetchAssetCategory(
+					classPKInfoItemIdentifier.getClassPK());
+
+			if (assetCategory == null) {
+				throw new NoSuchInfoItemException(
+					"Unable to get asset category with info item identifier " +
+						infoItemIdentifier);
+			}
+
+			return assetCategory;
+		}
+
+		ERCInfoItemIdentifier ercInfoItemIdentifier =
+			(ERCInfoItemIdentifier)infoItemIdentifier;
 
 		AssetCategory assetCategory =
-			_assetCategoryLocalService.fetchAssetCategory(
-				classPKInfoItemIdentifier.getClassPK());
+			_assetCategoryLocalService.
+				fetchAssetCategoryByExternalReferenceCode(
+					ercInfoItemIdentifier.getExternalReferenceCode(),
+					_getGroupId(companyId, ercInfoItemIdentifier, groupId));
 
 		if (assetCategory == null) {
 			throw new NoSuchInfoItemException(
@@ -55,5 +162,8 @@ public class AssetCategoryInfoItemObjectProvider
 
 	@Reference
 	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/info/item/provider/AssetCategoryInfoItemObjectProvider.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/info/item/provider/AssetCategoryInfoItemObjectProvider.java
@@ -50,7 +50,8 @@ public class AssetCategoryInfoItemObjectProvider
 			long groupId, InfoItemIdentifier infoItemIdentifier)
 		throws NoSuchInfoItemException {
 
-		return _getInfoItem(_getCompanyId(), groupId, infoItemIdentifier);
+		return _getInfoItem(
+			_getGroupId(groupId, infoItemIdentifier), infoItemIdentifier);
 	}
 
 	private long _getCompanyId() {
@@ -92,11 +93,17 @@ public class AssetCategoryInfoItemObjectProvider
 	}
 
 	private long _getGroupId(
-			long companyId, ERCInfoItemIdentifier ercInfoItemIdentifier,
-			long groupId)
+			long groupId, InfoItemIdentifier infoItemIdentifier)
 		throws NoSuchInfoItemException {
 
 		try {
+			if (!(infoItemIdentifier instanceof ERCInfoItemIdentifier)) {
+				return groupId;
+			}
+
+			ERCInfoItemIdentifier ercInfoItemIdentifier =
+				(ERCInfoItemIdentifier)infoItemIdentifier;
+
 			if (Validator.isNull(
 					ercInfoItemIdentifier.getScopeExternalReferenceCode())) {
 
@@ -105,7 +112,7 @@ public class AssetCategoryInfoItemObjectProvider
 
 			Group group = _groupLocalService.getGroupByExternalReferenceCode(
 				ercInfoItemIdentifier.getScopeExternalReferenceCode(),
-				companyId);
+				_getCompanyId());
 
 			return group.getGroupId();
 		}
@@ -115,7 +122,7 @@ public class AssetCategoryInfoItemObjectProvider
 	}
 
 	private AssetCategory _getInfoItem(
-			long companyId, long groupId, InfoItemIdentifier infoItemIdentifier)
+			long groupId, InfoItemIdentifier infoItemIdentifier)
 		throws NoSuchInfoItemException {
 
 		if (!(infoItemIdentifier instanceof ClassPKInfoItemIdentifier) &&
@@ -148,8 +155,7 @@ public class AssetCategoryInfoItemObjectProvider
 		AssetCategory assetCategory =
 			_assetCategoryLocalService.
 				fetchAssetCategoryByExternalReferenceCode(
-					ercInfoItemIdentifier.getExternalReferenceCode(),
-					_getGroupId(companyId, ercInfoItemIdentifier, groupId));
+					ercInfoItemIdentifier.getExternalReferenceCode(), groupId);
 
 		if (assetCategory == null) {
 			throw new NoSuchInfoItemException(

--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/info/item/provider/AssetCategoryInfoItemObjectProvider.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/info/item/provider/AssetCategoryInfoItemObjectProvider.java
@@ -11,15 +11,8 @@ import com.liferay.info.exception.NoSuchInfoItemException;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.ERCInfoItemIdentifier;
 import com.liferay.info.item.InfoItemIdentifier;
+import com.liferay.info.item.provider.BaseInfoItemObjectProvider;
 import com.liferay.info.item.provider.InfoItemObjectProvider;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.util.GroupThreadLocal;
-import com.liferay.portal.kernel.util.Validator;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -31,97 +24,16 @@ import org.osgi.service.component.annotations.Reference;
 	property = {
 		"info.item.identifier=com.liferay.info.item.ClassPKInfoItemIdentifier",
 		"info.item.identifier=com.liferay.info.item.ERCInfoItemIdentifier",
+		"item.class.name=com.liferay.asset.kernel.model.AssetCategory",
 		"service.ranking:Integer=100"
 	},
 	service = InfoItemObjectProvider.class
 )
 public class AssetCategoryInfoItemObjectProvider
-	implements InfoItemObjectProvider<AssetCategory> {
+	extends BaseInfoItemObjectProvider<AssetCategory> {
 
 	@Override
-	public AssetCategory getInfoItem(InfoItemIdentifier infoItemIdentifier)
-		throws NoSuchInfoItemException {
-
-		return getInfoItem(_getGroupId(), infoItemIdentifier);
-	}
-
-	@Override
-	public AssetCategory getInfoItem(
-			long groupId, InfoItemIdentifier infoItemIdentifier)
-		throws NoSuchInfoItemException {
-
-		return _getInfoItem(
-			_getGroupId(groupId, infoItemIdentifier), infoItemIdentifier);
-	}
-
-	private long _getCompanyId() {
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		if (serviceContext != null) {
-			return serviceContext.getCompanyId();
-		}
-
-		Long companyId = CompanyThreadLocal.getCompanyId();
-
-		if (companyId != null) {
-			return companyId;
-		}
-
-		throw new IllegalStateException(
-			"Neither service context thread local nor company thread local " +
-				"are initialized");
-	}
-
-	private long _getGroupId() {
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		if (serviceContext != null) {
-			return serviceContext.getScopeGroupId();
-		}
-
-		Long groupId = GroupThreadLocal.getGroupId();
-
-		if (groupId != null) {
-			return groupId;
-		}
-
-		throw new IllegalStateException(
-			"Neither service context thread local nor group thread local are " +
-				"initialized");
-	}
-
-	private long _getGroupId(
-			long groupId, InfoItemIdentifier infoItemIdentifier)
-		throws NoSuchInfoItemException {
-
-		try {
-			if (!(infoItemIdentifier instanceof ERCInfoItemIdentifier)) {
-				return groupId;
-			}
-
-			ERCInfoItemIdentifier ercInfoItemIdentifier =
-				(ERCInfoItemIdentifier)infoItemIdentifier;
-
-			if (Validator.isNull(
-					ercInfoItemIdentifier.getScopeExternalReferenceCode())) {
-
-				return groupId;
-			}
-
-			Group group = _groupLocalService.getGroupByExternalReferenceCode(
-				ercInfoItemIdentifier.getScopeExternalReferenceCode(),
-				_getCompanyId());
-
-			return group.getGroupId();
-		}
-		catch (PortalException portalException) {
-			throw new NoSuchInfoItemException(portalException);
-		}
-	}
-
-	private AssetCategory _getInfoItem(
+	protected AssetCategory doGetInfoItem(
 			long groupId, InfoItemIdentifier infoItemIdentifier)
 		throws NoSuchInfoItemException {
 
@@ -168,8 +80,5 @@ public class AssetCategoryInfoItemObjectProvider
 
 	@Reference
 	private AssetCategoryLocalService _assetCategoryLocalService;
-
-	@Reference
-	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/admin/web/internal/info/item/provider/test/AssetCategoryInfoItemDetailsProviderTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/admin/web/internal/info/item/provider/test/AssetCategoryInfoItemDetailsProviderTest.java
@@ -1,0 +1,121 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.categories.admin.web.internal.info.item.provider.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetVocabularyConstants;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.info.item.ERCInfoItemIdentifier;
+import com.liferay.info.item.GroupKeyInfoItemIdentifier;
+import com.liferay.info.item.GroupUrlTitleInfoItemIdentifier;
+import com.liferay.info.item.InfoItemDetails;
+import com.liferay.info.item.InfoItemReference;
+import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.info.item.provider.InfoItemDetailsProvider;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Adolfo Pérez
+ */
+@RunWith(Arquillian.class)
+public class AssetCategoryInfoItemDetailsProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_assetCategory = _assetCategoryLocalService.addCategory(
+			TestPropsValues.getUserId(), _group.getGroupId(),
+			StringUtil.randomString(),
+			AssetVocabularyConstants.EMPTY_VOCABULARY_ID,
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	@Test
+	public void testGetInfoItemDetails() throws Exception {
+		InfoItemDetailsProvider<AssetCategory> infoItemDetailsProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoItemDetailsProvider.class, AssetCategory.class.getName());
+
+		InfoItemDetails classPKInfoItemDetails =
+			infoItemDetailsProvider.getInfoItemDetails(_assetCategory);
+
+		Assert.assertEquals(
+			AssetCategory.class.getName(),
+			classPKInfoItemDetails.getClassName());
+		Assert.assertEquals(
+			new InfoItemReference(
+				AssetCategory.class.getName(), _assetCategory.getCategoryId()),
+			classPKInfoItemDetails.getInfoItemReference());
+
+		InfoItemDetails ercInfoItemDetails =
+			infoItemDetailsProvider.getInfoItemDetails(
+				_group.getGroupId(), ERCInfoItemIdentifier.class,
+				_assetCategory);
+
+		Assert.assertEquals(
+			new InfoItemReference(
+				AssetCategory.class.getName(),
+				new ERCInfoItemIdentifier(
+					_assetCategory.getExternalReferenceCode())),
+			ercInfoItemDetails.getInfoItemReference());
+
+		InfoItemDetails randomGroupERCInfoItemDetails =
+			infoItemDetailsProvider.getInfoItemDetails(
+				RandomTestUtil.randomLong(), ERCInfoItemIdentifier.class,
+				_assetCategory);
+
+		Assert.assertEquals(
+			new InfoItemReference(
+				AssetCategory.class.getName(),
+				new ERCInfoItemIdentifier(
+					_assetCategory.getExternalReferenceCode(),
+					_group.getExternalReferenceCode())),
+			randomGroupERCInfoItemDetails.getInfoItemReference());
+
+		Assert.assertNull(
+			infoItemDetailsProvider.getInfoItemDetails(
+				_group.getGroupId(), GroupKeyInfoItemIdentifier.class,
+				_assetCategory));
+		Assert.assertNull(
+			infoItemDetailsProvider.getInfoItemDetails(
+				_group.getGroupId(), GroupUrlTitleInfoItemIdentifier.class,
+				_assetCategory));
+	}
+
+	private AssetCategory _assetCategory;
+
+	@Inject
+	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private InfoItemServiceRegistry _infoItemServiceRegistry;
+
+}

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/admin/web/internal/info/item/provider/test/AssetCategoryInfoItemObjectProviderTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/admin/web/internal/info/item/provider/test/AssetCategoryInfoItemObjectProviderTest.java
@@ -1,0 +1,92 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.categories.admin.web.internal.info.item.provider.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetVocabularyConstants;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.info.item.ClassPKInfoItemIdentifier;
+import com.liferay.info.item.ERCInfoItemIdentifier;
+import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.info.item.provider.InfoItemObjectProvider;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Adolfo Pérez
+ */
+@RunWith(Arquillian.class)
+public class AssetCategoryInfoItemObjectProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_assetCategory = _assetCategoryLocalService.addCategory(
+			TestPropsValues.getUserId(), _group.getGroupId(),
+			StringUtil.randomString(),
+			AssetVocabularyConstants.EMPTY_VOCABULARY_ID,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+	}
+
+	@Test
+	public void testGetInfoItem() throws Exception {
+		InfoItemObjectProvider<AssetCategory> infoItemObjectProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoItemObjectProvider.class, AssetCategory.class.getName());
+
+		Assert.assertEquals(
+			_assetCategory,
+			infoItemObjectProvider.getInfoItem(
+				_group.getGroupId(),
+				new ClassPKInfoItemIdentifier(_assetCategory.getCategoryId())));
+		Assert.assertEquals(
+			_assetCategory,
+			infoItemObjectProvider.getInfoItem(
+				_group.getGroupId(),
+				new ERCInfoItemIdentifier(
+					_assetCategory.getExternalReferenceCode())));
+		Assert.assertEquals(
+			_assetCategory,
+			infoItemObjectProvider.getInfoItem(
+				RandomTestUtil.randomLong(),
+				new ERCInfoItemIdentifier(
+					_assetCategory.getExternalReferenceCode(),
+					_group.getExternalReferenceCode())));
+	}
+
+	private AssetCategory _assetCategory;
+
+	@Inject
+	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private InfoItemServiceRegistry _infoItemServiceRegistry;
+
+}

--- a/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/internal/info/item/provider/test/BlogsEntryInfoItemDetailsProviderTest.java
+++ b/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/internal/info/item/provider/test/BlogsEntryInfoItemDetailsProviderTest.java
@@ -1,0 +1,117 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.blogs.web.internal.info.item.provider.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.blogs.model.BlogsEntry;
+import com.liferay.blogs.service.BlogsEntryLocalService;
+import com.liferay.info.item.ERCInfoItemIdentifier;
+import com.liferay.info.item.GroupKeyInfoItemIdentifier;
+import com.liferay.info.item.GroupUrlTitleInfoItemIdentifier;
+import com.liferay.info.item.InfoItemDetails;
+import com.liferay.info.item.InfoItemReference;
+import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.info.item.provider.InfoItemDetailsProvider;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Adolfo Pérez
+ */
+@RunWith(Arquillian.class)
+public class BlogsEntryInfoItemDetailsProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_blogsEntry = _blogsEntryLocalService.addEntry(
+			TestPropsValues.getUserId(), StringUtil.randomString(),
+			StringUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+	}
+
+	@Test
+	public void testGetInfoItemDetails() throws Exception {
+		InfoItemDetailsProvider<BlogsEntry> infoItemDetailsProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoItemDetailsProvider.class, BlogsEntry.class.getName());
+
+		InfoItemDetails classPKInfoItemDetails =
+			infoItemDetailsProvider.getInfoItemDetails(_blogsEntry);
+
+		Assert.assertEquals(
+			BlogsEntry.class.getName(), classPKInfoItemDetails.getClassName());
+		Assert.assertEquals(
+			new InfoItemReference(
+				BlogsEntry.class.getName(), _blogsEntry.getEntryId()),
+			classPKInfoItemDetails.getInfoItemReference());
+
+		InfoItemDetails ercInfoItemDetails =
+			infoItemDetailsProvider.getInfoItemDetails(
+				_group.getGroupId(), ERCInfoItemIdentifier.class, _blogsEntry);
+
+		Assert.assertEquals(
+			new InfoItemReference(
+				BlogsEntry.class.getName(),
+				new ERCInfoItemIdentifier(
+					_blogsEntry.getExternalReferenceCode())),
+			ercInfoItemDetails.getInfoItemReference());
+
+		InfoItemDetails randomGroupERCInfoItemDetails =
+			infoItemDetailsProvider.getInfoItemDetails(
+				RandomTestUtil.randomLong(), ERCInfoItemIdentifier.class,
+				_blogsEntry);
+
+		Assert.assertEquals(
+			new InfoItemReference(
+				BlogsEntry.class.getName(),
+				new ERCInfoItemIdentifier(
+					_blogsEntry.getExternalReferenceCode(),
+					_group.getExternalReferenceCode())),
+			randomGroupERCInfoItemDetails.getInfoItemReference());
+
+		Assert.assertNull(
+			infoItemDetailsProvider.getInfoItemDetails(
+				_group.getGroupId(), GroupKeyInfoItemIdentifier.class,
+				_blogsEntry));
+		Assert.assertNull(
+			infoItemDetailsProvider.getInfoItemDetails(
+				_group.getGroupId(), GroupUrlTitleInfoItemIdentifier.class,
+				_blogsEntry));
+	}
+
+	private BlogsEntry _blogsEntry;
+
+	@Inject
+	private BlogsEntryLocalService _blogsEntryLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private InfoItemServiceRegistry _infoItemServiceRegistry;
+
+}

--- a/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/internal/info/item/provider/test/BlogsEntryInfoItemObjectProviderTest.java
+++ b/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/internal/info/item/provider/test/BlogsEntryInfoItemObjectProviderTest.java
@@ -1,0 +1,89 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.blogs.web.internal.info.item.provider.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.blogs.model.BlogsEntry;
+import com.liferay.blogs.service.BlogsEntryLocalService;
+import com.liferay.info.item.ClassPKInfoItemIdentifier;
+import com.liferay.info.item.ERCInfoItemIdentifier;
+import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.info.item.provider.InfoItemObjectProvider;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Adolfo Pérez
+ */
+@RunWith(Arquillian.class)
+public class BlogsEntryInfoItemObjectProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_blogsEntry = _blogsEntryLocalService.addEntry(
+			TestPropsValues.getUserId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+	}
+
+	@Test
+	public void testGetInfoItem() throws Exception {
+		InfoItemObjectProvider<BlogsEntry> infoItemObjectProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoItemObjectProvider.class, BlogsEntry.class.getName());
+
+		Assert.assertEquals(
+			_blogsEntry,
+			infoItemObjectProvider.getInfoItem(
+				_group.getGroupId(),
+				new ClassPKInfoItemIdentifier(_blogsEntry.getEntryId())));
+		Assert.assertEquals(
+			_blogsEntry,
+			infoItemObjectProvider.getInfoItem(
+				_group.getGroupId(),
+				new ERCInfoItemIdentifier(
+					_blogsEntry.getExternalReferenceCode())));
+		Assert.assertEquals(
+			_blogsEntry,
+			infoItemObjectProvider.getInfoItem(
+				RandomTestUtil.randomLong(),
+				new ERCInfoItemIdentifier(
+					_blogsEntry.getExternalReferenceCode(),
+					_group.getExternalReferenceCode())));
+	}
+
+	private BlogsEntry _blogsEntry;
+
+	@Inject
+	private BlogsEntryLocalService _blogsEntryLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private InfoItemServiceRegistry _infoItemServiceRegistry;
+
+}

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/info/item/provider/BlogsEntryInfoItemDetailsProvider.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/info/item/provider/BlogsEntryInfoItemDetailsProvider.java
@@ -6,13 +6,25 @@
 package com.liferay.blogs.web.internal.info.item.provider;
 
 import com.liferay.blogs.model.BlogsEntry;
+import com.liferay.info.item.ClassPKInfoItemIdentifier;
+import com.liferay.info.item.ERCInfoItemIdentifier;
 import com.liferay.info.item.InfoItemClassDetails;
 import com.liferay.info.item.InfoItemDetails;
+import com.liferay.info.item.InfoItemIdentifier;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.info.item.provider.InfoItemDetailsProvider;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
+
+import java.util.Objects;
 
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Alejandro Tardín
@@ -32,10 +44,76 @@ public class BlogsEntryInfoItemDetailsProvider
 
 	@Override
 	public InfoItemDetails getInfoItemDetails(BlogsEntry blogsEntry) {
-		return new InfoItemDetails(
-			getInfoItemClassDetails(),
-			new InfoItemReference(
-				BlogsEntry.class.getName(), blogsEntry.getEntryId()));
+		return getInfoItemDetails(
+			_getGroupId(), ClassPKInfoItemIdentifier.class, blogsEntry);
 	}
+
+	@Override
+	public InfoItemDetails getInfoItemDetails(
+		long groupId,
+		Class<? extends InfoItemIdentifier> infoItemIdentifierClass,
+		BlogsEntry blogsEntry) {
+
+		if (Objects.equals(
+				infoItemIdentifierClass, ClassPKInfoItemIdentifier.class)) {
+
+			return new InfoItemDetails(
+				getInfoItemClassDetails(),
+				new InfoItemReference(
+					BlogsEntry.class.getName(), blogsEntry.getEntryId()));
+		}
+
+		if (Objects.equals(
+				infoItemIdentifierClass, ERCInfoItemIdentifier.class)) {
+
+			return new InfoItemDetails(
+				getInfoItemClassDetails(),
+				new InfoItemReference(
+					BlogsEntry.class.getName(),
+					new ERCInfoItemIdentifier(
+						blogsEntry.getExternalReferenceCode(),
+						_getScopeExternalReferenceCode(groupId, blogsEntry))));
+		}
+
+		return null;
+	}
+
+	private long _getGroupId() {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext != null) {
+			return serviceContext.getScopeGroupId();
+		}
+
+		Long groupId = GroupThreadLocal.getGroupId();
+
+		if (groupId != null) {
+			return groupId;
+		}
+
+		throw new IllegalStateException(
+			"Neither service context thread local nor group thread local are " +
+				"initialized");
+	}
+
+	private String _getScopeExternalReferenceCode(
+		long groupId, GroupedModel groupedModel) {
+
+		if (groupId == groupedModel.getGroupId()) {
+			return null;
+		}
+
+		Group group = _groupLocalService.fetchGroup(groupedModel.getGroupId());
+
+		if (group == null) {
+			return null;
+		}
+
+		return group.getExternalReferenceCode();
+	}
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/info/item/provider/BlogsEntryInfoItemDetailsProvider.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/info/item/provider/BlogsEntryInfoItemDetailsProvider.java
@@ -9,33 +9,25 @@ import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.ERCInfoItemIdentifier;
 import com.liferay.info.item.InfoItemClassDetails;
-import com.liferay.info.item.InfoItemDetails;
-import com.liferay.info.item.InfoItemIdentifier;
-import com.liferay.info.item.InfoItemReference;
+import com.liferay.info.item.provider.BaseInfoItemDetailsProvider;
 import com.liferay.info.item.provider.InfoItemDetailsProvider;
-import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupedModel;
-import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.util.GroupThreadLocal;
-
-import java.util.Objects;
 
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Alejandro Tardín
  * @author Jorge Ferrer
  */
 @Component(
-	property = Constants.SERVICE_RANKING + ":Integer=10",
+	property = {
+		Constants.SERVICE_RANKING + ":Integer=10",
+		"item.class.name=com.liferay.blogs.model.BlogsEntry"
+	},
 	service = InfoItemDetailsProvider.class
 )
 public class BlogsEntryInfoItemDetailsProvider
-	implements InfoItemDetailsProvider<BlogsEntry> {
+	extends BaseInfoItemDetailsProvider<BlogsEntry> {
 
 	@Override
 	public InfoItemClassDetails getInfoItemClassDetails() {
@@ -43,77 +35,28 @@ public class BlogsEntryInfoItemDetailsProvider
 	}
 
 	@Override
-	public InfoItemDetails getInfoItemDetails(BlogsEntry blogsEntry) {
-		return getInfoItemDetails(
-			_getGroupId(), ClassPKInfoItemIdentifier.class, blogsEntry);
+	protected InfoItemIdentifierFactory<BlogsEntry>
+		getInfoItemIdentifierFactory() {
+
+		return new InfoItemIdentifierFactory<>() {
+
+			@Override
+			public ClassPKInfoItemIdentifier createClassPKInfoItemIdentifier(
+				BlogsEntry blogsEntry) {
+
+				return new ClassPKInfoItemIdentifier(blogsEntry.getEntryId());
+			}
+
+			@Override
+			public ERCInfoItemIdentifier createERCInfoItemIdentifier(
+				String externalReferenceCode,
+				String scopeExternalReferenceCode) {
+
+				return new ERCInfoItemIdentifier(
+					externalReferenceCode, scopeExternalReferenceCode);
+			}
+
+		};
 	}
-
-	@Override
-	public InfoItemDetails getInfoItemDetails(
-		long groupId,
-		Class<? extends InfoItemIdentifier> infoItemIdentifierClass,
-		BlogsEntry blogsEntry) {
-
-		if (Objects.equals(
-				infoItemIdentifierClass, ClassPKInfoItemIdentifier.class)) {
-
-			return new InfoItemDetails(
-				getInfoItemClassDetails(),
-				new InfoItemReference(
-					BlogsEntry.class.getName(), blogsEntry.getEntryId()));
-		}
-
-		if (Objects.equals(
-				infoItemIdentifierClass, ERCInfoItemIdentifier.class)) {
-
-			return new InfoItemDetails(
-				getInfoItemClassDetails(),
-				new InfoItemReference(
-					BlogsEntry.class.getName(),
-					new ERCInfoItemIdentifier(
-						blogsEntry.getExternalReferenceCode(),
-						_getScopeExternalReferenceCode(groupId, blogsEntry))));
-		}
-
-		return null;
-	}
-
-	private long _getGroupId() {
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		if (serviceContext != null) {
-			return serviceContext.getScopeGroupId();
-		}
-
-		Long groupId = GroupThreadLocal.getGroupId();
-
-		if (groupId != null) {
-			return groupId;
-		}
-
-		throw new IllegalStateException(
-			"Neither service context thread local nor group thread local are " +
-				"initialized");
-	}
-
-	private String _getScopeExternalReferenceCode(
-		long groupId, GroupedModel groupedModel) {
-
-		if (groupId == groupedModel.getGroupId()) {
-			return null;
-		}
-
-		Group group = _groupLocalService.fetchGroup(groupedModel.getGroupId());
-
-		if (group == null) {
-			return null;
-		}
-
-		return group.getExternalReferenceCode();
-	}
-
-	@Reference
-	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/info/item/provider/BlogsEntryInfoItemObjectProvider.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/info/item/provider/BlogsEntryInfoItemObjectProvider.java
@@ -9,9 +9,18 @@ import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.blogs.service.BlogsEntryLocalService;
 import com.liferay.info.exception.NoSuchInfoItemException;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
+import com.liferay.info.item.ERCInfoItemIdentifier;
 import com.liferay.info.item.GroupUrlTitleInfoItemIdentifier;
 import com.liferay.info.item.InfoItemIdentifier;
 import com.liferay.info.item.provider.InfoItemObjectProvider;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
+import com.liferay.portal.kernel.util.Validator;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -22,6 +31,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = {
 		"info.item.identifier=com.liferay.info.item.ClassPKInfoItemIdentifier",
+		"info.item.identifier=com.liferay.info.item.ERCInfoItemIdentifier",
 		"info.item.identifier=com.liferay.info.item.GroupUrlTitleInfoItemIdentifier",
 		"service.ranking:Integer=100"
 	},
@@ -34,7 +44,84 @@ public class BlogsEntryInfoItemObjectProvider
 	public BlogsEntry getInfoItem(InfoItemIdentifier infoItemIdentifier)
 		throws NoSuchInfoItemException {
 
+		return getInfoItem(_getGroupId(), infoItemIdentifier);
+	}
+
+	@Override
+	public BlogsEntry getInfoItem(
+			long groupId, InfoItemIdentifier infoItemIdentifier)
+		throws NoSuchInfoItemException {
+
+		return _getInfoItem(_getCompanyId(), groupId, infoItemIdentifier);
+	}
+
+	private long _getCompanyId() {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext != null) {
+			return serviceContext.getCompanyId();
+		}
+
+		Long companyId = CompanyThreadLocal.getCompanyId();
+
+		if (companyId != null) {
+			return companyId;
+		}
+
+		throw new IllegalStateException(
+			"Neither service context thread local nor company thread local " +
+				"are initialized");
+	}
+
+	private long _getGroupId() {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext != null) {
+			return serviceContext.getScopeGroupId();
+		}
+
+		Long groupId = GroupThreadLocal.getGroupId();
+
+		if (groupId != null) {
+			return groupId;
+		}
+
+		throw new IllegalStateException(
+			"Neither service context thread local nor group thread local are " +
+				"initialized");
+	}
+
+	private long _getGroupId(
+			long companyId, ERCInfoItemIdentifier ercInfoItemIdentifier,
+			long groupId)
+		throws NoSuchInfoItemException {
+
+		try {
+			if (Validator.isNull(
+					ercInfoItemIdentifier.getScopeExternalReferenceCode())) {
+
+				return groupId;
+			}
+
+			Group group = _groupLocalService.getGroupByExternalReferenceCode(
+				ercInfoItemIdentifier.getScopeExternalReferenceCode(),
+				companyId);
+
+			return group.getGroupId();
+		}
+		catch (PortalException portalException) {
+			throw new NoSuchInfoItemException(portalException);
+		}
+	}
+
+	private BlogsEntry _getInfoItem(
+			long companyId, long groupId, InfoItemIdentifier infoItemIdentifier)
+		throws NoSuchInfoItemException {
+
 		if (!(infoItemIdentifier instanceof ClassPKInfoItemIdentifier) &&
+			!(infoItemIdentifier instanceof ERCInfoItemIdentifier) &&
 			!(infoItemIdentifier instanceof GroupUrlTitleInfoItemIdentifier)) {
 
 			throw new NoSuchInfoItemException(
@@ -49,6 +136,15 @@ public class BlogsEntryInfoItemObjectProvider
 
 			blogsEntry = _blogsEntryLocalService.fetchBlogsEntry(
 				classPKInfoItemIdentifier.getClassPK());
+		}
+		else if (infoItemIdentifier instanceof ERCInfoItemIdentifier) {
+			ERCInfoItemIdentifier ercInfoItemIdentifier =
+				(ERCInfoItemIdentifier)infoItemIdentifier;
+
+			blogsEntry =
+				_blogsEntryLocalService.fetchBlogsEntryByExternalReferenceCode(
+					ercInfoItemIdentifier.getExternalReferenceCode(),
+					_getGroupId(companyId, ercInfoItemIdentifier, groupId));
 		}
 		else if (infoItemIdentifier instanceof
 					GroupUrlTitleInfoItemIdentifier) {
@@ -74,5 +170,8 @@ public class BlogsEntryInfoItemObjectProvider
 
 	@Reference
 	private BlogsEntryLocalService _blogsEntryLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/info/item/provider/BlogsEntryInfoItemObjectProvider.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/info/item/provider/BlogsEntryInfoItemObjectProvider.java
@@ -52,7 +52,8 @@ public class BlogsEntryInfoItemObjectProvider
 			long groupId, InfoItemIdentifier infoItemIdentifier)
 		throws NoSuchInfoItemException {
 
-		return _getInfoItem(_getCompanyId(), groupId, infoItemIdentifier);
+		return _getInfoItem(
+			_getGroupId(groupId, infoItemIdentifier), infoItemIdentifier);
 	}
 
 	private long _getCompanyId() {
@@ -94,11 +95,17 @@ public class BlogsEntryInfoItemObjectProvider
 	}
 
 	private long _getGroupId(
-			long companyId, ERCInfoItemIdentifier ercInfoItemIdentifier,
-			long groupId)
+			long groupId, InfoItemIdentifier infoItemIdentifier)
 		throws NoSuchInfoItemException {
 
 		try {
+			if (!(infoItemIdentifier instanceof ERCInfoItemIdentifier)) {
+				return groupId;
+			}
+
+			ERCInfoItemIdentifier ercInfoItemIdentifier =
+				(ERCInfoItemIdentifier)infoItemIdentifier;
+
 			if (Validator.isNull(
 					ercInfoItemIdentifier.getScopeExternalReferenceCode())) {
 
@@ -107,7 +114,7 @@ public class BlogsEntryInfoItemObjectProvider
 
 			Group group = _groupLocalService.getGroupByExternalReferenceCode(
 				ercInfoItemIdentifier.getScopeExternalReferenceCode(),
-				companyId);
+				_getCompanyId());
 
 			return group.getGroupId();
 		}
@@ -117,7 +124,7 @@ public class BlogsEntryInfoItemObjectProvider
 	}
 
 	private BlogsEntry _getInfoItem(
-			long companyId, long groupId, InfoItemIdentifier infoItemIdentifier)
+			long groupId, InfoItemIdentifier infoItemIdentifier)
 		throws NoSuchInfoItemException {
 
 		if (!(infoItemIdentifier instanceof ClassPKInfoItemIdentifier) &&
@@ -143,8 +150,7 @@ public class BlogsEntryInfoItemObjectProvider
 
 			blogsEntry =
 				_blogsEntryLocalService.fetchBlogsEntryByExternalReferenceCode(
-					ercInfoItemIdentifier.getExternalReferenceCode(),
-					_getGroupId(companyId, ercInfoItemIdentifier, groupId));
+					ercInfoItemIdentifier.getExternalReferenceCode(), groupId);
 		}
 		else if (infoItemIdentifier instanceof
 					GroupUrlTitleInfoItemIdentifier) {

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/info/item/provider/BlogsEntryInfoItemObjectProvider.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/info/item/provider/BlogsEntryInfoItemObjectProvider.java
@@ -12,15 +12,8 @@ import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.ERCInfoItemIdentifier;
 import com.liferay.info.item.GroupUrlTitleInfoItemIdentifier;
 import com.liferay.info.item.InfoItemIdentifier;
+import com.liferay.info.item.provider.BaseInfoItemObjectProvider;
 import com.liferay.info.item.provider.InfoItemObjectProvider;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.util.GroupThreadLocal;
-import com.liferay.portal.kernel.util.Validator;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -33,97 +26,16 @@ import org.osgi.service.component.annotations.Reference;
 		"info.item.identifier=com.liferay.info.item.ClassPKInfoItemIdentifier",
 		"info.item.identifier=com.liferay.info.item.ERCInfoItemIdentifier",
 		"info.item.identifier=com.liferay.info.item.GroupUrlTitleInfoItemIdentifier",
+		"item.class.name=com.liferay.blogs.model.BlogsEntry",
 		"service.ranking:Integer=100"
 	},
 	service = InfoItemObjectProvider.class
 )
 public class BlogsEntryInfoItemObjectProvider
-	implements InfoItemObjectProvider<BlogsEntry> {
+	extends BaseInfoItemObjectProvider<BlogsEntry> {
 
 	@Override
-	public BlogsEntry getInfoItem(InfoItemIdentifier infoItemIdentifier)
-		throws NoSuchInfoItemException {
-
-		return getInfoItem(_getGroupId(), infoItemIdentifier);
-	}
-
-	@Override
-	public BlogsEntry getInfoItem(
-			long groupId, InfoItemIdentifier infoItemIdentifier)
-		throws NoSuchInfoItemException {
-
-		return _getInfoItem(
-			_getGroupId(groupId, infoItemIdentifier), infoItemIdentifier);
-	}
-
-	private long _getCompanyId() {
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		if (serviceContext != null) {
-			return serviceContext.getCompanyId();
-		}
-
-		Long companyId = CompanyThreadLocal.getCompanyId();
-
-		if (companyId != null) {
-			return companyId;
-		}
-
-		throw new IllegalStateException(
-			"Neither service context thread local nor company thread local " +
-				"are initialized");
-	}
-
-	private long _getGroupId() {
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		if (serviceContext != null) {
-			return serviceContext.getScopeGroupId();
-		}
-
-		Long groupId = GroupThreadLocal.getGroupId();
-
-		if (groupId != null) {
-			return groupId;
-		}
-
-		throw new IllegalStateException(
-			"Neither service context thread local nor group thread local are " +
-				"initialized");
-	}
-
-	private long _getGroupId(
-			long groupId, InfoItemIdentifier infoItemIdentifier)
-		throws NoSuchInfoItemException {
-
-		try {
-			if (!(infoItemIdentifier instanceof ERCInfoItemIdentifier)) {
-				return groupId;
-			}
-
-			ERCInfoItemIdentifier ercInfoItemIdentifier =
-				(ERCInfoItemIdentifier)infoItemIdentifier;
-
-			if (Validator.isNull(
-					ercInfoItemIdentifier.getScopeExternalReferenceCode())) {
-
-				return groupId;
-			}
-
-			Group group = _groupLocalService.getGroupByExternalReferenceCode(
-				ercInfoItemIdentifier.getScopeExternalReferenceCode(),
-				_getCompanyId());
-
-			return group.getGroupId();
-		}
-		catch (PortalException portalException) {
-			throw new NoSuchInfoItemException(portalException);
-		}
-	}
-
-	private BlogsEntry _getInfoItem(
+	protected BlogsEntry doGetInfoItem(
 			long groupId, InfoItemIdentifier infoItemIdentifier)
 		throws NoSuchInfoItemException {
 
@@ -176,8 +88,5 @@ public class BlogsEntryInfoItemObjectProvider
 
 	@Reference
 	private BlogsEntryLocalService _blogsEntryLocalService;
-
-	@Reference
-	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/document-library/document-library-repository-cmis-impl/src/main/java/com/liferay/document/library/repository/cmis/internal/RepositoryProxyBean.java
+++ b/modules/apps/document-library/document-library-repository-cmis-impl/src/main/java/com/liferay/document/library/repository/cmis/internal/RepositoryProxyBean.java
@@ -217,6 +217,17 @@ public class RepositoryProxyBean
 	}
 
 	@Override
+	public FileEntry fetchFileEntry(long fileEntryId) throws PortalException {
+		FileEntry fileEntry = _repository.fetchFileEntry(fileEntryId);
+
+		if (fileEntry == null) {
+			return fileEntry;
+		}
+
+		return newFileEntryProxyBean(fileEntry);
+	}
+
+	@Override
 	public <T extends Capability> T getCapability(Class<T> capabilityClass) {
 		return _repository.getCapability(capabilityClass);
 	}

--- a/modules/apps/document-library/document-library-repository-cmis-impl/src/main/java/com/liferay/document/library/repository/cmis/internal/model/CMISFileEntry.java
+++ b/modules/apps/document-library/document-library-repository-cmis-impl/src/main/java/com/liferay/document/library/repository/cmis/internal/model/CMISFileEntry.java
@@ -676,6 +676,11 @@ public class CMISFileEntry extends BaseCMISModel implements FileEntry {
 	public void setCreateDate(Date createDate) {
 	}
 
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		throw new UnsupportedOperationException();
+	}
+
 	public void setFileEntryId(long fileEntryId) {
 		_fileEntryId = fileEntryId;
 	}

--- a/modules/apps/document-library/document-library-repository-external-api/bnd.bnd
+++ b/modules/apps/document-library/document-library-repository-external-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Document Library Repository External API
 Bundle-SymbolicName: com.liferay.document.library.repository.external.api
-Bundle-Version: 11.0.3
+Bundle-Version: 11.1.0
 Export-Package:\
 	com.liferay.document.library.repository.external,\
 	com.liferay.document.library.repository.external.cache,\

--- a/modules/apps/document-library/document-library-repository-external-api/src/main/java/com/liferay/document/library/repository/external/model/ExtRepositoryFileEntryAdapter.java
+++ b/modules/apps/document-library/document-library-repository-external-api/src/main/java/com/liferay/document/library/repository/external/model/ExtRepositoryFileEntryAdapter.java
@@ -384,6 +384,11 @@ public class ExtRepositoryFileEntryAdapter
 		return true;
 	}
 
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		throw new UnsupportedOperationException();
+	}
+
 	private List<ExtRepositoryFileVersionAdapter>
 			_getExtRepositoryFileVersionAdapters()
 		throws PortalException {

--- a/modules/apps/document-library/document-library-repository-external-api/src/main/resources/com/liferay/document/library/repository/external/model/packageinfo
+++ b/modules/apps/document-library/document-library-repository-external-api/src/main/resources/com/liferay/document/library/repository/external/model/packageinfo
@@ -1,1 +1,1 @@
-version 2.4.0
+version 2.5.0

--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/info/item/provider/test/FileEntryInfoItemDetailsProviderTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/info/item/provider/test/FileEntryInfoItemDetailsProviderTest.java
@@ -1,0 +1,132 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.web.internal.info.item.provider.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.info.item.ClassPKInfoItemIdentifier;
+import com.liferay.info.item.ERCInfoItemIdentifier;
+import com.liferay.info.item.GroupKeyInfoItemIdentifier;
+import com.liferay.info.item.GroupUrlTitleInfoItemIdentifier;
+import com.liferay.info.item.InfoItemDetails;
+import com.liferay.info.item.InfoItemReference;
+import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.info.item.provider.InfoItemDetailsProvider;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Adolfo Pérez
+ */
+@RunWith(Arquillian.class)
+public class FileEntryInfoItemDetailsProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_fileEntry = _dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(),
+			ContentTypes.APPLICATION_OCTET_STREAM, null, null, null, null,
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	@Test
+	public void testGetInfoItemDetails() throws Exception {
+		InfoItemDetailsProvider<FileEntry> infoItemDetailsProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoItemDetailsProvider.class, FileEntry.class.getName());
+
+		InfoItemDetails classPKInfoItemDetails =
+			infoItemDetailsProvider.getInfoItemDetails(
+				_group.getGroupId(), ClassPKInfoItemIdentifier.class,
+				_fileEntry);
+
+		Assert.assertEquals(
+			FileEntry.class.getName(), classPKInfoItemDetails.getClassName());
+		Assert.assertEquals(
+			new InfoItemReference(
+				FileEntry.class.getName(), _fileEntry.getFileEntryId()),
+			classPKInfoItemDetails.getInfoItemReference());
+
+		InfoItemDetails ercInfoItemDetails =
+			infoItemDetailsProvider.getInfoItemDetails(
+				_group.getGroupId(), ERCInfoItemIdentifier.class, _fileEntry);
+
+		Assert.assertEquals(
+			new InfoItemReference(
+				FileEntry.class.getName(),
+				new ERCInfoItemIdentifier(
+					_fileEntry.getExternalReferenceCode())),
+			ercInfoItemDetails.getInfoItemReference());
+
+		InfoItemDetails randomGroupERCInfoItemDetails =
+			infoItemDetailsProvider.getInfoItemDetails(
+				RandomTestUtil.randomLong(), ERCInfoItemIdentifier.class,
+				_fileEntry);
+
+		Assert.assertEquals(
+			new InfoItemReference(
+				FileEntry.class.getName(),
+				new ERCInfoItemIdentifier(
+					_fileEntry.getExternalReferenceCode(),
+					_group.getExternalReferenceCode())),
+			randomGroupERCInfoItemDetails.getInfoItemReference());
+
+		Assert.assertNull(
+			infoItemDetailsProvider.getInfoItemDetails(
+				_group.getGroupId(), GroupKeyInfoItemIdentifier.class,
+				_fileEntry));
+
+		InfoItemDetails groupUrlTitleInfoItemDetails =
+			infoItemDetailsProvider.getInfoItemDetails(
+				_group.getGroupId(), GroupUrlTitleInfoItemIdentifier.class,
+				_fileEntry);
+
+		Assert.assertEquals(
+			new InfoItemReference(
+				FileEntry.class.getName(),
+				new GroupUrlTitleInfoItemIdentifier(
+					_fileEntry.getGroupId(),
+					String.valueOf(_fileEntry.getFileEntryId()))),
+			groupUrlTitleInfoItemDetails.getInfoItemReference());
+	}
+
+	@Inject
+	private DLAppLocalService _dlAppLocalService;
+
+	private FileEntry _fileEntry;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private InfoItemServiceRegistry _infoItemServiceRegistry;
+
+}

--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/info/item/provider/test/FileEntryInfoItemObjectProviderTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/info/item/provider/test/FileEntryInfoItemObjectProviderTest.java
@@ -1,0 +1,100 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.web.internal.info.item.provider.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.info.item.ClassPKInfoItemIdentifier;
+import com.liferay.info.item.ERCInfoItemIdentifier;
+import com.liferay.info.item.GroupUrlTitleInfoItemIdentifier;
+import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.info.item.provider.InfoItemObjectProvider;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Adolfo Pérez
+ */
+@RunWith(Arquillian.class)
+public class FileEntryInfoItemObjectProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_fileEntry = _dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new byte[0], null, null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+	}
+
+	@Test
+	public void testGetInfoItem() throws Exception {
+		InfoItemObjectProvider<FileEntry> infoItemObjectProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoItemObjectProvider.class, FileEntry.class.getName());
+
+		Assert.assertEquals(
+			_fileEntry,
+			infoItemObjectProvider.getInfoItem(
+				_group.getGroupId(),
+				new ClassPKInfoItemIdentifier(_fileEntry.getFileEntryId())));
+		Assert.assertEquals(
+			_fileEntry,
+			infoItemObjectProvider.getInfoItem(
+				_group.getGroupId(),
+				new ERCInfoItemIdentifier(
+					_fileEntry.getExternalReferenceCode())));
+		Assert.assertEquals(
+			_fileEntry,
+			infoItemObjectProvider.getInfoItem(
+				RandomTestUtil.randomLong(),
+				new ERCInfoItemIdentifier(
+					_fileEntry.getExternalReferenceCode(),
+					_group.getExternalReferenceCode())));
+		Assert.assertEquals(
+			_fileEntry,
+			infoItemObjectProvider.getInfoItem(
+				_group.getGroupId(),
+				new GroupUrlTitleInfoItemIdentifier(
+					_group.getGroupId(),
+					String.valueOf(_fileEntry.getFileEntryId()))));
+	}
+
+	@Inject
+	private DLAppLocalService _dlAppLocalService;
+
+	private FileEntry _fileEntry;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private InfoItemServiceRegistry _infoItemServiceRegistry;
+
+}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemDetailsProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemDetailsProvider.java
@@ -5,13 +5,26 @@
 
 package com.liferay.document.library.web.internal.info.item.provider;
 
+import com.liferay.info.item.ClassPKInfoItemIdentifier;
+import com.liferay.info.item.ERCInfoItemIdentifier;
+import com.liferay.info.item.GroupUrlTitleInfoItemIdentifier;
 import com.liferay.info.item.InfoItemClassDetails;
 import com.liferay.info.item.InfoItemDetails;
+import com.liferay.info.item.InfoItemIdentifier;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.info.item.provider.InfoItemDetailsProvider;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
+
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Jorge Ferrer
@@ -27,10 +40,88 @@ public class FileEntryInfoItemDetailsProvider
 
 	@Override
 	public InfoItemDetails getInfoItemDetails(FileEntry fileEntry) {
-		return new InfoItemDetails(
-			getInfoItemClassDetails(),
-			new InfoItemReference(
-				FileEntry.class.getName(), fileEntry.getFileEntryId()));
+		return getInfoItemDetails(
+			_getGroupId(), ClassPKInfoItemIdentifier.class, fileEntry);
 	}
+
+	@Override
+	public InfoItemDetails getInfoItemDetails(
+		long groupId,
+		Class<? extends InfoItemIdentifier> infoItemIdentifierClass,
+		FileEntry fileEntry) {
+
+		if (Objects.equals(
+				infoItemIdentifierClass, ClassPKInfoItemIdentifier.class)) {
+
+			return new InfoItemDetails(
+				getInfoItemClassDetails(),
+				new InfoItemReference(
+					FileEntry.class.getName(), fileEntry.getFileEntryId()));
+		}
+
+		if (Objects.equals(
+				infoItemIdentifierClass, ERCInfoItemIdentifier.class)) {
+
+			return new InfoItemDetails(
+				getInfoItemClassDetails(),
+				new InfoItemReference(
+					FileEntry.class.getName(),
+					new ERCInfoItemIdentifier(
+						fileEntry.getExternalReferenceCode(),
+						_getScopeExternalReferenceCode(groupId, fileEntry))));
+		}
+
+		if (Objects.equals(
+				infoItemIdentifierClass,
+				GroupUrlTitleInfoItemIdentifier.class)) {
+
+			return new InfoItemDetails(
+				getInfoItemClassDetails(),
+				new InfoItemReference(
+					FileEntry.class.getName(),
+					new GroupUrlTitleInfoItemIdentifier(
+						groupId, String.valueOf(fileEntry.getFileEntryId()))));
+		}
+
+		return null;
+	}
+
+	private long _getGroupId() {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext != null) {
+			return serviceContext.getScopeGroupId();
+		}
+
+		Long groupId = GroupThreadLocal.getGroupId();
+
+		if (groupId != null) {
+			return groupId;
+		}
+
+		throw new IllegalStateException(
+			"Neither service context thread local nor group thread local are " +
+				"initialized");
+	}
+
+	private String _getScopeExternalReferenceCode(
+		long groupId, GroupedModel groupedModel) {
+
+		if (groupId == groupedModel.getGroupId()) {
+			return null;
+		}
+
+		Group group = _groupLocalService.fetchGroup(groupedModel.getGroupId());
+
+		if (group == null) {
+			return null;
+		}
+
+		return group.getExternalReferenceCode();
+	}
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemDetailsProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemDetailsProvider.java
@@ -9,29 +9,21 @@ import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.ERCInfoItemIdentifier;
 import com.liferay.info.item.GroupUrlTitleInfoItemIdentifier;
 import com.liferay.info.item.InfoItemClassDetails;
-import com.liferay.info.item.InfoItemDetails;
-import com.liferay.info.item.InfoItemIdentifier;
-import com.liferay.info.item.InfoItemReference;
+import com.liferay.info.item.provider.BaseInfoItemDetailsProvider;
 import com.liferay.info.item.provider.InfoItemDetailsProvider;
-import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.repository.model.FileEntry;
-import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.util.GroupThreadLocal;
-
-import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Jorge Ferrer
  */
-@Component(service = InfoItemDetailsProvider.class)
+@Component(
+	property = "item.class.name=com.liferay.portal.kernel.repository.model.FileEntry",
+	service = InfoItemDetailsProvider.class
+)
 public class FileEntryInfoItemDetailsProvider
-	implements InfoItemDetailsProvider<FileEntry> {
+	extends BaseInfoItemDetailsProvider<FileEntry> {
 
 	@Override
 	public InfoItemClassDetails getInfoItemClassDetails() {
@@ -39,89 +31,38 @@ public class FileEntryInfoItemDetailsProvider
 	}
 
 	@Override
-	public InfoItemDetails getInfoItemDetails(FileEntry fileEntry) {
-		return getInfoItemDetails(
-			_getGroupId(), ClassPKInfoItemIdentifier.class, fileEntry);
+	protected InfoItemIdentifierFactory<FileEntry>
+		getInfoItemIdentifierFactory() {
+
+		return new InfoItemIdentifierFactory<>() {
+
+			@Override
+			public ClassPKInfoItemIdentifier createClassPKInfoItemIdentifier(
+				FileEntry fileEntry) {
+
+				return new ClassPKInfoItemIdentifier(
+					fileEntry.getFileEntryId());
+			}
+
+			@Override
+			public ERCInfoItemIdentifier createERCInfoItemIdentifier(
+				String externalReferenceCode,
+				String scopeExternalReferenceCode) {
+
+				return new ERCInfoItemIdentifier(
+					externalReferenceCode, scopeExternalReferenceCode);
+			}
+
+			@Override
+			public GroupUrlTitleInfoItemIdentifier
+				createGroupUrlTitleInfoItemIdentifier(
+					long groupId, FileEntry fileEntry) {
+
+				return new GroupUrlTitleInfoItemIdentifier(
+					groupId, String.valueOf(fileEntry.getFileEntryId()));
+			}
+
+		};
 	}
-
-	@Override
-	public InfoItemDetails getInfoItemDetails(
-		long groupId,
-		Class<? extends InfoItemIdentifier> infoItemIdentifierClass,
-		FileEntry fileEntry) {
-
-		if (Objects.equals(
-				infoItemIdentifierClass, ClassPKInfoItemIdentifier.class)) {
-
-			return new InfoItemDetails(
-				getInfoItemClassDetails(),
-				new InfoItemReference(
-					FileEntry.class.getName(), fileEntry.getFileEntryId()));
-		}
-
-		if (Objects.equals(
-				infoItemIdentifierClass, ERCInfoItemIdentifier.class)) {
-
-			return new InfoItemDetails(
-				getInfoItemClassDetails(),
-				new InfoItemReference(
-					FileEntry.class.getName(),
-					new ERCInfoItemIdentifier(
-						fileEntry.getExternalReferenceCode(),
-						_getScopeExternalReferenceCode(groupId, fileEntry))));
-		}
-
-		if (Objects.equals(
-				infoItemIdentifierClass,
-				GroupUrlTitleInfoItemIdentifier.class)) {
-
-			return new InfoItemDetails(
-				getInfoItemClassDetails(),
-				new InfoItemReference(
-					FileEntry.class.getName(),
-					new GroupUrlTitleInfoItemIdentifier(
-						groupId, String.valueOf(fileEntry.getFileEntryId()))));
-		}
-
-		return null;
-	}
-
-	private long _getGroupId() {
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		if (serviceContext != null) {
-			return serviceContext.getScopeGroupId();
-		}
-
-		Long groupId = GroupThreadLocal.getGroupId();
-
-		if (groupId != null) {
-			return groupId;
-		}
-
-		throw new IllegalStateException(
-			"Neither service context thread local nor group thread local are " +
-				"initialized");
-	}
-
-	private String _getScopeExternalReferenceCode(
-		long groupId, GroupedModel groupedModel) {
-
-		if (groupId == groupedModel.getGroupId()) {
-			return null;
-		}
-
-		Group group = _groupLocalService.fetchGroup(groupedModel.getGroupId());
-
-		if (group == null) {
-			return null;
-		}
-
-		return group.getExternalReferenceCode();
-	}
-
-	@Reference
-	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemObjectProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemObjectProvider.java
@@ -5,15 +5,24 @@
 
 package com.liferay.document.library.web.internal.info.item.provider;
 
+import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.info.exception.NoSuchInfoItemException;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
+import com.liferay.info.item.ERCInfoItemIdentifier;
 import com.liferay.info.item.GroupUrlTitleInfoItemIdentifier;
 import com.liferay.info.item.InfoItemIdentifier;
 import com.liferay.info.item.provider.InfoItemObjectProvider;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.repository.LocalRepository;
 import com.liferay.portal.kernel.repository.RepositoryProvider;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
+import com.liferay.portal.kernel.util.Validator;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -25,6 +34,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = {
 		"info.item.identifier=com.liferay.info.item.ClassPKInfoItemIdentifier",
+		"info.item.identifier=com.liferay.info.item.ERCInfoItemIdentifier",
 		"info.item.identifier=com.liferay.info.item.GroupUrlTitleInfoItemIdentifier",
 		"service.ranking:Integer=100"
 	},
@@ -37,7 +47,84 @@ public class FileEntryInfoItemObjectProvider
 	public FileEntry getInfoItem(InfoItemIdentifier infoItemIdentifier)
 		throws NoSuchInfoItemException {
 
+		return getInfoItem(_getGroupId(), infoItemIdentifier);
+	}
+
+	@Override
+	public FileEntry getInfoItem(
+			long groupId, InfoItemIdentifier infoItemIdentifier)
+		throws NoSuchInfoItemException {
+
+		return _getInfoItem(_getCompanyId(), _getGroupId(), infoItemIdentifier);
+	}
+
+	private long _getCompanyId() {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext != null) {
+			return serviceContext.getCompanyId();
+		}
+
+		Long companyId = CompanyThreadLocal.getCompanyId();
+
+		if (companyId != null) {
+			return companyId;
+		}
+
+		throw new IllegalStateException(
+			"Neither service context thread local nor company thread local " +
+				"are initialized");
+	}
+
+	private long _getGroupId() {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext != null) {
+			return serviceContext.getScopeGroupId();
+		}
+
+		Long groupId = GroupThreadLocal.getGroupId();
+
+		if (groupId != null) {
+			return groupId;
+		}
+
+		throw new IllegalStateException(
+			"Neither service context thread local nor group thread local are " +
+				"initialized");
+	}
+
+	private long _getGroupId(
+			long companyId, ERCInfoItemIdentifier ercInfoItemIdentifier,
+			long groupId)
+		throws NoSuchInfoItemException {
+
+		try {
+			if (Validator.isNull(
+					ercInfoItemIdentifier.getScopeExternalReferenceCode())) {
+
+				return groupId;
+			}
+
+			Group group = _groupLocalService.getGroupByExternalReferenceCode(
+				ercInfoItemIdentifier.getScopeExternalReferenceCode(),
+				companyId);
+
+			return group.getGroupId();
+		}
+		catch (PortalException portalException) {
+			throw new NoSuchInfoItemException(portalException);
+		}
+	}
+
+	private FileEntry _getInfoItem(
+			long companyId, long groupId, InfoItemIdentifier infoItemIdentifier)
+		throws NoSuchInfoItemException {
+
 		if (!(infoItemIdentifier instanceof ClassPKInfoItemIdentifier) &&
+			!(infoItemIdentifier instanceof ERCInfoItemIdentifier) &&
 			!(infoItemIdentifier instanceof GroupUrlTitleInfoItemIdentifier)) {
 
 			throw new NoSuchInfoItemException(
@@ -51,6 +138,19 @@ public class FileEntryInfoItemObjectProvider
 				(ClassPKInfoItemIdentifier)infoItemIdentifier;
 
 			classPK = classPKInfoItemIdentifier.getClassPK();
+		}
+		else if (infoItemIdentifier instanceof ERCInfoItemIdentifier) {
+			try {
+				ERCInfoItemIdentifier ercInfoItemIdentifier =
+					(ERCInfoItemIdentifier)infoItemIdentifier;
+
+				return _dlAppLocalService.fetchFileEntryByExternalReferenceCode(
+					_getGroupId(companyId, ercInfoItemIdentifier, groupId),
+					ercInfoItemIdentifier.getExternalReferenceCode());
+			}
+			catch (PortalException portalException) {
+				throw new NoSuchInfoItemException(portalException);
+			}
 		}
 		else if (infoItemIdentifier instanceof
 					GroupUrlTitleInfoItemIdentifier) {
@@ -85,6 +185,12 @@ public class FileEntryInfoItemObjectProvider
 				portalException);
 		}
 	}
+
+	@Reference
+	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private RepositoryProvider _repositoryProvider;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemObjectProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemObjectProvider.java
@@ -54,7 +54,8 @@ public class FileEntryInfoItemObjectProvider
 			long groupId, InfoItemIdentifier infoItemIdentifier)
 		throws NoSuchInfoItemException {
 
-		return _getInfoItem(_getCompanyId(), _getGroupId(), infoItemIdentifier);
+		return _getInfoItem(
+			_getGroupId(groupId, infoItemIdentifier), infoItemIdentifier);
 	}
 
 	private long _getCompanyId() {
@@ -96,11 +97,17 @@ public class FileEntryInfoItemObjectProvider
 	}
 
 	private long _getGroupId(
-			long companyId, ERCInfoItemIdentifier ercInfoItemIdentifier,
-			long groupId)
+			long groupId, InfoItemIdentifier infoItemIdentifier)
 		throws NoSuchInfoItemException {
 
 		try {
+			if (!(infoItemIdentifier instanceof ERCInfoItemIdentifier)) {
+				return groupId;
+			}
+
+			ERCInfoItemIdentifier ercInfoItemIdentifier =
+				(ERCInfoItemIdentifier)infoItemIdentifier;
+
 			if (Validator.isNull(
 					ercInfoItemIdentifier.getScopeExternalReferenceCode())) {
 
@@ -109,7 +116,7 @@ public class FileEntryInfoItemObjectProvider
 
 			Group group = _groupLocalService.getGroupByExternalReferenceCode(
 				ercInfoItemIdentifier.getScopeExternalReferenceCode(),
-				companyId);
+				_getCompanyId());
 
 			return group.getGroupId();
 		}
@@ -119,7 +126,7 @@ public class FileEntryInfoItemObjectProvider
 	}
 
 	private FileEntry _getInfoItem(
-			long companyId, long groupId, InfoItemIdentifier infoItemIdentifier)
+			long groupId, InfoItemIdentifier infoItemIdentifier)
 		throws NoSuchInfoItemException {
 
 		if (!(infoItemIdentifier instanceof ClassPKInfoItemIdentifier) &&
@@ -144,8 +151,7 @@ public class FileEntryInfoItemObjectProvider
 					(ERCInfoItemIdentifier)infoItemIdentifier;
 
 				return _dlAppLocalService.fetchFileEntryByExternalReferenceCode(
-					_getGroupId(companyId, ercInfoItemIdentifier, groupId),
-					ercInfoItemIdentifier.getExternalReferenceCode());
+					groupId, ercInfoItemIdentifier.getExternalReferenceCode());
 			}
 
 			GroupUrlTitleInfoItemIdentifier groupURLTitleInfoItemIdentifier =

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemObjectProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemObjectProvider.java
@@ -14,13 +14,12 @@ import com.liferay.info.item.InfoItemIdentifier;
 import com.liferay.info.item.provider.InfoItemObjectProvider;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.repository.LocalRepository;
-import com.liferay.portal.kernel.repository.RepositoryProvider;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -131,16 +130,16 @@ public class FileEntryInfoItemObjectProvider
 				"Unsupported info item identifier " + infoItemIdentifier);
 		}
 
-		long classPK = 0;
+		try {
+			if (infoItemIdentifier instanceof ClassPKInfoItemIdentifier) {
+				ClassPKInfoItemIdentifier classPKInfoItemIdentifier =
+					(ClassPKInfoItemIdentifier)infoItemIdentifier;
 
-		if (infoItemIdentifier instanceof ClassPKInfoItemIdentifier) {
-			ClassPKInfoItemIdentifier classPKInfoItemIdentifier =
-				(ClassPKInfoItemIdentifier)infoItemIdentifier;
+				return _dlAppLocalService.fetchFileEntry(
+					classPKInfoItemIdentifier.getClassPK());
+			}
 
-			classPK = classPKInfoItemIdentifier.getClassPK();
-		}
-		else if (infoItemIdentifier instanceof ERCInfoItemIdentifier) {
-			try {
+			if (infoItemIdentifier instanceof ERCInfoItemIdentifier) {
 				ERCInfoItemIdentifier ercInfoItemIdentifier =
 					(ERCInfoItemIdentifier)infoItemIdentifier;
 
@@ -148,35 +147,13 @@ public class FileEntryInfoItemObjectProvider
 					_getGroupId(companyId, ercInfoItemIdentifier, groupId),
 					ercInfoItemIdentifier.getExternalReferenceCode());
 			}
-			catch (PortalException portalException) {
-				throw new NoSuchInfoItemException(portalException);
-			}
-		}
-		else if (infoItemIdentifier instanceof
-					GroupUrlTitleInfoItemIdentifier) {
 
 			GroupUrlTitleInfoItemIdentifier groupURLTitleInfoItemIdentifier =
 				(GroupUrlTitleInfoItemIdentifier)infoItemIdentifier;
 
-			classPK = Long.valueOf(
-				groupURLTitleInfoItemIdentifier.getUrlTitle());
-		}
-
-		try {
-			LocalRepository localRepository =
-				_repositoryProvider.fetchFileEntryLocalRepository(classPK);
-
-			if (localRepository == null) {
-				return null;
-			}
-
-			FileEntry fileEntry = localRepository.getFileEntry(classPK);
-
-			if (fileEntry.isInTrash()) {
-				return null;
-			}
-
-			return fileEntry;
+			return _dlAppLocalService.fetchFileEntry(
+				GetterUtil.getLong(
+					groupURLTitleInfoItemIdentifier.getUrlTitle()));
 		}
 		catch (PortalException portalException) {
 			throw new NoSuchInfoItemException(
@@ -191,8 +168,5 @@ public class FileEntryInfoItemObjectProvider
 
 	@Reference
 	private GroupLocalService _groupLocalService;
-
-	@Reference
-	private RepositoryProvider _repositoryProvider;
 
 }

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemObjectProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemObjectProvider.java
@@ -11,17 +11,11 @@ import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.ERCInfoItemIdentifier;
 import com.liferay.info.item.GroupUrlTitleInfoItemIdentifier;
 import com.liferay.info.item.InfoItemIdentifier;
+import com.liferay.info.item.provider.BaseInfoItemObjectProvider;
 import com.liferay.info.item.provider.InfoItemObjectProvider;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.repository.model.FileEntry;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.GroupThreadLocal;
-import com.liferay.portal.kernel.util.Validator;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -35,97 +29,16 @@ import org.osgi.service.component.annotations.Reference;
 		"info.item.identifier=com.liferay.info.item.ClassPKInfoItemIdentifier",
 		"info.item.identifier=com.liferay.info.item.ERCInfoItemIdentifier",
 		"info.item.identifier=com.liferay.info.item.GroupUrlTitleInfoItemIdentifier",
+		"item.class.name=com.liferay.portal.kernel.repository.model.FileEntry",
 		"service.ranking:Integer=100"
 	},
 	service = InfoItemObjectProvider.class
 )
 public class FileEntryInfoItemObjectProvider
-	implements InfoItemObjectProvider<FileEntry> {
+	extends BaseInfoItemObjectProvider<FileEntry> {
 
 	@Override
-	public FileEntry getInfoItem(InfoItemIdentifier infoItemIdentifier)
-		throws NoSuchInfoItemException {
-
-		return getInfoItem(_getGroupId(), infoItemIdentifier);
-	}
-
-	@Override
-	public FileEntry getInfoItem(
-			long groupId, InfoItemIdentifier infoItemIdentifier)
-		throws NoSuchInfoItemException {
-
-		return _getInfoItem(
-			_getGroupId(groupId, infoItemIdentifier), infoItemIdentifier);
-	}
-
-	private long _getCompanyId() {
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		if (serviceContext != null) {
-			return serviceContext.getCompanyId();
-		}
-
-		Long companyId = CompanyThreadLocal.getCompanyId();
-
-		if (companyId != null) {
-			return companyId;
-		}
-
-		throw new IllegalStateException(
-			"Neither service context thread local nor company thread local " +
-				"are initialized");
-	}
-
-	private long _getGroupId() {
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		if (serviceContext != null) {
-			return serviceContext.getScopeGroupId();
-		}
-
-		Long groupId = GroupThreadLocal.getGroupId();
-
-		if (groupId != null) {
-			return groupId;
-		}
-
-		throw new IllegalStateException(
-			"Neither service context thread local nor group thread local are " +
-				"initialized");
-	}
-
-	private long _getGroupId(
-			long groupId, InfoItemIdentifier infoItemIdentifier)
-		throws NoSuchInfoItemException {
-
-		try {
-			if (!(infoItemIdentifier instanceof ERCInfoItemIdentifier)) {
-				return groupId;
-			}
-
-			ERCInfoItemIdentifier ercInfoItemIdentifier =
-				(ERCInfoItemIdentifier)infoItemIdentifier;
-
-			if (Validator.isNull(
-					ercInfoItemIdentifier.getScopeExternalReferenceCode())) {
-
-				return groupId;
-			}
-
-			Group group = _groupLocalService.getGroupByExternalReferenceCode(
-				ercInfoItemIdentifier.getScopeExternalReferenceCode(),
-				_getCompanyId());
-
-			return group.getGroupId();
-		}
-		catch (PortalException portalException) {
-			throw new NoSuchInfoItemException(portalException);
-		}
-	}
-
-	private FileEntry _getInfoItem(
+	protected FileEntry doGetInfoItem(
 			long groupId, InfoItemIdentifier infoItemIdentifier)
 		throws NoSuchInfoItemException {
 
@@ -171,8 +84,5 @@ public class FileEntryInfoItemObjectProvider
 
 	@Reference
 	private DLAppLocalService _dlAppLocalService;
-
-	@Reference
-	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/exception/NoSuchInfoItemException.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/exception/NoSuchInfoItemException.java
@@ -20,4 +20,8 @@ public class NoSuchInfoItemException extends PortalException {
 		super(throwable);
 	}
 
+	public NoSuchInfoItemException(Throwable throwable) {
+		super(throwable);
+	}
+
 }

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/item/provider/BaseInfoItemDetailsProvider.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/item/provider/BaseInfoItemDetailsProvider.java
@@ -1,0 +1,184 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.info.item.provider;
+
+import com.liferay.info.item.ClassPKInfoItemIdentifier;
+import com.liferay.info.item.ERCInfoItemIdentifier;
+import com.liferay.info.item.GroupKeyInfoItemIdentifier;
+import com.liferay.info.item.GroupUrlTitleInfoItemIdentifier;
+import com.liferay.info.item.InfoItemClassDetails;
+import com.liferay.info.item.InfoItemDetails;
+import com.liferay.info.item.InfoItemIdentifier;
+import com.liferay.info.item.InfoItemReference;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
+
+import java.util.Objects;
+
+/**
+ * @author Adolfo Pérez
+ */
+public abstract class BaseInfoItemDetailsProvider
+	<T extends ExternalReferenceCodeModel & GroupedModel>
+		implements InfoItemDetailsProvider<T> {
+
+	@Override
+	public InfoItemDetails getInfoItemDetails(
+		long groupId,
+		Class<? extends InfoItemIdentifier> infoItemIdentifierClass, T model) {
+
+		InfoItemIdentifierFactory<T> infoItemIdentifierFactory =
+			getInfoItemIdentifierFactory();
+
+		if (Objects.equals(
+				infoItemIdentifierClass, ClassPKInfoItemIdentifier.class)) {
+
+			return new InfoItemDetails(
+				getInfoItemClassDetails(),
+				new InfoItemReference(
+					_getModelClassName(),
+					infoItemIdentifierFactory.createClassPKInfoItemIdentifier(
+						model)));
+		}
+
+		if (Objects.equals(
+				infoItemIdentifierClass, ERCInfoItemIdentifier.class)) {
+
+			ERCInfoItemIdentifier ercInfoItemIdentifier =
+				infoItemIdentifierFactory.createERCInfoItemIdentifier(
+					model.getExternalReferenceCode(),
+					_getScopeExternalReferenceCode(groupId, model));
+
+			if (ercInfoItemIdentifier == null) {
+				return null;
+			}
+
+			return new InfoItemDetails(
+				getInfoItemClassDetails(),
+				new InfoItemReference(
+					_getModelClassName(), ercInfoItemIdentifier));
+		}
+
+		if (Objects.equals(
+				infoItemIdentifierClass, GroupKeyInfoItemIdentifier.class)) {
+
+			GroupKeyInfoItemIdentifier groupKeyInfoItemIdentifier =
+				infoItemIdentifierFactory.createGroupKeyInfoItemIdentifier(
+					model.getGroupId(), model);
+
+			if (groupKeyInfoItemIdentifier == null) {
+				return null;
+			}
+
+			return new InfoItemDetails(
+				getInfoItemClassDetails(),
+				new InfoItemReference(
+					_getModelClassName(), groupKeyInfoItemIdentifier));
+		}
+
+		if (Objects.equals(
+				infoItemIdentifierClass,
+				GroupUrlTitleInfoItemIdentifier.class)) {
+
+			GroupUrlTitleInfoItemIdentifier groupUrlTitleInfoItemIdentifier =
+				infoItemIdentifierFactory.createGroupUrlTitleInfoItemIdentifier(
+					model.getGroupId(), model);
+
+			if (groupUrlTitleInfoItemIdentifier == null) {
+				return null;
+			}
+
+			return new InfoItemDetails(
+				getInfoItemClassDetails(),
+				new InfoItemReference(
+					_getModelClassName(), groupUrlTitleInfoItemIdentifier));
+		}
+
+		return null;
+	}
+
+	@Override
+	public InfoItemDetails getInfoItemDetails(T model) {
+		return getInfoItemDetails(
+			_getGroupId(), ClassPKInfoItemIdentifier.class, model);
+	}
+
+	public interface InfoItemIdentifierFactory<T> {
+
+		public ClassPKInfoItemIdentifier createClassPKInfoItemIdentifier(
+			T model);
+
+		public default ERCInfoItemIdentifier createERCInfoItemIdentifier(
+			String externalReferenceCode, String scopeExternalReferenceCode) {
+
+			return null;
+		}
+
+		public default GroupKeyInfoItemIdentifier
+			createGroupKeyInfoItemIdentifier(long groupId, T model) {
+
+			return null;
+		}
+
+		public default GroupUrlTitleInfoItemIdentifier
+			createGroupUrlTitleInfoItemIdentifier(long groupId, T model) {
+
+			return null;
+		}
+
+	}
+
+	protected abstract InfoItemIdentifierFactory<T>
+		getInfoItemIdentifierFactory();
+
+	private long _getGroupId() {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext != null) {
+			return serviceContext.getScopeGroupId();
+		}
+
+		Long groupId = GroupThreadLocal.getGroupId();
+
+		if (groupId != null) {
+			return groupId;
+		}
+
+		throw new IllegalStateException(
+			"Neither service context thread local nor group thread local are " +
+				"initialized");
+	}
+
+	private String _getModelClassName() {
+		InfoItemClassDetails infoItemClassDetails = getInfoItemClassDetails();
+
+		return infoItemClassDetails.getClassName();
+	}
+
+	private String _getScopeExternalReferenceCode(
+		long groupId, GroupedModel groupedModel) {
+
+		if (groupId == groupedModel.getGroupId()) {
+			return null;
+		}
+
+		Group group = GroupLocalServiceUtil.fetchGroup(
+			groupedModel.getGroupId());
+
+		if (group == null) {
+			return null;
+		}
+
+		return group.getExternalReferenceCode();
+	}
+
+}

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/item/provider/BaseInfoItemObjectProvider.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/item/provider/BaseInfoItemObjectProvider.java
@@ -1,0 +1,112 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.info.item.provider;
+
+import com.liferay.info.exception.NoSuchInfoItemException;
+import com.liferay.info.item.ERCInfoItemIdentifier;
+import com.liferay.info.item.InfoItemIdentifier;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
+import com.liferay.portal.kernel.util.Validator;
+
+/**
+ * @author Adolfo Pérez
+ */
+public abstract class BaseInfoItemObjectProvider<T>
+	implements InfoItemObjectProvider<T> {
+
+	@Override
+	public T getInfoItem(InfoItemIdentifier infoItemIdentifier)
+		throws NoSuchInfoItemException {
+
+		return getInfoItem(_getGroupId(), infoItemIdentifier);
+	}
+
+	@Override
+	public T getInfoItem(long groupId, InfoItemIdentifier infoItemIdentifier)
+		throws NoSuchInfoItemException {
+
+		return doGetInfoItem(
+			_getGroupId(groupId, infoItemIdentifier), infoItemIdentifier);
+	}
+
+	protected abstract T doGetInfoItem(
+			long groupId, InfoItemIdentifier infoItemIdentifier)
+		throws NoSuchInfoItemException;
+
+	private long _getCompanyId() {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext != null) {
+			return serviceContext.getCompanyId();
+		}
+
+		Long companyId = CompanyThreadLocal.getCompanyId();
+
+		if (companyId != null) {
+			return companyId;
+		}
+
+		throw new IllegalStateException(
+			"Neither service context thread local nor company thread local " +
+				"are initialized");
+	}
+
+	private long _getGroupId() {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext != null) {
+			return serviceContext.getScopeGroupId();
+		}
+
+		Long groupId = GroupThreadLocal.getGroupId();
+
+		if (groupId != null) {
+			return groupId;
+		}
+
+		throw new IllegalStateException(
+			"Neither service context thread local nor group thread local are " +
+				"initialized");
+	}
+
+	private long _getGroupId(
+			long groupId, InfoItemIdentifier infoItemIdentifier)
+		throws NoSuchInfoItemException {
+
+		try {
+			if (!(infoItemIdentifier instanceof ERCInfoItemIdentifier)) {
+				return groupId;
+			}
+
+			ERCInfoItemIdentifier ercInfoItemIdentifier =
+				(ERCInfoItemIdentifier)infoItemIdentifier;
+
+			if (Validator.isNull(
+					ercInfoItemIdentifier.getScopeExternalReferenceCode())) {
+
+				return groupId;
+			}
+
+			Group group = GroupLocalServiceUtil.getGroupByExternalReferenceCode(
+				ercInfoItemIdentifier.getScopeExternalReferenceCode(),
+				_getCompanyId());
+
+			return group.getGroupId();
+		}
+		catch (PortalException portalException) {
+			throw new NoSuchInfoItemException(portalException);
+		}
+	}
+
+}

--- a/modules/apps/info/info-api/src/main/resources/com/liferay/info/exception/packageinfo
+++ b/modules/apps/info/info-api/src/main/resources/com/liferay/info/exception/packageinfo
@@ -1,1 +1,1 @@
-version 6.1.0
+version 6.2.0

--- a/modules/apps/info/info-api/src/main/resources/com/liferay/info/item/provider/packageinfo
+++ b/modules/apps/info/info-api/src/main/resources/com/liferay/info/item/provider/packageinfo
@@ -1,1 +1,1 @@
-version 5.3.0
+version 5.4.0

--- a/modules/apps/journal/journal-web-test/src/testIntegration/java/com/liferay/journal/web/internal/info/item/provider/test/JournalArticleInfoItemDetailsProviderTest.java
+++ b/modules/apps/journal/journal-web-test/src/testIntegration/java/com/liferay/journal/web/internal/info/item/provider/test/JournalArticleInfoItemDetailsProviderTest.java
@@ -1,0 +1,146 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.web.internal.info.item.provider.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.info.item.ClassPKInfoItemIdentifier;
+import com.liferay.info.item.ERCInfoItemIdentifier;
+import com.liferay.info.item.GroupKeyInfoItemIdentifier;
+import com.liferay.info.item.GroupUrlTitleInfoItemIdentifier;
+import com.liferay.info.item.InfoItemDetails;
+import com.liferay.info.item.InfoItemReference;
+import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.info.item.provider.InfoItemDetailsProvider;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Adolfo Pérez
+ */
+@RunWith(Arquillian.class)
+public class JournalArticleInfoItemDetailsProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_journalArticle = _journalArticleLocalService.addArticle(
+			null, TestPropsValues.getUserId(), _group.getGroupId(), 0,
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			StringUtil.randomString(), 0, null,
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	@Test
+	public void testGetInfoItemDetails() throws Exception {
+		InfoItemDetailsProvider<JournalArticle> infoItemDetailsProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoItemDetailsProvider.class, JournalArticle.class.getName());
+
+		InfoItemDetails classPKInfoItemDetails =
+			infoItemDetailsProvider.getInfoItemDetails(
+				_group.getGroupId(), ClassPKInfoItemIdentifier.class,
+				_journalArticle);
+
+		Assert.assertEquals(
+			JournalArticle.class.getName(),
+			classPKInfoItemDetails.getClassName());
+		Assert.assertEquals(
+			new InfoItemReference(
+				JournalArticle.class.getName(),
+				_journalArticle.getResourcePrimKey()),
+			classPKInfoItemDetails.getInfoItemReference());
+
+		InfoItemDetails ercInfoItemDetails =
+			infoItemDetailsProvider.getInfoItemDetails(
+				_group.getGroupId(), ERCInfoItemIdentifier.class,
+				_journalArticle);
+
+		Assert.assertEquals(
+			new InfoItemReference(
+				JournalArticle.class.getName(),
+				new ERCInfoItemIdentifier(
+					_journalArticle.getExternalReferenceCode())),
+			ercInfoItemDetails.getInfoItemReference());
+
+		InfoItemDetails randomGroupERCInfoItemDetails =
+			infoItemDetailsProvider.getInfoItemDetails(
+				RandomTestUtil.randomLong(), ERCInfoItemIdentifier.class,
+				_journalArticle);
+
+		Assert.assertEquals(
+			new InfoItemReference(
+				JournalArticle.class.getName(),
+				new ERCInfoItemIdentifier(
+					_journalArticle.getExternalReferenceCode(),
+					_group.getExternalReferenceCode())),
+			randomGroupERCInfoItemDetails.getInfoItemReference());
+
+		InfoItemDetails groupKeyInfoItemDetails =
+			infoItemDetailsProvider.getInfoItemDetails(
+				_group.getGroupId(), GroupKeyInfoItemIdentifier.class,
+				_journalArticle);
+
+		Assert.assertEquals(
+			new InfoItemReference(
+				JournalArticle.class.getName(),
+				new GroupKeyInfoItemIdentifier(
+					_group.getGroupId(), _journalArticle.getArticleId())),
+			groupKeyInfoItemDetails.getInfoItemReference());
+
+		InfoItemDetails groupUrlTitleInfoItemDetails =
+			infoItemDetailsProvider.getInfoItemDetails(
+				_group.getGroupId(), GroupUrlTitleInfoItemIdentifier.class,
+				_journalArticle);
+
+		Assert.assertEquals(
+			new InfoItemReference(
+				JournalArticle.class.getName(),
+				new GroupUrlTitleInfoItemIdentifier(
+					_group.getGroupId(), _journalArticle.getUrlTitle())),
+			groupUrlTitleInfoItemDetails.getInfoItemReference());
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private InfoItemServiceRegistry _infoItemServiceRegistry;
+
+	private JournalArticle _journalArticle;
+
+	@Inject
+	private JournalArticleLocalService _journalArticleLocalService;
+
+}

--- a/modules/apps/journal/journal-web-test/src/testIntegration/java/com/liferay/journal/web/internal/info/item/provider/test/JournalArticleInfoItemObjectProviderTest.java
+++ b/modules/apps/journal/journal-web-test/src/testIntegration/java/com/liferay/journal/web/internal/info/item/provider/test/JournalArticleInfoItemObjectProviderTest.java
@@ -1,0 +1,100 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.web.internal.info.item.provider.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.info.item.ClassPKInfoItemIdentifier;
+import com.liferay.info.item.ERCInfoItemIdentifier;
+import com.liferay.info.item.GroupKeyInfoItemIdentifier;
+import com.liferay.info.item.GroupUrlTitleInfoItemIdentifier;
+import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.info.item.provider.InfoItemObjectProvider;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleLocalService;
+import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Adolfo Pérez
+ */
+@RunWith(Arquillian.class)
+public class JournalArticleInfoItemObjectProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_journalArticle = JournalTestUtil.addArticle(_group.getGroupId(), 0);
+	}
+
+	@Test
+	public void testGetInfoItem() throws Exception {
+		InfoItemObjectProvider<JournalArticle> infoItemObjectProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoItemObjectProvider.class, JournalArticle.class.getName());
+
+		Assert.assertEquals(
+			_journalArticle,
+			infoItemObjectProvider.getInfoItem(
+				_group.getGroupId(),
+				new ClassPKInfoItemIdentifier(
+					_journalArticle.getResourcePrimKey())));
+		Assert.assertEquals(
+			_journalArticle,
+			infoItemObjectProvider.getInfoItem(
+				_group.getGroupId(),
+				new ERCInfoItemIdentifier(
+					_journalArticle.getExternalReferenceCode())));
+		Assert.assertEquals(
+			_journalArticle,
+			infoItemObjectProvider.getInfoItem(
+				RandomTestUtil.randomLong(),
+				new ERCInfoItemIdentifier(
+					_journalArticle.getExternalReferenceCode(),
+					_group.getExternalReferenceCode())));
+		Assert.assertEquals(
+			_journalArticle,
+			infoItemObjectProvider.getInfoItem(
+				_group.getGroupId(),
+				new GroupKeyInfoItemIdentifier(
+					_group.getGroupId(), _journalArticle.getArticleId())));
+		Assert.assertEquals(
+			_journalArticle,
+			infoItemObjectProvider.getInfoItem(
+				_group.getGroupId(),
+				new GroupUrlTitleInfoItemIdentifier(
+					_group.getGroupId(), _journalArticle.getUrlTitle())));
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private InfoItemServiceRegistry _infoItemServiceRegistry;
+
+	private JournalArticle _journalArticle;
+
+	@Inject
+	private JournalArticleLocalService _journalArticleLocalService;
+
+}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemDetailsProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemDetailsProvider.java
@@ -5,14 +5,28 @@
 
 package com.liferay.journal.web.internal.info.item.provider;
 
+import com.liferay.info.item.ClassPKInfoItemIdentifier;
+import com.liferay.info.item.ERCInfoItemIdentifier;
+import com.liferay.info.item.GroupKeyInfoItemIdentifier;
+import com.liferay.info.item.GroupUrlTitleInfoItemIdentifier;
 import com.liferay.info.item.InfoItemClassDetails;
 import com.liferay.info.item.InfoItemDetails;
+import com.liferay.info.item.InfoItemIdentifier;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.info.item.provider.InfoItemDetailsProvider;
 import com.liferay.journal.model.JournalArticle;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
+
+import java.util.Objects;
 
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Jürgen Kappler
@@ -35,11 +49,103 @@ public class JournalArticleInfoItemDetailsProvider
 
 	@Override
 	public InfoItemDetails getInfoItemDetails(JournalArticle journalArticle) {
-		return new InfoItemDetails(
-			getInfoItemClassDetails(),
-			new InfoItemReference(
-				JournalArticle.class.getName(),
-				journalArticle.getResourcePrimKey()));
+		return getInfoItemDetails(
+			_getGroupId(), ClassPKInfoItemIdentifier.class, journalArticle);
 	}
+
+	@Override
+	public InfoItemDetails getInfoItemDetails(
+		long groupId,
+		Class<? extends InfoItemIdentifier> infoItemIdentifierClass,
+		JournalArticle journalArticle) {
+
+		if (Objects.equals(
+				infoItemIdentifierClass, ClassPKInfoItemIdentifier.class)) {
+
+			return new InfoItemDetails(
+				getInfoItemClassDetails(),
+				new InfoItemReference(
+					JournalArticle.class.getName(),
+					journalArticle.getResourcePrimKey()));
+		}
+
+		if (Objects.equals(
+				infoItemIdentifierClass, ERCInfoItemIdentifier.class)) {
+
+			return new InfoItemDetails(
+				getInfoItemClassDetails(),
+				new InfoItemReference(
+					JournalArticle.class.getName(),
+					new ERCInfoItemIdentifier(
+						journalArticle.getExternalReferenceCode(),
+						_getScopeExternalReferenceCode(
+							groupId, journalArticle))));
+		}
+
+		if (Objects.equals(
+				infoItemIdentifierClass, GroupKeyInfoItemIdentifier.class)) {
+
+			return new InfoItemDetails(
+				getInfoItemClassDetails(),
+				new InfoItemReference(
+					JournalArticle.class.getName(),
+					new GroupKeyInfoItemIdentifier(
+						journalArticle.getGroupId(),
+						journalArticle.getArticleId())));
+		}
+
+		if (Objects.equals(
+				infoItemIdentifierClass,
+				GroupUrlTitleInfoItemIdentifier.class)) {
+
+			return new InfoItemDetails(
+				getInfoItemClassDetails(),
+				new InfoItemReference(
+					JournalArticle.class.getName(),
+					new GroupUrlTitleInfoItemIdentifier(
+						journalArticle.getGroupId(),
+						journalArticle.getUrlTitle())));
+		}
+
+		return null;
+	}
+
+	private long _getGroupId() {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext != null) {
+			return serviceContext.getScopeGroupId();
+		}
+
+		Long groupId = GroupThreadLocal.getGroupId();
+
+		if (groupId != null) {
+			return groupId;
+		}
+
+		throw new IllegalStateException(
+			"Neither service context thread local nor group thread local are " +
+				"initialized");
+	}
+
+	private String _getScopeExternalReferenceCode(
+		long groupId, GroupedModel groupedModel) {
+
+		if (groupId == groupedModel.getGroupId()) {
+			return null;
+		}
+
+		Group group = _groupLocalService.fetchGroup(groupedModel.getGroupId());
+
+		if (group == null) {
+			return null;
+		}
+
+		return group.getExternalReferenceCode();
+	}
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemDetailsProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemDetailsProvider.java
@@ -10,23 +10,12 @@ import com.liferay.info.item.ERCInfoItemIdentifier;
 import com.liferay.info.item.GroupKeyInfoItemIdentifier;
 import com.liferay.info.item.GroupUrlTitleInfoItemIdentifier;
 import com.liferay.info.item.InfoItemClassDetails;
-import com.liferay.info.item.InfoItemDetails;
-import com.liferay.info.item.InfoItemIdentifier;
-import com.liferay.info.item.InfoItemReference;
+import com.liferay.info.item.provider.BaseInfoItemDetailsProvider;
 import com.liferay.info.item.provider.InfoItemDetailsProvider;
 import com.liferay.journal.model.JournalArticle;
-import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupedModel;
-import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.util.GroupThreadLocal;
-
-import java.util.Objects;
 
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Jürgen Kappler
@@ -40,7 +29,7 @@ import org.osgi.service.component.annotations.Reference;
 	service = InfoItemDetailsProvider.class
 )
 public class JournalArticleInfoItemDetailsProvider
-	implements InfoItemDetailsProvider<JournalArticle> {
+	extends BaseInfoItemDetailsProvider<JournalArticle> {
 
 	@Override
 	public InfoItemClassDetails getInfoItemClassDetails() {
@@ -48,104 +37,46 @@ public class JournalArticleInfoItemDetailsProvider
 	}
 
 	@Override
-	public InfoItemDetails getInfoItemDetails(JournalArticle journalArticle) {
-		return getInfoItemDetails(
-			_getGroupId(), ClassPKInfoItemIdentifier.class, journalArticle);
+	protected InfoItemIdentifierFactory<JournalArticle>
+		getInfoItemIdentifierFactory() {
+
+		return new InfoItemIdentifierFactory<>() {
+
+			@Override
+			public ClassPKInfoItemIdentifier createClassPKInfoItemIdentifier(
+				JournalArticle journalArticle) {
+
+				return new ClassPKInfoItemIdentifier(
+					journalArticle.getResourcePrimKey());
+			}
+
+			@Override
+			public ERCInfoItemIdentifier createERCInfoItemIdentifier(
+				String externalReferenceCode,
+				String scopeExternalReferenceCode) {
+
+				return new ERCInfoItemIdentifier(
+					externalReferenceCode, scopeExternalReferenceCode);
+			}
+
+			@Override
+			public GroupKeyInfoItemIdentifier createGroupKeyInfoItemIdentifier(
+				long groupId, JournalArticle journalArticle) {
+
+				return new GroupKeyInfoItemIdentifier(
+					journalArticle.getGroupId(), journalArticle.getArticleId());
+			}
+
+			@Override
+			public GroupUrlTitleInfoItemIdentifier
+				createGroupUrlTitleInfoItemIdentifier(
+					long groupId, JournalArticle journalArticle) {
+
+				return new GroupUrlTitleInfoItemIdentifier(
+					journalArticle.getGroupId(), journalArticle.getUrlTitle());
+			}
+
+		};
 	}
-
-	@Override
-	public InfoItemDetails getInfoItemDetails(
-		long groupId,
-		Class<? extends InfoItemIdentifier> infoItemIdentifierClass,
-		JournalArticle journalArticle) {
-
-		if (Objects.equals(
-				infoItemIdentifierClass, ClassPKInfoItemIdentifier.class)) {
-
-			return new InfoItemDetails(
-				getInfoItemClassDetails(),
-				new InfoItemReference(
-					JournalArticle.class.getName(),
-					journalArticle.getResourcePrimKey()));
-		}
-
-		if (Objects.equals(
-				infoItemIdentifierClass, ERCInfoItemIdentifier.class)) {
-
-			return new InfoItemDetails(
-				getInfoItemClassDetails(),
-				new InfoItemReference(
-					JournalArticle.class.getName(),
-					new ERCInfoItemIdentifier(
-						journalArticle.getExternalReferenceCode(),
-						_getScopeExternalReferenceCode(
-							groupId, journalArticle))));
-		}
-
-		if (Objects.equals(
-				infoItemIdentifierClass, GroupKeyInfoItemIdentifier.class)) {
-
-			return new InfoItemDetails(
-				getInfoItemClassDetails(),
-				new InfoItemReference(
-					JournalArticle.class.getName(),
-					new GroupKeyInfoItemIdentifier(
-						journalArticle.getGroupId(),
-						journalArticle.getArticleId())));
-		}
-
-		if (Objects.equals(
-				infoItemIdentifierClass,
-				GroupUrlTitleInfoItemIdentifier.class)) {
-
-			return new InfoItemDetails(
-				getInfoItemClassDetails(),
-				new InfoItemReference(
-					JournalArticle.class.getName(),
-					new GroupUrlTitleInfoItemIdentifier(
-						journalArticle.getGroupId(),
-						journalArticle.getUrlTitle())));
-		}
-
-		return null;
-	}
-
-	private long _getGroupId() {
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		if (serviceContext != null) {
-			return serviceContext.getScopeGroupId();
-		}
-
-		Long groupId = GroupThreadLocal.getGroupId();
-
-		if (groupId != null) {
-			return groupId;
-		}
-
-		throw new IllegalStateException(
-			"Neither service context thread local nor group thread local are " +
-				"initialized");
-	}
-
-	private String _getScopeExternalReferenceCode(
-		long groupId, GroupedModel groupedModel) {
-
-		if (groupId == groupedModel.getGroupId()) {
-			return null;
-		}
-
-		Group group = _groupLocalService.fetchGroup(groupedModel.getGroupId());
-
-		if (group == null) {
-			return null;
-		}
-
-		return group.getExternalReferenceCode();
-	}
-
-	@Reference
-	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemDetailsProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemDetailsProvider.java
@@ -19,7 +19,10 @@ import org.osgi.service.component.annotations.Component;
  * @author Jorge Ferrer
  */
 @Component(
-	property = Constants.SERVICE_RANKING + ":Integer=10",
+	property = {
+		Constants.SERVICE_RANKING + ":Integer=10",
+		"item.class.name=com.liferay.journal.model.JournalArticle"
+	},
 	service = InfoItemDetailsProvider.class
 )
 public class JournalArticleInfoItemDetailsProvider

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemObjectProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemObjectProvider.java
@@ -7,6 +7,7 @@ package com.liferay.journal.web.internal.info.item.provider;
 
 import com.liferay.info.exception.NoSuchInfoItemException;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
+import com.liferay.info.item.ERCInfoItemIdentifier;
 import com.liferay.info.item.GroupKeyInfoItemIdentifier;
 import com.liferay.info.item.GroupUrlTitleInfoItemIdentifier;
 import com.liferay.info.item.InfoItemIdentifier;
@@ -20,11 +21,17 @@ import com.liferay.journal.service.JournalArticleResourceLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
@@ -39,6 +46,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = {
 		"info.item.identifier=com.liferay.info.item.ClassPKInfoItemIdentifier",
+		"info.item.identifier=com.liferay.info.item.ERCInfoItemIdentifier",
 		"info.item.identifier=com.liferay.info.item.GroupKeyInfoItemIdentifier",
 		"info.item.identifier=com.liferay.info.item.GroupUrlTitleInfoItemIdentifier",
 		"item.class.name=com.liferay.journal.model.JournalArticle",
@@ -53,7 +61,185 @@ public class JournalArticleInfoItemObjectProvider
 	public JournalArticle getInfoItem(InfoItemIdentifier infoItemIdentifier)
 		throws NoSuchInfoItemException {
 
+		return getInfoItem(_getGroupId(), infoItemIdentifier);
+	}
+
+	@Override
+	public JournalArticle getInfoItem(
+			long groupId, InfoItemIdentifier infoItemIdentifier)
+		throws NoSuchInfoItemException {
+
+		return _getInfoItem(_getCompanyId(), groupId, infoItemIdentifier);
+	}
+
+	private JournalArticle _getArticle(long classPK, String version)
+		throws PortalException {
+
+		if (Validator.isNull(version) ||
+			Objects.equals(
+				version, InfoItemIdentifier.VERSION_LATEST_APPROVED)) {
+
+			return _journalArticleLocalService.fetchLatestArticle(classPK);
+		}
+		else if (Objects.equals(version, InfoItemIdentifier.VERSION_LATEST)) {
+			JournalArticleResource articleResource =
+				_journalArticleResourceLocalService.getArticleResource(classPK);
+
+			return _journalArticleLocalService.fetchLatestArticle(
+				articleResource.getGroupId(), articleResource.getArticleId(),
+				WorkflowConstants.STATUS_ANY);
+		}
+
+		JournalArticleResource articleResource =
+			_journalArticleResourceLocalService.getArticleResource(classPK);
+
+		return _journalArticleLocalService.getArticle(
+			articleResource.getGroupId(), articleResource.getArticleId(),
+			GetterUtil.getDouble(version));
+	}
+
+	private JournalArticle _getArticle(
+			long groupId, String articleId, String version)
+		throws PortalException {
+
+		if (Validator.isNull(version) ||
+			Objects.equals(
+				version, InfoItemIdentifier.VERSION_LATEST_APPROVED)) {
+
+			return _journalArticleLocalService.fetchLatestArticle(
+				groupId, articleId, WorkflowConstants.STATUS_APPROVED);
+		}
+		else if (Objects.equals(version, InfoItemIdentifier.VERSION_LATEST)) {
+			return _journalArticleLocalService.fetchLatestArticle(
+				groupId, articleId, WorkflowConstants.STATUS_ANY);
+		}
+
+		return _journalArticleLocalService.getArticle(
+			groupId, articleId, GetterUtil.getDouble(version));
+	}
+
+	private JournalArticle _getArticle(
+			String externalReferenceCode, long groupId, String version)
+		throws PortalException {
+
+		if (Validator.isNull(version) ||
+			Objects.equals(
+				version, InfoItemIdentifier.VERSION_LATEST_APPROVED)) {
+
+			return _journalArticleLocalService.
+				fetchLatestArticleByExternalReferenceCode(
+					groupId, externalReferenceCode,
+					WorkflowConstants.STATUS_APPROVED, true);
+		}
+
+		if (Objects.equals(version, InfoItemIdentifier.VERSION_LATEST)) {
+			return _journalArticleLocalService.
+				fetchLatestArticleByExternalReferenceCode(
+					groupId, externalReferenceCode);
+		}
+
+		JournalArticle journalArticle =
+			_journalArticleLocalService.
+				fetchLatestArticleByExternalReferenceCode(
+					groupId, externalReferenceCode);
+
+		return _journalArticleLocalService.getArticle(
+			journalArticle.getGroupId(), journalArticle.getArticleId(),
+			GetterUtil.getDouble(version));
+	}
+
+	private JournalArticle _getArticleByUrlTitle(
+			long groupId, String urlTitle, String version)
+		throws PortalException {
+
+		if (Validator.isNull(version) ||
+			Objects.equals(
+				version, InfoItemIdentifier.VERSION_LATEST_APPROVED)) {
+
+			return _journalArticleLocalService.fetchLatestArticleByUrlTitle(
+				groupId, urlTitle, WorkflowConstants.STATUS_APPROVED);
+		}
+		else if (Objects.equals(version, InfoItemIdentifier.VERSION_LATEST)) {
+			return _journalArticleLocalService.fetchLatestArticleByUrlTitle(
+				groupId, urlTitle, WorkflowConstants.STATUS_ANY);
+		}
+
+		JournalArticle journalArticle =
+			_journalArticleLocalService.fetchLatestArticleByUrlTitle(
+				groupId, urlTitle, WorkflowConstants.STATUS_ANY);
+
+		return _journalArticleLocalService.getArticle(
+			groupId, journalArticle.getArticleId(),
+			GetterUtil.getDouble(version));
+	}
+
+	private long _getCompanyId() {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext != null) {
+			return serviceContext.getCompanyId();
+		}
+
+		Long companyId = CompanyThreadLocal.getCompanyId();
+
+		if (companyId != null) {
+			return companyId;
+		}
+
+		throw new IllegalStateException(
+			"Neither service context thread local nor company thread local " +
+				"are initialized");
+	}
+
+	private long _getGroupId() {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext != null) {
+			return serviceContext.getScopeGroupId();
+		}
+
+		Long groupId = GroupThreadLocal.getGroupId();
+
+		if (groupId != null) {
+			return groupId;
+		}
+
+		throw new IllegalStateException(
+			"Neither service context thread local nor group thread local are " +
+				"initialized");
+	}
+
+	private long _getGroupId(
+			long companyId, ERCInfoItemIdentifier ercInfoItemIdentifier,
+			long groupId)
+		throws NoSuchInfoItemException {
+
+		try {
+			if (Validator.isNull(
+					ercInfoItemIdentifier.getScopeExternalReferenceCode())) {
+
+				return groupId;
+			}
+
+			Group group = _groupLocalService.getGroupByExternalReferenceCode(
+				ercInfoItemIdentifier.getScopeExternalReferenceCode(),
+				companyId);
+
+			return group.getGroupId();
+		}
+		catch (PortalException portalException) {
+			throw new NoSuchInfoItemException(portalException);
+		}
+	}
+
+	private JournalArticle _getInfoItem(
+			long companyId, long groupId, InfoItemIdentifier infoItemIdentifier)
+		throws NoSuchInfoItemException {
+
 		if (!(infoItemIdentifier instanceof ClassPKInfoItemIdentifier) &&
+			!(infoItemIdentifier instanceof ERCInfoItemIdentifier) &&
 			!(infoItemIdentifier instanceof GroupKeyInfoItemIdentifier) &&
 			!(infoItemIdentifier instanceof GroupUrlTitleInfoItemIdentifier)) {
 
@@ -72,6 +258,15 @@ public class JournalArticleInfoItemObjectProvider
 
 				article = _getArticle(
 					classPKInfoItemIdentifier.getClassPK(), version);
+			}
+			else if (infoItemIdentifier instanceof ERCInfoItemIdentifier) {
+				ERCInfoItemIdentifier ercInfoItemIdentifier =
+					(ERCInfoItemIdentifier)infoItemIdentifier;
+
+				article = _getArticle(
+					ercInfoItemIdentifier.getExternalReferenceCode(),
+					_getGroupId(companyId, ercInfoItemIdentifier, groupId),
+					version);
 			}
 			else if (infoItemIdentifier instanceof GroupKeyInfoItemIdentifier) {
 				GroupKeyInfoItemIdentifier groupKeyInfoItemIdentifier =
@@ -127,77 +322,6 @@ public class JournalArticleInfoItemObjectProvider
 		return article;
 	}
 
-	private JournalArticle _getArticle(long classPK, String version)
-		throws PortalException {
-
-		if (Validator.isNull(version) ||
-			Objects.equals(
-				version, InfoItemIdentifier.VERSION_LATEST_APPROVED)) {
-
-			return _journalArticleLocalService.fetchLatestArticle(classPK);
-		}
-		else if (Objects.equals(version, InfoItemIdentifier.VERSION_LATEST)) {
-			JournalArticleResource articleResource =
-				_journalArticleResourceLocalService.getArticleResource(classPK);
-
-			return _journalArticleLocalService.fetchLatestArticle(
-				articleResource.getGroupId(), articleResource.getArticleId(),
-				WorkflowConstants.STATUS_ANY);
-		}
-
-		JournalArticleResource articleResource =
-			_journalArticleResourceLocalService.getArticleResource(classPK);
-
-		return _journalArticleLocalService.getArticle(
-			articleResource.getGroupId(), articleResource.getArticleId(),
-			GetterUtil.getDouble(version));
-	}
-
-	private JournalArticle _getArticle(
-			long groupId, String articleId, String version)
-		throws PortalException {
-
-		if (Validator.isNull(version) ||
-			Objects.equals(
-				version, InfoItemIdentifier.VERSION_LATEST_APPROVED)) {
-
-			return _journalArticleLocalService.fetchLatestArticle(
-				groupId, articleId, WorkflowConstants.STATUS_APPROVED);
-		}
-		else if (Objects.equals(version, InfoItemIdentifier.VERSION_LATEST)) {
-			return _journalArticleLocalService.fetchLatestArticle(
-				groupId, articleId, WorkflowConstants.STATUS_ANY);
-		}
-
-		return _journalArticleLocalService.getArticle(
-			groupId, articleId, GetterUtil.getDouble(version));
-	}
-
-	private JournalArticle _getArticleByUrlTitle(
-			long groupId, String urlTitle, String version)
-		throws PortalException {
-
-		if (Validator.isNull(version) ||
-			Objects.equals(
-				version, InfoItemIdentifier.VERSION_LATEST_APPROVED)) {
-
-			return _journalArticleLocalService.fetchLatestArticleByUrlTitle(
-				groupId, urlTitle, WorkflowConstants.STATUS_APPROVED);
-		}
-		else if (Objects.equals(version, InfoItemIdentifier.VERSION_LATEST)) {
-			return _journalArticleLocalService.fetchLatestArticleByUrlTitle(
-				groupId, urlTitle, WorkflowConstants.STATUS_ANY);
-		}
-
-		JournalArticle journalArticle =
-			_journalArticleLocalService.fetchLatestArticleByUrlTitle(
-				groupId, urlTitle, WorkflowConstants.STATUS_ANY);
-
-		return _journalArticleLocalService.getArticle(
-			groupId, journalArticle.getArticleId(),
-			GetterUtil.getDouble(version));
-	}
-
 	private boolean _hasPermission(JournalArticle article) {
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
@@ -234,6 +358,9 @@ public class JournalArticleInfoItemObjectProvider
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		JournalArticleInfoItemObjectProvider.class);
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private JournalArticleLocalService _journalArticleLocalService;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemObjectProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemObjectProvider.java
@@ -69,7 +69,8 @@ public class JournalArticleInfoItemObjectProvider
 			long groupId, InfoItemIdentifier infoItemIdentifier)
 		throws NoSuchInfoItemException {
 
-		return _getInfoItem(_getCompanyId(), groupId, infoItemIdentifier);
+		return _getInfoItem(
+			_getGroupId(groupId, infoItemIdentifier), infoItemIdentifier);
 	}
 
 	private JournalArticle _getArticle(long classPK, String version)
@@ -212,11 +213,17 @@ public class JournalArticleInfoItemObjectProvider
 	}
 
 	private long _getGroupId(
-			long companyId, ERCInfoItemIdentifier ercInfoItemIdentifier,
-			long groupId)
+			long groupId, InfoItemIdentifier infoItemIdentifier)
 		throws NoSuchInfoItemException {
 
 		try {
+			if (!(infoItemIdentifier instanceof ERCInfoItemIdentifier)) {
+				return groupId;
+			}
+
+			ERCInfoItemIdentifier ercInfoItemIdentifier =
+				(ERCInfoItemIdentifier)infoItemIdentifier;
+
 			if (Validator.isNull(
 					ercInfoItemIdentifier.getScopeExternalReferenceCode())) {
 
@@ -225,7 +232,7 @@ public class JournalArticleInfoItemObjectProvider
 
 			Group group = _groupLocalService.getGroupByExternalReferenceCode(
 				ercInfoItemIdentifier.getScopeExternalReferenceCode(),
-				companyId);
+				_getCompanyId());
 
 			return group.getGroupId();
 		}
@@ -235,7 +242,7 @@ public class JournalArticleInfoItemObjectProvider
 	}
 
 	private JournalArticle _getInfoItem(
-			long companyId, long groupId, InfoItemIdentifier infoItemIdentifier)
+			long groupId, InfoItemIdentifier infoItemIdentifier)
 		throws NoSuchInfoItemException {
 
 		if (!(infoItemIdentifier instanceof ClassPKInfoItemIdentifier) &&
@@ -263,8 +270,7 @@ public class JournalArticleInfoItemObjectProvider
 					(ERCInfoItemIdentifier)infoItemIdentifier;
 
 				article = _getArticle(
-					ercInfoItemIdentifier.getExternalReferenceCode(),
-					_getGroupId(companyId, ercInfoItemIdentifier, groupId),
+					ercInfoItemIdentifier.getExternalReferenceCode(), groupId,
 					infoItemIdentifier.getVersion());
 			}
 			else if (infoItemIdentifier instanceof GroupKeyInfoItemIdentifier) {

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemObjectProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemObjectProvider.java
@@ -249,15 +249,14 @@ public class JournalArticleInfoItemObjectProvider
 
 		JournalArticle article = null;
 
-		String version = infoItemIdentifier.getVersion();
-
 		try {
 			if (infoItemIdentifier instanceof ClassPKInfoItemIdentifier) {
 				ClassPKInfoItemIdentifier classPKInfoItemIdentifier =
 					(ClassPKInfoItemIdentifier)infoItemIdentifier;
 
 				article = _getArticle(
-					classPKInfoItemIdentifier.getClassPK(), version);
+					classPKInfoItemIdentifier.getClassPK(),
+					infoItemIdentifier.getVersion());
 			}
 			else if (infoItemIdentifier instanceof ERCInfoItemIdentifier) {
 				ERCInfoItemIdentifier ercInfoItemIdentifier =
@@ -266,7 +265,7 @@ public class JournalArticleInfoItemObjectProvider
 				article = _getArticle(
 					ercInfoItemIdentifier.getExternalReferenceCode(),
 					_getGroupId(companyId, ercInfoItemIdentifier, groupId),
-					version);
+					infoItemIdentifier.getVersion());
 			}
 			else if (infoItemIdentifier instanceof GroupKeyInfoItemIdentifier) {
 				GroupKeyInfoItemIdentifier groupKeyInfoItemIdentifier =
@@ -274,7 +273,8 @@ public class JournalArticleInfoItemObjectProvider
 
 				article = _getArticle(
 					groupKeyInfoItemIdentifier.getGroupId(),
-					groupKeyInfoItemIdentifier.getKey(), version);
+					groupKeyInfoItemIdentifier.getKey(),
+					infoItemIdentifier.getVersion());
 			}
 			else if (infoItemIdentifier instanceof
 						GroupUrlTitleInfoItemIdentifier) {
@@ -285,12 +285,14 @@ public class JournalArticleInfoItemObjectProvider
 
 				article = _getArticleByUrlTitle(
 					groupURLTitleInfoItemIdentifier.getGroupId(),
-					groupURLTitleInfoItemIdentifier.getUrlTitle(), version);
+					groupURLTitleInfoItemIdentifier.getUrlTitle(),
+					infoItemIdentifier.getVersion());
 			}
 
 			if ((article != null) &&
 				!Objects.equals(
-					version, InfoItemIdentifier.VERSION_LATEST_APPROVED) &&
+					infoItemIdentifier.getVersion(),
+					InfoItemIdentifier.VERSION_LATEST_APPROVED) &&
 				_isSignedIn() && !_hasPermission(article)) {
 
 				article = _getArticle(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemObjectProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemObjectProvider.java
@@ -11,6 +11,7 @@ import com.liferay.info.item.ERCInfoItemIdentifier;
 import com.liferay.info.item.GroupKeyInfoItemIdentifier;
 import com.liferay.info.item.GroupUrlTitleInfoItemIdentifier;
 import com.liferay.info.item.InfoItemIdentifier;
+import com.liferay.info.item.provider.BaseInfoItemObjectProvider;
 import com.liferay.info.item.provider.InfoItemObjectProvider;
 import com.liferay.journal.exception.NoSuchArticleException;
 import com.liferay.journal.exception.NoSuchArticleResourceException;
@@ -21,17 +22,11 @@ import com.liferay.journal.service.JournalArticleResourceLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
-import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
@@ -55,22 +50,96 @@ import org.osgi.service.component.annotations.Reference;
 	service = InfoItemObjectProvider.class
 )
 public class JournalArticleInfoItemObjectProvider
-	implements InfoItemObjectProvider<JournalArticle> {
+	extends BaseInfoItemObjectProvider<JournalArticle> {
 
 	@Override
-	public JournalArticle getInfoItem(InfoItemIdentifier infoItemIdentifier)
-		throws NoSuchInfoItemException {
-
-		return getInfoItem(_getGroupId(), infoItemIdentifier);
-	}
-
-	@Override
-	public JournalArticle getInfoItem(
+	protected JournalArticle doGetInfoItem(
 			long groupId, InfoItemIdentifier infoItemIdentifier)
 		throws NoSuchInfoItemException {
 
-		return _getInfoItem(
-			_getGroupId(groupId, infoItemIdentifier), infoItemIdentifier);
+		if (!(infoItemIdentifier instanceof ClassPKInfoItemIdentifier) &&
+			!(infoItemIdentifier instanceof ERCInfoItemIdentifier) &&
+			!(infoItemIdentifier instanceof GroupKeyInfoItemIdentifier) &&
+			!(infoItemIdentifier instanceof GroupUrlTitleInfoItemIdentifier)) {
+
+			throw new NoSuchInfoItemException(
+				"Unsupported info item identifier " + infoItemIdentifier);
+		}
+
+		JournalArticle article = null;
+
+		try {
+			if (infoItemIdentifier instanceof ClassPKInfoItemIdentifier) {
+				ClassPKInfoItemIdentifier classPKInfoItemIdentifier =
+					(ClassPKInfoItemIdentifier)infoItemIdentifier;
+
+				article = _getArticle(
+					classPKInfoItemIdentifier.getClassPK(),
+					infoItemIdentifier.getVersion());
+			}
+			else if (infoItemIdentifier instanceof ERCInfoItemIdentifier) {
+				ERCInfoItemIdentifier ercInfoItemIdentifier =
+					(ERCInfoItemIdentifier)infoItemIdentifier;
+
+				article = _getArticle(
+					ercInfoItemIdentifier.getExternalReferenceCode(), groupId,
+					infoItemIdentifier.getVersion());
+			}
+			else if (infoItemIdentifier instanceof GroupKeyInfoItemIdentifier) {
+				GroupKeyInfoItemIdentifier groupKeyInfoItemIdentifier =
+					(GroupKeyInfoItemIdentifier)infoItemIdentifier;
+
+				article = _getArticle(
+					groupKeyInfoItemIdentifier.getGroupId(),
+					groupKeyInfoItemIdentifier.getKey(),
+					infoItemIdentifier.getVersion());
+			}
+			else if (infoItemIdentifier instanceof
+						GroupUrlTitleInfoItemIdentifier) {
+
+				GroupUrlTitleInfoItemIdentifier
+					groupURLTitleInfoItemIdentifier =
+						(GroupUrlTitleInfoItemIdentifier)infoItemIdentifier;
+
+				article = _getArticleByUrlTitle(
+					groupURLTitleInfoItemIdentifier.getGroupId(),
+					groupURLTitleInfoItemIdentifier.getUrlTitle(),
+					infoItemIdentifier.getVersion());
+			}
+
+			if ((article != null) &&
+				!Objects.equals(
+					infoItemIdentifier.getVersion(),
+					InfoItemIdentifier.VERSION_LATEST_APPROVED) &&
+				_isSignedIn() && !_hasPermission(article)) {
+
+				article = _getArticle(
+					article.getResourcePrimKey(),
+					InfoItemIdentifier.VERSION_LATEST_APPROVED);
+			}
+		}
+		catch (NoSuchArticleException | NoSuchArticleResourceException
+					exception) {
+
+			throw new NoSuchInfoItemException(
+				"Unable to get journal article with identifier " +
+					infoItemIdentifier,
+				exception);
+		}
+		catch (PortalException portalException) {
+			throw new RuntimeException(portalException);
+		}
+
+		if (article == null) {
+			throw new NoSuchInfoItemException(
+				"Unable to get journal article " + infoItemIdentifier);
+		}
+
+		if (article.isInTrash()) {
+			return null;
+		}
+
+		return article;
 	}
 
 	private JournalArticle _getArticle(long classPK, String version)
@@ -174,162 +243,6 @@ public class JournalArticleInfoItemObjectProvider
 			GetterUtil.getDouble(version));
 	}
 
-	private long _getCompanyId() {
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		if (serviceContext != null) {
-			return serviceContext.getCompanyId();
-		}
-
-		Long companyId = CompanyThreadLocal.getCompanyId();
-
-		if (companyId != null) {
-			return companyId;
-		}
-
-		throw new IllegalStateException(
-			"Neither service context thread local nor company thread local " +
-				"are initialized");
-	}
-
-	private long _getGroupId() {
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		if (serviceContext != null) {
-			return serviceContext.getScopeGroupId();
-		}
-
-		Long groupId = GroupThreadLocal.getGroupId();
-
-		if (groupId != null) {
-			return groupId;
-		}
-
-		throw new IllegalStateException(
-			"Neither service context thread local nor group thread local are " +
-				"initialized");
-	}
-
-	private long _getGroupId(
-			long groupId, InfoItemIdentifier infoItemIdentifier)
-		throws NoSuchInfoItemException {
-
-		try {
-			if (!(infoItemIdentifier instanceof ERCInfoItemIdentifier)) {
-				return groupId;
-			}
-
-			ERCInfoItemIdentifier ercInfoItemIdentifier =
-				(ERCInfoItemIdentifier)infoItemIdentifier;
-
-			if (Validator.isNull(
-					ercInfoItemIdentifier.getScopeExternalReferenceCode())) {
-
-				return groupId;
-			}
-
-			Group group = _groupLocalService.getGroupByExternalReferenceCode(
-				ercInfoItemIdentifier.getScopeExternalReferenceCode(),
-				_getCompanyId());
-
-			return group.getGroupId();
-		}
-		catch (PortalException portalException) {
-			throw new NoSuchInfoItemException(portalException);
-		}
-	}
-
-	private JournalArticle _getInfoItem(
-			long groupId, InfoItemIdentifier infoItemIdentifier)
-		throws NoSuchInfoItemException {
-
-		if (!(infoItemIdentifier instanceof ClassPKInfoItemIdentifier) &&
-			!(infoItemIdentifier instanceof ERCInfoItemIdentifier) &&
-			!(infoItemIdentifier instanceof GroupKeyInfoItemIdentifier) &&
-			!(infoItemIdentifier instanceof GroupUrlTitleInfoItemIdentifier)) {
-
-			throw new NoSuchInfoItemException(
-				"Unsupported info item identifier " + infoItemIdentifier);
-		}
-
-		JournalArticle article = null;
-
-		try {
-			if (infoItemIdentifier instanceof ClassPKInfoItemIdentifier) {
-				ClassPKInfoItemIdentifier classPKInfoItemIdentifier =
-					(ClassPKInfoItemIdentifier)infoItemIdentifier;
-
-				article = _getArticle(
-					classPKInfoItemIdentifier.getClassPK(),
-					infoItemIdentifier.getVersion());
-			}
-			else if (infoItemIdentifier instanceof ERCInfoItemIdentifier) {
-				ERCInfoItemIdentifier ercInfoItemIdentifier =
-					(ERCInfoItemIdentifier)infoItemIdentifier;
-
-				article = _getArticle(
-					ercInfoItemIdentifier.getExternalReferenceCode(), groupId,
-					infoItemIdentifier.getVersion());
-			}
-			else if (infoItemIdentifier instanceof GroupKeyInfoItemIdentifier) {
-				GroupKeyInfoItemIdentifier groupKeyInfoItemIdentifier =
-					(GroupKeyInfoItemIdentifier)infoItemIdentifier;
-
-				article = _getArticle(
-					groupKeyInfoItemIdentifier.getGroupId(),
-					groupKeyInfoItemIdentifier.getKey(),
-					infoItemIdentifier.getVersion());
-			}
-			else if (infoItemIdentifier instanceof
-						GroupUrlTitleInfoItemIdentifier) {
-
-				GroupUrlTitleInfoItemIdentifier
-					groupURLTitleInfoItemIdentifier =
-						(GroupUrlTitleInfoItemIdentifier)infoItemIdentifier;
-
-				article = _getArticleByUrlTitle(
-					groupURLTitleInfoItemIdentifier.getGroupId(),
-					groupURLTitleInfoItemIdentifier.getUrlTitle(),
-					infoItemIdentifier.getVersion());
-			}
-
-			if ((article != null) &&
-				!Objects.equals(
-					infoItemIdentifier.getVersion(),
-					InfoItemIdentifier.VERSION_LATEST_APPROVED) &&
-				_isSignedIn() && !_hasPermission(article)) {
-
-				article = _getArticle(
-					article.getResourcePrimKey(),
-					InfoItemIdentifier.VERSION_LATEST_APPROVED);
-			}
-		}
-		catch (NoSuchArticleException | NoSuchArticleResourceException
-					exception) {
-
-			throw new NoSuchInfoItemException(
-				"Unable to get journal article with identifier " +
-					infoItemIdentifier,
-				exception);
-		}
-		catch (PortalException portalException) {
-			throw new RuntimeException(portalException);
-		}
-
-		if (article == null) {
-			throw new NoSuchInfoItemException(
-				"Unable to get journal article " + infoItemIdentifier);
-		}
-
-		if (article.isInTrash()) {
-			return null;
-		}
-
-		return article;
-	}
-
 	private boolean _hasPermission(JournalArticle article) {
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
@@ -366,9 +279,6 @@ public class JournalArticleInfoItemObjectProvider
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		JournalArticleInfoItemObjectProvider.class);
-
-	@Reference
-	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private JournalArticleLocalService _journalArticleLocalService;

--- a/modules/apps/knowledge-base/knowledge-base-api/bnd.bnd
+++ b/modules/apps/knowledge-base/knowledge-base-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Knowledge Base API
 Bundle-SymbolicName: com.liferay.knowledge.base.api
-Bundle-Version: 28.0.2
+Bundle-Version: 28.1.0
 Export-Package:\
 	com.liferay.knowledge.base.configuration,\
 	com.liferay.knowledge.base.constants,\

--- a/modules/apps/knowledge-base/knowledge-base-api/bnd.bnd
+++ b/modules/apps/knowledge-base/knowledge-base-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Knowledge Base API
 Bundle-SymbolicName: com.liferay.knowledge.base.api
-Bundle-Version: 28.1.0
+Bundle-Version: 29.0.0
 Export-Package:\
 	com.liferay.knowledge.base.configuration,\
 	com.liferay.knowledge.base.constants,\

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalService.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalService.java
@@ -296,6 +296,10 @@ public interface KBArticleLocalService
 		long resourcePrimKey, long groupId, int version);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public KBArticle fetchKBArticleByExternalReferenceCode(
+		long groupId, String externalReferenceCode, int version);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public KBArticle fetchKBArticleByUrlTitle(
 		long groupId, long kbFolderId, String urlTitle);
 
@@ -322,6 +326,10 @@ public interface KBArticleLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public KBArticle fetchLatestKBArticleByExternalReferenceCode(
 		long groupId, String externalReferenceCode);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public KBArticle fetchLatestKBArticleByExternalReferenceCode(
+		long groupId, String externalReferenceCode, int status);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public KBArticle fetchLatestKBArticleByUrlTitle(

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceUtil.java
@@ -348,6 +348,13 @@ public class KBArticleLocalServiceUtil {
 		return getService().fetchKBArticle(resourcePrimKey, groupId, version);
 	}
 
+	public static KBArticle fetchKBArticleByExternalReferenceCode(
+		long groupId, String externalReferenceCode, int version) {
+
+		return getService().fetchKBArticleByExternalReferenceCode(
+			groupId, externalReferenceCode, version);
+	}
+
 	public static KBArticle fetchKBArticleByUrlTitle(
 		long groupId, long kbFolderId, String urlTitle) {
 
@@ -392,6 +399,13 @@ public class KBArticleLocalServiceUtil {
 
 		return getService().fetchLatestKBArticleByExternalReferenceCode(
 			groupId, externalReferenceCode);
+	}
+
+	public static KBArticle fetchLatestKBArticleByExternalReferenceCode(
+		long groupId, String externalReferenceCode, int status) {
+
+		return getService().fetchLatestKBArticleByExternalReferenceCode(
+			groupId, externalReferenceCode, status);
 	}
 
 	public static KBArticle fetchLatestKBArticleByUrlTitle(

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceWrapper.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceWrapper.java
@@ -387,6 +387,14 @@ public class KBArticleLocalServiceWrapper
 	}
 
 	@Override
+	public KBArticle fetchKBArticleByExternalReferenceCode(
+		long groupId, String externalReferenceCode, int version) {
+
+		return _kbArticleLocalService.fetchKBArticleByExternalReferenceCode(
+			groupId, externalReferenceCode, version);
+	}
+
+	@Override
 	public KBArticle fetchKBArticleByUrlTitle(
 		long groupId, long kbFolderId, String urlTitle) {
 
@@ -434,6 +442,15 @@ public class KBArticleLocalServiceWrapper
 		return _kbArticleLocalService.
 			fetchLatestKBArticleByExternalReferenceCode(
 				groupId, externalReferenceCode);
+	}
+
+	@Override
+	public KBArticle fetchLatestKBArticleByExternalReferenceCode(
+		long groupId, String externalReferenceCode, int status) {
+
+		return _kbArticleLocalService.
+			fetchLatestKBArticleByExternalReferenceCode(
+				groupId, externalReferenceCode, status);
 	}
 
 	@Override

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/persistence/KBArticlePersistence.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/persistence/KBArticlePersistence.java
@@ -5753,6 +5753,257 @@ public interface KBArticlePersistence
 		long groupId, String externalReferenceCode, int version);
 
 	/**
+	 * Returns all the kb articles where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @return the matching kb articles
+	 */
+	public java.util.List<KBArticle> findByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status);
+
+	/**
+	 * Returns a range of all the kb articles where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @return the range of matching kb articles
+	 */
+	public java.util.List<KBArticle> findByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status, int start,
+		int end);
+
+	/**
+	 * Returns an ordered range of all the kb articles where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching kb articles
+	 */
+	public java.util.List<KBArticle> findByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status, int start,
+		int end,
+		com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the kb articles where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching kb articles
+	 */
+	public java.util.List<KBArticle> findByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status, int start,
+		int end,
+		com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching kb article
+	 * @throws NoSuchArticleException if a matching kb article could not be found
+	 */
+	public KBArticle findByG_ERC_ST_First(
+			long groupId, String externalReferenceCode, int status,
+			com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
+				orderByComparator)
+		throws NoSuchArticleException;
+
+	/**
+	 * Returns the first kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching kb article, or <code>null</code> if a matching kb article could not be found
+	 */
+	public KBArticle fetchByG_ERC_ST_First(
+		long groupId, String externalReferenceCode, int status,
+		com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
+			orderByComparator);
+
+	/**
+	 * Returns the last kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching kb article
+	 * @throws NoSuchArticleException if a matching kb article could not be found
+	 */
+	public KBArticle findByG_ERC_ST_Last(
+			long groupId, String externalReferenceCode, int status,
+			com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
+				orderByComparator)
+		throws NoSuchArticleException;
+
+	/**
+	 * Returns the last kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching kb article, or <code>null</code> if a matching kb article could not be found
+	 */
+	public KBArticle fetchByG_ERC_ST_Last(
+		long groupId, String externalReferenceCode, int status,
+		com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
+			orderByComparator);
+
+	/**
+	 * Returns the kb articles before and after the current kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param kbArticleId the primary key of the current kb article
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next kb article
+	 * @throws NoSuchArticleException if a kb article with the primary key could not be found
+	 */
+	public KBArticle[] findByG_ERC_ST_PrevAndNext(
+			long kbArticleId, long groupId, String externalReferenceCode,
+			int status,
+			com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
+				orderByComparator)
+		throws NoSuchArticleException;
+
+	/**
+	 * Returns all the kb articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @return the matching kb articles that the user has permission to view
+	 */
+	public java.util.List<KBArticle> filterFindByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status);
+
+	/**
+	 * Returns a range of all the kb articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @return the range of matching kb articles that the user has permission to view
+	 */
+	public java.util.List<KBArticle> filterFindByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status, int start,
+		int end);
+
+	/**
+	 * Returns an ordered range of all the kb articles that the user has permissions to view where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching kb articles that the user has permission to view
+	 */
+	public java.util.List<KBArticle> filterFindByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status, int start,
+		int end,
+		com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
+			orderByComparator);
+
+	/**
+	 * Returns the kb articles before and after the current kb article in the ordered set of kb articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param kbArticleId the primary key of the current kb article
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next kb article
+	 * @throws NoSuchArticleException if a kb article with the primary key could not be found
+	 */
+	public KBArticle[] filterFindByG_ERC_ST_PrevAndNext(
+			long kbArticleId, long groupId, String externalReferenceCode,
+			int status,
+			com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
+				orderByComparator)
+		throws NoSuchArticleException;
+
+	/**
+	 * Removes all the kb articles where groupId = &#63; and externalReferenceCode = &#63; and status = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 */
+	public void removeByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status);
+
+	/**
+	 * Returns the number of kb articles where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @return the number of matching kb articles
+	 */
+	public int countByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status);
+
+	/**
+	 * Returns the number of kb articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @return the number of matching kb articles that the user has permission to view
+	 */
+	public int filterCountByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status);
+
+	/**
 	 * Returns all the kb articles where groupId = &#63; and parentResourcePrimKey = &#63; and latest = &#63;.
 	 *
 	 * @param groupId the group ID

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/persistence/KBArticlePersistence.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/persistence/KBArticlePersistence.java
@@ -5760,7 +5760,7 @@ public interface KBArticlePersistence
 	 * @param status the status
 	 * @return the matching kb articles
 	 */
-	public java.util.List<KBArticle> findByG_ERC_ST(
+	public java.util.List<KBArticle> findByG_ERC_S(
 		long groupId, String externalReferenceCode, int status);
 
 	/**
@@ -5777,7 +5777,7 @@ public interface KBArticlePersistence
 	 * @param end the upper bound of the range of kb articles (not inclusive)
 	 * @return the range of matching kb articles
 	 */
-	public java.util.List<KBArticle> findByG_ERC_ST(
+	public java.util.List<KBArticle> findByG_ERC_S(
 		long groupId, String externalReferenceCode, int status, int start,
 		int end);
 
@@ -5796,7 +5796,7 @@ public interface KBArticlePersistence
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching kb articles
 	 */
-	public java.util.List<KBArticle> findByG_ERC_ST(
+	public java.util.List<KBArticle> findByG_ERC_S(
 		long groupId, String externalReferenceCode, int status, int start,
 		int end,
 		com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
@@ -5818,7 +5818,7 @@ public interface KBArticlePersistence
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the ordered range of matching kb articles
 	 */
-	public java.util.List<KBArticle> findByG_ERC_ST(
+	public java.util.List<KBArticle> findByG_ERC_S(
 		long groupId, String externalReferenceCode, int status, int start,
 		int end,
 		com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
@@ -5835,7 +5835,7 @@ public interface KBArticlePersistence
 	 * @return the first matching kb article
 	 * @throws NoSuchArticleException if a matching kb article could not be found
 	 */
-	public KBArticle findByG_ERC_ST_First(
+	public KBArticle findByG_ERC_S_First(
 			long groupId, String externalReferenceCode, int status,
 			com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
 				orderByComparator)
@@ -5850,7 +5850,7 @@ public interface KBArticlePersistence
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching kb article, or <code>null</code> if a matching kb article could not be found
 	 */
-	public KBArticle fetchByG_ERC_ST_First(
+	public KBArticle fetchByG_ERC_S_First(
 		long groupId, String externalReferenceCode, int status,
 		com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
 			orderByComparator);
@@ -5865,7 +5865,7 @@ public interface KBArticlePersistence
 	 * @return the last matching kb article
 	 * @throws NoSuchArticleException if a matching kb article could not be found
 	 */
-	public KBArticle findByG_ERC_ST_Last(
+	public KBArticle findByG_ERC_S_Last(
 			long groupId, String externalReferenceCode, int status,
 			com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
 				orderByComparator)
@@ -5880,7 +5880,7 @@ public interface KBArticlePersistence
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching kb article, or <code>null</code> if a matching kb article could not be found
 	 */
-	public KBArticle fetchByG_ERC_ST_Last(
+	public KBArticle fetchByG_ERC_S_Last(
 		long groupId, String externalReferenceCode, int status,
 		com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
 			orderByComparator);
@@ -5896,7 +5896,7 @@ public interface KBArticlePersistence
 	 * @return the previous, current, and next kb article
 	 * @throws NoSuchArticleException if a kb article with the primary key could not be found
 	 */
-	public KBArticle[] findByG_ERC_ST_PrevAndNext(
+	public KBArticle[] findByG_ERC_S_PrevAndNext(
 			long kbArticleId, long groupId, String externalReferenceCode,
 			int status,
 			com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
@@ -5911,7 +5911,7 @@ public interface KBArticlePersistence
 	 * @param status the status
 	 * @return the matching kb articles that the user has permission to view
 	 */
-	public java.util.List<KBArticle> filterFindByG_ERC_ST(
+	public java.util.List<KBArticle> filterFindByG_ERC_S(
 		long groupId, String externalReferenceCode, int status);
 
 	/**
@@ -5928,7 +5928,7 @@ public interface KBArticlePersistence
 	 * @param end the upper bound of the range of kb articles (not inclusive)
 	 * @return the range of matching kb articles that the user has permission to view
 	 */
-	public java.util.List<KBArticle> filterFindByG_ERC_ST(
+	public java.util.List<KBArticle> filterFindByG_ERC_S(
 		long groupId, String externalReferenceCode, int status, int start,
 		int end);
 
@@ -5947,7 +5947,7 @@ public interface KBArticlePersistence
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching kb articles that the user has permission to view
 	 */
-	public java.util.List<KBArticle> filterFindByG_ERC_ST(
+	public java.util.List<KBArticle> filterFindByG_ERC_S(
 		long groupId, String externalReferenceCode, int status, int start,
 		int end,
 		com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
@@ -5964,7 +5964,7 @@ public interface KBArticlePersistence
 	 * @return the previous, current, and next kb article
 	 * @throws NoSuchArticleException if a kb article with the primary key could not be found
 	 */
-	public KBArticle[] filterFindByG_ERC_ST_PrevAndNext(
+	public KBArticle[] filterFindByG_ERC_S_PrevAndNext(
 			long kbArticleId, long groupId, String externalReferenceCode,
 			int status,
 			com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
@@ -5978,7 +5978,7 @@ public interface KBArticlePersistence
 	 * @param externalReferenceCode the external reference code
 	 * @param status the status
 	 */
-	public void removeByG_ERC_ST(
+	public void removeByG_ERC_S(
 		long groupId, String externalReferenceCode, int status);
 
 	/**
@@ -5989,7 +5989,7 @@ public interface KBArticlePersistence
 	 * @param status the status
 	 * @return the number of matching kb articles
 	 */
-	public int countByG_ERC_ST(
+	public int countByG_ERC_S(
 		long groupId, String externalReferenceCode, int status);
 
 	/**
@@ -6000,7 +6000,7 @@ public interface KBArticlePersistence
 	 * @param status the status
 	 * @return the number of matching kb articles that the user has permission to view
 	 */
-	public int filterCountByG_ERC_ST(
+	public int filterCountByG_ERC_S(
 		long groupId, String externalReferenceCode, int status);
 
 	/**
@@ -12992,7 +12992,7 @@ public interface KBArticlePersistence
 	 * @param status the status
 	 * @return the matching kb articles
 	 */
-	public java.util.List<KBArticle> findByG_KBFI_UT_ST(
+	public java.util.List<KBArticle> findByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status);
 
 	/**
@@ -13010,7 +13010,7 @@ public interface KBArticlePersistence
 	 * @param end the upper bound of the range of kb articles (not inclusive)
 	 * @return the range of matching kb articles
 	 */
-	public java.util.List<KBArticle> findByG_KBFI_UT_ST(
+	public java.util.List<KBArticle> findByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status, int start,
 		int end);
 
@@ -13030,7 +13030,7 @@ public interface KBArticlePersistence
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching kb articles
 	 */
-	public java.util.List<KBArticle> findByG_KBFI_UT_ST(
+	public java.util.List<KBArticle> findByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status, int start,
 		int end,
 		com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
@@ -13053,7 +13053,7 @@ public interface KBArticlePersistence
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the ordered range of matching kb articles
 	 */
-	public java.util.List<KBArticle> findByG_KBFI_UT_ST(
+	public java.util.List<KBArticle> findByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status, int start,
 		int end,
 		com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
@@ -13071,7 +13071,7 @@ public interface KBArticlePersistence
 	 * @return the first matching kb article
 	 * @throws NoSuchArticleException if a matching kb article could not be found
 	 */
-	public KBArticle findByG_KBFI_UT_ST_First(
+	public KBArticle findByG_KBFI_UT_S_First(
 			long groupId, long kbFolderId, String urlTitle, int status,
 			com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
 				orderByComparator)
@@ -13087,7 +13087,7 @@ public interface KBArticlePersistence
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching kb article, or <code>null</code> if a matching kb article could not be found
 	 */
-	public KBArticle fetchByG_KBFI_UT_ST_First(
+	public KBArticle fetchByG_KBFI_UT_S_First(
 		long groupId, long kbFolderId, String urlTitle, int status,
 		com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
 			orderByComparator);
@@ -13103,7 +13103,7 @@ public interface KBArticlePersistence
 	 * @return the last matching kb article
 	 * @throws NoSuchArticleException if a matching kb article could not be found
 	 */
-	public KBArticle findByG_KBFI_UT_ST_Last(
+	public KBArticle findByG_KBFI_UT_S_Last(
 			long groupId, long kbFolderId, String urlTitle, int status,
 			com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
 				orderByComparator)
@@ -13119,7 +13119,7 @@ public interface KBArticlePersistence
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching kb article, or <code>null</code> if a matching kb article could not be found
 	 */
-	public KBArticle fetchByG_KBFI_UT_ST_Last(
+	public KBArticle fetchByG_KBFI_UT_S_Last(
 		long groupId, long kbFolderId, String urlTitle, int status,
 		com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
 			orderByComparator);
@@ -13136,7 +13136,7 @@ public interface KBArticlePersistence
 	 * @return the previous, current, and next kb article
 	 * @throws NoSuchArticleException if a kb article with the primary key could not be found
 	 */
-	public KBArticle[] findByG_KBFI_UT_ST_PrevAndNext(
+	public KBArticle[] findByG_KBFI_UT_S_PrevAndNext(
 			long kbArticleId, long groupId, long kbFolderId, String urlTitle,
 			int status,
 			com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
@@ -13152,7 +13152,7 @@ public interface KBArticlePersistence
 	 * @param status the status
 	 * @return the matching kb articles that the user has permission to view
 	 */
-	public java.util.List<KBArticle> filterFindByG_KBFI_UT_ST(
+	public java.util.List<KBArticle> filterFindByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status);
 
 	/**
@@ -13170,7 +13170,7 @@ public interface KBArticlePersistence
 	 * @param end the upper bound of the range of kb articles (not inclusive)
 	 * @return the range of matching kb articles that the user has permission to view
 	 */
-	public java.util.List<KBArticle> filterFindByG_KBFI_UT_ST(
+	public java.util.List<KBArticle> filterFindByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status, int start,
 		int end);
 
@@ -13190,7 +13190,7 @@ public interface KBArticlePersistence
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching kb articles that the user has permission to view
 	 */
-	public java.util.List<KBArticle> filterFindByG_KBFI_UT_ST(
+	public java.util.List<KBArticle> filterFindByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status, int start,
 		int end,
 		com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
@@ -13208,7 +13208,7 @@ public interface KBArticlePersistence
 	 * @return the previous, current, and next kb article
 	 * @throws NoSuchArticleException if a kb article with the primary key could not be found
 	 */
-	public KBArticle[] filterFindByG_KBFI_UT_ST_PrevAndNext(
+	public KBArticle[] filterFindByG_KBFI_UT_S_PrevAndNext(
 			long kbArticleId, long groupId, long kbFolderId, String urlTitle,
 			int status,
 			com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
@@ -13224,7 +13224,7 @@ public interface KBArticlePersistence
 	 * @param statuses the statuses
 	 * @return the matching kb articles that the user has permission to view
 	 */
-	public java.util.List<KBArticle> filterFindByG_KBFI_UT_ST(
+	public java.util.List<KBArticle> filterFindByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses);
 
 	/**
@@ -13242,7 +13242,7 @@ public interface KBArticlePersistence
 	 * @param end the upper bound of the range of kb articles (not inclusive)
 	 * @return the range of matching kb articles that the user has permission to view
 	 */
-	public java.util.List<KBArticle> filterFindByG_KBFI_UT_ST(
+	public java.util.List<KBArticle> filterFindByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses,
 		int start, int end);
 
@@ -13262,7 +13262,7 @@ public interface KBArticlePersistence
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching kb articles that the user has permission to view
 	 */
-	public java.util.List<KBArticle> filterFindByG_KBFI_UT_ST(
+	public java.util.List<KBArticle> filterFindByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses,
 		int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
@@ -13281,7 +13281,7 @@ public interface KBArticlePersistence
 	 * @param statuses the statuses
 	 * @return the matching kb articles
 	 */
-	public java.util.List<KBArticle> findByG_KBFI_UT_ST(
+	public java.util.List<KBArticle> findByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses);
 
 	/**
@@ -13299,7 +13299,7 @@ public interface KBArticlePersistence
 	 * @param end the upper bound of the range of kb articles (not inclusive)
 	 * @return the range of matching kb articles
 	 */
-	public java.util.List<KBArticle> findByG_KBFI_UT_ST(
+	public java.util.List<KBArticle> findByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses,
 		int start, int end);
 
@@ -13319,7 +13319,7 @@ public interface KBArticlePersistence
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching kb articles
 	 */
-	public java.util.List<KBArticle> findByG_KBFI_UT_ST(
+	public java.util.List<KBArticle> findByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses,
 		int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
@@ -13342,7 +13342,7 @@ public interface KBArticlePersistence
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the ordered range of matching kb articles
 	 */
-	public java.util.List<KBArticle> findByG_KBFI_UT_ST(
+	public java.util.List<KBArticle> findByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses,
 		int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
@@ -13357,7 +13357,7 @@ public interface KBArticlePersistence
 	 * @param urlTitle the url title
 	 * @param status the status
 	 */
-	public void removeByG_KBFI_UT_ST(
+	public void removeByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status);
 
 	/**
@@ -13369,7 +13369,7 @@ public interface KBArticlePersistence
 	 * @param status the status
 	 * @return the number of matching kb articles
 	 */
-	public int countByG_KBFI_UT_ST(
+	public int countByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status);
 
 	/**
@@ -13381,7 +13381,7 @@ public interface KBArticlePersistence
 	 * @param statuses the statuses
 	 * @return the number of matching kb articles
 	 */
-	public int countByG_KBFI_UT_ST(
+	public int countByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses);
 
 	/**
@@ -13393,7 +13393,7 @@ public interface KBArticlePersistence
 	 * @param status the status
 	 * @return the number of matching kb articles that the user has permission to view
 	 */
-	public int filterCountByG_KBFI_UT_ST(
+	public int filterCountByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status);
 
 	/**
@@ -13405,7 +13405,7 @@ public interface KBArticlePersistence
 	 * @param statuses the statuses
 	 * @return the number of matching kb articles that the user has permission to view
 	 */
-	public int filterCountByG_KBFI_UT_ST(
+	public int filterCountByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses);
 
 	/**

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/persistence/KBArticleUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/persistence/KBArticleUtil.java
@@ -7032,6 +7032,312 @@ public class KBArticleUtil {
 	}
 
 	/**
+	 * Returns all the kb articles where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @return the matching kb articles
+	 */
+	public static List<KBArticle> findByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status) {
+
+		return getPersistence().findByG_ERC_ST(
+			groupId, externalReferenceCode, status);
+	}
+
+	/**
+	 * Returns a range of all the kb articles where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @return the range of matching kb articles
+	 */
+	public static List<KBArticle> findByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status, int start,
+		int end) {
+
+		return getPersistence().findByG_ERC_ST(
+			groupId, externalReferenceCode, status, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the kb articles where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching kb articles
+	 */
+	public static List<KBArticle> findByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status, int start,
+		int end, OrderByComparator<KBArticle> orderByComparator) {
+
+		return getPersistence().findByG_ERC_ST(
+			groupId, externalReferenceCode, status, start, end,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the kb articles where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching kb articles
+	 */
+	public static List<KBArticle> findByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status, int start,
+		int end, OrderByComparator<KBArticle> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByG_ERC_ST(
+			groupId, externalReferenceCode, status, start, end,
+			orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching kb article
+	 * @throws NoSuchArticleException if a matching kb article could not be found
+	 */
+	public static KBArticle findByG_ERC_ST_First(
+			long groupId, String externalReferenceCode, int status,
+			OrderByComparator<KBArticle> orderByComparator)
+		throws com.liferay.knowledge.base.exception.NoSuchArticleException {
+
+		return getPersistence().findByG_ERC_ST_First(
+			groupId, externalReferenceCode, status, orderByComparator);
+	}
+
+	/**
+	 * Returns the first kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching kb article, or <code>null</code> if a matching kb article could not be found
+	 */
+	public static KBArticle fetchByG_ERC_ST_First(
+		long groupId, String externalReferenceCode, int status,
+		OrderByComparator<KBArticle> orderByComparator) {
+
+		return getPersistence().fetchByG_ERC_ST_First(
+			groupId, externalReferenceCode, status, orderByComparator);
+	}
+
+	/**
+	 * Returns the last kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching kb article
+	 * @throws NoSuchArticleException if a matching kb article could not be found
+	 */
+	public static KBArticle findByG_ERC_ST_Last(
+			long groupId, String externalReferenceCode, int status,
+			OrderByComparator<KBArticle> orderByComparator)
+		throws com.liferay.knowledge.base.exception.NoSuchArticleException {
+
+		return getPersistence().findByG_ERC_ST_Last(
+			groupId, externalReferenceCode, status, orderByComparator);
+	}
+
+	/**
+	 * Returns the last kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching kb article, or <code>null</code> if a matching kb article could not be found
+	 */
+	public static KBArticle fetchByG_ERC_ST_Last(
+		long groupId, String externalReferenceCode, int status,
+		OrderByComparator<KBArticle> orderByComparator) {
+
+		return getPersistence().fetchByG_ERC_ST_Last(
+			groupId, externalReferenceCode, status, orderByComparator);
+	}
+
+	/**
+	 * Returns the kb articles before and after the current kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param kbArticleId the primary key of the current kb article
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next kb article
+	 * @throws NoSuchArticleException if a kb article with the primary key could not be found
+	 */
+	public static KBArticle[] findByG_ERC_ST_PrevAndNext(
+			long kbArticleId, long groupId, String externalReferenceCode,
+			int status, OrderByComparator<KBArticle> orderByComparator)
+		throws com.liferay.knowledge.base.exception.NoSuchArticleException {
+
+		return getPersistence().findByG_ERC_ST_PrevAndNext(
+			kbArticleId, groupId, externalReferenceCode, status,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns all the kb articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @return the matching kb articles that the user has permission to view
+	 */
+	public static List<KBArticle> filterFindByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status) {
+
+		return getPersistence().filterFindByG_ERC_ST(
+			groupId, externalReferenceCode, status);
+	}
+
+	/**
+	 * Returns a range of all the kb articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @return the range of matching kb articles that the user has permission to view
+	 */
+	public static List<KBArticle> filterFindByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status, int start,
+		int end) {
+
+		return getPersistence().filterFindByG_ERC_ST(
+			groupId, externalReferenceCode, status, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the kb articles that the user has permissions to view where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching kb articles that the user has permission to view
+	 */
+	public static List<KBArticle> filterFindByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status, int start,
+		int end, OrderByComparator<KBArticle> orderByComparator) {
+
+		return getPersistence().filterFindByG_ERC_ST(
+			groupId, externalReferenceCode, status, start, end,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns the kb articles before and after the current kb article in the ordered set of kb articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param kbArticleId the primary key of the current kb article
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next kb article
+	 * @throws NoSuchArticleException if a kb article with the primary key could not be found
+	 */
+	public static KBArticle[] filterFindByG_ERC_ST_PrevAndNext(
+			long kbArticleId, long groupId, String externalReferenceCode,
+			int status, OrderByComparator<KBArticle> orderByComparator)
+		throws com.liferay.knowledge.base.exception.NoSuchArticleException {
+
+		return getPersistence().filterFindByG_ERC_ST_PrevAndNext(
+			kbArticleId, groupId, externalReferenceCode, status,
+			orderByComparator);
+	}
+
+	/**
+	 * Removes all the kb articles where groupId = &#63; and externalReferenceCode = &#63; and status = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 */
+	public static void removeByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status) {
+
+		getPersistence().removeByG_ERC_ST(
+			groupId, externalReferenceCode, status);
+	}
+
+	/**
+	 * Returns the number of kb articles where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @return the number of matching kb articles
+	 */
+	public static int countByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status) {
+
+		return getPersistence().countByG_ERC_ST(
+			groupId, externalReferenceCode, status);
+	}
+
+	/**
+	 * Returns the number of kb articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @return the number of matching kb articles that the user has permission to view
+	 */
+	public static int filterCountByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status) {
+
+		return getPersistence().filterCountByG_ERC_ST(
+			groupId, externalReferenceCode, status);
+	}
+
+	/**
 	 * Returns all the kb articles where groupId = &#63; and parentResourcePrimKey = &#63; and latest = &#63;.
 	 *
 	 * @param groupId the group ID

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/persistence/KBArticleUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/persistence/KBArticleUtil.java
@@ -7039,10 +7039,10 @@ public class KBArticleUtil {
 	 * @param status the status
 	 * @return the matching kb articles
 	 */
-	public static List<KBArticle> findByG_ERC_ST(
+	public static List<KBArticle> findByG_ERC_S(
 		long groupId, String externalReferenceCode, int status) {
 
-		return getPersistence().findByG_ERC_ST(
+		return getPersistence().findByG_ERC_S(
 			groupId, externalReferenceCode, status);
 	}
 
@@ -7060,11 +7060,11 @@ public class KBArticleUtil {
 	 * @param end the upper bound of the range of kb articles (not inclusive)
 	 * @return the range of matching kb articles
 	 */
-	public static List<KBArticle> findByG_ERC_ST(
+	public static List<KBArticle> findByG_ERC_S(
 		long groupId, String externalReferenceCode, int status, int start,
 		int end) {
 
-		return getPersistence().findByG_ERC_ST(
+		return getPersistence().findByG_ERC_S(
 			groupId, externalReferenceCode, status, start, end);
 	}
 
@@ -7083,11 +7083,11 @@ public class KBArticleUtil {
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching kb articles
 	 */
-	public static List<KBArticle> findByG_ERC_ST(
+	public static List<KBArticle> findByG_ERC_S(
 		long groupId, String externalReferenceCode, int status, int start,
 		int end, OrderByComparator<KBArticle> orderByComparator) {
 
-		return getPersistence().findByG_ERC_ST(
+		return getPersistence().findByG_ERC_S(
 			groupId, externalReferenceCode, status, start, end,
 			orderByComparator);
 	}
@@ -7108,12 +7108,12 @@ public class KBArticleUtil {
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the ordered range of matching kb articles
 	 */
-	public static List<KBArticle> findByG_ERC_ST(
+	public static List<KBArticle> findByG_ERC_S(
 		long groupId, String externalReferenceCode, int status, int start,
 		int end, OrderByComparator<KBArticle> orderByComparator,
 		boolean useFinderCache) {
 
-		return getPersistence().findByG_ERC_ST(
+		return getPersistence().findByG_ERC_S(
 			groupId, externalReferenceCode, status, start, end,
 			orderByComparator, useFinderCache);
 	}
@@ -7128,12 +7128,12 @@ public class KBArticleUtil {
 	 * @return the first matching kb article
 	 * @throws NoSuchArticleException if a matching kb article could not be found
 	 */
-	public static KBArticle findByG_ERC_ST_First(
+	public static KBArticle findByG_ERC_S_First(
 			long groupId, String externalReferenceCode, int status,
 			OrderByComparator<KBArticle> orderByComparator)
 		throws com.liferay.knowledge.base.exception.NoSuchArticleException {
 
-		return getPersistence().findByG_ERC_ST_First(
+		return getPersistence().findByG_ERC_S_First(
 			groupId, externalReferenceCode, status, orderByComparator);
 	}
 
@@ -7146,11 +7146,11 @@ public class KBArticleUtil {
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching kb article, or <code>null</code> if a matching kb article could not be found
 	 */
-	public static KBArticle fetchByG_ERC_ST_First(
+	public static KBArticle fetchByG_ERC_S_First(
 		long groupId, String externalReferenceCode, int status,
 		OrderByComparator<KBArticle> orderByComparator) {
 
-		return getPersistence().fetchByG_ERC_ST_First(
+		return getPersistence().fetchByG_ERC_S_First(
 			groupId, externalReferenceCode, status, orderByComparator);
 	}
 
@@ -7164,12 +7164,12 @@ public class KBArticleUtil {
 	 * @return the last matching kb article
 	 * @throws NoSuchArticleException if a matching kb article could not be found
 	 */
-	public static KBArticle findByG_ERC_ST_Last(
+	public static KBArticle findByG_ERC_S_Last(
 			long groupId, String externalReferenceCode, int status,
 			OrderByComparator<KBArticle> orderByComparator)
 		throws com.liferay.knowledge.base.exception.NoSuchArticleException {
 
-		return getPersistence().findByG_ERC_ST_Last(
+		return getPersistence().findByG_ERC_S_Last(
 			groupId, externalReferenceCode, status, orderByComparator);
 	}
 
@@ -7182,11 +7182,11 @@ public class KBArticleUtil {
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching kb article, or <code>null</code> if a matching kb article could not be found
 	 */
-	public static KBArticle fetchByG_ERC_ST_Last(
+	public static KBArticle fetchByG_ERC_S_Last(
 		long groupId, String externalReferenceCode, int status,
 		OrderByComparator<KBArticle> orderByComparator) {
 
-		return getPersistence().fetchByG_ERC_ST_Last(
+		return getPersistence().fetchByG_ERC_S_Last(
 			groupId, externalReferenceCode, status, orderByComparator);
 	}
 
@@ -7201,12 +7201,12 @@ public class KBArticleUtil {
 	 * @return the previous, current, and next kb article
 	 * @throws NoSuchArticleException if a kb article with the primary key could not be found
 	 */
-	public static KBArticle[] findByG_ERC_ST_PrevAndNext(
+	public static KBArticle[] findByG_ERC_S_PrevAndNext(
 			long kbArticleId, long groupId, String externalReferenceCode,
 			int status, OrderByComparator<KBArticle> orderByComparator)
 		throws com.liferay.knowledge.base.exception.NoSuchArticleException {
 
-		return getPersistence().findByG_ERC_ST_PrevAndNext(
+		return getPersistence().findByG_ERC_S_PrevAndNext(
 			kbArticleId, groupId, externalReferenceCode, status,
 			orderByComparator);
 	}
@@ -7219,10 +7219,10 @@ public class KBArticleUtil {
 	 * @param status the status
 	 * @return the matching kb articles that the user has permission to view
 	 */
-	public static List<KBArticle> filterFindByG_ERC_ST(
+	public static List<KBArticle> filterFindByG_ERC_S(
 		long groupId, String externalReferenceCode, int status) {
 
-		return getPersistence().filterFindByG_ERC_ST(
+		return getPersistence().filterFindByG_ERC_S(
 			groupId, externalReferenceCode, status);
 	}
 
@@ -7240,11 +7240,11 @@ public class KBArticleUtil {
 	 * @param end the upper bound of the range of kb articles (not inclusive)
 	 * @return the range of matching kb articles that the user has permission to view
 	 */
-	public static List<KBArticle> filterFindByG_ERC_ST(
+	public static List<KBArticle> filterFindByG_ERC_S(
 		long groupId, String externalReferenceCode, int status, int start,
 		int end) {
 
-		return getPersistence().filterFindByG_ERC_ST(
+		return getPersistence().filterFindByG_ERC_S(
 			groupId, externalReferenceCode, status, start, end);
 	}
 
@@ -7263,11 +7263,11 @@ public class KBArticleUtil {
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching kb articles that the user has permission to view
 	 */
-	public static List<KBArticle> filterFindByG_ERC_ST(
+	public static List<KBArticle> filterFindByG_ERC_S(
 		long groupId, String externalReferenceCode, int status, int start,
 		int end, OrderByComparator<KBArticle> orderByComparator) {
 
-		return getPersistence().filterFindByG_ERC_ST(
+		return getPersistence().filterFindByG_ERC_S(
 			groupId, externalReferenceCode, status, start, end,
 			orderByComparator);
 	}
@@ -7283,12 +7283,12 @@ public class KBArticleUtil {
 	 * @return the previous, current, and next kb article
 	 * @throws NoSuchArticleException if a kb article with the primary key could not be found
 	 */
-	public static KBArticle[] filterFindByG_ERC_ST_PrevAndNext(
+	public static KBArticle[] filterFindByG_ERC_S_PrevAndNext(
 			long kbArticleId, long groupId, String externalReferenceCode,
 			int status, OrderByComparator<KBArticle> orderByComparator)
 		throws com.liferay.knowledge.base.exception.NoSuchArticleException {
 
-		return getPersistence().filterFindByG_ERC_ST_PrevAndNext(
+		return getPersistence().filterFindByG_ERC_S_PrevAndNext(
 			kbArticleId, groupId, externalReferenceCode, status,
 			orderByComparator);
 	}
@@ -7300,10 +7300,10 @@ public class KBArticleUtil {
 	 * @param externalReferenceCode the external reference code
 	 * @param status the status
 	 */
-	public static void removeByG_ERC_ST(
+	public static void removeByG_ERC_S(
 		long groupId, String externalReferenceCode, int status) {
 
-		getPersistence().removeByG_ERC_ST(
+		getPersistence().removeByG_ERC_S(
 			groupId, externalReferenceCode, status);
 	}
 
@@ -7315,10 +7315,10 @@ public class KBArticleUtil {
 	 * @param status the status
 	 * @return the number of matching kb articles
 	 */
-	public static int countByG_ERC_ST(
+	public static int countByG_ERC_S(
 		long groupId, String externalReferenceCode, int status) {
 
-		return getPersistence().countByG_ERC_ST(
+		return getPersistence().countByG_ERC_S(
 			groupId, externalReferenceCode, status);
 	}
 
@@ -7330,10 +7330,10 @@ public class KBArticleUtil {
 	 * @param status the status
 	 * @return the number of matching kb articles that the user has permission to view
 	 */
-	public static int filterCountByG_ERC_ST(
+	public static int filterCountByG_ERC_S(
 		long groupId, String externalReferenceCode, int status) {
 
-		return getPersistence().filterCountByG_ERC_ST(
+		return getPersistence().filterCountByG_ERC_S(
 			groupId, externalReferenceCode, status);
 	}
 
@@ -15833,10 +15833,10 @@ public class KBArticleUtil {
 	 * @param status the status
 	 * @return the matching kb articles
 	 */
-	public static List<KBArticle> findByG_KBFI_UT_ST(
+	public static List<KBArticle> findByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status) {
 
-		return getPersistence().findByG_KBFI_UT_ST(
+		return getPersistence().findByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, status);
 	}
 
@@ -15855,11 +15855,11 @@ public class KBArticleUtil {
 	 * @param end the upper bound of the range of kb articles (not inclusive)
 	 * @return the range of matching kb articles
 	 */
-	public static List<KBArticle> findByG_KBFI_UT_ST(
+	public static List<KBArticle> findByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status, int start,
 		int end) {
 
-		return getPersistence().findByG_KBFI_UT_ST(
+		return getPersistence().findByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, status, start, end);
 	}
 
@@ -15879,11 +15879,11 @@ public class KBArticleUtil {
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching kb articles
 	 */
-	public static List<KBArticle> findByG_KBFI_UT_ST(
+	public static List<KBArticle> findByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status, int start,
 		int end, OrderByComparator<KBArticle> orderByComparator) {
 
-		return getPersistence().findByG_KBFI_UT_ST(
+		return getPersistence().findByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, status, start, end,
 			orderByComparator);
 	}
@@ -15905,12 +15905,12 @@ public class KBArticleUtil {
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the ordered range of matching kb articles
 	 */
-	public static List<KBArticle> findByG_KBFI_UT_ST(
+	public static List<KBArticle> findByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status, int start,
 		int end, OrderByComparator<KBArticle> orderByComparator,
 		boolean useFinderCache) {
 
-		return getPersistence().findByG_KBFI_UT_ST(
+		return getPersistence().findByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, status, start, end,
 			orderByComparator, useFinderCache);
 	}
@@ -15926,12 +15926,12 @@ public class KBArticleUtil {
 	 * @return the first matching kb article
 	 * @throws NoSuchArticleException if a matching kb article could not be found
 	 */
-	public static KBArticle findByG_KBFI_UT_ST_First(
+	public static KBArticle findByG_KBFI_UT_S_First(
 			long groupId, long kbFolderId, String urlTitle, int status,
 			OrderByComparator<KBArticle> orderByComparator)
 		throws com.liferay.knowledge.base.exception.NoSuchArticleException {
 
-		return getPersistence().findByG_KBFI_UT_ST_First(
+		return getPersistence().findByG_KBFI_UT_S_First(
 			groupId, kbFolderId, urlTitle, status, orderByComparator);
 	}
 
@@ -15945,11 +15945,11 @@ public class KBArticleUtil {
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching kb article, or <code>null</code> if a matching kb article could not be found
 	 */
-	public static KBArticle fetchByG_KBFI_UT_ST_First(
+	public static KBArticle fetchByG_KBFI_UT_S_First(
 		long groupId, long kbFolderId, String urlTitle, int status,
 		OrderByComparator<KBArticle> orderByComparator) {
 
-		return getPersistence().fetchByG_KBFI_UT_ST_First(
+		return getPersistence().fetchByG_KBFI_UT_S_First(
 			groupId, kbFolderId, urlTitle, status, orderByComparator);
 	}
 
@@ -15964,12 +15964,12 @@ public class KBArticleUtil {
 	 * @return the last matching kb article
 	 * @throws NoSuchArticleException if a matching kb article could not be found
 	 */
-	public static KBArticle findByG_KBFI_UT_ST_Last(
+	public static KBArticle findByG_KBFI_UT_S_Last(
 			long groupId, long kbFolderId, String urlTitle, int status,
 			OrderByComparator<KBArticle> orderByComparator)
 		throws com.liferay.knowledge.base.exception.NoSuchArticleException {
 
-		return getPersistence().findByG_KBFI_UT_ST_Last(
+		return getPersistence().findByG_KBFI_UT_S_Last(
 			groupId, kbFolderId, urlTitle, status, orderByComparator);
 	}
 
@@ -15983,11 +15983,11 @@ public class KBArticleUtil {
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching kb article, or <code>null</code> if a matching kb article could not be found
 	 */
-	public static KBArticle fetchByG_KBFI_UT_ST_Last(
+	public static KBArticle fetchByG_KBFI_UT_S_Last(
 		long groupId, long kbFolderId, String urlTitle, int status,
 		OrderByComparator<KBArticle> orderByComparator) {
 
-		return getPersistence().fetchByG_KBFI_UT_ST_Last(
+		return getPersistence().fetchByG_KBFI_UT_S_Last(
 			groupId, kbFolderId, urlTitle, status, orderByComparator);
 	}
 
@@ -16003,12 +16003,12 @@ public class KBArticleUtil {
 	 * @return the previous, current, and next kb article
 	 * @throws NoSuchArticleException if a kb article with the primary key could not be found
 	 */
-	public static KBArticle[] findByG_KBFI_UT_ST_PrevAndNext(
+	public static KBArticle[] findByG_KBFI_UT_S_PrevAndNext(
 			long kbArticleId, long groupId, long kbFolderId, String urlTitle,
 			int status, OrderByComparator<KBArticle> orderByComparator)
 		throws com.liferay.knowledge.base.exception.NoSuchArticleException {
 
-		return getPersistence().findByG_KBFI_UT_ST_PrevAndNext(
+		return getPersistence().findByG_KBFI_UT_S_PrevAndNext(
 			kbArticleId, groupId, kbFolderId, urlTitle, status,
 			orderByComparator);
 	}
@@ -16022,10 +16022,10 @@ public class KBArticleUtil {
 	 * @param status the status
 	 * @return the matching kb articles that the user has permission to view
 	 */
-	public static List<KBArticle> filterFindByG_KBFI_UT_ST(
+	public static List<KBArticle> filterFindByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status) {
 
-		return getPersistence().filterFindByG_KBFI_UT_ST(
+		return getPersistence().filterFindByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, status);
 	}
 
@@ -16044,11 +16044,11 @@ public class KBArticleUtil {
 	 * @param end the upper bound of the range of kb articles (not inclusive)
 	 * @return the range of matching kb articles that the user has permission to view
 	 */
-	public static List<KBArticle> filterFindByG_KBFI_UT_ST(
+	public static List<KBArticle> filterFindByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status, int start,
 		int end) {
 
-		return getPersistence().filterFindByG_KBFI_UT_ST(
+		return getPersistence().filterFindByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, status, start, end);
 	}
 
@@ -16068,11 +16068,11 @@ public class KBArticleUtil {
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching kb articles that the user has permission to view
 	 */
-	public static List<KBArticle> filterFindByG_KBFI_UT_ST(
+	public static List<KBArticle> filterFindByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status, int start,
 		int end, OrderByComparator<KBArticle> orderByComparator) {
 
-		return getPersistence().filterFindByG_KBFI_UT_ST(
+		return getPersistence().filterFindByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, status, start, end,
 			orderByComparator);
 	}
@@ -16089,12 +16089,12 @@ public class KBArticleUtil {
 	 * @return the previous, current, and next kb article
 	 * @throws NoSuchArticleException if a kb article with the primary key could not be found
 	 */
-	public static KBArticle[] filterFindByG_KBFI_UT_ST_PrevAndNext(
+	public static KBArticle[] filterFindByG_KBFI_UT_S_PrevAndNext(
 			long kbArticleId, long groupId, long kbFolderId, String urlTitle,
 			int status, OrderByComparator<KBArticle> orderByComparator)
 		throws com.liferay.knowledge.base.exception.NoSuchArticleException {
 
-		return getPersistence().filterFindByG_KBFI_UT_ST_PrevAndNext(
+		return getPersistence().filterFindByG_KBFI_UT_S_PrevAndNext(
 			kbArticleId, groupId, kbFolderId, urlTitle, status,
 			orderByComparator);
 	}
@@ -16108,10 +16108,10 @@ public class KBArticleUtil {
 	 * @param statuses the statuses
 	 * @return the matching kb articles that the user has permission to view
 	 */
-	public static List<KBArticle> filterFindByG_KBFI_UT_ST(
+	public static List<KBArticle> filterFindByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses) {
 
-		return getPersistence().filterFindByG_KBFI_UT_ST(
+		return getPersistence().filterFindByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, statuses);
 	}
 
@@ -16130,11 +16130,11 @@ public class KBArticleUtil {
 	 * @param end the upper bound of the range of kb articles (not inclusive)
 	 * @return the range of matching kb articles that the user has permission to view
 	 */
-	public static List<KBArticle> filterFindByG_KBFI_UT_ST(
+	public static List<KBArticle> filterFindByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses,
 		int start, int end) {
 
-		return getPersistence().filterFindByG_KBFI_UT_ST(
+		return getPersistence().filterFindByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, statuses, start, end);
 	}
 
@@ -16154,11 +16154,11 @@ public class KBArticleUtil {
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching kb articles that the user has permission to view
 	 */
-	public static List<KBArticle> filterFindByG_KBFI_UT_ST(
+	public static List<KBArticle> filterFindByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses,
 		int start, int end, OrderByComparator<KBArticle> orderByComparator) {
 
-		return getPersistence().filterFindByG_KBFI_UT_ST(
+		return getPersistence().filterFindByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, statuses, start, end,
 			orderByComparator);
 	}
@@ -16176,10 +16176,10 @@ public class KBArticleUtil {
 	 * @param statuses the statuses
 	 * @return the matching kb articles
 	 */
-	public static List<KBArticle> findByG_KBFI_UT_ST(
+	public static List<KBArticle> findByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses) {
 
-		return getPersistence().findByG_KBFI_UT_ST(
+		return getPersistence().findByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, statuses);
 	}
 
@@ -16198,11 +16198,11 @@ public class KBArticleUtil {
 	 * @param end the upper bound of the range of kb articles (not inclusive)
 	 * @return the range of matching kb articles
 	 */
-	public static List<KBArticle> findByG_KBFI_UT_ST(
+	public static List<KBArticle> findByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses,
 		int start, int end) {
 
-		return getPersistence().findByG_KBFI_UT_ST(
+		return getPersistence().findByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, statuses, start, end);
 	}
 
@@ -16222,11 +16222,11 @@ public class KBArticleUtil {
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching kb articles
 	 */
-	public static List<KBArticle> findByG_KBFI_UT_ST(
+	public static List<KBArticle> findByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses,
 		int start, int end, OrderByComparator<KBArticle> orderByComparator) {
 
-		return getPersistence().findByG_KBFI_UT_ST(
+		return getPersistence().findByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, statuses, start, end,
 			orderByComparator);
 	}
@@ -16248,12 +16248,12 @@ public class KBArticleUtil {
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the ordered range of matching kb articles
 	 */
-	public static List<KBArticle> findByG_KBFI_UT_ST(
+	public static List<KBArticle> findByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses,
 		int start, int end, OrderByComparator<KBArticle> orderByComparator,
 		boolean useFinderCache) {
 
-		return getPersistence().findByG_KBFI_UT_ST(
+		return getPersistence().findByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, statuses, start, end,
 			orderByComparator, useFinderCache);
 	}
@@ -16266,10 +16266,10 @@ public class KBArticleUtil {
 	 * @param urlTitle the url title
 	 * @param status the status
 	 */
-	public static void removeByG_KBFI_UT_ST(
+	public static void removeByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status) {
 
-		getPersistence().removeByG_KBFI_UT_ST(
+		getPersistence().removeByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, status);
 	}
 
@@ -16282,10 +16282,10 @@ public class KBArticleUtil {
 	 * @param status the status
 	 * @return the number of matching kb articles
 	 */
-	public static int countByG_KBFI_UT_ST(
+	public static int countByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status) {
 
-		return getPersistence().countByG_KBFI_UT_ST(
+		return getPersistence().countByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, status);
 	}
 
@@ -16298,10 +16298,10 @@ public class KBArticleUtil {
 	 * @param statuses the statuses
 	 * @return the number of matching kb articles
 	 */
-	public static int countByG_KBFI_UT_ST(
+	public static int countByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses) {
 
-		return getPersistence().countByG_KBFI_UT_ST(
+		return getPersistence().countByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, statuses);
 	}
 
@@ -16314,10 +16314,10 @@ public class KBArticleUtil {
 	 * @param status the status
 	 * @return the number of matching kb articles that the user has permission to view
 	 */
-	public static int filterCountByG_KBFI_UT_ST(
+	public static int filterCountByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status) {
 
-		return getPersistence().filterCountByG_KBFI_UT_ST(
+		return getPersistence().filterCountByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, status);
 	}
 
@@ -16330,10 +16330,10 @@ public class KBArticleUtil {
 	 * @param statuses the statuses
 	 * @return the number of matching kb articles that the user has permission to view
 	 */
-	public static int filterCountByG_KBFI_UT_ST(
+	public static int filterCountByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses) {
 
-		return getPersistence().filterCountByG_KBFI_UT_ST(
+		return getPersistence().filterCountByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, statuses);
 	}
 

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/packageinfo
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/packageinfo
@@ -1,1 +1,1 @@
-version 14.2.0
+version 14.3.0

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/persistence/packageinfo
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.1.0

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/persistence/packageinfo
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 5.1.0
+version 6.0.0

--- a/modules/apps/knowledge-base/knowledge-base-service/service.xml
+++ b/modules/apps/knowledge-base/knowledge-base-service/service.xml
@@ -163,7 +163,7 @@
 			<finder-column name="externalReferenceCode" />
 			<finder-column name="version" />
 		</finder>
-		<finder name="G_ERC_ST" return-type="Collection">
+		<finder name="G_ERC_S" return-type="Collection">
 			<finder-column name="groupId" />
 			<finder-column name="externalReferenceCode" />
 			<finder-column name="status" />
@@ -279,7 +279,7 @@
 			<finder-column name="main" />
 			<finder-column comparator="!=" name="status" />
 		</finder>
-		<finder name="G_KBFI_UT_ST" return-type="Collection">
+		<finder name="G_KBFI_UT_S" return-type="Collection">
 			<finder-column name="groupId" />
 			<finder-column name="kbFolderId" />
 			<finder-column name="urlTitle" />

--- a/modules/apps/knowledge-base/knowledge-base-service/service.xml
+++ b/modules/apps/knowledge-base/knowledge-base-service/service.xml
@@ -163,6 +163,11 @@
 			<finder-column name="externalReferenceCode" />
 			<finder-column name="version" />
 		</finder>
+		<finder name="G_ERC_ST" return-type="Collection">
+			<finder-column name="groupId" />
+			<finder-column name="externalReferenceCode" />
+			<finder-column name="status" />
+		</finder>
 		<finder name="G_P_L" return-type="Collection">
 			<finder-column name="groupId" />
 			<finder-column arrayable-operator="OR" name="parentResourcePrimKey" />

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -744,7 +744,7 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 		}
 
 		return kbArticlePersistence.fetchByG_ERC_ST_First(
-			groupId, externalReferenceCode,
+			groupId, externalReferenceCode, status,
 			KBArticleVersionComparator.getInstance(false));
 	}
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -743,7 +743,7 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 			return latestKBArticle;
 		}
 
-		return kbArticlePersistence.fetchByG_ERC_ST_First(
+		return kbArticlePersistence.fetchByG_ERC_S_First(
 			groupId, externalReferenceCode, status,
 			KBArticleVersionComparator.getInstance(false));
 	}
@@ -766,7 +766,7 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 				WorkflowConstants.STATUS_IN_TRASH, 0, 1, orderByComparator);
 		}
 		else {
-			kbArticles = kbArticlePersistence.findByG_KBFI_UT_ST(
+			kbArticles = kbArticlePersistence.findByG_KBFI_UT_S(
 				groupId, kbFolderId, urlTitle, status, 0, 1, orderByComparator);
 		}
 
@@ -2603,13 +2603,13 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 		String uniqueUrlTitle = urlTitle;
 
 		if (kbFolderId == KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
-			int kbArticlesCount = kbArticlePersistence.countByG_KBFI_UT_ST(
+			int kbArticlesCount = kbArticlePersistence.countByG_KBFI_UT_S(
 				groupId, kbFolderId, uniqueUrlTitle, _STATUSES);
 
 			for (int i = 1; kbArticlesCount > 0; i++) {
 				uniqueUrlTitle = _getUniqueUrlTitle(urlTitle, i);
 
-				kbArticlesCount = kbArticlePersistence.countByG_KBFI_UT_ST(
+				kbArticlesCount = kbArticlePersistence.countByG_KBFI_UT_S(
 					groupId, kbFolderId, uniqueUrlTitle, _STATUSES);
 			}
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -658,6 +658,14 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 	}
 
 	@Override
+	public KBArticle fetchKBArticleByExternalReferenceCode(
+		long groupId, String externalReferenceCode, int version) {
+
+		return kbArticlePersistence.fetchByG_ERC_V(
+			groupId, externalReferenceCode, version);
+	}
+
+	@Override
 	public KBArticle fetchKBArticleByUrlTitle(
 		long groupId, long kbFolderId, String urlTitle) {
 
@@ -716,6 +724,26 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 		long groupId, String externalReferenceCode) {
 
 		return kbArticlePersistence.fetchByG_ERC_Last(
+			groupId, externalReferenceCode,
+			KBArticleVersionComparator.getInstance(false));
+	}
+
+	@Override
+	public KBArticle fetchLatestKBArticleByExternalReferenceCode(
+		long groupId, String externalReferenceCode, int status) {
+
+		KBArticle latestKBArticle = kbArticlePersistence.fetchByG_ERC_Last(
+			groupId, externalReferenceCode,
+			KBArticleVersionComparator.getInstance(false));
+
+		if ((latestKBArticle == null) ||
+			(status == WorkflowConstants.STATUS_ANY) ||
+			(latestKBArticle.getStatus() == status)) {
+
+			return latestKBArticle;
+		}
+
+		return kbArticlePersistence.fetchByG_ERC_ST_First(
 			groupId, externalReferenceCode,
 			KBArticleVersionComparator.getInstance(false));
 	}

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBArticlePersistenceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBArticlePersistenceImpl.java
@@ -22399,6 +22399,1108 @@ public class KBArticlePersistenceImpl
 	private static final String _FINDER_COLUMN_G_ERC_V_VERSION_2 =
 		"kbArticle.version = ?";
 
+	private FinderPath _finderPathWithPaginationFindByG_ERC_ST;
+	private FinderPath _finderPathWithoutPaginationFindByG_ERC_ST;
+	private FinderPath _finderPathCountByG_ERC_ST;
+
+	/**
+	 * Returns all the kb articles where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @return the matching kb articles
+	 */
+	@Override
+	public List<KBArticle> findByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status) {
+
+		return findByG_ERC_ST(
+			groupId, externalReferenceCode, status, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the kb articles where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @return the range of matching kb articles
+	 */
+	@Override
+	public List<KBArticle> findByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status, int start,
+		int end) {
+
+		return findByG_ERC_ST(
+			groupId, externalReferenceCode, status, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the kb articles where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching kb articles
+	 */
+	@Override
+	public List<KBArticle> findByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status, int start,
+		int end, OrderByComparator<KBArticle> orderByComparator) {
+
+		return findByG_ERC_ST(
+			groupId, externalReferenceCode, status, start, end,
+			orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the kb articles where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching kb articles
+	 */
+	@Override
+	public List<KBArticle> findByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status, int start,
+		int end, OrderByComparator<KBArticle> orderByComparator,
+		boolean useFinderCache) {
+
+		try (SafeCloseable safeCloseable =
+				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
+					KBArticle.class)) {
+
+			externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+			FinderPath finderPath = null;
+			Object[] finderArgs = null;
+
+			if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+				(orderByComparator == null)) {
+
+				if (useFinderCache) {
+					finderPath = _finderPathWithoutPaginationFindByG_ERC_ST;
+					finderArgs = new Object[] {
+						groupId, externalReferenceCode, status
+					};
+				}
+			}
+			else if (useFinderCache) {
+				finderPath = _finderPathWithPaginationFindByG_ERC_ST;
+				finderArgs = new Object[] {
+					groupId, externalReferenceCode, status, start, end,
+					orderByComparator
+				};
+			}
+
+			List<KBArticle> list = null;
+
+			if (useFinderCache) {
+				list = (List<KBArticle>)finderCache.getResult(
+					finderPath, finderArgs, this);
+
+				if ((list != null) && !list.isEmpty()) {
+					for (KBArticle kbArticle : list) {
+						if ((groupId != kbArticle.getGroupId()) ||
+							!externalReferenceCode.equals(
+								kbArticle.getExternalReferenceCode()) ||
+							(status != kbArticle.getStatus())) {
+
+							list = null;
+
+							break;
+						}
+					}
+				}
+			}
+
+			if (list == null) {
+				StringBundler sb = null;
+
+				if (orderByComparator != null) {
+					sb = new StringBundler(
+						5 + (orderByComparator.getOrderByFields().length * 2));
+				}
+				else {
+					sb = new StringBundler(5);
+				}
+
+				sb.append(_SQL_SELECT_KBARTICLE_WHERE);
+
+				sb.append(_FINDER_COLUMN_G_ERC_ST_GROUPID_2);
+
+				boolean bindExternalReferenceCode = false;
+
+				if (externalReferenceCode.isEmpty()) {
+					sb.append(_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_3);
+				}
+				else {
+					bindExternalReferenceCode = true;
+
+					sb.append(_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_2);
+				}
+
+				sb.append(_FINDER_COLUMN_G_ERC_ST_STATUS_2);
+
+				if (orderByComparator != null) {
+					appendOrderByComparator(
+						sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+				}
+				else {
+					sb.append(KBArticleModelImpl.ORDER_BY_JPQL);
+				}
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(groupId);
+
+					if (bindExternalReferenceCode) {
+						queryPos.add(externalReferenceCode);
+					}
+
+					queryPos.add(status);
+
+					list = (List<KBArticle>)QueryUtil.list(
+						query, getDialect(), start, end);
+
+					cacheResult(list);
+
+					if (useFinderCache) {
+						finderCache.putResult(finderPath, finderArgs, list);
+					}
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return list;
+		}
+	}
+
+	/**
+	 * Returns the first kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching kb article
+	 * @throws NoSuchArticleException if a matching kb article could not be found
+	 */
+	@Override
+	public KBArticle findByG_ERC_ST_First(
+			long groupId, String externalReferenceCode, int status,
+			OrderByComparator<KBArticle> orderByComparator)
+		throws NoSuchArticleException {
+
+		KBArticle kbArticle = fetchByG_ERC_ST_First(
+			groupId, externalReferenceCode, status, orderByComparator);
+
+		if (kbArticle != null) {
+			return kbArticle;
+		}
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", externalReferenceCode=");
+		sb.append(externalReferenceCode);
+
+		sb.append(", status=");
+		sb.append(status);
+
+		sb.append("}");
+
+		throw new NoSuchArticleException(sb.toString());
+	}
+
+	/**
+	 * Returns the first kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching kb article, or <code>null</code> if a matching kb article could not be found
+	 */
+	@Override
+	public KBArticle fetchByG_ERC_ST_First(
+		long groupId, String externalReferenceCode, int status,
+		OrderByComparator<KBArticle> orderByComparator) {
+
+		List<KBArticle> list = findByG_ERC_ST(
+			groupId, externalReferenceCode, status, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching kb article
+	 * @throws NoSuchArticleException if a matching kb article could not be found
+	 */
+	@Override
+	public KBArticle findByG_ERC_ST_Last(
+			long groupId, String externalReferenceCode, int status,
+			OrderByComparator<KBArticle> orderByComparator)
+		throws NoSuchArticleException {
+
+		KBArticle kbArticle = fetchByG_ERC_ST_Last(
+			groupId, externalReferenceCode, status, orderByComparator);
+
+		if (kbArticle != null) {
+			return kbArticle;
+		}
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", externalReferenceCode=");
+		sb.append(externalReferenceCode);
+
+		sb.append(", status=");
+		sb.append(status);
+
+		sb.append("}");
+
+		throw new NoSuchArticleException(sb.toString());
+	}
+
+	/**
+	 * Returns the last kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching kb article, or <code>null</code> if a matching kb article could not be found
+	 */
+	@Override
+	public KBArticle fetchByG_ERC_ST_Last(
+		long groupId, String externalReferenceCode, int status,
+		OrderByComparator<KBArticle> orderByComparator) {
+
+		int count = countByG_ERC_ST(groupId, externalReferenceCode, status);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<KBArticle> list = findByG_ERC_ST(
+			groupId, externalReferenceCode, status, count - 1, count,
+			orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the kb articles before and after the current kb article in the ordered set where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param kbArticleId the primary key of the current kb article
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next kb article
+	 * @throws NoSuchArticleException if a kb article with the primary key could not be found
+	 */
+	@Override
+	public KBArticle[] findByG_ERC_ST_PrevAndNext(
+			long kbArticleId, long groupId, String externalReferenceCode,
+			int status, OrderByComparator<KBArticle> orderByComparator)
+		throws NoSuchArticleException {
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		KBArticle kbArticle = findByPrimaryKey(kbArticleId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			KBArticle[] array = new KBArticleImpl[3];
+
+			array[0] = getByG_ERC_ST_PrevAndNext(
+				session, kbArticle, groupId, externalReferenceCode, status,
+				orderByComparator, true);
+
+			array[1] = kbArticle;
+
+			array[2] = getByG_ERC_ST_PrevAndNext(
+				session, kbArticle, groupId, externalReferenceCode, status,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected KBArticle getByG_ERC_ST_PrevAndNext(
+		Session session, KBArticle kbArticle, long groupId,
+		String externalReferenceCode, int status,
+		OrderByComparator<KBArticle> orderByComparator, boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				6 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(5);
+		}
+
+		sb.append(_SQL_SELECT_KBARTICLE_WHERE);
+
+		sb.append(_FINDER_COLUMN_G_ERC_ST_GROUPID_2);
+
+		boolean bindExternalReferenceCode = false;
+
+		if (externalReferenceCode.isEmpty()) {
+			sb.append(_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_3);
+		}
+		else {
+			bindExternalReferenceCode = true;
+
+			sb.append(_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_2);
+		}
+
+		sb.append(_FINDER_COLUMN_G_ERC_ST_STATUS_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(KBArticleModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(groupId);
+
+		if (bindExternalReferenceCode) {
+			queryPos.add(externalReferenceCode);
+		}
+
+		queryPos.add(status);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(kbArticle)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<KBArticle> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Returns all the kb articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @return the matching kb articles that the user has permission to view
+	 */
+	@Override
+	public List<KBArticle> filterFindByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status) {
+
+		return filterFindByG_ERC_ST(
+			groupId, externalReferenceCode, status, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the kb articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @return the range of matching kb articles that the user has permission to view
+	 */
+	@Override
+	public List<KBArticle> filterFindByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status, int start,
+		int end) {
+
+		return filterFindByG_ERC_ST(
+			groupId, externalReferenceCode, status, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the kb articles that the user has permissions to view where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param start the lower bound of the range of kb articles
+	 * @param end the upper bound of the range of kb articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching kb articles that the user has permission to view
+	 */
+	@Override
+	public List<KBArticle> filterFindByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status, int start,
+		int end, OrderByComparator<KBArticle> orderByComparator) {
+
+		if (!InlineSQLHelperUtil.isEnabled(groupId)) {
+			return findByG_ERC_ST(
+				groupId, externalReferenceCode, status, start, end,
+				orderByComparator);
+		}
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				5 + (orderByComparator.getOrderByFields().length * 2));
+		}
+		else {
+			sb = new StringBundler(6);
+		}
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sb.append(_FILTER_SQL_SELECT_KBARTICLE_WHERE);
+		}
+		else {
+			sb.append(_FILTER_SQL_SELECT_KBARTICLE_NO_INLINE_DISTINCT_WHERE_1);
+		}
+
+		sb.append(_FINDER_COLUMN_G_ERC_ST_GROUPID_2);
+
+		boolean bindExternalReferenceCode = false;
+
+		if (externalReferenceCode.isEmpty()) {
+			sb.append(_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_3);
+		}
+		else {
+			bindExternalReferenceCode = true;
+
+			sb.append(_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_2);
+		}
+
+		sb.append(_FINDER_COLUMN_G_ERC_ST_STATUS_2);
+
+		if (!getDB().isSupportsInlineDistinct()) {
+			sb.append(_FILTER_SQL_SELECT_KBARTICLE_NO_INLINE_DISTINCT_WHERE_2);
+		}
+
+		if (orderByComparator != null) {
+			if (getDB().isSupportsInlineDistinct()) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator, true);
+			}
+			else {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_TABLE, orderByComparator, true);
+			}
+		}
+		else {
+			if (getDB().isSupportsInlineDistinct()) {
+				sb.append(KBArticleModelImpl.ORDER_BY_SQL_INLINE_DISTINCT);
+			}
+			else {
+				sb.append(KBArticleModelImpl.ORDER_BY_SQL);
+			}
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), KBArticle.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN, groupId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+			if (getDB().isSupportsInlineDistinct()) {
+				sqlQuery.addEntity(_FILTER_ENTITY_ALIAS, KBArticleImpl.class);
+			}
+			else {
+				sqlQuery.addEntity(_FILTER_ENTITY_TABLE, KBArticleImpl.class);
+			}
+
+			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+			queryPos.add(groupId);
+
+			if (bindExternalReferenceCode) {
+				queryPos.add(externalReferenceCode);
+			}
+
+			queryPos.add(status);
+
+			return (List<KBArticle>)QueryUtil.list(
+				sqlQuery, getDialect(), start, end);
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	/**
+	 * Returns the kb articles before and after the current kb article in the ordered set of kb articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param kbArticleId the primary key of the current kb article
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next kb article
+	 * @throws NoSuchArticleException if a kb article with the primary key could not be found
+	 */
+	@Override
+	public KBArticle[] filterFindByG_ERC_ST_PrevAndNext(
+			long kbArticleId, long groupId, String externalReferenceCode,
+			int status, OrderByComparator<KBArticle> orderByComparator)
+		throws NoSuchArticleException {
+
+		if (!InlineSQLHelperUtil.isEnabled(groupId)) {
+			return findByG_ERC_ST_PrevAndNext(
+				kbArticleId, groupId, externalReferenceCode, status,
+				orderByComparator);
+		}
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		KBArticle kbArticle = findByPrimaryKey(kbArticleId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			KBArticle[] array = new KBArticleImpl[3];
+
+			array[0] = filterGetByG_ERC_ST_PrevAndNext(
+				session, kbArticle, groupId, externalReferenceCode, status,
+				orderByComparator, true);
+
+			array[1] = kbArticle;
+
+			array[2] = filterGetByG_ERC_ST_PrevAndNext(
+				session, kbArticle, groupId, externalReferenceCode, status,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected KBArticle filterGetByG_ERC_ST_PrevAndNext(
+		Session session, KBArticle kbArticle, long groupId,
+		String externalReferenceCode, int status,
+		OrderByComparator<KBArticle> orderByComparator, boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				7 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(6);
+		}
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sb.append(_FILTER_SQL_SELECT_KBARTICLE_WHERE);
+		}
+		else {
+			sb.append(_FILTER_SQL_SELECT_KBARTICLE_NO_INLINE_DISTINCT_WHERE_1);
+		}
+
+		sb.append(_FINDER_COLUMN_G_ERC_ST_GROUPID_2);
+
+		boolean bindExternalReferenceCode = false;
+
+		if (externalReferenceCode.isEmpty()) {
+			sb.append(_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_3);
+		}
+		else {
+			bindExternalReferenceCode = true;
+
+			sb.append(_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_2);
+		}
+
+		sb.append(_FINDER_COLUMN_G_ERC_ST_STATUS_2);
+
+		if (!getDB().isSupportsInlineDistinct()) {
+			sb.append(_FILTER_SQL_SELECT_KBARTICLE_NO_INLINE_DISTINCT_WHERE_2);
+		}
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				if (getDB().isSupportsInlineDistinct()) {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_ALIAS, orderByConditionFields[i],
+							true));
+				}
+				else {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_TABLE, orderByConditionFields[i],
+							true));
+				}
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				if (getDB().isSupportsInlineDistinct()) {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_ALIAS, orderByFields[i], true));
+				}
+				else {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_TABLE, orderByFields[i], true));
+				}
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			if (getDB().isSupportsInlineDistinct()) {
+				sb.append(KBArticleModelImpl.ORDER_BY_SQL_INLINE_DISTINCT);
+			}
+			else {
+				sb.append(KBArticleModelImpl.ORDER_BY_SQL);
+			}
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), KBArticle.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN, groupId);
+
+		SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+		sqlQuery.setFirstResult(0);
+		sqlQuery.setMaxResults(2);
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sqlQuery.addEntity(_FILTER_ENTITY_ALIAS, KBArticleImpl.class);
+		}
+		else {
+			sqlQuery.addEntity(_FILTER_ENTITY_TABLE, KBArticleImpl.class);
+		}
+
+		QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+		queryPos.add(groupId);
+
+		if (bindExternalReferenceCode) {
+			queryPos.add(externalReferenceCode);
+		}
+
+		queryPos.add(status);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(kbArticle)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<KBArticle> list = sqlQuery.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the kb articles where groupId = &#63; and externalReferenceCode = &#63; and status = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 */
+	@Override
+	public void removeByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status) {
+
+		for (KBArticle kbArticle :
+				findByG_ERC_ST(
+					groupId, externalReferenceCode, status, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null)) {
+
+			remove(kbArticle);
+		}
+	}
+
+	/**
+	 * Returns the number of kb articles where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @return the number of matching kb articles
+	 */
+	@Override
+	public int countByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status) {
+
+		try (SafeCloseable safeCloseable =
+				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
+					KBArticle.class)) {
+
+			externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+			FinderPath finderPath = _finderPathCountByG_ERC_ST;
+
+			Object[] finderArgs = new Object[] {
+				groupId, externalReferenceCode, status
+			};
+
+			Long count = (Long)finderCache.getResult(
+				finderPath, finderArgs, this);
+
+			if (count == null) {
+				StringBundler sb = new StringBundler(4);
+
+				sb.append(_SQL_COUNT_KBARTICLE_WHERE);
+
+				sb.append(_FINDER_COLUMN_G_ERC_ST_GROUPID_2);
+
+				boolean bindExternalReferenceCode = false;
+
+				if (externalReferenceCode.isEmpty()) {
+					sb.append(_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_3);
+				}
+				else {
+					bindExternalReferenceCode = true;
+
+					sb.append(_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_2);
+				}
+
+				sb.append(_FINDER_COLUMN_G_ERC_ST_STATUS_2);
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(groupId);
+
+					if (bindExternalReferenceCode) {
+						queryPos.add(externalReferenceCode);
+					}
+
+					queryPos.add(status);
+
+					count = (Long)query.uniqueResult();
+
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return count.intValue();
+		}
+	}
+
+	/**
+	 * Returns the number of kb articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param status the status
+	 * @return the number of matching kb articles that the user has permission to view
+	 */
+	@Override
+	public int filterCountByG_ERC_ST(
+		long groupId, String externalReferenceCode, int status) {
+
+		if (!InlineSQLHelperUtil.isEnabled(groupId)) {
+			return countByG_ERC_ST(groupId, externalReferenceCode, status);
+		}
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		StringBundler sb = new StringBundler(4);
+
+		sb.append(_FILTER_SQL_COUNT_KBARTICLE_WHERE);
+
+		sb.append(_FINDER_COLUMN_G_ERC_ST_GROUPID_2);
+
+		boolean bindExternalReferenceCode = false;
+
+		if (externalReferenceCode.isEmpty()) {
+			sb.append(_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_3);
+		}
+		else {
+			bindExternalReferenceCode = true;
+
+			sb.append(_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_2);
+		}
+
+		sb.append(_FINDER_COLUMN_G_ERC_ST_STATUS_2);
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), KBArticle.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN, groupId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+			sqlQuery.addScalar(
+				COUNT_COLUMN_NAME, com.liferay.portal.kernel.dao.orm.Type.LONG);
+
+			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+			queryPos.add(groupId);
+
+			if (bindExternalReferenceCode) {
+				queryPos.add(externalReferenceCode);
+			}
+
+			queryPos.add(status);
+
+			Long count = (Long)sqlQuery.uniqueResult();
+
+			return count.intValue();
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	private static final String _FINDER_COLUMN_G_ERC_ST_GROUPID_2 =
+		"kbArticle.groupId = ? AND ";
+
+	private static final String
+		_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_2 =
+			"kbArticle.externalReferenceCode = ? AND ";
+
+	private static final String
+		_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_3 =
+			"(kbArticle.externalReferenceCode IS NULL OR kbArticle.externalReferenceCode = '') AND ";
+
+	private static final String _FINDER_COLUMN_G_ERC_ST_STATUS_2 =
+		"kbArticle.status = ?";
+
 	private FinderPath _finderPathWithPaginationFindByG_P_L;
 	private FinderPath _finderPathWithoutPaginationFindByG_P_L;
 	private FinderPath _finderPathCountByG_P_L;
@@ -59952,6 +61054,31 @@ public class KBArticlePersistenceImpl
 				Integer.class.getName()
 			},
 			new String[] {"groupId", "externalReferenceCode", "version"}, true);
+
+		_finderPathWithPaginationFindByG_ERC_ST = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_ERC_ST",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "externalReferenceCode", "status"}, true);
+
+		_finderPathWithoutPaginationFindByG_ERC_ST = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_ERC_ST",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {"groupId", "externalReferenceCode", "status"}, true);
+
+		_finderPathCountByG_ERC_ST = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_ERC_ST",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {"groupId", "externalReferenceCode", "status"}, false);
 
 		_finderPathWithPaginationFindByG_P_L = new FinderPath(
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_P_L",

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBArticlePersistenceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBArticlePersistenceImpl.java
@@ -22399,9 +22399,9 @@ public class KBArticlePersistenceImpl
 	private static final String _FINDER_COLUMN_G_ERC_V_VERSION_2 =
 		"kbArticle.version = ?";
 
-	private FinderPath _finderPathWithPaginationFindByG_ERC_ST;
-	private FinderPath _finderPathWithoutPaginationFindByG_ERC_ST;
-	private FinderPath _finderPathCountByG_ERC_ST;
+	private FinderPath _finderPathWithPaginationFindByG_ERC_S;
+	private FinderPath _finderPathWithoutPaginationFindByG_ERC_S;
+	private FinderPath _finderPathCountByG_ERC_S;
 
 	/**
 	 * Returns all the kb articles where groupId = &#63; and externalReferenceCode = &#63; and status = &#63;.
@@ -22412,10 +22412,10 @@ public class KBArticlePersistenceImpl
 	 * @return the matching kb articles
 	 */
 	@Override
-	public List<KBArticle> findByG_ERC_ST(
+	public List<KBArticle> findByG_ERC_S(
 		long groupId, String externalReferenceCode, int status) {
 
-		return findByG_ERC_ST(
+		return findByG_ERC_S(
 			groupId, externalReferenceCode, status, QueryUtil.ALL_POS,
 			QueryUtil.ALL_POS, null);
 	}
@@ -22435,11 +22435,11 @@ public class KBArticlePersistenceImpl
 	 * @return the range of matching kb articles
 	 */
 	@Override
-	public List<KBArticle> findByG_ERC_ST(
+	public List<KBArticle> findByG_ERC_S(
 		long groupId, String externalReferenceCode, int status, int start,
 		int end) {
 
-		return findByG_ERC_ST(
+		return findByG_ERC_S(
 			groupId, externalReferenceCode, status, start, end, null);
 	}
 
@@ -22459,11 +22459,11 @@ public class KBArticlePersistenceImpl
 	 * @return the ordered range of matching kb articles
 	 */
 	@Override
-	public List<KBArticle> findByG_ERC_ST(
+	public List<KBArticle> findByG_ERC_S(
 		long groupId, String externalReferenceCode, int status, int start,
 		int end, OrderByComparator<KBArticle> orderByComparator) {
 
-		return findByG_ERC_ST(
+		return findByG_ERC_S(
 			groupId, externalReferenceCode, status, start, end,
 			orderByComparator, true);
 	}
@@ -22485,7 +22485,7 @@ public class KBArticlePersistenceImpl
 	 * @return the ordered range of matching kb articles
 	 */
 	@Override
-	public List<KBArticle> findByG_ERC_ST(
+	public List<KBArticle> findByG_ERC_S(
 		long groupId, String externalReferenceCode, int status, int start,
 		int end, OrderByComparator<KBArticle> orderByComparator,
 		boolean useFinderCache) {
@@ -22503,14 +22503,14 @@ public class KBArticlePersistenceImpl
 				(orderByComparator == null)) {
 
 				if (useFinderCache) {
-					finderPath = _finderPathWithoutPaginationFindByG_ERC_ST;
+					finderPath = _finderPathWithoutPaginationFindByG_ERC_S;
 					finderArgs = new Object[] {
 						groupId, externalReferenceCode, status
 					};
 				}
 			}
 			else if (useFinderCache) {
-				finderPath = _finderPathWithPaginationFindByG_ERC_ST;
+				finderPath = _finderPathWithPaginationFindByG_ERC_S;
 				finderArgs = new Object[] {
 					groupId, externalReferenceCode, status, start, end,
 					orderByComparator
@@ -22551,20 +22551,20 @@ public class KBArticlePersistenceImpl
 
 				sb.append(_SQL_SELECT_KBARTICLE_WHERE);
 
-				sb.append(_FINDER_COLUMN_G_ERC_ST_GROUPID_2);
+				sb.append(_FINDER_COLUMN_G_ERC_S_GROUPID_2);
 
 				boolean bindExternalReferenceCode = false;
 
 				if (externalReferenceCode.isEmpty()) {
-					sb.append(_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_3);
+					sb.append(_FINDER_COLUMN_G_ERC_S_EXTERNALREFERENCECODE_3);
 				}
 				else {
 					bindExternalReferenceCode = true;
 
-					sb.append(_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_2);
+					sb.append(_FINDER_COLUMN_G_ERC_S_EXTERNALREFERENCECODE_2);
 				}
 
-				sb.append(_FINDER_COLUMN_G_ERC_ST_STATUS_2);
+				sb.append(_FINDER_COLUMN_G_ERC_S_STATUS_2);
 
 				if (orderByComparator != null) {
 					appendOrderByComparator(
@@ -22625,12 +22625,12 @@ public class KBArticlePersistenceImpl
 	 * @throws NoSuchArticleException if a matching kb article could not be found
 	 */
 	@Override
-	public KBArticle findByG_ERC_ST_First(
+	public KBArticle findByG_ERC_S_First(
 			long groupId, String externalReferenceCode, int status,
 			OrderByComparator<KBArticle> orderByComparator)
 		throws NoSuchArticleException {
 
-		KBArticle kbArticle = fetchByG_ERC_ST_First(
+		KBArticle kbArticle = fetchByG_ERC_S_First(
 			groupId, externalReferenceCode, status, orderByComparator);
 
 		if (kbArticle != null) {
@@ -22665,11 +22665,11 @@ public class KBArticlePersistenceImpl
 	 * @return the first matching kb article, or <code>null</code> if a matching kb article could not be found
 	 */
 	@Override
-	public KBArticle fetchByG_ERC_ST_First(
+	public KBArticle fetchByG_ERC_S_First(
 		long groupId, String externalReferenceCode, int status,
 		OrderByComparator<KBArticle> orderByComparator) {
 
-		List<KBArticle> list = findByG_ERC_ST(
+		List<KBArticle> list = findByG_ERC_S(
 			groupId, externalReferenceCode, status, 0, 1, orderByComparator);
 
 		if (!list.isEmpty()) {
@@ -22690,12 +22690,12 @@ public class KBArticlePersistenceImpl
 	 * @throws NoSuchArticleException if a matching kb article could not be found
 	 */
 	@Override
-	public KBArticle findByG_ERC_ST_Last(
+	public KBArticle findByG_ERC_S_Last(
 			long groupId, String externalReferenceCode, int status,
 			OrderByComparator<KBArticle> orderByComparator)
 		throws NoSuchArticleException {
 
-		KBArticle kbArticle = fetchByG_ERC_ST_Last(
+		KBArticle kbArticle = fetchByG_ERC_S_Last(
 			groupId, externalReferenceCode, status, orderByComparator);
 
 		if (kbArticle != null) {
@@ -22730,17 +22730,17 @@ public class KBArticlePersistenceImpl
 	 * @return the last matching kb article, or <code>null</code> if a matching kb article could not be found
 	 */
 	@Override
-	public KBArticle fetchByG_ERC_ST_Last(
+	public KBArticle fetchByG_ERC_S_Last(
 		long groupId, String externalReferenceCode, int status,
 		OrderByComparator<KBArticle> orderByComparator) {
 
-		int count = countByG_ERC_ST(groupId, externalReferenceCode, status);
+		int count = countByG_ERC_S(groupId, externalReferenceCode, status);
 
 		if (count == 0) {
 			return null;
 		}
 
-		List<KBArticle> list = findByG_ERC_ST(
+		List<KBArticle> list = findByG_ERC_S(
 			groupId, externalReferenceCode, status, count - 1, count,
 			orderByComparator);
 
@@ -22763,7 +22763,7 @@ public class KBArticlePersistenceImpl
 	 * @throws NoSuchArticleException if a kb article with the primary key could not be found
 	 */
 	@Override
-	public KBArticle[] findByG_ERC_ST_PrevAndNext(
+	public KBArticle[] findByG_ERC_S_PrevAndNext(
 			long kbArticleId, long groupId, String externalReferenceCode,
 			int status, OrderByComparator<KBArticle> orderByComparator)
 		throws NoSuchArticleException {
@@ -22779,13 +22779,13 @@ public class KBArticlePersistenceImpl
 
 			KBArticle[] array = new KBArticleImpl[3];
 
-			array[0] = getByG_ERC_ST_PrevAndNext(
+			array[0] = getByG_ERC_S_PrevAndNext(
 				session, kbArticle, groupId, externalReferenceCode, status,
 				orderByComparator, true);
 
 			array[1] = kbArticle;
 
-			array[2] = getByG_ERC_ST_PrevAndNext(
+			array[2] = getByG_ERC_S_PrevAndNext(
 				session, kbArticle, groupId, externalReferenceCode, status,
 				orderByComparator, false);
 
@@ -22799,7 +22799,7 @@ public class KBArticlePersistenceImpl
 		}
 	}
 
-	protected KBArticle getByG_ERC_ST_PrevAndNext(
+	protected KBArticle getByG_ERC_S_PrevAndNext(
 		Session session, KBArticle kbArticle, long groupId,
 		String externalReferenceCode, int status,
 		OrderByComparator<KBArticle> orderByComparator, boolean previous) {
@@ -22817,20 +22817,20 @@ public class KBArticlePersistenceImpl
 
 		sb.append(_SQL_SELECT_KBARTICLE_WHERE);
 
-		sb.append(_FINDER_COLUMN_G_ERC_ST_GROUPID_2);
+		sb.append(_FINDER_COLUMN_G_ERC_S_GROUPID_2);
 
 		boolean bindExternalReferenceCode = false;
 
 		if (externalReferenceCode.isEmpty()) {
-			sb.append(_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_3);
+			sb.append(_FINDER_COLUMN_G_ERC_S_EXTERNALREFERENCECODE_3);
 		}
 		else {
 			bindExternalReferenceCode = true;
 
-			sb.append(_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_2);
+			sb.append(_FINDER_COLUMN_G_ERC_S_EXTERNALREFERENCECODE_2);
 		}
 
-		sb.append(_FINDER_COLUMN_G_ERC_ST_STATUS_2);
+		sb.append(_FINDER_COLUMN_G_ERC_S_STATUS_2);
 
 		if (orderByComparator != null) {
 			String[] orderByConditionFields =
@@ -22936,10 +22936,10 @@ public class KBArticlePersistenceImpl
 	 * @return the matching kb articles that the user has permission to view
 	 */
 	@Override
-	public List<KBArticle> filterFindByG_ERC_ST(
+	public List<KBArticle> filterFindByG_ERC_S(
 		long groupId, String externalReferenceCode, int status) {
 
-		return filterFindByG_ERC_ST(
+		return filterFindByG_ERC_S(
 			groupId, externalReferenceCode, status, QueryUtil.ALL_POS,
 			QueryUtil.ALL_POS, null);
 	}
@@ -22959,11 +22959,11 @@ public class KBArticlePersistenceImpl
 	 * @return the range of matching kb articles that the user has permission to view
 	 */
 	@Override
-	public List<KBArticle> filterFindByG_ERC_ST(
+	public List<KBArticle> filterFindByG_ERC_S(
 		long groupId, String externalReferenceCode, int status, int start,
 		int end) {
 
-		return filterFindByG_ERC_ST(
+		return filterFindByG_ERC_S(
 			groupId, externalReferenceCode, status, start, end, null);
 	}
 
@@ -22983,14 +22983,24 @@ public class KBArticlePersistenceImpl
 	 * @return the ordered range of matching kb articles that the user has permission to view
 	 */
 	@Override
-	public List<KBArticle> filterFindByG_ERC_ST(
+	public List<KBArticle> filterFindByG_ERC_S(
 		long groupId, String externalReferenceCode, int status, int start,
 		int end, OrderByComparator<KBArticle> orderByComparator) {
 
 		if (!InlineSQLHelperUtil.isEnabled(groupId)) {
-			return findByG_ERC_ST(
+			return findByG_ERC_S(
 				groupId, externalReferenceCode, status, start, end,
 				orderByComparator);
+		}
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			isPermissionsInMemoryFilterEnabled()) {
+
+			return InlineSQLHelperUtil.filter(
+				findByG_ERC_S(
+					groupId, externalReferenceCode, status, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, orderByComparator),
+				groupId);
 		}
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
@@ -23012,20 +23022,20 @@ public class KBArticlePersistenceImpl
 			sb.append(_FILTER_SQL_SELECT_KBARTICLE_NO_INLINE_DISTINCT_WHERE_1);
 		}
 
-		sb.append(_FINDER_COLUMN_G_ERC_ST_GROUPID_2);
+		sb.append(_FINDER_COLUMN_G_ERC_S_GROUPID_2);
 
 		boolean bindExternalReferenceCode = false;
 
 		if (externalReferenceCode.isEmpty()) {
-			sb.append(_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_3);
+			sb.append(_FINDER_COLUMN_G_ERC_S_EXTERNALREFERENCECODE_3);
 		}
 		else {
 			bindExternalReferenceCode = true;
 
-			sb.append(_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_2);
+			sb.append(_FINDER_COLUMN_G_ERC_S_EXTERNALREFERENCECODE_2);
 		}
 
-		sb.append(_FINDER_COLUMN_G_ERC_ST_STATUS_2);
+		sb.append(_FINDER_COLUMN_G_ERC_S_STATUS_2);
 
 		if (!getDB().isSupportsInlineDistinct()) {
 			sb.append(_FILTER_SQL_SELECT_KBARTICLE_NO_INLINE_DISTINCT_WHERE_2);
@@ -23101,13 +23111,13 @@ public class KBArticlePersistenceImpl
 	 * @throws NoSuchArticleException if a kb article with the primary key could not be found
 	 */
 	@Override
-	public KBArticle[] filterFindByG_ERC_ST_PrevAndNext(
+	public KBArticle[] filterFindByG_ERC_S_PrevAndNext(
 			long kbArticleId, long groupId, String externalReferenceCode,
 			int status, OrderByComparator<KBArticle> orderByComparator)
 		throws NoSuchArticleException {
 
 		if (!InlineSQLHelperUtil.isEnabled(groupId)) {
-			return findByG_ERC_ST_PrevAndNext(
+			return findByG_ERC_S_PrevAndNext(
 				kbArticleId, groupId, externalReferenceCode, status,
 				orderByComparator);
 		}
@@ -23123,13 +23133,13 @@ public class KBArticlePersistenceImpl
 
 			KBArticle[] array = new KBArticleImpl[3];
 
-			array[0] = filterGetByG_ERC_ST_PrevAndNext(
+			array[0] = filterGetByG_ERC_S_PrevAndNext(
 				session, kbArticle, groupId, externalReferenceCode, status,
 				orderByComparator, true);
 
 			array[1] = kbArticle;
 
-			array[2] = filterGetByG_ERC_ST_PrevAndNext(
+			array[2] = filterGetByG_ERC_S_PrevAndNext(
 				session, kbArticle, groupId, externalReferenceCode, status,
 				orderByComparator, false);
 
@@ -23143,7 +23153,7 @@ public class KBArticlePersistenceImpl
 		}
 	}
 
-	protected KBArticle filterGetByG_ERC_ST_PrevAndNext(
+	protected KBArticle filterGetByG_ERC_S_PrevAndNext(
 		Session session, KBArticle kbArticle, long groupId,
 		String externalReferenceCode, int status,
 		OrderByComparator<KBArticle> orderByComparator, boolean previous) {
@@ -23166,20 +23176,20 @@ public class KBArticlePersistenceImpl
 			sb.append(_FILTER_SQL_SELECT_KBARTICLE_NO_INLINE_DISTINCT_WHERE_1);
 		}
 
-		sb.append(_FINDER_COLUMN_G_ERC_ST_GROUPID_2);
+		sb.append(_FINDER_COLUMN_G_ERC_S_GROUPID_2);
 
 		boolean bindExternalReferenceCode = false;
 
 		if (externalReferenceCode.isEmpty()) {
-			sb.append(_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_3);
+			sb.append(_FINDER_COLUMN_G_ERC_S_EXTERNALREFERENCECODE_3);
 		}
 		else {
 			bindExternalReferenceCode = true;
 
-			sb.append(_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_2);
+			sb.append(_FINDER_COLUMN_G_ERC_S_EXTERNALREFERENCECODE_2);
 		}
 
-		sb.append(_FINDER_COLUMN_G_ERC_ST_STATUS_2);
+		sb.append(_FINDER_COLUMN_G_ERC_S_STATUS_2);
 
 		if (!getDB().isSupportsInlineDistinct()) {
 			sb.append(_FILTER_SQL_SELECT_KBARTICLE_NO_INLINE_DISTINCT_WHERE_2);
@@ -23320,11 +23330,11 @@ public class KBArticlePersistenceImpl
 	 * @param status the status
 	 */
 	@Override
-	public void removeByG_ERC_ST(
+	public void removeByG_ERC_S(
 		long groupId, String externalReferenceCode, int status) {
 
 		for (KBArticle kbArticle :
-				findByG_ERC_ST(
+				findByG_ERC_S(
 					groupId, externalReferenceCode, status, QueryUtil.ALL_POS,
 					QueryUtil.ALL_POS, null)) {
 
@@ -23341,7 +23351,7 @@ public class KBArticlePersistenceImpl
 	 * @return the number of matching kb articles
 	 */
 	@Override
-	public int countByG_ERC_ST(
+	public int countByG_ERC_S(
 		long groupId, String externalReferenceCode, int status) {
 
 		try (SafeCloseable safeCloseable =
@@ -23350,7 +23360,7 @@ public class KBArticlePersistenceImpl
 
 			externalReferenceCode = Objects.toString(externalReferenceCode, "");
 
-			FinderPath finderPath = _finderPathCountByG_ERC_ST;
+			FinderPath finderPath = _finderPathCountByG_ERC_S;
 
 			Object[] finderArgs = new Object[] {
 				groupId, externalReferenceCode, status
@@ -23364,20 +23374,20 @@ public class KBArticlePersistenceImpl
 
 				sb.append(_SQL_COUNT_KBARTICLE_WHERE);
 
-				sb.append(_FINDER_COLUMN_G_ERC_ST_GROUPID_2);
+				sb.append(_FINDER_COLUMN_G_ERC_S_GROUPID_2);
 
 				boolean bindExternalReferenceCode = false;
 
 				if (externalReferenceCode.isEmpty()) {
-					sb.append(_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_3);
+					sb.append(_FINDER_COLUMN_G_ERC_S_EXTERNALREFERENCECODE_3);
 				}
 				else {
 					bindExternalReferenceCode = true;
 
-					sb.append(_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_2);
+					sb.append(_FINDER_COLUMN_G_ERC_S_EXTERNALREFERENCECODE_2);
 				}
 
-				sb.append(_FINDER_COLUMN_G_ERC_ST_STATUS_2);
+				sb.append(_FINDER_COLUMN_G_ERC_S_STATUS_2);
 
 				String sql = sb.toString();
 
@@ -23423,11 +23433,20 @@ public class KBArticlePersistenceImpl
 	 * @return the number of matching kb articles that the user has permission to view
 	 */
 	@Override
-	public int filterCountByG_ERC_ST(
+	public int filterCountByG_ERC_S(
 		long groupId, String externalReferenceCode, int status) {
 
 		if (!InlineSQLHelperUtil.isEnabled(groupId)) {
-			return countByG_ERC_ST(groupId, externalReferenceCode, status);
+			return countByG_ERC_S(groupId, externalReferenceCode, status);
+		}
+
+		if (isPermissionsInMemoryFilterEnabled()) {
+			List<KBArticle> kbArticles = findByG_ERC_S(
+				groupId, externalReferenceCode, status);
+
+			kbArticles = InlineSQLHelperUtil.filter(kbArticles, groupId);
+
+			return kbArticles.size();
 		}
 
 		externalReferenceCode = Objects.toString(externalReferenceCode, "");
@@ -23436,20 +23455,20 @@ public class KBArticlePersistenceImpl
 
 		sb.append(_FILTER_SQL_COUNT_KBARTICLE_WHERE);
 
-		sb.append(_FINDER_COLUMN_G_ERC_ST_GROUPID_2);
+		sb.append(_FINDER_COLUMN_G_ERC_S_GROUPID_2);
 
 		boolean bindExternalReferenceCode = false;
 
 		if (externalReferenceCode.isEmpty()) {
-			sb.append(_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_3);
+			sb.append(_FINDER_COLUMN_G_ERC_S_EXTERNALREFERENCECODE_3);
 		}
 		else {
 			bindExternalReferenceCode = true;
 
-			sb.append(_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_2);
+			sb.append(_FINDER_COLUMN_G_ERC_S_EXTERNALREFERENCECODE_2);
 		}
 
-		sb.append(_FINDER_COLUMN_G_ERC_ST_STATUS_2);
+		sb.append(_FINDER_COLUMN_G_ERC_S_STATUS_2);
 
 		String sql = InlineSQLHelperUtil.replacePermissionCheck(
 			sb.toString(), KBArticle.class.getName(),
@@ -23487,18 +23506,16 @@ public class KBArticlePersistenceImpl
 		}
 	}
 
-	private static final String _FINDER_COLUMN_G_ERC_ST_GROUPID_2 =
+	private static final String _FINDER_COLUMN_G_ERC_S_GROUPID_2 =
 		"kbArticle.groupId = ? AND ";
 
-	private static final String
-		_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_2 =
-			"kbArticle.externalReferenceCode = ? AND ";
+	private static final String _FINDER_COLUMN_G_ERC_S_EXTERNALREFERENCECODE_2 =
+		"kbArticle.externalReferenceCode = ? AND ";
 
-	private static final String
-		_FINDER_COLUMN_G_ERC_ST_EXTERNALREFERENCECODE_3 =
-			"(kbArticle.externalReferenceCode IS NULL OR kbArticle.externalReferenceCode = '') AND ";
+	private static final String _FINDER_COLUMN_G_ERC_S_EXTERNALREFERENCECODE_3 =
+		"(kbArticle.externalReferenceCode IS NULL OR kbArticle.externalReferenceCode = '') AND ";
 
-	private static final String _FINDER_COLUMN_G_ERC_ST_STATUS_2 =
+	private static final String _FINDER_COLUMN_G_ERC_S_STATUS_2 =
 		"kbArticle.status = ?";
 
 	private FinderPath _finderPathWithPaginationFindByG_P_L;
@@ -51821,10 +51838,10 @@ public class KBArticlePersistenceImpl
 	private static final String _FINDER_COLUMN_G_P_M_NOTS_STATUS_2 =
 		"kbArticle.status != ?";
 
-	private FinderPath _finderPathWithPaginationFindByG_KBFI_UT_ST;
-	private FinderPath _finderPathWithoutPaginationFindByG_KBFI_UT_ST;
-	private FinderPath _finderPathCountByG_KBFI_UT_ST;
-	private FinderPath _finderPathWithPaginationCountByG_KBFI_UT_ST;
+	private FinderPath _finderPathWithPaginationFindByG_KBFI_UT_S;
+	private FinderPath _finderPathWithoutPaginationFindByG_KBFI_UT_S;
+	private FinderPath _finderPathCountByG_KBFI_UT_S;
+	private FinderPath _finderPathWithPaginationCountByG_KBFI_UT_S;
 
 	/**
 	 * Returns all the kb articles where groupId = &#63; and kbFolderId = &#63; and urlTitle = &#63; and status = &#63;.
@@ -51836,10 +51853,10 @@ public class KBArticlePersistenceImpl
 	 * @return the matching kb articles
 	 */
 	@Override
-	public List<KBArticle> findByG_KBFI_UT_ST(
+	public List<KBArticle> findByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status) {
 
-		return findByG_KBFI_UT_ST(
+		return findByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, status, QueryUtil.ALL_POS,
 			QueryUtil.ALL_POS, null);
 	}
@@ -51860,11 +51877,11 @@ public class KBArticlePersistenceImpl
 	 * @return the range of matching kb articles
 	 */
 	@Override
-	public List<KBArticle> findByG_KBFI_UT_ST(
+	public List<KBArticle> findByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status, int start,
 		int end) {
 
-		return findByG_KBFI_UT_ST(
+		return findByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, status, start, end, null);
 	}
 
@@ -51885,11 +51902,11 @@ public class KBArticlePersistenceImpl
 	 * @return the ordered range of matching kb articles
 	 */
 	@Override
-	public List<KBArticle> findByG_KBFI_UT_ST(
+	public List<KBArticle> findByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status, int start,
 		int end, OrderByComparator<KBArticle> orderByComparator) {
 
-		return findByG_KBFI_UT_ST(
+		return findByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, status, start, end,
 			orderByComparator, true);
 	}
@@ -51912,7 +51929,7 @@ public class KBArticlePersistenceImpl
 	 * @return the ordered range of matching kb articles
 	 */
 	@Override
-	public List<KBArticle> findByG_KBFI_UT_ST(
+	public List<KBArticle> findByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status, int start,
 		int end, OrderByComparator<KBArticle> orderByComparator,
 		boolean useFinderCache) {
@@ -51930,14 +51947,14 @@ public class KBArticlePersistenceImpl
 				(orderByComparator == null)) {
 
 				if (useFinderCache) {
-					finderPath = _finderPathWithoutPaginationFindByG_KBFI_UT_ST;
+					finderPath = _finderPathWithoutPaginationFindByG_KBFI_UT_S;
 					finderArgs = new Object[] {
 						groupId, kbFolderId, urlTitle, status
 					};
 				}
 			}
 			else if (useFinderCache) {
-				finderPath = _finderPathWithPaginationFindByG_KBFI_UT_ST;
+				finderPath = _finderPathWithPaginationFindByG_KBFI_UT_S;
 				finderArgs = new Object[] {
 					groupId, kbFolderId, urlTitle, status, start, end,
 					orderByComparator
@@ -51978,22 +51995,22 @@ public class KBArticlePersistenceImpl
 
 				sb.append(_SQL_SELECT_KBARTICLE_WHERE);
 
-				sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_GROUPID_2);
+				sb.append(_FINDER_COLUMN_G_KBFI_UT_S_GROUPID_2);
 
-				sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_KBFOLDERID_2);
+				sb.append(_FINDER_COLUMN_G_KBFI_UT_S_KBFOLDERID_2);
 
 				boolean bindUrlTitle = false;
 
 				if (urlTitle.isEmpty()) {
-					sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_URLTITLE_3);
+					sb.append(_FINDER_COLUMN_G_KBFI_UT_S_URLTITLE_3);
 				}
 				else {
 					bindUrlTitle = true;
 
-					sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_URLTITLE_2);
+					sb.append(_FINDER_COLUMN_G_KBFI_UT_S_URLTITLE_2);
 				}
 
-				sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_STATUS_2);
+				sb.append(_FINDER_COLUMN_G_KBFI_UT_S_STATUS_2);
 
 				if (orderByComparator != null) {
 					appendOrderByComparator(
@@ -52057,12 +52074,12 @@ public class KBArticlePersistenceImpl
 	 * @throws NoSuchArticleException if a matching kb article could not be found
 	 */
 	@Override
-	public KBArticle findByG_KBFI_UT_ST_First(
+	public KBArticle findByG_KBFI_UT_S_First(
 			long groupId, long kbFolderId, String urlTitle, int status,
 			OrderByComparator<KBArticle> orderByComparator)
 		throws NoSuchArticleException {
 
-		KBArticle kbArticle = fetchByG_KBFI_UT_ST_First(
+		KBArticle kbArticle = fetchByG_KBFI_UT_S_First(
 			groupId, kbFolderId, urlTitle, status, orderByComparator);
 
 		if (kbArticle != null) {
@@ -52101,11 +52118,11 @@ public class KBArticlePersistenceImpl
 	 * @return the first matching kb article, or <code>null</code> if a matching kb article could not be found
 	 */
 	@Override
-	public KBArticle fetchByG_KBFI_UT_ST_First(
+	public KBArticle fetchByG_KBFI_UT_S_First(
 		long groupId, long kbFolderId, String urlTitle, int status,
 		OrderByComparator<KBArticle> orderByComparator) {
 
-		List<KBArticle> list = findByG_KBFI_UT_ST(
+		List<KBArticle> list = findByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, status, 0, 1, orderByComparator);
 
 		if (!list.isEmpty()) {
@@ -52127,12 +52144,12 @@ public class KBArticlePersistenceImpl
 	 * @throws NoSuchArticleException if a matching kb article could not be found
 	 */
 	@Override
-	public KBArticle findByG_KBFI_UT_ST_Last(
+	public KBArticle findByG_KBFI_UT_S_Last(
 			long groupId, long kbFolderId, String urlTitle, int status,
 			OrderByComparator<KBArticle> orderByComparator)
 		throws NoSuchArticleException {
 
-		KBArticle kbArticle = fetchByG_KBFI_UT_ST_Last(
+		KBArticle kbArticle = fetchByG_KBFI_UT_S_Last(
 			groupId, kbFolderId, urlTitle, status, orderByComparator);
 
 		if (kbArticle != null) {
@@ -52171,17 +52188,17 @@ public class KBArticlePersistenceImpl
 	 * @return the last matching kb article, or <code>null</code> if a matching kb article could not be found
 	 */
 	@Override
-	public KBArticle fetchByG_KBFI_UT_ST_Last(
+	public KBArticle fetchByG_KBFI_UT_S_Last(
 		long groupId, long kbFolderId, String urlTitle, int status,
 		OrderByComparator<KBArticle> orderByComparator) {
 
-		int count = countByG_KBFI_UT_ST(groupId, kbFolderId, urlTitle, status);
+		int count = countByG_KBFI_UT_S(groupId, kbFolderId, urlTitle, status);
 
 		if (count == 0) {
 			return null;
 		}
 
-		List<KBArticle> list = findByG_KBFI_UT_ST(
+		List<KBArticle> list = findByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, status, count - 1, count,
 			orderByComparator);
 
@@ -52205,7 +52222,7 @@ public class KBArticlePersistenceImpl
 	 * @throws NoSuchArticleException if a kb article with the primary key could not be found
 	 */
 	@Override
-	public KBArticle[] findByG_KBFI_UT_ST_PrevAndNext(
+	public KBArticle[] findByG_KBFI_UT_S_PrevAndNext(
 			long kbArticleId, long groupId, long kbFolderId, String urlTitle,
 			int status, OrderByComparator<KBArticle> orderByComparator)
 		throws NoSuchArticleException {
@@ -52221,13 +52238,13 @@ public class KBArticlePersistenceImpl
 
 			KBArticle[] array = new KBArticleImpl[3];
 
-			array[0] = getByG_KBFI_UT_ST_PrevAndNext(
+			array[0] = getByG_KBFI_UT_S_PrevAndNext(
 				session, kbArticle, groupId, kbFolderId, urlTitle, status,
 				orderByComparator, true);
 
 			array[1] = kbArticle;
 
-			array[2] = getByG_KBFI_UT_ST_PrevAndNext(
+			array[2] = getByG_KBFI_UT_S_PrevAndNext(
 				session, kbArticle, groupId, kbFolderId, urlTitle, status,
 				orderByComparator, false);
 
@@ -52241,7 +52258,7 @@ public class KBArticlePersistenceImpl
 		}
 	}
 
-	protected KBArticle getByG_KBFI_UT_ST_PrevAndNext(
+	protected KBArticle getByG_KBFI_UT_S_PrevAndNext(
 		Session session, KBArticle kbArticle, long groupId, long kbFolderId,
 		String urlTitle, int status,
 		OrderByComparator<KBArticle> orderByComparator, boolean previous) {
@@ -52259,22 +52276,22 @@ public class KBArticlePersistenceImpl
 
 		sb.append(_SQL_SELECT_KBARTICLE_WHERE);
 
-		sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_GROUPID_2);
+		sb.append(_FINDER_COLUMN_G_KBFI_UT_S_GROUPID_2);
 
-		sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_KBFOLDERID_2);
+		sb.append(_FINDER_COLUMN_G_KBFI_UT_S_KBFOLDERID_2);
 
 		boolean bindUrlTitle = false;
 
 		if (urlTitle.isEmpty()) {
-			sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_URLTITLE_3);
+			sb.append(_FINDER_COLUMN_G_KBFI_UT_S_URLTITLE_3);
 		}
 		else {
 			bindUrlTitle = true;
 
-			sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_URLTITLE_2);
+			sb.append(_FINDER_COLUMN_G_KBFI_UT_S_URLTITLE_2);
 		}
 
-		sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_STATUS_2);
+		sb.append(_FINDER_COLUMN_G_KBFI_UT_S_STATUS_2);
 
 		if (orderByComparator != null) {
 			String[] orderByConditionFields =
@@ -52383,10 +52400,10 @@ public class KBArticlePersistenceImpl
 	 * @return the matching kb articles that the user has permission to view
 	 */
 	@Override
-	public List<KBArticle> filterFindByG_KBFI_UT_ST(
+	public List<KBArticle> filterFindByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status) {
 
-		return filterFindByG_KBFI_UT_ST(
+		return filterFindByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, status, QueryUtil.ALL_POS,
 			QueryUtil.ALL_POS, null);
 	}
@@ -52407,11 +52424,11 @@ public class KBArticlePersistenceImpl
 	 * @return the range of matching kb articles that the user has permission to view
 	 */
 	@Override
-	public List<KBArticle> filterFindByG_KBFI_UT_ST(
+	public List<KBArticle> filterFindByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status, int start,
 		int end) {
 
-		return filterFindByG_KBFI_UT_ST(
+		return filterFindByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, status, start, end, null);
 	}
 
@@ -52432,12 +52449,12 @@ public class KBArticlePersistenceImpl
 	 * @return the ordered range of matching kb articles that the user has permission to view
 	 */
 	@Override
-	public List<KBArticle> filterFindByG_KBFI_UT_ST(
+	public List<KBArticle> filterFindByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status, int start,
 		int end, OrderByComparator<KBArticle> orderByComparator) {
 
 		if (!InlineSQLHelperUtil.isEnabled(groupId)) {
-			return findByG_KBFI_UT_ST(
+			return findByG_KBFI_UT_S(
 				groupId, kbFolderId, urlTitle, status, start, end,
 				orderByComparator);
 		}
@@ -52446,7 +52463,7 @@ public class KBArticlePersistenceImpl
 			isPermissionsInMemoryFilterEnabled()) {
 
 			return InlineSQLHelperUtil.filter(
-				findByG_KBFI_UT_ST(
+				findByG_KBFI_UT_S(
 					groupId, kbFolderId, urlTitle, status, QueryUtil.ALL_POS,
 					QueryUtil.ALL_POS, orderByComparator),
 				groupId);
@@ -52471,22 +52488,22 @@ public class KBArticlePersistenceImpl
 			sb.append(_FILTER_SQL_SELECT_KBARTICLE_NO_INLINE_DISTINCT_WHERE_1);
 		}
 
-		sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_GROUPID_2);
+		sb.append(_FINDER_COLUMN_G_KBFI_UT_S_GROUPID_2);
 
-		sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_KBFOLDERID_2);
+		sb.append(_FINDER_COLUMN_G_KBFI_UT_S_KBFOLDERID_2);
 
 		boolean bindUrlTitle = false;
 
 		if (urlTitle.isEmpty()) {
-			sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_URLTITLE_3);
+			sb.append(_FINDER_COLUMN_G_KBFI_UT_S_URLTITLE_3);
 		}
 		else {
 			bindUrlTitle = true;
 
-			sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_URLTITLE_2);
+			sb.append(_FINDER_COLUMN_G_KBFI_UT_S_URLTITLE_2);
 		}
 
-		sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_STATUS_2);
+		sb.append(_FINDER_COLUMN_G_KBFI_UT_S_STATUS_2);
 
 		if (!getDB().isSupportsInlineDistinct()) {
 			sb.append(_FILTER_SQL_SELECT_KBARTICLE_NO_INLINE_DISTINCT_WHERE_2);
@@ -52565,13 +52582,13 @@ public class KBArticlePersistenceImpl
 	 * @throws NoSuchArticleException if a kb article with the primary key could not be found
 	 */
 	@Override
-	public KBArticle[] filterFindByG_KBFI_UT_ST_PrevAndNext(
+	public KBArticle[] filterFindByG_KBFI_UT_S_PrevAndNext(
 			long kbArticleId, long groupId, long kbFolderId, String urlTitle,
 			int status, OrderByComparator<KBArticle> orderByComparator)
 		throws NoSuchArticleException {
 
 		if (!InlineSQLHelperUtil.isEnabled(groupId)) {
-			return findByG_KBFI_UT_ST_PrevAndNext(
+			return findByG_KBFI_UT_S_PrevAndNext(
 				kbArticleId, groupId, kbFolderId, urlTitle, status,
 				orderByComparator);
 		}
@@ -52587,13 +52604,13 @@ public class KBArticlePersistenceImpl
 
 			KBArticle[] array = new KBArticleImpl[3];
 
-			array[0] = filterGetByG_KBFI_UT_ST_PrevAndNext(
+			array[0] = filterGetByG_KBFI_UT_S_PrevAndNext(
 				session, kbArticle, groupId, kbFolderId, urlTitle, status,
 				orderByComparator, true);
 
 			array[1] = kbArticle;
 
-			array[2] = filterGetByG_KBFI_UT_ST_PrevAndNext(
+			array[2] = filterGetByG_KBFI_UT_S_PrevAndNext(
 				session, kbArticle, groupId, kbFolderId, urlTitle, status,
 				orderByComparator, false);
 
@@ -52607,7 +52624,7 @@ public class KBArticlePersistenceImpl
 		}
 	}
 
-	protected KBArticle filterGetByG_KBFI_UT_ST_PrevAndNext(
+	protected KBArticle filterGetByG_KBFI_UT_S_PrevAndNext(
 		Session session, KBArticle kbArticle, long groupId, long kbFolderId,
 		String urlTitle, int status,
 		OrderByComparator<KBArticle> orderByComparator, boolean previous) {
@@ -52630,22 +52647,22 @@ public class KBArticlePersistenceImpl
 			sb.append(_FILTER_SQL_SELECT_KBARTICLE_NO_INLINE_DISTINCT_WHERE_1);
 		}
 
-		sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_GROUPID_2);
+		sb.append(_FINDER_COLUMN_G_KBFI_UT_S_GROUPID_2);
 
-		sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_KBFOLDERID_2);
+		sb.append(_FINDER_COLUMN_G_KBFI_UT_S_KBFOLDERID_2);
 
 		boolean bindUrlTitle = false;
 
 		if (urlTitle.isEmpty()) {
-			sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_URLTITLE_3);
+			sb.append(_FINDER_COLUMN_G_KBFI_UT_S_URLTITLE_3);
 		}
 		else {
 			bindUrlTitle = true;
 
-			sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_URLTITLE_2);
+			sb.append(_FINDER_COLUMN_G_KBFI_UT_S_URLTITLE_2);
 		}
 
-		sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_STATUS_2);
+		sb.append(_FINDER_COLUMN_G_KBFI_UT_S_STATUS_2);
 
 		if (!getDB().isSupportsInlineDistinct()) {
 			sb.append(_FILTER_SQL_SELECT_KBARTICLE_NO_INLINE_DISTINCT_WHERE_2);
@@ -52790,10 +52807,10 @@ public class KBArticlePersistenceImpl
 	 * @return the matching kb articles that the user has permission to view
 	 */
 	@Override
-	public List<KBArticle> filterFindByG_KBFI_UT_ST(
+	public List<KBArticle> filterFindByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses) {
 
-		return filterFindByG_KBFI_UT_ST(
+		return filterFindByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, statuses, QueryUtil.ALL_POS,
 			QueryUtil.ALL_POS, null);
 	}
@@ -52814,11 +52831,11 @@ public class KBArticlePersistenceImpl
 	 * @return the range of matching kb articles that the user has permission to view
 	 */
 	@Override
-	public List<KBArticle> filterFindByG_KBFI_UT_ST(
+	public List<KBArticle> filterFindByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses,
 		int start, int end) {
 
-		return filterFindByG_KBFI_UT_ST(
+		return filterFindByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, statuses, start, end, null);
 	}
 
@@ -52839,12 +52856,12 @@ public class KBArticlePersistenceImpl
 	 * @return the ordered range of matching kb articles that the user has permission to view
 	 */
 	@Override
-	public List<KBArticle> filterFindByG_KBFI_UT_ST(
+	public List<KBArticle> filterFindByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses,
 		int start, int end, OrderByComparator<KBArticle> orderByComparator) {
 
 		if (!InlineSQLHelperUtil.isEnabled(groupId)) {
-			return findByG_KBFI_UT_ST(
+			return findByG_KBFI_UT_S(
 				groupId, kbFolderId, urlTitle, statuses, start, end,
 				orderByComparator);
 		}
@@ -52853,7 +52870,7 @@ public class KBArticlePersistenceImpl
 			isPermissionsInMemoryFilterEnabled()) {
 
 			return InlineSQLHelperUtil.filter(
-				findByG_KBFI_UT_ST(
+				findByG_KBFI_UT_S(
 					groupId, kbFolderId, urlTitle, statuses, QueryUtil.ALL_POS,
 					QueryUtil.ALL_POS, orderByComparator),
 				groupId);
@@ -52877,25 +52894,25 @@ public class KBArticlePersistenceImpl
 			sb.append(_FILTER_SQL_SELECT_KBARTICLE_NO_INLINE_DISTINCT_WHERE_1);
 		}
 
-		sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_GROUPID_2);
+		sb.append(_FINDER_COLUMN_G_KBFI_UT_S_GROUPID_2);
 
-		sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_KBFOLDERID_2);
+		sb.append(_FINDER_COLUMN_G_KBFI_UT_S_KBFOLDERID_2);
 
 		boolean bindUrlTitle = false;
 
 		if (urlTitle.isEmpty()) {
-			sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_URLTITLE_3);
+			sb.append(_FINDER_COLUMN_G_KBFI_UT_S_URLTITLE_3);
 		}
 		else {
 			bindUrlTitle = true;
 
-			sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_URLTITLE_2);
+			sb.append(_FINDER_COLUMN_G_KBFI_UT_S_URLTITLE_2);
 		}
 
 		if (statuses.length > 0) {
 			sb.append("(");
 
-			sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_STATUS_7);
+			sb.append(_FINDER_COLUMN_G_KBFI_UT_S_STATUS_7);
 
 			sb.append(StringUtil.merge(statuses));
 
@@ -52983,10 +53000,10 @@ public class KBArticlePersistenceImpl
 	 * @return the matching kb articles
 	 */
 	@Override
-	public List<KBArticle> findByG_KBFI_UT_ST(
+	public List<KBArticle> findByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses) {
 
-		return findByG_KBFI_UT_ST(
+		return findByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, statuses, QueryUtil.ALL_POS,
 			QueryUtil.ALL_POS, null);
 	}
@@ -53007,11 +53024,11 @@ public class KBArticlePersistenceImpl
 	 * @return the range of matching kb articles
 	 */
 	@Override
-	public List<KBArticle> findByG_KBFI_UT_ST(
+	public List<KBArticle> findByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses,
 		int start, int end) {
 
-		return findByG_KBFI_UT_ST(
+		return findByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, statuses, start, end, null);
 	}
 
@@ -53032,11 +53049,11 @@ public class KBArticlePersistenceImpl
 	 * @return the ordered range of matching kb articles
 	 */
 	@Override
-	public List<KBArticle> findByG_KBFI_UT_ST(
+	public List<KBArticle> findByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses,
 		int start, int end, OrderByComparator<KBArticle> orderByComparator) {
 
-		return findByG_KBFI_UT_ST(
+		return findByG_KBFI_UT_S(
 			groupId, kbFolderId, urlTitle, statuses, start, end,
 			orderByComparator, true);
 	}
@@ -53059,7 +53076,7 @@ public class KBArticlePersistenceImpl
 	 * @return the ordered range of matching kb articles
 	 */
 	@Override
-	public List<KBArticle> findByG_KBFI_UT_ST(
+	public List<KBArticle> findByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses,
 		int start, int end, OrderByComparator<KBArticle> orderByComparator,
 		boolean useFinderCache) {
@@ -53074,7 +53091,7 @@ public class KBArticlePersistenceImpl
 		}
 
 		if (statuses.length == 1) {
-			return findByG_KBFI_UT_ST(
+			return findByG_KBFI_UT_S(
 				groupId, kbFolderId, urlTitle, statuses[0], start, end,
 				orderByComparator);
 		}
@@ -53106,7 +53123,7 @@ public class KBArticlePersistenceImpl
 
 			if (useFinderCache) {
 				list = (List<KBArticle>)finderCache.getResult(
-					_finderPathWithPaginationFindByG_KBFI_UT_ST, finderArgs,
+					_finderPathWithPaginationFindByG_KBFI_UT_S, finderArgs,
 					this);
 
 				if ((list != null) && !list.isEmpty()) {
@@ -53130,25 +53147,25 @@ public class KBArticlePersistenceImpl
 
 				sb.append(_SQL_SELECT_KBARTICLE_WHERE);
 
-				sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_GROUPID_2);
+				sb.append(_FINDER_COLUMN_G_KBFI_UT_S_GROUPID_2);
 
-				sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_KBFOLDERID_2);
+				sb.append(_FINDER_COLUMN_G_KBFI_UT_S_KBFOLDERID_2);
 
 				boolean bindUrlTitle = false;
 
 				if (urlTitle.isEmpty()) {
-					sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_URLTITLE_3);
+					sb.append(_FINDER_COLUMN_G_KBFI_UT_S_URLTITLE_3);
 				}
 				else {
 					bindUrlTitle = true;
 
-					sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_URLTITLE_2);
+					sb.append(_FINDER_COLUMN_G_KBFI_UT_S_URLTITLE_2);
 				}
 
 				if (statuses.length > 0) {
 					sb.append("(");
 
-					sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_STATUS_7);
+					sb.append(_FINDER_COLUMN_G_KBFI_UT_S_STATUS_7);
 
 					sb.append(StringUtil.merge(statuses));
 
@@ -53195,7 +53212,7 @@ public class KBArticlePersistenceImpl
 
 					if (useFinderCache) {
 						finderCache.putResult(
-							_finderPathWithPaginationFindByG_KBFI_UT_ST,
+							_finderPathWithPaginationFindByG_KBFI_UT_S,
 							finderArgs, list);
 					}
 				}
@@ -53220,11 +53237,11 @@ public class KBArticlePersistenceImpl
 	 * @param status the status
 	 */
 	@Override
-	public void removeByG_KBFI_UT_ST(
+	public void removeByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status) {
 
 		for (KBArticle kbArticle :
-				findByG_KBFI_UT_ST(
+				findByG_KBFI_UT_S(
 					groupId, kbFolderId, urlTitle, status, QueryUtil.ALL_POS,
 					QueryUtil.ALL_POS, null)) {
 
@@ -53242,7 +53259,7 @@ public class KBArticlePersistenceImpl
 	 * @return the number of matching kb articles
 	 */
 	@Override
-	public int countByG_KBFI_UT_ST(
+	public int countByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status) {
 
 		try (SafeCloseable safeCloseable =
@@ -53251,7 +53268,7 @@ public class KBArticlePersistenceImpl
 
 			urlTitle = Objects.toString(urlTitle, "");
 
-			FinderPath finderPath = _finderPathCountByG_KBFI_UT_ST;
+			FinderPath finderPath = _finderPathCountByG_KBFI_UT_S;
 
 			Object[] finderArgs = new Object[] {
 				groupId, kbFolderId, urlTitle, status
@@ -53265,22 +53282,22 @@ public class KBArticlePersistenceImpl
 
 				sb.append(_SQL_COUNT_KBARTICLE_WHERE);
 
-				sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_GROUPID_2);
+				sb.append(_FINDER_COLUMN_G_KBFI_UT_S_GROUPID_2);
 
-				sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_KBFOLDERID_2);
+				sb.append(_FINDER_COLUMN_G_KBFI_UT_S_KBFOLDERID_2);
 
 				boolean bindUrlTitle = false;
 
 				if (urlTitle.isEmpty()) {
-					sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_URLTITLE_3);
+					sb.append(_FINDER_COLUMN_G_KBFI_UT_S_URLTITLE_3);
 				}
 				else {
 					bindUrlTitle = true;
 
-					sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_URLTITLE_2);
+					sb.append(_FINDER_COLUMN_G_KBFI_UT_S_URLTITLE_2);
 				}
 
-				sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_STATUS_2);
+				sb.append(_FINDER_COLUMN_G_KBFI_UT_S_STATUS_2);
 
 				String sql = sb.toString();
 
@@ -53329,7 +53346,7 @@ public class KBArticlePersistenceImpl
 	 * @return the number of matching kb articles
 	 */
 	@Override
-	public int countByG_KBFI_UT_ST(
+	public int countByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses) {
 
 		urlTitle = Objects.toString(urlTitle, "");
@@ -53350,32 +53367,32 @@ public class KBArticlePersistenceImpl
 			};
 
 			Long count = (Long)finderCache.getResult(
-				_finderPathWithPaginationCountByG_KBFI_UT_ST, finderArgs, this);
+				_finderPathWithPaginationCountByG_KBFI_UT_S, finderArgs, this);
 
 			if (count == null) {
 				StringBundler sb = new StringBundler();
 
 				sb.append(_SQL_COUNT_KBARTICLE_WHERE);
 
-				sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_GROUPID_2);
+				sb.append(_FINDER_COLUMN_G_KBFI_UT_S_GROUPID_2);
 
-				sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_KBFOLDERID_2);
+				sb.append(_FINDER_COLUMN_G_KBFI_UT_S_KBFOLDERID_2);
 
 				boolean bindUrlTitle = false;
 
 				if (urlTitle.isEmpty()) {
-					sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_URLTITLE_3);
+					sb.append(_FINDER_COLUMN_G_KBFI_UT_S_URLTITLE_3);
 				}
 				else {
 					bindUrlTitle = true;
 
-					sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_URLTITLE_2);
+					sb.append(_FINDER_COLUMN_G_KBFI_UT_S_URLTITLE_2);
 				}
 
 				if (statuses.length > 0) {
 					sb.append("(");
 
-					sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_STATUS_7);
+					sb.append(_FINDER_COLUMN_G_KBFI_UT_S_STATUS_7);
 
 					sb.append(StringUtil.merge(statuses));
 
@@ -53410,8 +53427,8 @@ public class KBArticlePersistenceImpl
 					count = (Long)query.uniqueResult();
 
 					finderCache.putResult(
-						_finderPathWithPaginationCountByG_KBFI_UT_ST,
-						finderArgs, count);
+						_finderPathWithPaginationCountByG_KBFI_UT_S, finderArgs,
+						count);
 				}
 				catch (Exception exception) {
 					throw processException(exception);
@@ -53435,15 +53452,15 @@ public class KBArticlePersistenceImpl
 	 * @return the number of matching kb articles that the user has permission to view
 	 */
 	@Override
-	public int filterCountByG_KBFI_UT_ST(
+	public int filterCountByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int status) {
 
 		if (!InlineSQLHelperUtil.isEnabled(groupId)) {
-			return countByG_KBFI_UT_ST(groupId, kbFolderId, urlTitle, status);
+			return countByG_KBFI_UT_S(groupId, kbFolderId, urlTitle, status);
 		}
 
 		if (isPermissionsInMemoryFilterEnabled()) {
-			List<KBArticle> kbArticles = findByG_KBFI_UT_ST(
+			List<KBArticle> kbArticles = findByG_KBFI_UT_S(
 				groupId, kbFolderId, urlTitle, status);
 
 			kbArticles = InlineSQLHelperUtil.filter(kbArticles, groupId);
@@ -53457,22 +53474,22 @@ public class KBArticlePersistenceImpl
 
 		sb.append(_FILTER_SQL_COUNT_KBARTICLE_WHERE);
 
-		sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_GROUPID_2);
+		sb.append(_FINDER_COLUMN_G_KBFI_UT_S_GROUPID_2);
 
-		sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_KBFOLDERID_2);
+		sb.append(_FINDER_COLUMN_G_KBFI_UT_S_KBFOLDERID_2);
 
 		boolean bindUrlTitle = false;
 
 		if (urlTitle.isEmpty()) {
-			sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_URLTITLE_3);
+			sb.append(_FINDER_COLUMN_G_KBFI_UT_S_URLTITLE_3);
 		}
 		else {
 			bindUrlTitle = true;
 
-			sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_URLTITLE_2);
+			sb.append(_FINDER_COLUMN_G_KBFI_UT_S_URLTITLE_2);
 		}
 
-		sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_STATUS_2);
+		sb.append(_FINDER_COLUMN_G_KBFI_UT_S_STATUS_2);
 
 		String sql = InlineSQLHelperUtil.replacePermissionCheck(
 			sb.toString(), KBArticle.class.getName(),
@@ -53522,16 +53539,16 @@ public class KBArticlePersistenceImpl
 	 * @return the number of matching kb articles that the user has permission to view
 	 */
 	@Override
-	public int filterCountByG_KBFI_UT_ST(
+	public int filterCountByG_KBFI_UT_S(
 		long groupId, long kbFolderId, String urlTitle, int[] statuses) {
 
 		if (!InlineSQLHelperUtil.isEnabled(groupId)) {
-			return countByG_KBFI_UT_ST(groupId, kbFolderId, urlTitle, statuses);
+			return countByG_KBFI_UT_S(groupId, kbFolderId, urlTitle, statuses);
 		}
 
 		if (isPermissionsInMemoryFilterEnabled()) {
 			List<KBArticle> kbArticles = InlineSQLHelperUtil.filter(
-				findByG_KBFI_UT_ST(groupId, kbFolderId, urlTitle, statuses),
+				findByG_KBFI_UT_S(groupId, kbFolderId, urlTitle, statuses),
 				groupId);
 
 			return kbArticles.size();
@@ -53550,25 +53567,25 @@ public class KBArticlePersistenceImpl
 
 		sb.append(_FILTER_SQL_COUNT_KBARTICLE_WHERE);
 
-		sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_GROUPID_2);
+		sb.append(_FINDER_COLUMN_G_KBFI_UT_S_GROUPID_2);
 
-		sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_KBFOLDERID_2);
+		sb.append(_FINDER_COLUMN_G_KBFI_UT_S_KBFOLDERID_2);
 
 		boolean bindUrlTitle = false;
 
 		if (urlTitle.isEmpty()) {
-			sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_URLTITLE_3);
+			sb.append(_FINDER_COLUMN_G_KBFI_UT_S_URLTITLE_3);
 		}
 		else {
 			bindUrlTitle = true;
 
-			sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_URLTITLE_2);
+			sb.append(_FINDER_COLUMN_G_KBFI_UT_S_URLTITLE_2);
 		}
 
 		if (statuses.length > 0) {
 			sb.append("(");
 
-			sb.append(_FINDER_COLUMN_G_KBFI_UT_ST_STATUS_7);
+			sb.append(_FINDER_COLUMN_G_KBFI_UT_S_STATUS_7);
 
 			sb.append(StringUtil.merge(statuses));
 
@@ -53616,22 +53633,22 @@ public class KBArticlePersistenceImpl
 		}
 	}
 
-	private static final String _FINDER_COLUMN_G_KBFI_UT_ST_GROUPID_2 =
+	private static final String _FINDER_COLUMN_G_KBFI_UT_S_GROUPID_2 =
 		"kbArticle.groupId = ? AND ";
 
-	private static final String _FINDER_COLUMN_G_KBFI_UT_ST_KBFOLDERID_2 =
+	private static final String _FINDER_COLUMN_G_KBFI_UT_S_KBFOLDERID_2 =
 		"kbArticle.kbFolderId = ? AND ";
 
-	private static final String _FINDER_COLUMN_G_KBFI_UT_ST_URLTITLE_2 =
+	private static final String _FINDER_COLUMN_G_KBFI_UT_S_URLTITLE_2 =
 		"kbArticle.urlTitle = ? AND ";
 
-	private static final String _FINDER_COLUMN_G_KBFI_UT_ST_URLTITLE_3 =
+	private static final String _FINDER_COLUMN_G_KBFI_UT_S_URLTITLE_3 =
 		"(kbArticle.urlTitle IS NULL OR kbArticle.urlTitle = '') AND ";
 
-	private static final String _FINDER_COLUMN_G_KBFI_UT_ST_STATUS_2 =
+	private static final String _FINDER_COLUMN_G_KBFI_UT_S_STATUS_2 =
 		"kbArticle.status = ?";
 
-	private static final String _FINDER_COLUMN_G_KBFI_UT_ST_STATUS_7 =
+	private static final String _FINDER_COLUMN_G_KBFI_UT_S_STATUS_7 =
 		"kbArticle.status IN (";
 
 	private FinderPath _finderPathWithPaginationFindByG_KBFI_UT_NotS;
@@ -61055,8 +61072,8 @@ public class KBArticlePersistenceImpl
 			},
 			new String[] {"groupId", "externalReferenceCode", "version"}, true);
 
-		_finderPathWithPaginationFindByG_ERC_ST = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_ERC_ST",
+		_finderPathWithPaginationFindByG_ERC_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_ERC_S",
 			new String[] {
 				Long.class.getName(), String.class.getName(),
 				Integer.class.getName(), Integer.class.getName(),
@@ -61064,16 +61081,16 @@ public class KBArticlePersistenceImpl
 			},
 			new String[] {"groupId", "externalReferenceCode", "status"}, true);
 
-		_finderPathWithoutPaginationFindByG_ERC_ST = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_ERC_ST",
+		_finderPathWithoutPaginationFindByG_ERC_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_ERC_S",
 			new String[] {
 				Long.class.getName(), String.class.getName(),
 				Integer.class.getName()
 			},
 			new String[] {"groupId", "externalReferenceCode", "status"}, true);
 
-		_finderPathCountByG_ERC_ST = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_ERC_ST",
+		_finderPathCountByG_ERC_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_ERC_S",
 			new String[] {
 				Long.class.getName(), String.class.getName(),
 				Integer.class.getName()
@@ -61575,8 +61592,8 @@ public class KBArticlePersistenceImpl
 			new String[] {"groupId", "parentResourcePrimKey", "main", "status"},
 			false);
 
-		_finderPathWithPaginationFindByG_KBFI_UT_ST = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_KBFI_UT_ST",
+		_finderPathWithPaginationFindByG_KBFI_UT_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_KBFI_UT_S",
 			new String[] {
 				Long.class.getName(), Long.class.getName(),
 				String.class.getName(), Integer.class.getName(),
@@ -61585,16 +61602,16 @@ public class KBArticlePersistenceImpl
 			},
 			new String[] {"groupId", "kbFolderId", "urlTitle", "status"}, true);
 
-		_finderPathWithoutPaginationFindByG_KBFI_UT_ST = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_KBFI_UT_ST",
+		_finderPathWithoutPaginationFindByG_KBFI_UT_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_KBFI_UT_S",
 			new String[] {
 				Long.class.getName(), Long.class.getName(),
 				String.class.getName(), Integer.class.getName()
 			},
 			new String[] {"groupId", "kbFolderId", "urlTitle", "status"}, true);
 
-		_finderPathCountByG_KBFI_UT_ST = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_KBFI_UT_ST",
+		_finderPathCountByG_KBFI_UT_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_KBFI_UT_S",
 			new String[] {
 				Long.class.getName(), Long.class.getName(),
 				String.class.getName(), Integer.class.getName()
@@ -61602,8 +61619,8 @@ public class KBArticlePersistenceImpl
 			new String[] {"groupId", "kbFolderId", "urlTitle", "status"},
 			false);
 
-		_finderPathWithPaginationCountByG_KBFI_UT_ST = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByG_KBFI_UT_ST",
+		_finderPathWithPaginationCountByG_KBFI_UT_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByG_KBFI_UT_S",
 			new String[] {
 				Long.class.getName(), Long.class.getName(),
 				String.class.getName(), Integer.class.getName()

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/resources/META-INF/sql/indexes.sql
@@ -1,6 +1,6 @@
 create index IX_7E9C8FF8 on KBArticle (externalReferenceCode[$COLUMN_LENGTH:75$]);
+create unique index IX_E832E86E on KBArticle (groupId, ctCollectionId, externalReferenceCode[$COLUMN_LENGTH:75$], version);
 create unique index IX_8DC73951 on KBArticle (groupId, ctCollectionId, uuid_[$COLUMN_LENGTH:75$]);
-create unique index IX_1096F938 on KBArticle (groupId, ctCollectionId, version, externalReferenceCode[$COLUMN_LENGTH:75$]);
 create index IX_4A49CDD6 on KBArticle (groupId, kbFolderId, urlTitle[$COLUMN_LENGTH:75$]);
 create index IX_7B1749F4 on KBArticle (groupId, latest, kbFolderId);
 create index IX_E2460F71 on KBArticle (groupId, latest, parentResourcePrimKey);

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/resources/service.properties
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.knowledge.base.service
-    build.number=15
-    build.date=1423136031621
+    build.number=16
+    build.date=1755785459547

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBArticlePersistenceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBArticlePersistenceTest.java
@@ -585,6 +585,16 @@ public class KBArticlePersistenceTest {
 	}
 
 	@Test
+	public void testCountByG_ERC_ST() throws Exception {
+		_persistence.countByG_ERC_ST(
+			RandomTestUtil.nextLong(), "", RandomTestUtil.nextInt());
+
+		_persistence.countByG_ERC_ST(0L, "null", 0);
+
+		_persistence.countByG_ERC_ST(0L, (String)null, 0);
+	}
+
+	@Test
 	public void testCountByG_P_L() throws Exception {
 		_persistence.countByG_P_L(
 			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(),

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBArticlePersistenceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBArticlePersistenceTest.java
@@ -585,13 +585,13 @@ public class KBArticlePersistenceTest {
 	}
 
 	@Test
-	public void testCountByG_ERC_ST() throws Exception {
-		_persistence.countByG_ERC_ST(
+	public void testCountByG_ERC_S() throws Exception {
+		_persistence.countByG_ERC_S(
 			RandomTestUtil.nextLong(), "", RandomTestUtil.nextInt());
 
-		_persistence.countByG_ERC_ST(0L, "null", 0);
+		_persistence.countByG_ERC_S(0L, "null", 0);
 
-		_persistence.countByG_ERC_ST(0L, (String)null, 0);
+		_persistence.countByG_ERC_S(0L, (String)null, 0);
 	}
 
 	@Test
@@ -912,19 +912,19 @@ public class KBArticlePersistenceTest {
 	}
 
 	@Test
-	public void testCountByG_KBFI_UT_ST() throws Exception {
-		_persistence.countByG_KBFI_UT_ST(
+	public void testCountByG_KBFI_UT_S() throws Exception {
+		_persistence.countByG_KBFI_UT_S(
 			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(), "",
 			RandomTestUtil.nextInt());
 
-		_persistence.countByG_KBFI_UT_ST(0L, 0L, "null", 0);
+		_persistence.countByG_KBFI_UT_S(0L, 0L, "null", 0);
 
-		_persistence.countByG_KBFI_UT_ST(0L, 0L, (String)null, 0);
+		_persistence.countByG_KBFI_UT_S(0L, 0L, (String)null, 0);
 	}
 
 	@Test
-	public void testCountByG_KBFI_UT_STArrayable() throws Exception {
-		_persistence.countByG_KBFI_UT_ST(
+	public void testCountByG_KBFI_UT_SArrayable() throws Exception {
+		_persistence.countByG_KBFI_UT_S(
 			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(),
 			RandomTestUtil.randomString(),
 			new int[] {RandomTestUtil.nextInt(), 0});

--- a/modules/apps/knowledge-base/knowledge-base-web-test/src/testIntegration/java/com/liferay/knowledge/base/web/internal/info/item/provider/test/KBArticleInfoItemDetailsProviderTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-web-test/src/testIntegration/java/com/liferay/knowledge/base/web/internal/info/item/provider/test/KBArticleInfoItemDetailsProviderTest.java
@@ -1,0 +1,129 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.knowledge.base.web.internal.info.item.provider.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.info.item.ERCInfoItemIdentifier;
+import com.liferay.info.item.GroupKeyInfoItemIdentifier;
+import com.liferay.info.item.GroupUrlTitleInfoItemIdentifier;
+import com.liferay.info.item.InfoItemDetails;
+import com.liferay.info.item.InfoItemReference;
+import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.info.item.provider.InfoItemDetailsProvider;
+import com.liferay.knowledge.base.constants.KBFolderConstants;
+import com.liferay.knowledge.base.model.KBArticle;
+import com.liferay.knowledge.base.service.KBArticleLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Adolfo Pérez
+ */
+@RunWith(Arquillian.class)
+public class KBArticleInfoItemDetailsProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_kbArticle = _kbArticleLocalService.addKBArticle(
+			null, TestPropsValues.getUserId(),
+			_classNameLocalService.getClassNameId(
+				KBFolderConstants.getClassName()),
+			KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), StringUtil.randomString(), null, null,
+			new Date(), null, null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+	}
+
+	@Test
+	public void testGetInfoItemDetails() throws Exception {
+		InfoItemDetailsProvider<KBArticle> infoItemDetailsProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoItemDetailsProvider.class, KBArticle.class.getName());
+
+		InfoItemDetails classPKInfoItemDetails =
+			infoItemDetailsProvider.getInfoItemDetails(_kbArticle);
+
+		Assert.assertEquals(
+			KBArticle.class.getName(), classPKInfoItemDetails.getClassName());
+		Assert.assertEquals(
+			new InfoItemReference(
+				KBArticle.class.getName(), _kbArticle.getResourcePrimKey()),
+			classPKInfoItemDetails.getInfoItemReference());
+
+		InfoItemDetails ercInfoItemDetails =
+			infoItemDetailsProvider.getInfoItemDetails(
+				_group.getGroupId(), ERCInfoItemIdentifier.class, _kbArticle);
+
+		Assert.assertEquals(
+			new InfoItemReference(
+				KBArticle.class.getName(),
+				new ERCInfoItemIdentifier(
+					_kbArticle.getExternalReferenceCode())),
+			ercInfoItemDetails.getInfoItemReference());
+
+		InfoItemDetails randomGroupERCInfoItemDetails =
+			infoItemDetailsProvider.getInfoItemDetails(
+				RandomTestUtil.randomLong(), ERCInfoItemIdentifier.class,
+				_kbArticle);
+
+		Assert.assertEquals(
+			new InfoItemReference(
+				KBArticle.class.getName(),
+				new ERCInfoItemIdentifier(
+					_kbArticle.getExternalReferenceCode(),
+					_group.getExternalReferenceCode())),
+			randomGroupERCInfoItemDetails.getInfoItemReference());
+
+		Assert.assertNull(
+			infoItemDetailsProvider.getInfoItemDetails(
+				_group.getGroupId(), GroupKeyInfoItemIdentifier.class,
+				_kbArticle));
+		Assert.assertNull(
+			infoItemDetailsProvider.getInfoItemDetails(
+				_group.getGroupId(), GroupUrlTitleInfoItemIdentifier.class,
+				_kbArticle));
+	}
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private InfoItemServiceRegistry _infoItemServiceRegistry;
+
+	private KBArticle _kbArticle;
+
+	@Inject
+	private KBArticleLocalService _kbArticleLocalService;
+
+}

--- a/modules/apps/knowledge-base/knowledge-base-web-test/src/testIntegration/java/com/liferay/knowledge/base/web/internal/info/item/provider/test/KBArticleInfoItemObjectProviderTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-web-test/src/testIntegration/java/com/liferay/knowledge/base/web/internal/info/item/provider/test/KBArticleInfoItemObjectProviderTest.java
@@ -1,0 +1,102 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.knowledge.base.web.internal.info.item.provider.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.info.item.ClassPKInfoItemIdentifier;
+import com.liferay.info.item.ERCInfoItemIdentifier;
+import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.info.item.provider.InfoItemObjectProvider;
+import com.liferay.knowledge.base.constants.KBFolderConstants;
+import com.liferay.knowledge.base.model.KBArticle;
+import com.liferay.knowledge.base.service.KBArticleLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Adolfo Pérez
+ */
+@RunWith(Arquillian.class)
+public class KBArticleInfoItemObjectProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_kbArticle = _kbArticleLocalService.addKBArticle(
+			null, TestPropsValues.getUserId(),
+			_classNameLocalService.getClassNameId(
+				KBFolderConstants.getClassName()),
+			KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			null, new Date(), null, null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+	}
+
+	@Test
+	public void testGetInfoItem() throws Exception {
+		InfoItemObjectProvider<KBArticle> infoItemObjectProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoItemObjectProvider.class, KBArticle.class.getName());
+
+		Assert.assertEquals(
+			_kbArticle,
+			infoItemObjectProvider.getInfoItem(
+				_group.getGroupId(),
+				new ClassPKInfoItemIdentifier(
+					_kbArticle.getResourcePrimKey())));
+		Assert.assertEquals(
+			_kbArticle,
+			infoItemObjectProvider.getInfoItem(
+				_group.getGroupId(),
+				new ERCInfoItemIdentifier(
+					_kbArticle.getExternalReferenceCode())));
+		Assert.assertEquals(
+			_kbArticle,
+			infoItemObjectProvider.getInfoItem(
+				RandomTestUtil.randomLong(),
+				new ERCInfoItemIdentifier(
+					_kbArticle.getExternalReferenceCode(),
+					_group.getExternalReferenceCode())));
+	}
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private InfoItemServiceRegistry _infoItemServiceRegistry;
+
+	private KBArticle _kbArticle;
+
+	@Inject
+	private KBArticleLocalService _kbArticleLocalService;
+
+}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/info/item/provider/KBArticleInfoItemDetailsProvider.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/info/item/provider/KBArticleInfoItemDetailsProvider.java
@@ -5,14 +5,26 @@
 
 package com.liferay.knowledge.base.web.internal.info.item.provider;
 
+import com.liferay.info.item.ClassPKInfoItemIdentifier;
+import com.liferay.info.item.ERCInfoItemIdentifier;
 import com.liferay.info.item.InfoItemClassDetails;
 import com.liferay.info.item.InfoItemDetails;
+import com.liferay.info.item.InfoItemIdentifier;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.info.item.provider.InfoItemDetailsProvider;
 import com.liferay.knowledge.base.model.KBArticle;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
+
+import java.util.Objects;
 
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Alicia García
@@ -31,10 +43,76 @@ public class KBArticleInfoItemDetailsProvider
 
 	@Override
 	public InfoItemDetails getInfoItemDetails(KBArticle kbArticle) {
-		return new InfoItemDetails(
-			getInfoItemClassDetails(),
-			new InfoItemReference(
-				KBArticle.class.getName(), kbArticle.getResourcePrimKey()));
+		return getInfoItemDetails(
+			_getGroupId(), ClassPKInfoItemIdentifier.class, kbArticle);
 	}
+
+	@Override
+	public InfoItemDetails getInfoItemDetails(
+		long groupId,
+		Class<? extends InfoItemIdentifier> infoItemIdentifierClass,
+		KBArticle kbArticle) {
+
+		if (Objects.equals(
+				infoItemIdentifierClass, ClassPKInfoItemIdentifier.class)) {
+
+			return new InfoItemDetails(
+				getInfoItemClassDetails(),
+				new InfoItemReference(
+					KBArticle.class.getName(), kbArticle.getResourcePrimKey()));
+		}
+
+		if (Objects.equals(
+				infoItemIdentifierClass, ERCInfoItemIdentifier.class)) {
+
+			return new InfoItemDetails(
+				getInfoItemClassDetails(),
+				new InfoItemReference(
+					KBArticle.class.getName(),
+					new ERCInfoItemIdentifier(
+						kbArticle.getExternalReferenceCode(),
+						_getScopeExternalReferenceCode(groupId, kbArticle))));
+		}
+
+		return null;
+	}
+
+	private long _getGroupId() {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext != null) {
+			return serviceContext.getScopeGroupId();
+		}
+
+		Long groupId = GroupThreadLocal.getGroupId();
+
+		if (groupId != null) {
+			return groupId;
+		}
+
+		throw new IllegalStateException(
+			"Neither service context thread local nor group thread local are " +
+				"initialized");
+	}
+
+	private String _getScopeExternalReferenceCode(
+		long groupId, GroupedModel groupedModel) {
+
+		if (groupId == groupedModel.getGroupId()) {
+			return null;
+		}
+
+		Group group = _groupLocalService.fetchGroup(groupedModel.getGroupId());
+
+		if (group == null) {
+			return null;
+		}
+
+		return group.getExternalReferenceCode();
+	}
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/info/item/provider/KBArticleInfoItemDetailsProvider.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/info/item/provider/KBArticleInfoItemDetailsProvider.java
@@ -8,33 +8,25 @@ package com.liferay.knowledge.base.web.internal.info.item.provider;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.ERCInfoItemIdentifier;
 import com.liferay.info.item.InfoItemClassDetails;
-import com.liferay.info.item.InfoItemDetails;
-import com.liferay.info.item.InfoItemIdentifier;
-import com.liferay.info.item.InfoItemReference;
+import com.liferay.info.item.provider.BaseInfoItemDetailsProvider;
 import com.liferay.info.item.provider.InfoItemDetailsProvider;
 import com.liferay.knowledge.base.model.KBArticle;
-import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupedModel;
-import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.util.GroupThreadLocal;
-
-import java.util.Objects;
 
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Alicia García
  */
 @Component(
-	property = Constants.SERVICE_RANKING + ":Integer=10",
+	property = {
+		Constants.SERVICE_RANKING + ":Integer=10",
+		"item.class.name=com.liferay.knowledge.base.model.KBArticle"
+	},
 	service = InfoItemDetailsProvider.class
 )
 public class KBArticleInfoItemDetailsProvider
-	implements InfoItemDetailsProvider<KBArticle> {
+	extends BaseInfoItemDetailsProvider<KBArticle> {
 
 	@Override
 	public InfoItemClassDetails getInfoItemClassDetails() {
@@ -42,77 +34,29 @@ public class KBArticleInfoItemDetailsProvider
 	}
 
 	@Override
-	public InfoItemDetails getInfoItemDetails(KBArticle kbArticle) {
-		return getInfoItemDetails(
-			_getGroupId(), ClassPKInfoItemIdentifier.class, kbArticle);
+	protected InfoItemIdentifierFactory<KBArticle>
+		getInfoItemIdentifierFactory() {
+
+		return new InfoItemIdentifierFactory<>() {
+
+			@Override
+			public ClassPKInfoItemIdentifier createClassPKInfoItemIdentifier(
+				KBArticle kbArticle) {
+
+				return new ClassPKInfoItemIdentifier(
+					kbArticle.getResourcePrimKey());
+			}
+
+			@Override
+			public ERCInfoItemIdentifier createERCInfoItemIdentifier(
+				String externalReferenceCode,
+				String scopeExternalReferenceCode) {
+
+				return new ERCInfoItemIdentifier(
+					externalReferenceCode, scopeExternalReferenceCode);
+			}
+
+		};
 	}
-
-	@Override
-	public InfoItemDetails getInfoItemDetails(
-		long groupId,
-		Class<? extends InfoItemIdentifier> infoItemIdentifierClass,
-		KBArticle kbArticle) {
-
-		if (Objects.equals(
-				infoItemIdentifierClass, ClassPKInfoItemIdentifier.class)) {
-
-			return new InfoItemDetails(
-				getInfoItemClassDetails(),
-				new InfoItemReference(
-					KBArticle.class.getName(), kbArticle.getResourcePrimKey()));
-		}
-
-		if (Objects.equals(
-				infoItemIdentifierClass, ERCInfoItemIdentifier.class)) {
-
-			return new InfoItemDetails(
-				getInfoItemClassDetails(),
-				new InfoItemReference(
-					KBArticle.class.getName(),
-					new ERCInfoItemIdentifier(
-						kbArticle.getExternalReferenceCode(),
-						_getScopeExternalReferenceCode(groupId, kbArticle))));
-		}
-
-		return null;
-	}
-
-	private long _getGroupId() {
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		if (serviceContext != null) {
-			return serviceContext.getScopeGroupId();
-		}
-
-		Long groupId = GroupThreadLocal.getGroupId();
-
-		if (groupId != null) {
-			return groupId;
-		}
-
-		throw new IllegalStateException(
-			"Neither service context thread local nor group thread local are " +
-				"initialized");
-	}
-
-	private String _getScopeExternalReferenceCode(
-		long groupId, GroupedModel groupedModel) {
-
-		if (groupId == groupedModel.getGroupId()) {
-			return null;
-		}
-
-		Group group = _groupLocalService.fetchGroup(groupedModel.getGroupId());
-
-		if (group == null) {
-			return null;
-		}
-
-		return group.getExternalReferenceCode();
-	}
-
-	@Reference
-	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/info/item/provider/KBArticleInfoItemObjectProvider.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/info/item/provider/KBArticleInfoItemObjectProvider.java
@@ -55,7 +55,8 @@ public class KBArticleInfoItemObjectProvider
 			long groupId, InfoItemIdentifier infoItemIdentifier)
 		throws NoSuchInfoItemException {
 
-		return _getInfoItem(_getCompanyId(), groupId, infoItemIdentifier);
+		return _getInfoItem(
+			_getGroupId(groupId, infoItemIdentifier), infoItemIdentifier);
 	}
 
 	private long _getCompanyId() {
@@ -97,20 +98,26 @@ public class KBArticleInfoItemObjectProvider
 	}
 
 	private long _getGroupId(
-			long companyId, ERCInfoItemIdentifier ercInfoItemIdentifier,
-			long scopeGroupId)
+			long groupId, InfoItemIdentifier infoItemIdentifier)
 		throws NoSuchInfoItemException {
 
 		try {
+			if (!(infoItemIdentifier instanceof ERCInfoItemIdentifier)) {
+				return groupId;
+			}
+
+			ERCInfoItemIdentifier ercInfoItemIdentifier =
+				(ERCInfoItemIdentifier)infoItemIdentifier;
+
 			if (Validator.isNull(
 					ercInfoItemIdentifier.getScopeExternalReferenceCode())) {
 
-				return scopeGroupId;
+				return groupId;
 			}
 
 			Group group = _groupLocalService.getGroupByExternalReferenceCode(
 				ercInfoItemIdentifier.getScopeExternalReferenceCode(),
-				companyId);
+				_getCompanyId());
 
 			return group.getGroupId();
 		}
@@ -120,7 +127,7 @@ public class KBArticleInfoItemObjectProvider
 	}
 
 	private KBArticle _getInfoItem(
-			long companyId, long groupId, InfoItemIdentifier infoItemIdentifier)
+			long groupId, InfoItemIdentifier infoItemIdentifier)
 		throws NoSuchInfoItemException {
 
 		if (!(infoItemIdentifier instanceof ClassPKInfoItemIdentifier) &&
@@ -145,8 +152,7 @@ public class KBArticleInfoItemObjectProvider
 				(ERCInfoItemIdentifier)infoItemIdentifier;
 
 			kbArticle = _getKbArticle(
-				ercInfoItemIdentifier.getExternalReferenceCode(),
-				_getGroupId(companyId, ercInfoItemIdentifier, groupId),
+				ercInfoItemIdentifier.getExternalReferenceCode(), groupId,
 				ercInfoItemIdentifier.getVersion());
 		}
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/info/item/provider/KBArticleInfoItemObjectProvider.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/info/item/provider/KBArticleInfoItemObjectProvider.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2020 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/info/item/provider/KBArticleInfoItemObjectProvider.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/info/item/provider/KBArticleInfoItemObjectProvider.java
@@ -7,11 +7,19 @@ package com.liferay.knowledge.base.web.internal.info.item.provider;
 
 import com.liferay.info.exception.NoSuchInfoItemException;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
+import com.liferay.info.item.ERCInfoItemIdentifier;
 import com.liferay.info.item.InfoItemIdentifier;
 import com.liferay.info.item.provider.InfoItemObjectProvider;
 import com.liferay.knowledge.base.model.KBArticle;
 import com.liferay.knowledge.base.service.KBArticleLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
@@ -26,6 +34,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = {
 		"info.item.identifier=com.liferay.info.item.ClassPKInfoItemIdentifier",
+		"info.item.identifier=com.liferay.info.item.ERCInfoItemIdentifier",
 		"item.class.name=com.liferay.knowledge.base.model.KBArticle",
 		"service.ranking:Integer=100"
 	},
@@ -38,24 +47,112 @@ public class KBArticleInfoItemObjectProvider
 	public KBArticle getInfoItem(InfoItemIdentifier infoItemIdentifier)
 		throws NoSuchInfoItemException {
 
-		if (!(infoItemIdentifier instanceof ClassPKInfoItemIdentifier)) {
+		return getInfoItem(_getGroupId(), infoItemIdentifier);
+	}
+
+	@Override
+	public KBArticle getInfoItem(
+			long groupId, InfoItemIdentifier infoItemIdentifier)
+		throws NoSuchInfoItemException {
+
+		return _getInfoItem(_getCompanyId(), groupId, infoItemIdentifier);
+	}
+
+	private long _getCompanyId() {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext != null) {
+			return serviceContext.getCompanyId();
+		}
+
+		Long companyId = CompanyThreadLocal.getCompanyId();
+
+		if (companyId != null) {
+			return companyId;
+		}
+
+		throw new IllegalStateException(
+			"Neither service context thread local nor company thread local " +
+				"are initialized");
+	}
+
+	private long _getGroupId() {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext != null) {
+			return serviceContext.getScopeGroupId();
+		}
+
+		Long groupId = GroupThreadLocal.getGroupId();
+
+		if (groupId != null) {
+			return groupId;
+		}
+
+		throw new IllegalStateException(
+			"Neither service context thread local nor group thread local are " +
+				"initialized");
+	}
+
+	private long _getGroupId(
+			long companyId, ERCInfoItemIdentifier ercInfoItemIdentifier,
+			long scopeGroupId)
+		throws NoSuchInfoItemException {
+
+		try {
+			if (Validator.isNull(
+					ercInfoItemIdentifier.getScopeExternalReferenceCode())) {
+
+				return scopeGroupId;
+			}
+
+			Group group = _groupLocalService.getGroupByExternalReferenceCode(
+				ercInfoItemIdentifier.getScopeExternalReferenceCode(),
+				companyId);
+
+			return group.getGroupId();
+		}
+		catch (PortalException portalException) {
+			throw new NoSuchInfoItemException(portalException);
+		}
+	}
+
+	private KBArticle _getInfoItem(
+			long companyId, long groupId, InfoItemIdentifier infoItemIdentifier)
+		throws NoSuchInfoItemException {
+
+		if (!(infoItemIdentifier instanceof ClassPKInfoItemIdentifier) &&
+			!(infoItemIdentifier instanceof ERCInfoItemIdentifier)) {
+
 			throw new NoSuchInfoItemException(
 				"Unsupported info item identifier " + infoItemIdentifier);
 		}
 
 		KBArticle kbArticle = null;
 
-		String version = infoItemIdentifier.getVersion();
-
 		if (infoItemIdentifier instanceof ClassPKInfoItemIdentifier) {
 			ClassPKInfoItemIdentifier classPKInfoItemIdentifier =
 				(ClassPKInfoItemIdentifier)infoItemIdentifier;
 
-			kbArticle = _getKbArticle(version, classPKInfoItemIdentifier);
+			kbArticle = _getKbArticle(
+				infoItemIdentifier.getVersion(), classPKInfoItemIdentifier);
+		}
+		else {
+			ERCInfoItemIdentifier ercInfoItemIdentifier =
+				(ERCInfoItemIdentifier)infoItemIdentifier;
+
+			kbArticle = _getKbArticle(
+				ercInfoItemIdentifier.getExternalReferenceCode(),
+				_getGroupId(companyId, ercInfoItemIdentifier, groupId),
+				ercInfoItemIdentifier.getVersion());
 		}
 
 		if ((kbArticle == null) ||
-			(!Objects.equals(version, InfoItemIdentifier.VERSION_LATEST) &&
+			(!Objects.equals(
+				infoItemIdentifier.getVersion(),
+				InfoItemIdentifier.VERSION_LATEST) &&
 			 kbArticle.isDraft())) {
 
 			throw new NoSuchInfoItemException(
@@ -97,6 +194,40 @@ public class KBArticleInfoItemObjectProvider
 
 		return kbArticle;
 	}
+
+	private KBArticle _getKbArticle(
+		String externalReferenceCode, long groupId, String version) {
+
+		KBArticle kbArticle;
+
+		if (Validator.isNull(version) ||
+			Objects.equals(
+				version, InfoItemIdentifier.VERSION_LATEST_APPROVED)) {
+
+			kbArticle =
+				_kbArticleLocalService.
+					fetchLatestKBArticleByExternalReferenceCode(
+						groupId, externalReferenceCode,
+						WorkflowConstants.STATUS_APPROVED);
+		}
+		else if (Objects.equals(version, InfoItemIdentifier.VERSION_LATEST)) {
+			kbArticle =
+				_kbArticleLocalService.
+					fetchLatestKBArticleByExternalReferenceCode(
+						groupId, externalReferenceCode);
+		}
+		else {
+			kbArticle =
+				_kbArticleLocalService.fetchKBArticleByExternalReferenceCode(
+					groupId, externalReferenceCode,
+					GetterUtil.getInteger(version));
+		}
+
+		return kbArticle;
+	}
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private KBArticleLocalService _kbArticleLocalService;

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/info/item/provider/KBArticleInfoItemObjectProvider.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/info/item/provider/KBArticleInfoItemObjectProvider.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2020 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/info/item/provider/KBArticleInfoItemObjectProvider.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/info/item/provider/KBArticleInfoItemObjectProvider.java
@@ -137,7 +137,8 @@ public class KBArticleInfoItemObjectProvider
 				(ClassPKInfoItemIdentifier)infoItemIdentifier;
 
 			kbArticle = _getKbArticle(
-				infoItemIdentifier.getVersion(), classPKInfoItemIdentifier);
+				classPKInfoItemIdentifier.getClassPK(),
+				classPKInfoItemIdentifier.getVersion());
 		}
 		else {
 			ERCInfoItemIdentifier ercInfoItemIdentifier =
@@ -163,67 +164,49 @@ public class KBArticleInfoItemObjectProvider
 		return kbArticle;
 	}
 
-	private KBArticle _getKbArticle(
-		String version, ClassPKInfoItemIdentifier classPKInfoItemIdentifier) {
-
-		KBArticle kbArticle;
-
+	private KBArticle _getKbArticle(long classPK, String version) {
 		if (Validator.isNull(version) ||
 			Objects.equals(
 				version, InfoItemIdentifier.VERSION_LATEST_APPROVED)) {
 
-			kbArticle = _kbArticleLocalService.fetchLatestKBArticle(
-				classPKInfoItemIdentifier.getClassPK(),
-				WorkflowConstants.STATUS_APPROVED);
-		}
-		else if (Objects.equals(version, InfoItemIdentifier.VERSION_LATEST)) {
-			kbArticle = _kbArticleLocalService.fetchLatestKBArticle(
-				classPKInfoItemIdentifier.getClassPK(),
-				WorkflowConstants.STATUS_ANY);
-		}
-		else {
-			KBArticle latestKBArticle =
-				_kbArticleLocalService.fetchLatestKBArticle(
-					classPKInfoItemIdentifier.getClassPK(),
-					WorkflowConstants.STATUS_ANY);
-
-			kbArticle = _kbArticleLocalService.fetchKBArticle(
-				classPKInfoItemIdentifier.getClassPK(),
-				latestKBArticle.getGroupId(), GetterUtil.getInteger(version));
+			return _kbArticleLocalService.fetchLatestKBArticle(
+				classPK, WorkflowConstants.STATUS_APPROVED);
 		}
 
-		return kbArticle;
+		if (Objects.equals(version, InfoItemIdentifier.VERSION_LATEST)) {
+			return _kbArticleLocalService.fetchLatestKBArticle(
+				classPK, WorkflowConstants.STATUS_ANY);
+		}
+
+		KBArticle latestKBArticle = _kbArticleLocalService.fetchLatestKBArticle(
+			classPK, WorkflowConstants.STATUS_ANY);
+
+		return _kbArticleLocalService.fetchKBArticle(
+			classPK, latestKBArticle.getGroupId(),
+			GetterUtil.getInteger(version));
 	}
 
 	private KBArticle _getKbArticle(
 		String externalReferenceCode, long groupId, String version) {
 
-		KBArticle kbArticle;
-
 		if (Validator.isNull(version) ||
 			Objects.equals(
 				version, InfoItemIdentifier.VERSION_LATEST_APPROVED)) {
 
-			kbArticle =
-				_kbArticleLocalService.
-					fetchLatestKBArticleByExternalReferenceCode(
-						groupId, externalReferenceCode,
-						WorkflowConstants.STATUS_APPROVED);
-		}
-		else if (Objects.equals(version, InfoItemIdentifier.VERSION_LATEST)) {
-			kbArticle =
-				_kbArticleLocalService.
-					fetchLatestKBArticleByExternalReferenceCode(
-						groupId, externalReferenceCode);
-		}
-		else {
-			kbArticle =
-				_kbArticleLocalService.fetchKBArticleByExternalReferenceCode(
+			return _kbArticleLocalService.
+				fetchLatestKBArticleByExternalReferenceCode(
 					groupId, externalReferenceCode,
-					GetterUtil.getInteger(version));
+					WorkflowConstants.STATUS_APPROVED);
 		}
 
-		return kbArticle;
+		if (Objects.equals(version, InfoItemIdentifier.VERSION_LATEST)) {
+			return _kbArticleLocalService.
+				fetchLatestKBArticleByExternalReferenceCode(
+					groupId, externalReferenceCode);
+		}
+
+		return _kbArticleLocalService.fetchKBArticleByExternalReferenceCode(
+			groupId, externalReferenceCode, GetterUtil.getInteger(version));
 	}
 
 	@Reference

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/info/item/provider/KBArticleInfoItemObjectProvider.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/info/item/provider/KBArticleInfoItemObjectProvider.java
@@ -9,17 +9,11 @@ import com.liferay.info.exception.NoSuchInfoItemException;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.ERCInfoItemIdentifier;
 import com.liferay.info.item.InfoItemIdentifier;
+import com.liferay.info.item.provider.BaseInfoItemObjectProvider;
 import com.liferay.info.item.provider.InfoItemObjectProvider;
 import com.liferay.knowledge.base.model.KBArticle;
 import com.liferay.knowledge.base.service.KBArticleLocalService;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
@@ -41,92 +35,10 @@ import org.osgi.service.component.annotations.Reference;
 	service = InfoItemObjectProvider.class
 )
 public class KBArticleInfoItemObjectProvider
-	implements InfoItemObjectProvider<KBArticle> {
+	extends BaseInfoItemObjectProvider<KBArticle> {
 
 	@Override
-	public KBArticle getInfoItem(InfoItemIdentifier infoItemIdentifier)
-		throws NoSuchInfoItemException {
-
-		return getInfoItem(_getGroupId(), infoItemIdentifier);
-	}
-
-	@Override
-	public KBArticle getInfoItem(
-			long groupId, InfoItemIdentifier infoItemIdentifier)
-		throws NoSuchInfoItemException {
-
-		return _getInfoItem(
-			_getGroupId(groupId, infoItemIdentifier), infoItemIdentifier);
-	}
-
-	private long _getCompanyId() {
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		if (serviceContext != null) {
-			return serviceContext.getCompanyId();
-		}
-
-		Long companyId = CompanyThreadLocal.getCompanyId();
-
-		if (companyId != null) {
-			return companyId;
-		}
-
-		throw new IllegalStateException(
-			"Neither service context thread local nor company thread local " +
-				"are initialized");
-	}
-
-	private long _getGroupId() {
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		if (serviceContext != null) {
-			return serviceContext.getScopeGroupId();
-		}
-
-		Long groupId = GroupThreadLocal.getGroupId();
-
-		if (groupId != null) {
-			return groupId;
-		}
-
-		throw new IllegalStateException(
-			"Neither service context thread local nor group thread local are " +
-				"initialized");
-	}
-
-	private long _getGroupId(
-			long groupId, InfoItemIdentifier infoItemIdentifier)
-		throws NoSuchInfoItemException {
-
-		try {
-			if (!(infoItemIdentifier instanceof ERCInfoItemIdentifier)) {
-				return groupId;
-			}
-
-			ERCInfoItemIdentifier ercInfoItemIdentifier =
-				(ERCInfoItemIdentifier)infoItemIdentifier;
-
-			if (Validator.isNull(
-					ercInfoItemIdentifier.getScopeExternalReferenceCode())) {
-
-				return groupId;
-			}
-
-			Group group = _groupLocalService.getGroupByExternalReferenceCode(
-				ercInfoItemIdentifier.getScopeExternalReferenceCode(),
-				_getCompanyId());
-
-			return group.getGroupId();
-		}
-		catch (PortalException portalException) {
-			throw new NoSuchInfoItemException(portalException);
-		}
-	}
-
-	private KBArticle _getInfoItem(
+	protected KBArticle doGetInfoItem(
 			long groupId, InfoItemIdentifier infoItemIdentifier)
 		throws NoSuchInfoItemException {
 
@@ -214,9 +126,6 @@ public class KBArticleInfoItemObjectProvider
 		return _kbArticleLocalService.fetchKBArticleByExternalReferenceCode(
 			groupId, externalReferenceCode, GetterUtil.getInteger(version));
 	}
-
-	@Reference
-	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private KBArticleLocalService _kbArticleLocalService;

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/upload/test/TestFileEntry.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/upload/test/TestFileEntry.java
@@ -377,6 +377,10 @@ public class TestFileEntry implements FileEntry {
 	}
 
 	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+	}
+
+	@Override
 	public void setGroupId(long groupId) {
 		_groupId = groupId;
 	}

--- a/portal-impl/src/com/liferay/portal/repository/InitializedDocumentRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/InitializedDocumentRepository.java
@@ -171,6 +171,13 @@ public abstract class InitializedDocumentRepository
 	}
 
 	@Override
+	public FileEntry fetchFileEntry(long fileEntryId) throws PortalException {
+		checkDocumentRepository();
+
+		return documentRepository.fetchFileEntry(fileEntryId);
+	}
+
+	@Override
 	public FileEntry fetchFileEntry(long folderId, String title)
 		throws PortalException {
 

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityLocalRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityLocalRepository.java
@@ -245,6 +245,11 @@ public class CapabilityLocalRepository
 	}
 
 	@Override
+	public FileEntry fetchFileEntry(long fileEntryId) throws PortalException {
+		return getRepository().fetchFileEntry(fileEntryId);
+	}
+
+	@Override
 	public FileEntry fetchFileEntry(long folderId, String title)
 		throws PortalException {
 

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityRepository.java
@@ -341,6 +341,11 @@ public class CapabilityRepository
 	}
 
 	@Override
+	public FileEntry fetchFileEntry(long fileEntryId) throws PortalException {
+		return getRepository().fetchFileEntry(fileEntryId);
+	}
+
+	@Override
 	public FileEntry fetchFileEntry(long folderId, String title)
 		throws PortalException {
 

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayLocalRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayLocalRepository.java
@@ -242,6 +242,18 @@ public class LiferayLocalRepository
 	}
 
 	@Override
+	public FileEntry fetchFileEntry(long fileEntryId) throws PortalException {
+		DLFileEntry dlFileEntry = dlFileEntryLocalService.fetchDLFileEntry(
+			fileEntryId);
+
+		if (dlFileEntry == null) {
+			return null;
+		}
+
+		return new LiferayFileEntry(dlFileEntry);
+	}
+
+	@Override
 	public FileEntry fetchFileEntry(long folderId, String title) {
 		DLFileEntry dlFileEntry = dlFileEntryLocalService.fetchFileEntry(
 			getGroupId(), toFolderId(folderId), title);

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepository.java
@@ -312,6 +312,18 @@ public class LiferayRepository
 	}
 
 	@Override
+	public FileEntry fetchFileEntry(long fileEntryId) throws PortalException {
+		DLFileEntry dlFileEntry = dlFileEntryService.fetchFileEntry(
+			fileEntryId);
+
+		if (dlFileEntry == null) {
+			return null;
+		}
+
+		return new LiferayFileEntry(dlFileEntry);
+	}
+
+	@Override
 	public FileEntry fetchFileEntry(long folderId, String title)
 		throws PortalException {
 

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/model/LiferayFileEntry.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/model/LiferayFileEntry.java
@@ -508,6 +508,11 @@ public class LiferayFileEntry extends LiferayModel implements FileEntry {
 	}
 
 	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		_dlFileEntry.setExternalReferenceCode(externalReferenceCode);
+	}
+
+	@Override
 	public void setGroupId(long groupId) {
 		_dlFileEntry.setGroupId(groupId);
 	}

--- a/portal-impl/src/com/liferay/portal/repository/util/LocalRepositoryWrapper.java
+++ b/portal-impl/src/com/liferay/portal/repository/util/LocalRepositoryWrapper.java
@@ -147,6 +147,11 @@ public class LocalRepositoryWrapper implements LocalRepository {
 	}
 
 	@Override
+	public FileEntry fetchFileEntry(long fileEntryId) throws PortalException {
+		return _localRepository.fetchFileEntry(fileEntryId);
+	}
+
+	@Override
 	public FileEntry fetchFileEntry(long folderId, String title)
 		throws PortalException {
 

--- a/portal-impl/src/com/liferay/portal/repository/util/RepositoryWrapper.java
+++ b/portal-impl/src/com/liferay/portal/repository/util/RepositoryWrapper.java
@@ -196,6 +196,11 @@ public class RepositoryWrapper implements Repository {
 	}
 
 	@Override
+	public FileEntry fetchFileEntry(long fileEntryId) throws PortalException {
+		return _repository.fetchFileEntry(fileEntryId);
+	}
+
+	@Override
 	public FileEntry fetchFileEntry(long folderId, String title)
 		throws PortalException {
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLFileEntryServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLFileEntryServiceHttp.java
@@ -498,6 +498,47 @@ public class DLFileEntryServiceHttp {
 	}
 
 	public static com.liferay.document.library.kernel.model.DLFileEntry
+			fetchFileEntry(HttpPrincipal httpPrincipal, long fileEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				DLFileEntryServiceUtil.class, "fetchFileEntry",
+				_fetchFileEntryParameterTypes11);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, fileEntryId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.document.library.kernel.model.DLFileEntry)
+				returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.document.library.kernel.model.DLFileEntry
 			fetchFileEntry(
 				HttpPrincipal httpPrincipal, long groupId, long folderId,
 				String title)
@@ -506,7 +547,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "fetchFileEntry",
-				_fetchFileEntryParameterTypes11);
+				_fetchFileEntryParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, title);
@@ -550,7 +591,7 @@ public class DLFileEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class,
 				"fetchFileEntryByExternalReferenceCode",
-				_fetchFileEntryByExternalReferenceCodeParameterTypes12);
+				_fetchFileEntryByExternalReferenceCodeParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, externalReferenceCode);
@@ -591,7 +632,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "fetchFileEntryByImageId",
-				_fetchFileEntryByImageIdParameterTypes13);
+				_fetchFileEntryByImageIdParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, imageId);
 
@@ -631,7 +672,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "getFileAsStream",
-				_getFileAsStreamParameterTypes14);
+				_getFileAsStreamParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, version);
@@ -672,7 +713,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "getFileAsStream",
-				_getFileAsStreamParameterTypes15);
+				_getFileAsStreamParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, version, incrementCounter);
@@ -714,7 +755,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "getFileEntries",
-				_getFileEntriesParameterTypes16);
+				_getFileEntriesParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, score, start, end);
@@ -761,7 +802,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "getFileEntries",
-				_getFileEntriesParameterTypes17);
+				_getFileEntriesParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, status, start, end,
@@ -809,7 +850,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "getFileEntries",
-				_getFileEntriesParameterTypes18);
+				_getFileEntriesParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, start, end, orderByComparator);
@@ -856,7 +897,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "getFileEntries",
-				_getFileEntriesParameterTypes19);
+				_getFileEntriesParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, fileEntryTypeId, start, end,
@@ -904,7 +945,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "getFileEntries",
-				_getFileEntriesParameterTypes20);
+				_getFileEntriesParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, mimeTypes, status, start, end,
@@ -952,7 +993,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "getFileEntries",
-				_getFileEntriesParameterTypes21);
+				_getFileEntriesParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, mimeTypes, start, end,
@@ -995,7 +1036,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "getFileEntriesCount",
-				_getFileEntriesCountParameterTypes22);
+				_getFileEntriesCountParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, score);
@@ -1034,7 +1075,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "getFileEntriesCount",
-				_getFileEntriesCountParameterTypes23);
+				_getFileEntriesCountParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId);
@@ -1066,7 +1107,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "getFileEntriesCount",
-				_getFileEntriesCountParameterTypes24);
+				_getFileEntriesCountParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, status);
@@ -1099,7 +1140,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "getFileEntriesCount",
-				_getFileEntriesCountParameterTypes25);
+				_getFileEntriesCountParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, fileEntryTypeId);
@@ -1132,7 +1173,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "getFileEntriesCount",
-				_getFileEntriesCountParameterTypes26);
+				_getFileEntriesCountParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, mimeTypes);
@@ -1165,7 +1206,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "getFileEntriesCount",
-				_getFileEntriesCountParameterTypes27);
+				_getFileEntriesCountParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, mimeTypes, status);
@@ -1198,7 +1239,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "getFileEntry",
-				_getFileEntryParameterTypes28);
+				_getFileEntryParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId);
@@ -1241,7 +1282,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "getFileEntry",
-				_getFileEntryParameterTypes29);
+				_getFileEntryParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, title);
@@ -1285,7 +1326,7 @@ public class DLFileEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class,
 				"getFileEntryByExternalReferenceCode",
-				_getFileEntryByExternalReferenceCodeParameterTypes30);
+				_getFileEntryByExternalReferenceCodeParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId);
@@ -1328,7 +1369,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "getFileEntryByFileName",
-				_getFileEntryByFileNameParameterTypes31);
+				_getFileEntryByFileNameParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, fileName);
@@ -1370,7 +1411,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "getFileEntryByUuidAndGroupId",
-				_getFileEntryByUuidAndGroupIdParameterTypes32);
+				_getFileEntryByUuidAndGroupIdParameterTypes33);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, uuid, groupId);
@@ -1410,7 +1451,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "getFileEntryLock",
-				_getFileEntryLockParameterTypes33);
+				_getFileEntryLockParameterTypes34);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId);
@@ -1443,7 +1484,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "getFoldersFileEntriesCount",
-				_getFoldersFileEntriesCountParameterTypes34);
+				_getFoldersFileEntriesCountParameterTypes35);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderIds, status);
@@ -1482,7 +1523,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "getGroupFileEntries",
-				_getGroupFileEntriesParameterTypes35);
+				_getGroupFileEntriesParameterTypes36);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId, start, end,
@@ -1532,7 +1573,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "getGroupFileEntries",
-				_getGroupFileEntriesParameterTypes36);
+				_getGroupFileEntriesParameterTypes37);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, repositoryId, rootFolderId,
@@ -1582,7 +1623,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "getGroupFileEntries",
-				_getGroupFileEntriesParameterTypes37);
+				_getGroupFileEntriesParameterTypes38);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId, mimeTypes, status,
@@ -1626,7 +1667,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "getGroupFileEntriesCount",
-				_getGroupFileEntriesCountParameterTypes38);
+				_getGroupFileEntriesCountParameterTypes39);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId);
@@ -1668,7 +1709,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "getGroupFileEntriesCount",
-				_getGroupFileEntriesCountParameterTypes39);
+				_getGroupFileEntriesCountParameterTypes40);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, repositoryId, rootFolderId,
@@ -1710,7 +1751,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "getGroupFileEntriesCount",
-				_getGroupFileEntriesCountParameterTypes40);
+				_getGroupFileEntriesCountParameterTypes41);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId, mimeTypes, status);
@@ -1750,7 +1791,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "hasFileEntryLock",
-				_hasFileEntryLockParameterTypes41);
+				_hasFileEntryLockParameterTypes42);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId);
@@ -1790,7 +1831,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "isFileEntryCheckedOut",
-				_isFileEntryCheckedOutParameterTypes42);
+				_isFileEntryCheckedOutParameterTypes43);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId);
@@ -1832,7 +1873,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "moveFileEntry",
-				_moveFileEntryParameterTypes43);
+				_moveFileEntryParameterTypes44);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, newFolderId, serviceContext);
@@ -1874,7 +1915,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "refreshFileEntryLock",
-				_refreshFileEntryLockParameterTypes44);
+				_refreshFileEntryLockParameterTypes45);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, lockUuid, companyId, expirationTime);
@@ -1915,7 +1956,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "revertFileEntry",
-				_revertFileEntryParameterTypes45);
+				_revertFileEntryParameterTypes46);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, version, serviceContext);
@@ -1952,7 +1993,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "search",
-				_searchParameterTypes46);
+				_searchParameterTypes47);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, creatorUserId, status, start, end);
@@ -1993,7 +2034,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "search",
-				_searchParameterTypes47);
+				_searchParameterTypes48);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, creatorUserId, folderId, mimeTypes, status,
@@ -2048,7 +2089,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "updateFileEntry",
-				_updateFileEntryParameterTypes48);
+				_updateFileEntryParameterTypes49);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, sourceFileName, mimeType, title,
@@ -2096,7 +2137,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "updateStatus",
-				_updateStatusParameterTypes49);
+				_updateStatusParameterTypes50);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, userId, fileVersionId, status, serviceContext,
@@ -2138,7 +2179,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "verifyFileEntryCheckOut",
-				_verifyFileEntryCheckOutParameterTypes50);
+				_verifyFileEntryCheckOutParameterTypes51);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, lockUuid);
@@ -2178,7 +2219,7 @@ public class DLFileEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DLFileEntryServiceUtil.class, "verifyFileEntryLock",
-				_verifyFileEntryLockParameterTypes51);
+				_verifyFileEntryLockParameterTypes52);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, lockUuid);
@@ -2261,128 +2302,130 @@ public class DLFileEntryServiceHttp {
 	private static final Class<?>[] _deleteFileVersionParameterTypes10 =
 		new Class[] {long.class, String.class};
 	private static final Class<?>[] _fetchFileEntryParameterTypes11 =
+		new Class[] {long.class};
+	private static final Class<?>[] _fetchFileEntryParameterTypes12 =
 		new Class[] {long.class, long.class, String.class};
 	private static final Class<?>[]
-		_fetchFileEntryByExternalReferenceCodeParameterTypes12 = new Class[] {
+		_fetchFileEntryByExternalReferenceCodeParameterTypes13 = new Class[] {
 			long.class, String.class
 		};
-	private static final Class<?>[] _fetchFileEntryByImageIdParameterTypes13 =
+	private static final Class<?>[] _fetchFileEntryByImageIdParameterTypes14 =
 		new Class[] {long.class};
-	private static final Class<?>[] _getFileAsStreamParameterTypes14 =
-		new Class[] {long.class, String.class};
 	private static final Class<?>[] _getFileAsStreamParameterTypes15 =
+		new Class[] {long.class, String.class};
+	private static final Class<?>[] _getFileAsStreamParameterTypes16 =
 		new Class[] {long.class, String.class, boolean.class};
-	private static final Class<?>[] _getFileEntriesParameterTypes16 =
-		new Class[] {long.class, double.class, int.class, int.class};
 	private static final Class<?>[] _getFileEntriesParameterTypes17 =
+		new Class[] {long.class, double.class, int.class, int.class};
+	private static final Class<?>[] _getFileEntriesParameterTypes18 =
 		new Class[] {
 			long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getFileEntriesParameterTypes18 =
+	private static final Class<?>[] _getFileEntriesParameterTypes19 =
 		new Class[] {
 			long.class, long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getFileEntriesParameterTypes19 =
+	private static final Class<?>[] _getFileEntriesParameterTypes20 =
 		new Class[] {
 			long.class, long.class, long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
-		};
-	private static final Class<?>[] _getFileEntriesParameterTypes20 =
-		new Class[] {
-			long.class, long.class, String[].class, int.class, int.class,
-			int.class, com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[] _getFileEntriesParameterTypes21 =
 		new Class[] {
 			long.class, long.class, String[].class, int.class, int.class,
+			int.class, com.liferay.portal.kernel.util.OrderByComparator.class
+		};
+	private static final Class<?>[] _getFileEntriesParameterTypes22 =
+		new Class[] {
+			long.class, long.class, String[].class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getFileEntriesCountParameterTypes22 =
-		new Class[] {long.class, double.class};
 	private static final Class<?>[] _getFileEntriesCountParameterTypes23 =
-		new Class[] {long.class, long.class};
+		new Class[] {long.class, double.class};
 	private static final Class<?>[] _getFileEntriesCountParameterTypes24 =
-		new Class[] {long.class, long.class, int.class};
+		new Class[] {long.class, long.class};
 	private static final Class<?>[] _getFileEntriesCountParameterTypes25 =
-		new Class[] {long.class, long.class, long.class};
+		new Class[] {long.class, long.class, int.class};
 	private static final Class<?>[] _getFileEntriesCountParameterTypes26 =
-		new Class[] {long.class, long.class, String[].class};
+		new Class[] {long.class, long.class, long.class};
 	private static final Class<?>[] _getFileEntriesCountParameterTypes27 =
+		new Class[] {long.class, long.class, String[].class};
+	private static final Class<?>[] _getFileEntriesCountParameterTypes28 =
 		new Class[] {long.class, long.class, String[].class, int.class};
-	private static final Class<?>[] _getFileEntryParameterTypes28 =
-		new Class[] {long.class};
 	private static final Class<?>[] _getFileEntryParameterTypes29 =
+		new Class[] {long.class};
+	private static final Class<?>[] _getFileEntryParameterTypes30 =
 		new Class[] {long.class, long.class, String.class};
 	private static final Class<?>[]
-		_getFileEntryByExternalReferenceCodeParameterTypes30 = new Class[] {
+		_getFileEntryByExternalReferenceCodeParameterTypes31 = new Class[] {
 			String.class, long.class
 		};
-	private static final Class<?>[] _getFileEntryByFileNameParameterTypes31 =
+	private static final Class<?>[] _getFileEntryByFileNameParameterTypes32 =
 		new Class[] {long.class, long.class, String.class};
 	private static final Class<?>[]
-		_getFileEntryByUuidAndGroupIdParameterTypes32 = new Class[] {
+		_getFileEntryByUuidAndGroupIdParameterTypes33 = new Class[] {
 			String.class, long.class
 		};
-	private static final Class<?>[] _getFileEntryLockParameterTypes33 =
+	private static final Class<?>[] _getFileEntryLockParameterTypes34 =
 		new Class[] {long.class};
 	private static final Class<?>[]
-		_getFoldersFileEntriesCountParameterTypes34 = new Class[] {
+		_getFoldersFileEntriesCountParameterTypes35 = new Class[] {
 			long.class, java.util.List.class, int.class
 		};
-	private static final Class<?>[] _getGroupFileEntriesParameterTypes35 =
+	private static final Class<?>[] _getGroupFileEntriesParameterTypes36 =
 		new Class[] {
 			long.class, long.class, long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupFileEntriesParameterTypes36 =
+	private static final Class<?>[] _getGroupFileEntriesParameterTypes37 =
 		new Class[] {
 			long.class, long.class, long.class, long.class, String[].class,
 			int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupFileEntriesParameterTypes37 =
+	private static final Class<?>[] _getGroupFileEntriesParameterTypes38 =
 		new Class[] {
 			long.class, long.class, long.class, String[].class, int.class,
 			int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupFileEntriesCountParameterTypes38 =
-		new Class[] {long.class, long.class, long.class};
 	private static final Class<?>[] _getGroupFileEntriesCountParameterTypes39 =
+		new Class[] {long.class, long.class, long.class};
+	private static final Class<?>[] _getGroupFileEntriesCountParameterTypes40 =
 		new Class[] {
 			long.class, long.class, long.class, long.class, String[].class,
 			int.class
 		};
-	private static final Class<?>[] _getGroupFileEntriesCountParameterTypes40 =
+	private static final Class<?>[] _getGroupFileEntriesCountParameterTypes41 =
 		new Class[] {
 			long.class, long.class, long.class, String[].class, int.class
 		};
-	private static final Class<?>[] _hasFileEntryLockParameterTypes41 =
+	private static final Class<?>[] _hasFileEntryLockParameterTypes42 =
 		new Class[] {long.class};
-	private static final Class<?>[] _isFileEntryCheckedOutParameterTypes42 =
+	private static final Class<?>[] _isFileEntryCheckedOutParameterTypes43 =
 		new Class[] {long.class};
-	private static final Class<?>[] _moveFileEntryParameterTypes43 =
+	private static final Class<?>[] _moveFileEntryParameterTypes44 =
 		new Class[] {
 			long.class, long.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _refreshFileEntryLockParameterTypes44 =
+	private static final Class<?>[] _refreshFileEntryLockParameterTypes45 =
 		new Class[] {String.class, long.class, long.class};
-	private static final Class<?>[] _revertFileEntryParameterTypes45 =
+	private static final Class<?>[] _revertFileEntryParameterTypes46 =
 		new Class[] {
 			long.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _searchParameterTypes46 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes47 = new Class[] {
 		long.class, long.class, int.class, int.class, int.class
 	};
-	private static final Class<?>[] _searchParameterTypes47 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes48 = new Class[] {
 		long.class, long.class, long.class, String[].class, int.class,
 		int.class, int.class
 	};
-	private static final Class<?>[] _updateFileEntryParameterTypes48 =
+	private static final Class<?>[] _updateFileEntryParameterTypes49 =
 		new Class[] {
 			long.class, String.class, String.class, String.class, String.class,
 			String.class, String.class,
@@ -2393,15 +2436,15 @@ public class DLFileEntryServiceHttp {
 			java.util.Date.class, java.util.Date.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateStatusParameterTypes49 =
+	private static final Class<?>[] _updateStatusParameterTypes50 =
 		new Class[] {
 			long.class, long.class, int.class,
 			com.liferay.portal.kernel.service.ServiceContext.class,
 			java.util.Map.class
 		};
-	private static final Class<?>[] _verifyFileEntryCheckOutParameterTypes50 =
+	private static final Class<?>[] _verifyFileEntryCheckOutParameterTypes51 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _verifyFileEntryLockParameterTypes51 =
+	private static final Class<?>[] _verifyFileEntryLockParameterTypes52 =
 		new Class[] {long.class, String.class};
 
 }

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
@@ -581,6 +581,14 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 		_dlAppHelperLocalService.deleteFolder(folder);
 	}
 
+	@Override
+	public FileEntry fetchFileEntry(long fileEntryId) throws PortalException {
+		LocalRepository localRepository =
+			RepositoryProviderUtil.getFileEntryLocalRepository(fileEntryId);
+
+		return localRepository.fetchFileEntry(fileEntryId);
+	}
+
 	/**
 	 * Returns the document library file entry with the matching external
 	 * reference code and group.

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
@@ -583,10 +583,19 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 
 	@Override
 	public FileEntry fetchFileEntry(long fileEntryId) throws PortalException {
-		LocalRepository localRepository =
-			RepositoryProviderUtil.getFileEntryLocalRepository(fileEntryId);
+		try {
+			LocalRepository localRepository =
+				RepositoryProviderUtil.getFileEntryLocalRepository(fileEntryId);
 
-		return localRepository.fetchFileEntry(fileEntryId);
+			return localRepository.fetchFileEntry(fileEntryId);
+		}
+		catch (NoSuchFileEntryException noSuchFileEntryException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchFileEntryException);
+			}
+
+			return null;
+		}
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryServiceImpl.java
@@ -245,6 +245,24 @@ public class DLFileEntryServiceImpl extends DLFileEntryServiceBaseImpl {
 	}
 
 	@Override
+	public DLFileEntry fetchFileEntry(long fileEntryId) throws PortalException {
+		DLFileEntry dlFileEntry = dlFileEntryLocalService.fetchDLFileEntry(
+			fileEntryId);
+
+		if (dlFileEntry != null) {
+			ModelResourcePermission<DLFileEntry>
+				dlFileEntryModelResourcePermission =
+					ModelResourcePermissionRegistryUtil.
+						getModelResourcePermission(DLFileEntry.class.getName());
+
+			dlFileEntryModelResourcePermission.check(
+				getPermissionChecker(), dlFileEntry, ActionKeys.VIEW);
+		}
+
+		return dlFileEntry;
+	}
+
+	@Override
 	public DLFileEntry fetchFileEntry(long groupId, long folderId, String title)
 		throws PortalException {
 

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalService.java
@@ -345,6 +345,9 @@ public interface DLAppLocalService extends BaseLocalService {
 	 */
 	public void deleteFolder(long folderId) throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FileEntry fetchFileEntry(long fileEntryId) throws PortalException;
+
 	/**
 	 * Returns the document library file entry with the matching external
 	 * reference code and group.

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceUtil.java
@@ -409,6 +409,13 @@ public class DLAppLocalServiceUtil {
 		getService().deleteFolder(folderId);
 	}
 
+	public static com.liferay.portal.kernel.repository.model.FileEntry
+			fetchFileEntry(long fileEntryId)
+		throws PortalException {
+
+		return getService().fetchFileEntry(fileEntryId);
+	}
+
 	/**
 	 * Returns the document library file entry with the matching external
 	 * reference code and group.

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceWrapper.java
@@ -420,6 +420,14 @@ public class DLAppLocalServiceWrapper
 		_dlAppLocalService.deleteFolder(folderId);
 	}
 
+	@Override
+	public com.liferay.portal.kernel.repository.model.FileEntry fetchFileEntry(
+			long fileEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _dlAppLocalService.fetchFileEntry(fileEntryId);
+	}
+
 	/**
 	 * Returns the document library file entry with the matching external
 	 * reference code and group.

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryService.java
@@ -105,6 +105,9 @@ public interface DLFileEntryService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public DLFileEntry fetchFileEntry(long fileEntryId) throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public DLFileEntry fetchFileEntry(long groupId, long folderId, String title)
 		throws PortalException;
 

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryServiceUtil.java
@@ -136,6 +136,12 @@ public class DLFileEntryServiceUtil {
 		getService().deleteFileVersion(fileEntryId, version);
 	}
 
+	public static DLFileEntry fetchFileEntry(long fileEntryId)
+		throws PortalException {
+
+		return getService().fetchFileEntry(fileEntryId);
+	}
+
 	public static DLFileEntry fetchFileEntry(
 			long groupId, long folderId, String title)
 		throws PortalException {

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryServiceWrapper.java
@@ -142,6 +142,13 @@ public class DLFileEntryServiceWrapper
 	}
 
 	@Override
+	public DLFileEntry fetchFileEntry(long fileEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _dlFileEntryService.fetchFileEntry(fileEntryId);
+	}
+
+	@Override
 	public DLFileEntry fetchFileEntry(long groupId, long folderId, String title)
 		throws com.liferay.portal.kernel.exception.PortalException {
 

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 21.3.0
+version 21.4.0

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/DefaultLocalRepositoryImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/DefaultLocalRepositoryImpl.java
@@ -143,6 +143,11 @@ public class DefaultLocalRepositoryImpl implements LocalRepository {
 	}
 
 	@Override
+	public FileEntry fetchFileEntry(long fileEntryId) throws PortalException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	public FileEntry fetchFileEntry(long folderId, String title)
 		throws PortalException {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/DocumentRepository.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/DocumentRepository.java
@@ -81,6 +81,12 @@ public interface DocumentRepository extends CapabilityProvider {
 
 	public void deleteFolder(long folderId) throws PortalException;
 
+	public default FileEntry fetchFileEntry(long fileEntryId)
+		throws PortalException {
+
+		return getFileEntry(fileEntryId);
+	}
+
 	public default FileEntry fetchFileEntry(long folderId, String title)
 		throws PortalException {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/model/FileEntry.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/model/FileEntry.java
@@ -8,6 +8,7 @@ package com.liferay.portal.kernel.repository.model;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSON;
 import com.liferay.portal.kernel.lock.Lock;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.repository.capabilities.Capability;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.util.Accessor;
@@ -24,7 +25,9 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @JSON
 @ProviderType
-public interface FileEntry extends RepositoryEntry, RepositoryModel<FileEntry> {
+public interface FileEntry
+	extends ExternalReferenceCodeModel, RepositoryEntry,
+			RepositoryModel<FileEntry> {
 
 	public static final Accessor<FileEntry, Long> FILE_ENTRY_ID_ACCESSOR =
 		new Accessor<FileEntry, Long>() {

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/model/FileEntryWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/model/FileEntryWrapper.java
@@ -382,6 +382,11 @@ public class FileEntryWrapper implements FileEntry, ModelWrapper<FileEntry> {
 	}
 
 	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		_fileEntry.setExternalReferenceCode(externalReferenceCode);
+	}
+
+	@Override
 	public void setGroupId(long groupId) {
 		_fileEntry.setGroupId(groupId);
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/model/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/model/packageinfo
@@ -1,1 +1,1 @@
-version 13.2.0
+version 14.0.0

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/packageinfo
@@ -1,1 +1,1 @@
-version 16.1.0
+version 16.2.0

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/proxy/FileEntryProxyBean.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/proxy/FileEntryProxyBean.java
@@ -374,6 +374,11 @@ public class FileEntryProxyBean
 	}
 
 	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		_fileEntry.setExternalReferenceCode(externalReferenceCode);
+	}
+
+	@Override
 	public void setGroupId(long groupId) {
 		_fileEntry.setGroupId(groupId);
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/proxy/LocalRepositoryProxyBean.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/proxy/LocalRepositoryProxyBean.java
@@ -162,6 +162,17 @@ public class LocalRepositoryProxyBean
 	}
 
 	@Override
+	public FileEntry fetchFileEntry(long fileEntryId) throws PortalException {
+		FileEntry fileEntry = _localRepository.fetchFileEntry(fileEntryId);
+
+		if (fileEntry == null) {
+			return null;
+		}
+
+		return newFileEntryProxyBean(fileEntry);
+	}
+
+	@Override
 	public FileEntry fetchFileEntry(long folderId, String title)
 		throws PortalException {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/proxy/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/proxy/packageinfo
@@ -1,1 +1,1 @@
-version 9.0.0
+version 9.1.0


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-61435

Support ERC info item identifier in AssetCategory, BlogsEntry, FileEntry, JournalArticle and KBArticle.

This is a followup to https://github.com/brianchandotcom/liferay-portal/pull/165424.

All changes in the last 3 commits; the rest is the same.