### PR TITLE
LPD-55156 Enable FDS action links to be styled

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/AdvancedPropsTransformer.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/AdvancedPropsTransformer.ts
@@ -15,11 +15,13 @@ import type {
 	ICardSchema,
 	IFileDropSettings,
 	IInternalRenderer,
+	IItemsActions,
 	IView,
 } from '@liferay/frontend-data-set-web';
 
 export default function propsTransformer({
 	additionalProps: {greeting},
+	itemsActions,
 	selectedItemsKey,
 	...otherProps
 }: any) {
@@ -110,6 +112,18 @@ export default function propsTransformer({
 		},
 		fileDropSettings,
 		infoPanelComponent: SampleInfoPanel,
+		itemsActions: itemsActions.map((action: IItemsActions) => {
+			const key = action?.data?.id as string;
+
+			if (!key || key !== 'sampleDeleteMessage') {
+				return action;
+			}
+
+			return {
+				...action,
+				className: 'text-danger',
+			};
+		}),
 		onActionDropdownItemClick({
 			action,
 			itemData,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/ActionsDropdown.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/ActionsDropdown.tsx
@@ -9,6 +9,7 @@ import ClayIcon from '@clayui/icon';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {LinkOrButton} from '@clayui/shared';
 import {useIsMounted} from '@liferay/frontend-js-react-web';
+import classNames from 'classnames';
 import React, {useContext} from 'react';
 
 import FrontendDataSetContext, {
@@ -20,17 +21,25 @@ import {IActionsDropdown, IItemsActions} from '../utils/types';
 
 interface IDropdownItem {
 	action: IItemsActions;
+	className?: string;
 	closeMenu: Function;
 	onClick: Function;
 	setLoading: Function;
 	url: string | undefined;
 }
 
-function DropdownItem({action, closeMenu, onClick, url}: IDropdownItem) {
+function DropdownItem({
+	action,
+	className,
+	closeMenu,
+	onClick,
+	url,
+}: IDropdownItem) {
 	const {icon, label, target} = action;
 
 	return (
 		<ClayDropDown.Item
+			className={className}
 			disabled={action.disabled}
 			href={isLink(target, null) ? url : undefined}
 			onClick={(event) =>
@@ -151,7 +160,10 @@ function ActionsDropdown({
 		return (
 			<LinkOrButton
 				aria-label={action.label}
-				className="btn btn-secondary btn-sm"
+				className={classNames(
+					'btn btn-secondary btn-sm',
+					action.className
+				)}
 				disabled={action.disabled}
 				href={
 					isLink(
@@ -196,6 +208,7 @@ function ActionsDropdown({
 			return (
 				<DropdownItem
 					action={item}
+					className={item.className}
 					closeMenu={() =>
 						onMenuActiveChange && onMenuActiveChange(false)
 					}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/types.ts
@@ -112,6 +112,7 @@ export interface ICreationActionItem {
 }
 
 export interface IItemsActions {
+	className?: string;
 	data?: IItemActionsData;
 	disabled?: boolean;
 	href?: string;

--- a/modules/test/playwright/tests/frontend-data-set-web/main/pages/FDSSamplePage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/pages/FDSSamplePage.ts
@@ -208,7 +208,7 @@ export class FDSSamplePage {
 			.click();
 	}
 
-	async checkDropdownMenuIconsAreVisible(itemActionButton: Locator) {
+	async getDropdownId(itemActionButton: Locator) {
 		await itemActionButton.click();
 
 		const dropdownId = await itemActionButton.getAttribute('aria-controls');
@@ -216,6 +216,12 @@ export class FDSSamplePage {
 		const dropdownMenu = this.page.locator(`#${dropdownId}`);
 
 		await dropdownMenu.filter({has: this.page.getByRole('menu')}).waitFor();
+
+		return dropdownMenu;
+	}
+
+	async checkDropdownMenuIconsAreVisible(itemActionButton: Locator) {
+		const dropdownMenu = await this.getDropdownId(itemActionButton);
 
 		const menuItems = dropdownMenu.getByRole('menuitem');
 

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/actions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/actions.spec.ts
@@ -51,19 +51,11 @@ test('Behavior of item actions', async ({fdsSamplePage, page}) => {
 
 		await expect(tableItemActionButton).toBeVisible();
 
-		const dropdownId =
-			await tableItemActionButton.getAttribute('aria-controls');
+		const dropdownMenu = await fdsSamplePage.getDropdownId(
+			tableItemActionButton
+		);
 
-		await tableItemActionButton.click();
-
-		await page
-			.locator(`#${dropdownId}`)
-			.filter({has: page.getByRole('menu')})
-			.waitFor();
-
-		await expect(
-			page.locator(`#${dropdownId}`).getByRole('menuitem')
-		).toHaveCount(14);
+		await expect(dropdownMenu.getByRole('menuitem')).toHaveCount(14);
 
 		await page.keyboard.press('Escape');
 	});
@@ -256,18 +248,11 @@ test('Behavior of item actions', async ({fdsSamplePage, page}) => {
 
 		await expect(tableItemActionButton).toBeVisible();
 
-		const dropdownId =
-			await tableItemActionButton.getAttribute('aria-controls');
+		const dropdownMenu = await fdsSamplePage.getDropdownId(
+			tableItemActionButton
+		);
 
-		await tableItemActionButton.click();
-
-		await page
-			.locator(`#${dropdownId}`)
-			.filter({has: page.getByRole('menu')})
-			.waitFor();
-
-		const sampleDeleteActionItem = page
-			.locator(`#${dropdownId}`)
+		const sampleDeleteActionItem = dropdownMenu
 			.getByRole('menuitem')
 			.filter({hasText: 'Sample Delete'});
 

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/actions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/actions.spec.ts
@@ -249,4 +249,32 @@ test('Behavior of item actions', async ({fdsSamplePage, page}) => {
 
 		await waitForAlert(page);
 	});
+
+	await test.step('Check that Sample Delete action has custom className applied', async () => {
+		const tableItemActionButton =
+			fdsSamplePage.table.itemActionButtons.first();
+
+		await expect(tableItemActionButton).toBeVisible();
+
+		const dropdownId =
+			await tableItemActionButton.getAttribute('aria-controls');
+
+		await tableItemActionButton.click();
+
+		await page
+			.locator(`#${dropdownId}`)
+			.filter({has: page.getByRole('menu')})
+			.waitFor();
+
+		const sampleDeleteActionItem = page
+			.locator(`#${dropdownId}`)
+			.getByRole('menuitem')
+			.filter({hasText: 'Sample Delete'});
+
+		await expect(sampleDeleteActionItem).toBeVisible();
+
+		await expect(sampleDeleteActionItem).toHaveClass(/text-danger/);
+
+		await page.keyboard.press('Escape');
+	});
 });


### PR DESCRIPTION
## Manual forward of https://github.com/liferay-frontend/liferay-portal/pull/5066 due to unrelated CI failures

[Story](https://liferay.atlassian.net/browse/LPD-51362)

Example usage in the `Advanced` tab of the `fds-sample-web` module

<img width="658" height="1166" alt="image" src="https://github.com/user-attachments/assets/fc744bf6-1d42-474c-97e7-32bb538034c6" />

