### PR TITLE
LPD-65225 Don't remove the guest permissions to the portlets of private pages as we are already removing them at page level

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PermissionImporterImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PermissionImporterImpl.java
@@ -15,11 +15,9 @@ import com.liferay.petra.lang.CentralizedThreadLocal;
 import com.liferay.portal.kernel.exception.NoSuchTeamException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.Team;
-import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
@@ -248,18 +246,6 @@ public class PermissionImporterImpl implements PermissionImporter {
 				continue;
 			}
 
-			Group group = _groupLocalService.getGroup(groupId);
-
-			if (!group.isLayoutPrototype() && !group.isLayoutSetPrototype() &&
-				layout.isPrivateLayout()) {
-
-				String roleName = role.getName();
-
-				if (roleName.equals(RoleConstants.GUEST)) {
-					continue;
-				}
-			}
-
 			List<String> actions = _getActions(roleElement);
 
 			importedRoleIdsToActionIds.put(
@@ -278,9 +264,6 @@ public class PermissionImporterImpl implements PermissionImporter {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		PermissionImporterImpl.class);
-
-	@Reference
-	private GroupLocalService _groupLocalService;
 
 	private CentralizedThreadLocal<LayoutCache> _layoutCacheThreadLocal;
 

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PermissionImporterImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PermissionImporterImpl.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.Team;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
-import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.TeamLocalService;
@@ -94,8 +93,8 @@ public class PermissionImporterImpl implements PermissionImporter {
 				layout.getPlid(), portletId);
 
 			_importPermissions(
-				companyId, groupId, userId, layout, resourceName,
-				resourcePrimKey, permissionsElement);
+				companyId, groupId, userId, resourceName, resourcePrimKey,
+				permissionsElement);
 		}
 	}
 
@@ -226,9 +225,8 @@ public class PermissionImporterImpl implements PermissionImporter {
 	}
 
 	private void _importPermissions(
-			long companyId, long groupId, long userId, Layout layout,
-			String resourceName, String resourcePrimKey,
-			Element permissionsElement)
+			long companyId, long groupId, long userId, String resourceName,
+			String resourcePrimKey, Element permissionsElement)
 		throws Exception {
 
 		Map<Long, Set<String>> existingRoleIdsToActionIds =


### PR DESCRIPTION
Test successfully executed in https://github.com/liferay-headless/liferay-portal/pull/3116. 
Forwarded manually as CI is not working correctly.

> https://liferay.atlassian.net/browse/LPD-65225
> 
> This code was added by [LPS-29597](https://liferay.atlassian.net/browse/LPS-29597) to avoid a security problem of non-members of the site accessing to the private pages. (see https://github.com/brianchandotcom/liferay-portal/pull/6765)
> In Liferay 6.1 the code was executed to import both Layout and portlet permissions.
> 
> After [LPS-34428](https://liferay.atlassian.net/browse/LPS-34428) changes, it seems it is not longer used to set the Layout permissions, and only applies to portlets. (see https://github.com/brianchandotcom/liferay-portal/pull/11089)
> (In fact the original LPS-29597 issue was reproduced again after this change and it was resolved in [LPS-53236](https://liferay.atlassian.net/browse/LPS-53236), see https://github.com/brianchandotcom/liferay-portal/pull/30984)
> 
> Guest permissions at portlet level are necessary to be able to index them in a content page, because the page is rendered using the guest permission.