### PR TITLE
LPD-63231 bulk part1 post

### DIFF
--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/ExpiredAssetResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/ExpiredAssetResourceImpl.java
@@ -10,6 +10,7 @@ import com.liferay.analytics.cms.rest.internal.depot.entry.util.DepotEntryUtil;
 import com.liferay.analytics.cms.rest.internal.resource.v1_0.util.ObjectEntryVersionTitleExpressionUtil;
 import com.liferay.analytics.cms.rest.resource.v1_0.ExpiredAssetResource;
 import com.liferay.layout.service.LayoutClassedModelUsageLocalService;
+import com.liferay.object.entry.util.ObjectEntryThreadLocal;
 import com.liferay.object.model.ObjectDefinitionTable;
 import com.liferay.object.model.ObjectEntryTable;
 import com.liferay.object.model.ObjectEntryVersionTable;
@@ -24,7 +25,6 @@ import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.sql.dsl.query.DSLQuery;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
@@ -97,9 +97,9 @@ public class ExpiredAssetResourceImpl extends BaseExpiredAssetResourceImpl {
 							return String.valueOf(objects[4]);
 						});
 					expiredAsset.setUsages(
-						() -> _getUsages(
-							String.valueOf(objects[0]), groupIds,
-							(Long)objects[2], objectEntryId));
+						() -> _getUsagesCount(
+							String.valueOf(objects[0]), (Long)objects[2],
+							objectEntryId));
 
 					return expiredAsset;
 				}),
@@ -209,35 +209,44 @@ public class ExpiredAssetResourceImpl extends BaseExpiredAssetResourceImpl {
 		return predicate;
 	}
 
-	private int _getUsages(
-			String className, Long[] groupIds, long objectDefinitionId,
-			long objectEntryId)
-		throws PortalException {
+	private long _getUsagesCount(
+			String className, long objectDefinitionId, long objectEntryId)
+		throws Exception {
 
-		int usages =
+		int usagesCount =
 			_layoutClassedModelUsageLocalService.
 				getLayoutClassedModelUsagesCount(
 					_portal.getClassNameId(className), objectEntryId);
 
-		List<ObjectRelationship> objectRelationships =
-			_objectRelationshipLocalService.
-				getObjectRelationshipsByObjectDefinitionId2(objectDefinitionId);
+		boolean skipObjectEntryResourcePermission =
+			ObjectEntryThreadLocal.isSkipObjectEntryResourcePermission();
 
-		for (ObjectRelationship objectRelationship : objectRelationships) {
-			ObjectRelatedModelsProvider objectRelatedModelsProvider =
-				_objectRelatedModelsProviderRegistry.
-					getObjectRelatedModelsProvider(
-						className, contextCompany.getCompanyId(),
-						objectRelationship.getType());
+		try {
+			ObjectEntryThreadLocal.setSkipObjectEntryResourcePermission(true);
 
-			for (long groupId : groupIds) {
-				usages += objectRelatedModelsProvider.getRelatedModelsCount(
-					groupId, objectRelationship.getObjectRelationshipId(), null,
-					objectEntryId, null);
+			List<ObjectRelationship> objectRelationships =
+				_objectRelationshipLocalService.getObjectRelationships(
+					objectDefinitionId);
+
+			for (ObjectRelationship objectRelationship : objectRelationships) {
+				ObjectRelatedModelsProvider objectRelatedModelsProvider =
+					_objectRelatedModelsProviderRegistry.
+						getObjectRelatedModelsProvider(
+							className, contextCompany.getCompanyId(),
+							objectRelationship.getType());
+
+				usagesCount +=
+					objectRelatedModelsProvider.getRelatedModelsCount(
+						0, objectRelationship.getObjectRelationshipId(), null,
+						objectEntryId, null);
 			}
 		}
+		finally {
+			ObjectEntryThreadLocal.setSkipObjectEntryResourcePermission(
+				skipObjectEntryResourcePermission);
+		}
 
-		return usages;
+		return usagesCount;
 	}
 
 	@Reference

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/BulkActionItem.java
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/BulkActionItem.java
@@ -18,6 +18,8 @@ import com.liferay.portal.vulcan.util.ObjectMapperUtil;
 
 import jakarta.annotation.Generated;
 
+import jakarta.validation.Valid;
+
 import jakarta.xml.bind.annotation.XmlRootElement;
 
 import java.io.Serializable;
@@ -45,6 +47,49 @@ public class BulkActionItem implements Serializable {
 	public static BulkActionItem unsafeToDTO(String json) {
 		return ObjectMapperUtil.unsafeReadValue(BulkActionItem.class, json);
 	}
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public Map<String, Object> getAttributes() {
+		if (_attributesSupplier != null) {
+			attributes = _attributesSupplier.get();
+
+			_attributesSupplier = null;
+		}
+
+		return attributes;
+	}
+
+	public void setAttributes(Map<String, Object> attributes) {
+		this.attributes = attributes;
+
+		_attributesSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setAttributes(
+		UnsafeSupplier<Map<String, Object>, Exception>
+			attributesUnsafeSupplier) {
+
+		_attributesSupplier = () -> {
+			try {
+				return attributesUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Map<String, Object> attributes;
+
+	@JsonIgnore
+	private Supplier<Map<String, Object>> _attributesSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
 	public String getClassExternalReferenceCode() {
@@ -238,6 +283,18 @@ public class BulkActionItem implements Serializable {
 		StringBundler sb = new StringBundler();
 
 		sb.append("{");
+
+		Map<String, Object> attributes = getAttributes();
+
+		if (attributes != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"attributes\": ");
+
+			sb.append(_toJSON(attributes));
+		}
 
 		String classExternalReferenceCode = getClassExternalReferenceCode();
 

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/resource/v1_0/BulkActionResource.java
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/resource/v1_0/BulkActionResource.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.cms.resource.v1_0;
 
 import com.liferay.headless.cms.dto.v1_0.BulkAction;
+import com.liferay.headless.cms.dto.v1_0.BulkActionItem;
 import com.liferay.headless.cms.dto.v1_0.BulkActionTask;
 import com.liferay.portal.kernel.change.tracking.CTAware;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -16,6 +17,8 @@ import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
 
 import jakarta.annotation.Generated;
 
@@ -47,6 +50,14 @@ public interface BulkActionResource {
 	public BulkActionTask postBulkAction(
 			String search,
 			com.liferay.portal.kernel.search.filter.Filter filter,
+			BulkAction bulkAction)
+		throws Exception;
+
+	public Page<BulkActionItem> postBulkActionItemPreviewPage(
+			String search,
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts,
 			BulkAction bulkAction)
 		throws Exception;
 

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/resources/com/liferay/headless/cms/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/resources/com/liferay/headless/cms/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/BulkActionItem.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/BulkActionItem.java
@@ -12,6 +12,7 @@ import jakarta.annotation.Generated;
 
 import java.io.Serializable;
 
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -24,6 +25,28 @@ public class BulkActionItem implements Cloneable, Serializable {
 	public static BulkActionItem toDTO(String json) {
 		return BulkActionItemSerDes.toDTO(json);
 	}
+
+	public Map<String, Object> getAttributes() {
+		return attributes;
+	}
+
+	public void setAttributes(Map<String, Object> attributes) {
+		this.attributes = attributes;
+	}
+
+	public void setAttributes(
+		UnsafeSupplier<Map<String, Object>, Exception>
+			attributesUnsafeSupplier) {
+
+		try {
+			attributes = attributesUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Map<String, Object> attributes;
 
 	public String getClassExternalReferenceCode() {
 		return classExternalReferenceCode;

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/resource/v1_0/BulkActionResource.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/resource/v1_0/BulkActionResource.java
@@ -6,9 +6,13 @@
 package com.liferay.headless.cms.client.resource.v1_0;
 
 import com.liferay.headless.cms.client.dto.v1_0.BulkAction;
+import com.liferay.headless.cms.client.dto.v1_0.BulkActionItem;
 import com.liferay.headless.cms.client.dto.v1_0.BulkActionTask;
 import com.liferay.headless.cms.client.http.HttpInvoker;
+import com.liferay.headless.cms.client.pagination.Page;
+import com.liferay.headless.cms.client.pagination.Pagination;
 import com.liferay.headless.cms.client.problem.Problem;
+import com.liferay.headless.cms.client.serdes.v1_0.BulkActionItemSerDes;
 import com.liferay.headless.cms.client.serdes.v1_0.BulkActionTaskSerDes;
 
 import jakarta.annotation.Generated;
@@ -39,6 +43,16 @@ public interface BulkActionResource {
 
 	public HttpInvoker.HttpResponse postBulkActionHttpResponse(
 			String search, String filterString, BulkAction bulkAction)
+		throws Exception;
+
+	public Page<BulkActionItem> postBulkActionItemPreviewPage(
+			String search, String filterString, Pagination pagination,
+			String sortString, BulkAction bulkAction)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postBulkActionItemPreviewPageHttpResponse(
+			String search, String filterString, Pagination pagination,
+			String sortString, BulkAction bulkAction)
 		throws Exception;
 
 	public static class Builder {
@@ -254,6 +268,135 @@ public interface BulkActionResource {
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
 						"/o/headless-cms/v1.0/bulk-action");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public Page<BulkActionItem> postBulkActionItemPreviewPage(
+				String search, String filterString, Pagination pagination,
+				String sortString, BulkAction bulkAction)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postBulkActionItemPreviewPageHttpResponse(
+					search, filterString, pagination, sortString, bulkAction);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, BulkActionItemSerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				postBulkActionItemPreviewPageHttpResponse(
+					String search, String filterString, Pagination pagination,
+					String sortString, BulkAction bulkAction)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(bulkAction.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (search != null) {
+				httpInvoker.parameter("search", String.valueOf(search));
+			}
+
+			if (filterString != null) {
+				httpInvoker.parameter("filter", filterString);
+			}
+
+			if (pagination != null) {
+				httpInvoker.parameter(
+					"page", String.valueOf(pagination.getPage()));
+				httpInvoker.parameter(
+					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
+
+			if (sortString != null) {
+				httpInvoker.parameter("sort", sortString);
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-cms/v1.0/bulk-action-item/preview");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/BulkActionItemSerDes.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/BulkActionItemSerDes.java
@@ -46,6 +46,16 @@ public class BulkActionItemSerDes {
 
 		sb.append("{");
 
+		if (bulkActionItem.getAttributes() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"attributes\": ");
+
+			sb.append(_toJSON(bulkActionItem.getAttributes()));
+		}
+
 		if (bulkActionItem.getClassExternalReferenceCode() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -117,6 +127,14 @@ public class BulkActionItemSerDes {
 
 		Map<String, String> map = new TreeMap<>();
 
+		if (bulkActionItem.getAttributes() == null) {
+			map.put("attributes", null);
+		}
+		else {
+			map.put(
+				"attributes", String.valueOf(bulkActionItem.getAttributes()));
+		}
+
 		if (bulkActionItem.getClassExternalReferenceCode() == null) {
 			map.put("classExternalReferenceCode", null);
 		}
@@ -165,8 +183,11 @@ public class BulkActionItemSerDes {
 
 		@Override
 		protected boolean parseMaps(String jsonParserFieldName) {
-			if (Objects.equals(
-					jsonParserFieldName, "classExternalReferenceCode")) {
+			if (Objects.equals(jsonParserFieldName, "attributes")) {
+				return true;
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "classExternalReferenceCode")) {
 
 				return false;
 			}
@@ -188,8 +209,14 @@ public class BulkActionItemSerDes {
 			BulkActionItem bulkActionItem, String jsonParserFieldName,
 			Object jsonParserFieldValue) {
 
-			if (Objects.equals(
-					jsonParserFieldName, "classExternalReferenceCode")) {
+			if (Objects.equals(jsonParserFieldName, "attributes")) {
+				if (jsonParserFieldValue != null) {
+					bulkActionItem.setAttributes(
+						(Map<String, Object>)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "classExternalReferenceCode")) {
 
 				if (jsonParserFieldValue != null) {
 					bulkActionItem.setClassExternalReferenceCode(

--- a/modules/apps/headless/headless-cms/headless-cms-impl/build.gradle
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/build.gradle
@@ -12,10 +12,12 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:depot:depot-api")
+	compileOnly project(":apps:document-library:document-library-api")
 	compileOnly project(":apps:headless:headless-batch-engine:headless-batch-engine-api")
 	compileOnly project(":apps:headless:headless-cms:headless-cms-api")
 	compileOnly project(":apps:headless:headless-common-spi")
 	compileOnly project(":apps:headless:headless-delivery:headless-delivery-api")
+	compileOnly project(":apps:layout:layout-api")
 	compileOnly project(":apps:object:object-api")
 	compileOnly project(":apps:object:object-rest-api")
 	compileOnly project(":apps:portal-odata:portal-odata-api")
@@ -23,6 +25,7 @@ dependencies {
 	compileOnly project(":apps:portal-search:portal-search-rest-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:sharing:sharing-api")
+	compileOnly project(":apps:trash:trash-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")

--- a/modules/apps/headless/headless-cms/headless-cms-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/rest-openapi.yaml
@@ -30,6 +30,10 @@ components:
                     type: string
         BulkActionItem:
             properties:
+                attributes:
+                    additionalProperties:
+                        type: object
+                    type: object
                 classExternalReferenceCode:
                     type: string
                 className:
@@ -158,4 +162,54 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/BulkActionTask"
+            tags: ["BulkAction"]
+    "/bulk-action-item/preview":
+        post:
+            description:
+                Creates a preview for each item based on the bulk action type
+            operationId: postBulkActionItemPreviewPage
+            parameters:
+                -   in: query
+                    name: filter
+                    schema:
+                        type: string
+                -   in: query
+                    name: page
+                    required: true
+                    schema:
+                        type: integer
+                -   in: query
+                    name: pageSize
+                    required: true
+                    schema:
+                        type: integer
+                -   in: query
+                    name: search
+                    schema:
+                        type: string
+                -   in: query
+                    name: sort
+                    schema:
+                        type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/BulkAction"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/BulkAction"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/BulkActionItem"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/BulkActionItem"
+                                type: array
             tags: ["BulkAction"]

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/mutation/v1_0/Mutation.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.cms.internal.graphql.mutation.v1_0;
 
 import com.liferay.headless.cms.dto.v1_0.BulkAction;
+import com.liferay.headless.cms.dto.v1_0.BulkActionItem;
 import com.liferay.headless.cms.dto.v1_0.BulkActionTask;
 import com.liferay.headless.cms.resource.v1_0.BulkActionResource;
 import com.liferay.petra.function.UnsafeConsumer;
@@ -15,6 +16,8 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
 
 import jakarta.annotation.Generated;
 
@@ -56,6 +59,35 @@ public class Mutation {
 				search,
 				_filterBiFunction.apply(bulkActionResource, filterString),
 				bulkAction));
+	}
+
+	@GraphQLField(
+		description = "Creates a preview for each item based on the bulk action type"
+	)
+	public java.util.Collection<BulkActionItem> createBulkActionItemPreviewPage(
+			@GraphQLName("search") String search,
+			@GraphQLName("filter") String filterString,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page,
+			@GraphQLName("sort") String sortsString,
+			@GraphQLName("bulkAction") BulkAction bulkAction)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_bulkActionResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			bulkActionResource -> {
+				Page paginationPage =
+					bulkActionResource.postBulkActionItemPreviewPage(
+						search,
+						_filterBiFunction.apply(
+							bulkActionResource, filterString),
+						Pagination.of(page, pageSize),
+						_sortsBiFunction.apply(bulkActionResource, sortsString),
+						bulkAction);
+
+				return paginationPage.getItems();
+			});
 	}
 
 	private <T, R, E1 extends Throwable, E2 extends Throwable> R

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -76,6 +76,11 @@ public class ServletDataImpl implements ServletData {
 						"mutation#createBulkAction",
 						new ObjectValuePair<>(
 							BulkActionResourceImpl.class, "postBulkAction"));
+					put(
+						"mutation#createBulkActionItemPreviewPage",
+						new ObjectValuePair<>(
+							BulkActionResourceImpl.class,
+							"postBulkActionItemPreviewPage"));
 				}
 			};
 

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/odata/entity/v1_0/BulkActionEntityModel.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/odata/entity/v1_0/BulkActionEntityModel.java
@@ -8,6 +8,7 @@ package com.liferay.headless.cms.internal.odata.entity.v1_0;
 import com.liferay.portal.odata.entity.BooleanEntityField;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.odata.entity.IntegerEntityField;
 import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.Map;
@@ -20,7 +21,11 @@ public class BulkActionEntityModel implements EntityModel {
 	public BulkActionEntityModel() {
 		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new BooleanEntityField("cmsRoot", locale -> "cms_root"),
-			new StringEntityField("cmsSection", locale -> "cms_section"));
+			new IntegerEntityField("folderId", locale -> "folderId"),
+			new IntegerEntityField("status", locale -> "status"),
+			new StringEntityField("cmsKind", locale -> "cms_kind"),
+			new StringEntityField("cmsSection", locale -> "cms_section"),
+			new StringEntityField("name", locale -> "name"));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BaseBulkActionResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BaseBulkActionResourceImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.cms.internal.resource.v1_0;
 
 import com.liferay.headless.cms.dto.v1_0.BulkAction;
+import com.liferay.headless.cms.dto.v1_0.BulkActionItem;
 import com.liferay.headless.cms.dto.v1_0.BulkActionTask;
 import com.liferay.headless.cms.resource.v1_0.BulkActionResource;
 import com.liferay.petra.function.UnsafeFunction;
@@ -21,6 +22,8 @@ import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.UriInfoUtil;
@@ -34,6 +37,7 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.UriInfo;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -84,6 +88,61 @@ public abstract class BaseBulkActionResourceImpl
 		throws Exception {
 
 		return new BulkActionTask();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-cms/v1.0/bulk-action-item/preview' -d $'{"bulkActionItems": ___, "selectAll": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Creates a preview for each item based on the bulk action type"
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "filter"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "search"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "sort"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "BulkAction")}
+	)
+	@jakarta.ws.rs.Consumes({"application/json", "application/xml"})
+	@jakarta.ws.rs.Path("/bulk-action-item/preview")
+	@jakarta.ws.rs.POST
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<BulkActionItem> postBulkActionItemPreviewPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("search")
+			String search,
+			@jakarta.ws.rs.core.Context
+				com.liferay.portal.kernel.search.filter.Filter filter,
+			@jakarta.ws.rs.core.Context Pagination pagination,
+			@jakarta.ws.rs.core.Context com.liferay.portal.kernel.search.Sort[]
+				sorts,
+			BulkAction bulkAction)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
 	}
 
 	@Override

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BulkActionResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BulkActionResourceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.headless.cms.internal.resource.v1_0;
 
+import com.liferay.document.library.display.context.DLMimeTypeDisplayContext;
 import com.liferay.headless.batch.engine.dto.v1_0.ImportTask;
 import com.liferay.headless.batch.engine.resource.v1_0.ImportTaskResource;
 import com.liferay.headless.cms.dto.v1_0.BulkAction;
@@ -14,27 +15,43 @@ import com.liferay.headless.cms.dto.v1_0.DefaultPermissionBulkAction;
 import com.liferay.headless.cms.dto.v1_0.DeleteBulkAction;
 import com.liferay.headless.cms.internal.odata.entity.v1_0.BulkActionEntityModel;
 import com.liferay.headless.cms.resource.v1_0.BulkActionResource;
+import com.liferay.layout.service.LayoutClassedModelUsageLocalService;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.entry.util.ObjectEntryThreadLocal;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.model.ObjectEntryVersion;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.related.models.ObjectRelatedModelsProvider;
+import com.liferay.object.related.models.ObjectRelatedModelsProviderRegistry;
 import com.liferay.object.rest.filter.factory.FilterFactory;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectEntryVersionLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.servlet.DynamicServletRequest;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -42,17 +59,21 @@ import com.liferay.portal.search.rest.dto.v1_0.SearchResult;
 import com.liferay.portal.search.rest.resource.v1_0.SearchResultResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.trash.TrashHelper;
 
 import jakarta.validation.ValidationException;
 
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.core.MultivaluedMap;
 
 import java.io.Serializable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -60,6 +81,7 @@ import org.osgi.service.component.annotations.ServiceScope;
 
 /**
  * @author Crescenzo Rega
+ * @author Thiago Buarque
  */
 @Component(
 	properties = "OSGI-INF/liferay/rest/v1_0/bulk-action.properties",
@@ -112,6 +134,47 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 		}
 
 		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Page<BulkActionItem> postBulkActionItemPreviewPage(
+			String search, Filter filter, Pagination pagination, Sort[] sorts,
+			BulkAction bulkAction)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-17564") ||
+			!Objects.equals(
+				bulkAction.getType(), BulkAction.Type.DELETE_BULK_ACTION)) {
+
+			throw new UnsupportedOperationException();
+		}
+
+		BulkActionItem[] bulkActionItems = bulkAction.getBulkActionItems();
+
+		if (ArrayUtil.isEmpty(bulkActionItems) &&
+			!GetterUtil.getBoolean(bulkAction.getSelectAll())) {
+
+			return Page.of(Collections.emptyList());
+		}
+
+		if (ArrayUtil.isNotEmpty(sorts)) {
+			Sort sort = sorts[0];
+
+			if (!StringUtil.equalsIgnoreCase(sort.getFieldName(), "name") ||
+				(sorts.length > 1)) {
+
+				throw new BadRequestException(
+					"Only the 'name' field is sortable");
+			}
+		}
+
+		if (!GetterUtil.getBoolean(bulkAction.getSelectAll())) {
+			return _getBulkActionItemPreviewPage(
+				ListUtil.fromArray(bulkActionItems), pagination, search, sorts);
+		}
+
+		return _getBulkActionItemPreviewPage(filter, pagination, search, sorts);
 	}
 
 	private BulkActionTask _addBulkActionTask(String type) throws Exception {
@@ -293,6 +356,107 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 		return bulkActionTask;
 	}
 
+	private Page<BulkActionItem> _getBulkActionItemPreviewPage(
+			Filter filter, Pagination pagination, String search, Sort[] sorts)
+		throws Exception {
+
+		if (filter == null) {
+			throw new ValidationException("Filter must not be null");
+		}
+
+		List<BulkActionItem> bulkActionItems = new ArrayList<>();
+
+		DynamicServletRequest dynamicServletRequest = new DynamicServletRequest(
+			contextHttpServletRequest);
+
+		dynamicServletRequest.setParameter("nestedFields", "embedded");
+
+		SearchResultResource searchResultResource =
+			_searchResultResourceFactory.create(
+			).httpServletRequest(
+				dynamicServletRequest
+			).httpServletResponse(
+				contextHttpServletResponse
+			).preferredLocale(
+				contextUser.getLocale()
+			).uriInfo(
+				contextUriInfo
+			).user(
+				contextUser
+			).build();
+
+		if (ArrayUtil.isNotEmpty(sorts)) {
+			Sort sort = sorts[0];
+
+			sort.setFieldName(
+				Field.getSortableFieldName(
+					"localized_title_".concat(contextUser.getLanguageId())));
+		}
+
+		Page<SearchResult> searchPage = searchResultResource.getSearchPage(
+			null, true, null, null, search, filter, pagination, sorts);
+
+		for (SearchResult searchResult : searchPage.getItems()) {
+			JSONObject jsonObject = _jsonFactory.createJSONObject(
+				String.valueOf(searchResult.getEmbedded()));
+
+			bulkActionItems.add(_toBulkActionItem(jsonObject.getLong("id")));
+		}
+
+		return Page.of(bulkActionItems, pagination, searchPage.getTotalCount());
+	}
+
+	private Page<BulkActionItem> _getBulkActionItemPreviewPage(
+			List<BulkActionItem> bulkActionItems1, Pagination pagination,
+			String search, Sort[] sorts)
+		throws Exception {
+
+		List<BulkActionItem> bulkActionItems2 = new ArrayList<>();
+
+		long totalCount = bulkActionItems1.size();
+
+		if (Validator.isNull(search) && ArrayUtil.isEmpty(sorts)) {
+			bulkActionItems1 = ListUtil.subList(
+				bulkActionItems1, pagination.getStartPosition(),
+				pagination.getEndPosition());
+		}
+
+		for (BulkActionItem bulkActionItem : bulkActionItems1) {
+			bulkActionItems2.add(
+				_toBulkActionItem(
+					GetterUtil.getLong(bulkActionItem.getClassPK())));
+		}
+
+		if (Validator.isNotNull(search)) {
+			bulkActionItems2 = ListUtil.filter(
+				bulkActionItems2,
+				bulkActionItem -> StringUtil.containsIgnoreCase(
+					bulkActionItem.getName(), search, StringPool.BLANK));
+
+			totalCount = bulkActionItems2.size();
+		}
+
+		if (ArrayUtil.isNotEmpty(sorts)) {
+			Sort sort = sorts[0];
+
+			bulkActionItems2 = ListUtil.sort(
+				bulkActionItems2,
+				(bulkActionItem1, bulkActionItem2) -> {
+					String name = bulkActionItem1.getName();
+
+					int value = name.compareTo(bulkActionItem2.getName());
+
+					if (!sort.isReverse()) {
+						return value;
+					}
+
+					return -value;
+				});
+		}
+
+		return Page.of(bulkActionItems2, pagination, totalCount);
+	}
+
 	private long _getBulkActionTaskItemObjectDefinitionId() throws Exception {
 		if (_bulkActionTaskItemObjectDefinition != null) {
 			return _bulkActionTaskItemObjectDefinition.getObjectDefinitionId();
@@ -472,6 +636,56 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 		return bulkActionItemsMap;
 	}
 
+	private String _getDeletionType(long groupId) throws PortalException {
+		if (_trashHelper.isTrashEnabled(groupId)) {
+			return "RECYCLE_BIN";
+		}
+
+		return "PERMANENT_DELETION";
+	}
+
+	private String _getMimeType(
+			ObjectDefinition objectDefinition, ObjectEntry objectEntry)
+		throws Exception {
+
+		if (Objects.equals(
+				objectDefinition.getExternalReferenceCode(),
+				"L_BASIC_WEB_CONTENT")) {
+
+			return "basic-web-content";
+		}
+		else if (Objects.equals(
+					objectDefinition.getExternalReferenceCode(), "L_BLOG")) {
+
+			return "blog";
+		}
+		else if (Objects.equals(
+					objectDefinition.getExternalReferenceCode(),
+					"L_KNOWLEDGE_BASE")) {
+
+			return "knowledge-base";
+		}
+
+		ObjectEntryVersion objectEntryVersion =
+			_objectEntryVersionLocalService.getObjectEntryVersion(
+				objectEntry.getObjectEntryId(), objectEntry.getVersion());
+
+		JSONObject contentJSONObject = _jsonFactory.createJSONObject(
+			objectEntryVersion.getContent());
+
+		JSONObject propertiesJSONObject = contentJSONObject.getJSONObject(
+			"properties");
+
+		JSONObject fileJSONObject = propertiesJSONObject.getJSONObject("file");
+
+		if (fileJSONObject != null) {
+			return _dlMimeTypeDisplayContext.getIconFileMimeType(
+				fileJSONObject.getString("mimeType"));
+		}
+
+		return "custom-structure";
+	}
+
 	private String _getTaskItemDelegateName(String className) throws Exception {
 		if (StringUtil.equals(
 				"com.liferay.object.model.ObjectEntryFolder", className)) {
@@ -486,10 +700,109 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 		return objectDefinition.getName();
 	}
 
+	private long _getUsages(
+			String className, long objectDefinitionId, long objectEntryId)
+		throws Exception {
+
+		int usages =
+			_layoutClassedModelUsageLocalService.
+				getLayoutClassedModelUsagesCount(
+					_portal.getClassNameId(className), objectEntryId);
+
+		boolean skipObjectEntryResourcePermission =
+			ObjectEntryThreadLocal.isSkipObjectEntryResourcePermission();
+
+		try {
+			ObjectEntryThreadLocal.setSkipObjectEntryResourcePermission(true);
+
+			List<ObjectRelationship> objectRelationships =
+				_objectRelationshipLocalService.getObjectRelationships(
+					objectDefinitionId);
+
+			for (ObjectRelationship objectRelationship : objectRelationships) {
+				ObjectRelatedModelsProvider objectRelatedModelsProvider =
+					_objectRelatedModelsProviderRegistry.
+						getObjectRelatedModelsProvider(
+							className, contextCompany.getCompanyId(),
+							objectRelationship.getType());
+
+				usages += objectRelatedModelsProvider.getRelatedModelsCount(
+					0, objectRelationship.getObjectRelationshipId(), null,
+					objectEntryId, null);
+			}
+		}
+		finally {
+			ObjectEntryThreadLocal.setSkipObjectEntryResourcePermission(
+				skipObjectEntryResourcePermission);
+		}
+
+		return usages;
+	}
+
+	private BulkActionItem _toBulkActionItem(long classPK) {
+		BulkActionItem bulkActionItem = new BulkActionItem();
+
+		bulkActionItem.setClassPK(() -> classPK);
+
+		ObjectEntry objectEntry = _objectEntryLocalService.fetchObjectEntry(
+			classPK);
+
+		if (objectEntry != null) {
+			ObjectDefinition objectDefinition =
+				_objectDefinitionLocalService.fetchObjectDefinition(
+					objectEntry.getObjectDefinitionId());
+
+			bulkActionItem.setAttributes(
+				() -> HashMapBuilder.<String, Object>put(
+					"deletionType",
+					() -> _getDeletionType(objectEntry.getGroupId())
+				).put(
+					"mimeType", _getMimeType(objectDefinition, objectEntry)
+				).put(
+					"type", "ASSET"
+				).put(
+					"usages",
+					_getUsages(
+						objectDefinition.getClassName(),
+						objectDefinition.getObjectDefinitionId(),
+						objectEntry.getObjectEntryId())
+				).build());
+			bulkActionItem.setClassName(objectDefinition::getClassName);
+
+			bulkActionItem.setClassExternalReferenceCode(
+				objectEntry::getExternalReferenceCode);
+			bulkActionItem.setName(
+				() -> objectEntry.getTitleValue(
+					LocaleUtil.toLanguageId(contextUser.getLocale()), true));
+
+			return bulkActionItem;
+		}
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.fetchObjectEntryFolder(classPK);
+
+		bulkActionItem.setAttributes(
+			() -> HashMapBuilder.<String, Object>put(
+				"deletionType",
+				() -> _getDeletionType(objectEntryFolder.getGroupId())
+			).put(
+				"type", "FOLDER"
+			).build());
+		bulkActionItem.setClassName(objectEntryFolder::getModelClassName);
+		bulkActionItem.setClassExternalReferenceCode(
+			objectEntryFolder::getExternalReferenceCode);
+		bulkActionItem.setName(objectEntryFolder::getName);
+
+		return bulkActionItem;
+	}
+
 	private static final EntityModel _entityModel = new BulkActionEntityModel();
 
 	private ObjectDefinition _bulkActionTaskItemObjectDefinition;
 	private ObjectDefinition _bulkActionTaskObjectDefinition;
+
+	@Reference
+	private DLMimeTypeDisplayContext _dlMimeTypeDisplayContext;
 
 	@Reference(
 		target = "(filter.factory.key=" + ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT + ")"
@@ -503,12 +816,35 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 	private JSONFactory _jsonFactory;
 
 	@Reference
+	private LayoutClassedModelUsageLocalService
+		_layoutClassedModelUsageLocalService;
+
+	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
 
 	@Reference
 	private ObjectEntryLocalService _objectEntryLocalService;
 
 	@Reference
+	private ObjectEntryVersionLocalService _objectEntryVersionLocalService;
+
+	@Reference
+	private ObjectRelatedModelsProviderRegistry
+		_objectRelatedModelsProviderRegistry;
+
+	@Reference
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	@Reference
+	private Portal _portal;
+
+	@Reference
 	private SearchResultResource.Factory _searchResultResourceFactory;
+
+	@Reference
+	private TrashHelper _trashHelper;
 
 }

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BulkActionResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BulkActionResourceImpl.java
@@ -700,11 +700,11 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 		return objectDefinition.getName();
 	}
 
-	private long _getUsages(
+	private long _getUsagesCount(
 			String className, long objectDefinitionId, long objectEntryId)
 		throws Exception {
 
-		int usages =
+		int usagesCount =
 			_layoutClassedModelUsageLocalService.
 				getLayoutClassedModelUsagesCount(
 					_portal.getClassNameId(className), objectEntryId);
@@ -726,9 +726,10 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 							className, contextCompany.getCompanyId(),
 							objectRelationship.getType());
 
-				usages += objectRelatedModelsProvider.getRelatedModelsCount(
-					0, objectRelationship.getObjectRelationshipId(), null,
-					objectEntryId, null);
+				usagesCount +=
+					objectRelatedModelsProvider.getRelatedModelsCount(
+						0, objectRelationship.getObjectRelationshipId(), null,
+						objectEntryId, null);
 			}
 		}
 		finally {
@@ -736,7 +737,7 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 				skipObjectEntryResourcePermission);
 		}
 
-		return usages;
+		return usagesCount;
 	}
 
 	private BulkActionItem _toBulkActionItem(long classPK) {
@@ -762,7 +763,7 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 					"type", "ASSET"
 				).put(
 					"usages",
-					_getUsages(
+					_getUsagesCount(
 						objectDefinition.getClassName(),
 						objectDefinition.getObjectDefinitionId(),
 						objectEntry.getObjectEntryId())

--- a/modules/apps/headless/headless-cms/headless-cms-test/build.gradle
+++ b/modules/apps/headless/headless-cms/headless-cms-test/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:headless:headless-batch-engine:headless-batch-engine-client")
 	testIntegrationImplementation project(":apps:headless:headless-cms:headless-cms-api")
 	testIntegrationImplementation project(":apps:headless:headless-cms:headless-cms-client")
+	testIntegrationImplementation project(":apps:layout:layout-api")
 	testIntegrationImplementation project(":apps:oauth2-provider:oauth2-provider-scope-api")
 	testIntegrationImplementation project(":apps:object:object-api")
 	testIntegrationImplementation project(":apps:object:object-rest-api")

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BaseBulkActionResourceTestCase.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BaseBulkActionResourceTestCase.java
@@ -182,6 +182,11 @@ public abstract class BaseBulkActionResourceTestCase {
 	}
 
 	@Test
+	public void testPostBulkActionItemPreviewPage() throws Exception {
+		Assert.assertTrue(false);
+	}
+
+	@Test
 	public void testPostBulkAction() throws Exception {
 		Assert.assertTrue(true);
 	}

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BulkActionResourceTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BulkActionResourceTest.java
@@ -18,7 +18,10 @@ import com.liferay.headless.cms.client.dto.v1_0.BulkActionItem;
 import com.liferay.headless.cms.client.dto.v1_0.BulkActionTask;
 import com.liferay.headless.cms.client.dto.v1_0.DefaultPermissionBulkAction;
 import com.liferay.headless.cms.client.dto.v1_0.DeleteBulkAction;
+import com.liferay.headless.cms.client.pagination.Page;
+import com.liferay.headless.cms.client.pagination.Pagination;
 import com.liferay.headless.cms.client.problem.Problem;
+import com.liferay.layout.service.LayoutClassedModelUsageLocalService;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
@@ -36,21 +39,28 @@ import com.liferay.object.service.ObjectFolderLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -60,7 +70,9 @@ import java.io.File;
 import java.io.Serializable;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -79,7 +91,13 @@ import org.osgi.framework.FrameworkUtil;
 /**
  * @author Crescenzo Rega
  */
-@FeatureFlag("LPD-17564")
+@FeatureFlags(
+	featureFlags = {
+		@FeatureFlag("LPD-17564"), @FeatureFlag("LPD-21926"),
+		@FeatureFlag("LPD-31149"), @FeatureFlag("LPD-34594"),
+		@FeatureFlag("LPS-179669")
+	}
+)
 @RunWith(Arquillian.class)
 public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 
@@ -136,16 +154,13 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 			_objectDefinitionLocalService.
 				getObjectDefinitionByExternalReferenceCode(
 					"L_BULK_ACTION_TASK", testCompany.getCompanyId());
-		_depotEntry = _depotEntryLocalService.addDepotEntry(
-			HashMapBuilder.put(
-				LocaleUtil.getDefault(), RandomTestUtil.randomString()
-			).build(),
-			HashMapBuilder.put(
-				LocaleUtil.getDefault(), RandomTestUtil.randomString()
-			).build(),
-			DepotConstants.TYPE_ASSET_LIBRARY,
-			ServiceContextTestUtil.getServiceContext(
-				testGroup.getGroupId(), TestPropsValues.getUserId()));
+
+		_depotEntry1 = _addDepotEntry(true);
+		_depotEntry2 = _addDepotEntry(false);
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_depotEntry1.getGroupId(), TestPropsValues.getUserId());
+
 		_importTaskResource = ImportTaskResource.builder(
 		).authentication(
 			"test@liferay.com", PropsValues.DEFAULT_ADMIN_PASSWORD
@@ -156,6 +171,8 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 		).parameter(
 			"siteId", String.valueOf(TestPropsValues.getGroupId())
 		).build();
+
+		_user = UserTestUtil.addUser();
 	}
 
 	@Override
@@ -163,6 +180,91 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 	public void testPostBulkAction() throws Exception {
 		_testPostBulkActionWithTypeDefaultPermission();
 		_testPostBulkActionWithTypeDelete();
+	}
+
+	@Override
+	@Test
+	public void testPostBulkActionItemPreviewPage() throws Exception {
+		_testPostBulkActionItemPreviewPage(_depotEntry1, "RECYCLE_BIN");
+		_testPostBulkActionItemPreviewPage(_depotEntry2, "PERMANENT_DELETION");
+	}
+
+	private DepotEntry _addDepotEntry(boolean trashEnabled) throws Exception {
+		Map<Locale, String> nameMap = Collections.singletonMap(
+			LocaleUtil.US, RandomTestUtil.randomString());
+
+		ServiceContext serviceContext = new ServiceContext() {
+			{
+				setCompanyId(testGroup.getCompanyId());
+				setUserId(TestPropsValues.getUserId());
+			}
+		};
+
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			nameMap, null, DepotConstants.TYPE_ASSET_LIBRARY, serviceContext);
+
+		return _depotEntryLocalService.updateDepotEntry(
+			depotEntry.getDepotEntryId(), nameMap, null, Collections.emptyMap(),
+			UnicodePropertiesBuilder.put(
+				"trashEnabled", trashEnabled
+			).build(),
+			serviceContext);
+	}
+
+	private ObjectEntry _addObjectEntry(long groupId, long objectEntryFolderId)
+		throws Exception {
+
+		return _objectEntryLocalService.addObjectEntry(
+			groupId, _user.getUserId(),
+			_basicWebContentObjectDefinition.getObjectDefinitionId(),
+			objectEntryFolderId, _LANGUAGE_ID,
+			HashMapBuilder.<String, Serializable>put(
+				"title_i18n",
+				HashMapBuilder.<String, Serializable>put(
+					_LANGUAGE_ID, RandomTestUtil.randomString()
+				).build()
+			).build(),
+			_serviceContext);
+	}
+
+	private ObjectEntryFolder _addObjectEntryFolder(
+			long groupId, long parentObjectEntryFolderId)
+		throws Exception {
+
+		String name = RandomTestUtil.randomString();
+
+		return _objectEntryFolderLocalService.addObjectEntryFolder(
+			null, groupId, _user.getUserId(), parentObjectEntryFolderId, null,
+			HashMapBuilder.put(
+				LocaleUtil.US, name
+			).build(),
+			name, _serviceContext);
+	}
+
+	private void _assertBulkActionItem(
+		BulkActionItem bulkActionItem, long expectedClassPK,
+		String expectedDeletionType, String expectedMimeType,
+		String expectedName, String expectedType, Long usages1) {
+
+		Map<String, Object> attributes = bulkActionItem.getAttributes();
+
+		Assert.assertEquals(
+			expectedDeletionType, attributes.get("deletionType"));
+		Assert.assertEquals(expectedMimeType, attributes.get("mimeType"));
+		Assert.assertEquals(expectedType, attributes.get("type"));
+
+		Object usages2 = attributes.get("usages");
+
+		if (usages1 == null) {
+			Assert.assertNull(usages2);
+		}
+		else {
+			Assert.assertEquals(
+				usages1.longValue(), GetterUtil.getLong(usages2));
+		}
+
+		Assert.assertEquals(expectedClassPK, (long)bulkActionItem.getClassPK());
+		Assert.assertEquals(expectedName, bulkActionItem.getName());
 	}
 
 	private void _deleteFile(Bundle bundle, String fileName) {
@@ -189,7 +291,7 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 			objectDefinition);
 
 		List<Long> primaryKeys = _objectEntryLocalService.getPrimaryKeys(
-			new Long[0], _depotEntry.getCompanyId(),
+			new Long[0], _depotEntry2.getCompanyId(),
 			TestPropsValues.getUserId(),
 			objectDefinition.getObjectDefinitionId(), predicate, null,
 			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
@@ -246,6 +348,102 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 		return false;
 	}
 
+	private void _testPostBulkActionItemPreviewPage(
+			DepotEntry depotEntry, String expectedDeletionType)
+		throws Exception {
+
+		ObjectEntryFolder contentObjectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					"L_CONTENTS", depotEntry.getGroupId(),
+					testCompany.getCompanyId());
+
+		ObjectEntryFolder objectEntryFolder1 = _addObjectEntryFolder(
+			depotEntry.getGroupId(),
+			contentObjectEntryFolder.getObjectEntryFolderId());
+
+		_serviceContext.setAttribute(
+			"friendlyUrlMap", new HashMap<String, String>());
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			depotEntry.getGroupId(),
+			objectEntryFolder1.getObjectEntryFolderId());
+
+		_layoutClassedModelUsageLocalService.addLayoutClassedModelUsage(
+			testGroup.getGroupId(), StringPool.BLANK,
+			_portal.getClassNameId(
+				_basicWebContentObjectDefinition.getClassName()),
+			objectEntry.getObjectEntryId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomInt(), RandomTestUtil.randomInt(),
+			_serviceContext);
+
+		ObjectEntryFolder objectEntryFolder2 = _addObjectEntryFolder(
+			depotEntry.getGroupId(),
+			objectEntryFolder1.getObjectEntryFolderId());
+
+		BulkAction bulkAction = new DeleteBulkAction();
+
+		bulkAction.setBulkActionItems(
+			new BulkActionItem[] {
+				_toBulkActionItem(
+					_basicWebContentObjectDefinition.getClassName(),
+					objectEntry),
+				_toBulkActionItem(objectEntryFolder2)
+			});
+		bulkAction.setSelectAll(false);
+		bulkAction.setType(BulkAction.Type.DELETE_BULK_ACTION);
+
+		Page<BulkActionItem> page =
+			bulkActionResource.postBulkActionItemPreviewPage(
+				null, null, Pagination.of(1, 10), "name:desc", bulkAction);
+
+		Assert.assertEquals(2, page.getTotalCount());
+
+		List<BulkActionItem> items = ListUtil.fromCollection(page.getItems());
+
+		Assert.assertEquals(items.toString(), 2, items.size());
+
+		String name = objectEntry.getTitleValue(_LANGUAGE_ID);
+
+		if (name.compareTo(objectEntryFolder2.getName()) < 0) {
+			_assertBulkActionItem(
+				items.get(0), objectEntryFolder2.getObjectEntryFolderId(),
+				expectedDeletionType, null, objectEntryFolder2.getName(),
+				"FOLDER", null);
+			_assertBulkActionItem(
+				items.get(1), objectEntry.getObjectEntryId(),
+				expectedDeletionType, "basic-web-content",
+				objectEntry.getTitleValue(_LANGUAGE_ID), "ASSET", 1L);
+		}
+		else {
+			_assertBulkActionItem(
+				items.get(0), objectEntry.getObjectEntryId(),
+				expectedDeletionType, "basic-web-content",
+				objectEntry.getTitleValue(_LANGUAGE_ID), "ASSET", 1L);
+			_assertBulkActionItem(
+				items.get(1), objectEntryFolder2.getObjectEntryFolderId(),
+				expectedDeletionType, null, objectEntryFolder2.getName(),
+				"FOLDER", null);
+		}
+
+		bulkAction.setSelectAll(true);
+
+		page = bulkActionResource.postBulkActionItemPreviewPage(
+			objectEntryFolder2.getName(),
+			"folderId eq " + objectEntryFolder1.getObjectEntryFolderId(),
+			Pagination.of(1, 10), null, bulkAction);
+
+		items = ListUtil.fromCollection(page.getItems());
+
+		Assert.assertEquals(items.toString(), 1, items.size());
+		Assert.assertEquals(items.toString(), 1, page.getTotalCount());
+
+		_assertBulkActionItem(
+			items.get(0), objectEntryFolder2.getObjectEntryFolderId(),
+			expectedDeletionType, null, objectEntryFolder2.getName(), "FOLDER",
+			null);
+	}
+
 	private void _testPostBulkActionWithTypeDefaultPermission()
 		throws Exception {
 
@@ -271,17 +469,17 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 		ObjectDefinition objectDefinition =
 			ObjectDefinitionLocalServiceUtil.
 				getObjectDefinitionByExternalReferenceCode(
-					"L_CMS_DEFAULT_PERMISSION", _depotEntry.getCompanyId());
+					"L_CMS_DEFAULT_PERMISSION", _depotEntry2.getCompanyId());
 
 		ObjectEntryFolder objectEntryFolder1 =
 			_objectEntryFolderLocalService.
 				getObjectEntryFolderByExternalReferenceCode(
 					ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS,
-					_depotEntry.getGroupId(), _depotEntry.getCompanyId());
+					_depotEntry2.getGroupId(), _depotEntry2.getCompanyId());
 
 		ObjectEntryFolder objectEntryFolder2 =
 			_objectEntryFolderLocalService.addObjectEntryFolder(
-				RandomTestUtil.randomString(), _depotEntry.getGroupId(),
+				RandomTestUtil.randomString(), _depotEntry2.getGroupId(),
 				TestPropsValues.getUserId(),
 				objectEntryFolder1.getObjectEntryFolderId(), "",
 				HashMapBuilder.put(
@@ -299,7 +497,7 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 
 		ObjectEntryFolder objectEntryFolder3 =
 			_objectEntryFolderLocalService.addObjectEntryFolder(
-				RandomTestUtil.randomString(), _depotEntry.getGroupId(),
+				RandomTestUtil.randomString(), _depotEntry2.getGroupId(),
 				TestPropsValues.getUserId(),
 				objectEntryFolder1.getObjectEntryFolderId(), "",
 				HashMapBuilder.put(
@@ -315,7 +513,7 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 			jsonObject.has(
 				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS));
 
-		defaultPermissionBulkAction.setDepotGroupId(_depotEntry.getGroupId());
+		defaultPermissionBulkAction.setDepotGroupId(_depotEntry2.getGroupId());
 
 		BulkActionTask bulkActionTask = bulkActionResource.postBulkAction(
 			null, null, defaultPermissionBulkAction);
@@ -342,7 +540,7 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 
 		ObjectEntryFolder objectEntryFolder4 =
 			_objectEntryFolderLocalService.addObjectEntryFolder(
-				RandomTestUtil.randomString(), _depotEntry.getGroupId(),
+				RandomTestUtil.randomString(), _depotEntry2.getGroupId(),
 				TestPropsValues.getUserId(),
 				objectEntryFolder3.getObjectEntryFolderId(), "",
 				HashMapBuilder.put(
@@ -414,7 +612,7 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 
 		ObjectEntry basicWebContentObjectEntry =
 			ObjectEntryTestUtil.addObjectEntry(
-				_depotEntry.getGroupId(), _basicWebContentObjectDefinition,
+				_depotEntry2.getGroupId(), _basicWebContentObjectDefinition,
 				Collections.emptyMap());
 
 		bulkAction.setBulkActionItems(
@@ -457,6 +655,35 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 				basicWebContentObjectEntry.getObjectEntryId()));
 	}
 
+	private BulkActionItem _toBulkActionItem(
+		ObjectEntryFolder objectEntryFolder) {
+
+		BulkActionItem bulkActionItem = new BulkActionItem();
+
+		bulkActionItem.setClassPK(objectEntryFolder.getObjectEntryFolderId());
+		bulkActionItem.setClassName(objectEntryFolder.getModelClassName());
+		bulkActionItem.setClassExternalReferenceCode(
+			objectEntryFolder.getExternalReferenceCode());
+		bulkActionItem.setName(objectEntryFolder.getName());
+
+		return bulkActionItem;
+	}
+
+	private BulkActionItem _toBulkActionItem(
+			String className, ObjectEntry objectEntry)
+		throws Exception {
+
+		BulkActionItem bulkActionItem = new BulkActionItem();
+
+		bulkActionItem.setClassPK(objectEntry.getObjectEntryId());
+		bulkActionItem.setClassName(className);
+		bulkActionItem.setClassExternalReferenceCode(
+			objectEntry.getExternalReferenceCode());
+		bulkActionItem.setName(objectEntry.getTitleValue(_LANGUAGE_ID));
+
+		return bulkActionItem;
+	}
+
 	private void _waitForFinish(long importTaskId) throws Exception {
 		while (true) {
 			ImportTask importTask = _importTaskResource.getImportTask(
@@ -475,6 +702,8 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 		}
 	}
 
+	private static final String _LANGUAGE_ID = "en_US";
+
 	private ObjectDefinition _basicWebContentObjectDefinition;
 
 	@Inject
@@ -484,7 +713,8 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 	private BatchEngineUnitReader _batchEngineUnitReader;
 
 	private ObjectDefinition _bulkActionTaskObjectDefinition;
-	private DepotEntry _depotEntry;
+	private DepotEntry _depotEntry1;
+	private DepotEntry _depotEntry2;
 
 	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;
@@ -495,6 +725,10 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 	private FilterFactory<Predicate> _filterFactory;
 
 	private ImportTaskResource _importTaskResource;
+
+	@Inject
+	private LayoutClassedModelUsageLocalService
+		_layoutClassedModelUsageLocalService;
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
@@ -510,5 +744,11 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 
 	@Inject
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	@Inject
+	private Portal _portal;
+
+	private ServiceContext _serviceContext;
+	private User _user;
 
 }


### PR DESCRIPTION
Fixing rebase issues https://github.com/brianchandotcom/liferay-portal/pull/165644

# Original description

Links:
- Related epic: https://liferay.atlassian.net/browse/LPD-48123
- Related story: https://liferay.atlassian.net/browse/LPD-62929
- Related task: https://liferay.atlassian.net/browse/LPD-63231

## Goal

To add a way of previewing what will happen to a assets/folders that are being marked for deletion. The idea is to prevent broken links.

## How?

I am adding a new post endpoint to the `headless-cms` module using REST builder. The idea is to add it dynamic, so it's possible to add preview for other bulk actions as well. With that in mind, a new entity is being added to return custom data based on the action being previewed:
```yaml
        BulkActionPreviewItem:
            properties:
                attributes:
                    additionalProperties:
                        type: object
                    type: object
                className:
                    type: string
                classPK:
                    format: int64
                    type: integer
                externalReferenceCode:
                    type: string
                name:
                    type: string
```

## Images

This endpoint will provide data for the following modals. For the entire design the [see Figma file](https://www.figma.com/design/IeYGhyy3lIJZ2qfe0id9LE/LPD-48123---Prevent-Broken-Links?node-id=1549-17451&p=f&t=WWc5cDzBptmuGmen-0).

<img width="1728" height="1117" alt="png(2)" src="https://github.com/user-attachments/assets/39dce2d7-0ec0-49e7-8e6f-6d9c2f81ea9d" />

and

<img width="1728" height="1117" alt="png(1)" src="https://github.com/user-attachments/assets/2ced7269-4e96-4d41-8e60-5c8046513001" />
