### PR TITLE
LPD-65055 Autogenerate UPDATE strategy for batch for ERC exclusive APIs 

### DIFF
--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCatalogResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCatalogResourceImpl.java
@@ -643,8 +643,17 @@ public abstract class BaseCatalogResourceImpl
 					Catalog persistedCatalog = null;
 
 					try {
-						getCatalog = getCatalogByExternalReferenceCode(
-							catalog.getExternalReferenceCode());
+						if (parameters.containsKey("externalReferenceCode")) {
+							getCatalog =
+								getProductByExternalReferenceCodeCatalog(
+									(String)parameters.get(
+										"externalReferenceCode"),
+									(Pagination)parameters.get("pagination"));
+						}
+						else {
+							getCatalog = getCatalogByExternalReferenceCode(
+								catalog.getExternalReferenceCode());
+						}
 
 						patchCatalog(getCatalog.getId(), catalog);
 					}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseDisplayPageTemplateFolderResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseDisplayPageTemplateFolderResourceImpl.java
@@ -884,6 +884,37 @@ public abstract class BaseDisplayPageTemplateFolderResourceImpl
 			}
 		}
 
+		if (StringUtil.equalsIgnoreCase(createStrategy, "UPSERT")) {
+			String updateStrategy = (String)parameters.getOrDefault(
+				"updateStrategy", "UPDATE");
+
+			if (StringUtil.equalsIgnoreCase(updateStrategy, "UPDATE")) {
+				displayPageTemplateFolderUnsafeFunction =
+					displayPageTemplateFolder -> {
+						DisplayPageTemplateFolder
+							persistedDisplayPageTemplateFolder = null;
+
+						if (parameters.containsKey(
+								"siteExternalReferenceCode")) {
+
+							persistedDisplayPageTemplateFolder =
+								putSiteDisplayPageTemplateFolder(
+									(String)parameters.get(
+										"siteExternalReferenceCode"),
+									displayPageTemplateFolder.
+										getExternalReferenceCode(),
+									displayPageTemplateFolder);
+						}
+						else {
+							throw new NotSupportedException(
+								"One of the following parameters must be specified: [siteExternalReferenceCode]");
+						}
+
+						return persistedDisplayPageTemplateFolder;
+					};
+			}
+		}
+
 		if (displayPageTemplateFolderUnsafeFunction == null) {
 			throw new NotSupportedException(
 				"Create strategy \"" + createStrategy +
@@ -957,7 +988,7 @@ public abstract class BaseDisplayPageTemplateFolderResourceImpl
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
-		return SetUtil.fromArray("INSERT");
+		return SetUtil.fromArray("INSERT", "UPSERT");
 	}
 
 	public Set<String> getAvailableUpdateStrategies() {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseDisplayPageTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseDisplayPageTemplateResourceImpl.java
@@ -1058,6 +1058,32 @@ public abstract class BaseDisplayPageTemplateResourceImpl
 			}
 		}
 
+		if (StringUtil.equalsIgnoreCase(createStrategy, "UPSERT")) {
+			String updateStrategy = (String)parameters.getOrDefault(
+				"updateStrategy", "UPDATE");
+
+			if (StringUtil.equalsIgnoreCase(updateStrategy, "UPDATE")) {
+				displayPageTemplateUnsafeFunction = displayPageTemplate -> {
+					DisplayPageTemplate persistedDisplayPageTemplate = null;
+
+					if (parameters.containsKey("siteExternalReferenceCode")) {
+						persistedDisplayPageTemplate =
+							putSiteDisplayPageTemplate(
+								(String)parameters.get(
+									"siteExternalReferenceCode"),
+								displayPageTemplate.getExternalReferenceCode(),
+								displayPageTemplate);
+					}
+					else {
+						throw new NotSupportedException(
+							"One of the following parameters must be specified: [siteExternalReferenceCode]");
+					}
+
+					return persistedDisplayPageTemplate;
+				};
+			}
+		}
+
 		if (displayPageTemplateUnsafeFunction == null) {
 			throw new NotSupportedException(
 				"Create strategy \"" + createStrategy +
@@ -1119,7 +1145,7 @@ public abstract class BaseDisplayPageTemplateResourceImpl
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
-		return SetUtil.fromArray("INSERT");
+		return SetUtil.fromArray("INSERT", "UPSERT");
 	}
 
 	public Set<String> getAvailableUpdateStrategies() {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseFragmentCompositionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseFragmentCompositionResourceImpl.java
@@ -683,6 +683,32 @@ public abstract class BaseFragmentCompositionResourceImpl
 			}
 		}
 
+		if (StringUtil.equalsIgnoreCase(createStrategy, "UPSERT")) {
+			String updateStrategy = (String)parameters.getOrDefault(
+				"updateStrategy", "UPDATE");
+
+			if (StringUtil.equalsIgnoreCase(updateStrategy, "UPDATE")) {
+				fragmentCompositionUnsafeFunction = fragmentComposition -> {
+					FragmentComposition persistedFragmentComposition = null;
+
+					if (parameters.containsKey("siteExternalReferenceCode")) {
+						persistedFragmentComposition =
+							putSiteFragmentComposition(
+								(String)parameters.get(
+									"siteExternalReferenceCode"),
+								fragmentComposition.getExternalReferenceCode(),
+								fragmentComposition);
+					}
+					else {
+						throw new NotSupportedException(
+							"One of the following parameters must be specified: [siteExternalReferenceCode]");
+					}
+
+					return persistedFragmentComposition;
+				};
+			}
+		}
+
 		if (fragmentCompositionUnsafeFunction == null) {
 			throw new NotSupportedException(
 				"Create strategy \"" + createStrategy +
@@ -744,7 +770,7 @@ public abstract class BaseFragmentCompositionResourceImpl
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
-		return SetUtil.fromArray("INSERT");
+		return SetUtil.fromArray("INSERT", "UPSERT");
 	}
 
 	public Set<String> getAvailableUpdateStrategies() {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseMasterPageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseMasterPageResourceImpl.java
@@ -861,6 +861,29 @@ public abstract class BaseMasterPageResourceImpl
 			}
 		}
 
+		if (StringUtil.equalsIgnoreCase(createStrategy, "UPSERT")) {
+			String updateStrategy = (String)parameters.getOrDefault(
+				"updateStrategy", "UPDATE");
+
+			if (StringUtil.equalsIgnoreCase(updateStrategy, "UPDATE")) {
+				masterPageUnsafeFunction = masterPage -> {
+					MasterPage persistedMasterPage = null;
+
+					if (parameters.containsKey("siteExternalReferenceCode")) {
+						persistedMasterPage = putSiteMasterPage(
+							(String)parameters.get("siteExternalReferenceCode"),
+							masterPage.getExternalReferenceCode(), masterPage);
+					}
+					else {
+						throw new NotSupportedException(
+							"One of the following parameters must be specified: [siteExternalReferenceCode]");
+					}
+
+					return persistedMasterPage;
+				};
+			}
+		}
+
 		if (masterPageUnsafeFunction == null) {
 			throw new NotSupportedException(
 				"Create strategy \"" + createStrategy +
@@ -918,7 +941,7 @@ public abstract class BaseMasterPageResourceImpl
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
-		return SetUtil.fromArray("INSERT");
+		return SetUtil.fromArray("INSERT", "UPSERT");
 	}
 
 	public Set<String> getAvailableUpdateStrategies() {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageExperienceResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageExperienceResourceImpl.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
@@ -42,6 +43,7 @@ import jakarta.annotation.Generated;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import jakarta.ws.rs.NotSupportedException;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.UriInfo;
@@ -454,8 +456,55 @@ public abstract class BasePageExperienceResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
+		UnsafeFunction<PageExperience, PageExperience, Exception>
+			pageExperienceUnsafeFunction = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if (StringUtil.equalsIgnoreCase(createStrategy, "UPSERT")) {
+			String updateStrategy = (String)parameters.getOrDefault(
+				"updateStrategy", "UPDATE");
+
+			if (StringUtil.equalsIgnoreCase(updateStrategy, "UPDATE")) {
+				pageExperienceUnsafeFunction = pageExperience -> {
+					PageExperience persistedPageExperience = null;
+
+					if (parameters.containsKey("siteExternalReferenceCode")) {
+						persistedPageExperience = putSitePageExperience(
+							(String)parameters.get("siteExternalReferenceCode"),
+							pageExperience.getExternalReferenceCode(),
+							pageExperience);
+					}
+					else {
+						throw new NotSupportedException(
+							"One of the following parameters must be specified: [siteExternalReferenceCode]");
+					}
+
+					return persistedPageExperience;
+				};
+			}
+		}
+
+		if (pageExperienceUnsafeFunction == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" is not supported for PageExperience");
+		}
+
+		if (contextBatchUnsafeBiConsumer != null) {
+			contextBatchUnsafeBiConsumer.accept(
+				pageExperiences, pageExperienceUnsafeFunction);
+		}
+		else if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				pageExperiences, pageExperienceUnsafeFunction::apply);
+		}
+		else {
+			for (PageExperience pageExperience : pageExperiences) {
+				pageExperienceUnsafeFunction.apply(pageExperience);
+			}
+		}
 	}
 
 	@Override
@@ -494,7 +543,7 @@ public abstract class BasePageExperienceResourceImpl
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
-		return SetUtil.fromArray();
+		return SetUtil.fromArray("UPSERT");
 	}
 
 	public Set<String> getAvailableUpdateStrategies() {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageRuleActionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageRuleActionResourceImpl.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
@@ -42,6 +43,7 @@ import jakarta.annotation.Generated;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import jakarta.ws.rs.NotSupportedException;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.UriInfo;
@@ -448,8 +450,55 @@ public abstract class BasePageRuleActionResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
+		UnsafeFunction<PageRuleAction, PageRuleAction, Exception>
+			pageRuleActionUnsafeFunction = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if (StringUtil.equalsIgnoreCase(createStrategy, "UPSERT")) {
+			String updateStrategy = (String)parameters.getOrDefault(
+				"updateStrategy", "UPDATE");
+
+			if (StringUtil.equalsIgnoreCase(updateStrategy, "UPDATE")) {
+				pageRuleActionUnsafeFunction = pageRuleAction -> {
+					PageRuleAction persistedPageRuleAction = null;
+
+					if (parameters.containsKey("siteExternalReferenceCode")) {
+						persistedPageRuleAction = putSitePageRuleAction(
+							(String)parameters.get("siteExternalReferenceCode"),
+							pageRuleAction.getExternalReferenceCode(),
+							pageRuleAction);
+					}
+					else {
+						throw new NotSupportedException(
+							"One of the following parameters must be specified: [siteExternalReferenceCode]");
+					}
+
+					return persistedPageRuleAction;
+				};
+			}
+		}
+
+		if (pageRuleActionUnsafeFunction == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" is not supported for PageRuleAction");
+		}
+
+		if (contextBatchUnsafeBiConsumer != null) {
+			contextBatchUnsafeBiConsumer.accept(
+				pageRuleActions, pageRuleActionUnsafeFunction);
+		}
+		else if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				pageRuleActions, pageRuleActionUnsafeFunction::apply);
+		}
+		else {
+			for (PageRuleAction pageRuleAction : pageRuleActions) {
+				pageRuleActionUnsafeFunction.apply(pageRuleAction);
+			}
+		}
 	}
 
 	@Override
@@ -488,7 +537,7 @@ public abstract class BasePageRuleActionResourceImpl
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
-		return SetUtil.fromArray();
+		return SetUtil.fromArray("UPSERT");
 	}
 
 	public Set<String> getAvailableUpdateStrategies() {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageRuleConditionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageRuleConditionResourceImpl.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
@@ -42,6 +43,7 @@ import jakarta.annotation.Generated;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import jakarta.ws.rs.NotSupportedException;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.UriInfo;
@@ -449,8 +451,55 @@ public abstract class BasePageRuleConditionResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
+		UnsafeFunction<PageRuleCondition, PageRuleCondition, Exception>
+			pageRuleConditionUnsafeFunction = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if (StringUtil.equalsIgnoreCase(createStrategy, "UPSERT")) {
+			String updateStrategy = (String)parameters.getOrDefault(
+				"updateStrategy", "UPDATE");
+
+			if (StringUtil.equalsIgnoreCase(updateStrategy, "UPDATE")) {
+				pageRuleConditionUnsafeFunction = pageRuleCondition -> {
+					PageRuleCondition persistedPageRuleCondition = null;
+
+					if (parameters.containsKey("siteExternalReferenceCode")) {
+						persistedPageRuleCondition = putSitePageRuleCondition(
+							(String)parameters.get("siteExternalReferenceCode"),
+							pageRuleCondition.getExternalReferenceCode(),
+							pageRuleCondition);
+					}
+					else {
+						throw new NotSupportedException(
+							"One of the following parameters must be specified: [siteExternalReferenceCode]");
+					}
+
+					return persistedPageRuleCondition;
+				};
+			}
+		}
+
+		if (pageRuleConditionUnsafeFunction == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" is not supported for PageRuleCondition");
+		}
+
+		if (contextBatchUnsafeBiConsumer != null) {
+			contextBatchUnsafeBiConsumer.accept(
+				pageRuleConditions, pageRuleConditionUnsafeFunction);
+		}
+		else if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				pageRuleConditions, pageRuleConditionUnsafeFunction::apply);
+		}
+		else {
+			for (PageRuleCondition pageRuleCondition : pageRuleConditions) {
+				pageRuleConditionUnsafeFunction.apply(pageRuleCondition);
+			}
+		}
 	}
 
 	@Override
@@ -489,7 +538,7 @@ public abstract class BasePageRuleConditionResourceImpl
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
-		return SetUtil.fromArray();
+		return SetUtil.fromArray("UPSERT");
 	}
 
 	public Set<String> getAvailableUpdateStrategies() {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageRuleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageRuleResourceImpl.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
@@ -42,6 +43,7 @@ import jakarta.annotation.Generated;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import jakarta.ws.rs.NotSupportedException;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.UriInfo;
@@ -431,8 +433,54 @@ public abstract class BasePageRuleResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
+		UnsafeFunction<PageRule, PageRule, Exception> pageRuleUnsafeFunction =
+			null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if (StringUtil.equalsIgnoreCase(createStrategy, "UPSERT")) {
+			String updateStrategy = (String)parameters.getOrDefault(
+				"updateStrategy", "UPDATE");
+
+			if (StringUtil.equalsIgnoreCase(updateStrategy, "UPDATE")) {
+				pageRuleUnsafeFunction = pageRule -> {
+					PageRule persistedPageRule = null;
+
+					if (parameters.containsKey("siteExternalReferenceCode")) {
+						persistedPageRule = putSitePageRule(
+							(String)parameters.get("siteExternalReferenceCode"),
+							pageRule.getExternalReferenceCode(), pageRule);
+					}
+					else {
+						throw new NotSupportedException(
+							"One of the following parameters must be specified: [siteExternalReferenceCode]");
+					}
+
+					return persistedPageRule;
+				};
+			}
+		}
+
+		if (pageRuleUnsafeFunction == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" is not supported for PageRule");
+		}
+
+		if (contextBatchUnsafeBiConsumer != null) {
+			contextBatchUnsafeBiConsumer.accept(
+				pageRules, pageRuleUnsafeFunction);
+		}
+		else if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				pageRules, pageRuleUnsafeFunction::apply);
+		}
+		else {
+			for (PageRule pageRule : pageRules) {
+				pageRuleUnsafeFunction.apply(pageRule);
+			}
+		}
 	}
 
 	@Override
@@ -471,7 +519,7 @@ public abstract class BasePageRuleResourceImpl
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
-		return SetUtil.fromArray();
+		return SetUtil.fromArray("UPSERT");
 	}
 
 	public Set<String> getAvailableUpdateStrategies() {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageSpecificationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageSpecificationResourceImpl.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
@@ -42,6 +43,7 @@ import jakarta.annotation.Generated;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import jakarta.ws.rs.NotSupportedException;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.UriInfo;
@@ -678,8 +680,55 @@ public abstract class BasePageSpecificationResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
+		UnsafeFunction<PageSpecification, PageSpecification, Exception>
+			pageSpecificationUnsafeFunction = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if (StringUtil.equalsIgnoreCase(createStrategy, "UPSERT")) {
+			String updateStrategy = (String)parameters.getOrDefault(
+				"updateStrategy", "UPDATE");
+
+			if (StringUtil.equalsIgnoreCase(updateStrategy, "UPDATE")) {
+				pageSpecificationUnsafeFunction = pageSpecification -> {
+					PageSpecification persistedPageSpecification = null;
+
+					if (parameters.containsKey("siteExternalReferenceCode")) {
+						persistedPageSpecification = putSitePageSpecification(
+							(String)parameters.get("siteExternalReferenceCode"),
+							pageSpecification.getExternalReferenceCode(),
+							pageSpecification);
+					}
+					else {
+						throw new NotSupportedException(
+							"One of the following parameters must be specified: [siteExternalReferenceCode]");
+					}
+
+					return persistedPageSpecification;
+				};
+			}
+		}
+
+		if (pageSpecificationUnsafeFunction == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" is not supported for PageSpecification");
+		}
+
+		if (contextBatchUnsafeBiConsumer != null) {
+			contextBatchUnsafeBiConsumer.accept(
+				pageSpecifications, pageSpecificationUnsafeFunction);
+		}
+		else if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				pageSpecifications, pageSpecificationUnsafeFunction::apply);
+		}
+		else {
+			for (PageSpecification pageSpecification : pageSpecifications) {
+				pageSpecificationUnsafeFunction.apply(pageSpecification);
+			}
+		}
 	}
 
 	@Override
@@ -718,7 +767,7 @@ public abstract class BasePageSpecificationResourceImpl
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
-		return SetUtil.fromArray();
+		return SetUtil.fromArray("UPSERT");
 	}
 
 	public Set<String> getAvailableUpdateStrategies() {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageTemplateResourceImpl.java
@@ -984,6 +984,30 @@ public abstract class BasePageTemplateResourceImpl
 			}
 		}
 
+		if (StringUtil.equalsIgnoreCase(createStrategy, "UPSERT")) {
+			String updateStrategy = (String)parameters.getOrDefault(
+				"updateStrategy", "UPDATE");
+
+			if (StringUtil.equalsIgnoreCase(updateStrategy, "UPDATE")) {
+				pageTemplateUnsafeFunction = pageTemplate -> {
+					PageTemplate persistedPageTemplate = null;
+
+					if (parameters.containsKey("siteExternalReferenceCode")) {
+						persistedPageTemplate = putSitePageTemplate(
+							(String)parameters.get("siteExternalReferenceCode"),
+							pageTemplate.getExternalReferenceCode(),
+							pageTemplate);
+					}
+					else {
+						throw new NotSupportedException(
+							"One of the following parameters must be specified: [siteExternalReferenceCode]");
+					}
+
+					return persistedPageTemplate;
+				};
+			}
+		}
+
 		if (pageTemplateUnsafeFunction == null) {
 			throw new NotSupportedException(
 				"Create strategy \"" + createStrategy +
@@ -1041,7 +1065,7 @@ public abstract class BasePageTemplateResourceImpl
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
-		return SetUtil.fromArray("INSERT");
+		return SetUtil.fromArray("INSERT", "UPSERT");
 	}
 
 	public Set<String> getAvailableUpdateStrategies() {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageTemplateSetResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageTemplateSetResourceImpl.java
@@ -820,6 +820,30 @@ public abstract class BasePageTemplateSetResourceImpl
 			}
 		}
 
+		if (StringUtil.equalsIgnoreCase(createStrategy, "UPSERT")) {
+			String updateStrategy = (String)parameters.getOrDefault(
+				"updateStrategy", "UPDATE");
+
+			if (StringUtil.equalsIgnoreCase(updateStrategy, "UPDATE")) {
+				pageTemplateSetUnsafeFunction = pageTemplateSet -> {
+					PageTemplateSet persistedPageTemplateSet = null;
+
+					if (parameters.containsKey("siteExternalReferenceCode")) {
+						persistedPageTemplateSet = putSitePageTemplateSet(
+							(String)parameters.get("siteExternalReferenceCode"),
+							pageTemplateSet.getExternalReferenceCode(),
+							pageTemplateSet);
+					}
+					else {
+						throw new NotSupportedException(
+							"One of the following parameters must be specified: [siteExternalReferenceCode]");
+					}
+
+					return persistedPageTemplateSet;
+				};
+			}
+		}
+
 		if (pageTemplateSetUnsafeFunction == null) {
 			throw new NotSupportedException(
 				"Create strategy \"" + createStrategy +
@@ -877,7 +901,7 @@ public abstract class BasePageTemplateSetResourceImpl
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
-		return SetUtil.fromArray("INSERT");
+		return SetUtil.fromArray("INSERT", "UPSERT");
 	}
 
 	public Set<String> getAvailableUpdateStrategies() {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseSitePageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseSitePageResourceImpl.java
@@ -868,6 +868,29 @@ public abstract class BaseSitePageResourceImpl
 			}
 		}
 
+		if (StringUtil.equalsIgnoreCase(createStrategy, "UPSERT")) {
+			String updateStrategy = (String)parameters.getOrDefault(
+				"updateStrategy", "UPDATE");
+
+			if (StringUtil.equalsIgnoreCase(updateStrategy, "UPDATE")) {
+				sitePageUnsafeFunction = sitePage -> {
+					SitePage persistedSitePage = null;
+
+					if (parameters.containsKey("siteExternalReferenceCode")) {
+						persistedSitePage = putSiteSitePage(
+							(String)parameters.get("siteExternalReferenceCode"),
+							sitePage.getExternalReferenceCode(), sitePage);
+					}
+					else {
+						throw new NotSupportedException(
+							"One of the following parameters must be specified: [siteExternalReferenceCode]");
+					}
+
+					return persistedSitePage;
+				};
+			}
+		}
+
 		if (sitePageUnsafeFunction == null) {
 			throw new NotSupportedException(
 				"Create strategy \"" + createStrategy +
@@ -925,7 +948,7 @@ public abstract class BaseSitePageResourceImpl
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
-		return SetUtil.fromArray("INSERT");
+		return SetUtil.fromArray("INSERT", "UPSERT");
 	}
 
 	public Set<String> getAvailableUpdateStrategies() {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseUtilityPageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseUtilityPageResourceImpl.java
@@ -864,6 +864,30 @@ public abstract class BaseUtilityPageResourceImpl
 			}
 		}
 
+		if (StringUtil.equalsIgnoreCase(createStrategy, "UPSERT")) {
+			String updateStrategy = (String)parameters.getOrDefault(
+				"updateStrategy", "UPDATE");
+
+			if (StringUtil.equalsIgnoreCase(updateStrategy, "UPDATE")) {
+				utilityPageUnsafeFunction = utilityPage -> {
+					UtilityPage persistedUtilityPage = null;
+
+					if (parameters.containsKey("siteExternalReferenceCode")) {
+						persistedUtilityPage = putSiteUtilityPage(
+							(String)parameters.get("siteExternalReferenceCode"),
+							utilityPage.getExternalReferenceCode(),
+							utilityPage);
+					}
+					else {
+						throw new NotSupportedException(
+							"One of the following parameters must be specified: [siteExternalReferenceCode]");
+					}
+
+					return persistedUtilityPage;
+				};
+			}
+		}
+
 		if (utilityPageUnsafeFunction == null) {
 			throw new NotSupportedException(
 				"Create strategy \"" + createStrategy +
@@ -921,7 +945,7 @@ public abstract class BaseUtilityPageResourceImpl
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
-		return SetUtil.fromArray("INSERT");
+		return SetUtil.fromArray("INSERT", "UPSERT");
 	}
 
 	public Set<String> getAvailableUpdateStrategies() {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/page-experience.properties
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/page-experience.properties
@@ -6,7 +6,7 @@ api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.site.dto.v1_0.PageExperience
 batch.engine.task.item.delegate=true
 batch.planner.export.enabled=false
-batch.planner.import.enabled=false
+batch.planner.import.enabled=true
 entity.class.name=com.liferay.headless.admin.site.dto.v1_0.PageExperience
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.Site)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/page-rule-action.properties
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/page-rule-action.properties
@@ -6,7 +6,7 @@ api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.site.dto.v1_0.PageRuleAction
 batch.engine.task.item.delegate=true
 batch.planner.export.enabled=false
-batch.planner.import.enabled=false
+batch.planner.import.enabled=true
 entity.class.name=com.liferay.headless.admin.site.dto.v1_0.PageRuleAction
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.Site)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/page-rule-condition.properties
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/page-rule-condition.properties
@@ -6,7 +6,7 @@ api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.site.dto.v1_0.PageRuleCondition
 batch.engine.task.item.delegate=true
 batch.planner.export.enabled=false
-batch.planner.import.enabled=false
+batch.planner.import.enabled=true
 entity.class.name=com.liferay.headless.admin.site.dto.v1_0.PageRuleCondition
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.Site)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/page-rule.properties
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/page-rule.properties
@@ -6,7 +6,7 @@ api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.site.dto.v1_0.PageRule
 batch.engine.task.item.delegate=true
 batch.planner.export.enabled=false
-batch.planner.import.enabled=false
+batch.planner.import.enabled=true
 entity.class.name=com.liferay.headless.admin.site.dto.v1_0.PageRule
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.Site)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/page-specification.properties
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/page-specification.properties
@@ -6,7 +6,7 @@ api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.site.dto.v1_0.PageSpecification
 batch.engine.task.item.delegate=true
 batch.planner.export.enabled=false
-batch.planner.import.enabled=false
+batch.planner.import.enabled=true
 entity.class.name=com.liferay.headless.admin.site.dto.v1_0.PageSpecification
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.Site)
 osgi.jaxrs.resource=true

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
@@ -13,6 +13,7 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.exception.NoSuchModelException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Resource;
 import com.liferay.portal.kernel.model.ResourceAction;
@@ -2300,6 +2301,26 @@ public abstract class BaseObjectEntryResourceImpl
 		if (StringUtil.equalsIgnoreCase(createStrategy, "UPSERT")) {
 			String updateStrategy = (String)parameters.getOrDefault(
 				"updateStrategy", "UPDATE");
+
+			if (StringUtil.equalsIgnoreCase(updateStrategy, "PARTIAL_UPDATE")) {
+				objectEntryUnsafeFunction = objectEntry -> {
+					ObjectEntry getObjectEntry = null;
+					ObjectEntry persistedObjectEntry = null;
+
+					try {
+						getObjectEntry = getByExternalReferenceCode(
+							objectEntry.getExternalReferenceCode());
+
+						persistedObjectEntry = patchObjectEntry(
+							getObjectEntry.getId(), objectEntry);
+					}
+					catch (NoSuchModelException noSuchModelException) {
+						persistedObjectEntry = postObjectEntry(objectEntry);
+					}
+
+					return persistedObjectEntry;
+				};
+			}
 
 			if (StringUtil.equalsIgnoreCase(updateStrategy, "UPDATE")) {
 				objectEntryUnsafeFunction = objectEntry -> {

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -130,57 +130,7 @@ public class ObjectEntryResourceImpl
 				objectEntries, objectEntryUnsafeFunction);
 		}
 		else {
-			UnsafeFunction<ObjectEntry, ObjectEntry, Exception>
-				objectEntryUnsafeFunction = null;
-
-			String createStrategy = (String)parameters.getOrDefault(
-				"createStrategy", "INSERT");
-
-			if (StringUtil.equalsIgnoreCase(createStrategy, "INSERT")) {
-				objectEntryUnsafeFunction = this::postObjectEntry;
-			}
-
-			if (StringUtil.equalsIgnoreCase(createStrategy, "UPSERT")) {
-				String updateStrategy = (String)parameters.getOrDefault(
-					"updateStrategy", "UPDATE");
-
-				if (StringUtil.equalsIgnoreCase(
-						updateStrategy, "PARTIAL_UPDATE")) {
-
-					objectEntryUnsafeFunction =
-						objectEntry -> patchByExternalReferenceCode(
-							objectEntry.getExternalReferenceCode(),
-							objectEntry);
-				}
-				else if (StringUtil.equalsIgnoreCase(
-							updateStrategy, "UPDATE")) {
-
-					objectEntryUnsafeFunction =
-						objectEntry -> putByExternalReferenceCode(
-							objectEntry.getExternalReferenceCode(),
-							objectEntry);
-				}
-			}
-
-			if (objectEntryUnsafeFunction == null) {
-				throw new NotSupportedException(
-					"Create strategy \"" + createStrategy +
-						"\" is not supported");
-			}
-
-			if (contextBatchUnsafeBiConsumer != null) {
-				contextBatchUnsafeBiConsumer.accept(
-					objectEntries, objectEntryUnsafeFunction);
-			}
-			else if (contextBatchUnsafeConsumer != null) {
-				contextBatchUnsafeConsumer.accept(
-					objectEntries, objectEntryUnsafeFunction::apply);
-			}
-			else {
-				for (ObjectEntry objectEntry : objectEntries) {
-					objectEntryUnsafeFunction.apply(objectEntry);
-				}
-			}
+			super.create(objectEntries, parameters);
 		}
 	}
 

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseERCAssetLibraryTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseERCAssetLibraryTestEntityResourceImpl.java
@@ -197,6 +197,12 @@ public abstract class BaseERCAssetLibraryTestEntityResourceImpl
 		return ercAssetLibraryTestEntitiesPage;
 	}
 
+	protected abstract ERCAssetLibraryTestEntity
+			doGetAssetLibraryERCAssetLibraryTestEntity(
+				String assetLibraryExternalReferenceCode,
+				String ercAssetLibraryTestEntityExternalReferenceCode)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -227,20 +233,44 @@ public abstract class BaseERCAssetLibraryTestEntityResourceImpl
 	)
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public ERCAssetLibraryTestEntity getAssetLibraryERCAssetLibraryTestEntity(
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("assetLibraryExternalReferenceCode")
-			String assetLibraryExternalReferenceCode,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam(
-				"ercAssetLibraryTestEntityExternalReferenceCode"
-			)
-			String ercAssetLibraryTestEntityExternalReferenceCode)
+	public final ERCAssetLibraryTestEntity
+			getAssetLibraryERCAssetLibraryTestEntity(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("assetLibraryExternalReferenceCode")
+				String assetLibraryExternalReferenceCode,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam(
+					"ercAssetLibraryTestEntityExternalReferenceCode"
+				)
+				String ercAssetLibraryTestEntityExternalReferenceCode)
 		throws Exception {
 
-		return new ERCAssetLibraryTestEntity();
+		ERCAssetLibraryTestEntity getERCAssetLibraryTestEntity =
+			doGetAssetLibraryERCAssetLibraryTestEntity(
+				assetLibraryExternalReferenceCode,
+				ercAssetLibraryTestEntityExternalReferenceCode);
+
+		getERCAssetLibraryTestEntity.setPermissions(
+			() -> NestedFieldsSupplier.supply(
+				"permissions",
+				nestedField -> {
+					Page<Permission> permissionsPage =
+						getAssetLibraryERCAssetLibraryTestEntityPermissionsPage(
+							assetLibraryExternalReferenceCode,
+							getERCAssetLibraryTestEntity.
+								getExternalReferenceCode(),
+							null);
+
+					Collection<Permission> permissions =
+						permissionsPage.getItems();
+
+					return permissions.toArray(
+						new Permission[permissions.size()]);
+				}));
+
+		return getERCAssetLibraryTestEntity;
 	}
 
 	/**
@@ -535,6 +565,13 @@ public abstract class BaseERCAssetLibraryTestEntityResourceImpl
 		).build();
 	}
 
+	protected abstract ERCAssetLibraryTestEntity
+			doPutAssetLibraryERCAssetLibraryTestEntity(
+				String assetLibraryExternalReferenceCode,
+				String ercAssetLibraryTestEntityExternalReferenceCode,
+				ERCAssetLibraryTestEntity ercAssetLibraryTestEntity)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -566,21 +603,49 @@ public abstract class BaseERCAssetLibraryTestEntityResourceImpl
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@jakarta.ws.rs.PUT
 	@Override
-	public ERCAssetLibraryTestEntity putAssetLibraryERCAssetLibraryTestEntity(
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("assetLibraryExternalReferenceCode")
-			String assetLibraryExternalReferenceCode,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam(
-				"ercAssetLibraryTestEntityExternalReferenceCode"
-			)
-			String ercAssetLibraryTestEntityExternalReferenceCode,
-			ERCAssetLibraryTestEntity ercAssetLibraryTestEntity)
+	public final ERCAssetLibraryTestEntity
+			putAssetLibraryERCAssetLibraryTestEntity(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("assetLibraryExternalReferenceCode")
+				String assetLibraryExternalReferenceCode,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam(
+					"ercAssetLibraryTestEntityExternalReferenceCode"
+				)
+				String ercAssetLibraryTestEntityExternalReferenceCode,
+				ERCAssetLibraryTestEntity ercAssetLibraryTestEntity)
 		throws Exception {
 
-		return new ERCAssetLibraryTestEntity();
+		Permission[] permissions = ercAssetLibraryTestEntity.getPermissions();
+
+		ERCAssetLibraryTestEntity putERCAssetLibraryTestEntity =
+			doPutAssetLibraryERCAssetLibraryTestEntity(
+				assetLibraryExternalReferenceCode,
+				ercAssetLibraryTestEntityExternalReferenceCode,
+				ercAssetLibraryTestEntity);
+
+		if (permissions != null) {
+			Page<Permission> permissionsPage =
+				putAssetLibraryERCAssetLibraryTestEntityPermissionsPage(
+					assetLibraryExternalReferenceCode,
+					putERCAssetLibraryTestEntity.getExternalReferenceCode(),
+					permissions);
+
+			putERCAssetLibraryTestEntity.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Collection<Permission> collection =
+							permissionsPage.getItems();
+
+						return collection.toArray(
+							new Permission[collection.size()]);
+					}));
+		}
+
+		return putERCAssetLibraryTestEntity;
 	}
 
 	/**
@@ -724,6 +789,37 @@ public abstract class BaseERCAssetLibraryTestEntityResourceImpl
 			}
 		}
 
+		if (StringUtil.equalsIgnoreCase(createStrategy, "UPSERT")) {
+			String updateStrategy = (String)parameters.getOrDefault(
+				"updateStrategy", "UPDATE");
+
+			if (StringUtil.equalsIgnoreCase(updateStrategy, "UPDATE")) {
+				ercAssetLibraryTestEntityUnsafeFunction =
+					ercAssetLibraryTestEntity -> {
+						ERCAssetLibraryTestEntity
+							persistedERCAssetLibraryTestEntity = null;
+
+						if (parameters.containsKey(
+								"assetLibraryExternalReferenceCode")) {
+
+							persistedERCAssetLibraryTestEntity =
+								putAssetLibraryERCAssetLibraryTestEntity(
+									(String)parameters.get(
+										"assetLibraryExternalReferenceCode"),
+									ercAssetLibraryTestEntity.
+										getExternalReferenceCode(),
+									ercAssetLibraryTestEntity);
+						}
+						else {
+							throw new NotSupportedException(
+								"One of the following parameters must be specified: [assetLibraryExternalReferenceCode]");
+						}
+
+						return persistedERCAssetLibraryTestEntity;
+					};
+			}
+		}
+
 		if (ercAssetLibraryTestEntityUnsafeFunction == null) {
 			throw new NotSupportedException(
 				"Create strategy \"" + createStrategy +
@@ -797,7 +893,7 @@ public abstract class BaseERCAssetLibraryTestEntityResourceImpl
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
-		return SetUtil.fromArray("INSERT");
+		return SetUtil.fromArray("INSERT", "UPSERT");
 	}
 
 	public Set<String> getAvailableUpdateStrategies() {

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseERCScopedTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseERCScopedTestEntityResourceImpl.java
@@ -781,6 +781,44 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 			}
 		}
 
+		if (StringUtil.equalsIgnoreCase(createStrategy, "UPSERT")) {
+			String updateStrategy = (String)parameters.getOrDefault(
+				"updateStrategy", "UPDATE");
+
+			if (StringUtil.equalsIgnoreCase(updateStrategy, "UPDATE")) {
+				ercScopedTestEntityUnsafeFunction = ercScopedTestEntity -> {
+					ERCScopedTestEntity persistedERCScopedTestEntity = null;
+
+					if (parameters.containsKey(
+							"assetLibraryExternalReferenceCode")) {
+
+						persistedERCScopedTestEntity =
+							putAssetLibraryERCScopedTestEntity(
+								(String)parameters.get(
+									"assetLibraryExternalReferenceCode"),
+								ercScopedTestEntity.getExternalReferenceCode(),
+								ercScopedTestEntity);
+					}
+					else if (parameters.containsKey(
+								"siteExternalReferenceCode")) {
+
+						persistedERCScopedTestEntity =
+							putSiteERCScopedTestEntity(
+								(String)parameters.get(
+									"siteExternalReferenceCode"),
+								ercScopedTestEntity.getExternalReferenceCode(),
+								ercScopedTestEntity);
+					}
+					else {
+						throw new NotSupportedException(
+							"One of the following parameters must be specified: [assetLibraryExternalReferenceCode, siteExternalReferenceCode]");
+					}
+
+					return persistedERCScopedTestEntity;
+				};
+			}
+		}
+
 		if (ercScopedTestEntityUnsafeFunction == null) {
 			throw new NotSupportedException(
 				"Create strategy \"" + createStrategy +
@@ -854,7 +892,7 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
-		return SetUtil.fromArray("INSERT");
+		return SetUtil.fromArray("INSERT", "UPSERT");
 	}
 
 	public Set<String> getAvailableUpdateStrategies() {

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseERCSiteTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseERCSiteTestEntityResourceImpl.java
@@ -187,6 +187,11 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 		return ercSiteTestEntitiesPage;
 	}
 
+	protected abstract ERCSiteTestEntity doGetSiteERCSiteTestEntity(
+			String siteExternalReferenceCode,
+			String ercSiteTestEntityExternalReferenceCode)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -215,7 +220,7 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 	)
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public ERCSiteTestEntity getSiteERCSiteTestEntity(
+	public final ERCSiteTestEntity getSiteERCSiteTestEntity(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
@@ -226,7 +231,27 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 			String ercSiteTestEntityExternalReferenceCode)
 		throws Exception {
 
-		return new ERCSiteTestEntity();
+		ERCSiteTestEntity getERCSiteTestEntity = doGetSiteERCSiteTestEntity(
+			siteExternalReferenceCode, ercSiteTestEntityExternalReferenceCode);
+
+		getERCSiteTestEntity.setPermissions(
+			() -> NestedFieldsSupplier.supply(
+				"permissions",
+				nestedField -> {
+					Page<Permission> permissionsPage =
+						getSiteERCSiteTestEntityPermissionsPage(
+							siteExternalReferenceCode,
+							getERCSiteTestEntity.getExternalReferenceCode(),
+							null);
+
+					Collection<Permission> permissions =
+						permissionsPage.getItems();
+
+					return permissions.toArray(
+						new Permission[permissions.size()]);
+				}));
+
+		return getERCSiteTestEntity;
 	}
 
 	/**
@@ -503,6 +528,12 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 		).build();
 	}
 
+	protected abstract ERCSiteTestEntity doPutSiteERCSiteTestEntity(
+			String siteExternalReferenceCode,
+			String ercSiteTestEntityExternalReferenceCode,
+			ERCSiteTestEntity ercSiteTestEntity)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -532,7 +563,7 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@jakarta.ws.rs.PUT
 	@Override
-	public ERCSiteTestEntity putSiteERCSiteTestEntity(
+	public final ERCSiteTestEntity putSiteERCSiteTestEntity(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
@@ -544,7 +575,32 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 			ERCSiteTestEntity ercSiteTestEntity)
 		throws Exception {
 
-		return new ERCSiteTestEntity();
+		Permission[] permissions = ercSiteTestEntity.getPermissions();
+
+		ERCSiteTestEntity putERCSiteTestEntity = doPutSiteERCSiteTestEntity(
+			siteExternalReferenceCode, ercSiteTestEntityExternalReferenceCode,
+			ercSiteTestEntity);
+
+		if (permissions != null) {
+			Page<Permission> permissionsPage =
+				putSiteERCSiteTestEntityPermissionsPage(
+					siteExternalReferenceCode,
+					putERCSiteTestEntity.getExternalReferenceCode(),
+					permissions);
+
+			putERCSiteTestEntity.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Collection<Permission> collection =
+							permissionsPage.getItems();
+
+						return collection.toArray(
+							new Permission[collection.size()]);
+					}));
+		}
+
+		return putERCSiteTestEntity;
 	}
 
 	/**
@@ -677,6 +733,30 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 			}
 		}
 
+		if (StringUtil.equalsIgnoreCase(createStrategy, "UPSERT")) {
+			String updateStrategy = (String)parameters.getOrDefault(
+				"updateStrategy", "UPDATE");
+
+			if (StringUtil.equalsIgnoreCase(updateStrategy, "UPDATE")) {
+				ercSiteTestEntityUnsafeFunction = ercSiteTestEntity -> {
+					ERCSiteTestEntity persistedERCSiteTestEntity = null;
+
+					if (parameters.containsKey("siteExternalReferenceCode")) {
+						persistedERCSiteTestEntity = putSiteERCSiteTestEntity(
+							(String)parameters.get("siteExternalReferenceCode"),
+							ercSiteTestEntity.getExternalReferenceCode(),
+							ercSiteTestEntity);
+					}
+					else {
+						throw new NotSupportedException(
+							"One of the following parameters must be specified: [siteExternalReferenceCode]");
+					}
+
+					return persistedERCSiteTestEntity;
+				};
+			}
+		}
+
 		if (ercSiteTestEntityUnsafeFunction == null) {
 			throw new NotSupportedException(
 				"Create strategy \"" + createStrategy +
@@ -734,7 +814,7 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
-		return SetUtil.fromArray("INSERT");
+		return SetUtil.fromArray("INSERT", "UPSERT");
 	}
 
 	public Set<String> getAvailableUpdateStrategies() {

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseScopedTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseScopedTestEntityResourceImpl.java
@@ -1155,11 +1155,12 @@ public abstract class BaseScopedTestEntityResourceImpl
 									scopedTestEntity.
 										getExternalReferenceCode());
 						}
-						else
-
-						getScopedTestEntity =
-							getScopedTestEntityByExternalReferenceCode(
-								scopedTestEntity.getExternalReferenceCode());
+						else {
+							getScopedTestEntity =
+								getScopedTestEntityByExternalReferenceCode(
+									scopedTestEntity.
+										getExternalReferenceCode());
+						}
 
 						persistedScopedTestEntity = patchScopedTestEntity(
 							getScopedTestEntity.getId(), scopedTestEntity);

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/ERCAssetLibraryTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/ERCAssetLibraryTestEntityResourceImpl.java
@@ -34,8 +34,29 @@ public class ERCAssetLibraryTestEntityResourceImpl
 
 	@Override
 	protected ERCAssetLibraryTestEntity
+			doGetAssetLibraryERCAssetLibraryTestEntity(
+				String assetLibraryExternalReferenceCode,
+				String ercAssetLibraryTestEntityExternalReferenceCode)
+		throws Exception {
+
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	protected ERCAssetLibraryTestEntity
 			doPostAssetLibraryERCAssetLibraryTestEntity(
 				String assetLibraryExternalReferenceCode,
+				ERCAssetLibraryTestEntity ercAssetLibraryTestEntity)
+		throws Exception {
+
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	protected ERCAssetLibraryTestEntity
+			doPutAssetLibraryERCAssetLibraryTestEntity(
+				String assetLibraryExternalReferenceCode,
+				String ercAssetLibraryTestEntityExternalReferenceCode,
 				ERCAssetLibraryTestEntity ercAssetLibraryTestEntity)
 		throws Exception {
 

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/ERCSiteTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/ERCSiteTestEntityResourceImpl.java
@@ -31,8 +31,27 @@ public class ERCSiteTestEntityResourceImpl
 	}
 
 	@Override
+	protected ERCSiteTestEntity doGetSiteERCSiteTestEntity(
+			String siteExternalReferenceCode,
+			String ercSiteTestEntityExternalReferenceCode)
+		throws Exception {
+
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	protected ERCSiteTestEntity doPostSiteERCSiteTestEntity(
 			String siteExternalReferenceCode,
+			ERCSiteTestEntity ercSiteTestEntity)
+		throws Exception {
+
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	protected ERCSiteTestEntity doPutSiteERCSiteTestEntity(
+			String siteExternalReferenceCode,
+			String ercSiteTestEntityExternalReferenceCode,
 			ERCSiteTestEntity ercSiteTestEntity)
 		throws Exception {
 

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCAssetLibraryTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCAssetLibraryTestEntityResourceTestCase.java
@@ -440,6 +440,17 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 		assertEquals(
 			postERCAssetLibraryTestEntity, getERCAssetLibraryTestEntity);
 		assertValid(getERCAssetLibraryTestEntity);
+
+		Assert.assertNull(getERCAssetLibraryTestEntity.getPermissions());
+
+		getERCAssetLibraryTestEntity =
+			permissionsERCAssetLibraryTestEntityResource.
+				getAssetLibraryERCAssetLibraryTestEntity(
+					postERCAssetLibraryTestEntity.
+						getAssetLibraryExternalReferenceCode(),
+					postERCAssetLibraryTestEntity.getExternalReferenceCode());
+
+		Assert.assertNotNull(getERCAssetLibraryTestEntity.getPermissions());
 	}
 
 	protected ERCAssetLibraryTestEntity
@@ -694,6 +705,8 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 			randomERCAssetLibraryTestEntity, putERCAssetLibraryTestEntity);
 		assertValid(putERCAssetLibraryTestEntity);
 
+		Assert.assertNull(putERCAssetLibraryTestEntity.getPermissions());
+
 		ERCAssetLibraryTestEntity getERCAssetLibraryTestEntity =
 			ercAssetLibraryTestEntityResource.
 				getAssetLibraryERCAssetLibraryTestEntity(
@@ -704,6 +717,34 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 		assertEquals(
 			randomERCAssetLibraryTestEntity, getERCAssetLibraryTestEntity);
 		assertValid(getERCAssetLibraryTestEntity);
+
+		ERCAssetLibraryTestEntity randomPermissionsERCAssetLibraryTestEntity =
+			randomPermissionsERCAssetLibraryTestEntity();
+
+		putERCAssetLibraryTestEntity =
+			ercAssetLibraryTestEntityResource.
+				putAssetLibraryERCAssetLibraryTestEntity(
+					postERCAssetLibraryTestEntity.
+						getAssetLibraryExternalReferenceCode(),
+					postERCAssetLibraryTestEntity.getExternalReferenceCode(),
+					randomPermissionsERCAssetLibraryTestEntity);
+
+		assertEquals(
+			randomPermissionsERCAssetLibraryTestEntity,
+			putERCAssetLibraryTestEntity);
+		assertValid(putERCAssetLibraryTestEntity);
+
+		Assert.assertNull(putERCAssetLibraryTestEntity.getPermissions());
+
+		putERCAssetLibraryTestEntity =
+			permissionsERCAssetLibraryTestEntityResource.
+				putAssetLibraryERCAssetLibraryTestEntity(
+					postERCAssetLibraryTestEntity.
+						getAssetLibraryExternalReferenceCode(),
+					postERCAssetLibraryTestEntity.getExternalReferenceCode(),
+					randomPermissionsERCAssetLibraryTestEntity);
+
+		Assert.assertNotNull(putERCAssetLibraryTestEntity.getPermissions());
 	}
 
 	protected ERCAssetLibraryTestEntity

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCSiteTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCSiteTestEntityResourceTestCase.java
@@ -466,6 +466,15 @@ public abstract class BaseERCSiteTestEntityResourceTestCase {
 
 		assertEquals(postERCSiteTestEntity, getERCSiteTestEntity);
 		assertValid(getERCSiteTestEntity);
+
+		Assert.assertNull(getERCSiteTestEntity.getPermissions());
+
+		getERCSiteTestEntity =
+			permissionsERCSiteTestEntityResource.getSiteERCSiteTestEntity(
+				postERCSiteTestEntity.getSiteExternalReferenceCode(),
+				postERCSiteTestEntity.getExternalReferenceCode());
+
+		Assert.assertNotNull(getERCSiteTestEntity.getPermissions());
 	}
 
 	protected ERCSiteTestEntity
@@ -707,6 +716,8 @@ public abstract class BaseERCSiteTestEntityResourceTestCase {
 		assertEquals(randomERCSiteTestEntity, putERCSiteTestEntity);
 		assertValid(putERCSiteTestEntity);
 
+		Assert.assertNull(putERCSiteTestEntity.getPermissions());
+
 		ERCSiteTestEntity getERCSiteTestEntity =
 			ercSiteTestEntityResource.getSiteERCSiteTestEntity(
 				putERCSiteTestEntity.getSiteExternalReferenceCode(),
@@ -714,6 +725,28 @@ public abstract class BaseERCSiteTestEntityResourceTestCase {
 
 		assertEquals(randomERCSiteTestEntity, getERCSiteTestEntity);
 		assertValid(getERCSiteTestEntity);
+
+		ERCSiteTestEntity randomPermissionsERCSiteTestEntity =
+			randomPermissionsERCSiteTestEntity();
+
+		putERCSiteTestEntity =
+			ercSiteTestEntityResource.putSiteERCSiteTestEntity(
+				postERCSiteTestEntity.getSiteExternalReferenceCode(),
+				postERCSiteTestEntity.getExternalReferenceCode(),
+				randomPermissionsERCSiteTestEntity);
+
+		assertEquals(randomPermissionsERCSiteTestEntity, putERCSiteTestEntity);
+		assertValid(putERCSiteTestEntity);
+
+		Assert.assertNull(putERCSiteTestEntity.getPermissions());
+
+		putERCSiteTestEntity =
+			permissionsERCSiteTestEntityResource.putSiteERCSiteTestEntity(
+				postERCSiteTestEntity.getSiteExternalReferenceCode(),
+				postERCSiteTestEntity.getExternalReferenceCode(),
+				randomPermissionsERCSiteTestEntity);
+
+		Assert.assertNotNull(putERCSiteTestEntity.getPermissions());
 	}
 
 	protected ERCSiteTestEntity

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -1120,6 +1120,66 @@ public class FreeMarkerTool {
 		return mediaTypes.contains(mediaType);
 	}
 
+	public boolean isByExternalReferenceCode(
+		String httpMethod, JavaMethodSignature javaMethodSignature,
+		String parentSchemaName, String schemaName) {
+
+		httpMethod = StringUtil.toLowerCase(httpMethod);
+		boolean hasSchemaExternalReferenceCodePathParameter = hasPathParameter(
+			javaMethodSignature,
+			TextFormatter.format(schemaName, TextFormatter.I) +
+				"ExternalReferenceCode");
+
+		if (parentSchemaName.isEmpty()) {
+			if (Objects.equals(
+					javaMethodSignature.getMethodName(),
+					httpMethod + "ByExternalReferenceCode") ||
+				Objects.equals(
+					javaMethodSignature.getMethodName(),
+					StringBundler.concat(
+						httpMethod, schemaName, "ByExternalReferenceCode")) ||
+				(Objects.equals(
+					javaMethodSignature.getMethodName(),
+					httpMethod + schemaName) &&
+				 hasSchemaExternalReferenceCodePathParameter)) {
+
+				return true;
+			}
+
+			return false;
+		}
+
+		String formattedParentSchemaName = TextFormatter.format(
+			parentSchemaName, TextFormatter.I);
+
+		if (Objects.equals(
+				javaMethodSignature.getMethodName(),
+				StringBundler.concat(
+					httpMethod, parentSchemaName, schemaName,
+					"ByExternalReferenceCode")) ||
+			Objects.equals(
+				javaMethodSignature.getMethodName(),
+				StringBundler.concat(
+					httpMethod, parentSchemaName, "ByExternalReferenceCode",
+					schemaName)) ||
+			(Objects.equals(
+				javaMethodSignature.getMethodName(),
+				StringBundler.concat(
+					httpMethod, parentSchemaName, schemaName)) &&
+			 hasSchemaExternalReferenceCodePathParameter &&
+			 hasPathParameter(
+				 javaMethodSignature,
+				 formattedParentSchemaName + "ExternalReferenceCode")) ||
+			(Objects.equals(
+				javaMethodSignature.getMethodName(), httpMethod + schemaName) &&
+			 hasSchemaExternalReferenceCodePathParameter)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	public boolean isCollection(
 		JavaMethodSignature javaMethodSignaturePathItem,
 		List<JavaMethodSignature> javaMethodSignatures, String schemaNames) {

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -1121,11 +1121,10 @@ public class FreeMarkerTool {
 	}
 
 	public boolean isByExternalReferenceCode(
-		String httpMethod, JavaMethodSignature javaMethodSignature,
-		String parentSchemaName, String schemaName) {
+		String httpMethod, JavaMethodSignature javaMethodSignature) {
 
 		return ResourceOpenAPIParser.isByExternalReferenceCode(
-			httpMethod, javaMethodSignature, parentSchemaName, schemaName);
+			httpMethod, javaMethodSignature);
 	}
 
 	public boolean isCollection(

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -1058,16 +1058,8 @@ public class FreeMarkerTool {
 	public boolean hasPathParameter(
 		JavaMethodSignature javaMethodSignature, String parameterName) {
 
-		List<JavaMethodParameter> javaMethodParameters =
-			javaMethodSignature.getPathJavaMethodParameters();
-
-		for (JavaMethodParameter javaMethodParameter : javaMethodParameters) {
-			if (parameterName.equals(javaMethodParameter.getParameterName())) {
-				return true;
-			}
-		}
-
-		return false;
+		return ResourceOpenAPIParser.hasPathParameter(
+			javaMethodSignature, parameterName);
 	}
 
 	public boolean hasPostSchemaJavaMethodSignature(

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -1124,60 +1124,8 @@ public class FreeMarkerTool {
 		String httpMethod, JavaMethodSignature javaMethodSignature,
 		String parentSchemaName, String schemaName) {
 
-		httpMethod = StringUtil.toLowerCase(httpMethod);
-		boolean hasSchemaExternalReferenceCodePathParameter = hasPathParameter(
-			javaMethodSignature,
-			TextFormatter.format(schemaName, TextFormatter.I) +
-				"ExternalReferenceCode");
-
-		if (parentSchemaName.isEmpty()) {
-			if (Objects.equals(
-					javaMethodSignature.getMethodName(),
-					httpMethod + "ByExternalReferenceCode") ||
-				Objects.equals(
-					javaMethodSignature.getMethodName(),
-					StringBundler.concat(
-						httpMethod, schemaName, "ByExternalReferenceCode")) ||
-				(Objects.equals(
-					javaMethodSignature.getMethodName(),
-					httpMethod + schemaName) &&
-				 hasSchemaExternalReferenceCodePathParameter)) {
-
-				return true;
-			}
-
-			return false;
-		}
-
-		String formattedParentSchemaName = TextFormatter.format(
-			parentSchemaName, TextFormatter.I);
-
-		if (Objects.equals(
-				javaMethodSignature.getMethodName(),
-				StringBundler.concat(
-					httpMethod, parentSchemaName, schemaName,
-					"ByExternalReferenceCode")) ||
-			Objects.equals(
-				javaMethodSignature.getMethodName(),
-				StringBundler.concat(
-					httpMethod, parentSchemaName, "ByExternalReferenceCode",
-					schemaName)) ||
-			(Objects.equals(
-				javaMethodSignature.getMethodName(),
-				StringBundler.concat(
-					httpMethod, parentSchemaName, schemaName)) &&
-			 hasSchemaExternalReferenceCodePathParameter &&
-			 hasPathParameter(
-				 javaMethodSignature,
-				 formattedParentSchemaName + "ExternalReferenceCode")) ||
-			(Objects.equals(
-				javaMethodSignature.getMethodName(), httpMethod + schemaName) &&
-			 hasSchemaExternalReferenceCodePathParameter)) {
-
-			return true;
-		}
-
-		return false;
+		return ResourceOpenAPIParser.isByExternalReferenceCode(
+			httpMethod, javaMethodSignature, parentSchemaName, schemaName);
 	}
 
 	public boolean isCollection(

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -1120,10 +1120,10 @@ public class FreeMarkerTool {
 		return mediaTypes.contains(mediaType);
 	}
 
-	public boolean isByExternalReferenceCode(
+	public boolean isByExternalReferenceCodeMethod(
 		String httpMethod, JavaMethodSignature javaMethodSignature) {
 
-		return ResourceOpenAPIParser.isByExternalReferenceCode(
+		return ResourceOpenAPIParser.isByExternalReferenceCodeMethod(
 			httpMethod, javaMethodSignature);
 	}
 

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -1120,13 +1120,6 @@ public class FreeMarkerTool {
 		return mediaTypes.contains(mediaType);
 	}
 
-	public boolean isByExternalReferenceCodeMethod(
-		String httpMethod, JavaMethodSignature javaMethodSignature) {
-
-		return ResourceOpenAPIParser.isByExternalReferenceCodeMethod(
-			httpMethod, javaMethodSignature);
-	}
-
 	public boolean isCollection(
 		JavaMethodSignature javaMethodSignaturePathItem,
 		List<JavaMethodSignature> javaMethodSignatures, String schemaNames) {
@@ -1157,6 +1150,13 @@ public class FreeMarkerTool {
 
 		return DTOOpenAPIParser.isSchemaProperty(
 			configYAML, propertyName, schema, schemas);
+	}
+
+	public boolean isExternalReferenceCodeMethod(
+		String httpMethod, JavaMethodSignature javaMethodSignature) {
+
+		return ResourceOpenAPIParser.isExternalReferenceCodeMethod(
+			httpMethod, javaMethodSignature);
 	}
 
 	public boolean isExternalReferenceCodeParameter(

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
@@ -1311,7 +1311,16 @@ public class ResourceOpenAPIParser {
 		String basePath = path;
 
 		if (basePath.endsWith(
-				"/by-external-reference-code/{externalReferenceCode}")) {
+				"/{" + OpenAPIParserUtil.getSchemaVarName(schemaName) +
+					"ExternalReferenceCode}")) {
+
+			basePath = StringUtil.removeLast(
+				path,
+				"/{" + OpenAPIParserUtil.getSchemaVarName(schemaName) +
+					"ExternalReferenceCode}");
+		}
+		else if (basePath.endsWith(
+					"/by-external-reference-code/{externalReferenceCode}")) {
 
 			basePath = StringUtil.removeLast(
 				path, "/by-external-reference-code/{externalReferenceCode}");
@@ -1324,26 +1333,17 @@ public class ResourceOpenAPIParser {
 		}
 
 		basePath = basePath.substring(0, lastIndexOfSlash);
-		String schemaPath = TextFormatter.format(
-			TextFormatter.formatPlural(schemaName), TextFormatter.K);
 
 		if (basePath.equals(
 				"/asset-libraries/{assetLibraryExternalReferenceCode}") ||
-			basePath.equals(
-				"/asset-libraries/{assetLibraryExternalReferenceCode}/" +
-					schemaPath) ||
 			basePath.equals("/asset-libraries/{assetLibraryId}")) {
 
 			return "AssetLibrary";
 		}
-		else {
-			if (basePath.equals("/sites/{siteExternalReferenceCode}") ||
-				basePath.equals(
-					"/sites/{siteExternalReferenceCode}/" + schemaPath) ||
-				basePath.equals("/sites/{siteId}")) {
+		else if (basePath.equals("/sites/{siteExternalReferenceCode}") ||
+				 basePath.equals("/sites/{siteId}")) {
 
-				return "Site";
-			}
+			return "Site";
 		}
 
 		for (Map.Entry<String, PathItem> entry : pathItems.entrySet()) {

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
@@ -384,16 +384,12 @@ public class ResourceOpenAPIParser {
 			}
 
 			if (methodName.equals("post" + parentSchemaName + schemaName) ||
-				isByExternalReferenceCode(
-					"post", javaMethodSignature, parentSchemaName,
-					schemaName)) {
+				isByExternalReferenceCode("post", javaMethodSignature)) {
 
 				createStrategies.add("INSERT");
 			}
 			else if (propertyNames.contains("externalReferenceCode") &&
-					 isByExternalReferenceCode(
-						 "put", javaMethodSignature, parentSchemaName,
-						 schemaName)) {
+					 isByExternalReferenceCode("put", javaMethodSignature)) {
 
 				createStrategies.add("UPSERT");
 			}
@@ -495,8 +491,11 @@ public class ResourceOpenAPIParser {
 	}
 
 	public static boolean isByExternalReferenceCode(
-		String httpMethod, JavaMethodSignature javaMethodSignature,
-		String parentSchemaName, String schemaName) {
+		String httpMethod, JavaMethodSignature javaMethodSignature) {
+
+		String parentSchemaName = javaMethodSignature.getParentSchemaName();
+
+		String schemaName = javaMethodSignature.getSchemaName();
 
 		httpMethod = StringUtil.toLowerCase(httpMethod);
 		boolean hasSchemaExternalReferenceCodePathParameter = hasPathParameter(
@@ -504,7 +503,7 @@ public class ResourceOpenAPIParser {
 			TextFormatter.format(schemaName, TextFormatter.I) +
 				"ExternalReferenceCode");
 
-		if (parentSchemaName.isEmpty()) {
+		if (parentSchemaName == null) {
 			if (Objects.equals(
 					javaMethodSignature.getMethodName(),
 					httpMethod + "ByExternalReferenceCode") ||

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
@@ -384,46 +384,18 @@ public class ResourceOpenAPIParser {
 			}
 
 			if (methodName.equals("post" + parentSchemaName + schemaName) ||
-				methodName.equals(
-					StringBundler.concat(
-						"post", parentSchemaName, "ByExternalReferenceCode",
-						schemaName)) ||
-				methodName.equals(
-					StringBundler.concat(
-						"post", parentSchemaName, schemaName,
-						"ByExternalReferenceCode"))) {
+				isByExternalReferenceCode(
+					"post", javaMethodSignature, parentSchemaName,
+					schemaName)) {
 
 				createStrategies.add("INSERT");
 			}
-			else {
-				String formattedParentSchemaName = TextFormatter.format(
-					parentSchemaName, TextFormatter.I);
-				boolean hasSchemaExternalReferenceCodePathParameter =
-					hasPathParameter(
-						javaMethodSignature,
-						TextFormatter.format(schemaName, TextFormatter.I) +
-							"ExternalReferenceCode");
+			else if (propertyNames.contains("externalReferenceCode") &&
+					 isByExternalReferenceCode(
+						 "put", javaMethodSignature, parentSchemaName,
+						 schemaName)) {
 
-				if (propertyNames.contains("externalReferenceCode") &&
-					(methodName.equals("putByExternalReferenceCode") ||
-					 methodName.equals(
-						 StringBundler.concat(
-							 "put", parentSchemaName, schemaName,
-							 "ByExternalReferenceCode")) ||
-					 (Objects.equals(
-						 methodName,
-						 StringBundler.concat(
-							 "put", parentSchemaName, schemaName)) &&
-					  hasSchemaExternalReferenceCodePathParameter &&
-					  hasPathParameter(
-						  javaMethodSignature,
-						  formattedParentSchemaName +
-							  "ExternalReferenceCode")) ||
-					 (Objects.equals(methodName, "put" + schemaName) &&
-					  hasSchemaExternalReferenceCodePathParameter))) {
-
-					createStrategies.add("UPSERT");
-				}
+				createStrategies.add("UPSERT");
 			}
 		}
 
@@ -517,6 +489,66 @@ public class ResourceOpenAPIParser {
 
 				return true;
 			}
+		}
+
+		return false;
+	}
+
+	public static boolean isByExternalReferenceCode(
+		String httpMethod, JavaMethodSignature javaMethodSignature,
+		String parentSchemaName, String schemaName) {
+
+		httpMethod = StringUtil.toLowerCase(httpMethod);
+		boolean hasSchemaExternalReferenceCodePathParameter = hasPathParameter(
+			javaMethodSignature,
+			TextFormatter.format(schemaName, TextFormatter.I) +
+				"ExternalReferenceCode");
+
+		if (parentSchemaName.isEmpty()) {
+			if (Objects.equals(
+					javaMethodSignature.getMethodName(),
+					httpMethod + "ByExternalReferenceCode") ||
+				Objects.equals(
+					javaMethodSignature.getMethodName(),
+					StringBundler.concat(
+						httpMethod, schemaName, "ByExternalReferenceCode")) ||
+				(Objects.equals(
+					javaMethodSignature.getMethodName(),
+					httpMethod + schemaName) &&
+				 hasSchemaExternalReferenceCodePathParameter)) {
+
+				return true;
+			}
+
+			return false;
+		}
+
+		String formattedParentSchemaName = TextFormatter.format(
+			parentSchemaName, TextFormatter.I);
+
+		if (Objects.equals(
+				javaMethodSignature.getMethodName(),
+				StringBundler.concat(
+					httpMethod, parentSchemaName, schemaName,
+					"ByExternalReferenceCode")) ||
+			Objects.equals(
+				javaMethodSignature.getMethodName(),
+				StringBundler.concat(
+					httpMethod, parentSchemaName, "ByExternalReferenceCode",
+					schemaName)) ||
+			(Objects.equals(
+				javaMethodSignature.getMethodName(),
+				StringBundler.concat(
+					httpMethod, parentSchemaName, schemaName)) &&
+			 hasSchemaExternalReferenceCodePathParameter &&
+			 hasPathParameter(
+				 javaMethodSignature,
+				 formattedParentSchemaName + "ExternalReferenceCode")) ||
+			(Objects.equals(
+				javaMethodSignature.getMethodName(), httpMethod + schemaName) &&
+			 hasSchemaExternalReferenceCodePathParameter)) {
+
+			return true;
 		}
 
 		return false;

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
@@ -384,12 +384,12 @@ public class ResourceOpenAPIParser {
 			}
 
 			if (methodName.equals("post" + parentSchemaName + schemaName) ||
-				isByExternalReferenceCodeMethod("post", javaMethodSignature)) {
+				isExternalReferenceCodeMethod("post", javaMethodSignature)) {
 
 				createStrategies.add("INSERT");
 			}
 			else if (propertyNames.contains("externalReferenceCode") &&
-					 isByExternalReferenceCodeMethod(
+					 isExternalReferenceCodeMethod(
 						 "put", javaMethodSignature)) {
 
 				createStrategies.add("UPSERT");
@@ -491,7 +491,7 @@ public class ResourceOpenAPIParser {
 		return false;
 	}
 
-	public static boolean isByExternalReferenceCodeMethod(
+	public static boolean isExternalReferenceCodeMethod(
 		String httpMethod, JavaMethodSignature javaMethodSignature) {
 
 		String parentSchemaName = GetterUtil.getString(

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
@@ -494,64 +494,42 @@ public class ResourceOpenAPIParser {
 	public static boolean isByExternalReferenceCodeMethod(
 		String httpMethod, JavaMethodSignature javaMethodSignature) {
 
-		String parentSchemaName = javaMethodSignature.getParentSchemaName();
+		String parentSchemaName = GetterUtil.getString(
+			javaMethodSignature.getParentSchemaName());
+		String schemaName = GetterUtil.getString(
+			javaMethodSignature.getSchemaName());
 
-		String schemaName = javaMethodSignature.getSchemaName();
+		Set<String> validMethodNames = new HashSet<>();
 
-		httpMethod = StringUtil.toLowerCase(httpMethod);
-		boolean hasSchemaExternalReferenceCodePathParameter = hasPathParameter(
-			javaMethodSignature,
-			TextFormatter.format(schemaName, TextFormatter.I) +
-				"ExternalReferenceCode");
+		validMethodNames.add(httpMethod + "ByExternalReferenceCode");
+		validMethodNames.add(
+			StringBundler.concat(
+				httpMethod, parentSchemaName, "ByExternalReferenceCode",
+				schemaName));
+		validMethodNames.add(
+			StringBundler.concat(
+				httpMethod, parentSchemaName, schemaName,
+				"ByExternalReferenceCode"));
 
-		if (parentSchemaName == null) {
-			if (Objects.equals(
-					javaMethodSignature.getMethodName(),
-					httpMethod + "ByExternalReferenceCode") ||
-				Objects.equals(
-					javaMethodSignature.getMethodName(),
+		if (hasPathParameter(
+				javaMethodSignature,
+				OpenAPIParserUtil.getSchemaVarName(schemaName) +
+					"ExternalReferenceCode")) {
+
+			validMethodNames.add(httpMethod + schemaName);
+
+			if (hasPathParameter(
+					javaMethodSignature,
+					OpenAPIParserUtil.getSchemaVarName(parentSchemaName) +
+						"ExternalReferenceCode")) {
+
+				validMethodNames.add(
 					StringBundler.concat(
-						httpMethod, schemaName, "ByExternalReferenceCode")) ||
-				(Objects.equals(
-					javaMethodSignature.getMethodName(),
-					httpMethod + schemaName) &&
-				 hasSchemaExternalReferenceCodePathParameter)) {
-
-				return true;
+						httpMethod, parentSchemaName, schemaName));
 			}
-
-			return false;
 		}
 
-		String formattedParentSchemaName = TextFormatter.format(
-			parentSchemaName, TextFormatter.I);
-
-		if (Objects.equals(
-				javaMethodSignature.getMethodName(),
-				StringBundler.concat(
-					httpMethod, parentSchemaName, schemaName,
-					"ByExternalReferenceCode")) ||
-			Objects.equals(
-				javaMethodSignature.getMethodName(),
-				StringBundler.concat(
-					httpMethod, parentSchemaName, "ByExternalReferenceCode",
-					schemaName)) ||
-			(Objects.equals(
-				javaMethodSignature.getMethodName(),
-				StringBundler.concat(
-					httpMethod, parentSchemaName, schemaName)) &&
-			 hasSchemaExternalReferenceCodePathParameter &&
-			 hasPathParameter(
-				 javaMethodSignature,
-				 formattedParentSchemaName + "ExternalReferenceCode")) ||
-			(Objects.equals(
-				javaMethodSignature.getMethodName(), httpMethod + schemaName) &&
-			 hasSchemaExternalReferenceCodePathParameter)) {
-
-			return true;
-		}
-
-		return false;
+		return validMethodNames.contains(javaMethodSignature.getMethodName());
 	}
 
 	private static void _addBatchJavaMethodSignature(

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
@@ -395,14 +395,35 @@ public class ResourceOpenAPIParser {
 
 				createStrategies.add("INSERT");
 			}
-			else if ((methodName.equals("putByExternalReferenceCode") ||
-					  methodName.equals(
-						  StringBundler.concat(
-							  "put", parentSchemaName, schemaName,
-							  "ByExternalReferenceCode"))) &&
-					 propertyNames.contains("externalReferenceCode")) {
+			else {
+				String formattedParentSchemaName = TextFormatter.format(
+					parentSchemaName, TextFormatter.I);
+				boolean hasSchemaExternalReferenceCodePathParameter =
+					hasPathParameter(
+						javaMethodSignature,
+						TextFormatter.format(schemaName, TextFormatter.I) +
+							"ExternalReferenceCode");
 
-				createStrategies.add("UPSERT");
+				if (propertyNames.contains("externalReferenceCode") &&
+					(methodName.equals("putByExternalReferenceCode") ||
+					 methodName.equals(
+						 StringBundler.concat(
+							 "put", parentSchemaName, schemaName,
+							 "ByExternalReferenceCode")) ||
+					 (Objects.equals(
+						 methodName,
+						 StringBundler.concat(
+							 "put", parentSchemaName, schemaName)) &&
+					  hasSchemaExternalReferenceCodePathParameter &&
+					  hasPathParameter(
+						  javaMethodSignature,
+						  formattedParentSchemaName +
+							  "ExternalReferenceCode")) ||
+					 (Objects.equals(methodName, "put" + schemaName) &&
+					  hasSchemaExternalReferenceCodePathParameter))) {
+
+					createStrategies.add("UPSERT");
+				}
 			}
 		}
 
@@ -427,6 +448,21 @@ public class ResourceOpenAPIParser {
 		}
 
 		return updateStrategies;
+	}
+
+	public static boolean hasPathParameter(
+		JavaMethodSignature javaMethodSignature, String parameterName) {
+
+		List<JavaMethodParameter> javaMethodParameters =
+			javaMethodSignature.getPathJavaMethodParameters();
+
+		for (JavaMethodParameter javaMethodParameter : javaMethodParameters) {
+			if (parameterName.equals(javaMethodParameter.getParameterName())) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	public static boolean hasReadVulcanBatchImplementation(
@@ -1278,17 +1314,26 @@ public class ResourceOpenAPIParser {
 		}
 
 		basePath = basePath.substring(0, lastIndexOfSlash);
+		String schemaPath = TextFormatter.format(
+			TextFormatter.formatPlural(schemaName), TextFormatter.K);
 
 		if (basePath.equals(
 				"/asset-libraries/{assetLibraryExternalReferenceCode}") ||
+			basePath.equals(
+				"/asset-libraries/{assetLibraryExternalReferenceCode}/" +
+					schemaPath) ||
 			basePath.equals("/asset-libraries/{assetLibraryId}")) {
 
 			return "AssetLibrary";
 		}
-		else if (basePath.equals("/sites/{siteExternalReferenceCode}") ||
-				 basePath.equals("/sites/{siteId}")) {
+		else {
+			if (basePath.equals("/sites/{siteExternalReferenceCode}") ||
+				basePath.equals(
+					"/sites/{siteExternalReferenceCode}/" + schemaPath) ||
+				basePath.equals("/sites/{siteId}")) {
 
-			return "Site";
+				return "Site";
+			}
 		}
 
 		for (Map.Entry<String, PathItem> entry : pathItems.entrySet()) {

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
@@ -384,12 +384,13 @@ public class ResourceOpenAPIParser {
 			}
 
 			if (methodName.equals("post" + parentSchemaName + schemaName) ||
-				isByExternalReferenceCode("post", javaMethodSignature)) {
+				isByExternalReferenceCodeMethod("post", javaMethodSignature)) {
 
 				createStrategies.add("INSERT");
 			}
 			else if (propertyNames.contains("externalReferenceCode") &&
-					 isByExternalReferenceCode("put", javaMethodSignature)) {
+					 isByExternalReferenceCodeMethod(
+						 "put", javaMethodSignature)) {
 
 				createStrategies.add("UPSERT");
 			}
@@ -490,7 +491,7 @@ public class ResourceOpenAPIParser {
 		return false;
 	}
 
-	public static boolean isByExternalReferenceCode(
+	public static boolean isByExternalReferenceCodeMethod(
 		String httpMethod, JavaMethodSignature javaMethodSignature) {
 
 		String parentSchemaName = javaMethodSignature.getParentSchemaName();

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -166,7 +166,7 @@ public abstract class Base${schemaName}ResourceImpl
 			<#assign deleteSiteBatchJavaMethodSignature = javaMethodSignature />
 		<#elseif stringUtil.equals(javaMethodSignature.methodName, "get" + schemaName)>
 			<#assign getByIdJavaMethodSignature = javaMethodSignature />
-		<#elseif freeMarkerTool.isByExternalReferenceCode("get", javaMethodSignature, parentSchemaName, schemaName)>
+		<#elseif freeMarkerTool.isByExternalReferenceCode("get", javaMethodSignature)>
 			<#if parentSchemaName?has_content>
 				<#assign getParentByExternalReferenceCodeBatchJavaMethodSignatures = getParentByExternalReferenceCodeBatchJavaMethodSignatures + [javaMethodSignature] />
 			<#else>
@@ -192,11 +192,11 @@ public abstract class Base${schemaName}ResourceImpl
 			<#else>
 				<#assign postBatchJavaMethodSignature = javaMethodSignature />
 			</#if>
-		<#elseif freeMarkerTool.isByExternalReferenceCode("post", javaMethodSignature, parentSchemaName, schemaName) && parentSchemaName?has_content>
+		<#elseif freeMarkerTool.isByExternalReferenceCode("post", javaMethodSignature) && parentSchemaName?has_content>
 			<#assign postParentByExternalReferenceCodeBatchJavaMethodSignatures = postParentByExternalReferenceCodeBatchJavaMethodSignatures + [javaMethodSignature] />
 		<#elseif stringUtil.equals(javaMethodSignature.methodName, "put" + schemaName)>
 			<#assign putBatchJavaMethodSignature = javaMethodSignature />
-		<#elseif freeMarkerTool.isByExternalReferenceCode("put", javaMethodSignature, parentSchemaName, schemaName)>
+		<#elseif freeMarkerTool.isByExternalReferenceCode("put", javaMethodSignature)>
 			<#if parentSchemaName?has_content>
 				<#assign putParentByExternalReferenceCodeBatchJavaMethodSignatures = putParentByExternalReferenceCodeBatchJavaMethodSignatures + [javaMethodSignature] />
 			<#else>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -166,10 +166,12 @@ public abstract class Base${schemaName}ResourceImpl
 			<#assign deleteSiteBatchJavaMethodSignature = javaMethodSignature />
 		<#elseif stringUtil.equals(javaMethodSignature.methodName, "get" + schemaName)>
 			<#assign getByIdJavaMethodSignature = javaMethodSignature />
-		<#elseif stringUtil.equals(javaMethodSignature.methodName, "get" + schemaName + "ByExternalReferenceCode")>
-			<#assign getByExternalReferenceCodeBatchJavaMethodSignature = javaMethodSignature />
-		<#elseif stringUtil.equals(javaMethodSignature.methodName, "get" + parentSchemaName + schemaName + "ByExternalReferenceCode")>
-			<#assign getParentByExternalReferenceCodeBatchJavaMethodSignatures = getParentByExternalReferenceCodeBatchJavaMethodSignatures + [javaMethodSignature] />
+		<#elseif freeMarkerTool.isByExternalReferenceCode("get", javaMethodSignature, parentSchemaName, schemaName)>
+			<#if parentSchemaName?has_content>
+				<#assign getParentByExternalReferenceCodeBatchJavaMethodSignatures = getParentByExternalReferenceCodeBatchJavaMethodSignatures + [javaMethodSignature] />
+			<#else>
+				<#assign getByExternalReferenceCodeBatchJavaMethodSignature = javaMethodSignature />
+			</#if>
 		<#elseif stringUtil.equals(javaMethodSignature.methodName, "get" + parentSchemaName + schemaNames + "Page")>
 			<#if stringUtil.equals(javaMethodSignature.methodName, "getAssetLibrary" + schemaNames + "Page")>
 				<#assign getAssetLibraryBatchJavaMethodSignature = javaMethodSignature />
@@ -190,11 +192,11 @@ public abstract class Base${schemaName}ResourceImpl
 			<#else>
 				<#assign postBatchJavaMethodSignature = javaMethodSignature />
 			</#if>
-		<#elseif (stringUtil.equals(javaMethodSignature.methodName, "post" + parentSchemaName + "ByExternalReferenceCode" + schemaName) || stringUtil.equals(javaMethodSignature.methodName, "post" + parentSchemaName + schemaName + "ByExternalReferenceCode")) && parentSchemaName?has_content>
+		<#elseif freeMarkerTool.isByExternalReferenceCode("post", javaMethodSignature, parentSchemaName, schemaName) && parentSchemaName?has_content>
 			<#assign postParentByExternalReferenceCodeBatchJavaMethodSignatures = postParentByExternalReferenceCodeBatchJavaMethodSignatures + [javaMethodSignature] />
 		<#elseif stringUtil.equals(javaMethodSignature.methodName, "put" + schemaName)>
 			<#assign putBatchJavaMethodSignature = javaMethodSignature />
-		<#elseif stringUtil.equals(javaMethodSignature.methodName, "putByExternalReferenceCode") || stringUtil.equals(javaMethodSignature.methodName, "put" + parentSchemaName + "ByExternalReferenceCode" + schemaName) || stringUtil.equals(javaMethodSignature.methodName, "put" + parentSchemaName + schemaName + "ByExternalReferenceCode")>
+		<#elseif freeMarkerTool.isByExternalReferenceCode("put", javaMethodSignature, parentSchemaName, schemaName)>
 			<#if parentSchemaName?has_content>
 				<#assign putParentByExternalReferenceCodeBatchJavaMethodSignatures = putParentByExternalReferenceCodeBatchJavaMethodSignatures + [javaMethodSignature] />
 			<#else>
@@ -808,7 +810,7 @@ public abstract class Base${schemaName}ResourceImpl
 
 									<#if getByExternalReferenceCodeBatchJavaMethodSignature??>
 										<#if getParentByExternalReferenceCodeBatchJavaMethodSignatures?has_content>
-											else
+											else {
 										</#if>
 
 										get${schemaName} = ${getByExternalReferenceCodeBatchJavaMethodSignature.methodName}(
@@ -819,6 +821,10 @@ public abstract class Base${schemaName}ResourceImpl
 										/>
 
 										);
+
+										<#if getParentByExternalReferenceCodeBatchJavaMethodSignatures?has_content>
+											}
+										</#if>
 									</#if>
 
 									<#if !getByExternalReferenceCodeBatchJavaMethodSignature?? && parentParameterNames?has_content>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -166,7 +166,7 @@ public abstract class Base${schemaName}ResourceImpl
 			<#assign deleteSiteBatchJavaMethodSignature = javaMethodSignature />
 		<#elseif stringUtil.equals(javaMethodSignature.methodName, "get" + schemaName)>
 			<#assign getByIdJavaMethodSignature = javaMethodSignature />
-		<#elseif freeMarkerTool.isByExternalReferenceCode("get", javaMethodSignature)>
+		<#elseif freeMarkerTool.isByExternalReferenceCodeMethod("get", javaMethodSignature)>
 			<#if parentSchemaName?has_content>
 				<#assign getParentByExternalReferenceCodeBatchJavaMethodSignatures = getParentByExternalReferenceCodeBatchJavaMethodSignatures + [javaMethodSignature] />
 			<#else>
@@ -192,11 +192,11 @@ public abstract class Base${schemaName}ResourceImpl
 			<#else>
 				<#assign postBatchJavaMethodSignature = javaMethodSignature />
 			</#if>
-		<#elseif freeMarkerTool.isByExternalReferenceCode("post", javaMethodSignature) && parentSchemaName?has_content>
+		<#elseif freeMarkerTool.isByExternalReferenceCodeMethod("post", javaMethodSignature) && parentSchemaName?has_content>
 			<#assign postParentByExternalReferenceCodeBatchJavaMethodSignatures = postParentByExternalReferenceCodeBatchJavaMethodSignatures + [javaMethodSignature] />
 		<#elseif stringUtil.equals(javaMethodSignature.methodName, "put" + schemaName)>
 			<#assign putBatchJavaMethodSignature = javaMethodSignature />
-		<#elseif freeMarkerTool.isByExternalReferenceCode("put", javaMethodSignature)>
+		<#elseif freeMarkerTool.isByExternalReferenceCodeMethod("put", javaMethodSignature)>
 			<#if parentSchemaName?has_content>
 				<#assign putParentByExternalReferenceCodeBatchJavaMethodSignatures = putParentByExternalReferenceCodeBatchJavaMethodSignatures + [javaMethodSignature] />
 			<#else>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -166,7 +166,7 @@ public abstract class Base${schemaName}ResourceImpl
 			<#assign deleteSiteBatchJavaMethodSignature = javaMethodSignature />
 		<#elseif stringUtil.equals(javaMethodSignature.methodName, "get" + schemaName)>
 			<#assign getByIdJavaMethodSignature = javaMethodSignature />
-		<#elseif freeMarkerTool.isByExternalReferenceCodeMethod("get", javaMethodSignature)>
+		<#elseif freeMarkerTool.isExternalReferenceCodeMethod("get", javaMethodSignature)>
 			<#if parentSchemaName?has_content>
 				<#assign getParentByExternalReferenceCodeBatchJavaMethodSignatures = getParentByExternalReferenceCodeBatchJavaMethodSignatures + [javaMethodSignature] />
 			<#else>
@@ -192,11 +192,11 @@ public abstract class Base${schemaName}ResourceImpl
 			<#else>
 				<#assign postBatchJavaMethodSignature = javaMethodSignature />
 			</#if>
-		<#elseif freeMarkerTool.isByExternalReferenceCodeMethod("post", javaMethodSignature) && parentSchemaName?has_content>
+		<#elseif freeMarkerTool.isExternalReferenceCodeMethod("post", javaMethodSignature) && parentSchemaName?has_content>
 			<#assign postParentByExternalReferenceCodeBatchJavaMethodSignatures = postParentByExternalReferenceCodeBatchJavaMethodSignatures + [javaMethodSignature] />
 		<#elseif stringUtil.equals(javaMethodSignature.methodName, "put" + schemaName)>
 			<#assign putBatchJavaMethodSignature = javaMethodSignature />
-		<#elseif freeMarkerTool.isByExternalReferenceCodeMethod("put", javaMethodSignature)>
+		<#elseif freeMarkerTool.isExternalReferenceCodeMethod("put", javaMethodSignature)>
 			<#if parentSchemaName?has_content>
 				<#assign putParentByExternalReferenceCodeBatchJavaMethodSignatures = putParentByExternalReferenceCodeBatchJavaMethodSignatures + [javaMethodSignature] />
 			<#else>


### PR DESCRIPTION
**What's changed?**
- New logic has been added in order to recognize properly the parent schemas for ERC exclusive endpoints.
- UPSERT is now being reconized as one of the available create strategies for ERC exclusive APIs if the pattern is followed.
- UPDATE update strategy code is being autogenerated for the aforementioned case.

See the following Jira Ticket: [LPD-65055](https://liferay.atlassian.net/browse/LPD-65055)

cc: @achaparro