### PR TITLE
LPD-63231 part 2 | add endpoint to retrieve usages of an asset

### DIFF
--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/AssetUsage.java
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/dto/v1_0/AssetUsage.java
@@ -1,0 +1,286 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+@GraphQLName("AssetUsage")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "AssetUsage")
+public class AssetUsage implements Serializable {
+
+	public static AssetUsage toDTO(String json) {
+		return ObjectMapperUtil.readValue(AssetUsage.class, json);
+	}
+
+	public static AssetUsage unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(AssetUsage.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getName() {
+		if (_nameSupplier != null) {
+			name = _nameSupplier.get();
+
+			_nameSupplier = null;
+		}
+
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+
+		_nameSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		_nameSupplier = () -> {
+			try {
+				return nameUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String name;
+
+	@JsonIgnore
+	private Supplier<String> _nameSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getType() {
+		if (_typeSupplier != null) {
+			type = _typeSupplier.get();
+
+			_typeSupplier = null;
+		}
+
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+
+		_typeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setType(UnsafeSupplier<String, Exception> typeUnsafeSupplier) {
+		_typeSupplier = () -> {
+			try {
+				return typeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String type;
+
+	@JsonIgnore
+	private Supplier<String> _typeSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof AssetUsage)) {
+			return false;
+		}
+
+		AssetUsage assetUsage = (AssetUsage)object;
+
+		return Objects.equals(toString(), assetUsage.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		String name = getName();
+
+		if (name != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(name));
+
+			sb.append("\"");
+		}
+
+		String type = getType();
+
+		if (type != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(type));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.cms.dto.v1_0.AssetUsage",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}

--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/resource/v1_0/AssetUsageResource.java
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/resource/v1_0/AssetUsageResource.java
@@ -1,0 +1,140 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.resource.v1_0;
+
+import com.liferay.headless.cms.dto.v1_0.AssetUsage;
+import com.liferay.portal.kernel.change.tracking.CTAware;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * To access this resource, run:
+ *
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/headless-cms/v1.0
+ *
+ * @author Crescenzo Rega
+ * @generated
+ */
+@CTAware
+@Generated("")
+@ProviderType
+public interface AssetUsageResource {
+
+	public Page<AssetUsage> getAssetUsagesAssetPage(
+			Long assetId, String search, Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts)
+		throws Exception;
+
+	public default void setContextAcceptLanguage(
+		AcceptLanguage contextAcceptLanguage) {
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser);
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert);
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider);
+
+	public void setGroupLocalService(GroupLocalService groupLocalService);
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService);
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService);
+
+	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider);
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString) {
+
+		return toFilter(
+			filterString, Collections.<String, List<String>>emptyMap());
+	}
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		return null;
+	}
+
+	public default com.liferay.portal.kernel.search.Sort[] toSorts(
+		String sortsString) {
+
+		return new com.liferay.portal.kernel.search.Sort[0];
+	}
+
+	@ProviderType
+	public interface Builder {
+
+		public AssetUsageResource build();
+
+		public Builder checkPermissions(boolean checkPermissions);
+
+		public Builder httpServletRequest(
+			HttpServletRequest httpServletRequest);
+
+		public Builder httpServletResponse(
+			HttpServletResponse httpServletResponse);
+
+		public Builder preferredLocale(Locale preferredLocale);
+
+		public Builder uriInfo(UriInfo uriInfo);
+
+		public Builder user(com.liferay.portal.kernel.model.User user);
+
+	}
+
+	@ProviderType
+	public interface Factory {
+
+		public Builder create();
+
+	}
+
+}

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/AssetUsage.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/dto/v1_0/AssetUsage.java
@@ -1,0 +1,97 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.dto.v1_0;
+
+import com.liferay.headless.cms.client.function.UnsafeSupplier;
+import com.liferay.headless.cms.client.serdes.v1_0.AssetUsageSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public class AssetUsage implements Cloneable, Serializable {
+
+	public static AssetUsage toDTO(String json) {
+		return AssetUsageSerDes.toDTO(json);
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		try {
+			name = nameUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String name;
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public void setType(UnsafeSupplier<String, Exception> typeUnsafeSupplier) {
+		try {
+			type = typeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String type;
+
+	@Override
+	public AssetUsage clone() throws CloneNotSupportedException {
+		return (AssetUsage)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof AssetUsage)) {
+			return false;
+		}
+
+		AssetUsage assetUsage = (AssetUsage)object;
+
+		return Objects.equals(toString(), assetUsage.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return AssetUsageSerDes.toJSON(this);
+	}
+
+}

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/resource/v1_0/AssetUsageResource.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/resource/v1_0/AssetUsageResource.java
@@ -1,0 +1,290 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.resource.v1_0;
+
+import com.liferay.headless.cms.client.dto.v1_0.AssetUsage;
+import com.liferay.headless.cms.client.http.HttpInvoker;
+import com.liferay.headless.cms.client.pagination.Page;
+import com.liferay.headless.cms.client.pagination.Pagination;
+import com.liferay.headless.cms.client.problem.Problem;
+import com.liferay.headless.cms.client.serdes.v1_0.AssetUsageSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.net.URL;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public interface AssetUsageResource {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public Page<AssetUsage> getAssetUsagesAssetPage(
+			Long assetId, String search, Pagination pagination,
+			String sortString)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getAssetUsagesAssetPageHttpResponse(
+			Long assetId, String search, Pagination pagination,
+			String sortString)
+		throws Exception;
+
+	public static class Builder {
+
+		public Builder authentication(String login, String password) {
+			_login = login;
+			_password = password;
+
+			return this;
+		}
+
+		public Builder bearerToken(String token) {
+			return header("Authorization", "Bearer " + token);
+		}
+
+		public AssetUsageResource build() {
+			return new AssetUsageResourceImpl(this);
+		}
+
+		public Builder contextPath(String contextPath) {
+			_contextPath = contextPath;
+
+			return this;
+		}
+
+		public Builder endpoint(String address, String scheme) {
+			String[] addressParts = address.split(":");
+
+			String host = addressParts[0];
+
+			int port = 443;
+
+			if (addressParts.length > 1) {
+				String portString = addressParts[1];
+
+				try {
+					port = Integer.parseInt(portString);
+				}
+				catch (NumberFormatException numberFormatException) {
+					throw new IllegalArgumentException(
+						"Unable to parse port from " + portString);
+				}
+			}
+
+			return endpoint(host, port, scheme);
+		}
+
+		public Builder endpoint(String host, int port, String scheme) {
+			_host = host;
+			_port = port;
+			_scheme = scheme;
+
+			return this;
+		}
+
+		public Builder endpoint(URL url) {
+			return endpoint(url.getHost(), url.getPort(), url.getProtocol());
+		}
+
+		public Builder header(String key, String value) {
+			_headers.put(key, value);
+
+			return this;
+		}
+
+		public Builder locale(Locale locale) {
+			_locale = locale;
+
+			return this;
+		}
+
+		public Builder parameter(String key, String value) {
+			_parameters.put(key, value);
+
+			return this;
+		}
+
+		public Builder parameters(String... parameters) {
+			if ((parameters.length % 2) != 0) {
+				throw new IllegalArgumentException(
+					"Parameters length is not an even number");
+			}
+
+			for (int i = 0; i < parameters.length; i += 2) {
+				String parameterName = String.valueOf(parameters[i]);
+				String parameterValue = String.valueOf(parameters[i + 1]);
+
+				_parameters.put(parameterName, parameterValue);
+			}
+
+			return this;
+		}
+
+		private Builder() {
+		}
+
+		private String _contextPath = "";
+		private Map<String, String> _headers = new LinkedHashMap<>();
+		private String _host = "localhost";
+		private Locale _locale;
+		private String _login;
+		private String _password;
+		private Map<String, String> _parameters = new LinkedHashMap<>();
+		private int _port = 8080;
+		private String _scheme = "http";
+
+	}
+
+	public static class AssetUsageResourceImpl implements AssetUsageResource {
+
+		public Page<AssetUsage> getAssetUsagesAssetPage(
+				Long assetId, String search, Pagination pagination,
+				String sortString)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getAssetUsagesAssetPageHttpResponse(
+					assetId, search, pagination, sortString);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, AssetUsageSerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse getAssetUsagesAssetPageHttpResponse(
+				Long assetId, String search, Pagination pagination,
+				String sortString)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (search != null) {
+				httpInvoker.parameter("search", String.valueOf(search));
+			}
+
+			if (pagination != null) {
+				httpInvoker.parameter(
+					"page", String.valueOf(pagination.getPage()));
+				httpInvoker.parameter(
+					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
+
+			if (sortString != null) {
+				httpInvoker.parameter("sort", sortString);
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-cms/v1.0/asset-usages/{assetId}");
+
+			httpInvoker.path("assetId", assetId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		private AssetUsageResourceImpl(Builder builder) {
+			_builder = builder;
+		}
+
+		private static final Logger _logger = Logger.getLogger(
+			AssetUsageResource.class.getName());
+
+		private Builder _builder;
+
+	}
+
+}

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/AssetUsageSerDes.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/serdes/v1_0/AssetUsageSerDes.java
@@ -1,0 +1,230 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.client.serdes.v1_0;
+
+import com.liferay.headless.cms.client.dto.v1_0.AssetUsage;
+import com.liferay.headless.cms.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public class AssetUsageSerDes {
+
+	public static AssetUsage toDTO(String json) {
+		AssetUsageJSONParser assetUsageJSONParser = new AssetUsageJSONParser();
+
+		return assetUsageJSONParser.parseToDTO(json);
+	}
+
+	public static AssetUsage[] toDTOs(String json) {
+		AssetUsageJSONParser assetUsageJSONParser = new AssetUsageJSONParser();
+
+		return assetUsageJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(AssetUsage assetUsage) {
+		if (assetUsage == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (assetUsage.getName() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(assetUsage.getName()));
+
+			sb.append("\"");
+		}
+
+		if (assetUsage.getType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(assetUsage.getType()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		AssetUsageJSONParser assetUsageJSONParser = new AssetUsageJSONParser();
+
+		return assetUsageJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(AssetUsage assetUsage) {
+		if (assetUsage == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (assetUsage.getName() == null) {
+			map.put("name", null);
+		}
+		else {
+			map.put("name", String.valueOf(assetUsage.getName()));
+		}
+
+		if (assetUsage.getType() == null) {
+			map.put("type", null);
+		}
+		else {
+			map.put("type", String.valueOf(assetUsage.getType()));
+		}
+
+		return map;
+	}
+
+	public static class AssetUsageJSONParser
+		extends BaseJSONParser<AssetUsage> {
+
+		@Override
+		protected AssetUsage createDTO() {
+			return new AssetUsage();
+		}
+
+		@Override
+		protected AssetUsage[] createDTOArray(int size) {
+			return new AssetUsage[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "name")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			AssetUsage assetUsage, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "name")) {
+				if (jsonParserFieldValue != null) {
+					assetUsage.setName((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				if (jsonParserFieldValue != null) {
+					assetUsage.setType((String)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}

--- a/modules/apps/headless/headless-cms/headless-cms-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/rest-openapi.yaml
@@ -1,5 +1,11 @@
 components:
     schemas:
+        AssetUsage:
+            properties:
+                name:
+                    type: string
+                type:
+                    type: string
         BulkAction:
             discriminator:
                 mapping:
@@ -129,6 +135,46 @@ info:
     version: v1.0
 openapi: 3.0.1
 paths:
+    "/asset-usages/{assetId}":
+        get:
+            operationId: getAssetUsagesAssetPage
+            parameters:
+                -   in: path
+                    name: assetId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: page
+                    schema:
+                        type: integer
+                -   in: query
+                    name: pageSize
+                    schema:
+                        type: integer
+                -   in: query
+                    name: search
+                    schema:
+                        type: string
+                -   in: query
+                    name: sort
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/AssetUsage"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/AssetUsage"
+                                type: array
+            tags: ["AssetUsage"]
     "/bulk-action":
         post:
             description:

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/query/v1_0/Query.java
@@ -5,11 +5,17 @@
 
 package com.liferay.headless.cms.internal.graphql.query.v1_0;
 
+import com.liferay.headless.cms.dto.v1_0.AssetUsage;
+import com.liferay.headless.cms.resource.v1_0.AssetUsageResource;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
 
 import jakarta.annotation.Generated;
 
@@ -18,6 +24,7 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import jakarta.ws.rs.core.UriInfo;
 
+import java.util.Map;
 import java.util.function.BiFunction;
 
 import org.osgi.service.component.ComponentServiceObjects;
@@ -28,6 +35,70 @@ import org.osgi.service.component.ComponentServiceObjects;
  */
 @Generated("")
 public class Query {
+
+	public static void setAssetUsageResourceComponentServiceObjects(
+		ComponentServiceObjects<AssetUsageResource>
+			assetUsageResourceComponentServiceObjects) {
+
+		_assetUsageResourceComponentServiceObjects =
+			assetUsageResourceComponentServiceObjects;
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {assetUsagesAsset(assetId: ___, page: ___, pageSize: ___, search: ___, sorts: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField
+	public AssetUsagePage assetUsagesAsset(
+			@GraphQLName("assetId") Long assetId,
+			@GraphQLName("search") String search,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page,
+			@GraphQLName("sort") String sortsString)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_assetUsageResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			assetUsageResource -> new AssetUsagePage(
+				assetUsageResource.getAssetUsagesAssetPage(
+					assetId, search, Pagination.of(page, pageSize),
+					_sortsBiFunction.apply(assetUsageResource, sortsString))));
+	}
+
+	@GraphQLName("AssetUsagePage")
+	public class AssetUsagePage {
+
+		public AssetUsagePage(Page assetUsagePage) {
+			actions = assetUsagePage.getActions();
+
+			items = assetUsagePage.getItems();
+			lastPage = assetUsagePage.getLastPage();
+			page = assetUsagePage.getPage();
+			pageSize = assetUsagePage.getPageSize();
+			totalCount = assetUsagePage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected java.util.Collection<AssetUsage> items;
+
+		@GraphQLField
+		protected long lastPage;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
 
 	private <T, R, E1 extends Throwable, E2 extends Throwable> R
 			_applyComponentServiceObjects(
@@ -47,6 +118,22 @@ public class Query {
 			componentServiceObjects.ungetService(resource);
 		}
 	}
+
+	private void _populateResourceContext(AssetUsageResource assetUsageResource)
+		throws Exception {
+
+		assetUsageResource.setContextAcceptLanguage(_acceptLanguage);
+		assetUsageResource.setContextCompany(_company);
+		assetUsageResource.setContextHttpServletRequest(_httpServletRequest);
+		assetUsageResource.setContextHttpServletResponse(_httpServletResponse);
+		assetUsageResource.setContextUriInfo(_uriInfo);
+		assetUsageResource.setContextUser(_user);
+		assetUsageResource.setGroupLocalService(_groupLocalService);
+		assetUsageResource.setRoleLocalService(_roleLocalService);
+	}
+
+	private static ComponentServiceObjects<AssetUsageResource>
+		_assetUsageResourceComponentServiceObjects;
 
 	private AcceptLanguage _acceptLanguage;
 	private com.liferay.portal.kernel.model.Company _company;

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -7,7 +7,9 @@ package com.liferay.headless.cms.internal.graphql.servlet.v1_0;
 
 import com.liferay.headless.cms.internal.graphql.mutation.v1_0.Mutation;
 import com.liferay.headless.cms.internal.graphql.query.v1_0.Query;
+import com.liferay.headless.cms.internal.resource.v1_0.AssetUsageResourceImpl;
 import com.liferay.headless.cms.internal.resource.v1_0.BulkActionResourceImpl;
+import com.liferay.headless.cms.resource.v1_0.AssetUsageResource;
 import com.liferay.headless.cms.resource.v1_0.BulkActionResource;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.vulcan.graphql.servlet.ServletData;
@@ -36,6 +38,9 @@ public class ServletDataImpl implements ServletData {
 	public void activate(BundleContext bundleContext) {
 		Mutation.setBulkActionResourceComponentServiceObjects(
 			_bulkActionResourceComponentServiceObjects);
+
+		Query.setAssetUsageResourceComponentServiceObjects(
+			_assetUsageResourceComponentServiceObjects);
 	}
 
 	public String getApplicationName() {
@@ -81,11 +86,21 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							BulkActionResourceImpl.class,
 							"postBulkActionItemPreviewPage"));
+
+					put(
+						"query#assetUsagesAsset",
+						new ObjectValuePair<>(
+							AssetUsageResourceImpl.class,
+							"getAssetUsagesAssetPage"));
 				}
 			};
 
 	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
 	private ComponentServiceObjects<BulkActionResource>
 		_bulkActionResourceComponentServiceObjects;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<AssetUsageResource>
+		_assetUsageResourceComponentServiceObjects;
 
 }

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetUsageResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetUsageResourceImpl.java
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.internal.resource.v1_0;
+
+import com.liferay.headless.cms.resource.v1_0.AssetUsageResource;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * @author Crescenzo Rega
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0/asset-usage.properties",
+	scope = ServiceScope.PROTOTYPE, service = AssetUsageResource.class
+)
+public class AssetUsageResourceImpl extends BaseAssetUsageResourceImpl {
+}

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetUsageResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetUsageResourceImpl.java
@@ -5,17 +5,405 @@
 
 package com.liferay.headless.cms.internal.resource.v1_0;
 
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.model.DepotEntryGroupRel;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryService;
+import com.liferay.headless.cms.dto.v1_0.AssetUsage;
 import com.liferay.headless.cms.resource.v1_0.AssetUsageResource;
+import com.liferay.layout.model.LayoutClassedModelUsageTable;
+import com.liferay.layout.service.LayoutClassedModelUsageLocalService;
+import com.liferay.layout.util.constants.LayoutClassedModelUsageConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryTable;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.related.models.ObjectRelatedModelsProvider;
+import com.liferay.object.related.models.ObjectRelatedModelsProviderRegistry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutTable;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Localization;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.odata.entity.StringEntityField;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.util.SearchUtil;
+
+import jakarta.ws.rs.core.MultivaluedMap;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
 
 /**
- * @author Crescenzo Rega
+ * @author Thiago Buarque
  */
 @Component(
 	properties = "OSGI-INF/liferay/rest/v1_0/asset-usage.properties",
 	scope = ServiceScope.PROTOTYPE, service = AssetUsageResource.class
 )
 public class AssetUsageResourceImpl extends BaseAssetUsageResourceImpl {
+
+	public Page<AssetUsage> getAssetUsagesAssetPage(
+			Long assetId, String search, Pagination pagination, Sort[] sorts)
+		throws Exception {
+
+		List<AssetUsage> assetUsages = _getAssetUsages(assetId, search);
+
+		Sort sort = null;
+
+		if (ArrayUtil.isEmpty(sorts)) {
+			sort = new Sort("name", false);
+		}
+		else {
+			sort = sorts[0];
+		}
+
+		boolean reverse = sort.isReverse();
+
+		return Page.of(
+			ListUtil.subList(
+				ListUtil.sort(
+					assetUsages,
+					(assetUsage1, assetUsage2) -> {
+						String name = assetUsage1.getName();
+
+						int value = name.compareTo(assetUsage2.getName());
+
+						if (!reverse) {
+							return value;
+						}
+
+						return -value;
+					}),
+				pagination.getStartPosition(), pagination.getEndPosition()),
+			pagination, assetUsages.size());
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap)
+		throws Exception {
+
+		return _entityModel;
+	}
+
+	private void _appendLayoutUsages(
+			Long assetId, List<AssetUsage> assetUsages, String className,
+			String search)
+		throws Exception {
+
+		PermissionChecker permissionChecker =
+			PermissionCheckerFactoryUtil.create(contextUser);
+
+		String languageId = contextUser.getLanguageId();
+
+		for (Object[] objects :
+				_getLayoutClassedModelUsageObjectsList(
+					className, assetId, search)) {
+
+			Layout layout = _layoutLocalService.getLayout((Long)objects[0]);
+
+			if (!_hasViewPermission(layout, permissionChecker)) {
+				continue;
+			}
+
+			AssetUsage assetUsage = new AssetUsage();
+
+			assetUsage.setName(
+				() -> _getName(
+					layout.isDraftLayout(),
+					_localization.getLocalization(
+						(String)objects[2], languageId, true)));
+			assetUsage.setType(
+				() -> _getLayoutUsageTypeLabel((Integer)objects[1]));
+
+			assetUsages.add(assetUsage);
+		}
+	}
+
+	private void _appendObjectEntryUsages(
+			Long assetId, List<AssetUsage> assetUsages,
+			ObjectDefinition objectDefinition, String search)
+		throws Exception {
+
+		List<ObjectRelationship> objectRelationships =
+			_objectRelationshipLocalService.getObjectRelationships(
+				objectDefinition.getObjectDefinitionId());
+
+		Long[] groupIds = _getGroupIds(_getViewableDepotEntries());
+
+		String languageId = contextUser.getLanguageId();
+
+		for (ObjectRelationship objectRelationship : objectRelationships) {
+			ObjectRelatedModelsProvider objectRelatedModelsProvider =
+				_objectRelatedModelsProviderRegistry.
+					getObjectRelatedModelsProvider(
+						objectDefinition.getClassName(),
+						contextCompany.getCompanyId(),
+						objectRelationship.getType());
+
+			List<ObjectEntry> objectEntries =
+				objectRelatedModelsProvider.getRelatedModels(
+					0, objectRelationship.getObjectRelationshipId(),
+					ObjectEntryTable.INSTANCE.groupId.in(groupIds), assetId,
+					search, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+
+			for (ObjectEntry objectEntry : objectEntries) {
+				String name = _getName(
+					objectEntry.isDraft(),
+					objectEntry.getTitleValue(languageId));
+
+				if (!Validator.isBlank(search) &&
+					!StringUtil.containsIgnoreCase(name, search)) {
+
+					continue;
+				}
+
+				AssetUsage assetUsage = new AssetUsage();
+
+				assetUsage.setName(() -> name);
+
+				ObjectDefinition relatedObjectDefinition =
+					_objectDefinitionLocalService.getObjectDefinition(
+						objectEntry.getObjectDefinitionId());
+
+				assetUsage.setType(
+					() -> relatedObjectDefinition.getLabel(languageId));
+
+				assetUsages.add(assetUsage);
+			}
+		}
+	}
+
+	private List<AssetUsage> _getAssetUsages(Long assetId, String search)
+		throws Exception {
+
+		List<AssetUsage> assetUsages = new ArrayList<>();
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			assetId);
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.getObjectDefinition(
+				objectEntry.getObjectDefinitionId());
+
+		_appendLayoutUsages(
+			assetId, assetUsages, objectDefinition.getClassName(), search);
+		_appendObjectEntryUsages(
+			assetId, assetUsages, objectDefinition, search);
+
+		return assetUsages;
+	}
+
+	private Long[] _getGroupIds(List<DepotEntry> depotEntries) {
+		Long[] groupIds = new Long[0];
+
+		for (DepotEntry depotEntry : depotEntries) {
+			groupIds = ArrayUtil.append(groupIds, depotEntry.getGroupId());
+
+			List<DepotEntryGroupRel> depotEntryGroupRels =
+				_depotEntryGroupRelLocalService.getDepotEntryGroupRels(
+					depotEntry);
+
+			for (DepotEntryGroupRel depotEntryGroupRel : depotEntryGroupRels) {
+				groupIds = ArrayUtil.append(
+					groupIds, depotEntryGroupRel.getGroupId());
+			}
+		}
+
+		return groupIds;
+	}
+
+	private List<Object[]> _getLayoutClassedModelUsageObjectsList(
+		String className, Long assetId, String search) {
+
+		LayoutClassedModelUsageTable layoutClassedModelUsageTable =
+			LayoutClassedModelUsageTable.INSTANCE;
+
+		LayoutTable layoutTable = LayoutTable.INSTANCE;
+
+		return _layoutClassedModelUsageLocalService.dslQuery(
+			DSLQueryFactoryUtil.select(
+				layoutClassedModelUsageTable.plid,
+				layoutClassedModelUsageTable.type, layoutTable.name
+			).from(
+				layoutClassedModelUsageTable
+			).innerJoinON(
+				layoutTable,
+				layoutClassedModelUsageTable.plid.eq(layoutTable.plid)
+			).where(
+				layoutClassedModelUsageTable.classNameId.eq(
+					_portal.getClassNameId(className)
+				).and(
+					layoutClassedModelUsageTable.classPK.eq(assetId)
+				).and(
+					layoutClassedModelUsageTable.containerKey.isNotNull()
+				).and(
+					layoutClassedModelUsageTable.groupId.in(
+						ArrayUtil.toArray(contextUser.getGroupIds()))
+				).and(
+					layoutTable.name.like(
+						StringBundler.concat(
+							"%<Name%>%", GetterUtil.getString(search, ""),
+							"%</Name>%"))
+				)
+			));
+	}
+
+	private String _getLayoutUsageTypeLabel(long type) {
+		if (type ==
+				LayoutClassedModelUsageConstants.TYPE_DISPLAY_PAGE_TEMPLATE) {
+
+			return LanguageUtil.get(
+				contextUser.getLocale(), "display-page-template");
+		}
+		else if (type == LayoutClassedModelUsageConstants.TYPE_PAGE_TEMPLATE) {
+			return LanguageUtil.get(contextUser.getLocale(), "page-template");
+		}
+
+		return LanguageUtil.get(contextUser.getLocale(), "page");
+	}
+
+	private String _getName(boolean draft, String name) {
+		if (draft) {
+			name += StringBundler.concat(
+				StringPool.SPACE, StringPool.OPEN_PARENTHESIS,
+				LanguageUtil.get(
+					LocaleUtil.fromLanguageId(
+						contextUser.getLanguageId(), true, true),
+					"draft"),
+				StringPool.CLOSE_PARENTHESIS);
+		}
+
+		return name;
+	}
+
+	private List<DepotEntry> _getViewableDepotEntries() throws Exception {
+		List<DepotEntry> depotEntries = new ArrayList<>();
+
+		SearchUtil.search(
+			Collections.emptyMap(),
+			booleanQuery -> {
+			},
+			null, DepotEntry.class.getName(), null,
+			Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+			queryConfig -> {
+			},
+			searchContext -> searchContext.setCompanyId(
+				contextCompany.getCompanyId()),
+			null,
+			document -> {
+				try {
+					depotEntries.add(
+						_depotEntryService.getDepotEntry(
+							GetterUtil.getLong(
+								document.get(Field.ENTRY_CLASS_PK))));
+				}
+				catch (PortalException portalException) {
+					if (_log.isInfoEnabled()) {
+						_log.info(
+							"User does not have access to view space " +
+								document.get(Field.ENTRY_CLASS_PK),
+							portalException);
+					}
+				}
+
+				return null;
+			});
+
+		return depotEntries;
+	}
+
+	private boolean _hasViewPermission(
+		Layout layout, PermissionChecker permissionChecker) {
+
+		try {
+			long plid = layout.getPlid();
+
+			if (layout.isDraftLayout()) {
+				plid = layout.getClassPK();
+			}
+
+			LayoutPermissionUtil.check(
+				permissionChecker, plid, ActionKeys.VIEW);
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			return false;
+		}
+
+		return true;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AssetUsageResourceImpl.class);
+
+	private static final EntityModel _entityModel =
+		() -> EntityModel.toEntityFieldsMap(
+			new StringEntityField("name", locale -> "name"));
+
+	@Reference
+	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
+
+	@Reference
+	private DepotEntryService _depotEntryService;
+
+	@Reference
+	private LayoutClassedModelUsageLocalService
+		_layoutClassedModelUsageLocalService;
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
+
+	@Reference
+	private Localization _localization;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private ObjectRelatedModelsProviderRegistry
+		_objectRelatedModelsProviderRegistry;
+
+	@Reference
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	@Reference
+	private Portal _portal;
+
 }

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetUsageResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetUsageResourceImpl.java
@@ -73,6 +73,7 @@ import org.osgi.service.component.annotations.ServiceScope;
 )
 public class AssetUsageResourceImpl extends BaseAssetUsageResourceImpl {
 
+	@Override
 	public Page<AssetUsage> getAssetUsagesAssetPage(
 			Long assetId, String search, Pagination pagination, Sort[] sorts)
 		throws Exception {

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BaseAssetUsageResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BaseAssetUsageResourceImpl.java
@@ -1,0 +1,554 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.internal.resource.v1_0;
+
+import com.liferay.headless.cms.dto.v1_0.AssetUsage;
+import com.liferay.headless.cms.resource.v1_0.AssetUsageResource;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+import com.liferay.portal.vulcan.util.ActionUtil;
+import com.liferay.portal.vulcan.util.UriInfoUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+@jakarta.ws.rs.Path("/v1.0")
+public abstract class BaseAssetUsageResourceImpl
+	implements AssetUsageResource, EntityModelResource {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-cms/v1.0/asset-usages/{assetId}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "assetId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "search"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "sort"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "AssetUsage")}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path("/asset-usages/{assetId}")
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<AssetUsage> getAssetUsagesAssetPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("assetId")
+			Long assetId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("search")
+			String search,
+			@jakarta.ws.rs.core.Context Pagination pagination,
+			@jakarta.ws.rs.core.Context com.liferay.portal.kernel.search.Sort[]
+				sorts)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap)
+		throws Exception {
+
+		return null;
+	}
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany) {
+
+		this.contextCompany = contextCompany;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = UriInfoUtil.getVulcanUriInfo(
+			getApplicationPath(), contextUriInfo);
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser) {
+
+		this.contextUser = contextUser;
+	}
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert) {
+
+		this.expressionConvert = expressionConvert;
+	}
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider) {
+
+		this.filterParserProvider = filterParserProvider;
+	}
+
+	public void setGroupLocalService(GroupLocalService groupLocalService) {
+		this.groupLocalService = groupLocalService;
+	}
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService) {
+
+		this.resourceActionLocalService = resourceActionLocalService;
+	}
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		this.resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	public void setRoleLocalService(RoleLocalService roleLocalService) {
+		this.roleLocalService = roleLocalService;
+	}
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider) {
+		this.sortParserProvider = sortParserProvider;
+	}
+
+	protected String getApplicationPath() {
+		return "headless-cms";
+	}
+
+	protected Map<String, String> addAction(
+		String actionName,
+		com.liferay.portal.kernel.model.GroupedModel groupedModel,
+		String methodName) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), groupedModel, methodName,
+			contextScopeChecker, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName, Long ownerId,
+		String permissionName, Long siteId) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			ownerId, permissionName, siteId, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName,
+		ModelResourcePermission modelResourcePermission) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			modelResourcePermission, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, String methodName, String permissionName,
+		Long siteId) {
+
+		return addAction(
+			actionName, siteId, methodName, null, permissionName, siteId);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transform(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transform(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transformToArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		Collection<T> collection,
+		UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		T[] array, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		Collection<T> collection, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		T[] array, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		Collection<T> collection, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		T[] array, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] transformToIntArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] transformToIntArray(
+		T[] array, UnsafeFunction<T, Integer, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transformToList(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] transformToLongArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] transformToLongArray(
+		T[] array, UnsafeFunction<T, Long, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		Collection<T> collection, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		T[] array, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransform(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransform(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			T[] array, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				T[] array, UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			T[] array, UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] unsafeTransformToIntArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] unsafeTransformToIntArray(
+			T[] array, UnsafeFunction<T, Integer, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransformToList(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] unsafeTransformToLongArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] unsafeTransformToLongArray(
+			T[] array, UnsafeFunction<T, Long, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			T[] array, UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(array, unsafeFunction);
+	}
+
+	protected AcceptLanguage contextAcceptLanguage;
+	protected com.liferay.portal.kernel.model.Company contextCompany;
+	protected HttpServletRequest contextHttpServletRequest;
+	protected HttpServletResponse contextHttpServletResponse;
+	protected Object contextScopeChecker;
+	protected UriInfo contextUriInfo;
+	protected com.liferay.portal.kernel.model.User contextUser;
+	protected ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+		expressionConvert;
+	protected FilterParserProvider filterParserProvider;
+	protected GroupLocalService groupLocalService;
+	protected ResourceActionLocalService resourceActionLocalService;
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+	protected RoleLocalService roleLocalService;
+	protected SortParserProvider sortParserProvider;
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseAssetUsageResourceImpl.class);
+
+}

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -85,6 +85,8 @@ public class OpenAPIResourceImpl {
 
 	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
 		{
+			add(AssetUsageResourceImpl.class);
+
 			add(BulkActionResourceImpl.class);
 
 			add(OpenAPIResourceImpl.class);

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/factory/AssetUsageResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/factory/AssetUsageResourceFactoryImpl.java
@@ -1,0 +1,331 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.internal.resource.v1_0.factory;
+
+import com.liferay.headless.cms.internal.security.permission.LiberalPermissionChecker;
+import com.liferay.headless.cms.resource.v1_0.AssetUsageResource;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import org.osgi.service.component.ComponentServiceObjects;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceScope;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Component(
+	property = "resource.locator.key=/headless-cms/v1.0/AssetUsage",
+	service = AssetUsageResource.Factory.class
+)
+@Generated("")
+public class AssetUsageResourceFactoryImpl
+	implements AssetUsageResource.Factory {
+
+	@Override
+	public AssetUsageResource.Builder create() {
+		return new AssetUsageResource.Builder() {
+
+			@Override
+			public AssetUsageResource build() {
+				if (_user == null) {
+					throw new IllegalArgumentException("User is not set");
+				}
+
+				Function<InvocationHandler, AssetUsageResource>
+					assetUsageResourceProxyProviderFunction =
+						ResourceProxyProviderFunctionHolder.
+							_assetUsageResourceProxyProviderFunction;
+
+				return assetUsageResourceProxyProviderFunction.apply(
+					(proxy, method, arguments) -> _invoke(
+						method, arguments, _checkPermissions,
+						_httpServletRequest, _httpServletResponse,
+						_preferredLocale, _uriInfo, _user));
+			}
+
+			@Override
+			public AssetUsageResource.Builder checkPermissions(
+				boolean checkPermissions) {
+
+				_checkPermissions = checkPermissions;
+
+				return this;
+			}
+
+			@Override
+			public AssetUsageResource.Builder httpServletRequest(
+				HttpServletRequest httpServletRequest) {
+
+				_httpServletRequest = httpServletRequest;
+
+				return this;
+			}
+
+			@Override
+			public AssetUsageResource.Builder httpServletResponse(
+				HttpServletResponse httpServletResponse) {
+
+				_httpServletResponse = httpServletResponse;
+
+				return this;
+			}
+
+			@Override
+			public AssetUsageResource.Builder preferredLocale(
+				Locale preferredLocale) {
+
+				_preferredLocale = preferredLocale;
+
+				return this;
+			}
+
+			@Override
+			public AssetUsageResource.Builder uriInfo(UriInfo uriInfo) {
+				_uriInfo = uriInfo;
+
+				return this;
+			}
+
+			@Override
+			public AssetUsageResource.Builder user(User user) {
+				_user = user;
+
+				return this;
+			}
+
+			private boolean _checkPermissions = true;
+			private HttpServletRequest _httpServletRequest;
+			private HttpServletResponse _httpServletResponse;
+			private Locale _preferredLocale;
+			private UriInfo _uriInfo;
+			private User _user;
+
+		};
+	}
+
+	private static Function<InvocationHandler, AssetUsageResource>
+		_getProxyProviderFunction() {
+
+		Class<?> proxyClass = ProxyUtil.getProxyClass(
+			AssetUsageResource.class.getClassLoader(),
+			AssetUsageResource.class);
+
+		try {
+			Constructor<AssetUsageResource> constructor =
+				(Constructor<AssetUsageResource>)proxyClass.getConstructor(
+					InvocationHandler.class);
+
+			return invocationHandler -> {
+				try {
+					return constructor.newInstance(invocationHandler);
+				}
+				catch (ReflectiveOperationException
+							reflectiveOperationException) {
+
+					throw new InternalError(reflectiveOperationException);
+				}
+			};
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			throw new InternalError(noSuchMethodException);
+		}
+	}
+
+	private Object _invoke(
+			Method method, Object[] arguments, boolean checkPermissions,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Locale preferredLocale,
+			UriInfo uriInfo, User user)
+		throws Throwable {
+
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (checkPermissions) {
+			PermissionThreadLocal.setPermissionChecker(
+				_defaultPermissionCheckerFactory.create(user));
+		}
+		else {
+			PermissionThreadLocal.setPermissionChecker(
+				new LiberalPermissionChecker(user));
+		}
+
+		AssetUsageResource assetUsageResource =
+			_componentServiceObjects.getService();
+
+		assetUsageResource.setContextAcceptLanguage(
+			new AcceptLanguageImpl(httpServletRequest, preferredLocale, user));
+
+		Company company = _companyLocalService.getCompany(user.getCompanyId());
+
+		assetUsageResource.setContextCompany(company);
+
+		assetUsageResource.setContextHttpServletRequest(httpServletRequest);
+		assetUsageResource.setContextHttpServletResponse(httpServletResponse);
+		assetUsageResource.setContextUriInfo(uriInfo);
+		assetUsageResource.setContextUser(user);
+		assetUsageResource.setExpressionConvert(_expressionConvert);
+		assetUsageResource.setFilterParserProvider(_filterParserProvider);
+		assetUsageResource.setGroupLocalService(_groupLocalService);
+		assetUsageResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		assetUsageResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		assetUsageResource.setRoleLocalService(_roleLocalService);
+		assetUsageResource.setSortParserProvider(_sortParserProvider);
+
+		try {
+			return method.invoke(assetUsageResource, arguments);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			throw invocationTargetException.getTargetException();
+		}
+		finally {
+			_componentServiceObjects.ungetService(assetUsageResource);
+
+			PrincipalThreadLocal.setName(name);
+
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+		}
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<AssetUsageResource>
+		_componentServiceObjects;
+
+	@Reference
+	private PermissionCheckerFactory _defaultPermissionCheckerFactory;
+
+	@Reference(
+		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
+	)
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private SortParserProvider _sortParserProvider;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	private static class ResourceProxyProviderFunctionHolder {
+
+		private static final Function<InvocationHandler, AssetUsageResource>
+			_assetUsageResourceProxyProviderFunction =
+				_getProxyProviderFunction();
+
+	}
+
+	private class AcceptLanguageImpl implements AcceptLanguage {
+
+		public AcceptLanguageImpl(
+			HttpServletRequest httpServletRequest, Locale preferredLocale,
+			User user) {
+
+			_httpServletRequest = httpServletRequest;
+			_preferredLocale = preferredLocale;
+			_user = user;
+		}
+
+		@Override
+		public List<Locale> getLocales() {
+			return Arrays.asList(getPreferredLocale());
+		}
+
+		@Override
+		public String getPreferredLanguageId() {
+			return LocaleUtil.toLanguageId(getPreferredLocale());
+		}
+
+		@Override
+		public Locale getPreferredLocale() {
+			if (_preferredLocale != null) {
+				return _preferredLocale;
+			}
+
+			if (_httpServletRequest != null) {
+				Locale locale = (Locale)_httpServletRequest.getAttribute(
+					WebKeys.LOCALE);
+
+				if (locale != null) {
+					return locale;
+				}
+			}
+
+			return _user.getLocale();
+		}
+
+		@Override
+		public boolean isAcceptAllLanguages() {
+			return false;
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+		private final Locale _preferredLocale;
+		private final User _user;
+
+	}
+
+}

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/asset-usage.properties
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/asset-usage.properties
@@ -1,0 +1,8 @@
+#
+# This is a generated file.
+#
+
+api.version=v1.0
+entity.class.name=com.liferay.headless.cms.dto.v1_0.AssetUsage
+osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.CMS)
+osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-cms/headless-cms-test/build.gradle
+++ b/modules/apps/headless/headless-cms/headless-cms-test/build.gradle
@@ -6,10 +6,12 @@ dependencies {
 	testIntegrationImplementation group: "jakarta.annotation", name: "jakarta.annotation-api", version: "2.1.1"
 	testIntegrationImplementation project(":apps:batch-engine:batch-engine-api")
 	testIntegrationImplementation project(":apps:depot:depot-api")
+	testIntegrationImplementation project(":apps:document-library:document-library-test-util")
 	testIntegrationImplementation project(":apps:headless:headless-batch-engine:headless-batch-engine-client")
 	testIntegrationImplementation project(":apps:headless:headless-cms:headless-cms-api")
 	testIntegrationImplementation project(":apps:headless:headless-cms:headless-cms-client")
 	testIntegrationImplementation project(":apps:layout:layout-api")
+	testIntegrationImplementation project(":apps:layout:layout-page-template-api")
 	testIntegrationImplementation project(":apps:oauth2-provider:oauth2-provider-scope-api")
 	testIntegrationImplementation project(":apps:object:object-api")
 	testIntegrationImplementation project(":apps:object:object-rest-api")

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/AssetUsageResourceTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/AssetUsageResourceTest.java
@@ -6,14 +6,432 @@
 package com.liferay.headless.cms.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.batch.engine.unit.BatchEngineUnitProcessor;
+import com.liferay.batch.engine.unit.BatchEngineUnitReader;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFolder;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.test.util.DLTestUtil;
+import com.liferay.headless.cms.client.dto.v1_0.AssetUsage;
+import com.liferay.headless.cms.client.pagination.Page;
+import com.liferay.headless.cms.client.pagination.Pagination;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
+import com.liferay.layout.service.LayoutClassedModelUsageLocalService;
+import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.ObjectFolder;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.object.service.ObjectFolderLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.constants.TestDataConstants;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
-import org.junit.Ignore;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.Serializable;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+
 /**
- * @author Crescenzo Rega
+ * @author Thiago Buarque
  */
-@Ignore
+@FeatureFlags(
+	featureFlags = {
+		@FeatureFlag("LPD-17564"), @FeatureFlag("LPD-21926"),
+		@FeatureFlag("LPD-31149"), @FeatureFlag("LPD-34594"),
+		@FeatureFlag("LPS-179669")
+	}
+)
 @RunWith(Arquillian.class)
 public class AssetUsageResourceTest extends BaseAssetUsageResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		if (!_isCMSSiteInitialized()) {
+			Bundle testBundle = FrameworkUtil.getBundle(
+				BulkActionResourceTest.class);
+
+			BundleContext bundleContext = testBundle.getBundleContext();
+
+			for (Bundle bundle : bundleContext.getBundles()) {
+				if (Objects.equals(
+						bundle.getSymbolicName(),
+						"com.liferay.site.initializer.cms")) {
+
+					_deleteFile(bundle, "01.object.folder");
+					_deleteFile(bundle, "02.object.definition");
+
+					CompletableFuture<Void> completableFuture =
+						_batchEngineUnitProcessor.processBatchEngineUnits(
+							_batchEngineUnitReader.getBatchEngineUnits(bundle));
+
+					completableFuture.join();
+
+					break;
+				}
+			}
+		}
+
+		_documentObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_BASIC_DOCUMENT", testCompany.getCompanyId());
+
+		_serviceContext = new ServiceContext() {
+			{
+				setCompanyId(testGroup.getCompanyId());
+				setUserId(TestPropsValues.getUserId());
+			}
+		};
+
+		_serviceContext.setAttribute(
+			"friendlyUrlMap", new HashMap<String, String>());
+
+		_depotEntry = _depotEntryLocalService.addDepotEntry(
+			Collections.singletonMap(
+				LocaleUtil.US, RandomTestUtil.randomString()),
+			null, DepotConstants.TYPE_ASSET_LIBRARY, _serviceContext);
+
+		_objectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					"L_FILES", _depotEntry.getGroupId(),
+					testCompany.getCompanyId());
+
+		_webContentObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_BASIC_WEB_CONTENT", testCompany.getCompanyId());
+	}
+
+	@Override
+	@Test
+	public void testGetAssetUsagesAssetPage() throws Exception {
+		_addObjectRelationship(
+			_documentObjectDefinition, _webContentObjectDefinition);
+
+		long assetId = testGetAssetUsagesAssetPage_getAssetId();
+
+		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
+			_depotEntry.getGroupId(), TestPropsValues.getUserId(),
+			_webContentObjectDefinition.getObjectDefinitionId(),
+			_objectEntryFolder.getObjectEntryFolderId(), null,
+			HashMapBuilder.<String, Serializable>put(
+				"title", RandomTestUtil.randomString()
+			).put(
+				_relationshipObjectField.getName(), assetId
+			).build(),
+			_serviceContext);
+
+		AssetUsage assetUsage1 = new AssetUsage();
+
+		assetUsage1.setName(() -> objectEntry.getTitleValue(_LANGUAGE_ID));
+		assetUsage1.setType(
+			() -> _webContentObjectDefinition.getLabel(_LANGUAGE_ID));
+
+		AssetUsage assetUsage2 = _addAssetLayoutUsage(
+			randomAssetUsage(), assetId,
+			LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT);
+
+		Page<AssetUsage> page = assetUsageResource.getAssetUsagesAssetPage(
+			assetId, null, Pagination.of(1, 10), "name:asc");
+
+		List<AssetUsage> items = ListUtil.fromCollection(page.getItems());
+
+		Assert.assertEquals(items.toString(), 2, items.size());
+
+		String name = assetUsage1.getName();
+
+		if (name.compareTo(assetUsage2.getName()) < 0) {
+			equals(assetUsage1, items.get(0));
+			equals(assetUsage2, items.get(1));
+		}
+		else {
+			equals(assetUsage1, items.get(1));
+			equals(assetUsage2, items.get(0));
+		}
+
+		page = assetUsageResource.getAssetUsagesAssetPage(
+			assetId, null, Pagination.of(1, 10), "name:desc");
+
+		items = ListUtil.fromCollection(page.getItems());
+
+		Assert.assertEquals(items.toString(), 2, items.size());
+
+		if (name.compareTo(assetUsage2.getName()) < 0) {
+			Assert.assertTrue(equals(assetUsage1, items.get(1)));
+			Assert.assertTrue(equals(assetUsage2, items.get(0)));
+		}
+		else {
+			Assert.assertTrue(equals(assetUsage1, items.get(0)));
+			Assert.assertTrue(equals(assetUsage2, items.get(1)));
+		}
+	}
+
+	@Override
+	@Test
+	public void testGetAssetUsagesAssetPageWithPagination() throws Exception {
+		Long assetId = testGetAssetUsagesAssetPage_getAssetId();
+
+		AssetUsage assetUsage1 = testGetAssetUsagesAssetPage_addAssetUsage(
+			assetId, randomAssetUsage());
+
+		AssetUsage assetUsage2 = testGetAssetUsagesAssetPage_addAssetUsage(
+			assetId, randomAssetUsage());
+
+		AssetUsage assetUsage3 = testGetAssetUsagesAssetPage_addAssetUsage(
+			assetId, randomAssetUsage());
+
+		Page<AssetUsage> page1 = assetUsageResource.getAssetUsagesAssetPage(
+			assetId, null, Pagination.of(1, 2), null);
+
+		List<AssetUsage> assetUsages1 = (List<AssetUsage>)page1.getItems();
+
+		Assert.assertEquals(assetUsages1.toString(), 2, assetUsages1.size());
+
+		Page<AssetUsage> page2 = assetUsageResource.getAssetUsagesAssetPage(
+			assetId, null, Pagination.of(2, 2), null);
+
+		Assert.assertEquals(3, page2.getTotalCount());
+
+		List<AssetUsage> assetUsages2 = (List<AssetUsage>)page2.getItems();
+
+		Assert.assertEquals(assetUsages2.toString(), 1, assetUsages2.size());
+
+		Page<AssetUsage> page3 = assetUsageResource.getAssetUsagesAssetPage(
+			assetId, null, Pagination.of(1, 3), null);
+
+		assertContains(assetUsage1, (List<AssetUsage>)page3.getItems());
+		assertContains(assetUsage2, (List<AssetUsage>)page3.getItems());
+		assertContains(assetUsage3, (List<AssetUsage>)page3.getItems());
+	}
+
+	@Override
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[] {"name", "type"};
+	}
+
+	@Override
+	protected AssetUsage testGetAssetUsagesAssetPage_addAssetUsage(
+			Long assetId, AssetUsage assetUsage)
+		throws Exception {
+
+		return _addAssetLayoutUsage(
+			assetUsage, assetId,
+			LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE);
+	}
+
+	@Override
+	protected Long testGetAssetUsagesAssetPage_getAssetId() throws Exception {
+		DLFolder dlFolder = DLTestUtil.addDLFolder(_depotEntry.getGroupId());
+
+		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
+
+		DLFileEntry dlFileEntry = _dlFileEntryLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), dlFolder.getGroupId(),
+			dlFolder.getRepositoryId(), dlFolder.getFolderId(),
+			RandomTestUtil.randomString() + ".pdf",
+			ContentTypes.APPLICATION_PDF, RandomTestUtil.randomString(),
+			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
+			null, new ByteArrayInputStream(bytes), bytes.length, null, null,
+			null,
+			ServiceContextTestUtil.getServiceContext(dlFolder.getGroupId()));
+
+		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
+			_depotEntry.getGroupId(), _depotEntry.getUserId(),
+			_documentObjectDefinition.getObjectDefinitionId(),
+			_objectEntryFolder.getObjectEntryFolderId(), _LANGUAGE_ID,
+			HashMapBuilder.<String, Serializable>put(
+				"file", String.valueOf(dlFileEntry.getFileEntryId())
+			).build(),
+			_serviceContext);
+
+		return objectEntry.getObjectEntryId();
+	}
+
+	private AssetUsage _addAssetLayoutUsage(
+			AssetUsage assetUsage, Long assetId, int type)
+		throws Exception {
+
+		String name = RandomTestUtil.randomString();
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
+				null, TestPropsValues.getUserId(), testGroup.getGroupId(), 0,
+				null, 0, 0, name, type, 0, true, 0, 0, 0,
+				WorkflowConstants.STATUS_APPROVED, _serviceContext);
+
+		_layoutClassedModelUsageLocalService.addLayoutClassedModelUsage(
+			testGroup.getGroupId(), StringPool.BLANK,
+			_portal.getClassNameId(_documentObjectDefinition.getClassName()),
+			assetId, RandomTestUtil.randomString(), RandomTestUtil.randomInt(),
+			layoutPageTemplateEntry.getPlid(), _serviceContext);
+
+		assetUsage.setName(name);
+
+		if (type == LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE) {
+			assetUsage.setType("Display Page Template");
+		}
+		else if (type == LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT) {
+			assetUsage.setType("Page Template");
+		}
+
+		return assetUsage;
+	}
+
+	private void _addObjectRelationship(
+			ObjectDefinition objectDefinition1,
+			ObjectDefinition objectDefinition2)
+		throws Exception {
+
+		ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				null, TestPropsValues.getUserId(),
+				objectDefinition1.getObjectDefinitionId(),
+				objectDefinition2.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				StringUtil.randomId(), false,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+
+		_relationshipObjectField = _objectFieldLocalService.getObjectField(
+			objectRelationship.getObjectFieldId2());
+	}
+
+	private void _deleteFile(Bundle bundle, String fileName) {
+		File file = bundle.getDataFile(
+			".com.liferay.site.initializer.cms.internal.batch." + fileName +
+				".batch.engine.data.json.0.processed");
+
+		if ((file != null) && file.exists()) {
+			file.delete();
+		}
+	}
+
+	private boolean _isCMSSiteInitialized() throws Exception {
+		ObjectFolder objectFolder =
+			_objectFolderLocalService.fetchObjectFolderByExternalReferenceCode(
+				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES,
+				TestPropsValues.getCompanyId());
+
+		if (objectFolder != null) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private static final String _LANGUAGE_ID = "en_US";
+
+	@Inject
+	private BatchEngineUnitProcessor _batchEngineUnitProcessor;
+
+	@Inject
+	private BatchEngineUnitReader _batchEngineUnitReader;
+
+	@DeleteAfterTestRun
+	private DepotEntry _depotEntry;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	private ObjectDefinition _documentObjectDefinition;
+
+	@Inject
+	private LayoutClassedModelUsageLocalService
+		_layoutClassedModelUsageLocalService;
+
+	@Inject
+	private LayoutPageTemplateEntryLocalService
+		_layoutPageTemplateEntryLocalService;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	private ObjectEntryFolder _objectEntryFolder;
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private ObjectFieldLocalService _objectFieldLocalService;
+
+	@Inject
+	private ObjectFolderLocalService _objectFolderLocalService;
+
+	@Inject
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	@Inject
+	private Portal _portal;
+
+	private ObjectField _relationshipObjectField;
+	private ServiceContext _serviceContext;
+	private ObjectDefinition _webContentObjectDefinition;
+
 }

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/AssetUsageResourceTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/AssetUsageResourceTest.java
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Crescenzo Rega
+ */
+@Ignore
+@RunWith(Arquillian.class)
+public class AssetUsageResourceTest extends BaseAssetUsageResourceTestCase {
+}

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BaseAssetUsageResourceTestCase.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BaseAssetUsageResourceTestCase.java
@@ -1,0 +1,1170 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cms.resource.v1_0.test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
+import com.liferay.headless.cms.client.dto.v1_0.AssetUsage;
+import com.liferay.headless.cms.client.http.HttpInvoker;
+import com.liferay.headless.cms.client.pagination.Page;
+import com.liferay.headless.cms.client.pagination.Pagination;
+import com.liferay.headless.cms.client.resource.v1_0.AssetUsageResource;
+import com.liferay.headless.cms.client.serdes.v1_0.AssetUsageSerDes;
+import com.liferay.petra.function.UnsafeTriConsumer;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+
+import jakarta.annotation.Generated;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+
+import java.lang.reflect.Method;
+
+import java.text.Format;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Crescenzo Rega
+ * @generated
+ */
+@Generated("")
+public abstract class BaseAssetUsageResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_format = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		irrelevantGroup = GroupTestUtil.addGroup();
+		testGroup = GroupTestUtil.addGroup();
+
+		testCompany = CompanyLocalServiceUtil.getCompany(
+			testGroup.getCompanyId());
+
+		_assetUsageResource.setContextCompany(testCompany);
+
+		_testCompanyAdminUser = UserTestUtil.getAdminUser(
+			testCompany.getCompanyId());
+
+		assetUsageResource = AssetUsageResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(), 8080, "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		GroupTestUtil.deleteGroup(irrelevantGroup);
+		GroupTestUtil.deleteGroup(testGroup);
+	}
+
+	@Test
+	public void testClientSerDesToDTO() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		AssetUsage assetUsage1 = randomAssetUsage();
+
+		String json = objectMapper.writeValueAsString(assetUsage1);
+
+		AssetUsage assetUsage2 = AssetUsageSerDes.toDTO(json);
+
+		Assert.assertTrue(equals(assetUsage1, assetUsage2));
+	}
+
+	@Test
+	public void testClientSerDesToJSON() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		AssetUsage assetUsage = randomAssetUsage();
+
+		String json1 = objectMapper.writeValueAsString(assetUsage);
+		String json2 = AssetUsageSerDes.toJSON(assetUsage);
+
+		Assert.assertEquals(
+			objectMapper.readTree(json1), objectMapper.readTree(json2));
+	}
+
+	protected ObjectMapper getClientSerDesObjectMapper() {
+		return new ObjectMapper() {
+			{
+				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				configure(
+					SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+				enable(SerializationFeature.INDENT_OUTPUT);
+				setDateFormat(new ISO8601DateFormat());
+				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+				setSerializationInclusion(JsonInclude.Include.NON_NULL);
+				setVisibility(
+					PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+				setVisibility(
+					PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+			}
+		};
+	}
+
+	@Test
+	public void testEscapeRegexInStringFields() throws Exception {
+		String regex = "^[0-9]+(\\.[0-9]{1,2})\"?";
+
+		AssetUsage assetUsage = randomAssetUsage();
+
+		assetUsage.setName(regex);
+		assetUsage.setType(regex);
+
+		String json = AssetUsageSerDes.toJSON(assetUsage);
+
+		Assert.assertFalse(json.contains(regex));
+
+		assetUsage = AssetUsageSerDes.toDTO(json);
+
+		Assert.assertEquals(regex, assetUsage.getName());
+		Assert.assertEquals(regex, assetUsage.getType());
+	}
+
+	@Test
+	public void testGetAssetUsagesAssetPage() throws Exception {
+		Long assetId = testGetAssetUsagesAssetPage_getAssetId();
+		Long irrelevantAssetId =
+			testGetAssetUsagesAssetPage_getIrrelevantAssetId();
+
+		Page<AssetUsage> page = assetUsageResource.getAssetUsagesAssetPage(
+			assetId, null, Pagination.of(1, 10), null);
+
+		long totalCount = page.getTotalCount();
+
+		if (irrelevantAssetId != null) {
+			AssetUsage irrelevantAssetUsage =
+				testGetAssetUsagesAssetPage_addAssetUsage(
+					irrelevantAssetId, randomIrrelevantAssetUsage());
+
+			page = assetUsageResource.getAssetUsagesAssetPage(
+				irrelevantAssetId, null, Pagination.of(1, (int)totalCount + 1),
+				null);
+
+			Assert.assertEquals(totalCount + 1, page.getTotalCount());
+
+			assertContains(
+				irrelevantAssetUsage, (List<AssetUsage>)page.getItems());
+			assertValid(
+				page,
+				testGetAssetUsagesAssetPage_getExpectedActions(
+					irrelevantAssetId));
+		}
+
+		AssetUsage assetUsage1 = testGetAssetUsagesAssetPage_addAssetUsage(
+			assetId, randomAssetUsage());
+
+		AssetUsage assetUsage2 = testGetAssetUsagesAssetPage_addAssetUsage(
+			assetId, randomAssetUsage());
+
+		page = assetUsageResource.getAssetUsagesAssetPage(
+			assetId, null, Pagination.of(1, 10), null);
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(assetUsage1, (List<AssetUsage>)page.getItems());
+		assertContains(assetUsage2, (List<AssetUsage>)page.getItems());
+		assertValid(
+			page, testGetAssetUsagesAssetPage_getExpectedActions(assetId));
+	}
+
+	protected Map<String, Map<String, String>>
+			testGetAssetUsagesAssetPage_getExpectedActions(Long assetId)
+		throws Exception {
+
+		Map<String, Map<String, String>> expectedActions = new HashMap<>();
+
+		return expectedActions;
+	}
+
+	@Test
+	public void testGetAssetUsagesAssetPageWithPagination() throws Exception {
+		Long assetId = testGetAssetUsagesAssetPage_getAssetId();
+
+		Page<AssetUsage> assetUsagesPage =
+			assetUsageResource.getAssetUsagesAssetPage(
+				assetId, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(assetUsagesPage.getTotalCount());
+
+		AssetUsage assetUsage1 = testGetAssetUsagesAssetPage_addAssetUsage(
+			assetId, randomAssetUsage());
+
+		AssetUsage assetUsage2 = testGetAssetUsagesAssetPage_addAssetUsage(
+			assetId, randomAssetUsage());
+
+		AssetUsage assetUsage3 = testGetAssetUsagesAssetPage_addAssetUsage(
+			assetId, randomAssetUsage());
+
+		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
+
+		int pageSizeLimit = 500;
+
+		if (totalCount >= (pageSizeLimit - 2)) {
+			Page<AssetUsage> page1 = assetUsageResource.getAssetUsagesAssetPage(
+				assetId, null,
+				Pagination.of(
+					(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
+					pageSizeLimit),
+				null);
+
+			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
+
+			assertContains(assetUsage1, (List<AssetUsage>)page1.getItems());
+
+			Page<AssetUsage> page2 = assetUsageResource.getAssetUsagesAssetPage(
+				assetId, null,
+				Pagination.of(
+					(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
+					pageSizeLimit),
+				null);
+
+			assertContains(assetUsage2, (List<AssetUsage>)page2.getItems());
+
+			Page<AssetUsage> page3 = assetUsageResource.getAssetUsagesAssetPage(
+				assetId, null,
+				Pagination.of(
+					(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
+					pageSizeLimit),
+				null);
+
+			assertContains(assetUsage3, (List<AssetUsage>)page3.getItems());
+		}
+		else {
+			Page<AssetUsage> page1 = assetUsageResource.getAssetUsagesAssetPage(
+				assetId, null, Pagination.of(1, totalCount + 2), null);
+
+			List<AssetUsage> assetUsages1 = (List<AssetUsage>)page1.getItems();
+
+			Assert.assertEquals(
+				assetUsages1.toString(), totalCount + 2, assetUsages1.size());
+
+			Page<AssetUsage> page2 = assetUsageResource.getAssetUsagesAssetPage(
+				assetId, null, Pagination.of(2, totalCount + 2), null);
+
+			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+			List<AssetUsage> assetUsages2 = (List<AssetUsage>)page2.getItems();
+
+			Assert.assertEquals(
+				assetUsages2.toString(), 1, assetUsages2.size());
+
+			Page<AssetUsage> page3 = assetUsageResource.getAssetUsagesAssetPage(
+				assetId, null, Pagination.of(1, (int)totalCount + 3), null);
+
+			assertContains(assetUsage1, (List<AssetUsage>)page3.getItems());
+			assertContains(assetUsage2, (List<AssetUsage>)page3.getItems());
+			assertContains(assetUsage3, (List<AssetUsage>)page3.getItems());
+		}
+	}
+
+	@Test
+	public void testGetAssetUsagesAssetPageWithSortDateTime() throws Exception {
+		testGetAssetUsagesAssetPageWithSort(
+			EntityField.Type.DATE_TIME,
+			(entityField, assetUsage1, assetUsage2) -> {
+				BeanTestUtil.setProperty(
+					assetUsage1, entityField.getName(),
+					new Date(System.currentTimeMillis() - (2 * Time.MINUTE)));
+			});
+	}
+
+	@Test
+	public void testGetAssetUsagesAssetPageWithSortDouble() throws Exception {
+		testGetAssetUsagesAssetPageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, assetUsage1, assetUsage2) -> {
+				BeanTestUtil.setProperty(
+					assetUsage1, entityField.getName(), 0.1);
+				BeanTestUtil.setProperty(
+					assetUsage2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
+	public void testGetAssetUsagesAssetPageWithSortInteger() throws Exception {
+		testGetAssetUsagesAssetPageWithSort(
+			EntityField.Type.INTEGER,
+			(entityField, assetUsage1, assetUsage2) -> {
+				BeanTestUtil.setProperty(assetUsage1, entityField.getName(), 0);
+				BeanTestUtil.setProperty(assetUsage2, entityField.getName(), 1);
+			});
+	}
+
+	@Test
+	public void testGetAssetUsagesAssetPageWithSortString() throws Exception {
+		testGetAssetUsagesAssetPageWithSort(
+			EntityField.Type.STRING,
+			(entityField, assetUsage1, assetUsage2) -> {
+				Class<?> clazz = assetUsage1.getClass();
+
+				String entityFieldName = entityField.getName();
+
+				Method method = clazz.getMethod(
+					"get" + StringUtil.upperCaseFirstLetter(entityFieldName));
+
+				Class<?> returnType = method.getReturnType();
+
+				if (returnType.isAssignableFrom(Map.class)) {
+					BeanTestUtil.setProperty(
+						assetUsage1, entityFieldName,
+						Collections.singletonMap("Aaa", "Aaa"));
+					BeanTestUtil.setProperty(
+						assetUsage2, entityFieldName,
+						Collections.singletonMap("Bbb", "Bbb"));
+				}
+				else if (entityFieldName.contains("email")) {
+					BeanTestUtil.setProperty(
+						assetUsage1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+					BeanTestUtil.setProperty(
+						assetUsage2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+				}
+				else {
+					BeanTestUtil.setProperty(
+						assetUsage1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+					BeanTestUtil.setProperty(
+						assetUsage2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+				}
+			});
+	}
+
+	protected void testGetAssetUsagesAssetPageWithSort(
+			EntityField.Type type,
+			UnsafeTriConsumer<EntityField, AssetUsage, AssetUsage, Exception>
+				unsafeTriConsumer)
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(type);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long assetId = testGetAssetUsagesAssetPage_getAssetId();
+
+		AssetUsage assetUsage1 = randomAssetUsage();
+		AssetUsage assetUsage2 = randomAssetUsage();
+
+		for (EntityField entityField : entityFields) {
+			unsafeTriConsumer.accept(entityField, assetUsage1, assetUsage2);
+		}
+
+		assetUsage1 = testGetAssetUsagesAssetPage_addAssetUsage(
+			assetId, assetUsage1);
+
+		assetUsage2 = testGetAssetUsagesAssetPage_addAssetUsage(
+			assetId, assetUsage2);
+
+		Page<AssetUsage> page = assetUsageResource.getAssetUsagesAssetPage(
+			assetId, null, null, null);
+
+		for (EntityField entityField : entityFields) {
+			Page<AssetUsage> ascPage =
+				assetUsageResource.getAssetUsagesAssetPage(
+					assetId, null,
+					Pagination.of(1, (int)page.getTotalCount() + 1),
+					entityField.getName() + ":asc");
+
+			assertContains(assetUsage1, (List<AssetUsage>)ascPage.getItems());
+			assertContains(assetUsage2, (List<AssetUsage>)ascPage.getItems());
+
+			Page<AssetUsage> descPage =
+				assetUsageResource.getAssetUsagesAssetPage(
+					assetId, null,
+					Pagination.of(1, (int)page.getTotalCount() + 1),
+					entityField.getName() + ":desc");
+
+			assertContains(assetUsage2, (List<AssetUsage>)descPage.getItems());
+			assertContains(assetUsage1, (List<AssetUsage>)descPage.getItems());
+		}
+	}
+
+	protected AssetUsage testGetAssetUsagesAssetPage_addAssetUsage(
+			Long assetId, AssetUsage assetUsage)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Long testGetAssetUsagesAssetPage_getAssetId() throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Long testGetAssetUsagesAssetPage_getIrrelevantAssetId()
+		throws Exception {
+
+		return null;
+	}
+
+	protected void assertContains(
+		AssetUsage assetUsage, List<AssetUsage> assetUsages) {
+
+		boolean contains = false;
+
+		for (AssetUsage item : assetUsages) {
+			if (equals(assetUsage, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			assetUsages + " does not contain " + assetUsage, contains);
+	}
+
+	protected void assertHttpResponseStatusCode(
+		int expectedHttpResponseStatusCode,
+		HttpInvoker.HttpResponse actualHttpResponse) {
+
+		Assert.assertEquals(
+			expectedHttpResponseStatusCode, actualHttpResponse.getStatusCode());
+	}
+
+	protected void assertEquals(
+		AssetUsage assetUsage1, AssetUsage assetUsage2) {
+
+		Assert.assertTrue(
+			assetUsage1 + " does not equal " + assetUsage2,
+			equals(assetUsage1, assetUsage2));
+	}
+
+	protected void assertEquals(
+		List<AssetUsage> assetUsages1, List<AssetUsage> assetUsages2) {
+
+		Assert.assertEquals(assetUsages1.size(), assetUsages2.size());
+
+		for (int i = 0; i < assetUsages1.size(); i++) {
+			AssetUsage assetUsage1 = assetUsages1.get(i);
+			AssetUsage assetUsage2 = assetUsages2.get(i);
+
+			assertEquals(assetUsage1, assetUsage2);
+		}
+	}
+
+	protected void assertEqualsIgnoringOrder(
+		List<AssetUsage> assetUsages1, List<AssetUsage> assetUsages2) {
+
+		Assert.assertEquals(assetUsages1.size(), assetUsages2.size());
+
+		for (AssetUsage assetUsage1 : assetUsages1) {
+			boolean contains = false;
+
+			for (AssetUsage assetUsage2 : assetUsages2) {
+				if (equals(assetUsage1, assetUsage2)) {
+					contains = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(
+				assetUsages2 + " does not contain " + assetUsage1, contains);
+		}
+	}
+
+	protected void assertValid(AssetUsage assetUsage) throws Exception {
+		boolean valid = true;
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("name", additionalAssertFieldName)) {
+				if (assetUsage.getName() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("type", additionalAssertFieldName)) {
+				if (assetUsage.getType() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected void assertValid(Page<AssetUsage> page) {
+		assertValid(page, Collections.emptyMap());
+	}
+
+	protected void assertValid(
+		Page<AssetUsage> page,
+		Map<String, Map<String, String>> expectedActions) {
+
+		boolean valid = false;
+
+		java.util.Collection<AssetUsage> assetUsages = page.getItems();
+
+		int size = assetUsages.size();
+
+		if ((page.getLastPage() > 0) && (page.getPage() > 0) &&
+			(page.getPageSize() > 0) && (page.getTotalCount() > 0) &&
+			(size > 0)) {
+
+			valid = true;
+		}
+
+		Assert.assertTrue(valid);
+
+		assertValid(page.getActions(), expectedActions);
+	}
+
+	protected void assertValid(
+		Map<String, Map<String, String>> actions1,
+		Map<String, Map<String, String>> actions2) {
+
+		for (String key : actions2.keySet()) {
+			Map action = actions1.get(key);
+
+			Assert.assertNotNull(key + " does not contain an action", action);
+
+			Map<String, String> expectedAction = actions2.get(key);
+
+			Assert.assertEquals(
+				expectedAction.get("method"), action.get("method"));
+			Assert.assertEquals(expectedAction.get("href"), action.get("href"));
+		}
+	}
+
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[0];
+	}
+
+	protected List<GraphQLField> getGraphQLFields() throws Exception {
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field :
+				getDeclaredFields(
+					com.liferay.headless.cms.dto.v1_0.AssetUsage.class)) {
+
+			if (!ArrayUtil.contains(
+					getAdditionalAssertFieldNames(), field.getName())) {
+
+				continue;
+			}
+
+			graphQLFields.addAll(getGraphQLFields(field));
+		}
+
+		return graphQLFields;
+	}
+
+	protected List<GraphQLField> getGraphQLFields(
+			java.lang.reflect.Field... fields)
+		throws Exception {
+
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field : fields) {
+			com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+				vulcanGraphQLField = field.getAnnotation(
+					com.liferay.portal.vulcan.graphql.annotation.GraphQLField.
+						class);
+
+			if (vulcanGraphQLField != null) {
+				Class<?> clazz = field.getType();
+
+				if (clazz.isArray()) {
+					clazz = clazz.getComponentType();
+				}
+
+				List<GraphQLField> childrenGraphQLFields = getGraphQLFields(
+					getDeclaredFields(clazz));
+
+				graphQLFields.add(
+					new GraphQLField(field.getName(), childrenGraphQLFields));
+			}
+		}
+
+		return graphQLFields;
+	}
+
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[0];
+	}
+
+	protected boolean equals(AssetUsage assetUsage1, AssetUsage assetUsage2) {
+		if (assetUsage1 == assetUsage2) {
+			return true;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("name", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						assetUsage1.getName(), assetUsage2.getName())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("type", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						assetUsage1.getType(), assetUsage2.getType())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		return true;
+	}
+
+	protected boolean equals(
+		Map<String, Object> map1, Map<String, Object> map2) {
+
+		if (Objects.equals(map1.keySet(), map2.keySet())) {
+			for (Map.Entry<String, Object> entry : map1.entrySet()) {
+				if (entry.getValue() instanceof Map) {
+					if (!equals(
+							(Map)entry.getValue(),
+							(Map)map2.get(entry.getKey()))) {
+
+						return false;
+					}
+				}
+				else if (!Objects.deepEquals(
+							entry.getValue(), map2.get(entry.getKey()))) {
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	protected java.lang.reflect.Field[] getDeclaredFields(Class clazz)
+		throws Exception {
+
+		if (clazz.getClassLoader() == null) {
+			return new java.lang.reflect.Field[0];
+		}
+
+		return TransformUtil.transform(
+			ReflectionUtil.getDeclaredFields(clazz),
+			field -> {
+				if (field.isSynthetic()) {
+					return null;
+				}
+
+				return field;
+			},
+			java.lang.reflect.Field.class);
+	}
+
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
+		if (!(_assetUsageResource instanceof EntityModelResource)) {
+			throw new UnsupportedOperationException(
+				"Resource is not an instance of EntityModelResource");
+		}
+
+		EntityModelResource entityModelResource =
+			(EntityModelResource)_assetUsageResource;
+
+		EntityModel entityModel = entityModelResource.getEntityModel(
+			new MultivaluedHashMap());
+
+		if (entityModel == null) {
+			return Collections.emptyList();
+		}
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		return entityFieldsMap.values();
+	}
+
+	protected List<EntityField> getEntityFields(EntityField.Type type)
+		throws Exception {
+
+		return TransformUtil.transform(
+			getEntityFields(),
+			entityField -> {
+				if (!Objects.equals(entityField.getType(), type) ||
+					ArrayUtil.contains(
+						getIgnoredEntityFieldNames(), entityField.getName())) {
+
+					return null;
+				}
+
+				return entityField;
+			});
+	}
+
+	protected String getFilterString(
+		EntityField entityField, String operator, AssetUsage assetUsage) {
+
+		StringBundler sb = new StringBundler();
+
+		String entityFieldName = entityField.getName();
+
+		sb.append(entityFieldName);
+
+		sb.append(" ");
+		sb.append(operator);
+		sb.append(" ");
+
+		if (entityFieldName.equals("name")) {
+			Object object = assetUsage.getName();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("type")) {
+			Object object = assetUsage.getType();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid entity field " + entityFieldName);
+	}
+
+	protected String invoke(String query) throws Exception {
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(
+			JSONUtil.put(
+				"query", query
+			).toString(),
+			"application/json");
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+		httpInvoker.path("http://localhost:8080/o/graphql");
+		httpInvoker.userNameAndPassword(
+			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		return httpResponse.getContent();
+	}
+
+	protected JSONObject invokeGraphQLMutation(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField mutationGraphQLField = new GraphQLField(
+			"mutation", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(mutationGraphQLField.toString()));
+	}
+
+	protected JSONObject invokeGraphQLQuery(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField queryGraphQLField = new GraphQLField(
+			"query", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(queryGraphQLField.toString()));
+	}
+
+	protected AssetUsage randomAssetUsage() throws Exception {
+		return new AssetUsage() {
+			{
+				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
+				type = StringUtil.toLowerCase(RandomTestUtil.randomString());
+			}
+		};
+	}
+
+	protected AssetUsage randomIrrelevantAssetUsage() throws Exception {
+		AssetUsage randomIrrelevantAssetUsage = randomAssetUsage();
+
+		return randomIrrelevantAssetUsage;
+	}
+
+	protected AssetUsage randomPatchAssetUsage() throws Exception {
+		return randomAssetUsage();
+	}
+
+	protected AssetUsageResource assetUsageResource;
+	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected com.liferay.portal.kernel.model.Company testCompany;
+	protected com.liferay.portal.kernel.model.Group testGroup;
+
+	protected static class BeanTestUtil {
+
+		public static void copyProperties(Object source, Object target)
+			throws Exception {
+
+			Class<?> sourceClass = source.getClass();
+
+			Class<?> targetClass = target.getClass();
+
+			for (java.lang.reflect.Field field :
+					_getAllDeclaredFields(sourceClass)) {
+
+				if (field.isSynthetic()) {
+					continue;
+				}
+
+				Method getMethod = _getMethod(
+					sourceClass, field.getName(), "get");
+
+				try {
+					Method setMethod = _getMethod(
+						targetClass, field.getName(), "set",
+						getMethod.getReturnType());
+
+					setMethod.invoke(target, getMethod.invoke(source));
+				}
+				catch (Exception e) {
+					continue;
+				}
+			}
+		}
+
+		public static boolean hasProperty(Object bean, String name) {
+			Method setMethod = _getMethod(
+				bean.getClass(), "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod != null) {
+				return true;
+			}
+
+			return false;
+		}
+
+		public static void setProperty(Object bean, String name, Object value)
+			throws Exception {
+
+			Class<?> clazz = bean.getClass();
+
+			Method setMethod = _getMethod(
+				clazz, "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod == null) {
+				throw new NoSuchMethodException();
+			}
+
+			Class<?>[] parameterTypes = setMethod.getParameterTypes();
+
+			setMethod.invoke(bean, _translateValue(parameterTypes[0], value));
+		}
+
+		private static List<java.lang.reflect.Field> _getAllDeclaredFields(
+			Class<?> clazz) {
+
+			List<java.lang.reflect.Field> fields = new ArrayList<>();
+
+			while ((clazz != null) && (clazz != Object.class)) {
+				for (java.lang.reflect.Field field :
+						clazz.getDeclaredFields()) {
+
+					fields.add(field);
+				}
+
+				clazz = clazz.getSuperclass();
+			}
+
+			return fields;
+		}
+
+		private static Method _getMethod(Class<?> clazz, String name) {
+			for (Method method : clazz.getMethods()) {
+				if (name.equals(method.getName()) &&
+					(method.getParameterCount() == 1) &&
+					_parameterTypes.contains(method.getParameterTypes()[0])) {
+
+					return method;
+				}
+			}
+
+			return null;
+		}
+
+		private static Method _getMethod(
+				Class<?> clazz, String fieldName, String prefix,
+				Class<?>... parameterTypes)
+			throws Exception {
+
+			return clazz.getMethod(
+				prefix + StringUtil.upperCaseFirstLetter(fieldName),
+				parameterTypes);
+		}
+
+		private static Object _translateValue(
+			Class<?> parameterType, Object value) {
+
+			if ((value instanceof Integer) &&
+				parameterType.equals(Long.class)) {
+
+				Integer intValue = (Integer)value;
+
+				return intValue.longValue();
+			}
+
+			return value;
+		}
+
+		private static final Set<Class<?>> _parameterTypes = new HashSet<>(
+			Arrays.asList(
+				Boolean.class, Date.class, Double.class, Integer.class,
+				Long.class, Map.class, String.class));
+
+	}
+
+	protected class GraphQLField {
+
+		public GraphQLField(String key, GraphQLField... graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(String key, List<GraphQLField> graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			GraphQLField... graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = Arrays.asList(graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			List<GraphQLField> graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = graphQLFields;
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder(_key);
+
+			if (!_parameterMap.isEmpty()) {
+				sb.append("(");
+
+				for (Map.Entry<String, Object> entry :
+						_parameterMap.entrySet()) {
+
+					sb.append(entry.getKey());
+					sb.append(": ");
+					sb.append(entry.getValue());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append(")");
+			}
+
+			if (!_graphQLFields.isEmpty()) {
+				sb.append("{");
+
+				for (GraphQLField graphQLField : _graphQLFields) {
+					sb.append(graphQLField.toString());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append("}");
+			}
+
+			return sb.toString();
+		}
+
+		private final List<GraphQLField> _graphQLFields;
+		private final String _key;
+		private final Map<String, Object> _parameterMap;
+
+	}
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseAssetUsageResourceTestCase.class);
+
+	private static Format _format;
+
+	private com.liferay.portal.kernel.model.User _testCompanyAdminUser;
+
+	@Inject
+	private com.liferay.headless.cms.resource.v1_0.AssetUsageResource
+		_assetUsageResource;
+
+}


### PR DESCRIPTION
Adding `@Override`, my bad 

# Original Description

Resent from https://github.com/liferay-ac/liferay-portal/pull/2433

Links:
- Related epic: https://liferay.atlassian.net/browse/LPD-48123
- Related story: https://liferay.atlassian.net/browse/LPD-62929
- Related task: https://liferay.atlassian.net/browse/LPD-63231

## Goal

To add a way to retrieve pages/assets where the specified asset is being used at

## How?

By adding a new endpoint to the shared CMS module `headless-cms`.

## Images

This PR is providing data for the following modal (see [full Figma design](https://www.figma.com/design/IeYGhyy3lIJZ2qfe0id9LE/LPD-48123---Prevent-Broken-Links?node-id=1621-38039&t=00BFqijFBJyanq0U-0))

<img width="1728" height="1117" alt="png(3)" src="https://github.com/user-attachments/assets/1486eb12-0211-4544-97cc-9a22a46c5731" />
