### PR TITLE
LPD-60099 Follow-up

### DIFF
--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/util/LayoutUtil.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/util/LayoutUtil.java
@@ -101,13 +101,13 @@ public class LayoutUtil {
 		List<Layout> layouts = ListUtil.filter(
 			LayoutServiceUtil.getLayouts(
 				groupId, privateLayout, parentLayoutId),
-			layout -> !_isExcludedLayout(layout));
+			layout -> _isIncluded(layout));
 
 		for (Layout layout : ListUtil.subList(layouts, start, end)) {
 			List<Layout> childLayouts = ListUtil.filter(
 				LayoutServiceUtil.getLayouts(
 					groupId, layout.isPrivateLayout(), layout.getLayoutId()),
-				curLayout -> !_isExcludedLayout(curLayout));
+				curLayout -> _isIncluded(curLayout));
 
 			jsonArray.put(
 				JSONUtil.put(
@@ -197,24 +197,20 @@ public class LayoutUtil {
 		);
 	}
 
-	private static boolean _isExcludedLayout(Layout layout) {
-		if (layout.isTypeEmpty()) {
+	private static boolean _isIncluded(Layout layout) {
+		if (!layout.isTypeContent() && !layout.isTypeEmpty()) {
 			return true;
 		}
 
-		if (!layout.isTypeContent()) {
-			return false;
-		}
-
 		if (layout.fetchDraftLayout() != null) {
-			return !layout.isPublished();
+			return layout.isPublished();
 		}
 
 		if (layout.isApproved() && !layout.isHidden() && !layout.isSystem()) {
-			return false;
+			return true;
 		}
 
-		return true;
+		return false;
 	}
 
 }

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/test/SelectLayoutTagTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/test/SelectLayoutTagTest.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -89,7 +90,7 @@ public class SelectLayoutTagTest {
 
 	@Test
 	public void testEmptyLayouts() throws Exception {
-		LayoutTestUtil.addTypeEmptyLayout(_group);
+		Layout layout = LayoutTestUtil.addTypeEmptyLayout(_group);
 
 		SelectLayoutTag selectLayoutTag = new SelectLayoutTag();
 
@@ -106,7 +107,24 @@ public class SelectLayoutTagTest {
 
 		JSONObject nodeJSONObject = nodesJSONArray.getJSONObject(0);
 
-		Assert.assertTrue(nodeJSONObject.getBoolean("disabled"));
+		JSONArray childrenJSONArray = nodeJSONObject.getJSONArray("children");
+
+		boolean found = false;
+
+		for (JSONObject childrenJSONObject :
+				(Iterable<JSONObject>)childrenJSONArray) {
+
+			if (StringUtil.contains(
+					childrenJSONObject.getString("externalReferenceCode"),
+					layout.getExternalReferenceCode())) {
+
+				found = true;
+
+				break;
+			}
+		}
+
+		Assert.assertFalse(found);
 	}
 
 	@Test


### PR DESCRIPTION
- **LPD-65095 ckeditor5 - add min-height to the editor content**
- **LPD-65095 ckeditor5 - increase the css selector specificity**
- **LPD-62892 Create base DropdownItem methods to replace logic in BaseSectionDisplayContext**
- **LPD-62892 Create DropdownItem methods for system object definitions**
- **LPD-62892 Create DropdownItem methods for custom object definitions**
- **LPD-62892 Create methods to get dropdown items for Creation Menus in different sections**
- **LPD-62892 Use new methods to create the Creation Menu**
- **LPD-62892 Fix creation menu tests**
- **LPD-62892 Testing the ordering of dropdown items in the creation menu (making sense of the usage of LinkedHashMap)**
- **LPD-62892 Fix playwright test**
- **LPD-62892 Fix testGetAdditionalProps**
- **LPD-62892 Fix method name**
- **LPD-62892 Burrito (the clue is that you are returning dropdownItems, so we want to wrap the vars around this**
- **LPD-62892 Rename**
- **LPD-62892 Sort**
- **LPD-61241 Migrate DocumentPreviewer to tsx**
- **LPD-61241 Fix React Compiler issues**
- **LPD-61241 Disable jump-to-page for single-page documents**
- **LPD-61241 Add aria-labels to buttons**
- **LPD-61241 Update jest snapshots**
- **LPD-64573 Remove toolbar code from view folder since it has a breadcrumb**
- **LPD-64999 Add ClayDatePicker component to sample portlet so we can use it for testing purposes**
- **LPD-64999 Add test to check Date Picker weekdays are shown in Basque**
- **LPD-64999 Bump AlloyUI version to 3.1.0-deprecated.129**
- **LPD-64999 Adding some specific translation for Basque language since it's not supported by all browsers**
- **LPD-64999 Fix test to correctly find short weekdays in Basque**
- **LPD-64999 SF**
- **LRCI-6379 Throw IOException & TimeoutException not RuntimeException for consistency with other methods and for more graceful handling**
- **LRCI-6379 Catch the exceptions from CloudBucketUtil.syncS3Files; the usage is not critical so only log any issues and let the empty list be returned for cached build reports**
- **LRCI-6379 SF**
- **LRCI-6379 prep next**
- **LPD-65106 Rename the Site schema to ConnectedSite to distinguish between other Sites schemas**
- **LPD-65106 rename to be more accurate to the use of the properties**
- **LPD-65106 rename to be more accurate to the use of the API endpoints**
- **LPD-65106 buildRest**
- **LPD-65106 baseline**
- **LPD-65106 use the properties new names**
- **LPD-65106 update name on the uses**
- **LPD-65106 not needed**
- **LPD-65106 use new endpoints names**
- **LPD-65106 update objects files with new names/classes**
- **LPD-65106 add method to show the connectedSites to the AssetLibrary if present on nestedField**
- **LPD-65106 rename action to match new object**
- **LPD-65106 SF**
- **LPD-65725 Strings starting with ! should be permitted to have quotes around them**
- **LPD-65727 Skip checking playwright dependencies**
- **LPD-65280 Added a new language key (schedule[verb])**
- **LPD-65280 build Lang**
- **LPD-65280 Fixed the Test**
- **LPD-64407 Update language keys**
- **LPD-64407 Autogenerated Code (buildLang)**
- **LPD-64407 Autogenerated Code (baseline)**
- **LPD-64407 Functional Test**
- **LPD-61504 Encapsulating the current upgrade process inside another upgrade process to be able to add more upgrades to the DLFileEntryDataCleanupPreupgradeProcess**
- **LPD-61504 Removing entries from other tables referencing missing DLFileEntry references**
- **LPD-61504 Adding integration tests to verify that all DLFileEntry related data is deleted by the data cleanup preupgrade process**
- **LPD-61504 Adding cleanup for DDMStorageLink entries pointing to missing DLFileEntryMetadata entries**
- **LPD-61504 Now the DDMStorageLink entry is deleted by the data cleanup process, so no need to delete it manually for the test**
- **LPD-61504 It is needed to check both class names as both are used depending on the source table**
- **LPD-61504 Using DLAppService instead of DLFileEntryService to generate AssetEntry values and improve coverage.**
- **LPD-61504 Adding new methods to be able to define programmatically the dependencies between upgrade processes**
- **LPD-61504 Defining programmatically the dependencies between upgrade processes in DLFileEntryDataCleanupPreupgradeProcess class**
- **LPD-61504 Rename**
- **LPD-61504 Defining dependencies between upgrade processes programatically**
- **LPD-61504 Unifying implementations for defining dependencies programmatically to avoid code duplications**
- **LPD-61504 Adapting tests**
- **LPD-61504 Using LoggingTimer to log the total time of execution of the whole DataCleanupPreupgradeProcessSuite**
- **LPD-61504 Typo**
- **LPD-61504 Sort**
- **LPD-61504 Now a DataCleanupPreupgradeProcess can be constructed by using other DataCleanupPreupgradeProcess classes**
- **LPD-61504 Baseline**
- **LPD-61504 Avoiding the usage of static block**
- **LPD-65583 Fix playwright tests**
- **LPD-65787 Add property to generic group criterion**
- **LPD-65787 Replace usages**
- **LPD-65787 Package no longer exported**
- **LPD-65787 Baseline**
- **LPD-64088 Auto SF**
- **LPD-62892 Auto SF**
- **LPD-65236 Create empty state for inventory analysis and expired assets cards**
- **LPD-65236 Create unit tests**
- **LPD-65236 buildlang**
- **LPD-65790 Add styles for the structure dropdown menu**
- **LPD-65859 Add cms classes**
- **LPD-65859 Add left icons and divider**
- **LPD-65859 Set dropdown menu height to auto**
- **LPD-65859 Add title to the Add Field button**
- **LPD-65859 Adapt test**
- **LPD-4641 Add alt text to images for cards in Clay Sample Web.**
- **LPD-65367 Close toast when redirect to recycle bin**
- **LPD-65367 Update playwright test**
- **LPD-65594 Better loading screen**
- **LPD-57834 align BulkActionEntityModel entity fields to SearchResultEntityModel**
- **LPD-65845 Add feature flag checks for showing remote publications options in instance settings**
- **LPD-65400 Preventing component registration conflicts during search**
- **LPD-65400 playwright: Include test for date picker component warnings**
- **LPD-65901 Show correct value configuration sidebar select**
- **LPD-65901 Adapt test**
- **LPD-65544 Add hidden input with required attribute to validate CKEditor when the field is required**
- **LPD-65544 Always render hidden error element to support required validation**
- **LPD-65544 Validate if the required input is valid on submit. If not, show an error and focus the CKEditor**
- **LPD-65544 Update the required input and the error when CKEditor content changes for unlocalizable fields**
- **LPD-65544 Update the required input when CKEditor content changes for localizable fields**
- **LPD-65544 Add tests**
- **LPD-58792 Add suport for icons to recent assets view in CMS**
- **LPD-58792 Add icon rendering in AssetRenderer**
- **LPS-77699 Update Translations**
- **LRSD-9491 Fix article formats and other inconsistencies**
- **LRSD-9491 Sort**
- **LPD-65878 Add public friendly url prefix to url**
- **LPD-65515 Disable save and publish button while content page loading**
- **LPD-65515 Add functional test**
- **LPD-48735 Add close button with keyboard access**
- **LPD-48735 The first two lines of setupTrigger should only be called for the sidebarTrigger, so we can just share the addSidebarToggleClickEventListener.**
- **LPD-48735 Prefer utility classes over additional CSS.**
- **LPD-48735 Ensure the close icon is visible over the menu item hover state.**
- **LPD-65914 Fix bug that is caused by LPS-204321, redo it**
- **LPD-65914 Add test case**
- **LPD-65914 Add an empty line, as we finished referencing variable "group"**
- **LPD-65914 SF, add missing empty lines**
- **LPD-65856 - Add tests for 8 digit hex values.**
- **LPD-65856 - Update getValidHexColors to support 8 digit hex values.**
- **LPD-65856 - Move from the deprecated "onColorsChange" method to the supported "onChange" method.**
- **LPD-65563 Redirect to 404 page if cms ff not enabled**
- **LPD-65563 Build service**
- **LPD-65563 Rename**
- **LPD-65563 Buy space**
- **LPD-65563 Auto SF**
- **LRCI-6399 Update default testray environment factor for JDK**
- **LRCI-6397 Add a more specific subdir to track build failure types**
- **LRCI-6397 Add bundle type to notification**
- **LRCI-6279 rename methods referencing com-liferay-osb-asah-private**
- **LRCI-6279 rename references to methods using com-liferay-osb-asah-private**
- **LRCI-6279 rename methods referencing liferay-release-tool-ee**
- **LRCI-6279 rename references to methods using liferay-release-tool-ee**
- **LRCI-6279 rename methods referencing liferay-qa-portal-legacy-ee**
- **LRCI-6279 rename references to methods using liferay-qa-portal-legacy-ee**
- **LRCI-6279 SF**
- **LRCI-6279 rename**
- **LRCI-6279 Rename**
- **LRCI-6279 SF**
- **LRCI-6279 prep next**
- **LRSD-9587 Add missing permissions for Documentation Admin role**
- **LPD-65894 Add missing link in the performance tab to the documentation**
- **LRSD-10987 Add LRSD-8280 feature flag to custom element CX**
- **LRSD-10987 Addjust ticket status tag to fit new statuses returned by the api**
- **LPD-65839 Display the enable condition checkbox for the onAfterLogin trigger**
- **LPD-65839 Add unit test**
- **LPD-65864 A draft version label may extend beyond DLFileEntryConstants.PRIVATE_WORKING_COPY_VERSION with additional suffixes**
- **LPD-65864 Add test for draft version labels with UUID suffixes**
- **LPD-61504 Fixing broken test due to #c652d033. Now the start and end of DataCleanupPreupgradeProcessSuite is printed by the LoggingTimer class**
- **LPD-61504 Printing the content of the array in case of test failure to easier debug**
- **LPD-61505 Adding more cleanups to the DDMStructureDataCleanupPreupgradeProcess to cover more data**
- **LPD-61505 Adding integration test to check the complete cleanup of DDMStructureDataCleanupPreupgradeProcess**
- **LPD-61505 Renaming classes as they perform the cleanup over all the DDM tables as they are related**
- **LPD-61505 Updating the configuration for manually executing the DDM clean up**
- **LPD-61505 buildLang**
- **LPD-61505 ant update-portal-osgi-configuration-properties**
- **LPD-61505 New data cleanup preupgrade process for deleting orphaned data related to DDMStorageLink, which can be deleted from main DDMData cleanup process, Journal cleanup process, or DLFileEntry cleanup process**
- **LPD-61505 Adding DDMStorageLinkDataCleanupPreupgradeProcess to DataCleanupPreupgradeProcessSuite**
- **LPD-61505 Adding integration tests for DDMStorageLinkDataCleanupPreupgradeProcess**
- **LPD-61505 Executing the DDMStorageLinkDataCleanupPreupgradeProcess in the DataRemovalExecutor under the saunder the same removeDDMOrphanData configuration**
- **LPD-61505 Auto SF**
- **LPD-61505 Defining dependencies programmatically**
- **LPD-64151 site-cms-site-initializer: Update style + visibility for "Shared from X" icon**
- **LPD-64151 site-cms-site-initializer: Add frontend test to assert 'Shared from X' icon**
- **LPD-65103 Added null check for nested fields**
- **LPD-65103 Test Added test method for null check for nested fields**
- **LPD-65103 Test removed method chains in the test method.**
- **LPD-65103 Test source format.**
- **LPD-63839 Add video previewURL**
- **LPD-63839 Update FilePreviewerModalContent to support video previews**
- **LPD-63839 Add DLVideoIframe**
- **LPD-63839 Export DLVideoIframe from document-library-video**
- **LPD-63839 Use DLVideoIframe in FilePreviewerModalContent**
- **LPD-63839 Replace deprecated frameborder attribute with CSS**
- **LPD-63839 Add test**
- **LPD-63839 Remove unnecessary ts-ignore**
- **LPD-63839 Remove unnecessary mock**
- **LPD-64955 Create a FE component for the assignee object field**
- **LPD-64955 Create a functional test for the assignee object field**
- **LPD-64955 Use the user's picture and the initials of the role name to represent the elements in the list**
- **LPD-64955 Assignee unit tests**
- **LPD-65590 use distinct count**
- **LPD-65590 update test**
- **LPD-65449 AMImage still generated for PortletFiles in some cases, we should let the delete method to check it and remove.**
- **LPD-65449 Integration test**
- **LPD-66041 Inline PropsValues.FEATURE_FLAGS_JSON to its only user in order to decouple PropsValues from JSONObjectImpl**
- **LPD-66041 Move PropsValues to kernel**
- **LPD-66041 Global search replace**
- **LPD-66041 Add back a deprecated bridging PropsValues to keep backward compatibility, since this class is widely used in customer code.**
- **LPD-66041 Semantic versioning**
- **LPD-66041 Sort SF test case files**
- **LPD-66041 What is this for? The test was created with this weird forking configuring while it is not needed at all.**
- **LPD-66041 Auto SF**
- **LPD-47852 add automation to change return type of getFieldNames method from RawMetadataProcessor class**
- **LPD-47852 add testcase for changes on return type of getFieldNames method from RawMetadataProcessor class**
- **LPD-7753 add automation to change return type from deleteProduct and deleteProductByExternalReferenceCode methods from BaseProductResourceImpl class**
- **LPD-7753 add testcase for deleteProduct and deleteProductByExternalReferenceCode methods from BaseProductResourceImpl class**
- **LPD-61145 add new replacement for parameterMapToString method from Http to HttpComponentsUtil class**
- **LPD-61145 update testcase for parameterMapToString method from Http to HttpComponentsUtil class**
- **LPD-61132 update imports.txt**
- **LPD-7864 add new automation for validate method from CommerceOrderValidator class**
- **LPD-7864 add new test case for validate method from CommerceOrderValidator class**
- **LPD-7864 delete UpgradeJavaCommerceOrderValidatorCheck since now is covered by catchAll automation**
- **LRSD-8410 Update copyright year on footer**
- **LPD-65204 Improve Breadcrumb styles**
- **LPD-65204 Fix space sticker size in breadcrumb**
- **LPD-65204 Remove text decoration if the item don't have a link in breadrcumb**
- **LPD-65204 Use Breadcrumb in dashboard view**
- **LPD-65204 Use Breadcrumb instead of Toolbar in View All page**
- **LPD-65204 Add base getBreadcrumbProps method in BaseSectionDisplayContext**
- **LPD-65204 Use Breadcrumb instead of Toolbar in Share With Me page**
- **LPD-65204 Fix Recycle Bin page title**
- **LPD-65204 Use Breadcrumb instead of Toolbar in Contents and Files page**
- **LPD-65204 Use Breadcrumb instead of Toobar in Structures page**
- **LPD-65204 Use Breadcrumb component in CategorizationToolbar**
- **LPD-65204 Use common Breadcrumb instead of custom CategorizationBreadcrumb**
- **LPD-65204 Remove unnecessary actionItems**
- **LPD-65204 Use Breadcrumb instead of Toolbar in All Spaces page**
- **LPD-65204 Change the method to private**
- **LPD-65204 FIx tests**
- **LPD-66007 This is not a connected site, but the depot site**
- **LPD-66007 Build REST**
- **LPD-66007 Replace usages**
- **LPD-66007 SF**
- **LPD-66007 SF**
- **LPD-65813 Use event.target instead**
- **LPD-65813 Playwright test**
- **LPD-65862 select correct listbox**
- **LPD-64740 Divider Color Change**
- **LPD-64740 Add className prop in Toolbar.Item**
- **LPD-64740 Use nav-divider instead of custom css**
- **LPD-61436 Add new column ERC for CalendarBooking table**
- **LPD-61436 buildService**
- **LPD-61436 Support ERC in InfoFramework Implementation for CalendarBooking**
- **LPD-61436 CalendarBookingInfoItemDetailsProvider testIntegration**
- **LPD-61436 CalendarBookingInfoItemObjectProvider testIntegration**
- **LPD-61436 baseline**
- **LPD-61436 Adapt test**
- **LPD-61436 This is not needed when you have external-reference-code='true' because it'll always generate this. We only add this when we do manually manage the ERC.**
- **LRSD-11073 Add Customer FLS ticket statuses**
- **LPD-65893 Merge extraPlugins from standard and CX customizations**
- **LPD-65893 Support addition of official plugin from CX, remove unused**
- **LPD-65893 Add samples for adding official and custom plugins**
- **LPD-65893 Extend test for CKE5 CX sample**
- **LPD-65893 Add importmap entry for `ckeditor5`. This enables use of `import {...} from 'ckeditor5'` in client extentions.**
- **LPD-65893 Use AbsolutePortalURLBuilder, in case there's a configured CDN.**
- **LPD-65780 use the correct object for the ModelResourcePermission**
- **LPD-65931 portal-search-solr8: Update imports to deploy on 2025.Q3.0**
- **LPD-65932 portal-search-opensearch2-impl: Update imports to deploy on 2025.Q3.0**
- **portal-search-solr8-api 5.0.2 prep next**
- **portal-search-solr8-impl 5.0.45 prep next**
- **portal-search-opensearch2-api 1.0.4 prep next**
- **portal-search-opensearch2-impl 1.0.11 prep next**
- **LPD-62475 Display new texts**
- **LPD-62475 Add new keywords**
- **LPD-62475 Autogenerated Code (buildLang)**
- **LRSD-11101 Fix category facet template on search page**
- **LPD-59841 create report only language tag**
- **LPD-59841 gw buildLang**
- **LPD-59841 create Report Only checkbox and enforce accordingly header**
- **LPD-59841 adjust tests  and test Report Only header**
- **LPD-59841 adjust and add new playwright tests for report-only**
- **LPD-59841 adjust poshi tests**
- **LPD-59841 update portal osgi configuration properties**
- **LPD-59841 Redundant check**
- **LRCI-6397 mkdirs before creating the file**
- **LRCI-6397 prep next**
- **LPD-65091 When partially updating a localized object field value, merge the new values with the existing ones, keeping any original values that aren't in the new data**
- **LPD-65091 Add integration test**
- **LPD-66041 gw buildRest**
- **LPD-60099 Simplify**
- **LPD-60099 Fix test**
