### PR TITLE
LPD-65515 [follow up] ObjectDefinition columns lost when Save button clicked before page fully loads

### DIFF
--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/ManagementToolbar/index.tsx
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/ManagementToolbar/index.tsx
@@ -31,7 +31,7 @@ interface ManagementToolbarProps {
 	isApproved?: boolean;
 	isRootDescendantNode?: boolean;
 	label: string;
-	loading: boolean;
+	loading?: boolean;
 	objectDefinitionExternalReferenceCode: string;
 	objectDefinitionExternalReferenceCodeSaveURL: string;
 	onExternalReferenceCodeChange?: (value: string) => void;


### PR DESCRIPTION
Related issue: https://liferay.atlassian.net/browse/LPD-65515