### PR TITLE
LPD-46127 - Nested Folders Navigation in the modal

### DIFF
--- a/modules/apps/commerce/commerce-frontend-js/test/components/CurrencySelector/CurrencySelector.js
+++ b/modules/apps/commerce/commerce-frontend-js/test/components/CurrencySelector/CurrencySelector.js
@@ -293,7 +293,7 @@ describe('CurrencySelector', () => {
 			jest.spyOn(CurrencySelectorUtils, 'storeCommerceCurrency');
 
 			const {getByText} = render(
-				<CurrencySelector {...{...BASE_PROPS, commerceOrderId: 123}} />
+				<CurrencySelector {...BASE_PROPS} commerceOrderId={123} />
 			);
 
 			await waitFor(() => {

--- a/modules/apps/commerce/commerce-frontend-js/test/components/Price/Price.js
+++ b/modules/apps/commerce/commerce-frontend-js/test/components/Price/Price.js
@@ -45,10 +45,8 @@ describe('Price', () => {
 
 			const {container} = render(
 				<Price
-					{...{
-						...BASE_PROPS,
-						price: {...BASE_PRICE_PROPS, ...price},
-					}}
+					{...BASE_PROPS}
+					price={{...BASE_PRICE_PROPS, ...price}}
 				/>
 			);
 
@@ -92,10 +90,8 @@ describe('Price', () => {
 
 			const {container} = render(
 				<Price
-					{...{
-						...BASE_PROPS,
-						price: {...BASE_PRICE_PROPS, ...price},
-					}}
+					{...BASE_PROPS}
+					price={{...BASE_PRICE_PROPS, ...price}}
 				/>
 			);
 
@@ -153,10 +149,8 @@ describe('Price', () => {
 
 			const {container} = render(
 				<Price
-					{...{
-						...BASE_PROPS,
-						price: {...BASE_PRICE_PROPS, ...price},
-					}}
+					{...BASE_PROPS}
+					price={{...BASE_PRICE_PROPS, ...price}}
 				/>
 			);
 
@@ -223,10 +217,8 @@ describe('Price', () => {
 
 			const {container} = render(
 				<Price
-					{...{
-						...BASE_PROPS,
-						price: {...BASE_PRICE_PROPS, ...price},
-					}}
+					{...BASE_PROPS}
+					price={{...BASE_PRICE_PROPS, ...price}}
 				/>
 			);
 
@@ -317,11 +309,9 @@ describe('Price', () => {
 
 			const {container} = render(
 				<Price
-					{...{
-						...BASE_PROPS,
-						netPrice,
-						price: {...BASE_PRICE_PROPS, ...price},
-					}}
+					{...BASE_PROPS}
+					netPrice={netPrice}
+					price={{...BASE_PRICE_PROPS, ...price}}
 				/>
 			);
 
@@ -360,10 +350,8 @@ describe('Price', () => {
 
 			const {container} = render(
 				<Price
-					{...{
-						...BASE_PROPS,
-						price: {...BASE_PRICE_PROPS, ...price},
-					}}
+					{...BASE_PROPS}
+					price={{...BASE_PRICE_PROPS, ...price}}
 				/>
 			);
 
@@ -391,11 +379,9 @@ describe('Price', () => {
 
 			const {container} = render(
 				<Price
-					{...{
-						...BASE_PROPS,
-						price: {...BASE_PRICE_PROPS, ...price},
-						standalone,
-					}}
+					{...BASE_PROPS}
+					price={{...BASE_PRICE_PROPS, ...price}}
+					standalone={standalone}
 				/>
 			);
 
@@ -421,10 +407,8 @@ describe('Price', () => {
 
 			const {container} = render(
 				<Price
-					{...{
-						...BASE_PROPS,
-						price: {...BASE_PRICE_PROPS, ...price},
-					}}
+					{...BASE_PROPS}
+					price={{...BASE_PRICE_PROPS, ...price}}
 				/>
 			);
 
@@ -452,11 +436,9 @@ describe('Price', () => {
 
 			const {container} = render(
 				<Price
-					{...{
-						...BASE_PROPS,
-						compact,
-						price: {...BASE_PRICE_PROPS, ...price},
-					}}
+					{...BASE_PROPS}
+					compact={compact}
+					price={{...BASE_PRICE_PROPS, ...price}}
 				/>
 			);
 
@@ -484,11 +466,9 @@ describe('Price', () => {
 
 			const {container} = render(
 				<Price
-					{...{
-						...BASE_PROPS,
-						displayDiscountLevels,
-						price: {...BASE_PRICE_PROPS, ...price},
-					}}
+					{...BASE_PROPS}
+					displayDiscountLevels={displayDiscountLevels}
+					price={{...BASE_PRICE_PROPS, ...price}}
 				/>
 			);
 
@@ -552,11 +532,9 @@ describe('Price', () => {
 
 			render(
 				<Price
-					{...{
-						...BASE_PROPS,
-						namespace,
-						price: {...BASE_PRICE_PROPS, ...price},
-					}}
+					{...BASE_PROPS}
+					namespace={namespace}
+					price={{...BASE_PRICE_PROPS, ...price}}
 				/>
 			);
 
@@ -605,11 +583,9 @@ describe('Price', () => {
 
 			const {container} = render(
 				<Price
-					{...{
-						...BASE_PROPS,
-						namespace,
-						price: {...BASE_PRICE_PROPS, ...price},
-					}}
+					{...BASE_PROPS}
+					namespace={namespace}
+					price={{...BASE_PRICE_PROPS, ...price}}
 				/>
 			);
 

--- a/modules/apps/content-dashboard/content-dashboard-web/test/js/components/DownloadSpreadsheetButton.test.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/test/js/components/DownloadSpreadsheetButton.test.js
@@ -13,7 +13,7 @@ import DownloadSpreadsheetButton from '../../../src/main/resources/META-INF/reso
 import * as utils from '../../../src/main/resources/META-INF/resources/js/components/DownloadSpreadsheetButton/downloadSpreadsheetUtils';
 
 const getComponent = (fileURL = 'demo-file-url') => {
-	return <DownloadSpreadsheetButton {...{fileURL, total: 12}} />;
+	return <DownloadSpreadsheetButton fileURL={fileURL} total={12} />;
 };
 
 describe('DownloadSpreadsheetButton', () => {

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/index.d.ts
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/index.d.ts
@@ -67,6 +67,8 @@ export const FormReport: React.FC<{
 
 export const FormView: React.FC<{
 	children?: React.ReactNode;
+	portletNamespace?: string;
+	title?: string;
 }>;
 
 export const PartialResults: React.FC<{

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/js/FormView.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/js/FormView.tsx
@@ -25,7 +25,11 @@ const FormView: React.FC<{children?: React.ReactNode | undefined} & IProps> = ({
 				/>
 			)}
 
-			<DataEngineFormView {...{...otherProps, portletNamespace, title}} />
+			<DataEngineFormView
+				{...otherProps}
+				portletNamespace={portletNamespace}
+				title={title}
+			/>
 		</>
 	);
 };

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
@@ -201,11 +201,9 @@ const Card = forwardRef<HTMLDivElement, any>(
 		return (
 			<div ref={ref}>
 				<ClayCardWithInfo
-					{...{
-						...props,
-						...(activeView.setItemComponentProps?.({item, props}) ??
-							{}),
-					}}
+					{...props}
+					{...(activeView.setItemComponentProps?.({item, props}) ??
+						{})}
 				/>
 			</div>
 		);

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/list/List.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/list/List.tsx
@@ -101,11 +101,8 @@ const ListItem = forwardRef<HTMLLIElement, any>(
 
 		return (
 			<ClayList.Item
-				{...{
-					...props,
-					...(activeView.setItemComponentProps?.({item, props}) ??
-						{}),
-				}}
+				{...props}
+				{...(activeView.setItemComponentProps?.({item, props}) ?? {})}
 				ref={ref}
 			>
 				{selectable && (

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
@@ -424,10 +424,8 @@ function ClayTableRowOptionalDropTarget({
 
 	return (
 		<ClayTableRow
-			{...{
-				...props,
-				...(activeView.setItemComponentProps?.({item, props}) ?? {}),
-			}}
+			{...props}
+			{...(activeView.setItemComponentProps?.({item, props}) ?? {})}
 		>
 			{children}
 		</ClayTableRow>

--- a/modules/apps/frontend-js/frontend-js-item-selector-sample-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-item-selector-sample-web/package.json
@@ -9,7 +9,8 @@
 		"@liferay/frontend-data-set-web": "*",
 		"frontend-js-item-selector-web": "*",
 		"frontend-js-web": "*",
-		"react": "18.2.0"
+		"react": "18.2.0",
+		"uuid": "9.0.0"
 	},
 	"main": "js/index.ts",
 	"name": "@liferay/frontend-js-item-selector-sample-web",

--- a/modules/apps/frontend-js/frontend-js-item-selector-sample-web/src/main/resources/META-INF/resources/js/CMSFilesItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-sample-web/src/main/resources/META-INF/resources/js/CMSFilesItemSelectorModal.tsx
@@ -5,10 +5,12 @@
 
 import ClayButton from '@clayui/button';
 import {IView} from '@liferay/frontend-data-set-web';
+import {
+	IItemSelectorModalProps,
+	ItemSelectorModal,
+} from 'frontend-js-item-selector-web';
 import React, {useState} from 'react';
 import {v4 as uuidv4} from 'uuid';
-
-import ItemSelectorModal, {IItemSelectorModalProps} from './ItemSelectorModal';
 
 const OBJECT_ENTRY_FOLDER_CLASS_NAME =
 	'com.liferay.object.model.ObjectEntryFolder';
@@ -171,7 +173,6 @@ function CMSFilesItemSelectorModal({
 							) {
 								return {
 									...props,
-									href: '#',
 									onClick: () => {
 										onChildFolderClick({
 											folderId: item.embedded.id,

--- a/modules/apps/frontend-js/frontend-js-item-selector-sample-web/src/main/resources/META-INF/resources/js/ItemSelectorSamples.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-sample-web/src/main/resources/META-INF/resources/js/ItemSelectorSamples.tsx
@@ -9,6 +9,7 @@ import {ClayInput} from '@clayui/form';
 import ClayList from '@clayui/list';
 import {useModal} from '@clayui/modal';
 import ClaySticker from '@clayui/sticker';
+import {IFrontendDataSetProps} from '@liferay/frontend-data-set-web';
 import {
 	CMSFilesItemSelectorModal,
 	ItemSelector,
@@ -72,6 +73,14 @@ type User = {
 	roleBriefs?: {
 		name: string;
 	}[];
+};
+
+const FDS_DEFAULT_PROPS: Partial<IFrontendDataSetProps> = {
+	pagination: {
+		deltas: [{label: 20}, {label: 40}, {label: 60}],
+		initialDelta: 20,
+	},
+	selectionType: 'single',
 };
 
 const assetLibrariesItemSelectorConfig = {
@@ -256,6 +265,7 @@ export default function ItemSelectorSamples() {
 					apiURL={userAccountsItemSelectorConfig.apiURL}
 					itemSelectorModalProps={{
 						fdsProps: {
+							...FDS_DEFAULT_PROPS,
 							id: `itemSelectorModal-users-${getRandomId()}`,
 							views: getDefaultItemSelectorModalViews({
 								viewsConfig:
@@ -287,6 +297,7 @@ export default function ItemSelectorSamples() {
 					apiURL={userAccountsItemSelectorConfig.apiURL}
 					itemSelectorModalProps={{
 						fdsProps: {
+							...FDS_DEFAULT_PROPS,
 							id: `itemSelectorModal-documents-${getRandomId()}`,
 							views: getDefaultItemSelectorModalViews({
 								viewsConfig:
@@ -321,6 +332,7 @@ export default function ItemSelectorSamples() {
 					apiURL={`${location.origin}/o/headless-asset-library/v1.0/asset-libraries`}
 					itemSelectorModalProps={{
 						fdsProps: {
+							...FDS_DEFAULT_PROPS,
 							id: `itemSelectorModal-spaces-${getRandomId()}`,
 							views: getDefaultItemSelectorModalViews({
 								viewsConfig:
@@ -352,6 +364,7 @@ export default function ItemSelectorSamples() {
 					apiURL={`${location.origin}/o/headless-asset-library/v1.0/asset-libraries`}
 					itemSelectorModalProps={{
 						fdsProps: {
+							...FDS_DEFAULT_PROPS,
 							id: `itemSelectorModal-spaces-${getRandomId()}`,
 							views: getDefaultItemSelectorModalViews({
 								viewsConfig:
@@ -463,6 +476,7 @@ export default function ItemSelectorSamples() {
 				<ItemSelectorModal<Document>
 					apiURL={documentsItemSelectorConfig.apiURL}
 					fdsProps={{
+						...FDS_DEFAULT_PROPS,
 						id: `itemSelectorModal-documents-${getRandomId()}`,
 						views: getDefaultItemSelectorModalViews({
 							viewsConfig:
@@ -484,6 +498,7 @@ export default function ItemSelectorSamples() {
 				<ItemSelectorModal<Space>
 					apiURL={assetLibrariesItemSelectorConfig.apiURL}
 					fdsProps={{
+						...FDS_DEFAULT_PROPS,
 						id: `itemSelectorModal-assets-${getRandomId()}`,
 						views: getDefaultItemSelectorModalViews({
 							viewsConfig:
@@ -506,6 +521,7 @@ export default function ItemSelectorSamples() {
 				<ItemSelectorModal<User>
 					apiURL={userAccountsItemSelectorConfig.apiURL}
 					fdsProps={{
+						...FDS_DEFAULT_PROPS,
 						id: `itemSelectorModal-users-${getRandomId()}`,
 						views: getDefaultItemSelectorModalViews({
 							viewsConfig:

--- a/modules/apps/frontend-js/frontend-js-item-selector-sample-web/src/main/resources/META-INF/resources/js/ItemSelectorSamples.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-sample-web/src/main/resources/META-INF/resources/js/ItemSelectorSamples.tsx
@@ -470,123 +470,79 @@ export default function ItemSelectorSamples() {
 
 			<SampleContainer label="Item Selector Modal">
 				<CMSFilesItemSelectorModal
-					{...{
-						items: cmsFile ? [cmsFile] : [],
-						observer: cmsFileItemSelectorObserver,
-						onItemsChange: (items: any) => {
-							setCMSFile(items[0]);
-						},
-						onOpenChange: cmsFileItemSelectorOpenChange,
-						open: cmsFileItemSelectorOpen,
+					items={cmsFile ? [cmsFile] : []}
+					observer={cmsFileItemSelectorObserver}
+					onItemsChange={(items: any) => {
+						setCMSFile(items[0]);
 					}}
+					onOpenChange={cmsFileItemSelectorOpenChange}
+					open={cmsFileItemSelectorOpen}
 				/>
 
 				<ItemSelectorModal<Document>
-					{...{
-						apiURL: documentsItemSelectorConfig.apiURL,
-						fdsProps: {
-							...FDS_DEFAULT_PROPS,
-							id: `itemSelectorModal-documents-${getRandomId()}`,
-							views: getDefaultItemSelectorModalViews({
-								viewsConfig:
-									EItemSelectorModalViewsConfig.DOCUMENTS,
-							}),
-						},
-						itemTypeLabel:
-							documentsItemSelectorConfig.itemTypeLabel,
-						items: documentsItemSelectorModal,
-						locator: documentsItemSelectorConfig.locator,
-						multiSelect: true,
-						observer: documentItemSelectorObserver,
-						onItemsChange: (items: Document[]) => {
-							setDocumentsItemSelectorModal(items);
-						},
-						onOpenChange: documentItemSelectorOpenChange,
-						open: documentItemSelectorOpen,
+					apiURL={documentsItemSelectorConfig.apiURL}
+					fdsProps={{
+						...FDS_DEFAULT_PROPS,
+						id: `itemSelectorModal-documents-${getRandomId()}`,
+						views: getDefaultItemSelectorModalViews({
+							viewsConfig:
+								EItemSelectorModalViewsConfig.DOCUMENTS,
+						}),
 					}}
+					itemTypeLabel={documentsItemSelectorConfig.itemTypeLabel}
+					items={documentsItemSelectorModal}
+					locator={documentsItemSelectorConfig.locator}
+					multiSelect={true}
+					observer={documentItemSelectorObserver}
+					onItemsChange={(items: Document[]) => {
+						setDocumentsItemSelectorModal(items);
+					}}
+					onOpenChange={documentItemSelectorOpenChange}
+					open={documentItemSelectorOpen}
 				/>
 
 				<ItemSelectorModal<Space>
-					{...{
-						apiURL: assetLibrariesItemSelectorConfig.apiURL,
-						fdsProps: {
-							...FDS_DEFAULT_PROPS,
-							id: `itemSelectorModal-assets-${getRandomId()}`,
-							views: getDefaultItemSelectorModalViews({
-								viewsConfig:
-									EItemSelectorModalViewsConfig.ASSET_LIBRARIES,
-							}),
-						},
-						itemTypeLabel:
-							assetLibrariesItemSelectorConfig.itemTypeLabel,
-						items: spacesItemSelectorModal,
-						locator: assetLibrariesItemSelectorConfig.locator,
-						observer: spaceItemSelectorObserver,
-						onItemsChange: (items: Space[]) => {
-							setSpacesItemSelectorModal(items);
-						},
-						onOpenChange: spaceItemSelectorOpenChange,
-						open: spaceItemSelectorOpen,
+					apiURL={assetLibrariesItemSelectorConfig.apiURL}
+					fdsProps={{
+						...FDS_DEFAULT_PROPS,
+						id: `itemSelectorModal-assets-${getRandomId()}`,
+						views: getDefaultItemSelectorModalViews({
+							viewsConfig:
+								EItemSelectorModalViewsConfig.ASSET_LIBRARIES,
+						}),
 					}}
+					itemTypeLabel={
+						assetLibrariesItemSelectorConfig.itemTypeLabel
+					}
+					items={spacesItemSelectorModal}
+					locator={assetLibrariesItemSelectorConfig.locator}
+					observer={spaceItemSelectorObserver}
+					onItemsChange={(items: Space[]) => {
+						setSpacesItemSelectorModal(items);
+					}}
+					onOpenChange={spaceItemSelectorOpenChange}
+					open={spaceItemSelectorOpen}
 				/>
 
 				<ItemSelectorModal<User>
-					{...{
-						apiURL: userAccountsItemSelectorConfig.apiURL,
-						fdsProps: {
-							...FDS_DEFAULT_PROPS,
-							id: `itemSelectorModal-users-${getRandomId()}`,
-							views: getDefaultItemSelectorModalViews({
-								viewsConfig:
-									EItemSelectorModalViewsConfig.USER_ACCOUNTS,
-							}),
-						},
-						itemTypeLabel:
-							userAccountsItemSelectorConfig.itemTypeLabel,
-						items: usersItemSelectorModal,
-						locator: userAccountsItemSelectorConfig.locator,
-						observer: userItemSelectorObserver,
-						onItemsChange: (items: User[]) => {
-							setUsersItemSelectorModal(items);
-						},
-						onOpenChange: userItemSelectorOpenChange,
-						open: userItemSelectorOpen,
+					apiURL={userAccountsItemSelectorConfig.apiURL}
+					fdsProps={{
+						...FDS_DEFAULT_PROPS,
+						id: `itemSelectorModal-users-${getRandomId()}`,
+						views: getDefaultItemSelectorModalViews({
+							viewsConfig:
+								EItemSelectorModalViewsConfig.USER_ACCOUNTS,
+						}),
 					}}
-				/>
-
-				<ItemSelectorModal<CMSFile>
-					{...{
-						apiURL: cmsFileItemSelectorConfig.apiURL,
-						fdsProps: {
-							...FDS_DEFAULT_PROPS,
-							filters: [
-								{
-									apiURL: '/o/headless-asset-library/v1.0/asset-libraries',
-									entityFieldType: 'collection',
-									id: 'groupIds',
-									itemKey: 'siteId',
-									itemLabel: 'name',
-									label: Liferay.Language.get('space'),
-									multiple: true,
-									type: 'selection',
-								},
-							],
-							id: `itemSelectorModal-cms-files-${getRandomId()}`,
-							views: getDefaultItemSelectorModalViews({
-								viewsConfig:
-									EItemSelectorModalViewsConfig.CMS_FILES,
-							}),
-						},
-						itemTypeLabel: cmsFileItemSelectorConfig.itemTypeLabel,
-						items: cmsFile ? [cmsFile] : [],
-						locator: cmsFileItemSelectorConfig.locator,
-						observer: cmsFileItemSelectorObserver,
-						onItemsChange: (items: CMSFile[]) => {
-							setCMSFile(items[0]);
-						},
-						onOpenChange: cmsFileItemSelectorOpenChange,
-						open: cmsFileItemSelectorOpen,
+					itemTypeLabel={userAccountsItemSelectorConfig.itemTypeLabel}
+					items={usersItemSelectorModal}
+					locator={userAccountsItemSelectorConfig.locator}
+					observer={userItemSelectorObserver}
+					onItemsChange={(items: User[]) => {
+						setUsersItemSelectorModal(items);
 					}}
+					onOpenChange={userItemSelectorOpenChange}
+					open={userItemSelectorOpen}
 				/>
 
 				<ClayButton.Group className="mb-3" spaced>

--- a/modules/apps/frontend-js/frontend-js-item-selector-sample-web/src/main/resources/META-INF/resources/js/ItemSelectorSamples.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-sample-web/src/main/resources/META-INF/resources/js/ItemSelectorSamples.tsx
@@ -131,7 +131,7 @@ export default function ItemSelectorSamples() {
 	const [documents, setDocuments] = useState<Document[]>([]);
 	const [space, setSpace] = useState<Space>();
 
-	const [cmsFile, setCMSFile] = useState<CMSFile | null>(null);
+	const [cmsFiles, setCMSFiles] = useState<CMSFile[]>([]);
 	const [documentsItemSelectorModal, setDocumentsItemSelectorModal] =
 		useState<Document[]>([]);
 	const [spacesItemSelectorModal, setSpacesItemSelectorModal] = useState<
@@ -470,10 +470,11 @@ export default function ItemSelectorSamples() {
 
 			<SampleContainer label="Item Selector Modal">
 				<CMSFilesItemSelectorModal
-					items={cmsFile ? [cmsFile] : []}
+					items={cmsFiles}
+					multiSelect
 					observer={cmsFileItemSelectorObserver}
 					onItemsChange={(items: any) => {
-						setCMSFile(items[0]);
+						setCMSFiles(items);
 					}}
 					onOpenChange={cmsFileItemSelectorOpenChange}
 					open={cmsFileItemSelectorOpen}
@@ -492,7 +493,7 @@ export default function ItemSelectorSamples() {
 					itemTypeLabel={documentsItemSelectorConfig.itemTypeLabel}
 					items={documentsItemSelectorModal}
 					locator={documentsItemSelectorConfig.locator}
-					multiSelect={true}
+					multiSelect
 					observer={documentItemSelectorObserver}
 					onItemsChange={(items: Document[]) => {
 						setDocumentsItemSelectorModal(items);
@@ -583,6 +584,16 @@ export default function ItemSelectorSamples() {
 					</ClayButton>
 				</ClayButton.Group>
 
+				{!!cmsFiles.length &&
+					cmsFiles.map((cmsFile: any) => (
+						<ClayAlert
+							displayType="info"
+							key={cmsFile.title}
+							symbol="document"
+							title={cmsFile.title}
+						/>
+					))}
+
 				{!!documentsItemSelectorModal.length &&
 					documentsItemSelectorModal.map((document) => (
 						<ClayAlert
@@ -606,14 +617,6 @@ export default function ItemSelectorSamples() {
 						displayType="info"
 						symbol="user"
 						title={usersItemSelectorModal[0].name}
-					/>
-				)}
-
-				{cmsFile && (
-					<ClayAlert
-						displayType="info"
-						symbol="file-template"
-						title={cmsFile.title}
 					/>
 				)}
 			</SampleContainer>

--- a/modules/apps/frontend-js/frontend-js-item-selector-sample-web/src/main/resources/META-INF/resources/js/ItemSelectorSamples.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-sample-web/src/main/resources/META-INF/resources/js/ItemSelectorSamples.tsx
@@ -9,8 +9,11 @@ import {ClayInput} from '@clayui/form';
 import ClayList from '@clayui/list';
 import {useModal} from '@clayui/modal';
 import ClaySticker from '@clayui/sticker';
-import {IFrontendDataSetProps} from '@liferay/frontend-data-set-web';
-import {ItemSelector, ItemSelectorModal} from 'frontend-js-item-selector-web';
+import {
+	CMSFilesItemSelectorModal,
+	ItemSelector,
+	ItemSelectorModal,
+} from 'frontend-js-item-selector-web';
 import React, {useState} from 'react';
 
 import {
@@ -72,14 +75,6 @@ type User = {
 	}[];
 };
 
-const FDS_DEFAULT_PROPS: Partial<IFrontendDataSetProps> = {
-	pagination: {
-		deltas: [{label: 20}, {label: 40}, {label: 60}],
-		initialDelta: 20,
-	},
-	selectionType: 'single',
-};
-
 const assetLibrariesItemSelectorConfig = {
 	apiURL: `${location.origin}/o/headless-asset-library/v1.0/asset-libraries`,
 	itemTypeLabel: Liferay.Language.get('space'),
@@ -136,6 +131,7 @@ export default function ItemSelectorSamples() {
 	const [documents, setDocuments] = useState<Document[]>([]);
 	const [space, setSpace] = useState<Space>();
 
+	const [cmsFile, setCMSFile] = useState<CMSFile | null>(null);
 	const [documentsItemSelectorModal, setDocumentsItemSelectorModal] =
 		useState<Document[]>([]);
 	const [spacesItemSelectorModal, setSpacesItemSelectorModal] = useState<
@@ -144,7 +140,6 @@ export default function ItemSelectorSamples() {
 	const [usersItemSelectorModal, setUsersItemSelectorModal] = useState<
 		User[]
 	>([]);
-	const [cmsFile, setCMSFile] = useState<CMSFile | null>(null);
 	const [user2, setUser2] = useState<User | null>();
 	const [space3, setSpace3] = useState<Space | null>();
 	const [spacesMultiSelect, setSpacesMultiSelect] = useState<Space[]>([]);
@@ -474,6 +469,18 @@ export default function ItemSelectorSamples() {
 			</SampleContainer>
 
 			<SampleContainer label="Item Selector Modal">
+				<CMSFilesItemSelectorModal
+					{...{
+						items: cmsFile ? [cmsFile] : [],
+						observer: cmsFileItemSelectorObserver,
+						onItemsChange: (items: any) => {
+							setCMSFile(items[0]);
+						},
+						onOpenChange: cmsFileItemSelectorOpenChange,
+						open: cmsFileItemSelectorOpen,
+					}}
+				/>
+
 				<ItemSelectorModal<Document>
 					{...{
 						apiURL: documentsItemSelectorConfig.apiURL,
@@ -564,7 +571,6 @@ export default function ItemSelectorSamples() {
 									type: 'selection',
 								},
 							],
-
 							id: `itemSelectorModal-cms-files-${getRandomId()}`,
 							views: getDefaultItemSelectorModalViews({
 								viewsConfig:

--- a/modules/apps/frontend-js/frontend-js-item-selector-sample-web/src/main/resources/META-INF/resources/js/ItemSelectorSamples.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-sample-web/src/main/resources/META-INF/resources/js/ItemSelectorSamples.tsx
@@ -10,13 +10,10 @@ import ClayList from '@clayui/list';
 import {useModal} from '@clayui/modal';
 import ClaySticker from '@clayui/sticker';
 import {IFrontendDataSetProps} from '@liferay/frontend-data-set-web';
-import {
-	CMSFilesItemSelectorModal,
-	ItemSelector,
-	ItemSelectorModal,
-} from 'frontend-js-item-selector-web';
+import {ItemSelector, ItemSelectorModal} from 'frontend-js-item-selector-web';
 import React, {useState} from 'react';
 
+import CMSFilesItemSelectorModal from './CMSFilesItemSelectorModal';
 import {
 	assetLibraryViews,
 	documentViews,

--- a/modules/apps/frontend-js/frontend-js-item-selector-sample-web/src/main/resources/META-INF/resources/js/ItemSelectorSamples.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-sample-web/src/main/resources/META-INF/resources/js/ItemSelectorSamples.tsx
@@ -18,7 +18,6 @@ import React, {useState} from 'react';
 
 import {
 	assetLibraryViews,
-	cmsFileViews,
 	documentViews,
 	userViews,
 } from './utils/defaultViews';
@@ -108,21 +107,6 @@ const userAccountsItemSelectorConfig = {
 	views: userViews,
 };
 
-const cmsFileItemSelectorConfig = {
-	apiURL: `${location.origin}/o/search/v1.0/search?${[
-		'emptySearch=true',
-		'nestedFields=embedded,file.thumbnailURL',
-		"filter=(cmsKind eq 'object') and (cmsSection eq 'files') and (status in (0, 2, 3))",
-	].join('&')}`,
-	itemTypeLabel: Liferay.Language.get('file'),
-	locator: {
-		id: 'embedded.id',
-		label: 'embedded.title',
-		value: 'embedded.id',
-	},
-	views: cmsFileViews,
-};
-
 function getRandomId(): string {
 	return Math.random().toString(36).substring(2, 9);
 }
@@ -161,9 +145,9 @@ export default function ItemSelectorSamples() {
 		open: userItemSelectorOpen,
 	} = useModal();
 	const {
-		observer: cmsFileItemSelectorObserver,
-		onOpenChange: cmsFileItemSelectorOpenChange,
-		open: cmsFileItemSelectorOpen,
+		observer: cmsFilesItemSelectorObserver,
+		onOpenChange: cmsFilesItemSelectorOpenChange,
+		open: cmsFilesItemSelectorOpen,
 	} = useModal();
 
 	return (
@@ -272,7 +256,6 @@ export default function ItemSelectorSamples() {
 					apiURL={userAccountsItemSelectorConfig.apiURL}
 					itemSelectorModalProps={{
 						fdsProps: {
-							...FDS_DEFAULT_PROPS,
 							id: `itemSelectorModal-users-${getRandomId()}`,
 							views: getDefaultItemSelectorModalViews({
 								viewsConfig:
@@ -304,7 +287,6 @@ export default function ItemSelectorSamples() {
 					apiURL={userAccountsItemSelectorConfig.apiURL}
 					itemSelectorModalProps={{
 						fdsProps: {
-							...FDS_DEFAULT_PROPS,
 							id: `itemSelectorModal-documents-${getRandomId()}`,
 							views: getDefaultItemSelectorModalViews({
 								viewsConfig:
@@ -339,7 +321,6 @@ export default function ItemSelectorSamples() {
 					apiURL={`${location.origin}/o/headless-asset-library/v1.0/asset-libraries`}
 					itemSelectorModalProps={{
 						fdsProps: {
-							...FDS_DEFAULT_PROPS,
 							id: `itemSelectorModal-spaces-${getRandomId()}`,
 							views: getDefaultItemSelectorModalViews({
 								viewsConfig:
@@ -371,7 +352,6 @@ export default function ItemSelectorSamples() {
 					apiURL={`${location.origin}/o/headless-asset-library/v1.0/asset-libraries`}
 					itemSelectorModalProps={{
 						fdsProps: {
-							...FDS_DEFAULT_PROPS,
 							id: `itemSelectorModal-spaces-${getRandomId()}`,
 							views: getDefaultItemSelectorModalViews({
 								viewsConfig:
@@ -472,18 +452,17 @@ export default function ItemSelectorSamples() {
 				<CMSFilesItemSelectorModal
 					items={cmsFiles}
 					multiSelect
-					observer={cmsFileItemSelectorObserver}
+					observer={cmsFilesItemSelectorObserver}
 					onItemsChange={(items: any) => {
 						setCMSFiles(items);
 					}}
-					onOpenChange={cmsFileItemSelectorOpenChange}
-					open={cmsFileItemSelectorOpen}
+					onOpenChange={cmsFilesItemSelectorOpenChange}
+					open={cmsFilesItemSelectorOpen}
 				/>
 
 				<ItemSelectorModal<Document>
 					apiURL={documentsItemSelectorConfig.apiURL}
 					fdsProps={{
-						...FDS_DEFAULT_PROPS,
 						id: `itemSelectorModal-documents-${getRandomId()}`,
 						views: getDefaultItemSelectorModalViews({
 							viewsConfig:
@@ -505,7 +484,6 @@ export default function ItemSelectorSamples() {
 				<ItemSelectorModal<Space>
 					apiURL={assetLibrariesItemSelectorConfig.apiURL}
 					fdsProps={{
-						...FDS_DEFAULT_PROPS,
 						id: `itemSelectorModal-assets-${getRandomId()}`,
 						views: getDefaultItemSelectorModalViews({
 							viewsConfig:
@@ -528,7 +506,6 @@ export default function ItemSelectorSamples() {
 				<ItemSelectorModal<User>
 					apiURL={userAccountsItemSelectorConfig.apiURL}
 					fdsProps={{
-						...FDS_DEFAULT_PROPS,
 						id: `itemSelectorModal-users-${getRandomId()}`,
 						views: getDefaultItemSelectorModalViews({
 							viewsConfig:
@@ -577,10 +554,10 @@ export default function ItemSelectorSamples() {
 					<ClayButton
 						displayType="primary"
 						onClick={() => {
-							cmsFileItemSelectorOpenChange(true);
+							cmsFilesItemSelectorOpenChange(true);
 						}}
 					>
-						Select CMS File
+						Select CMS Files
 					</ClayButton>
 				</ClayButton.Group>
 

--- a/modules/apps/frontend-js/frontend-js-item-selector-sample-web/src/main/resources/META-INF/resources/js/utils/getDefaultItemSelectorModalViews.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-sample-web/src/main/resources/META-INF/resources/js/utils/getDefaultItemSelectorModalViews.ts
@@ -5,16 +5,10 @@
 
 import {IView} from '@liferay/frontend-data-set-web';
 
-import {
-	assetLibraryViews,
-	cmsFileViews,
-	documentViews,
-	userViews,
-} from './defaultViews';
+import {assetLibraryViews, documentViews, userViews} from './defaultViews';
 
 export enum EItemSelectorModalViewsConfig {
 	ASSET_LIBRARIES = 'assetLibraries',
-	CMS_FILES = 'cmsFiles',
 	DOCUMENTS = 'documents',
 	USER_ACCOUNTS = 'userAccounts',
 }
@@ -29,9 +23,6 @@ export const getDefaultItemSelectorModalViews = function ({
 	}
 	else if (viewsConfig === EItemSelectorModalViewsConfig.ASSET_LIBRARIES) {
 		return assetLibraryViews;
-	}
-	else if (viewsConfig === EItemSelectorModalViewsConfig.CMS_FILES) {
-		return cmsFileViews;
 	}
 	else if (viewsConfig === EItemSelectorModalViewsConfig.DOCUMENTS) {
 		return documentViews;

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/package.json
@@ -1,5 +1,8 @@
 {
 	"dependencies": {
+		"@clayui/breadcrumb": "*",
+		"@clayui/layout": "*",
+		"@clayui/link": "*",
 		"@clayui/autocomplete": "3.146.0",
 		"@clayui/button": "3.144.1",
 		"@clayui/core": "3.146.0",
@@ -13,7 +16,8 @@
 		"classnames": "2.3.1",
 		"frontend-js-web": "*",
 		"react": "18.2.0",
-		"react-dom": "18.2.0"
+		"react-dom": "18.2.0",
+		"uuid": "9.0.0"
 	},
 	"main": "index.ts",
 	"name": "frontend-js-item-selector-web",

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/package.json
@@ -1,13 +1,13 @@
 {
 	"dependencies": {
-		"@clayui/breadcrumb": "*",
-		"@clayui/layout": "*",
-		"@clayui/link": "*",
 		"@clayui/autocomplete": "3.146.0",
+		"@clayui/breadcrumb": "3.144.1",
 		"@clayui/button": "3.144.1",
 		"@clayui/core": "3.146.0",
 		"@clayui/data-provider": "3.145.0",
 		"@clayui/form": "3.145.0",
+		"@clayui/layout": "3.144.1",
+		"@clayui/link": "3.144.1",
 		"@clayui/modal": "3.145.0",
 		"@clayui/multi-select": "3.147.0",
 		"@clayui/shared": "3.145.0",

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/index.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/index.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-export {default as CMSFilesItemSelectorModal} from './item_selector/CMSFilesItemSelectorModal';
 export {default as ItemSelector} from './item_selector/ItemSelector';
 export {default as ItemSelectorModal} from './item_selector/ItemSelectorModal';
+
+export type {IItemSelectorModalProps} from './item_selector/ItemSelectorModal';

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/index.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/index.ts
@@ -3,5 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+export {default as CMSFilesItemSelectorModal} from './item_selector/CMSFilesItemSelectorModal';
 export {default as ItemSelector} from './item_selector/ItemSelector';
 export {default as ItemSelectorModal} from './item_selector/ItemSelectorModal';

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/CMSFilesItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/CMSFilesItemSelectorModal.tsx
@@ -102,6 +102,10 @@ function CMSFilesItemSelectorModal({
 					: undefined
 			}
 			fdsProps={{
+				pagination: {
+					deltas: [{label: 20}, {label: 40}, {label: 60}],
+					initialDelta: 20,
+				},
 				...fdsProps,
 				customRenderers: {
 					tableCell: [
@@ -130,7 +134,19 @@ function CMSFilesItemSelectorModal({
 						},
 					],
 				},
-				id: `itemSelectorModal-documents-${uuidv4()}`,
+				filters: [
+					{
+						apiURL: '/o/headless-asset-library/v1.0/asset-libraries',
+						entityFieldType: 'collection',
+						id: 'groupIds',
+						itemKey: 'siteId',
+						itemLabel: 'name',
+						label: Liferay.Language.get('space'),
+						multiple: true,
+						type: 'selection',
+					},
+				],
+				id: `itemSelectorModal-cms-${uuidv4()}`,
 				views: [
 					{
 						contentRenderer: 'cards',

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/CMSFilesItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/CMSFilesItemSelectorModal.tsx
@@ -52,6 +52,21 @@ function CMSFilesItemSelectorModal({
 	>([]);
 	const [url, setURL] = useState(CMS_ROOT_FILES_URL);
 
+	function onChildFolderClick({
+		folderId,
+		folderName,
+	}: {
+		folderId: string;
+		folderName: string;
+	}) {
+		setFolderStructure((prevStructure) => [
+			...prevStructure,
+			{folderId, folderName},
+		]);
+
+		setURL(getCMSChildFolderURL(folderId));
+	}
+
 	return (
 		<ItemSelectorModal
 			{...otherProps}
@@ -67,7 +82,7 @@ function CMSFilesItemSelectorModal({
 								},
 							},
 							...folderStructure.map(
-								({folderId, folderName}) => ({
+								({folderId, folderName}, index) => ({
 									href: '#',
 									label: folderName,
 									onClick: () => {
@@ -75,10 +90,7 @@ function CMSFilesItemSelectorModal({
 											(prevFolderStructure) =>
 												prevFolderStructure.slice(
 													0,
-													prevFolderStructure.findIndex(
-														({folderId: id}) =>
-															folderId === id
-													) + 1
+													index + 1
 												)
 										);
 
@@ -102,22 +114,10 @@ function CMSFilesItemSelectorModal({
 										<ClayLink
 											href="#"
 											onClick={() => {
-												const folderId = embedded.id;
-												const folderName =
-													embedded.title;
-
-												setFolderStructure(
-													(prevStructure) => [
-														...prevStructure,
-														{folderId, folderName},
-													]
-												);
-
-												setURL(
-													getCMSChildFolderURL(
-														folderId
-													)
-												);
+												onChildFolderClick({
+													folderId: embedded.id,
+													folderName: embedded.title,
+												});
 											}}
 										>
 											{value}
@@ -156,15 +156,10 @@ function CMSFilesItemSelectorModal({
 									...props,
 									href: '#',
 									onClick: () => {
-										const folderId = item.embedded.id;
-										const folderName = item.embedded.title;
-
-										setFolderStructure((prevStructure) => [
-											...prevStructure,
-											{folderId, folderName},
-										]);
-
-										setURL(getCMSChildFolderURL(folderId));
+										onChildFolderClick({
+											folderId: item.embedded.id,
+											folderName: item.embedded.title,
+										});
 									},
 									onSelectChange: null,
 									symbol: 'folder',

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/CMSFilesItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/CMSFilesItemSelectorModal.tsx
@@ -1,0 +1,232 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayLink from '@clayui/link';
+import {IView} from '@liferay/frontend-data-set-web';
+import React, {useState} from 'react';
+import {v4 as uuidv4} from 'uuid';
+
+import ItemSelectorModal, {IItemSelectorModalProps} from './itemSelectorModal';
+
+const OBJECT_ENTRY_FOLDER_CLASS_NAME =
+	'com.liferay.object.model.ObjectEntryFolder';
+
+const ROOT_URL = `${window.location.origin}${Liferay.ThemeDisplay.getPathContext()}/o/search/v1.0/search`;
+
+const BASE_SEARCH_PARAMS = {
+	currentURL: '/web/cms/files',
+	emptySearch: 'true',
+	nestedFields: 'description,embedded,file.thumbnailURL',
+};
+
+const CMS_ROOT_FILES_URL = `${ROOT_URL}?${new URLSearchParams({
+	...BASE_SEARCH_PARAMS,
+	filter: "cmsRoot eq true and cmsSection eq 'files' and status in (0, 2, 3)",
+}).toString()}`;
+
+function getCMSChildFolderURL(folderId: string) {
+	return `${ROOT_URL}?${new URLSearchParams({
+		...BASE_SEARCH_PARAMS,
+		filter: `folderId eq ${folderId}`,
+	}).toString()}`;
+}
+
+function CMSFilesItemSelectorModal<T extends Record<string, any>>({
+	fdsProps,
+	...otherProps
+}: IItemSelectorModalProps<T>) {
+	const [folderStructure, setFolderStructure] = useState<
+		{folderId: string; folderName: string}[]
+	>([]);
+	const [url, setURL] = useState(CMS_ROOT_FILES_URL);
+
+	return (
+		<ItemSelectorModal
+			{...otherProps}
+			breadcrumbs={
+				folderStructure.length
+					? [
+							{
+								label: Liferay.Language.get('default'),
+								onClick: () => {
+									setURL(CMS_ROOT_FILES_URL);
+									setFolderStructure([]);
+								},
+							},
+							...folderStructure.map(
+								({folderId, folderName}) => ({
+									href: '#',
+									label: folderName,
+									onClick: () => {
+										setFolderStructure(
+											(prevFolderStructure) =>
+												prevFolderStructure.slice(
+													0,
+													prevFolderStructure.findIndex(
+														({folderId: id}) =>
+															folderId === id
+													) + 1
+												)
+										);
+
+										setURL(getCMSChildFolderURL(folderId));
+									},
+								})
+							),
+						]
+					: undefined
+			}
+			fdsProps={{
+				...fdsProps,
+				apiURL: url,
+				customRenderers: {
+					tableCell: [
+						{
+							component: ({itemData, value}) => {
+								const {embedded} = itemData;
+
+								return (
+									<div className="align-items-center d-flex table-list-title">
+										<ClayLink
+											href="#"
+											onClick={() => {
+												const folderId = embedded.id;
+												const folderName =
+													embedded.title;
+
+												setFolderStructure(
+													(prevStructure) => [
+														...prevStructure,
+														{folderId, folderName},
+													]
+												);
+
+												setURL(
+													getCMSChildFolderURL(
+														folderId
+													)
+												);
+											}}
+										>
+											{value}
+										</ClayLink>
+									</div>
+								);
+							},
+							name: 'cmsFilesTitleCellRenderer',
+							type: 'internal',
+						},
+					],
+				},
+				id: `itemSelectorModal-documents-${uuidv4()}`,
+				views: [
+					{
+						contentRenderer: 'cards',
+						label: Liferay.Language.get('cards'),
+						name: 'cards',
+						schema: {
+							description: 'embedded.description',
+							image: 'embedded.file.thumbnailURL',
+							title: 'embedded.title',
+						},
+						setItemComponentProps: ({
+							item,
+							props,
+						}: {
+							item: any;
+							props: any;
+						}) => {
+							if (
+								item.entryClassName ===
+								OBJECT_ENTRY_FOLDER_CLASS_NAME
+							) {
+								return {
+									...props,
+									interactive: true,
+									onClick: () => {
+										const folderId = item.embedded.id;
+										const folderName = item.embedded.title;
+
+										setFolderStructure((prevStructure) => [
+											...prevStructure,
+											{folderId, folderName},
+										]);
+
+										setURL(getCMSChildFolderURL(folderId));
+									},
+									onSelectChange: null,
+									symbol: 'folder',
+								};
+							}
+
+							const stickerProps = {
+								stickerProps: {
+									className: 'file-icon-color-5',
+									displayType: 'unstyled',
+								},
+							};
+
+							if (
+								!item.embedded.file.mimeType.startsWith('image')
+							) {
+								return {
+									...props,
+									imgProps: null,
+									...stickerProps,
+								};
+							}
+
+							return {
+								...props,
+								...stickerProps,
+							};
+						},
+						thumbnail: 'cards2',
+					},
+					{
+						contentRenderer: 'table',
+						label: Liferay.Language.get('table'),
+						name: 'table',
+						schema: {
+							fields: [
+								{
+									contentRenderer:
+										'cmsFilesTitleCellRenderer',
+									fieldName: 'embedded.title',
+									label: Liferay.Language.get('title'),
+									sortable: false,
+								},
+								{
+									fieldName: 'embedded.description',
+									label: Liferay.Language.get('description'),
+									sortable: false,
+								},
+								{
+									fieldName: 'embedded.file.name',
+									label: Liferay.Language.get('file-name'),
+									sortable: false,
+								},
+								{
+									fieldName: 'embedded.file.mimeType',
+									label: Liferay.Language.get('type'),
+									sortable: false,
+								},
+							],
+						},
+						thumbnail: 'table',
+					},
+				] as IView[],
+			}}
+			locator={{
+				id: 'embedded.id',
+				label: 'embedded.title',
+				value: 'embedded.id',
+			}}
+			type={Liferay.Language.get('document')}
+		/>
+	);
+}
+
+export default CMSFilesItemSelectorModal;

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/CMSFilesItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/CMSFilesItemSelectorModal.tsx
@@ -33,10 +33,23 @@ function getCMSChildFolderURL(folderId: string) {
 	}).toString()}`;
 }
 
-function CMSFilesItemSelectorModal<T extends Record<string, any>>({
+type Document = {
+	contentUrl: string;
+	creator: {
+		name: string;
+	};
+	encodingFormat: string;
+	fileName: string;
+	id: string;
+	title: string;
+};
+
+function CMSFilesItemSelectorModal({
 	fdsProps,
 	...otherProps
-}: IItemSelectorModalProps<T>) {
+}: Omit<IItemSelectorModalProps<Document>, 'fdsProps' | 'type'> & {
+	fdsProps?: IItemSelectorModalProps<Document>['fdsProps'];
+}) {
 	const [folderStructure, setFolderStructure] = useState<
 		{folderId: string; folderName: string}[]
 	>([]);

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/CMSFilesItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/CMSFilesItemSelectorModal.tsx
@@ -8,7 +8,7 @@ import {IView} from '@liferay/frontend-data-set-web';
 import React, {useState} from 'react';
 import {v4 as uuidv4} from 'uuid';
 
-import ItemSelectorModal, {IItemSelectorModalProps} from './itemSelectorModal';
+import ItemSelectorModal, {IItemSelectorModalProps} from './ItemSelectorModal';
 
 const OBJECT_ENTRY_FOLDER_CLASS_NAME =
 	'com.liferay.object.model.ObjectEntryFolder';
@@ -33,22 +33,19 @@ function getCMSChildFolderURL(folderId: string) {
 	}).toString()}`;
 }
 
-type Document = {
-	contentUrl: string;
-	creator: {
-		name: string;
-	};
-	encodingFormat: string;
-	fileName: string;
-	id: string;
+type CMSFile = {
+	id: number;
 	title: string;
 };
 
 function CMSFilesItemSelectorModal({
 	fdsProps,
 	...otherProps
-}: Omit<IItemSelectorModalProps<Document>, 'fdsProps' | 'type'> & {
-	fdsProps?: IItemSelectorModalProps<Document>['fdsProps'];
+}: Omit<
+	IItemSelectorModalProps<CMSFile>,
+	'itemTypeLabel' | 'fdsProps' | 'apiURL'
+> & {
+	fdsProps?: IItemSelectorModalProps<CMSFile>['fdsProps'];
 }) {
 	const [folderStructure, setFolderStructure] = useState<
 		{folderId: string; folderName: string}[]
@@ -58,6 +55,7 @@ function CMSFilesItemSelectorModal({
 	return (
 		<ItemSelectorModal
 			{...otherProps}
+			apiURL={url}
 			breadcrumbs={
 				folderStructure.length
 					? [
@@ -93,7 +91,6 @@ function CMSFilesItemSelectorModal({
 			}
 			fdsProps={{
 				...fdsProps,
-				apiURL: url,
 				customRenderers: {
 					tableCell: [
 						{
@@ -230,12 +227,12 @@ function CMSFilesItemSelectorModal({
 					},
 				] as IView[],
 			}}
+			itemTypeLabel={Liferay.Language.get('files')}
 			locator={{
 				id: 'embedded.id',
 				label: 'embedded.title',
 				value: 'embedded.id',
 			}}
-			type={Liferay.Language.get('document')}
 		/>
 	);
 }

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/CMSFilesItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/CMSFilesItemSelectorModal.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import ClayLink from '@clayui/link';
+import ClayButton from '@clayui/button';
 import {IView} from '@liferay/frontend-data-set-web';
 import React, {useState} from 'react';
 import {v4 as uuidv4} from 'uuid';
@@ -83,7 +83,6 @@ function CMSFilesItemSelectorModal({
 							},
 							...folderStructure.map(
 								({folderId, folderName}, index) => ({
-									href: '#',
 									label: folderName,
 									onClick: () => {
 										setFolderStructure(
@@ -111,22 +110,24 @@ function CMSFilesItemSelectorModal({
 					tableCell: [
 						{
 							component: ({itemData, value}) => {
-								const {embedded} = itemData;
+								const {embedded, entryClassName} = itemData;
 
-								return (
-									<div className="align-items-center d-flex table-list-title">
-										<ClayLink
-											href="#"
-											onClick={() => {
-												onChildFolderClick({
-													folderId: embedded.id,
-													folderName: embedded.title,
-												});
-											}}
-										>
-											{value}
-										</ClayLink>
-									</div>
+								return entryClassName ===
+									OBJECT_ENTRY_FOLDER_CLASS_NAME ? (
+									<ClayButton
+										className="c-p-0"
+										displayType="link"
+										onClick={() => {
+											onChildFolderClick({
+												folderId: embedded.id,
+												folderName: embedded.title,
+											});
+										}}
+									>
+										{value}
+									</ClayButton>
+								) : (
+									value
 								);
 							},
 							name: 'cmsFilesTitleCellRenderer',

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/CMSFilesItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/CMSFilesItemSelectorModal.tsx
@@ -157,7 +157,7 @@ function CMSFilesItemSelectorModal({
 							) {
 								return {
 									...props,
-									interactive: true,
+									href: '#',
 									onClick: () => {
 										const folderId = item.embedded.id;
 										const folderName = item.embedded.title;
@@ -175,10 +175,8 @@ function CMSFilesItemSelectorModal({
 							}
 
 							const stickerProps = {
-								stickerProps: {
-									className: 'file-icon-color-5',
-									displayType: 'unstyled',
-								},
+								className: 'file-icon-color-5',
+								displayType: 'unstyled',
 							};
 
 							if (
@@ -187,13 +185,13 @@ function CMSFilesItemSelectorModal({
 								return {
 									...props,
 									imgProps: null,
-									...stickerProps,
+									stickerProps,
 								};
 							}
 
 							return {
 								...props,
-								...stickerProps,
+								stickerProps,
 							};
 						},
 						thumbnail: 'cards2',

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/ItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/ItemSelectorModal.tsx
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayBreadcrumb from '@clayui/breadcrumb';
 import ClayButton from '@clayui/button';
+import ClayLayout from '@clayui/layout';
 import ClayModal from '@clayui/modal';
 import {InternalDispatch} from '@clayui/shared';
 import {
@@ -28,6 +30,7 @@ type IItemSelectorModalFDSProps = Omit<
 >;
 
 export interface IItemSelectorModalProps<T> {
+	breadcrumbs?: React.ComponentProps<typeof ClayBreadcrumb>['items'];
 
 	/**
 	 * The URL that will be fetched to return the items.
@@ -88,6 +91,7 @@ export interface IItemSelectorModalProps<T> {
 
 function ItemSelectorModal<T extends Record<string, any>>({
 	apiURL,
+	breadcrumbs,
 	fdsProps,
 	itemTypeLabel,
 	items: externalItems,
@@ -126,6 +130,21 @@ function ItemSelectorModal<T extends Record<string, any>>({
 			</ClayModal.Header>
 
 			<ClayModal.Body className="p-0">
+				{breadcrumbs && (
+					<ClayLayout.Container fluid>
+						<h2 className="mb-0 mt-2">
+							{breadcrumbs[breadcrumbs.length - 1].label}
+						</h2>
+
+						<ClayBreadcrumb
+							items={breadcrumbs.map((breadcrumb, index) => ({
+								...breadcrumb,
+								active: index === breadcrumbs.length - 1,
+							}))}
+						/>
+					</ClayLayout.Container>
+				)}
+
 				<FrontendDataSet
 					{...fdsProps}
 					apiURL={apiURL}

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/ItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/ItemSelectorModal.tsx
@@ -30,12 +30,16 @@ type IItemSelectorModalFDSProps = Omit<
 >;
 
 export interface IItemSelectorModalProps<T> {
-	breadcrumbs?: React.ComponentProps<typeof ClayBreadcrumb>['items'];
 
 	/**
 	 * The URL that will be fetched to return the items.
 	 */
 	apiURL: string;
+
+	/**
+	 * Configuration of @clayui/breadcrumb items to show above the FDS table
+	 */
+	breadcrumbs?: React.ComponentProps<typeof ClayBreadcrumb>['items'];
 
 	/**
 	 * Configuration properties of the Frontend Data Set used to display data.

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/test/ItemSelectorModal.test.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/test/ItemSelectorModal.test.tsx
@@ -76,39 +76,37 @@ const ItemSelectorModalWrapper = ({
 			<button onClick={() => onOpenChange(true)}>open modal</button>
 
 			<ItemSelectorModal<TestItem>
-				{...{
-					apiURL: `${location.origin}/o/headless-delivery/v1.0/test-api-url`,
-					fdsProps: {
-						id: `itemSelectorModal-test-0001`,
-						pagination: {
-							deltas: [{label: 20}],
-							initialDelta: 20,
-						},
-						views: [
-							{
-								contentRenderer: 'cards',
-								label: 'Cards',
-								name: 'cards',
-								schema: {
-									description: 'description',
-									title: 'name',
-								},
-								thumbnail: 'cards2',
-							} as IView,
-						],
+				apiURL={`${location.origin}/o/headless-delivery/v1.0/test-api-url`}
+				fdsProps={{
+					id: `itemSelectorModal-test-0001`,
+					pagination: {
+						deltas: [{label: 20}],
+						initialDelta: 20,
 					},
-					itemTypeLabel: 'Space',
-					items: selectedItems,
-					locator: {
-						id: 'itemId',
-						label: 'name',
-						value: 'itemId',
-					},
-					observer,
-					onItemsChange,
-					onOpenChange,
-					open,
+					views: [
+						{
+							contentRenderer: 'cards',
+							label: 'Cards',
+							name: 'cards',
+							schema: {
+								description: 'description',
+								title: 'name',
+							},
+							thumbnail: 'cards2',
+						} as IView,
+					],
 				}}
+				itemTypeLabel="Space"
+				items={selectedItems}
+				locator={{
+					id: 'itemId',
+					label: 'name',
+					value: 'itemId',
+				}}
+				observer={observer}
+				onItemsChange={onItemsChange}
+				onOpenChange={onOpenChange}
+				open={open}
 			/>
 		</>
 	);

--- a/modules/apps/portal-workflow/portal-workflow-taglib/test/components/WorkflowStatus.js
+++ b/modules/apps/portal-workflow/portal-workflow-taglib/test/components/WorkflowStatus.js
@@ -42,14 +42,7 @@ describe('The WorkflowStatus should', () => {
 	});
 
 	it('render without a status label', () => {
-		render(
-			<WorkflowStatus
-				{...{
-					...INITIAL_PROPS,
-					showStatusLabel: false,
-				}}
-			/>
-		);
+		render(<WorkflowStatus {...INITIAL_PROPS} showStatusLabel={false} />);
 
 		const hasStatus = document.querySelector('workflow-label');
 

--- a/modules/apps/portal-workflow/portal-workflow-taglib/test/components/status-label/StatusLabel.js
+++ b/modules/apps/portal-workflow/portal-workflow-taglib/test/components/status-label/StatusLabel.js
@@ -32,9 +32,7 @@ describe('The WorkflowStatus should', () => {
 	});
 
 	it('render as not Linked Label', () => {
-		render(
-			<StatusLabel {...{...INITIAL_PROPS, showInstanceTracker: false}} />
-		);
+		render(<StatusLabel {...INITIAL_PROPS} showInstanceTracker={false} />);
 
 		const hasLink = document.querySelector('a');
 

--- a/modules/apps/segments/segments-simulation-web/test/js/components/PageContentSelectors.test.js
+++ b/modules/apps/segments/segments-simulation-web/test/js/components/PageContentSelectors.test.js
@@ -81,9 +81,7 @@ describe('PageContentSelectors', () => {
 	});
 
 	it('If no segments available renders empty segments message', () => {
-		render(
-			<PageContentSelectors {...{...mockProps, segmentsEntries: []}} />
-		);
+		render(<PageContentSelectors {...mockProps} segmentsEntries={[]} />);
 
 		expect(
 			screen.getByText('no-segments-have-been-added-yet')
@@ -93,11 +91,7 @@ describe('PageContentSelectors', () => {
 	it('If no experiences available renders empty experiences message', async () => {
 		jest.useFakeTimers();
 
-		render(
-			<PageContentSelectors
-				{...{...mockProps, segmentsExperiences: []}}
-			/>
-		);
+		render(<PageContentSelectors {...mockProps} segmentsEntries={[]} />);
 
 		const previewBySelector = screen.getByRole('combobox', {
 			name: /preview-by/i,

--- a/modules/apps/segments/segments-simulation-web/test/js/components/PageContentSelectors.test.js
+++ b/modules/apps/segments/segments-simulation-web/test/js/components/PageContentSelectors.test.js
@@ -91,7 +91,9 @@ describe('PageContentSelectors', () => {
 	it('If no experiences available renders empty experiences message', async () => {
 		jest.useFakeTimers();
 
-		render(<PageContentSelectors {...mockProps} segmentsEntries={[]} />);
+		render(
+			<PageContentSelectors {...mockProps} segmentsExperiences={[]} />
+		);
 
 		const previewBySelector = screen.getByRole('combobox', {
 			name: /preview-by/i,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/channels/pages/View.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/channels/pages/View.tsx
@@ -59,7 +59,9 @@ export const ViewContainer: React.FC<Omit<IViewProps, 'channel'>> = ({
 
 	return (
 		<SafeResults
-			{...{data, error, loading}}
+			data={data}
+			error={error}
+			loading={loading}
 			errorProps={{
 				href: toRoute(Routes.SETTINGS_CHANNELS, {groupId}),
 				linkLabel: Liferay.Language.get('go-to-properties'),
@@ -258,9 +260,8 @@ const View: React.FC<IViewProps> = ({
 												</p>
 											</>
 										),
-										deleteButtonLabel: Liferay.Language.get(
-											'clear-data'
-										),
+										deleteButtonLabel:
+											Liferay.Language.get('clear-data'),
 										deleteConfirmationText: sub(
 											Liferay.Language.get('clear-x'),
 											[name]
@@ -273,9 +274,10 @@ const View: React.FC<IViewProps> = ({
 													ids: [id]
 												})
 												.then(() => {
-													const clearedMessage = Liferay.Language.get(
-														'data-from-x-has-been-cleared'
-													);
+													const clearedMessage =
+														Liferay.Language.get(
+															'data-from-x-has-been-cleared'
+														);
 
 													addAlert({
 														alertType:
@@ -297,10 +299,10 @@ const View: React.FC<IViewProps> = ({
 															UNAUTHORIZED_ACCESS
 																? Liferay.Language.get(
 																		'unauthorized-access'
-																  )
+																	)
 																: Liferay.Language.get(
 																		'error'
-																  ),
+																	),
 														timeout: false
 													})
 												);
@@ -352,9 +354,8 @@ const View: React.FC<IViewProps> = ({
 												</p>
 											</>
 										),
-										deleteButtonLabel: Liferay.Language.get(
-											'delete'
-										),
+										deleteButtonLabel:
+											Liferay.Language.get('delete'),
 										deleteConfirmationText: sub(
 											Liferay.Language.get('delete-x'),
 											[name]
@@ -367,9 +368,10 @@ const View: React.FC<IViewProps> = ({
 													ids: [id]
 												})
 												.then(() => {
-													const deletedMessage = Liferay.Language.get(
-														'x-has-been-deleted'
-													);
+													const deletedMessage =
+														Liferay.Language.get(
+															'x-has-been-deleted'
+														);
 
 													close();
 
@@ -396,7 +398,8 @@ const View: React.FC<IViewProps> = ({
 														defaultChannelId === id
 													) {
 														updateDefaultChannelId({
-															defaultChannelId: null,
+															defaultChannelId:
+																null,
 															groupId
 														});
 
@@ -419,10 +422,10 @@ const View: React.FC<IViewProps> = ({
 															UNAUTHORIZED_ACCESS
 																? Liferay.Language.get(
 																		'unauthorized-access'
-																  )
+																	)
 																: Liferay.Language.get(
 																		'error'
-																  ),
+																	),
 														timeout: false
 													})
 												);

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/channels/pages/View.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/channels/pages/View.tsx
@@ -61,7 +61,6 @@ export const ViewContainer: React.FC<Omit<IViewProps, 'channel'>> = ({
 		<SafeResults
 			data={data}
 			error={error}
-			loading={loading}
 			errorProps={{
 				href: toRoute(Routes.SETTINGS_CHANNELS, {groupId}),
 				linkLabel: Liferay.Language.get('go-to-properties'),
@@ -70,6 +69,7 @@ export const ViewContainer: React.FC<Omit<IViewProps, 'channel'>> = ({
 				),
 				subtitle: Liferay.Language.get('property-not-found')
 			}}
+			loading={loading}
 			onReload={refetch}
 			pageDisplay
 			spacer
@@ -260,8 +260,9 @@ const View: React.FC<IViewProps> = ({
 												</p>
 											</>
 										),
-										deleteButtonLabel:
-											Liferay.Language.get('clear-data'),
+										deleteButtonLabel: Liferay.Language.get(
+											'clear-data'
+										),
 										deleteConfirmationText: sub(
 											Liferay.Language.get('clear-x'),
 											[name]
@@ -274,10 +275,9 @@ const View: React.FC<IViewProps> = ({
 													ids: [id]
 												})
 												.then(() => {
-													const clearedMessage =
-														Liferay.Language.get(
-															'data-from-x-has-been-cleared'
-														);
+													const clearedMessage = Liferay.Language.get(
+														'data-from-x-has-been-cleared'
+													);
 
 													addAlert({
 														alertType:
@@ -299,10 +299,10 @@ const View: React.FC<IViewProps> = ({
 															UNAUTHORIZED_ACCESS
 																? Liferay.Language.get(
 																		'unauthorized-access'
-																	)
+																  )
 																: Liferay.Language.get(
 																		'error'
-																	),
+																  ),
 														timeout: false
 													})
 												);
@@ -354,8 +354,9 @@ const View: React.FC<IViewProps> = ({
 												</p>
 											</>
 										),
-										deleteButtonLabel:
-											Liferay.Language.get('delete'),
+										deleteButtonLabel: Liferay.Language.get(
+											'delete'
+										),
 										deleteConfirmationText: sub(
 											Liferay.Language.get('delete-x'),
 											[name]
@@ -368,10 +369,9 @@ const View: React.FC<IViewProps> = ({
 													ids: [id]
 												})
 												.then(() => {
-													const deletedMessage =
-														Liferay.Language.get(
-															'x-has-been-deleted'
-														);
+													const deletedMessage = Liferay.Language.get(
+														'x-has-been-deleted'
+													);
 
 													close();
 
@@ -398,8 +398,7 @@ const View: React.FC<IViewProps> = ({
 														defaultChannelId === id
 													) {
 														updateDefaultChannelId({
-															defaultChannelId:
-																null,
+															defaultChannelId: null,
 															groupId
 														});
 
@@ -422,10 +421,10 @@ const View: React.FC<IViewProps> = ({
 															UNAUTHORIZED_ACCESS
 																? Liferay.Language.get(
 																		'unauthorized-access'
-																	)
+																  )
 																: Liferay.Language.get(
 																		'error'
-																	),
+																  ),
 														timeout: false
 													})
 												);

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/DeleteChannelModal.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/DeleteChannelModal.tsx
@@ -63,7 +63,9 @@ const DeleteChannelModal: React.FC<IDeleteChannelModalProps> = ({
 			}
 		>
 			<SafeResults
-				{...{data, error, loading}}
+				data={data}
+				error={error}
+				loading={loading}
 				page={false}
 				pageDisplay={false}
 				refetch={refetch}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hoc/CheckSegmentLink.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hoc/CheckSegmentLink.tsx
@@ -18,54 +18,54 @@ interface IWrappedComponentProps {
 	location: Location;
 }
 
-const checkSegmentLink = (
-	WrappedComponent: React.ComponentType<IWrappedComponentProps>
-) => ({groupId, history, location, ...otherProps}) => {
-	const [error, setError] = useState();
-	const [loading, setLoading] = useState(false);
+const checkSegmentLink =
+	(WrappedComponent: React.ComponentType<IWrappedComponentProps>) =>
+	({groupId, history, location, ...otherProps}) => {
+		const [error, setError] = useState();
+		const [loading, setLoading] = useState(false);
 
-	useEffect(() => {
-		const segment = matchPath<{channelId: string; id: string}>(
-			location.pathname,
-			{
-				exact: true,
-				path: Routes.CONTACTS_SEGMENT
+		useEffect(() => {
+			const segment = matchPath<{channelId: string; id: string}>(
+				location.pathname,
+				{
+					exact: true,
+					path: Routes.CONTACTS_SEGMENT
+				}
+			);
+
+			if (segment && !segment.params.channelId) {
+				setLoading(true);
+
+				API.individualSegment
+					.fetch({groupId, segmentId: segment.params.id})
+					.then(({channelId, id}) => {
+						setLoading(false);
+
+						history.replace(
+							toRoute(Routes.CONTACTS_SEGMENT, {
+								channelId,
+								groupId,
+								id
+							})
+						);
+					})
+					.catch(err => {
+						setLoading(false);
+						setError(err);
+					});
 			}
+		}, []);
+
+		return (
+			<WrapSafeResults error={error} loading={loading} page pageDisplay>
+				<WrappedComponent
+					{...otherProps}
+					groupId={groupId}
+					history={history}
+					location={location}
+				/>
+			</WrapSafeResults>
 		);
-
-		if (segment && !segment.params.channelId) {
-			setLoading(true);
-
-			API.individualSegment
-				.fetch({groupId, segmentId: segment.params.id})
-				.then(({channelId, id}) => {
-					setLoading(false);
-
-					history.replace(
-						toRoute(Routes.CONTACTS_SEGMENT, {
-							channelId,
-							groupId,
-							id
-						})
-					);
-				})
-				.catch(err => {
-					setLoading(false);
-					setError(err);
-				});
-		}
-	}, []);
-
-	return (
-		<WrapSafeResults {...{error, loading}} page pageDisplay>
-			<WrappedComponent
-				{...otherProps}
-				groupId={groupId}
-				history={history}
-				location={location}
-			/>
-		</WrapSafeResults>
-	);
-};
+	};
 
 export default checkSegmentLink;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hoc/CheckSegmentLink.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hoc/CheckSegmentLink.tsx
@@ -18,54 +18,54 @@ interface IWrappedComponentProps {
 	location: Location;
 }
 
-const checkSegmentLink =
-	(WrappedComponent: React.ComponentType<IWrappedComponentProps>) =>
-	({groupId, history, location, ...otherProps}) => {
-		const [error, setError] = useState();
-		const [loading, setLoading] = useState(false);
+const checkSegmentLink = (
+	WrappedComponent: React.ComponentType<IWrappedComponentProps>
+) => ({groupId, history, location, ...otherProps}) => {
+	const [error, setError] = useState();
+	const [loading, setLoading] = useState(false);
 
-		useEffect(() => {
-			const segment = matchPath<{channelId: string; id: string}>(
-				location.pathname,
-				{
-					exact: true,
-					path: Routes.CONTACTS_SEGMENT
-				}
-			);
-
-			if (segment && !segment.params.channelId) {
-				setLoading(true);
-
-				API.individualSegment
-					.fetch({groupId, segmentId: segment.params.id})
-					.then(({channelId, id}) => {
-						setLoading(false);
-
-						history.replace(
-							toRoute(Routes.CONTACTS_SEGMENT, {
-								channelId,
-								groupId,
-								id
-							})
-						);
-					})
-					.catch(err => {
-						setLoading(false);
-						setError(err);
-					});
+	useEffect(() => {
+		const segment = matchPath<{channelId: string; id: string}>(
+			location.pathname,
+			{
+				exact: true,
+				path: Routes.CONTACTS_SEGMENT
 			}
-		}, []);
-
-		return (
-			<WrapSafeResults error={error} loading={loading} page pageDisplay>
-				<WrappedComponent
-					{...otherProps}
-					groupId={groupId}
-					history={history}
-					location={location}
-				/>
-			</WrapSafeResults>
 		);
-	};
+
+		if (segment && !segment.params.channelId) {
+			setLoading(true);
+
+			API.individualSegment
+				.fetch({groupId, segmentId: segment.params.id})
+				.then(({channelId, id}) => {
+					setLoading(false);
+
+					history.replace(
+						toRoute(Routes.CONTACTS_SEGMENT, {
+							channelId,
+							groupId,
+							id
+						})
+					);
+				})
+				.catch(err => {
+					setLoading(false);
+					setError(err);
+				});
+		}
+	}, []);
+
+	return (
+		<WrapSafeResults error={error} loading={loading} page pageDisplay>
+			<WrappedComponent
+				{...otherProps}
+				groupId={groupId}
+				history={history}
+				location={location}
+			/>
+		</WrapSafeResults>
+	);
+};
 
 export default checkSegmentLink;

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/test/components/performance-by-assignee-page/PerformanceByAssigneePageBody.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/test/components/performance-by-assignee-page/PerformanceByAssigneePageBody.es.js
@@ -45,9 +45,10 @@ describe('The performance by assignee page body should', () => {
 	beforeEach(async () => {
 		const renderResult = render(
 			<PerformanceByAssigneePage.Body
-				{...{items, totalCount: items.length}}
+				items={items}
 				page="1"
 				pageSize="5"
+				totalCount={items.length}
 			/>,
 			{wrapper}
 		);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/test/components/performance-by-step-page/PerformanceByStepPageBody.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/test/components/performance-by-step-page/PerformanceByStepPageBody.es.js
@@ -46,8 +46,9 @@ describe('The performance by step page body should', () => {
 	beforeEach(async () => {
 		const renderResult = render(
 			<PerformanceByStepPage.Body
-				{...{items, totalCount: items.length}}
 				filtered={false}
+				items={items}
+				totalCount={items.length}
 			/>,
 			{wrapper}
 		);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/test/components/process-list-page/ProcessListPageBody.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/test/components/process-list-page/ProcessListPageBody.es.js
@@ -40,9 +40,10 @@ describe('The performance by assignee page body should', () => {
 		const renderResult = render(
 			<MockRouter>
 				<ProcessListPage.Body
-					{...{items, totalCount: items.length}}
+					items={items}
 					page="1"
 					pageSize="5"
+					totalCount={items.length}
 				/>
 			</MockRouter>
 		);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/test/components/process-metrics/performance-by-step-card/PerformanceByStepCardBody.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/test/components/process-metrics/performance-by-step-card/PerformanceByStepCardBody.es.js
@@ -56,8 +56,9 @@ describe('The performance by step body component should', () => {
 		);
 		const renderResult = render(
 			<PerformanceByStepCard.Body
-				{...{items, totalCount: items.length}}
+				items={items}
 				processId={123456}
+				totalCount={items.length}
 			/>,
 			{wrapper}
 		);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/test/components/process-metrics/workload-by-assignee-card/WorkloadByAssigneeCardBody.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/test/components/process-metrics/workload-by-assignee-card/WorkloadByAssigneeCardBody.es.js
@@ -88,9 +88,10 @@ describe('The workload by assignee body should', () => {
 			const renderResult = render(
 				<WorkloadByAssigneeCard.Body
 					currentTab="total"
-					{...{items: [items[0]], totalCount: 1}}
+					items={[items[0]]}
 					processId={12345}
 					processStepKey="review"
+					totalCount={1}
 				/>,
 				{wrapper}
 			);
@@ -122,9 +123,10 @@ describe('The workload by assignee body should', () => {
 			const renderResult = render(
 				<WorkloadByAssigneeCard.Body
 					currentTab="onTime"
-					{...{items: [items[1]], totalCount: 1}}
+					items={[items[1]]}
 					processId={12345}
 					processStepKey="update"
+					totalCount={1}
 				/>,
 				{wrapper}
 			);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/test/components/workload-by-assignee-page/WorkloadByAssigneePageBody.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/test/components/workload-by-assignee-page/WorkloadByAssigneePageBody.es.js
@@ -42,9 +42,10 @@ describe('The workload by assignee page body should', () => {
 	beforeEach(async () => {
 		const renderResult = render(
 			<WorkloadByAssigneePage.Body
-				{...{items, totalCount: items.length}}
+				items={items}
 				page="1"
 				pageSize="5"
+				totalCount={items.length}
 			/>,
 			{wrapper}
 		);

--- a/modules/test/playwright/tests/frontend-js-item-selector-web/main/pages/ItemSelectorSamplePage.ts
+++ b/modules/test/playwright/tests/frontend-js-item-selector-web/main/pages/ItemSelectorSamplePage.ts
@@ -69,11 +69,11 @@ export class ItemSelectorSamplePage {
 		});
 		this.selectCMSFileButton = page.getByRole('button', {
 			exact: true,
-			name: 'Select CMS File',
+			name: 'Select CMS Files',
 		});
 		this.selectCMSFileModalHeader = page.getByRole('heading', {
 			exact: true,
-			name: 'Select File',
+			name: 'Select Files',
 		});
 		this.selectDocumentButton = page.getByRole('button', {
 			exact: true,

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/components/MultiSelect/MultiSelect.tsx
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/components/MultiSelect/MultiSelect.tsx
@@ -54,12 +54,12 @@ const MultiSelect: React.FC<MultiSelectProps<any>> = ({
 			tooltip={tooltip}
 		>
 			<ClayMultiSelect
-				{...{placeholder}}
 				inputName={inputName}
 				items={selectedItems}
 				key={multiselectKey}
 				onChange={onChange}
 				onItemsChange={onItemsChange}
+				placeholder={placeholder}
 				sourceItems={sourceItems}
 				spritemap={getIconSpriteMap()}
 				value={value}

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/Apps/App/App.tsx
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/Apps/App/App.tsx
@@ -42,8 +42,8 @@ const getPriceList = (
 			<table className="qa-table">
 				<thead>
 					<tr>
-						<th {...{width: '40%'}}>{i18n.translate('type')}</th>
-						<th {...{width: '30%'}}>{i18n.translate('qty')}</th>
+						<th width="40%">{i18n.translate('type')}</th>
+						<th width="30%">{i18n.translate('qty')}</th>
 						<th>{i18n.translate('total')}</th>
 					</tr>
 				</thead>

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/PublisherDashboard/pages/Solutions/SolutionForm/pages/Profile.tsx
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/PublisherDashboard/pages/Solutions/SolutionForm/pages/Profile.tsx
@@ -193,7 +193,6 @@ const Profile = () => {
 					</Form.Label>
 
 					<ClayMultiSelect
-						{...{placeholder: 'Select categories'}}
 						inputName="description-selector"
 						items={categories}
 						key={`cat-${categories.length}`}
@@ -210,6 +209,7 @@ const Profile = () => {
 								target: {name: 'categories', value},
 							})
 						}
+						placeholder="Select categories"
 						sourceItems={getFilteredItems(
 							categories,
 							defaultSourceItems?.categories
@@ -230,7 +230,6 @@ const Profile = () => {
 					</Form.Label>
 
 					<ClayMultiSelect
-						{...{placeholder: 'Select tags'}}
 						inputName="tags-selector"
 						items={tags}
 						key={`tags-${tags.length}`}
@@ -247,6 +246,7 @@ const Profile = () => {
 								target: {name: 'tags', value},
 							})
 						}
+						placeholder="Select tags"
 						sourceItems={getFilteredItems(
 							tags,
 							defaultSourceItems?.tags


### PR DESCRIPTION
manual forward from https://github.com/liferay-platform-experience/liferay-portal/pull/1483

failures in original PR are unrelated

---------------------

https://liferay.atlassian.net/browse/LPD-46127

This adds the folder navigation needed for when going into sub-folders both for table view and cards view. This PR is specifically aimed at the breadcrumbs and folder navigation.

Note that the cards UI looks a bit odd with folders being larger than the other cards, this should probably be addressed in a separate ticket. Additionally, the selection portion isn't refined either as this should wait for the multi-select PR and also might fall under another ticket as this was specifically aimed at breadcrumbs and navigation.
