### PR TITLE
LPD-65008 Space Name Not Clickable and Styled Incorrectly

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllSpacesDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllSpacesDisplayContext.java
@@ -69,6 +69,8 @@ public class ViewAllSpacesDisplayContext {
 
 	public Map<String, Object> getAdditionalProps() {
 		return HashMapBuilder.<String, Object>put(
+			"baseSpaceURL", ActionUtil.getBaseSpaceURL(_themeDisplay)
+		).put(
 			"defaultPermissionAdditionalProps",
 			_getDefaultPermissionAdditionalProps()
 		).put(

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/SpaceSticker.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/SpaceSticker.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayLink from '@clayui/link';
 import ClaySticker from '@clayui/sticker';
 import cx from 'classnames';
 import React from 'react';
@@ -31,11 +32,13 @@ function getDisplayType(char: string): LogoColor {
 export default function SpaceSticker({
 	displayType,
 	hideName,
+	href,
 	name,
 	size,
 	...otherProps
 }: {
 	hideName?: boolean;
+	href?: string;
 	name: string;
 } & Pick<
 	React.ComponentProps<typeof ClaySticker>,
@@ -54,7 +57,12 @@ export default function SpaceSticker({
 				{name.charAt(0).toUpperCase()}
 			</ClaySticker>
 
-			{!hideName && <span>{name}</span>}
+			{!hideName &&
+				(href ? (
+					<ClayLink href={href}>{name}</ClayLink>
+				) : (
+					<span>{name}</span>
+				))}
 		</div>
 	);
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AllSpacesFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AllSpacesFDSPropsTransformer.ts
@@ -41,7 +41,13 @@ export default function AllSpacesFDSPropsTransformer({
 		customRenderers: {
 			tableCell: [
 				{
-					component: SpaceRenderer,
+					component: ({itemData, value}) =>
+						SpaceRenderer({
+							href: additionalProps.baseSpaceURL + itemData.id,
+							itemData,
+							size: 'sm',
+							value,
+						}),
 					name: 'spaceTableCellRenderer',
 					type: 'internal',
 				} as IInternalRenderer,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/SpaceRenderer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/SpaceRenderer.tsx
@@ -3,17 +3,39 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {IClayStickerProps} from '@clayui/sticker';
+import classNames from 'classnames';
 import React from 'react';
 
 import SpaceSticker from '../../../common/components/SpaceSticker';
 
-const SpaceRenderer = ({itemData, value}: {itemData: any; value: string}) => {
+const SpaceRenderer = ({
+	href,
+	itemData,
+	size,
+	value,
+}: {
+	href?: string;
+	itemData: {
+		settings?: {logoColor: IClayStickerProps['displayType']};
+	};
+	size?: IClayStickerProps['size'];
+	value: string;
+}) => {
 	return (
-		<span className="align-items-center d-flex space-renderer-sticker">
+		<span
+			className={classNames(
+				'align-items-center',
+				'd-flex',
+				'space-renderer-sticker',
+				{'list-group-title': !!href}
+			)}
+		>
 			<SpaceSticker
 				displayType={itemData.settings?.logoColor}
+				href={href}
 				name={value}
-				size="xs"
+				size={size || 'xs'}
 			/>
 		</span>
 	);

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/cell_renderers/SpaceRenderer.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/cell_renderers/SpaceRenderer.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom/extend-expect';
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+
+import SpaceRenderer from '../../../../../src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/SpaceRenderer';
+
+describe('SpaceRenderer', () => {
+	it('renders the default space', () => {
+		const {container} = render(
+			<SpaceRenderer
+				itemData={{settings: {logoColor: 'outline-0'}}}
+				value="Test Space"
+			/>
+		);
+
+		expect(screen.getByText('Test Space')).toBeInTheDocument();
+		expect(screen.queryByRole('link')).toBeNull();
+		expect(container.querySelectorAll('.sticker')[0]).toHaveClass(
+			...['sticker-outline-0', 'sticker-xs']
+		);
+	});
+
+	it('renders the correct size prop', () => {
+		const {container} = render(
+			<SpaceRenderer
+				itemData={{settings: {logoColor: 'outline-0'}}}
+				size="sm"
+				value="Test Space"
+			/>
+		);
+
+		expect(container.querySelectorAll('.sticker')[0]).toHaveClass(
+			'sticker-sm'
+		);
+	});
+
+	it('renders the space link correctly', () => {
+		render(
+			<SpaceRenderer
+				href="http://www.test.com/space"
+				itemData={{settings: {logoColor: 'outline-0'}}}
+				size="sm"
+				value="Test Space"
+			/>
+		);
+
+		expect(screen.getByRole('link')).toHaveAttribute(
+			'href',
+			'http://www.test.com/space'
+		);
+	});
+});


### PR DESCRIPTION
Forwarded manually from https://github.com/liferay-content-management/liferay-portal/pull/7148
Test failures do not look related.

### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-65008 - Space Name Not Clickable and Styled Incorrectly

### How am I fixing it?
These changes add the expected styling for the space name in the "All Spaces" section, as well as making it clickable to the proper space. It should not affect any other uses of the SpaceRenderer (size and href are optional props!).

### How can you verify that it works?
Deploy and view the "All Spaces" section. Also a unit test was added to assert the link and sticker size.

<img width="800" alt="Screenshot 2025-09-19 at 12 53 09 PM" src="https://github.com/user-attachments/assets/a24a839d-d1de-4d59-b4c8-c750ff45bb1d" />

Hopefully should be straightforward, let me know if there's any changes to make!