### PR TITLE
LPD-58909 Apply 'generatePermissions' to headless-admin-site to make them accessible through batch

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/bnd.bnd
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Admin Site API
 Bundle-SymbolicName: com.liferay.headless.admin.site.api
-Bundle-Version: 13.0.1
+Bundle-Version: 13.1.0
 Export-Package:\
 	com.liferay.headless.admin.site.dto.v1_0,\
 	com.liferay.headless.admin.site.resource.v1_0

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/ContentPageTemplate.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/ContentPageTemplate.java
@@ -275,6 +275,29 @@ public class ContentPageTemplate extends PageTemplate implements Serializable {
 			sb.append(String.valueOf(pageTemplateSettings));
 		}
 
+		com.liferay.portal.vulcan.permission.Permission[] permissions =
+			getPermissions();
+
+		if (permissions != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"permissions\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < permissions.length; i++) {
+				sb.append(permissions[i]);
+
+				if ((i + 1) < permissions.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
 		ItemExternalReference[] taxonomyCategoryItemExternalReferences =
 			getTaxonomyCategoryItemExternalReferences();
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/DisplayPageTemplate.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/DisplayPageTemplate.java
@@ -744,6 +744,53 @@ public class DisplayPageTemplate implements Serializable {
 	@JsonIgnore
 	private Supplier<DisplayPageTemplateFolder> _parentFolderSupplier;
 
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public com.liferay.portal.vulcan.permission.Permission[] getPermissions() {
+		if (_permissionsSupplier != null) {
+			permissions = _permissionsSupplier.get();
+
+			_permissionsSupplier = null;
+		}
+
+		return permissions;
+	}
+
+	public void setPermissions(
+		com.liferay.portal.vulcan.permission.Permission[] permissions) {
+
+		this.permissions = permissions;
+
+		_permissionsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setPermissions(
+		UnsafeSupplier
+			<com.liferay.portal.vulcan.permission.Permission[], Exception>
+				permissionsUnsafeSupplier) {
+
+		_permissionsSupplier = () -> {
+			try {
+				return permissionsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected com.liferay.portal.vulcan.permission.Permission[] permissions;
+
+	@JsonIgnore
+	private Supplier<com.liferay.portal.vulcan.permission.Permission[]>
+		_permissionsSupplier;
+
 	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "The display page template's thumbnail."
 	)
@@ -1079,6 +1126,29 @@ public class DisplayPageTemplate implements Serializable {
 			sb.append("\"parentFolder\": ");
 
 			sb.append(String.valueOf(parentFolder));
+		}
+
+		com.liferay.portal.vulcan.permission.Permission[] permissions =
+			getPermissions();
+
+		if (permissions != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"permissions\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < permissions.length; i++) {
+				sb.append(permissions[i]);
+
+				if ((i + 1) < permissions.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
 		}
 
 		ItemExternalReference thumbnail = getThumbnail();

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/DisplayPageTemplateFolder.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/DisplayPageTemplateFolder.java
@@ -520,6 +520,53 @@ public class DisplayPageTemplateFolder implements Serializable {
 	private Supplier<String>
 		_parentDisplayPageTemplateFolderExternalReferenceCodeSupplier;
 
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public com.liferay.portal.vulcan.permission.Permission[] getPermissions() {
+		if (_permissionsSupplier != null) {
+			permissions = _permissionsSupplier.get();
+
+			_permissionsSupplier = null;
+		}
+
+		return permissions;
+	}
+
+	public void setPermissions(
+		com.liferay.portal.vulcan.permission.Permission[] permissions) {
+
+		this.permissions = permissions;
+
+		_permissionsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setPermissions(
+		UnsafeSupplier
+			<com.liferay.portal.vulcan.permission.Permission[], Exception>
+				permissionsUnsafeSupplier) {
+
+		_permissionsSupplier = () -> {
+			try {
+				return permissionsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected com.liferay.portal.vulcan.permission.Permission[] permissions;
+
+	@JsonIgnore
+	private Supplier<com.liferay.portal.vulcan.permission.Permission[]>
+		_permissionsSupplier;
+
 	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "A valid external identifier to reference this page template folder."
 	)
@@ -748,6 +795,29 @@ public class DisplayPageTemplateFolder implements Serializable {
 				_escape(parentDisplayPageTemplateFolderExternalReferenceCode));
 
 			sb.append("\"");
+		}
+
+		com.liferay.portal.vulcan.permission.Permission[] permissions =
+			getPermissions();
+
+		if (permissions != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"permissions\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < permissions.length; i++) {
+				sb.append(permissions[i]);
+
+				if ((i + 1) < permissions.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
 		}
 
 		String uuid = getUuid();

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/MasterPage.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/MasterPage.java
@@ -544,6 +544,53 @@ public class MasterPage implements Serializable {
 	@JsonIgnore
 	private Supplier<PageSpecification[]> _pageSpecificationsSupplier;
 
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public com.liferay.portal.vulcan.permission.Permission[] getPermissions() {
+		if (_permissionsSupplier != null) {
+			permissions = _permissionsSupplier.get();
+
+			_permissionsSupplier = null;
+		}
+
+		return permissions;
+	}
+
+	public void setPermissions(
+		com.liferay.portal.vulcan.permission.Permission[] permissions) {
+
+		this.permissions = permissions;
+
+		_permissionsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setPermissions(
+		UnsafeSupplier
+			<com.liferay.portal.vulcan.permission.Permission[], Exception>
+				permissionsUnsafeSupplier) {
+
+		_permissionsSupplier = () -> {
+			try {
+				return permissionsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected com.liferay.portal.vulcan.permission.Permission[] permissions;
+
+	@JsonIgnore
+	private Supplier<com.liferay.portal.vulcan.permission.Permission[]>
+		_permissionsSupplier;
+
 	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "The external references to the associated categories."
 	)
@@ -892,6 +939,29 @@ public class MasterPage implements Serializable {
 				sb.append(String.valueOf(pageSpecifications[i]));
 
 				if ((i + 1) < pageSpecifications.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		com.liferay.portal.vulcan.permission.Permission[] permissions =
+			getPermissions();
+
+		if (permissions != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"permissions\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < permissions.length; i++) {
+				sb.append(permissions[i]);
+
+				if ((i + 1) < permissions.length) {
 					sb.append(", ");
 				}
 			}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageTemplate.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageTemplate.java
@@ -605,6 +605,53 @@ public abstract class PageTemplate implements Serializable {
 	@JsonIgnore
 	private Supplier<PageTemplateSettings> _pageTemplateSettingsSupplier;
 
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public com.liferay.portal.vulcan.permission.Permission[] getPermissions() {
+		if (_permissionsSupplier != null) {
+			permissions = _permissionsSupplier.get();
+
+			_permissionsSupplier = null;
+		}
+
+		return permissions;
+	}
+
+	public void setPermissions(
+		com.liferay.portal.vulcan.permission.Permission[] permissions) {
+
+		this.permissions = permissions;
+
+		_permissionsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setPermissions(
+		UnsafeSupplier
+			<com.liferay.portal.vulcan.permission.Permission[], Exception>
+				permissionsUnsafeSupplier) {
+
+		_permissionsSupplier = () -> {
+			try {
+				return permissionsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected com.liferay.portal.vulcan.permission.Permission[] permissions;
+
+	@JsonIgnore
+	private Supplier<com.liferay.portal.vulcan.permission.Permission[]>
+		_permissionsSupplier;
+
 	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "The external references to the associated categories."
 	)
@@ -979,6 +1026,29 @@ public abstract class PageTemplate implements Serializable {
 			sb.append("\"pageTemplateSettings\": ");
 
 			sb.append(String.valueOf(pageTemplateSettings));
+		}
+
+		com.liferay.portal.vulcan.permission.Permission[] permissions =
+			getPermissions();
+
+		if (permissions != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"permissions\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < permissions.length; i++) {
+				sb.append(permissions[i]);
+
+				if ((i + 1) < permissions.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
 		}
 
 		ItemExternalReference[] taxonomyCategoryItemExternalReferences =

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageTemplateSet.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageTemplateSet.java
@@ -404,6 +404,53 @@ public class PageTemplateSet implements Serializable {
 	@JsonIgnore
 	private Supplier<String> _nameSupplier;
 
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public com.liferay.portal.vulcan.permission.Permission[] getPermissions() {
+		if (_permissionsSupplier != null) {
+			permissions = _permissionsSupplier.get();
+
+			_permissionsSupplier = null;
+		}
+
+		return permissions;
+	}
+
+	public void setPermissions(
+		com.liferay.portal.vulcan.permission.Permission[] permissions) {
+
+		this.permissions = permissions;
+
+		_permissionsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setPermissions(
+		UnsafeSupplier
+			<com.liferay.portal.vulcan.permission.Permission[], Exception>
+				permissionsUnsafeSupplier) {
+
+		_permissionsSupplier = () -> {
+			try {
+				return permissionsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected com.liferay.portal.vulcan.permission.Permission[] permissions;
+
+	@JsonIgnore
+	private Supplier<com.liferay.portal.vulcan.permission.Permission[]>
+		_permissionsSupplier;
+
 	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "A valid external identifier to reference this page template set."
 	)
@@ -599,6 +646,29 @@ public class PageTemplateSet implements Serializable {
 			sb.append(_escape(name));
 
 			sb.append("\"");
+		}
+
+		com.liferay.portal.vulcan.permission.Permission[] permissions =
+			getPermissions();
+
+		if (permissions != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"permissions\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < permissions.length; i++) {
+				sb.append(permissions[i]);
+
+				if ((i + 1) < permissions.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
 		}
 
 		String uuid = getUuid();

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/SitePage.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/SitePage.java
@@ -698,6 +698,53 @@ public class SitePage implements Serializable {
 	@JsonIgnore
 	private Supplier<String> _parentSitePageExternalReferenceCodeSupplier;
 
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public com.liferay.portal.vulcan.permission.Permission[] getPermissions() {
+		if (_permissionsSupplier != null) {
+			permissions = _permissionsSupplier.get();
+
+			_permissionsSupplier = null;
+		}
+
+		return permissions;
+	}
+
+	public void setPermissions(
+		com.liferay.portal.vulcan.permission.Permission[] permissions) {
+
+		this.permissions = permissions;
+
+		_permissionsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setPermissions(
+		UnsafeSupplier
+			<com.liferay.portal.vulcan.permission.Permission[], Exception>
+				permissionsUnsafeSupplier) {
+
+		_permissionsSupplier = () -> {
+			try {
+				return permissionsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected com.liferay.portal.vulcan.permission.Permission[] permissions;
+
+	@JsonIgnore
+	private Supplier<com.liferay.portal.vulcan.permission.Permission[]>
+		_permissionsSupplier;
+
 	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "The external references to the associated categories."
 	)
@@ -1163,6 +1210,29 @@ public class SitePage implements Serializable {
 			sb.append(_escape(parentSitePageExternalReferenceCode));
 
 			sb.append("\"");
+		}
+
+		com.liferay.portal.vulcan.permission.Permission[] permissions =
+			getPermissions();
+
+		if (permissions != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"permissions\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < permissions.length; i++) {
+				sb.append(permissions[i]);
+
+				if ((i + 1) < permissions.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
 		}
 
 		ItemExternalReference[] taxonomyCategoryItemExternalReferences =

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/UtilityPage.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/UtilityPage.java
@@ -554,6 +554,53 @@ public class UtilityPage implements Serializable {
 	@JsonIgnore
 	private Supplier<PageSpecification[]> _pageSpecificationsSupplier;
 
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public com.liferay.portal.vulcan.permission.Permission[] getPermissions() {
+		if (_permissionsSupplier != null) {
+			permissions = _permissionsSupplier.get();
+
+			_permissionsSupplier = null;
+		}
+
+		return permissions;
+	}
+
+	public void setPermissions(
+		com.liferay.portal.vulcan.permission.Permission[] permissions) {
+
+		this.permissions = permissions;
+
+		_permissionsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setPermissions(
+		UnsafeSupplier
+			<com.liferay.portal.vulcan.permission.Permission[], Exception>
+				permissionsUnsafeSupplier) {
+
+		_permissionsSupplier = () -> {
+			try {
+				return permissionsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected com.liferay.portal.vulcan.permission.Permission[] permissions;
+
+	@JsonIgnore
+	private Supplier<com.liferay.portal.vulcan.permission.Permission[]>
+		_permissionsSupplier;
+
 	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "The utility page's thumbnail."
 	)
@@ -932,6 +979,29 @@ public class UtilityPage implements Serializable {
 				sb.append(String.valueOf(pageSpecifications[i]));
 
 				if ((i + 1) < pageSpecifications.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		com.liferay.portal.vulcan.permission.Permission[] permissions =
+			getPermissions();
+
+		if (permissions != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"permissions\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < permissions.length; i++) {
+				sb.append(permissions[i]);
+
+				if ((i + 1) < permissions.length) {
 					sb.append(", ");
 				}
 			}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/WidgetPageTemplate.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/WidgetPageTemplate.java
@@ -574,6 +574,29 @@ public class WidgetPageTemplate extends PageTemplate implements Serializable {
 			sb.append(String.valueOf(pageTemplateSettings));
 		}
 
+		com.liferay.portal.vulcan.permission.Permission[] permissions =
+			getPermissions();
+
+		if (permissions != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"permissions\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < permissions.length; i++) {
+				sb.append(permissions[i]);
+
+				if ((i + 1) < permissions.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
 		ItemExternalReference[] taxonomyCategoryItemExternalReferences =
 			getTaxonomyCategoryItemExternalReferences();
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/resources/com/liferay/headless/admin/site/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/resources/com/liferay/headless/admin/site/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 13.0.0
+version 13.1.0

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/DisplayPageTemplate.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/DisplayPageTemplate.java
@@ -355,6 +355,35 @@ public class DisplayPageTemplate implements Cloneable, Serializable {
 
 	protected DisplayPageTemplateFolder parentFolder;
 
+	public com.liferay.headless.admin.site.client.permission.Permission[]
+		getPermissions() {
+
+		return permissions;
+	}
+
+	public void setPermissions(
+		com.liferay.headless.admin.site.client.permission.Permission[]
+			permissions) {
+
+		this.permissions = permissions;
+	}
+
+	public void setPermissions(
+		UnsafeSupplier
+			<com.liferay.headless.admin.site.client.permission.Permission[],
+			 Exception> permissionsUnsafeSupplier) {
+
+		try {
+			permissions = permissionsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected com.liferay.headless.admin.site.client.permission.Permission[]
+		permissions;
+
 	public ItemExternalReference getThumbnail() {
 		return thumbnail;
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/DisplayPageTemplateFolder.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/DisplayPageTemplateFolder.java
@@ -246,6 +246,35 @@ public class DisplayPageTemplateFolder implements Cloneable, Serializable {
 
 	protected String parentDisplayPageTemplateFolderExternalReferenceCode;
 
+	public com.liferay.headless.admin.site.client.permission.Permission[]
+		getPermissions() {
+
+		return permissions;
+	}
+
+	public void setPermissions(
+		com.liferay.headless.admin.site.client.permission.Permission[]
+			permissions) {
+
+		this.permissions = permissions;
+	}
+
+	public void setPermissions(
+		UnsafeSupplier
+			<com.liferay.headless.admin.site.client.permission.Permission[],
+			 Exception> permissionsUnsafeSupplier) {
+
+		try {
+			permissions = permissionsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected com.liferay.headless.admin.site.client.permission.Permission[]
+		permissions;
+
 	public String getUuid() {
 		return uuid;
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/MasterPage.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/MasterPage.java
@@ -258,6 +258,35 @@ public class MasterPage implements Cloneable, Serializable {
 
 	protected PageSpecification[] pageSpecifications;
 
+	public com.liferay.headless.admin.site.client.permission.Permission[]
+		getPermissions() {
+
+		return permissions;
+	}
+
+	public void setPermissions(
+		com.liferay.headless.admin.site.client.permission.Permission[]
+			permissions) {
+
+		this.permissions = permissions;
+	}
+
+	public void setPermissions(
+		UnsafeSupplier
+			<com.liferay.headless.admin.site.client.permission.Permission[],
+			 Exception> permissionsUnsafeSupplier) {
+
+		try {
+			permissions = permissionsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected com.liferay.headless.admin.site.client.permission.Permission[]
+		permissions;
+
 	public ItemExternalReference[] getTaxonomyCategoryItemExternalReferences() {
 		return taxonomyCategoryItemExternalReferences;
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageTemplate.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageTemplate.java
@@ -283,6 +283,35 @@ public abstract class PageTemplate implements Cloneable, Serializable {
 
 	protected PageTemplateSettings pageTemplateSettings;
 
+	public com.liferay.headless.admin.site.client.permission.Permission[]
+		getPermissions() {
+
+		return permissions;
+	}
+
+	public void setPermissions(
+		com.liferay.headless.admin.site.client.permission.Permission[]
+			permissions) {
+
+		this.permissions = permissions;
+	}
+
+	public void setPermissions(
+		UnsafeSupplier
+			<com.liferay.headless.admin.site.client.permission.Permission[],
+			 Exception> permissionsUnsafeSupplier) {
+
+		try {
+			permissions = permissionsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected com.liferay.headless.admin.site.client.permission.Permission[]
+		permissions;
+
 	public ItemExternalReference[] getTaxonomyCategoryItemExternalReferences() {
 		return taxonomyCategoryItemExternalReferences;
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageTemplateSet.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageTemplateSet.java
@@ -194,6 +194,35 @@ public class PageTemplateSet implements Cloneable, Serializable {
 
 	protected String name;
 
+	public com.liferay.headless.admin.site.client.permission.Permission[]
+		getPermissions() {
+
+		return permissions;
+	}
+
+	public void setPermissions(
+		com.liferay.headless.admin.site.client.permission.Permission[]
+			permissions) {
+
+		this.permissions = permissions;
+	}
+
+	public void setPermissions(
+		UnsafeSupplier
+			<com.liferay.headless.admin.site.client.permission.Permission[],
+			 Exception> permissionsUnsafeSupplier) {
+
+		try {
+			permissions = permissionsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected com.liferay.headless.admin.site.client.permission.Permission[]
+		permissions;
+
 	public String getUuid() {
 		return uuid;
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/SitePage.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/SitePage.java
@@ -336,6 +336,35 @@ public class SitePage implements Cloneable, Serializable {
 
 	protected String parentSitePageExternalReferenceCode;
 
+	public com.liferay.headless.admin.site.client.permission.Permission[]
+		getPermissions() {
+
+		return permissions;
+	}
+
+	public void setPermissions(
+		com.liferay.headless.admin.site.client.permission.Permission[]
+			permissions) {
+
+		this.permissions = permissions;
+	}
+
+	public void setPermissions(
+		UnsafeSupplier
+			<com.liferay.headless.admin.site.client.permission.Permission[],
+			 Exception> permissionsUnsafeSupplier) {
+
+		try {
+			permissions = permissionsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected com.liferay.headless.admin.site.client.permission.Permission[]
+		permissions;
+
 	public ItemExternalReference[] getTaxonomyCategoryItemExternalReferences() {
 		return taxonomyCategoryItemExternalReferences;
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/UtilityPage.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/UtilityPage.java
@@ -265,6 +265,35 @@ public class UtilityPage implements Cloneable, Serializable {
 
 	protected PageSpecification[] pageSpecifications;
 
+	public com.liferay.headless.admin.site.client.permission.Permission[]
+		getPermissions() {
+
+		return permissions;
+	}
+
+	public void setPermissions(
+		com.liferay.headless.admin.site.client.permission.Permission[]
+			permissions) {
+
+		this.permissions = permissions;
+	}
+
+	public void setPermissions(
+		UnsafeSupplier
+			<com.liferay.headless.admin.site.client.permission.Permission[],
+			 Exception> permissionsUnsafeSupplier) {
+
+		try {
+			permissions = permissionsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected com.liferay.headless.admin.site.client.permission.Permission[]
+		permissions;
+
 	public ItemExternalReference getThumbnail() {
 		return thumbnail;
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/ContentPageTemplateSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/ContentPageTemplateSerDes.java
@@ -236,6 +236,28 @@ public class ContentPageTemplateSerDes {
 				String.valueOf(contentPageTemplate.getPageTemplateSettings()));
 		}
 
+		if (contentPageTemplate.getPermissions() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"permissions\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < contentPageTemplate.getPermissions().length;
+				 i++) {
+
+				sb.append(contentPageTemplate.getPermissions()[i]);
+
+				if ((i + 1) < contentPageTemplate.getPermissions().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
 		if (contentPageTemplate.getTaxonomyCategoryItemExternalReferences() !=
 				null) {
 
@@ -425,6 +447,15 @@ public class ContentPageTemplateSerDes {
 				String.valueOf(contentPageTemplate.getPageTemplateSettings()));
 		}
 
+		if (contentPageTemplate.getPermissions() == null) {
+			map.put("permissions", null);
+		}
+		else {
+			map.put(
+				"permissions",
+				String.valueOf(contentPageTemplate.getPermissions()));
+		}
+
 		if (contentPageTemplate.getTaxonomyCategoryItemExternalReferences() ==
 				null) {
 
@@ -512,6 +543,9 @@ public class ContentPageTemplateSerDes {
 			else if (Objects.equals(
 						jsonParserFieldName, "pageTemplateSettings")) {
 
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "permissions")) {
 				return false;
 			}
 			else if (Objects.equals(
@@ -625,6 +659,26 @@ public class ContentPageTemplateSerDes {
 					contentPageTemplate.setPageTemplateSettings(
 						PageTemplateSettingsSerDes.toDTO(
 							(String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "permissions")) {
+				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					com.liferay.headless.admin.site.client.permission.
+						Permission[] permissionsArray = new
+						com.liferay.headless.admin.site.client.permission.
+							Permission[jsonParserFieldValues.length];
+
+					for (int i = 0; i < permissionsArray.length; i++) {
+						permissionsArray[i] =
+							com.liferay.headless.admin.site.client.permission.
+								Permission.toDTO(
+									(String)jsonParserFieldValues[i]);
+					}
+
+					contentPageTemplate.setPermissions(permissionsArray);
 				}
 			}
 			else if (Objects.equals(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/DisplayPageTemplateFolderSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/DisplayPageTemplateFolderSerDes.java
@@ -210,6 +210,30 @@ public class DisplayPageTemplateFolderSerDes {
 			sb.append("\"");
 		}
 
+		if (displayPageTemplateFolder.getPermissions() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"permissions\": ");
+
+			sb.append("[");
+
+			for (int i = 0;
+				 i < displayPageTemplateFolder.getPermissions().length; i++) {
+
+				sb.append(displayPageTemplateFolder.getPermissions()[i]);
+
+				if ((i + 1) <
+						displayPageTemplateFolder.getPermissions().length) {
+
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
 		if (displayPageTemplateFolder.getUuid() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -353,6 +377,15 @@ public class DisplayPageTemplateFolderSerDes {
 						getParentDisplayPageTemplateFolderExternalReferenceCode()));
 		}
 
+		if (displayPageTemplateFolder.getPermissions() == null) {
+			map.put("permissions", null);
+		}
+		else {
+			map.put(
+				"permissions",
+				String.valueOf(displayPageTemplateFolder.getPermissions()));
+		}
+
 		if (displayPageTemplateFolder.getUuid() == null) {
 			map.put("uuid", null);
 		}
@@ -417,6 +450,9 @@ public class DisplayPageTemplateFolderSerDes {
 						jsonParserFieldName,
 						"parentDisplayPageTemplateFolderExternalReferenceCode")) {
 
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "permissions")) {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "uuid")) {
@@ -502,6 +538,26 @@ public class DisplayPageTemplateFolderSerDes {
 					displayPageTemplateFolder.
 						setParentDisplayPageTemplateFolderExternalReferenceCode(
 							(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "permissions")) {
+				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					com.liferay.headless.admin.site.client.permission.
+						Permission[] permissionsArray = new
+						com.liferay.headless.admin.site.client.permission.
+							Permission[jsonParserFieldValues.length];
+
+					for (int i = 0; i < permissionsArray.length; i++) {
+						permissionsArray[i] =
+							com.liferay.headless.admin.site.client.permission.
+								Permission.toDTO(
+									(String)jsonParserFieldValues[i]);
+					}
+
+					displayPageTemplateFolder.setPermissions(permissionsArray);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "uuid")) {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/DisplayPageTemplateSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/DisplayPageTemplateSerDes.java
@@ -258,6 +258,28 @@ public class DisplayPageTemplateSerDes {
 			sb.append(String.valueOf(displayPageTemplate.getParentFolder()));
 		}
 
+		if (displayPageTemplate.getPermissions() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"permissions\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < displayPageTemplate.getPermissions().length;
+				 i++) {
+
+				sb.append(displayPageTemplate.getPermissions()[i]);
+
+				if ((i + 1) < displayPageTemplate.getPermissions().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
 		if (displayPageTemplate.getThumbnail() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -441,6 +463,15 @@ public class DisplayPageTemplateSerDes {
 				String.valueOf(displayPageTemplate.getParentFolder()));
 		}
 
+		if (displayPageTemplate.getPermissions() == null) {
+			map.put("permissions", null);
+		}
+		else {
+			map.put(
+				"permissions",
+				String.valueOf(displayPageTemplate.getPermissions()));
+		}
+
 		if (displayPageTemplate.getThumbnail() == null) {
 			map.put("thumbnail", null);
 		}
@@ -530,6 +561,9 @@ public class DisplayPageTemplateSerDes {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "parentFolder")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "permissions")) {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "thumbnail")) {
@@ -661,6 +695,26 @@ public class DisplayPageTemplateSerDes {
 					displayPageTemplate.setParentFolder(
 						DisplayPageTemplateFolderSerDes.toDTO(
 							(String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "permissions")) {
+				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					com.liferay.headless.admin.site.client.permission.
+						Permission[] permissionsArray = new
+						com.liferay.headless.admin.site.client.permission.
+							Permission[jsonParserFieldValues.length];
+
+					for (int i = 0; i < permissionsArray.length; i++) {
+						permissionsArray[i] =
+							com.liferay.headless.admin.site.client.permission.
+								Permission.toDTO(
+									(String)jsonParserFieldValues[i]);
+					}
+
+					displayPageTemplate.setPermissions(permissionsArray);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "thumbnail")) {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/MasterPageSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/MasterPageSerDes.java
@@ -216,6 +216,26 @@ public class MasterPageSerDes {
 			sb.append("]");
 		}
 
+		if (masterPage.getPermissions() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"permissions\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < masterPage.getPermissions().length; i++) {
+				sb.append(masterPage.getPermissions()[i]);
+
+				if ((i + 1) < masterPage.getPermissions().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
 		if (masterPage.getTaxonomyCategoryItemExternalReferences() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -382,6 +402,13 @@ public class MasterPageSerDes {
 				String.valueOf(masterPage.getPageSpecifications()));
 		}
 
+		if (masterPage.getPermissions() == null) {
+			map.put("permissions", null);
+		}
+		else {
+			map.put("permissions", String.valueOf(masterPage.getPermissions()));
+		}
+
 		if (masterPage.getTaxonomyCategoryItemExternalReferences() == null) {
 			map.put("taxonomyCategoryItemExternalReferences", null);
 		}
@@ -461,6 +488,9 @@ public class MasterPageSerDes {
 			else if (Objects.equals(
 						jsonParserFieldName, "pageSpecifications")) {
 
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "permissions")) {
 				return false;
 			}
 			else if (Objects.equals(
@@ -563,6 +593,26 @@ public class MasterPageSerDes {
 					}
 
 					masterPage.setPageSpecifications(pageSpecificationsArray);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "permissions")) {
+				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					com.liferay.headless.admin.site.client.permission.
+						Permission[] permissionsArray = new
+						com.liferay.headless.admin.site.client.permission.
+							Permission[jsonParserFieldValues.length];
+
+					for (int i = 0; i < permissionsArray.length; i++) {
+						permissionsArray[i] =
+							com.liferay.headless.admin.site.client.permission.
+								Permission.toDTO(
+									(String)jsonParserFieldValues[i]);
+					}
+
+					masterPage.setPermissions(permissionsArray);
 				}
 			}
 			else if (Objects.equals(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageTemplateSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageTemplateSerDes.java
@@ -189,6 +189,14 @@ public class PageTemplateSerDes {
 				String.valueOf(pageTemplate.getPageTemplateSettings()));
 		}
 
+		if (pageTemplate.getPermissions() == null) {
+			map.put("permissions", null);
+		}
+		else {
+			map.put(
+				"permissions", String.valueOf(pageTemplate.getPermissions()));
+		}
+
 		if (pageTemplate.getTaxonomyCategoryItemExternalReferences() == null) {
 			map.put("taxonomyCategoryItemExternalReferences", null);
 		}
@@ -273,6 +281,9 @@ public class PageTemplateSerDes {
 			else if (Objects.equals(
 						jsonParserFieldName, "pageTemplateSettings")) {
 
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "permissions")) {
 				return false;
 			}
 			else if (Objects.equals(
@@ -410,6 +421,26 @@ public class PageTemplateSerDes {
 					pageTemplate.setPageTemplateSettings(
 						PageTemplateSettingsSerDes.toDTO(
 							(String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "permissions")) {
+				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					com.liferay.headless.admin.site.client.permission.
+						Permission[] permissionsArray = new
+						com.liferay.headless.admin.site.client.permission.
+							Permission[jsonParserFieldValues.length];
+
+					for (int i = 0; i < permissionsArray.length; i++) {
+						permissionsArray[i] =
+							com.liferay.headless.admin.site.client.permission.
+								Permission.toDTO(
+									(String)jsonParserFieldValues[i]);
+					}
+
+					pageTemplate.setPermissions(permissionsArray);
 				}
 			}
 			else if (Objects.equals(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageTemplateSetSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageTemplateSetSerDes.java
@@ -165,6 +165,26 @@ public class PageTemplateSetSerDes {
 			sb.append("\"");
 		}
 
+		if (pageTemplateSet.getPermissions() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"permissions\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < pageTemplateSet.getPermissions().length; i++) {
+				sb.append(pageTemplateSet.getPermissions()[i]);
+
+				if ((i + 1) < pageTemplateSet.getPermissions().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
 		if (pageTemplateSet.getUuid() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -270,6 +290,15 @@ public class PageTemplateSetSerDes {
 			map.put("name", String.valueOf(pageTemplateSet.getName()));
 		}
 
+		if (pageTemplateSet.getPermissions() == null) {
+			map.put("permissions", null);
+		}
+		else {
+			map.put(
+				"permissions",
+				String.valueOf(pageTemplateSet.getPermissions()));
+		}
+
 		if (pageTemplateSet.getUuid() == null) {
 			map.put("uuid", null);
 		}
@@ -321,6 +350,9 @@ public class PageTemplateSetSerDes {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "name")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "permissions")) {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "uuid")) {
@@ -383,6 +415,26 @@ public class PageTemplateSetSerDes {
 			else if (Objects.equals(jsonParserFieldName, "name")) {
 				if (jsonParserFieldValue != null) {
 					pageTemplateSet.setName((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "permissions")) {
+				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					com.liferay.headless.admin.site.client.permission.
+						Permission[] permissionsArray = new
+						com.liferay.headless.admin.site.client.permission.
+							Permission[jsonParserFieldValues.length];
+
+					for (int i = 0; i < permissionsArray.length; i++) {
+						permissionsArray[i] =
+							com.liferay.headless.admin.site.client.permission.
+								Permission.toDTO(
+									(String)jsonParserFieldValues[i]);
+					}
+
+					pageTemplateSet.setPermissions(permissionsArray);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "uuid")) {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/SitePageSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/SitePageSerDes.java
@@ -250,6 +250,26 @@ public class SitePageSerDes {
 			sb.append("\"");
 		}
 
+		if (sitePage.getPermissions() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"permissions\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < sitePage.getPermissions().length; i++) {
+				sb.append(sitePage.getPermissions()[i]);
+
+				if ((i + 1) < sitePage.getPermissions().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
 		if (sitePage.getTaxonomyCategoryItemExternalReferences() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -462,6 +482,13 @@ public class SitePageSerDes {
 					sitePage.getParentSitePageExternalReferenceCode()));
 		}
 
+		if (sitePage.getPermissions() == null) {
+			map.put("permissions", null);
+		}
+		else {
+			map.put("permissions", String.valueOf(sitePage.getPermissions()));
+		}
+
 		if (sitePage.getTaxonomyCategoryItemExternalReferences() == null) {
 			map.put("taxonomyCategoryItemExternalReferences", null);
 		}
@@ -563,6 +590,9 @@ public class SitePageSerDes {
 						jsonParserFieldName,
 						"parentSitePageExternalReferenceCode")) {
 
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "permissions")) {
 				return false;
 			}
 			else if (Objects.equals(
@@ -696,6 +726,26 @@ public class SitePageSerDes {
 				if (jsonParserFieldValue != null) {
 					sitePage.setParentSitePageExternalReferenceCode(
 						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "permissions")) {
+				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					com.liferay.headless.admin.site.client.permission.
+						Permission[] permissionsArray = new
+						com.liferay.headless.admin.site.client.permission.
+							Permission[jsonParserFieldValues.length];
+
+					for (int i = 0; i < permissionsArray.length; i++) {
+						permissionsArray[i] =
+							com.liferay.headless.admin.site.client.permission.
+								Permission.toDTO(
+									(String)jsonParserFieldValues[i]);
+					}
+
+					sitePage.setPermissions(permissionsArray);
 				}
 			}
 			else if (Objects.equals(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/UtilityPageSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/UtilityPageSerDes.java
@@ -203,6 +203,26 @@ public class UtilityPageSerDes {
 			sb.append("]");
 		}
 
+		if (utilityPage.getPermissions() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"permissions\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < utilityPage.getPermissions().length; i++) {
+				sb.append(utilityPage.getPermissions()[i]);
+
+				if ((i + 1) < utilityPage.getPermissions().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
 		if (utilityPage.getThumbnail() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -368,6 +388,14 @@ public class UtilityPageSerDes {
 				String.valueOf(utilityPage.getPageSpecifications()));
 		}
 
+		if (utilityPage.getPermissions() == null) {
+			map.put("permissions", null);
+		}
+		else {
+			map.put(
+				"permissions", String.valueOf(utilityPage.getPermissions()));
+		}
+
 		if (utilityPage.getThumbnail() == null) {
 			map.put("thumbnail", null);
 		}
@@ -457,6 +485,9 @@ public class UtilityPageSerDes {
 			else if (Objects.equals(
 						jsonParserFieldName, "pageSpecifications")) {
 
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "permissions")) {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "thumbnail")) {
@@ -567,6 +598,26 @@ public class UtilityPageSerDes {
 					}
 
 					utilityPage.setPageSpecifications(pageSpecificationsArray);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "permissions")) {
+				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					com.liferay.headless.admin.site.client.permission.
+						Permission[] permissionsArray = new
+						com.liferay.headless.admin.site.client.permission.
+							Permission[jsonParserFieldValues.length];
+
+					for (int i = 0; i < permissionsArray.length; i++) {
+						permissionsArray[i] =
+							com.liferay.headless.admin.site.client.permission.
+								Permission.toDTO(
+									(String)jsonParserFieldValues[i]);
+					}
+
+					utilityPage.setPermissions(permissionsArray);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "thumbnail")) {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/WidgetPageTemplateSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/WidgetPageTemplateSerDes.java
@@ -286,6 +286,28 @@ public class WidgetPageTemplateSerDes {
 				String.valueOf(widgetPageTemplate.getPageTemplateSettings()));
 		}
 
+		if (widgetPageTemplate.getPermissions() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"permissions\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < widgetPageTemplate.getPermissions().length;
+				 i++) {
+
+				sb.append(widgetPageTemplate.getPermissions()[i]);
+
+				if ((i + 1) < widgetPageTemplate.getPermissions().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
 		if (widgetPageTemplate.getTaxonomyCategoryItemExternalReferences() !=
 				null) {
 
@@ -516,6 +538,15 @@ public class WidgetPageTemplateSerDes {
 				String.valueOf(widgetPageTemplate.getPageTemplateSettings()));
 		}
 
+		if (widgetPageTemplate.getPermissions() == null) {
+			map.put("permissions", null);
+		}
+		else {
+			map.put(
+				"permissions",
+				String.valueOf(widgetPageTemplate.getPermissions()));
+		}
+
 		if (widgetPageTemplate.getTaxonomyCategoryItemExternalReferences() ==
 				null) {
 
@@ -622,6 +653,9 @@ public class WidgetPageTemplateSerDes {
 			else if (Objects.equals(
 						jsonParserFieldName, "pageTemplateSettings")) {
 
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "permissions")) {
 				return false;
 			}
 			else if (Objects.equals(
@@ -768,6 +802,26 @@ public class WidgetPageTemplateSerDes {
 					widgetPageTemplate.setPageTemplateSettings(
 						PageTemplateSettingsSerDes.toDTO(
 							(String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "permissions")) {
+				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					com.liferay.headless.admin.site.client.permission.
+						Permission[] permissionsArray = new
+						com.liferay.headless.admin.site.client.permission.
+							Permission[jsonParserFieldValues.length];
+
+					for (int i = 0; i < permissionsArray.length; i++) {
+						permissionsArray[i] =
+							com.liferay.headless.admin.site.client.permission.
+								Permission.toDTO(
+									(String)jsonParserFieldValues[i]);
+					}
+
+					widgetPageTemplate.setPermissions(permissionsArray);
 				}
 			}
 			else if (Objects.equals(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-config.yaml
@@ -10,5 +10,6 @@ compatibilityVersion: 12
 forcePredictableOperationId: true
 generateBatch: true
 generateGraphQL: false
+generatePermissions: true
 javaEEPackage: jakarta
 testDir: ../headless-admin-site-test/src/testIntegration/java

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
@@ -567,6 +567,10 @@ components:
                     # @review
                     description:
                         The display page template's parent folder.
+                permissions:
+                    items:
+                        type: permission
+                    type: array
                 thumbnail:
                     $ref: "#/components/schemas/ItemExternalReference"
                     # @review
@@ -637,6 +641,10 @@ components:
                     description:
                         The parent display page template folder's external reference code.
                     type: string
+                permissions:
+                    items:
+                        type: permission
+                    type: array
                 uuid:
                     # @review
                     description:
@@ -1816,6 +1824,10 @@ components:
                     items:
                         $ref: "#/components/schemas/PageSpecification"
                     type: array
+                permissions:
+                    items:
+                        type: permission
+                    type: array
                 taxonomyCategoryItemExternalReferences:
                     # @review
                     description:
@@ -2324,6 +2336,10 @@ components:
                     # @review
                     description:
                         The settings of the page template.
+                permissions:
+                    items:
+                        type: permission
+                    type: array
                 taxonomyCategoryItemExternalReferences:
                     # @review
                     description:
@@ -2394,6 +2410,10 @@ components:
                     description:
                         The page template set's name.
                     type: string
+                permissions:
+                    items:
+                        type: permission
+                    type: array
                 uuid:
                     description:
                         A valid external identifier to reference this page template set.
@@ -2740,6 +2760,10 @@ components:
                     description:
                         The parent page external reference code or null if it is a top level page.
                     type: string
+                permissions:
+                    items:
+                        type: permission
+                    type: array
                 taxonomyCategoryItemExternalReferences:
                     # @review
                     description:
@@ -2914,6 +2938,10 @@ components:
                         default. It can be requested via nestedFields.
                     items:
                         $ref: "#/components/schemas/PageSpecification"
+                    type: array
+                permissions:
+                    items:
+                        type: permission
                     type: array
                 thumbnail:
                     $ref: "#/components/schemas/ItemExternalReference"

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseDisplayPageTemplateFolderResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseDisplayPageTemplateFolderResourceImpl.java
@@ -42,6 +42,7 @@ import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.fields.NestedFieldsSupplier;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
@@ -276,6 +277,15 @@ public abstract class BaseDisplayPageTemplateFolderResourceImpl
 			resourceId, resourceName, roleNames);
 	}
 
+	protected abstract Page<DisplayPageTemplateFolder>
+			doGetSiteDisplayPageTemplateFoldersPage(
+				String siteExternalReferenceCode, String search,
+				com.liferay.portal.vulcan.aggregation.Aggregation aggregation,
+				com.liferay.portal.kernel.search.filter.Filter filter,
+				Pagination pagination,
+				com.liferay.portal.kernel.search.Sort[] sorts)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -341,7 +351,7 @@ public abstract class BaseDisplayPageTemplateFolderResourceImpl
 	)
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<DisplayPageTemplateFolder>
+	public final Page<DisplayPageTemplateFolder>
 			getSiteDisplayPageTemplateFoldersPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@jakarta.validation.constraints.NotNull
@@ -360,13 +370,40 @@ public abstract class BaseDisplayPageTemplateFolderResourceImpl
 					com.liferay.portal.kernel.search.Sort[] sorts)
 		throws Exception {
 
-		return Page.of(Collections.emptyList());
+		Page<DisplayPageTemplateFolder> displayPageTemplateFoldersPage =
+			doGetSiteDisplayPageTemplateFoldersPage(
+				siteExternalReferenceCode, search, aggregation, filter,
+				pagination, sorts);
+
+		for (DisplayPageTemplateFolder displayPageTemplateFolder :
+				displayPageTemplateFoldersPage.getItems()) {
+
+			displayPageTemplateFolder.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Page<Permission> permissionsPage =
+							getSiteDisplayPageTemplateFolderPermissionsPage(
+								siteExternalReferenceCode,
+								displayPageTemplateFolder.
+									getExternalReferenceCode(),
+								null);
+
+						Collection<Permission> permissions =
+							permissionsPage.getItems();
+
+						return permissions.toArray(
+							new Permission[permissions.size()]);
+					}));
+		}
+
+		return displayPageTemplateFoldersPage;
 	}
 
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/display-page-template-folders/{displayPageTemplateFolderExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "key": ___, "name": ___, "parentDisplayPageTemplateFolder": ___, "parentDisplayPageTemplateFolderExternalReferenceCode": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/display-page-template-folders/{displayPageTemplateFolderExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "key": ___, "name": ___, "parentDisplayPageTemplateFolder": ___, "parentDisplayPageTemplateFolderExternalReferenceCode": ___, "permissions": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates only the fields received in the request body, leaving any other fields untouched."
@@ -475,6 +512,11 @@ public abstract class BaseDisplayPageTemplateFolderResourceImpl
 						getParentDisplayPageTemplateFolderExternalReferenceCode());
 		}
 
+		if (displayPageTemplateFolder.getPermissions() != null) {
+			existingDisplayPageTemplateFolder.setPermissions(
+				displayPageTemplateFolder.getPermissions());
+		}
+
 		if (displayPageTemplateFolder.getUuid() != null) {
 			existingDisplayPageTemplateFolder.setUuid(
 				displayPageTemplateFolder.getUuid());
@@ -489,10 +531,16 @@ public abstract class BaseDisplayPageTemplateFolderResourceImpl
 			existingDisplayPageTemplateFolder);
 	}
 
+	protected abstract DisplayPageTemplateFolder
+			doPostSiteDisplayPageTemplateFolder(
+				String siteExternalReferenceCode,
+				DisplayPageTemplateFolder displayPageTemplateFolder)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/display-page-template-folders' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "key": ___, "name": ___, "parentDisplayPageTemplateFolder": ___, "parentDisplayPageTemplateFolderExternalReferenceCode": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/display-page-template-folders' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "key": ___, "name": ___, "parentDisplayPageTemplateFolder": ___, "parentDisplayPageTemplateFolderExternalReferenceCode": ___, "permissions": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Adds a new display page template folder."
@@ -519,7 +567,7 @@ public abstract class BaseDisplayPageTemplateFolderResourceImpl
 	@jakarta.ws.rs.POST
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public DisplayPageTemplateFolder postSiteDisplayPageTemplateFolder(
+	public final DisplayPageTemplateFolder postSiteDisplayPageTemplateFolder(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
@@ -527,7 +575,32 @@ public abstract class BaseDisplayPageTemplateFolderResourceImpl
 			DisplayPageTemplateFolder displayPageTemplateFolder)
 		throws Exception {
 
-		return new DisplayPageTemplateFolder();
+		Permission[] permissions = displayPageTemplateFolder.getPermissions();
+
+		DisplayPageTemplateFolder postDisplayPageTemplateFolder =
+			doPostSiteDisplayPageTemplateFolder(
+				siteExternalReferenceCode, displayPageTemplateFolder);
+
+		if (permissions != null) {
+			Page<Permission> permissionsPage =
+				putSiteDisplayPageTemplateFolderPermissionsPage(
+					siteExternalReferenceCode,
+					postDisplayPageTemplateFolder.getExternalReferenceCode(),
+					permissions);
+
+			postDisplayPageTemplateFolder.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Collection<Permission> collection =
+							permissionsPage.getItems();
+
+						return collection.toArray(
+							new Permission[collection.size()]);
+					}));
+		}
+
+		return postDisplayPageTemplateFolder;
 	}
 
 	/**
@@ -686,7 +759,7 @@ public abstract class BaseDisplayPageTemplateFolderResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/display-page-template-folders/{displayPageTemplateFolderExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "key": ___, "name": ___, "parentDisplayPageTemplateFolder": ___, "parentDisplayPageTemplateFolderExternalReferenceCode": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/display-page-template-folders/{displayPageTemplateFolderExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "key": ___, "name": ___, "parentDisplayPageTemplateFolder": ___, "parentDisplayPageTemplateFolderExternalReferenceCode": ___, "permissions": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates the display page template folder with the given external reference code, or creates it if it does not exist."

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseDisplayPageTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseDisplayPageTemplateResourceImpl.java
@@ -43,6 +43,7 @@ import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.fields.NestedFieldsSupplier;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
@@ -340,6 +341,15 @@ public abstract class BaseDisplayPageTemplateResourceImpl
 			resourceId, resourceName, roleNames);
 	}
 
+	protected abstract Page<DisplayPageTemplate>
+			doGetSiteDisplayPageTemplatesPage(
+				String siteExternalReferenceCode, String search,
+				com.liferay.portal.vulcan.aggregation.Aggregation aggregation,
+				com.liferay.portal.kernel.search.filter.Filter filter,
+				Pagination pagination,
+				com.liferay.portal.kernel.search.Sort[] sorts)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -405,7 +415,7 @@ public abstract class BaseDisplayPageTemplateResourceImpl
 	)
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<DisplayPageTemplate> getSiteDisplayPageTemplatesPage(
+	public final Page<DisplayPageTemplate> getSiteDisplayPageTemplatesPage(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
@@ -422,13 +432,39 @@ public abstract class BaseDisplayPageTemplateResourceImpl
 				sorts)
 		throws Exception {
 
-		return Page.of(Collections.emptyList());
+		Page<DisplayPageTemplate> displayPageTemplatesPage =
+			doGetSiteDisplayPageTemplatesPage(
+				siteExternalReferenceCode, search, aggregation, filter,
+				pagination, sorts);
+
+		for (DisplayPageTemplate displayPageTemplate :
+				displayPageTemplatesPage.getItems()) {
+
+			displayPageTemplate.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Page<Permission> permissionsPage =
+							getSiteDisplayPageTemplatePermissionsPage(
+								siteExternalReferenceCode,
+								displayPageTemplate.getExternalReferenceCode(),
+								null);
+
+						Collection<Permission> permissions =
+							permissionsPage.getItems();
+
+						return permissions.toArray(
+							new Permission[permissions.size()]);
+					}));
+		}
+
+		return displayPageTemplatesPage;
 	}
 
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/display-page-templates/{displayPageTemplateExternalReferenceCode}' -d $'{"contentTypeReference": ___, "creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "displayPageTemplateSettings": ___, "externalReferenceCode": ___, "friendlyUrlHistory": ___, "friendlyUrlPath_i18n": ___, "key": ___, "markedAsDefault": ___, "name": ___, "pageSpecifications": ___, "parentFolder": ___, "thumbnail": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/display-page-templates/{displayPageTemplateExternalReferenceCode}' -d $'{"contentTypeReference": ___, "creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "displayPageTemplateSettings": ___, "externalReferenceCode": ___, "friendlyUrlHistory": ___, "friendlyUrlPath_i18n": ___, "key": ___, "markedAsDefault": ___, "name": ___, "pageSpecifications": ___, "parentFolder": ___, "permissions": ___, "thumbnail": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates only the fields received in the request body, leaving any other fields untouched."
@@ -531,6 +567,11 @@ public abstract class BaseDisplayPageTemplateResourceImpl
 			existingDisplayPageTemplate.setName(displayPageTemplate.getName());
 		}
 
+		if (displayPageTemplate.getPermissions() != null) {
+			existingDisplayPageTemplate.setPermissions(
+				displayPageTemplate.getPermissions());
+		}
+
 		if (displayPageTemplate.getUuid() != null) {
 			existingDisplayPageTemplate.setUuid(displayPageTemplate.getUuid());
 		}
@@ -542,10 +583,15 @@ public abstract class BaseDisplayPageTemplateResourceImpl
 			existingDisplayPageTemplate);
 	}
 
+	protected abstract DisplayPageTemplate doPostSiteDisplayPageTemplate(
+			String siteExternalReferenceCode,
+			DisplayPageTemplate displayPageTemplate)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/display-page-templates' -d $'{"contentTypeReference": ___, "creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "displayPageTemplateSettings": ___, "externalReferenceCode": ___, "friendlyUrlHistory": ___, "friendlyUrlPath_i18n": ___, "key": ___, "markedAsDefault": ___, "name": ___, "pageSpecifications": ___, "parentFolder": ___, "thumbnail": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/display-page-templates' -d $'{"contentTypeReference": ___, "creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "displayPageTemplateSettings": ___, "externalReferenceCode": ___, "friendlyUrlHistory": ___, "friendlyUrlPath_i18n": ___, "key": ___, "markedAsDefault": ___, "name": ___, "pageSpecifications": ___, "parentFolder": ___, "permissions": ___, "thumbnail": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Adds a new display page template"
@@ -572,7 +618,7 @@ public abstract class BaseDisplayPageTemplateResourceImpl
 	@jakarta.ws.rs.POST
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public DisplayPageTemplate postSiteDisplayPageTemplate(
+	public final DisplayPageTemplate postSiteDisplayPageTemplate(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
@@ -580,7 +626,32 @@ public abstract class BaseDisplayPageTemplateResourceImpl
 			DisplayPageTemplate displayPageTemplate)
 		throws Exception {
 
-		return new DisplayPageTemplate();
+		Permission[] permissions = displayPageTemplate.getPermissions();
+
+		DisplayPageTemplate postDisplayPageTemplate =
+			doPostSiteDisplayPageTemplate(
+				siteExternalReferenceCode, displayPageTemplate);
+
+		if (permissions != null) {
+			Page<Permission> permissionsPage =
+				putSiteDisplayPageTemplatePermissionsPage(
+					siteExternalReferenceCode,
+					postDisplayPageTemplate.getExternalReferenceCode(),
+					permissions);
+
+			postDisplayPageTemplate.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Collection<Permission> collection =
+							permissionsPage.getItems();
+
+						return collection.toArray(
+							new Permission[collection.size()]);
+					}));
+		}
+
+		return postDisplayPageTemplate;
 	}
 
 	/**
@@ -644,7 +715,7 @@ public abstract class BaseDisplayPageTemplateResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/display-page-template-folders/{displayPageTemplateFolderExternalReferenceCode}/display-page-templates' -d $'{"contentTypeReference": ___, "creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "displayPageTemplateSettings": ___, "externalReferenceCode": ___, "friendlyUrlHistory": ___, "friendlyUrlPath_i18n": ___, "key": ___, "markedAsDefault": ___, "name": ___, "pageSpecifications": ___, "parentFolder": ___, "thumbnail": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/display-page-template-folders/{displayPageTemplateFolderExternalReferenceCode}/display-page-templates' -d $'{"contentTypeReference": ___, "creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "displayPageTemplateSettings": ___, "externalReferenceCode": ___, "friendlyUrlHistory": ___, "friendlyUrlPath_i18n": ___, "key": ___, "markedAsDefault": ___, "name": ___, "pageSpecifications": ___, "parentFolder": ___, "permissions": ___, "thumbnail": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Adds a new display page template in draft status to a display page template folder."
@@ -866,7 +937,7 @@ public abstract class BaseDisplayPageTemplateResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/display-page-templates/{displayPageTemplateExternalReferenceCode}' -d $'{"contentTypeReference": ___, "creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "displayPageTemplateSettings": ___, "externalReferenceCode": ___, "friendlyUrlHistory": ___, "friendlyUrlPath_i18n": ___, "key": ___, "markedAsDefault": ___, "name": ___, "pageSpecifications": ___, "parentFolder": ___, "thumbnail": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/display-page-templates/{displayPageTemplateExternalReferenceCode}' -d $'{"contentTypeReference": ___, "creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "displayPageTemplateSettings": ___, "externalReferenceCode": ___, "friendlyUrlHistory": ___, "friendlyUrlPath_i18n": ___, "key": ___, "markedAsDefault": ___, "name": ___, "pageSpecifications": ___, "parentFolder": ___, "permissions": ___, "thumbnail": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates the display page template with the given external reference code, or creates it if it does not exist."

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseMasterPageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseMasterPageResourceImpl.java
@@ -43,6 +43,7 @@ import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.fields.NestedFieldsSupplier;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
@@ -257,6 +258,14 @@ public abstract class BaseMasterPageResourceImpl
 			resourceId, resourceName, roleNames);
 	}
 
+	protected abstract Page<MasterPage> doGetSiteMasterPagesPage(
+			String siteExternalReferenceCode, String search,
+			com.liferay.portal.vulcan.aggregation.Aggregation aggregation,
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -316,7 +325,7 @@ public abstract class BaseMasterPageResourceImpl
 	@jakarta.ws.rs.Path("/sites/{siteExternalReferenceCode}/master-pages")
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<MasterPage> getSiteMasterPagesPage(
+	public final Page<MasterPage> getSiteMasterPagesPage(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
@@ -333,13 +342,35 @@ public abstract class BaseMasterPageResourceImpl
 				sorts)
 		throws Exception {
 
-		return Page.of(Collections.emptyList());
+		Page<MasterPage> masterPagesPage = doGetSiteMasterPagesPage(
+			siteExternalReferenceCode, search, aggregation, filter, pagination,
+			sorts);
+
+		for (MasterPage masterPage : masterPagesPage.getItems()) {
+			masterPage.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Page<Permission> permissionsPage =
+							getSiteMasterPagePermissionsPage(
+								siteExternalReferenceCode,
+								masterPage.getExternalReferenceCode(), null);
+
+						Collection<Permission> permissions =
+							permissionsPage.getItems();
+
+						return permissions.toArray(
+							new Permission[permissions.size()]);
+					}));
+		}
+
+		return masterPagesPage;
 	}
 
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/master-pages/{masterPageExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "externalReferenceCode": ___, "key": ___, "keywords": ___, "markedAsDefault": ___, "name": ___, "pageSpecifications": ___, "taxonomyCategoryItemExternalReferences": ___, "thumbnail": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/master-pages/{masterPageExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "externalReferenceCode": ___, "key": ___, "keywords": ___, "markedAsDefault": ___, "name": ___, "pageSpecifications": ___, "permissions": ___, "taxonomyCategoryItemExternalReferences": ___, "thumbnail": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates only the fields received in the request body, leaving any other fields untouched."
@@ -432,6 +463,10 @@ public abstract class BaseMasterPageResourceImpl
 			existingMasterPage.setName(masterPage.getName());
 		}
 
+		if (masterPage.getPermissions() != null) {
+			existingMasterPage.setPermissions(masterPage.getPermissions());
+		}
+
 		if (masterPage.getUuid() != null) {
 			existingMasterPage.setUuid(masterPage.getUuid());
 		}
@@ -443,10 +478,14 @@ public abstract class BaseMasterPageResourceImpl
 			existingMasterPage);
 	}
 
+	protected abstract MasterPage doPostSiteMasterPage(
+			String siteExternalReferenceCode, MasterPage masterPage)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/master-pages' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "externalReferenceCode": ___, "key": ___, "keywords": ___, "markedAsDefault": ___, "name": ___, "pageSpecifications": ___, "taxonomyCategoryItemExternalReferences": ___, "thumbnail": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/master-pages' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "externalReferenceCode": ___, "key": ___, "keywords": ___, "markedAsDefault": ___, "name": ___, "pageSpecifications": ___, "permissions": ___, "taxonomyCategoryItemExternalReferences": ___, "thumbnail": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Adds a new master page."
@@ -467,7 +506,7 @@ public abstract class BaseMasterPageResourceImpl
 	@jakarta.ws.rs.POST
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public MasterPage postSiteMasterPage(
+	public final MasterPage postSiteMasterPage(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
@@ -475,7 +514,29 @@ public abstract class BaseMasterPageResourceImpl
 			MasterPage masterPage)
 		throws Exception {
 
-		return new MasterPage();
+		Permission[] permissions = masterPage.getPermissions();
+
+		MasterPage postMasterPage = doPostSiteMasterPage(
+			siteExternalReferenceCode, masterPage);
+
+		if (permissions != null) {
+			Page<Permission> permissionsPage = putSiteMasterPagePermissionsPage(
+				siteExternalReferenceCode,
+				postMasterPage.getExternalReferenceCode(), permissions);
+
+			postMasterPage.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Collection<Permission> collection =
+							permissionsPage.getItems();
+
+						return collection.toArray(
+							new Permission[collection.size()]);
+					}));
+		}
+
+		return postMasterPage;
 	}
 
 	/**
@@ -680,7 +741,7 @@ public abstract class BaseMasterPageResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/master-pages/{masterPageExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "externalReferenceCode": ___, "key": ___, "keywords": ___, "markedAsDefault": ___, "name": ___, "pageSpecifications": ___, "taxonomyCategoryItemExternalReferences": ___, "thumbnail": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/master-pages/{masterPageExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "externalReferenceCode": ___, "key": ___, "keywords": ___, "markedAsDefault": ___, "name": ___, "pageSpecifications": ___, "permissions": ___, "taxonomyCategoryItemExternalReferences": ___, "thumbnail": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates the master page with the given external reference code, or creates it if it does not exist."

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageTemplateResourceImpl.java
@@ -43,6 +43,7 @@ import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.fields.NestedFieldsSupplier;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
@@ -319,6 +320,14 @@ public abstract class BasePageTemplateResourceImpl
 		return Page.of(Collections.emptyList());
 	}
 
+	protected abstract Page<PageTemplate> doGetSitePageTemplatesPage(
+			String siteExternalReferenceCode, String search,
+			com.liferay.portal.vulcan.aggregation.Aggregation aggregation,
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -378,7 +387,7 @@ public abstract class BasePageTemplateResourceImpl
 	@jakarta.ws.rs.Path("/sites/{siteExternalReferenceCode}/page-templates")
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<PageTemplate> getSitePageTemplatesPage(
+	public final Page<PageTemplate> getSitePageTemplatesPage(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
@@ -395,13 +404,35 @@ public abstract class BasePageTemplateResourceImpl
 				sorts)
 		throws Exception {
 
-		return Page.of(Collections.emptyList());
+		Page<PageTemplate> pageTemplatesPage = doGetSitePageTemplatesPage(
+			siteExternalReferenceCode, search, aggregation, filter, pagination,
+			sorts);
+
+		for (PageTemplate pageTemplate : pageTemplatesPage.getItems()) {
+			pageTemplate.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Page<Permission> permissionsPage =
+							getSitePageTemplatePermissionsPage(
+								siteExternalReferenceCode,
+								pageTemplate.getExternalReferenceCode(), null);
+
+						Collection<Permission> permissions =
+							permissionsPage.getItems();
+
+						return permissions.toArray(
+							new Permission[permissions.size()]);
+					}));
+		}
+
+		return pageTemplatesPage;
 	}
 
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-templates/{pageTemplateExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "externalReferenceCode": ___, "key": ___, "keywords": ___, "name": ___, "pageSpecifications": ___, "pageTemplateSet": ___, "pageTemplateSettings": ___, "taxonomyCategoryItemExternalReferences": ___, "type": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-templates/{pageTemplateExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "externalReferenceCode": ___, "key": ___, "keywords": ___, "name": ___, "pageSpecifications": ___, "pageTemplateSet": ___, "pageTemplateSettings": ___, "permissions": ___, "taxonomyCategoryItemExternalReferences": ___, "type": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates only the fields received in the request body, leaving any other fields untouched."
@@ -491,6 +522,10 @@ public abstract class BasePageTemplateResourceImpl
 			existingPageTemplate.setName(pageTemplate.getName());
 		}
 
+		if (pageTemplate.getPermissions() != null) {
+			existingPageTemplate.setPermissions(pageTemplate.getPermissions());
+		}
+
 		if (pageTemplate.getType() != null) {
 			existingPageTemplate.setType(pageTemplate.getType());
 		}
@@ -506,10 +541,14 @@ public abstract class BasePageTemplateResourceImpl
 			existingPageTemplate);
 	}
 
+	protected abstract PageTemplate doPostSitePageTemplate(
+			String siteExternalReferenceCode, PageTemplate pageTemplate)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-templates' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "externalReferenceCode": ___, "key": ___, "keywords": ___, "name": ___, "pageSpecifications": ___, "pageTemplateSet": ___, "pageTemplateSettings": ___, "taxonomyCategoryItemExternalReferences": ___, "type": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-templates' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "externalReferenceCode": ___, "key": ___, "keywords": ___, "name": ___, "pageSpecifications": ___, "pageTemplateSet": ___, "pageTemplateSettings": ___, "permissions": ___, "taxonomyCategoryItemExternalReferences": ___, "type": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Adds a new page template"
@@ -530,7 +569,7 @@ public abstract class BasePageTemplateResourceImpl
 	@jakarta.ws.rs.POST
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public PageTemplate postSitePageTemplate(
+	public final PageTemplate postSitePageTemplate(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
@@ -538,7 +577,30 @@ public abstract class BasePageTemplateResourceImpl
 			PageTemplate pageTemplate)
 		throws Exception {
 
-		return null;
+		Permission[] permissions = pageTemplate.getPermissions();
+
+		PageTemplate postPageTemplate = doPostSitePageTemplate(
+			siteExternalReferenceCode, pageTemplate);
+
+		if (permissions != null) {
+			Page<Permission> permissionsPage =
+				putSitePageTemplatePermissionsPage(
+					siteExternalReferenceCode,
+					postPageTemplate.getExternalReferenceCode(), permissions);
+
+			postPageTemplate.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Collection<Permission> collection =
+							permissionsPage.getItems();
+
+						return collection.toArray(
+							new Permission[collection.size()]);
+					}));
+		}
+
+		return postPageTemplate;
 	}
 
 	/**
@@ -655,7 +717,7 @@ public abstract class BasePageTemplateResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-template-sets/{pageTemplateSetExternalReferenceCode}/page-templates' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "externalReferenceCode": ___, "key": ___, "keywords": ___, "name": ___, "pageSpecifications": ___, "pageTemplateSet": ___, "pageTemplateSettings": ___, "taxonomyCategoryItemExternalReferences": ___, "type": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-template-sets/{pageTemplateSetExternalReferenceCode}/page-templates' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "externalReferenceCode": ___, "key": ___, "keywords": ___, "name": ___, "pageSpecifications": ___, "pageTemplateSet": ___, "pageTemplateSettings": ___, "permissions": ___, "taxonomyCategoryItemExternalReferences": ___, "type": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Adds a new page template in draft status to a page template set."
@@ -802,7 +864,7 @@ public abstract class BasePageTemplateResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-templates/{pageTemplateExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "externalReferenceCode": ___, "key": ___, "keywords": ___, "name": ___, "pageSpecifications": ___, "pageTemplateSet": ___, "pageTemplateSettings": ___, "taxonomyCategoryItemExternalReferences": ___, "type": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-templates/{pageTemplateExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "externalReferenceCode": ___, "key": ___, "keywords": ___, "name": ___, "pageSpecifications": ___, "pageTemplateSet": ___, "pageTemplateSettings": ___, "permissions": ___, "taxonomyCategoryItemExternalReferences": ___, "type": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates the page template with the given external reference code, or creates it if it does not exist."

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageTemplateSetResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageTemplateSetResourceImpl.java
@@ -42,6 +42,7 @@ import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.fields.NestedFieldsSupplier;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
@@ -262,6 +263,14 @@ public abstract class BasePageTemplateSetResourceImpl
 			resourceId, resourceName, roleNames);
 	}
 
+	protected abstract Page<PageTemplateSet> doGetSitePageTemplateSetsPage(
+			String siteExternalReferenceCode, String search,
+			com.liferay.portal.vulcan.aggregation.Aggregation aggregation,
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -323,7 +332,7 @@ public abstract class BasePageTemplateSetResourceImpl
 	@jakarta.ws.rs.Path("/sites/{siteExternalReferenceCode}/page-template-sets")
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<PageTemplateSet> getSitePageTemplateSetsPage(
+	public final Page<PageTemplateSet> getSitePageTemplateSetsPage(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
@@ -340,13 +349,39 @@ public abstract class BasePageTemplateSetResourceImpl
 				sorts)
 		throws Exception {
 
-		return Page.of(Collections.emptyList());
+		Page<PageTemplateSet> pageTemplateSetsPage =
+			doGetSitePageTemplateSetsPage(
+				siteExternalReferenceCode, search, aggregation, filter,
+				pagination, sorts);
+
+		for (PageTemplateSet pageTemplateSet :
+				pageTemplateSetsPage.getItems()) {
+
+			pageTemplateSet.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Page<Permission> permissionsPage =
+							getSitePageTemplateSetPermissionsPage(
+								siteExternalReferenceCode,
+								pageTemplateSet.getExternalReferenceCode(),
+								null);
+
+						Collection<Permission> permissions =
+							permissionsPage.getItems();
+
+						return permissions.toArray(
+							new Permission[permissions.size()]);
+					}));
+		}
+
+		return pageTemplateSetsPage;
 	}
 
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-template-sets/{pageTemplateSetExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "key": ___, "name": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-template-sets/{pageTemplateSetExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "key": ___, "name": ___, "permissions": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates only the fields received in the request body, leaving any other fields untouched."
@@ -435,6 +470,11 @@ public abstract class BasePageTemplateSetResourceImpl
 			existingPageTemplateSet.setName(pageTemplateSet.getName());
 		}
 
+		if (pageTemplateSet.getPermissions() != null) {
+			existingPageTemplateSet.setPermissions(
+				pageTemplateSet.getPermissions());
+		}
+
 		if (pageTemplateSet.getUuid() != null) {
 			existingPageTemplateSet.setUuid(pageTemplateSet.getUuid());
 		}
@@ -446,10 +486,14 @@ public abstract class BasePageTemplateSetResourceImpl
 			existingPageTemplateSet);
 	}
 
+	protected abstract PageTemplateSet doPostSitePageTemplateSet(
+			String siteExternalReferenceCode, PageTemplateSet pageTemplateSet)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-template-sets' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "key": ___, "name": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-template-sets' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "key": ___, "name": ___, "permissions": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Adds a new page template set"
@@ -472,7 +516,7 @@ public abstract class BasePageTemplateSetResourceImpl
 	@jakarta.ws.rs.POST
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public PageTemplateSet postSitePageTemplateSet(
+	public final PageTemplateSet postSitePageTemplateSet(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
@@ -480,7 +524,31 @@ public abstract class BasePageTemplateSetResourceImpl
 			PageTemplateSet pageTemplateSet)
 		throws Exception {
 
-		return new PageTemplateSet();
+		Permission[] permissions = pageTemplateSet.getPermissions();
+
+		PageTemplateSet postPageTemplateSet = doPostSitePageTemplateSet(
+			siteExternalReferenceCode, pageTemplateSet);
+
+		if (permissions != null) {
+			Page<Permission> permissionsPage =
+				putSitePageTemplateSetPermissionsPage(
+					siteExternalReferenceCode,
+					postPageTemplateSet.getExternalReferenceCode(),
+					permissions);
+
+			postPageTemplateSet.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Collection<Permission> collection =
+							permissionsPage.getItems();
+
+						return collection.toArray(
+							new Permission[collection.size()]);
+					}));
+		}
+
+		return postPageTemplateSet;
 	}
 
 	/**
@@ -634,7 +702,7 @@ public abstract class BasePageTemplateSetResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-template-sets/{pageTemplateSetExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "key": ___, "name": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-template-sets/{pageTemplateSetExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "key": ___, "name": ___, "permissions": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates the page template set with the given external reference code, or creates it if it does not exist."

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseSitePageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseSitePageResourceImpl.java
@@ -43,6 +43,7 @@ import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.fields.NestedFieldsSupplier;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
@@ -257,6 +258,14 @@ public abstract class BaseSitePageResourceImpl
 			resourceId, resourceName, roleNames);
 	}
 
+	protected abstract Page<SitePage> doGetSiteSitePagesPage(
+			String siteExternalReferenceCode, String search,
+			com.liferay.portal.vulcan.aggregation.Aggregation aggregation,
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -316,7 +325,7 @@ public abstract class BaseSitePageResourceImpl
 	@jakarta.ws.rs.Path("/sites/{siteExternalReferenceCode}/site-pages")
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<SitePage> getSiteSitePagesPage(
+	public final Page<SitePage> getSiteSitePagesPage(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
@@ -333,13 +342,35 @@ public abstract class BaseSitePageResourceImpl
 				sorts)
 		throws Exception {
 
-		return Page.of(Collections.emptyList());
+		Page<SitePage> sitePagesPage = doGetSiteSitePagesPage(
+			siteExternalReferenceCode, search, aggregation, filter, pagination,
+			sorts);
+
+		for (SitePage sitePage : sitePagesPage.getItems()) {
+			sitePage.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Page<Permission> permissionsPage =
+							getSiteSitePagePermissionsPage(
+								siteExternalReferenceCode,
+								sitePage.getExternalReferenceCode(), null);
+
+						Collection<Permission> permissions =
+							permissionsPage.getItems();
+
+						return permissions.toArray(
+							new Permission[permissions.size()]);
+					}));
+		}
+
+		return sitePagesPage;
 	}
 
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/site-pages/{sitePageExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "externalReferenceCode": ___, "friendlyUrlHistory": ___, "friendlyUrlPath_i18n": ___, "keywords": ___, "name_i18n": ___, "pageSettings": ___, "pageSpecifications": ___, "parentSitePageExternalReferenceCode": ___, "taxonomyCategoryItemExternalReferences": ___, "type": ___, "uuid": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/site-pages/{sitePageExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "externalReferenceCode": ___, "friendlyUrlHistory": ___, "friendlyUrlPath_i18n": ___, "keywords": ___, "name_i18n": ___, "pageSettings": ___, "pageSpecifications": ___, "parentSitePageExternalReferenceCode": ___, "permissions": ___, "taxonomyCategoryItemExternalReferences": ___, "type": ___, "uuid": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates only the fields received in the request body, leaving any other fields untouched."
@@ -433,6 +464,10 @@ public abstract class BaseSitePageResourceImpl
 				sitePage.getParentSitePageExternalReferenceCode());
 		}
 
+		if (sitePage.getPermissions() != null) {
+			existingSitePage.setPermissions(sitePage.getPermissions());
+		}
+
 		if (sitePage.getType() != null) {
 			existingSitePage.setType(sitePage.getType());
 		}
@@ -452,10 +487,14 @@ public abstract class BaseSitePageResourceImpl
 			existingSitePage);
 	}
 
+	protected abstract SitePage doPostSiteSitePage(
+			String siteExternalReferenceCode, SitePage sitePage)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/site-pages' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "externalReferenceCode": ___, "friendlyUrlHistory": ___, "friendlyUrlPath_i18n": ___, "keywords": ___, "name_i18n": ___, "pageSettings": ___, "pageSpecifications": ___, "parentSitePageExternalReferenceCode": ___, "taxonomyCategoryItemExternalReferences": ___, "type": ___, "uuid": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/site-pages' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "externalReferenceCode": ___, "friendlyUrlHistory": ___, "friendlyUrlPath_i18n": ___, "keywords": ___, "name_i18n": ___, "pageSettings": ___, "pageSpecifications": ___, "parentSitePageExternalReferenceCode": ___, "permissions": ___, "taxonomyCategoryItemExternalReferences": ___, "type": ___, "uuid": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Adds a new site page"
@@ -476,7 +515,7 @@ public abstract class BaseSitePageResourceImpl
 	@jakarta.ws.rs.POST
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public SitePage postSiteSitePage(
+	public final SitePage postSiteSitePage(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
@@ -484,7 +523,29 @@ public abstract class BaseSitePageResourceImpl
 			SitePage sitePage)
 		throws Exception {
 
-		return new SitePage();
+		Permission[] permissions = sitePage.getPermissions();
+
+		SitePage postSitePage = doPostSiteSitePage(
+			siteExternalReferenceCode, sitePage);
+
+		if (permissions != null) {
+			Page<Permission> permissionsPage = putSiteSitePagePermissionsPage(
+				siteExternalReferenceCode,
+				postSitePage.getExternalReferenceCode(), permissions);
+
+			postSitePage.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Collection<Permission> collection =
+							permissionsPage.getItems();
+
+						return collection.toArray(
+							new Permission[collection.size()]);
+					}));
+		}
+
+		return postSitePage;
 	}
 
 	/**
@@ -687,7 +748,7 @@ public abstract class BaseSitePageResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/site-pages/{sitePageExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "externalReferenceCode": ___, "friendlyUrlHistory": ___, "friendlyUrlPath_i18n": ___, "keywords": ___, "name_i18n": ___, "pageSettings": ___, "pageSpecifications": ___, "parentSitePageExternalReferenceCode": ___, "taxonomyCategoryItemExternalReferences": ___, "type": ___, "uuid": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/site-pages/{sitePageExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "externalReferenceCode": ___, "friendlyUrlHistory": ___, "friendlyUrlPath_i18n": ___, "keywords": ___, "name_i18n": ___, "pageSettings": ___, "pageSpecifications": ___, "parentSitePageExternalReferenceCode": ___, "permissions": ___, "taxonomyCategoryItemExternalReferences": ___, "type": ___, "uuid": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates the site page with the given external reference code, or creates it if it does not exist."

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseUtilityPageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseUtilityPageResourceImpl.java
@@ -43,6 +43,7 @@ import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.fields.NestedFieldsSupplier;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
@@ -257,6 +258,14 @@ public abstract class BaseUtilityPageResourceImpl
 			resourceId, resourceName, roleNames);
 	}
 
+	protected abstract Page<UtilityPage> doGetSiteUtilityPagesPage(
+			String siteExternalReferenceCode, String search,
+			com.liferay.portal.vulcan.aggregation.Aggregation aggregation,
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -316,7 +325,7 @@ public abstract class BaseUtilityPageResourceImpl
 	@jakarta.ws.rs.Path("/sites/{siteExternalReferenceCode}/utility-pages")
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<UtilityPage> getSiteUtilityPagesPage(
+	public final Page<UtilityPage> getSiteUtilityPagesPage(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
@@ -333,13 +342,35 @@ public abstract class BaseUtilityPageResourceImpl
 				sorts)
 		throws Exception {
 
-		return Page.of(Collections.emptyList());
+		Page<UtilityPage> utilityPagesPage = doGetSiteUtilityPagesPage(
+			siteExternalReferenceCode, search, aggregation, filter, pagination,
+			sorts);
+
+		for (UtilityPage utilityPage : utilityPagesPage.getItems()) {
+			utilityPage.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Page<Permission> permissionsPage =
+							getSiteUtilityPagePermissionsPage(
+								siteExternalReferenceCode,
+								utilityPage.getExternalReferenceCode(), null);
+
+						Collection<Permission> permissions =
+							permissionsPage.getItems();
+
+						return permissions.toArray(
+							new Permission[permissions.size()]);
+					}));
+		}
+
+		return utilityPagesPage;
 	}
 
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/utility-pages/{utilityPageExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "externalReferenceCode": ___, "friendlyUrlHistory": ___, "friendlyUrlPath_i18n": ___, "markedAsDefault": ___, "name": ___, "pageSpecifications": ___, "thumbnail": ___, "type": ___, "utilityPageSettings": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/utility-pages/{utilityPageExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "externalReferenceCode": ___, "friendlyUrlHistory": ___, "friendlyUrlPath_i18n": ___, "markedAsDefault": ___, "name": ___, "pageSpecifications": ___, "permissions": ___, "thumbnail": ___, "type": ___, "utilityPageSettings": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates only the fields received in the request body, leaving any other fields untouched."
@@ -430,6 +461,10 @@ public abstract class BaseUtilityPageResourceImpl
 			existingUtilityPage.setName(utilityPage.getName());
 		}
 
+		if (utilityPage.getPermissions() != null) {
+			existingUtilityPage.setPermissions(utilityPage.getPermissions());
+		}
+
 		if (utilityPage.getType() != null) {
 			existingUtilityPage.setType(utilityPage.getType());
 		}
@@ -445,10 +480,14 @@ public abstract class BaseUtilityPageResourceImpl
 			existingUtilityPage);
 	}
 
+	protected abstract UtilityPage doPostSiteUtilityPage(
+			String siteExternalReferenceCode, UtilityPage utilityPage)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/utility-pages' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "externalReferenceCode": ___, "friendlyUrlHistory": ___, "friendlyUrlPath_i18n": ___, "markedAsDefault": ___, "name": ___, "pageSpecifications": ___, "thumbnail": ___, "type": ___, "utilityPageSettings": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/utility-pages' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "externalReferenceCode": ___, "friendlyUrlHistory": ___, "friendlyUrlPath_i18n": ___, "markedAsDefault": ___, "name": ___, "pageSpecifications": ___, "permissions": ___, "thumbnail": ___, "type": ___, "utilityPageSettings": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Adds a new utility page"
@@ -469,7 +508,7 @@ public abstract class BaseUtilityPageResourceImpl
 	@jakarta.ws.rs.POST
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public UtilityPage postSiteUtilityPage(
+	public final UtilityPage postSiteUtilityPage(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
@@ -477,7 +516,30 @@ public abstract class BaseUtilityPageResourceImpl
 			UtilityPage utilityPage)
 		throws Exception {
 
-		return new UtilityPage();
+		Permission[] permissions = utilityPage.getPermissions();
+
+		UtilityPage postUtilityPage = doPostSiteUtilityPage(
+			siteExternalReferenceCode, utilityPage);
+
+		if (permissions != null) {
+			Page<Permission> permissionsPage =
+				putSiteUtilityPagePermissionsPage(
+					siteExternalReferenceCode,
+					postUtilityPage.getExternalReferenceCode(), permissions);
+
+			postUtilityPage.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Collection<Permission> collection =
+							permissionsPage.getItems();
+
+						return collection.toArray(
+							new Permission[collection.size()]);
+					}));
+		}
+
+		return postUtilityPage;
 	}
 
 	/**
@@ -683,7 +745,7 @@ public abstract class BaseUtilityPageResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/utility-pages/{utilityPageExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "externalReferenceCode": ___, "friendlyUrlHistory": ___, "friendlyUrlPath_i18n": ___, "markedAsDefault": ___, "name": ___, "pageSpecifications": ___, "thumbnail": ___, "type": ___, "utilityPageSettings": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/utility-pages/{utilityPageExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "datePublished": ___, "externalReferenceCode": ___, "friendlyUrlHistory": ___, "friendlyUrlPath_i18n": ___, "markedAsDefault": ___, "name": ___, "pageSpecifications": ___, "permissions": ___, "thumbnail": ___, "type": ___, "utilityPageSettings": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates the utility page with the given external reference code, or creates it if it does not exist."

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateFolderResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateFolderResourceImpl.java
@@ -196,6 +196,28 @@ public class DisplayPageTemplateFolderResourceImpl
 					displayPageTemplateFolder.getDescription()));
 	}
 
+	@Override
+	protected Long getPermissionCheckerResourceId(
+			String groupExternalReferenceCode, String externalReferenceCode)
+		throws Exception {
+
+		LayoutPageTemplateCollection layoutPageTemplateCollection =
+			_layoutPageTemplateCollectionService.
+				getLayoutPageTemplateCollection(
+					externalReferenceCode,
+					getPermissionCheckerGroupId(groupExternalReferenceCode));
+
+		return layoutPageTemplateCollection.getPrimaryKey();
+	}
+
+	@Override
+	protected String getPermissionCheckerResourceName(
+			String groupExternalReferenceCode, String externalReferenceCode)
+		throws Exception {
+
+		return LayoutPageTemplateCollection.class.getName();
+	}
+
 	private DisplayPageTemplateFolder _addDisplayPageTemplateFolder(
 			DisplayPageTemplateFolder displayPageTemplateFolder, long groupId)
 		throws Exception {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateFolderResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateFolderResourceImpl.java
@@ -64,32 +64,8 @@ public class DisplayPageTemplateFolderResourceImpl
 	}
 
 	@Override
-	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
-		return _entityModel;
-	}
-
-	@Override
-	public DisplayPageTemplateFolder getSiteDisplayPageTemplateFolder(
-			String siteExternalReferenceCode,
-			String displayPageTemplateFolderExternalReferenceCode)
-		throws Exception {
-
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
-			throw new UnsupportedOperationException();
-		}
-
-		return _toDisplayPageTemplateFolder(
-			_layoutPageTemplateCollectionService.
-				getLayoutPageTemplateCollection(
-					displayPageTemplateFolderExternalReferenceCode,
-					GroupUtil.getGroupId(
-						true, contextCompany.getCompanyId(),
-						siteExternalReferenceCode)));
-	}
-
-	@Override
 	public Page<DisplayPageTemplateFolder>
-			getSiteDisplayPageTemplateFoldersPage(
+			doGetSiteDisplayPageTemplateFoldersPage(
 				String siteExternalReferenceCode, String search,
 				Aggregation aggregation, Filter filter, Pagination pagination,
 				Sort[] sorts)
@@ -128,7 +104,7 @@ public class DisplayPageTemplateFolderResourceImpl
 	}
 
 	@Override
-	public DisplayPageTemplateFolder postSiteDisplayPageTemplateFolder(
+	public DisplayPageTemplateFolder doPostSiteDisplayPageTemplateFolder(
 			String siteExternalReferenceCode,
 			DisplayPageTemplateFolder displayPageTemplateFolder)
 		throws Exception {
@@ -142,6 +118,30 @@ public class DisplayPageTemplateFolderResourceImpl
 			GroupUtil.getGroupId(
 				false, contextCompany.getCompanyId(),
 				siteExternalReferenceCode));
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
+		return _entityModel;
+	}
+
+	@Override
+	public DisplayPageTemplateFolder getSiteDisplayPageTemplateFolder(
+			String siteExternalReferenceCode,
+			String displayPageTemplateFolderExternalReferenceCode)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
+			throw new UnsupportedOperationException();
+		}
+
+		return _toDisplayPageTemplateFolder(
+			_layoutPageTemplateCollectionService.
+				getLayoutPageTemplateCollection(
+					displayPageTemplateFolderExternalReferenceCode,
+					GroupUtil.getGroupId(
+						true, contextCompany.getCompanyId(),
+						siteExternalReferenceCode)));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateResourceImpl.java
@@ -414,6 +414,28 @@ public class DisplayPageTemplateResourceImpl
 	}
 
 	@Override
+	protected Long getPermissionCheckerResourceId(
+			String groupExternalReferenceCode, String externalReferenceCode)
+		throws Exception {
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_layoutPageTemplateEntryService.
+				getLayoutPageTemplateEntryByExternalReferenceCode(
+					externalReferenceCode,
+					getPermissionCheckerGroupId(groupExternalReferenceCode));
+
+		return layoutPageTemplateEntry.getPrimaryKey();
+	}
+
+	@Override
+	protected String getPermissionCheckerResourceName(
+			String groupExternalReferenceCode, String externalReferenceCode)
+		throws Exception {
+
+		return LayoutPageTemplateEntry.class.getName();
+	}
+
+	@Override
 	protected void preparePatch(
 		DisplayPageTemplate displayPageTemplate,
 		DisplayPageTemplate existingDisplayPageTemplate) {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateResourceImpl.java
@@ -42,7 +42,6 @@ import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.model.ClassName;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
-import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
@@ -59,7 +58,6 @@ import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
-import com.liferay.portal.vulcan.util.SearchUtil;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
@@ -99,6 +97,52 @@ public class DisplayPageTemplateResourceImpl
 			GroupUtil.getGroupId(
 				false, contextCompany.getCompanyId(),
 				siteExternalReferenceCode));
+	}
+
+	@Override
+	public Page<DisplayPageTemplate> doGetSiteDisplayPageTemplatesPage(
+			String siteExternalReferenceCode, String search,
+			Aggregation aggregation, Filter filter, Pagination pagination,
+			Sort[] sorts)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
+			throw new UnsupportedOperationException();
+		}
+
+		long groupId = GroupUtil.getGroupId(
+			true, contextCompany.getCompanyId(), siteExternalReferenceCode);
+
+		return Page.of(
+			transform(
+				_layoutPageTemplateEntryService.getLayoutPageTemplateEntries(
+					groupId, LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE,
+					pagination.getStartPosition(), pagination.getEndPosition(),
+					null),
+				layoutPageTemplateEntry ->
+					_displayPageTemplateDTOConverter.toDTO(
+						layoutPageTemplateEntry)),
+			pagination,
+			_layoutPageTemplateEntryService.getLayoutPageTemplateEntriesCount(
+				groupId, LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE));
+	}
+
+	@Override
+	public DisplayPageTemplate doPostSiteDisplayPageTemplate(
+			String siteExternalReferenceCode,
+			DisplayPageTemplate displayPageTemplate)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
+			throw new UnsupportedOperationException();
+		}
+
+		long groupId = GroupUtil.getGroupId(
+			false, contextCompany.getCompanyId(), siteExternalReferenceCode);
+
+		return _addDisplayPageTemplate(
+			displayPageTemplate, groupId,
+			_getLayoutPageTemplateCollectionId(displayPageTemplate, groupId));
 	}
 
 	@Override
@@ -171,61 +215,6 @@ public class DisplayPageTemplateResourceImpl
 				layoutPageTemplateEntry ->
 					_displayPageTemplateDTOConverter.toDTO(
 						layoutPageTemplateEntry)));
-	}
-
-	@Override
-	public Page<DisplayPageTemplate> getSiteDisplayPageTemplatesPage(
-			String siteExternalReferenceCode, String search,
-			Aggregation aggregation, Filter filter, Pagination pagination,
-			Sort[] sorts)
-		throws Exception {
-
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
-			throw new UnsupportedOperationException();
-		}
-
-		long groupId = GroupUtil.getGroupId(
-			true, contextCompany.getCompanyId(), siteExternalReferenceCode);
-
-		return SearchUtil.search(
-			Collections.emptyMap(),
-			booleanQuery -> {
-			},
-			filter, LayoutPageTemplateEntry.class.getName(), search, pagination,
-			queryConfig -> queryConfig.setSelectedFieldNames(
-				Field.ENTRY_CLASS_PK),
-			searchContext -> {
-				searchContext.setAttribute(
-					"types",
-					new String[] {
-						String.valueOf(
-							LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE)
-					});
-				searchContext.setCompanyId(contextCompany.getCompanyId());
-				searchContext.setGroupIds(new long[] {groupId});
-			},
-			sorts,
-			document -> _displayPageTemplateDTOConverter.toDTO(
-				_layoutPageTemplateEntryService.fetchLayoutPageTemplateEntry(
-					GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK)))));
-	}
-
-	@Override
-	public DisplayPageTemplate postSiteDisplayPageTemplate(
-			String siteExternalReferenceCode,
-			DisplayPageTemplate displayPageTemplate)
-		throws Exception {
-
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
-			throw new UnsupportedOperationException();
-		}
-
-		long groupId = GroupUtil.getGroupId(
-			false, contextCompany.getCompanyId(), siteExternalReferenceCode);
-
-		return _addDisplayPageTemplate(
-			displayPageTemplate, groupId,
-			_getLayoutPageTemplateCollectionId(displayPageTemplate, groupId));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/MasterPageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/MasterPageResourceImpl.java
@@ -274,6 +274,28 @@ public class MasterPageResourceImpl extends BaseMasterPageResourceImpl {
 	}
 
 	@Override
+	protected Long getPermissionCheckerResourceId(
+			String groupExternalReferenceCode, String externalReferenceCode)
+		throws Exception {
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_layoutPageTemplateEntryService.
+				getLayoutPageTemplateEntryByExternalReferenceCode(
+					externalReferenceCode,
+					getPermissionCheckerGroupId(groupExternalReferenceCode));
+
+		return layoutPageTemplateEntry.getPrimaryKey();
+	}
+
+	@Override
+	protected String getPermissionCheckerResourceName(
+			String groupExternalReferenceCode, String externalReferenceCode)
+		throws Exception {
+
+		return LayoutPageTemplateEntry.class.getName();
+	}
+
+	@Override
 	protected void preparePatch(
 		MasterPage masterPage, MasterPage existingMasterPage) {
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/MasterPageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/MasterPageResourceImpl.java
@@ -77,40 +77,7 @@ public class MasterPageResourceImpl extends BaseMasterPageResourceImpl {
 	}
 
 	@Override
-	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
-		return _entityModel;
-	}
-
-	@Override
-	public MasterPage getSiteMasterPage(
-			String siteExternalReferenceCode,
-			String masterPageExternalReferenceCode)
-		throws Exception {
-
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
-			throw new UnsupportedOperationException();
-		}
-
-		LayoutPageTemplateEntry layoutPageTemplateEntry =
-			_layoutPageTemplateEntryService.
-				getLayoutPageTemplateEntryByExternalReferenceCode(
-					masterPageExternalReferenceCode,
-					GroupUtil.getGroupId(
-						true, contextCompany.getCompanyId(),
-						siteExternalReferenceCode));
-
-		if (!Objects.equals(
-				LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT,
-				layoutPageTemplateEntry.getType())) {
-
-			throw new UnsupportedOperationException();
-		}
-
-		return _masterPageDTOConverter.toDTO(layoutPageTemplateEntry);
-	}
-
-	@Override
-	public Page<MasterPage> getSiteMasterPagesPage(
+	public Page<MasterPage> doGetSiteMasterPagesPage(
 			String siteExternalReferenceCode, String search,
 			Aggregation aggregation, Filter filter, Pagination pagination,
 			Sort[] sorts)
@@ -147,7 +114,7 @@ public class MasterPageResourceImpl extends BaseMasterPageResourceImpl {
 	}
 
 	@Override
-	public MasterPage postSiteMasterPage(
+	public MasterPage doPostSiteMasterPage(
 			String siteExternalReferenceCode, MasterPage masterPage)
 		throws Exception {
 
@@ -160,6 +127,39 @@ public class MasterPageResourceImpl extends BaseMasterPageResourceImpl {
 				false, contextCompany.getCompanyId(),
 				siteExternalReferenceCode),
 			masterPage);
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
+		return _entityModel;
+	}
+
+	@Override
+	public MasterPage getSiteMasterPage(
+			String siteExternalReferenceCode,
+			String masterPageExternalReferenceCode)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
+			throw new UnsupportedOperationException();
+		}
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_layoutPageTemplateEntryService.
+				getLayoutPageTemplateEntryByExternalReferenceCode(
+					masterPageExternalReferenceCode,
+					GroupUtil.getGroupId(
+						true, contextCompany.getCompanyId(),
+						siteExternalReferenceCode));
+
+		if (!Objects.equals(
+				LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT,
+				layoutPageTemplateEntry.getType())) {
+
+			throw new UnsupportedOperationException();
+		}
+
+		return _masterPageDTOConverter.toDTO(layoutPageTemplateEntry);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateResourceImpl.java
@@ -359,6 +359,28 @@ public class PageTemplateResourceImpl extends BasePageTemplateResourceImpl {
 	}
 
 	@Override
+	protected Long getPermissionCheckerResourceId(
+			String groupExternalReferenceCode, String externalReferenceCode)
+		throws Exception {
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_layoutPageTemplateEntryLocalService.
+				getLayoutPageTemplateEntryByExternalReferenceCode(
+					externalReferenceCode,
+					getPermissionCheckerGroupId(groupExternalReferenceCode));
+
+		return layoutPageTemplateEntry.getPrimaryKey();
+	}
+
+	@Override
+	protected String getPermissionCheckerResourceName(
+			String groupExternalReferenceCode, String externalReferenceCode)
+		throws Exception {
+
+		return LayoutPageTemplateEntry.class.getName();
+	}
+
+	@Override
 	protected void preparePatch(
 		PageTemplate pageTemplate, PageTemplate existingPageTemplate) {
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateResourceImpl.java
@@ -39,7 +39,6 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutPrototype;
 import com.liferay.portal.kernel.model.LayoutTypePortletConstants;
-import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.LayoutLocalService;
@@ -59,7 +58,6 @@ import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
-import com.liferay.portal.vulcan.util.SearchUtil;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
@@ -96,6 +94,58 @@ public class PageTemplateResourceImpl extends BasePageTemplateResourceImpl {
 			GroupUtil.getGroupId(
 				true, false, contextCompany.getCompanyId(),
 				siteExternalReferenceCode));
+	}
+
+	@Override
+	public Page<PageTemplate> doGetSitePageTemplatesPage(
+			String siteExternalReferenceCode, String search,
+			Aggregation aggregation, Filter filter, Pagination pagination,
+			Sort[] sorts)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
+			throw new UnsupportedOperationException();
+		}
+
+		long groupId = GroupUtil.getGroupId(
+			true, true, contextCompany.getCompanyId(),
+			siteExternalReferenceCode);
+
+		return Page.of(
+			transform(
+				_layoutPageTemplateEntryService.getLayoutPageTemplateEntries(
+					groupId,
+					new int[] {
+						LayoutPageTemplateEntryTypeConstants.BASIC,
+						LayoutPageTemplateEntryTypeConstants.WIDGET_PAGE
+					},
+					pagination.getStartPosition(), pagination.getEndPosition(),
+					null),
+				layoutPageTemplateEntry -> _pageTemplateDTOConverter.toDTO(
+					layoutPageTemplateEntry)),
+			pagination,
+			_layoutPageTemplateEntryService.getLayoutPageTemplateEntriesCount(
+				groupId,
+				new int[] {
+					LayoutPageTemplateEntryTypeConstants.BASIC,
+					LayoutPageTemplateEntryTypeConstants.WIDGET_PAGE
+				}));
+	}
+
+	@Override
+	public PageTemplate doPostSitePageTemplate(
+			String siteExternalReferenceCode, PageTemplate pageTemplate)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
+			throw new UnsupportedOperationException();
+		}
+
+		return _addPageTemplate(
+			GroupUtil.getGroupId(
+				_isTypeWidgetPageTemplate(pageTemplate), false,
+				contextCompany.getCompanyId(), siteExternalReferenceCode),
+			pageTemplate);
 	}
 
 	@Override
@@ -168,62 +218,6 @@ public class PageTemplateResourceImpl extends BasePageTemplateResourceImpl {
 					QueryUtil.ALL_POS, QueryUtil.ALL_POS, null),
 				layoutPageTemplateEntry -> _pageTemplateDTOConverter.toDTO(
 					layoutPageTemplateEntry)));
-	}
-
-	@Override
-	public Page<PageTemplate> getSitePageTemplatesPage(
-			String siteExternalReferenceCode, String search,
-			Aggregation aggregation, Filter filter, Pagination pagination,
-			Sort[] sorts)
-		throws Exception {
-
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
-			throw new UnsupportedOperationException();
-		}
-
-		long groupId = GroupUtil.getGroupId(
-			true, true, contextCompany.getCompanyId(),
-			siteExternalReferenceCode);
-
-		return SearchUtil.search(
-			Collections.emptyMap(),
-			booleanQuery -> {
-			},
-			filter, LayoutPageTemplateEntry.class.getName(), search, pagination,
-			queryConfig -> queryConfig.setSelectedFieldNames(
-				Field.ENTRY_CLASS_PK),
-			searchContext -> {
-				searchContext.setAttribute(
-					"types",
-					new String[] {
-						String.valueOf(
-							LayoutPageTemplateEntryTypeConstants.BASIC),
-						String.valueOf(
-							LayoutPageTemplateEntryTypeConstants.WIDGET_PAGE)
-					});
-				searchContext.setCompanyId(contextCompany.getCompanyId());
-				searchContext.setGroupIds(new long[] {groupId});
-			},
-			sorts,
-			document -> _pageTemplateDTOConverter.toDTO(
-				_layoutPageTemplateEntryService.fetchLayoutPageTemplateEntry(
-					GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK)))));
-	}
-
-	@Override
-	public PageTemplate postSitePageTemplate(
-			String siteExternalReferenceCode, PageTemplate pageTemplate)
-		throws Exception {
-
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
-			throw new UnsupportedOperationException();
-		}
-
-		return _addPageTemplate(
-			GroupUtil.getGroupId(
-				_isTypeWidgetPageTemplate(pageTemplate), false,
-				contextCompany.getCompanyId(), siteExternalReferenceCode),
-			pageTemplate);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateSetResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateSetResourceImpl.java
@@ -173,6 +173,28 @@ public class PageTemplateSetResourceImpl
 					pageTemplateSet.getDescription()));
 	}
 
+	@Override
+	protected Long getPermissionCheckerResourceId(
+			String groupExternalReferenceCode, String externalReferenceCode)
+		throws Exception {
+
+		LayoutPageTemplateCollection layoutPageTemplateCollection =
+			_layoutPageTemplateCollectionService.
+				getLayoutPageTemplateCollection(
+					externalReferenceCode,
+					getPermissionCheckerGroupId(groupExternalReferenceCode));
+
+		return layoutPageTemplateCollection.getPrimaryKey();
+	}
+
+	@Override
+	protected String getPermissionCheckerResourceName(
+			String groupExternalReferenceCode, String externalReferenceCode)
+		throws Exception {
+
+		return LayoutPageTemplateCollection.class.getName();
+	}
+
 	private PageTemplateSet _toPageTemplateSet(
 			LayoutPageTemplateCollection layoutPageTemplateCollection)
 		throws Exception {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateSetResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateSetResourceImpl.java
@@ -61,31 +61,7 @@ public class PageTemplateSetResourceImpl
 	}
 
 	@Override
-	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
-		return _entityModel;
-	}
-
-	@Override
-	public PageTemplateSet getSitePageTemplateSet(
-			String siteExternalReferenceCode,
-			String pageTemplateSetExternalReferenceCode)
-		throws Exception {
-
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
-			throw new UnsupportedOperationException();
-		}
-
-		return _toPageTemplateSet(
-			_layoutPageTemplateCollectionService.
-				getLayoutPageTemplateCollection(
-					pageTemplateSetExternalReferenceCode,
-					GroupUtil.getGroupId(
-						true, contextCompany.getCompanyId(),
-						siteExternalReferenceCode)));
-	}
-
-	@Override
-	public Page<PageTemplateSet> getSitePageTemplateSetsPage(
+	public Page<PageTemplateSet> doGetSitePageTemplateSetsPage(
 			String siteExternalReferenceCode, String search,
 			Aggregation aggregation, Filter filter, Pagination pagination,
 			Sort[] sorts)
@@ -123,7 +99,7 @@ public class PageTemplateSetResourceImpl
 	}
 
 	@Override
-	public PageTemplateSet postSitePageTemplateSet(
+	public PageTemplateSet doPostSitePageTemplateSet(
 			String siteExternalReferenceCode, PageTemplateSet pageTemplateSet)
 		throws Exception {
 
@@ -137,6 +113,30 @@ public class PageTemplateSetResourceImpl
 					false, contextCompany.getCompanyId(),
 					siteExternalReferenceCode),
 				contextHttpServletRequest, pageTemplateSet));
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
+		return _entityModel;
+	}
+
+	@Override
+	public PageTemplateSet getSitePageTemplateSet(
+			String siteExternalReferenceCode,
+			String pageTemplateSetExternalReferenceCode)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
+			throw new UnsupportedOperationException();
+		}
+
+		return _toPageTemplateSet(
+			_layoutPageTemplateCollectionService.
+				getLayoutPageTemplateCollection(
+					pageTemplateSetExternalReferenceCode,
+					GroupUtil.getGroupId(
+						true, contextCompany.getCompanyId(),
+						siteExternalReferenceCode)));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
@@ -95,28 +95,7 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 	}
 
 	@Override
-	public SitePage getSiteSitePage(
-			String siteExternalReferenceCode,
-			String sitePageExternalReferenceCode)
-		throws Exception {
-
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
-			throw new UnsupportedOperationException();
-		}
-
-		Layout layout = _layoutService.getLayoutByExternalReferenceCode(
-			sitePageExternalReferenceCode,
-			GroupUtil.getGroupId(
-				true, contextCompany.getCompanyId(),
-				siteExternalReferenceCode));
-
-		_validateSitePageLayout(layout);
-
-		return _toSitePage(layout);
-	}
-
-	@Override
-	public Page<SitePage> getSiteSitePagesPage(
+	public Page<SitePage> doGetSiteSitePagesPage(
 			String siteExternalReferenceCode, String search,
 			Aggregation aggregation, Filter filter, Pagination pagination,
 			Sort[] sorts)
@@ -153,7 +132,7 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 	}
 
 	@Override
-	public SitePage postSiteSitePage(
+	public SitePage doPostSiteSitePage(
 			String siteExternalReferenceCode, SitePage sitePage)
 		throws Exception {
 
@@ -168,6 +147,27 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 					false, contextCompany.getCompanyId(),
 					siteExternalReferenceCode),
 				sitePage));
+	}
+
+	@Override
+	public SitePage getSiteSitePage(
+			String siteExternalReferenceCode,
+			String sitePageExternalReferenceCode)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
+			throw new UnsupportedOperationException();
+		}
+
+		Layout layout = _layoutService.getLayoutByExternalReferenceCode(
+			sitePageExternalReferenceCode,
+			GroupUtil.getGroupId(
+				true, contextCompany.getCompanyId(),
+				siteExternalReferenceCode));
+
+		_validateSitePageLayout(layout);
+
+		return _toSitePage(layout);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
@@ -257,6 +257,26 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 	}
 
 	@Override
+	protected Long getPermissionCheckerResourceId(
+			String groupExternalReferenceCode, String externalReferenceCode)
+		throws Exception {
+
+		Layout layout = _layoutService.getLayoutByExternalReferenceCode(
+			externalReferenceCode,
+			getPermissionCheckerGroupId(groupExternalReferenceCode));
+
+		return layout.getPrimaryKey();
+	}
+
+	@Override
+	protected String getPermissionCheckerResourceName(
+			String groupExternalReferenceCode, String externalReferenceCode)
+		throws Exception {
+
+		return Layout.class.getName();
+	}
+
+	@Override
 	protected void preparePatch(SitePage sitePage, SitePage existingSitePage) {
 		if (sitePage.getPageSettings() != null) {
 			existingSitePage.setPageSettings(sitePage::getPageSettings);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/UtilityPageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/UtilityPageResourceImpl.java
@@ -78,31 +78,7 @@ public class UtilityPageResourceImpl extends BaseUtilityPageResourceImpl {
 	}
 
 	@Override
-	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
-		return _entityModel;
-	}
-
-	@Override
-	public UtilityPage getSiteUtilityPage(
-			String siteExternalReferenceCode,
-			String utilityPageExternalReferenceCode)
-		throws Exception {
-
-		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
-			throw new UnsupportedOperationException();
-		}
-
-		return _utilityPageDTOConverter.toDTO(
-			_layoutUtilityPageEntryService.
-				getLayoutUtilityPageEntryByExternalReferenceCode(
-					utilityPageExternalReferenceCode,
-					GroupUtil.getGroupId(
-						true, contextCompany.getCompanyId(),
-						siteExternalReferenceCode)));
-	}
-
-	@Override
-	public Page<UtilityPage> getSiteUtilityPagesPage(
+	public Page<UtilityPage> doGetSiteUtilityPagesPage(
 			String siteExternalReferenceCode, String search,
 			Aggregation aggregation, Filter filter, Pagination pagination,
 			Sort[] sorts)
@@ -133,7 +109,7 @@ public class UtilityPageResourceImpl extends BaseUtilityPageResourceImpl {
 	}
 
 	@Override
-	public UtilityPage postSiteUtilityPage(
+	public UtilityPage doPostSiteUtilityPage(
 			String siteExternalReferenceCode, UtilityPage utilityPage)
 		throws Exception {
 
@@ -146,6 +122,30 @@ public class UtilityPageResourceImpl extends BaseUtilityPageResourceImpl {
 				false, contextCompany.getCompanyId(),
 				siteExternalReferenceCode),
 			utilityPage);
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
+		return _entityModel;
+	}
+
+	@Override
+	public UtilityPage getSiteUtilityPage(
+			String siteExternalReferenceCode,
+			String utilityPageExternalReferenceCode)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
+			throw new UnsupportedOperationException();
+		}
+
+		return _utilityPageDTOConverter.toDTO(
+			_layoutUtilityPageEntryService.
+				getLayoutUtilityPageEntryByExternalReferenceCode(
+					utilityPageExternalReferenceCode,
+					GroupUtil.getGroupId(
+						true, contextCompany.getCompanyId(),
+						siteExternalReferenceCode)));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/UtilityPageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/UtilityPageResourceImpl.java
@@ -265,6 +265,28 @@ public class UtilityPageResourceImpl extends BaseUtilityPageResourceImpl {
 	}
 
 	@Override
+	protected Long getPermissionCheckerResourceId(
+			String groupExternalReferenceCode, String externalReferenceCode)
+		throws Exception {
+
+		LayoutUtilityPageEntry layoutUtilityPageEntry =
+			_layoutUtilityPageEntryService.
+				getLayoutUtilityPageEntryByExternalReferenceCode(
+					externalReferenceCode,
+					getPermissionCheckerGroupId(groupExternalReferenceCode));
+
+		return layoutUtilityPageEntry.getPrimaryKey();
+	}
+
+	@Override
+	protected String getPermissionCheckerResourceName(
+			String groupExternalReferenceCode, String externalReferenceCode)
+		throws Exception {
+
+		return LayoutUtilityPageEntry.class.getName();
+	}
+
+	@Override
 	protected void preparePatch(
 		UtilityPage utilityPage, UtilityPage existingUtilityPage) {
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseDisplayPageTemplateFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseDisplayPageTemplateFolderResourceTestCase.java
@@ -129,6 +129,19 @@ public abstract class BaseDisplayPageTemplateFolderResourceTestCase {
 		).locale(
 			LocaleUtil.getDefault()
 		).build();
+
+		permissionsDisplayPageTemplateFolderResource =
+			DisplayPageTemplateFolderResource.builder(
+			).authentication(
+				_testCompanyAdminUser.getEmailAddress(),
+				PropsValues.DEFAULT_ADMIN_PASSWORD
+			).endpoint(
+				testCompany.getVirtualHostname(), 8080, "http"
+			).locale(
+				LocaleUtil.getDefault()
+			).parameter(
+				"nestedFields", "permissions"
+			).build();
 	}
 
 	@After
@@ -395,6 +408,24 @@ public abstract class BaseDisplayPageTemplateFolderResourceTestCase {
 			page,
 			testGetSiteDisplayPageTemplateFoldersPage_getExpectedActions(
 				siteExternalReferenceCode));
+
+		for (DisplayPageTemplateFolder displayPageTemplateFolder :
+				page.getItems()) {
+
+			Assert.assertNull(displayPageTemplateFolder.getPermissions());
+		}
+
+		page =
+			permissionsDisplayPageTemplateFolderResource.
+				getSiteDisplayPageTemplateFoldersPage(
+					siteExternalReferenceCode, null, null, null,
+					Pagination.of(1, 10), null);
+
+		for (DisplayPageTemplateFolder displayPageTemplateFolder :
+				page.getItems()) {
+
+			Assert.assertNotNull(displayPageTemplateFolder.getPermissions());
+		}
 	}
 
 	protected Map<String, Map<String, String>>
@@ -897,6 +928,26 @@ public abstract class BaseDisplayPageTemplateFolderResourceTestCase {
 		assertEquals(
 			randomDisplayPageTemplateFolder, postDisplayPageTemplateFolder);
 		assertValid(postDisplayPageTemplateFolder);
+
+		DisplayPageTemplateFolder randomPermissionsDisplayPageTemplateFolder1 =
+			randomPermissionsDisplayPageTemplateFolder();
+
+		DisplayPageTemplateFolder postPermissionsDisplayPageTemplateFolder1 =
+			testPostSiteDisplayPageTemplateFolder_addDisplayPageTemplateFolder(
+				randomPermissionsDisplayPageTemplateFolder1);
+
+		Assert.assertNull(
+			postPermissionsDisplayPageTemplateFolder1.getPermissions());
+
+		DisplayPageTemplateFolder randomPermissionsDisplayPageTemplateFolder2 =
+			randomPermissionsDisplayPageTemplateFolder();
+
+		DisplayPageTemplateFolder postPermissionsDisplayPageTemplateFolder2 =
+			testPostSiteDisplayPageTemplateFolder_addPermissionsDisplayPageTemplateFolder(
+				randomPermissionsDisplayPageTemplateFolder2);
+
+		Assert.assertNotNull(
+			postPermissionsDisplayPageTemplateFolder2.getPermissions());
 	}
 
 	protected DisplayPageTemplateFolder
@@ -906,6 +957,17 @@ public abstract class BaseDisplayPageTemplateFolderResourceTestCase {
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	protected DisplayPageTemplateFolder
+			testPostSiteDisplayPageTemplateFolder_addPermissionsDisplayPageTemplateFolder(
+				DisplayPageTemplateFolder displayPageTemplateFolder)
+		throws Exception {
+
+		return permissionsDisplayPageTemplateFolderResource.
+			postSiteDisplayPageTemplateFolder(
+				testGetSiteDisplayPageTemplateFoldersPage_getSiteExternalReferenceCode(),
+				displayPageTemplateFolder);
 	}
 
 	@Test
@@ -1266,6 +1328,14 @@ public abstract class BaseDisplayPageTemplateFolderResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("permissions", additionalAssertFieldName)) {
+				if (displayPageTemplateFolder.getPermissions() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("uuid", additionalAssertFieldName)) {
 				if (displayPageTemplateFolder.getUuid() == null) {
 					valid = false;
@@ -1516,6 +1586,17 @@ public abstract class BaseDisplayPageTemplateFolderResourceTestCase {
 							getParentDisplayPageTemplateFolderExternalReferenceCode(),
 						displayPageTemplateFolder2.
 							getParentDisplayPageTemplateFolderExternalReferenceCode())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("permissions", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						displayPageTemplateFolder1.getPermissions(),
+						displayPageTemplateFolder2.getPermissions())) {
 
 					return false;
 				}
@@ -1997,6 +2078,11 @@ public abstract class BaseDisplayPageTemplateFolderResourceTestCase {
 			return sb.toString();
 		}
 
+		if (entityFieldName.equals("permissions")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
 		if (entityFieldName.equals("uuid")) {
 			Object object = displayPageTemplateFolder.getUuid();
 
@@ -2123,6 +2209,29 @@ public abstract class BaseDisplayPageTemplateFolderResourceTestCase {
 		return randomDisplayPageTemplateFolder();
 	}
 
+	protected DisplayPageTemplateFolder
+			randomPermissionsDisplayPageTemplateFolder()
+		throws Exception {
+
+		DisplayPageTemplateFolder displayPageTemplateFolder =
+			randomDisplayPageTemplateFolder();
+
+		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
+			RoleConstants.TYPE_REGULAR);
+
+		displayPageTemplateFolder.setPermissions(
+			new Permission[] {
+				new Permission() {
+					{
+						setActionIds(new String[] {"VIEW"});
+						setRoleName(role.getName());
+					}
+				}
+			});
+
+		return displayPageTemplateFolder;
+	}
+
 	protected final JSONObject waitForFinish(
 			String expectedExecuteStatus, JSONObject jsonObject)
 		throws Exception {
@@ -2149,6 +2258,8 @@ public abstract class BaseDisplayPageTemplateFolderResourceTestCase {
 		displayPageTemplateFolderResource;
 	protected ImportTaskResource importTaskResource;
 	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected DisplayPageTemplateFolderResource
+		permissionsDisplayPageTemplateFolderResource;
 	protected com.liferay.portal.kernel.model.Company testCompany;
 	protected com.liferay.portal.kernel.model.Group testGroup;
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseDisplayPageTemplateResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseDisplayPageTemplateResourceTestCase.java
@@ -129,6 +129,19 @@ public abstract class BaseDisplayPageTemplateResourceTestCase {
 		).locale(
 			LocaleUtil.getDefault()
 		).build();
+
+		permissionsDisplayPageTemplateResource =
+			DisplayPageTemplateResource.builder(
+			).authentication(
+				_testCompanyAdminUser.getEmailAddress(),
+				PropsValues.DEFAULT_ADMIN_PASSWORD
+			).endpoint(
+				testCompany.getVirtualHostname(), 8080, "http"
+			).locale(
+				LocaleUtil.getDefault()
+			).parameter(
+				"nestedFields", "permissions"
+			).build();
 	}
 
 	@After
@@ -495,6 +508,20 @@ public abstract class BaseDisplayPageTemplateResourceTestCase {
 			page,
 			testGetSiteDisplayPageTemplatesPage_getExpectedActions(
 				siteExternalReferenceCode));
+
+		for (DisplayPageTemplate displayPageTemplate : page.getItems()) {
+			Assert.assertNull(displayPageTemplate.getPermissions());
+		}
+
+		page =
+			permissionsDisplayPageTemplateResource.
+				getSiteDisplayPageTemplatesPage(
+					siteExternalReferenceCode, null, null, null,
+					Pagination.of(1, 10), null);
+
+		for (DisplayPageTemplate displayPageTemplate : page.getItems()) {
+			Assert.assertNotNull(displayPageTemplate.getPermissions());
+		}
 	}
 
 	protected Map<String, Map<String, String>>
@@ -963,6 +990,25 @@ public abstract class BaseDisplayPageTemplateResourceTestCase {
 
 		assertEquals(randomDisplayPageTemplate, postDisplayPageTemplate);
 		assertValid(postDisplayPageTemplate);
+
+		DisplayPageTemplate randomPermissionsDisplayPageTemplate1 =
+			randomPermissionsDisplayPageTemplate();
+
+		DisplayPageTemplate postPermissionsDisplayPageTemplate1 =
+			testPostSiteDisplayPageTemplate_addDisplayPageTemplate(
+				randomPermissionsDisplayPageTemplate1);
+
+		Assert.assertNull(postPermissionsDisplayPageTemplate1.getPermissions());
+
+		DisplayPageTemplate randomPermissionsDisplayPageTemplate2 =
+			randomPermissionsDisplayPageTemplate();
+
+		DisplayPageTemplate postPermissionsDisplayPageTemplate2 =
+			testPostSiteDisplayPageTemplate_addPermissionsDisplayPageTemplate(
+				randomPermissionsDisplayPageTemplate2);
+
+		Assert.assertNotNull(
+			postPermissionsDisplayPageTemplate2.getPermissions());
 	}
 
 	protected DisplayPageTemplate
@@ -972,6 +1018,17 @@ public abstract class BaseDisplayPageTemplateResourceTestCase {
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	protected DisplayPageTemplate
+			testPostSiteDisplayPageTemplate_addPermissionsDisplayPageTemplate(
+				DisplayPageTemplate displayPageTemplate)
+		throws Exception {
+
+		return permissionsDisplayPageTemplateResource.
+			postSiteDisplayPageTemplate(
+				testGetSiteDisplayPageTemplatesPage_getSiteExternalReferenceCode(),
+				displayPageTemplate);
 	}
 
 	@Test
@@ -1393,6 +1450,14 @@ public abstract class BaseDisplayPageTemplateResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("permissions", additionalAssertFieldName)) {
+				if (displayPageTemplate.getPermissions() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("thumbnail", additionalAssertFieldName)) {
 				if (displayPageTemplate.getThumbnail() == null) {
 					valid = false;
@@ -1747,6 +1812,17 @@ public abstract class BaseDisplayPageTemplateResourceTestCase {
 				if (!Objects.deepEquals(
 						displayPageTemplate1.getParentFolder(),
 						displayPageTemplate2.getParentFolder())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("permissions", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						displayPageTemplate1.getPermissions(),
+						displayPageTemplate2.getPermissions())) {
 
 					return false;
 				}
@@ -2244,6 +2320,11 @@ public abstract class BaseDisplayPageTemplateResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
+		if (entityFieldName.equals("permissions")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
 		if (entityFieldName.equals("thumbnail")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -2370,6 +2451,27 @@ public abstract class BaseDisplayPageTemplateResourceTestCase {
 		return randomDisplayPageTemplate();
 	}
 
+	protected DisplayPageTemplate randomPermissionsDisplayPageTemplate()
+		throws Exception {
+
+		DisplayPageTemplate displayPageTemplate = randomDisplayPageTemplate();
+
+		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
+			RoleConstants.TYPE_REGULAR);
+
+		displayPageTemplate.setPermissions(
+			new Permission[] {
+				new Permission() {
+					{
+						setActionIds(new String[] {"VIEW"});
+						setRoleName(role.getName());
+					}
+				}
+			});
+
+		return displayPageTemplate;
+	}
+
 	protected ContentPageSpecification randomContentPageSpecification()
 		throws Exception {
 
@@ -2406,6 +2508,8 @@ public abstract class BaseDisplayPageTemplateResourceTestCase {
 	protected DisplayPageTemplateResource displayPageTemplateResource;
 	protected ImportTaskResource importTaskResource;
 	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected DisplayPageTemplateResource
+		permissionsDisplayPageTemplateResource;
 	protected com.liferay.portal.kernel.model.Company testCompany;
 	protected com.liferay.portal.kernel.model.Group testGroup;
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseMasterPageResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseMasterPageResourceTestCase.java
@@ -129,6 +129,18 @@ public abstract class BaseMasterPageResourceTestCase {
 		).locale(
 			LocaleUtil.getDefault()
 		).build();
+
+		permissionsMasterPageResource = MasterPageResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(), 8080, "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).parameter(
+			"nestedFields", "permissions"
+		).build();
 	}
 
 	@After
@@ -341,6 +353,18 @@ public abstract class BaseMasterPageResourceTestCase {
 			page,
 			testGetSiteMasterPagesPage_getExpectedActions(
 				siteExternalReferenceCode));
+
+		for (MasterPage masterPage : page.getItems()) {
+			Assert.assertNull(masterPage.getPermissions());
+		}
+
+		page = permissionsMasterPageResource.getSiteMasterPagesPage(
+			siteExternalReferenceCode, null, null, null, Pagination.of(1, 10),
+			null);
+
+		for (MasterPage masterPage : page.getItems()) {
+			Assert.assertNotNull(masterPage.getPermissions());
+		}
 	}
 
 	protected Map<String, Map<String, String>>
@@ -738,6 +762,21 @@ public abstract class BaseMasterPageResourceTestCase {
 
 		assertEquals(randomMasterPage, postMasterPage);
 		assertValid(postMasterPage);
+
+		MasterPage randomPermissionsMasterPage1 = randomPermissionsMasterPage();
+
+		MasterPage postPermissionsMasterPage1 =
+			testPostSiteMasterPage_addMasterPage(randomPermissionsMasterPage1);
+
+		Assert.assertNull(postPermissionsMasterPage1.getPermissions());
+
+		MasterPage randomPermissionsMasterPage2 = randomPermissionsMasterPage();
+
+		MasterPage postPermissionsMasterPage2 =
+			testPostSiteMasterPage_addPermissionsMasterPage(
+				randomPermissionsMasterPage2);
+
+		Assert.assertNotNull(postPermissionsMasterPage2.getPermissions());
 	}
 
 	protected MasterPage testPostSiteMasterPage_addMasterPage(
@@ -746,6 +785,15 @@ public abstract class BaseMasterPageResourceTestCase {
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	protected MasterPage testPostSiteMasterPage_addPermissionsMasterPage(
+			MasterPage masterPage)
+		throws Exception {
+
+		return permissionsMasterPageResource.postSiteMasterPage(
+			testGetSiteMasterPagesPage_getSiteExternalReferenceCode(),
+			masterPage);
 	}
 
 	@Test
@@ -1069,6 +1117,14 @@ public abstract class BaseMasterPageResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("permissions", additionalAssertFieldName)) {
+				if (masterPage.getPermissions() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals(
 					"taxonomyCategoryItemExternalReferences",
 					additionalAssertFieldName)) {
@@ -1374,6 +1430,17 @@ public abstract class BaseMasterPageResourceTestCase {
 				if (!Objects.deepEquals(
 						masterPage1.getPageSpecifications(),
 						masterPage2.getPageSpecifications())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("permissions", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						masterPage1.getPermissions(),
+						masterPage2.getPermissions())) {
 
 					return false;
 				}
@@ -1861,6 +1928,11 @@ public abstract class BaseMasterPageResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
+		if (entityFieldName.equals("permissions")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
 		if (entityFieldName.equals("taxonomyCategoryItemExternalReferences")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -1987,6 +2059,25 @@ public abstract class BaseMasterPageResourceTestCase {
 		return randomMasterPage();
 	}
 
+	protected MasterPage randomPermissionsMasterPage() throws Exception {
+		MasterPage masterPage = randomMasterPage();
+
+		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
+			RoleConstants.TYPE_REGULAR);
+
+		masterPage.setPermissions(
+			new Permission[] {
+				new Permission() {
+					{
+						setActionIds(new String[] {"VIEW"});
+						setRoleName(role.getName());
+					}
+				}
+			});
+
+		return masterPage;
+	}
+
 	protected ContentPageSpecification randomContentPageSpecification()
 		throws Exception {
 
@@ -2023,6 +2114,7 @@ public abstract class BaseMasterPageResourceTestCase {
 	protected MasterPageResource masterPageResource;
 	protected ImportTaskResource importTaskResource;
 	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected MasterPageResource permissionsMasterPageResource;
 	protected com.liferay.portal.kernel.model.Company testCompany;
 	protected com.liferay.portal.kernel.model.Group testGroup;
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BasePageTemplateResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BasePageTemplateResourceTestCase.java
@@ -132,6 +132,18 @@ public abstract class BasePageTemplateResourceTestCase {
 		).locale(
 			LocaleUtil.getDefault()
 		).build();
+
+		permissionsPageTemplateResource = PageTemplateResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(), 8080, "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).parameter(
+			"nestedFields", "permissions"
+		).build();
 	}
 
 	@After
@@ -469,6 +481,18 @@ public abstract class BasePageTemplateResourceTestCase {
 			page,
 			testGetSitePageTemplatesPage_getExpectedActions(
 				siteExternalReferenceCode));
+
+		for (PageTemplate pageTemplate : page.getItems()) {
+			Assert.assertNull(pageTemplate.getPermissions());
+		}
+
+		page = permissionsPageTemplateResource.getSitePageTemplatesPage(
+			siteExternalReferenceCode, null, null, null, Pagination.of(1, 10),
+			null);
+
+		for (PageTemplate pageTemplate : page.getItems()) {
+			Assert.assertNotNull(pageTemplate.getPermissions());
+		}
 	}
 
 	protected Map<String, Map<String, String>>
@@ -895,6 +919,24 @@ public abstract class BasePageTemplateResourceTestCase {
 		assertEquals(randomPageTemplate, postPageTemplate);
 		assertValid(postPageTemplate);
 
+		PageTemplate randomPermissionsPageTemplate1 =
+			randomPermissionsPageTemplate();
+
+		PageTemplate postPermissionsPageTemplate1 =
+			testPostSitePageTemplate_addPageTemplate(
+				randomPermissionsPageTemplate1);
+
+		Assert.assertNull(postPermissionsPageTemplate1.getPermissions());
+
+		PageTemplate randomPermissionsPageTemplate2 =
+			randomPermissionsPageTemplate();
+
+		PageTemplate postPermissionsPageTemplate2 =
+			testPostSitePageTemplate_addPermissionsPageTemplate(
+				randomPermissionsPageTemplate2);
+
+		Assert.assertNotNull(postPermissionsPageTemplate2.getPermissions());
+
 		ContentPageTemplate contentPageTemplate = new ContentPageTemplate() {
 			{
 				creatorExternalReferenceCode = StringUtil.toLowerCase(
@@ -946,6 +988,15 @@ public abstract class BasePageTemplateResourceTestCase {
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	protected PageTemplate testPostSitePageTemplate_addPermissionsPageTemplate(
+			PageTemplate pageTemplate)
+		throws Exception {
+
+		return permissionsPageTemplateResource.postSitePageTemplate(
+			testGetSitePageTemplatesPage_getSiteExternalReferenceCode(),
+			pageTemplate);
 	}
 
 	@Test
@@ -1349,6 +1400,14 @@ public abstract class BasePageTemplateResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("permissions", additionalAssertFieldName)) {
+				if (pageTemplate.getPermissions() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals(
 					"taxonomyCategoryItemExternalReferences",
 					additionalAssertFieldName)) {
@@ -1741,6 +1800,17 @@ public abstract class BasePageTemplateResourceTestCase {
 				if (!Objects.deepEquals(
 						pageTemplate1.getPageTemplateSettings(),
 						pageTemplate2.getPageTemplateSettings())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("permissions", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						pageTemplate1.getPermissions(),
+						pageTemplate2.getPermissions())) {
 
 					return false;
 				}
@@ -2328,6 +2398,11 @@ public abstract class BasePageTemplateResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
+		if (entityFieldName.equals("permissions")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
 		if (entityFieldName.equals("taxonomyCategoryItemExternalReferences")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -2493,6 +2568,25 @@ public abstract class BasePageTemplateResourceTestCase {
 		return randomPageTemplate();
 	}
 
+	protected PageTemplate randomPermissionsPageTemplate() throws Exception {
+		PageTemplate pageTemplate = randomPageTemplate();
+
+		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
+			RoleConstants.TYPE_REGULAR);
+
+		pageTemplate.setPermissions(
+			new Permission[] {
+				new Permission() {
+					{
+						setActionIds(new String[] {"VIEW"});
+						setRoleName(role.getName());
+					}
+				}
+			});
+
+		return pageTemplate;
+	}
+
 	protected ContentPageSpecification randomContentPageSpecification()
 		throws Exception {
 
@@ -2529,6 +2623,7 @@ public abstract class BasePageTemplateResourceTestCase {
 	protected PageTemplateResource pageTemplateResource;
 	protected ImportTaskResource importTaskResource;
 	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected PageTemplateResource permissionsPageTemplateResource;
 	protected com.liferay.portal.kernel.model.Company testCompany;
 	protected com.liferay.portal.kernel.model.Group testGroup;
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BasePageTemplateSetResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BasePageTemplateSetResourceTestCase.java
@@ -128,6 +128,18 @@ public abstract class BasePageTemplateSetResourceTestCase {
 		).locale(
 			LocaleUtil.getDefault()
 		).build();
+
+		permissionsPageTemplateSetResource = PageTemplateSetResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(), 8080, "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).parameter(
+			"nestedFields", "permissions"
+		).build();
 	}
 
 	@After
@@ -355,6 +367,18 @@ public abstract class BasePageTemplateSetResourceTestCase {
 			page,
 			testGetSitePageTemplateSetsPage_getExpectedActions(
 				siteExternalReferenceCode));
+
+		for (PageTemplateSet pageTemplateSet : page.getItems()) {
+			Assert.assertNull(pageTemplateSet.getPermissions());
+		}
+
+		page = permissionsPageTemplateSetResource.getSitePageTemplateSetsPage(
+			siteExternalReferenceCode, null, null, null, Pagination.of(1, 10),
+			null);
+
+		for (PageTemplateSet pageTemplateSet : page.getItems()) {
+			Assert.assertNotNull(pageTemplateSet.getPermissions());
+		}
 	}
 
 	protected Map<String, Map<String, String>>
@@ -805,6 +829,24 @@ public abstract class BasePageTemplateSetResourceTestCase {
 
 		assertEquals(randomPageTemplateSet, postPageTemplateSet);
 		assertValid(postPageTemplateSet);
+
+		PageTemplateSet randomPermissionsPageTemplateSet1 =
+			randomPermissionsPageTemplateSet();
+
+		PageTemplateSet postPermissionsPageTemplateSet1 =
+			testPostSitePageTemplateSet_addPageTemplateSet(
+				randomPermissionsPageTemplateSet1);
+
+		Assert.assertNull(postPermissionsPageTemplateSet1.getPermissions());
+
+		PageTemplateSet randomPermissionsPageTemplateSet2 =
+			randomPermissionsPageTemplateSet();
+
+		PageTemplateSet postPermissionsPageTemplateSet2 =
+			testPostSitePageTemplateSet_addPermissionsPageTemplateSet(
+				randomPermissionsPageTemplateSet2);
+
+		Assert.assertNotNull(postPermissionsPageTemplateSet2.getPermissions());
 	}
 
 	protected PageTemplateSet testPostSitePageTemplateSet_addPageTemplateSet(
@@ -813,6 +855,16 @@ public abstract class BasePageTemplateSetResourceTestCase {
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	protected PageTemplateSet
+			testPostSitePageTemplateSet_addPermissionsPageTemplateSet(
+				PageTemplateSet pageTemplateSet)
+		throws Exception {
+
+		return permissionsPageTemplateSetResource.postSitePageTemplateSet(
+			testGetSitePageTemplateSetsPage_getSiteExternalReferenceCode(),
+			pageTemplateSet);
 	}
 
 	@Test
@@ -1110,6 +1162,14 @@ public abstract class BasePageTemplateSetResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("permissions", additionalAssertFieldName)) {
+				if (pageTemplateSet.getPermissions() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("uuid", additionalAssertFieldName)) {
 				if (pageTemplateSet.getUuid() == null) {
 					valid = false;
@@ -1323,6 +1383,17 @@ public abstract class BasePageTemplateSetResourceTestCase {
 				if (!Objects.deepEquals(
 						pageTemplateSet1.getName(),
 						pageTemplateSet2.getName())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("permissions", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						pageTemplateSet1.getPermissions(),
+						pageTemplateSet2.getPermissions())) {
 
 					return false;
 				}
@@ -1742,6 +1813,11 @@ public abstract class BasePageTemplateSetResourceTestCase {
 			return sb.toString();
 		}
 
+		if (entityFieldName.equals("permissions")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
 		if (entityFieldName.equals("uuid")) {
 			Object object = pageTemplateSet.getUuid();
 
@@ -1861,6 +1937,27 @@ public abstract class BasePageTemplateSetResourceTestCase {
 		return randomPageTemplateSet();
 	}
 
+	protected PageTemplateSet randomPermissionsPageTemplateSet()
+		throws Exception {
+
+		PageTemplateSet pageTemplateSet = randomPageTemplateSet();
+
+		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
+			RoleConstants.TYPE_REGULAR);
+
+		pageTemplateSet.setPermissions(
+			new Permission[] {
+				new Permission() {
+					{
+						setActionIds(new String[] {"VIEW"});
+						setRoleName(role.getName());
+					}
+				}
+			});
+
+		return pageTemplateSet;
+	}
+
 	protected final JSONObject waitForFinish(
 			String expectedExecuteStatus, JSONObject jsonObject)
 		throws Exception {
@@ -1886,6 +1983,7 @@ public abstract class BasePageTemplateSetResourceTestCase {
 	protected PageTemplateSetResource pageTemplateSetResource;
 	protected ImportTaskResource importTaskResource;
 	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected PageTemplateSetResource permissionsPageTemplateSetResource;
 	protected com.liferay.portal.kernel.model.Company testCompany;
 	protected com.liferay.portal.kernel.model.Group testGroup;
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseSitePageResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseSitePageResourceTestCase.java
@@ -129,6 +129,18 @@ public abstract class BaseSitePageResourceTestCase {
 		).locale(
 			LocaleUtil.getDefault()
 		).build();
+
+		permissionsSitePageResource = SitePageResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(), 8080, "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).parameter(
+			"nestedFields", "permissions"
+		).build();
 	}
 
 	@After
@@ -332,6 +344,18 @@ public abstract class BaseSitePageResourceTestCase {
 			page,
 			testGetSiteSitePagesPage_getExpectedActions(
 				siteExternalReferenceCode));
+
+		for (SitePage sitePage : page.getItems()) {
+			Assert.assertNull(sitePage.getPermissions());
+		}
+
+		page = permissionsSitePageResource.getSiteSitePagesPage(
+			siteExternalReferenceCode, null, null, null, Pagination.of(1, 10),
+			null);
+
+		for (SitePage sitePage : page.getItems()) {
+			Assert.assertNotNull(sitePage.getPermissions());
+		}
 	}
 
 	protected Map<String, Map<String, String>>
@@ -718,6 +742,21 @@ public abstract class BaseSitePageResourceTestCase {
 
 		assertEquals(randomSitePage, postSitePage);
 		assertValid(postSitePage);
+
+		SitePage randomPermissionsSitePage1 = randomPermissionsSitePage();
+
+		SitePage postPermissionsSitePage1 = testPostSiteSitePage_addSitePage(
+			randomPermissionsSitePage1);
+
+		Assert.assertNull(postPermissionsSitePage1.getPermissions());
+
+		SitePage randomPermissionsSitePage2 = randomPermissionsSitePage();
+
+		SitePage postPermissionsSitePage2 =
+			testPostSiteSitePage_addPermissionsSitePage(
+				randomPermissionsSitePage2);
+
+		Assert.assertNotNull(postPermissionsSitePage2.getPermissions());
 	}
 
 	protected SitePage testPostSiteSitePage_addSitePage(SitePage sitePage)
@@ -725,6 +764,14 @@ public abstract class BaseSitePageResourceTestCase {
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	protected SitePage testPostSiteSitePage_addPermissionsSitePage(
+			SitePage sitePage)
+		throws Exception {
+
+		return permissionsSitePageResource.postSiteSitePage(
+			testGetSiteSitePagesPage_getSiteExternalReferenceCode(), sitePage);
 	}
 
 	@Test
@@ -1067,6 +1114,14 @@ public abstract class BaseSitePageResourceTestCase {
 					additionalAssertFieldName)) {
 
 				if (sitePage.getParentSitePageExternalReferenceCode() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("permissions", additionalAssertFieldName)) {
+				if (sitePage.getPermissions() == null) {
 					valid = false;
 				}
 
@@ -1428,6 +1483,17 @@ public abstract class BaseSitePageResourceTestCase {
 				if (!Objects.deepEquals(
 						sitePage1.getParentSitePageExternalReferenceCode(),
 						sitePage2.getParentSitePageExternalReferenceCode())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("permissions", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						sitePage1.getPermissions(),
+						sitePage2.getPermissions())) {
 
 					return false;
 				}
@@ -1898,6 +1964,11 @@ public abstract class BaseSitePageResourceTestCase {
 			return sb.toString();
 		}
 
+		if (entityFieldName.equals("permissions")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
 		if (entityFieldName.equals("taxonomyCategoryItemExternalReferences")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -2028,6 +2099,25 @@ public abstract class BaseSitePageResourceTestCase {
 		return randomSitePage();
 	}
 
+	protected SitePage randomPermissionsSitePage() throws Exception {
+		SitePage sitePage = randomSitePage();
+
+		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
+			RoleConstants.TYPE_REGULAR);
+
+		sitePage.setPermissions(
+			new Permission[] {
+				new Permission() {
+					{
+						setActionIds(new String[] {"VIEW"});
+						setRoleName(role.getName());
+					}
+				}
+			});
+
+		return sitePage;
+	}
+
 	protected ContentPageSpecification randomContentPageSpecification()
 		throws Exception {
 
@@ -2064,6 +2154,7 @@ public abstract class BaseSitePageResourceTestCase {
 	protected SitePageResource sitePageResource;
 	protected ImportTaskResource importTaskResource;
 	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected SitePageResource permissionsSitePageResource;
 	protected com.liferay.portal.kernel.model.Company testCompany;
 	protected com.liferay.portal.kernel.model.Group testGroup;
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseUtilityPageResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseUtilityPageResourceTestCase.java
@@ -129,6 +129,18 @@ public abstract class BaseUtilityPageResourceTestCase {
 		).locale(
 			LocaleUtil.getDefault()
 		).build();
+
+		permissionsUtilityPageResource = UtilityPageResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(), 8080, "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).parameter(
+			"nestedFields", "permissions"
+		).build();
 	}
 
 	@After
@@ -340,6 +352,18 @@ public abstract class BaseUtilityPageResourceTestCase {
 			page,
 			testGetSiteUtilityPagesPage_getExpectedActions(
 				siteExternalReferenceCode));
+
+		for (UtilityPage utilityPage : page.getItems()) {
+			Assert.assertNull(utilityPage.getPermissions());
+		}
+
+		page = permissionsUtilityPageResource.getSiteUtilityPagesPage(
+			siteExternalReferenceCode, null, null, null, Pagination.of(1, 10),
+			null);
+
+		for (UtilityPage utilityPage : page.getItems()) {
+			Assert.assertNotNull(utilityPage.getPermissions());
+		}
 	}
 
 	protected Map<String, Map<String, String>>
@@ -752,6 +776,24 @@ public abstract class BaseUtilityPageResourceTestCase {
 
 		assertEquals(randomUtilityPage, postUtilityPage);
 		assertValid(postUtilityPage);
+
+		UtilityPage randomPermissionsUtilityPage1 =
+			randomPermissionsUtilityPage();
+
+		UtilityPage postPermissionsUtilityPage1 =
+			testPostSiteUtilityPage_addUtilityPage(
+				randomPermissionsUtilityPage1);
+
+		Assert.assertNull(postPermissionsUtilityPage1.getPermissions());
+
+		UtilityPage randomPermissionsUtilityPage2 =
+			randomPermissionsUtilityPage();
+
+		UtilityPage postPermissionsUtilityPage2 =
+			testPostSiteUtilityPage_addPermissionsUtilityPage(
+				randomPermissionsUtilityPage2);
+
+		Assert.assertNotNull(postPermissionsUtilityPage2.getPermissions());
 	}
 
 	protected UtilityPage testPostSiteUtilityPage_addUtilityPage(
@@ -760,6 +802,15 @@ public abstract class BaseUtilityPageResourceTestCase {
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	protected UtilityPage testPostSiteUtilityPage_addPermissionsUtilityPage(
+			UtilityPage utilityPage)
+		throws Exception {
+
+		return permissionsUtilityPageResource.postSiteUtilityPage(
+			testGetSiteUtilityPagesPage_getSiteExternalReferenceCode(),
+			utilityPage);
 	}
 
 	@Test
@@ -1087,6 +1138,14 @@ public abstract class BaseUtilityPageResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("permissions", additionalAssertFieldName)) {
+				if (utilityPage.getPermissions() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("thumbnail", additionalAssertFieldName)) {
 				if (utilityPage.getThumbnail() == null) {
 					valid = false;
@@ -1405,6 +1464,17 @@ public abstract class BaseUtilityPageResourceTestCase {
 				if (!Objects.deepEquals(
 						utilityPage1.getPageSpecifications(),
 						utilityPage2.getPageSpecifications())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("permissions", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						utilityPage1.getPermissions(),
+						utilityPage2.getPermissions())) {
 
 					return false;
 				}
@@ -1859,6 +1929,11 @@ public abstract class BaseUtilityPageResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
+		if (entityFieldName.equals("permissions")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
 		if (entityFieldName.equals("thumbnail")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -1989,6 +2064,25 @@ public abstract class BaseUtilityPageResourceTestCase {
 		return randomUtilityPage();
 	}
 
+	protected UtilityPage randomPermissionsUtilityPage() throws Exception {
+		UtilityPage utilityPage = randomUtilityPage();
+
+		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
+			RoleConstants.TYPE_REGULAR);
+
+		utilityPage.setPermissions(
+			new Permission[] {
+				new Permission() {
+					{
+						setActionIds(new String[] {"VIEW"});
+						setRoleName(role.getName());
+					}
+				}
+			});
+
+		return utilityPage;
+	}
+
 	protected ContentPageSpecification randomContentPageSpecification()
 		throws Exception {
 
@@ -2025,6 +2119,7 @@ public abstract class BaseUtilityPageResourceTestCase {
 	protected UtilityPageResource utilityPageResource;
 	protected ImportTaskResource importTaskResource;
 	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected UtilityPageResource permissionsUtilityPageResource;
 	protected com.liferay.portal.kernel.model.Company testCompany;
 	protected com.liferay.portal.kernel.model.Group testGroup;
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateFolderResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateFolderResourceTest.java
@@ -346,15 +346,6 @@ public class DisplayPageTemplateFolderResourceTest
 						liveGroupDisplayPageTemplateFolder));
 	}
 
-	@Ignore
-	@Override
-	@Test
-	public void testPutSiteDisplayPageTemplateFolderPermissionsPage()
-		throws Exception {
-
-		super.testPutSiteDisplayPageTemplateFolderPermissionsPage();
-	}
-
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
 		return new String[] {"description", "externalReferenceCode", "name"};
@@ -384,17 +375,6 @@ public class DisplayPageTemplateFolderResourceTest
 		throws Exception {
 
 		return testGroup.getExternalReferenceCode();
-	}
-
-	@Ignore
-	@Override
-	@Test
-	protected DisplayPageTemplateFolder
-			testGetSiteDisplayPageTemplateFolderPermissionsPage_addDisplayPageTemplateFolder()
-		throws Exception {
-
-		return super.
-			testGetSiteDisplayPageTemplateFolderPermissionsPage_addDisplayPageTemplateFolder();
 	}
 
 	@Override
@@ -435,17 +415,6 @@ public class DisplayPageTemplateFolderResourceTest
 
 		return testGetSiteDisplayPageTemplateFoldersPage_addDisplayPageTemplateFolder(
 			testGroup.getExternalReferenceCode(), displayPageTemplateFolder);
-	}
-
-	@Ignore
-	@Override
-	@Test
-	protected DisplayPageTemplateFolder
-			testPutSiteDisplayPageTemplateFolderPermissionsPage_addDisplayPageTemplateFolder()
-		throws Exception {
-
-		return super.
-			testPutSiteDisplayPageTemplateFolderPermissionsPage_addDisplayPageTemplateFolder();
 	}
 
 	private static

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateResourceTest.java
@@ -229,15 +229,6 @@ public class DisplayPageTemplateResourceTest
 		_testGetSiteDisplayPageTemplateWithNestedFields(displayPageTemplate);
 	}
 
-	@Ignore
-	@Override
-	@Test
-	public void testGetSiteDisplayPageTemplatePermissionsPage()
-		throws Exception {
-
-		super.testGetSiteDisplayPageTemplatePermissionsPage();
-	}
-
 	@Override
 	@Test
 	public void testGetSiteDisplayPageTemplatesPage() throws Exception {
@@ -491,15 +482,6 @@ public class DisplayPageTemplateResourceTest
 				displayPageTemplate));
 	}
 
-	@Ignore
-	@Override
-	@Test
-	public void testPutSiteDisplayPageTemplatePermissionsPage()
-		throws Exception {
-
-		super.testPutSiteDisplayPageTemplatePermissionsPage();
-	}
-
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
 		return new String[] {
@@ -565,17 +547,6 @@ public class DisplayPageTemplateResourceTest
 			irrelevantGroup.getGroupId());
 	}
 
-	@Ignore
-	@Override
-	@Test
-	protected DisplayPageTemplate
-			testGetSiteDisplayPageTemplatePermissionsPage_addDisplayPageTemplate()
-		throws Exception {
-
-		return super.
-			testGetSiteDisplayPageTemplatePermissionsPage_addDisplayPageTemplate();
-	}
-
 	@Override
 	protected DisplayPageTemplate
 			testGetSiteDisplayPageTemplatesPage_addDisplayPageTemplate(
@@ -603,17 +574,6 @@ public class DisplayPageTemplateResourceTest
 
 		return testGetSiteDisplayPageTemplatesPage_addDisplayPageTemplate(
 			testGroup.getExternalReferenceCode(), displayPageTemplate);
-	}
-
-	@Ignore
-	@Override
-	@Test
-	protected DisplayPageTemplate
-			testPutSiteDisplayPageTemplatePermissionsPage_addDisplayPageTemplate()
-		throws Exception {
-
-		return super.
-			testPutSiteDisplayPageTemplatePermissionsPage_addDisplayPageTemplate();
 	}
 
 	private static com.liferay.headless.admin.site.dto.v1_0.DisplayPageTemplate

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
@@ -146,13 +146,6 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 	@Ignore
 	@Override
 	@Test
-	public void testGetSiteMasterPagePermissionsPage() throws Exception {
-		super.testGetSiteMasterPagePermissionsPage();
-	}
-
-	@Ignore
-	@Override
-	@Test
 	public void testGetSiteMasterPagesPageWithSortDateTime() throws Exception {
 		super.testGetSiteMasterPagesPageWithSortDateTime();
 	}
@@ -359,13 +352,6 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 					null, masterPage.getExternalReferenceCode(), null)));
 	}
 
-	@Ignore
-	@Override
-	@Test
-	public void testPutSiteMasterPagePermissionsPage() throws Exception {
-		super.testPutSiteMasterPagePermissionsPage();
-	}
-
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
 		return new String[] {
@@ -401,15 +387,6 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 		return masterPage;
 	}
 
-	@Ignore
-	@Override
-	@Test
-	protected MasterPage testGetSiteMasterPagePermissionsPage_addMasterPage()
-		throws Exception {
-
-		return super.testGetSiteMasterPagePermissionsPage_addMasterPage();
-	}
-
 	@Override
 	protected MasterPage testGetSiteMasterPagesPage_addMasterPage(
 			String siteExternalReferenceCode, MasterPage masterPage)
@@ -434,15 +411,6 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 
 		return testGetSiteMasterPagesPage_addMasterPage(
 			testGroup.getExternalReferenceCode(), masterPage);
-	}
-
-	@Ignore
-	@Override
-	@Test
-	protected MasterPage testPutSiteMasterPagePermissionsPage_addMasterPage()
-		throws Exception {
-
-		return super.testPutSiteMasterPagePermissionsPage_addMasterPage();
 	}
 
 	private FileEntry _addPortletFileEntry(long folderId) throws Exception {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateResourceTest.java
@@ -202,13 +202,6 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 					RandomTestUtil.randomString())));
 	}
 
-	@Ignore
-	@Override
-	@Test
-	public void testGetSitePageTemplatePermissionsPage() throws Exception {
-		super.testGetSitePageTemplatePermissionsPage();
-	}
-
 	@Override
 	@Test
 	public void testGetSitePageTemplateSetPageTemplatesPage() throws Exception {
@@ -577,13 +570,6 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 				}));
 	}
 
-	@Ignore
-	@Override
-	@Test
-	public void testPutSitePageTemplatePermissionsPage() throws Exception {
-		super.testPutSitePageTemplatePermissionsPage();
-	}
-
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
 		return new String[] {
@@ -601,16 +587,6 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 	@Override
 	protected PageTemplate randomPageTemplate() throws Exception {
 		return _getPageTemplate(testGroup);
-	}
-
-	@Ignore
-	@Override
-	@Test
-	protected PageTemplate
-			testGetSitePageTemplatePermissionsPage_addPageTemplate()
-		throws Exception {
-
-		return super.testGetSitePageTemplatePermissionsPage_addPageTemplate();
 	}
 
 	@Override
@@ -685,16 +661,6 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 		return pageTemplateResource.postSitePageTemplateSetPageTemplate(
 			testGroup.getExternalReferenceCode(),
 			pageTemplateSet.getExternalReferenceCode(), pageTemplate);
-	}
-
-	@Ignore
-	@Override
-	@Test
-	protected PageTemplate
-			testPutSitePageTemplatePermissionsPage_addPageTemplate()
-		throws Exception {
-
-		return super.testPutSitePageTemplatePermissionsPage_addPageTemplate();
 	}
 
 	private static com.liferay.headless.admin.site.dto.v1_0.PageTemplate

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateSetResourceTest.java
@@ -102,13 +102,6 @@ public class PageTemplateSetResourceTest
 		_testGetSitePageTemplateSet(pageTemplateSet);
 	}
 
-	@Ignore
-	@Override
-	@Test
-	public void testGetSitePageTemplateSetPermissionsPage() throws Exception {
-		super.testGetSitePageTemplateSetPermissionsPage();
-	}
-
 	@Override
 	@Test
 	public void testGetSitePageTemplateSetsPage() throws Exception {
@@ -300,13 +293,6 @@ public class PageTemplateSetResourceTest
 				pageTemplateSet.getExternalReferenceCode(), pageTemplateSet));
 	}
 
-	@Ignore
-	@Override
-	@Test
-	public void testPutSitePageTemplateSetPermissionsPage() throws Exception {
-		super.testPutSitePageTemplateSetPermissionsPage();
-	}
-
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
 		return new String[] {"description", "externalReferenceCode", "name"};
@@ -320,17 +306,6 @@ public class PageTemplateSetResourceTest
 		pageTemplateSet.setDateModified(new Date(System.currentTimeMillis()));
 
 		return pageTemplateSet;
-	}
-
-	@Ignore
-	@Override
-	@Test
-	protected PageTemplateSet
-			testGetSitePageTemplateSetPermissionsPage_addPageTemplateSet()
-		throws Exception {
-
-		return super.
-			testGetSitePageTemplateSetPermissionsPage_addPageTemplateSet();
 	}
 
 	@Override
@@ -361,17 +336,6 @@ public class PageTemplateSetResourceTest
 		return pageTemplateSetResource.putSitePageTemplateSet(
 			testGroup.getExternalReferenceCode(),
 			pageTemplateSet.getExternalReferenceCode(), pageTemplateSet);
-	}
-
-	@Ignore
-	@Override
-	@Test
-	protected PageTemplateSet
-			testPutSitePageTemplateSetPermissionsPage_addPageTemplateSet()
-		throws Exception {
-
-		return super.
-			testPutSitePageTemplateSetPermissionsPage_addPageTemplateSet();
 	}
 
 	private void _assertProblemException(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -184,13 +184,6 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 				serviceContext));
 	}
 
-	@Ignore
-	@Override
-	@Test
-	public void testGetSiteSitePagePermissionsPage() throws Exception {
-		super.testGetSiteSitePagePermissionsPage();
-	}
-
 	@Override
 	@Test
 	public void testPatchSiteSitePage() throws Exception {
@@ -315,13 +308,6 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 				serviceContext));
 	}
 
-	@Ignore
-	@Override
-	@Test
-	public void testPutSiteSitePagePermissionsPage() throws Exception {
-		super.testPutSiteSitePagePermissionsPage();
-	}
-
 	@Override
 	protected boolean equals(SitePage sitePage1, SitePage sitePage2) {
 		super.equals(sitePage1, sitePage2);
@@ -365,15 +351,6 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		return _getRandomSitePage(_getRandomType(_types));
 	}
 
-	@Ignore
-	@Override
-	@Test
-	protected SitePage testGetSiteSitePagePermissionsPage_addSitePage()
-		throws Exception {
-
-		return super.testGetSiteSitePagePermissionsPage_addSitePage();
-	}
-
 	@Override
 	protected SitePage testGetSiteSitePagesPage_addSitePage(
 			String siteExternalReferenceCode, SitePage sitePage)
@@ -409,15 +386,6 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 		return sitePageResource.postSiteSitePage(
 			testGroup.getExternalReferenceCode(), sitePage);
-	}
-
-	@Ignore
-	@Override
-	@Test
-	protected SitePage testPutSiteSitePagePermissionsPage_addSitePage()
-		throws Exception {
-
-		return super.testPutSiteSitePagePermissionsPage_addSitePage();
 	}
 
 	private Layout _addLayout(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/UtilityPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/UtilityPageResourceTest.java
@@ -175,13 +175,6 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 		}
 	}
 
-	@Ignore
-	@Override
-	@Test
-	public void testGetSiteUtilityPagePermissionsPage() throws Exception {
-		super.testGetSiteUtilityPagePermissionsPage();
-	}
-
 	@Override
 	@Test
 	public void testGetSiteUtilityPagesPage() throws Exception {
@@ -444,13 +437,6 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 		_testPutSiteUtilityPageWithPageSpecifications();
 	}
 
-	@Ignore
-	@Override
-	@Test
-	public void testPutSiteUtilityPagePermissionsPage() throws Exception {
-		super.testPutSiteUtilityPagePermissionsPage();
-	}
-
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
 		return new String[] {
@@ -499,15 +485,6 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 		return utilityPage;
 	}
 
-	@Ignore
-	@Override
-	@Test
-	protected UtilityPage testGetSiteUtilityPagePermissionsPage_addUtilityPage()
-		throws Exception {
-
-		return super.testGetSiteUtilityPagePermissionsPage_addUtilityPage();
-	}
-
 	@Override
 	protected UtilityPage testGetSiteUtilityPagesPage_addUtilityPage(
 			String siteExternalReferenceCode, UtilityPage utilityPage)
@@ -532,15 +509,6 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 
 		return testGetSiteUtilityPagesPage_addUtilityPage(
 			testGroup.getExternalReferenceCode(), utilityPage);
-	}
-
-	@Ignore
-	@Override
-	@Test
-	protected UtilityPage testPutSiteUtilityPagePermissionsPage_addUtilityPage()
-		throws Exception {
-
-		return super.testPutSiteUtilityPagePermissionsPage_addUtilityPage();
 	}
 
 	private FileEntry _addPortletFileEntry(long folderId) throws Exception {


### PR DESCRIPTION
**What's new?:**
- 'generatePermissions' REST Builder setting has been turned on.
- Now the paginated get and the post endpoints aurtomatically support permissions nested fields in order to make it accessible to batch/export-import.

**What's changed?:**
- The necessary methods for returning the permissions have been manually implemented.
- The correspondant tests have been unignored.

Take a look at the following **Jira tickets**: [LPD-58909](https://liferay.atlassian.net/browse/LPD-58909), [LPD-57267](https://liferay.atlassian.net/browse/LPD-57267)

cc: @achaparro