### PR TITLE
LPD-63828 fix semver

### DIFF
--- a/modules/apps/static/portal-k8s-agent/portal-k8s-agent-api/bnd.bnd
+++ b/modules/apps/static/portal-k8s-agent/portal-k8s-agent-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal K8s Agent API
 Bundle-SymbolicName: com.liferay.portal.k8s.agent.api
-Bundle-Version: 3.1.2
+Bundle-Version: 4.0.0
 Export-Package:\
 	com.liferay.portal.k8s.agent,\
 	com.liferay.portal.k8s.agent.configuration,\

--- a/modules/apps/static/portal-k8s-agent/portal-k8s-agent-api/src/main/resources/com/liferay/portal/k8s/agent/configuration/packageinfo
+++ b/modules/apps/static/portal-k8s-agent/portal-k8s-agent-api/src/main/resources/com/liferay/portal/k8s/agent/configuration/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 3.0.0

--- a/modules/apps/static/portal-k8s-agent/portal-k8s-agent-api/src/main/resources/com/liferay/portal/k8s/agent/packageinfo
+++ b/modules/apps/static/portal-k8s-agent/portal-k8s-agent-api/src/main/resources/com/liferay/portal/k8s/agent/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0


### PR DESCRIPTION
# breaking

## What modules/apps/static/portal-k8s-agent/portal-k8s-agent-api/src/main/java/com/liferay/portal/k8s/agent/configuration/PortalK8sAgentConfiguration.java

Add new method called debounceDelayMillis() which is a configurable
property

## Why

This configuration option was added in order to let clients
configuration this in a cluster.  It has a default value so it should
not break clients since this is a Metatype configuration class that is
generated at runtime.

----
