### PR TITLE
LPD-66536 getListTypeDefinitionByExternalReferenceCode now throws an exception if the List Type Definition doesn't exist

### DIFF
--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -109,6 +109,7 @@ import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.utility.page.converter.LayoutUtilityPageEntryTypeConverter;
 import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
 import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalService;
+import com.liferay.list.type.exception.NoSuchListTypeDefinitionException;
 import com.liferay.list.type.service.ListTypeEntryLocalService;
 import com.liferay.message.boards.model.MBMessage;
 import com.liferay.notification.rest.dto.v1_0.NotificationTemplate;
@@ -2988,20 +2989,22 @@ public class BundleSiteInitializer implements SiteInitializer {
 				continue;
 			}
 
-			ListTypeDefinition existingListTypeDefinition =
-				listTypeDefinitionResource.
-					getListTypeDefinitionByExternalReferenceCode(
-						listTypeDefinition.getExternalReferenceCode());
+			try {
+				ListTypeDefinition existingListTypeDefinition =
+					listTypeDefinitionResource.
+						getListTypeDefinitionByExternalReferenceCode(
+							listTypeDefinition.getExternalReferenceCode());
 
-			if (existingListTypeDefinition == null) {
-				listTypeDefinition =
-					listTypeDefinitionResource.postListTypeDefinition(
-						listTypeDefinition);
-			}
-			else {
 				listTypeDefinition =
 					listTypeDefinitionResource.patchListTypeDefinition(
 						existingListTypeDefinition.getId(), listTypeDefinition);
+			}
+			catch (NoSuchListTypeDefinitionException
+						noSuchListTypeDefinitionException) {
+
+				listTypeDefinition =
+					listTypeDefinitionResource.postListTypeDefinition(
+						listTypeDefinition);
 			}
 
 			stringUtilReplaceValues.put(


### PR DESCRIPTION
Manually sending due to SF and Stable errors on brianchandotcom/liferay-portal/master.

Here are the Stable test results based on brianchandotcom/liferay-portal/master showing the `BundleSiteInitializerTest` is no longer failing - https://github.com/liferay-site-management/liferay-portal/pull/2526#issuecomment-3330599676

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-66536

# How am I fixing it?

This test was broken by LPD-60403 (https://github.com/brianchandotcom/liferay-portal/blob/master/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/ListTypeDefinitionResourceImpl.java#L80).

Now this method throws an exception if the definition doesn't exist. The logic has been adapted to this new pattern.

# How can you verify that it works?

In `site-initializer-extender-test` run `gw testIntegration --tests *.BundleSiteInitializerTest`