### PR TITLE
LPD-64508: Fix classPK, groupId and modelName being incorrectly stored in ExportImportReportEntry when error originating from batch

### DIFF
--- a/modules/apps/export-import/export-import-api/bnd.bnd
+++ b/modules/apps/export-import/export-import-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Export Import API
 Bundle-SymbolicName: com.liferay.exportimport.api
-Bundle-Version: 11.0.1
+Bundle-Version: 11.1.0
 Export-Package:\
 	com.liferay.exportimport.attachment,\
 	com.liferay.exportimport.configuration,\

--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/vulcan/batch/engine/ExportImportVulcanBatchEngineTaskItemDelegate.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/vulcan/batch/engine/ExportImportVulcanBatchEngineTaskItemDelegate.java
@@ -24,6 +24,10 @@ public interface ExportImportVulcanBatchEngineTaskItemDelegate<T>
 
 		public String getItemClassName();
 
+		public default String getItemModelName() {
+			return getItemClassName();
+		}
+
 		public default List<String> getNestedFields() {
 			return null;
 		}

--- a/modules/apps/export-import/export-import-api/src/main/resources/com/liferay/exportimport/vulcan/batch/engine/packageinfo
+++ b/modules/apps/export-import/export-import-api/src/main/resources/com/liferay/exportimport/vulcan/batch/engine/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/internal/empty/model/EmptyModelManagerImpl.java
+++ b/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/internal/empty/model/EmptyModelManagerImpl.java
@@ -63,8 +63,7 @@ public class EmptyModelManagerImpl implements EmptyModelManager {
 					GetterUtil.getLong(
 						ExportImportThreadLocal.
 							getExportImportConfigurationId()),
-					ExportImportReportEntryUtil.getModelName(clazz),
-					ExportImportReportEntryUtil.getOrigin(),
+					clazz.getName(), ExportImportReportEntryUtil.getOrigin(),
 					ObjectDefinitionConstants.SCOPE_COMPANY, null);
 
 			return emptyModelUnsafeSupplier.get();
@@ -85,7 +84,7 @@ public class EmptyModelManagerImpl implements EmptyModelManager {
 			clazz.getName(), null, emptyModelUnsafeSupplier,
 			externalReferenceCode, fetchByExternalReferenceCodeBiFunction,
 			getByExternalReferenceCodeUnsafeBiFunction, groupId,
-			ExportImportReportEntryUtil.getModelName(clazz));
+			clazz.getName());
 	}
 
 	@Override

--- a/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/internal/exception/handler/ExportImportBatchEngineImportTaskExceptionHandler.java
+++ b/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/internal/exception/handler/ExportImportBatchEngineImportTaskExceptionHandler.java
@@ -12,11 +12,9 @@ import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.report.constants.ExportImportReportEntryConstants;
 import com.liferay.exportimport.report.internal.util.ExportImportReportEntryUtil;
 import com.liferay.exportimport.report.service.ExportImportReportEntryLocalService;
-import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
-import com.liferay.portal.kernel.util.ClassUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.io.ByteArrayOutputStream;
@@ -45,58 +43,22 @@ public class ExportImportBatchEngineImportTaskExceptionHandler
 			return;
 		}
 
-		long groupId = 0;
-
-		if (batchEngineTaskItemDelegate instanceof
-				ExportImportVulcanBatchEngineTaskItemDelegate) {
-
-			ExportImportVulcanBatchEngineTaskItemDelegate<?>
-				exportImportVulcanBatchEngineTaskItemDelegate =
-					(ExportImportVulcanBatchEngineTaskItemDelegate)
-						batchEngineImportTask;
-
-			ExportImportVulcanBatchEngineTaskItemDelegate.ExportImportDescriptor
-				exportImportDescriptor =
-					exportImportVulcanBatchEngineTaskItemDelegate.
-						getExportImportDescriptor();
-
-			if (exportImportDescriptor.getScope() ==
-					ExportImportVulcanBatchEngineTaskItemDelegate.Scope.SITE) {
-
-				groupId = GetterUtil.getLong(
-					batchEngineImportTask.getParameterValue("siteId"));
-			}
-		}
+		long groupId = GetterUtil.getLong(
+			batchEngineImportTask.getParameterValue("siteId"));
 
 		_exportImportReportEntryLocalService.addErrorExportImportReportEntry(
 			groupId, batchEngineImportTask.getCompanyId(),
 			_getExternalReferenceCode(item),
-			_classNameLocalService.getClassNameId(ClassUtil.getClassName(item)),
-			_getClassPK(item),
+			_classNameLocalService.getClassNameId(
+				batchEngineImportTask.getParameterValue("itemClassName")),
+			_getId(item),
 			GetterUtil.getLong(
 				ExportImportThreadLocal.getExportImportConfigurationId()),
 			exception.getMessage(), _getErrorStackTrace(exception),
-			ExportImportReportEntryUtil.getModelName(item),
+			batchEngineImportTask.getParameterValue("itemModelName"),
 			ExportImportReportEntryConstants.ORIGIN_BATCH,
 			ExportImportReportEntryUtil.getScope(groupId),
 			ExportImportReportEntryUtil.getScopeKey(groupId));
-	}
-
-	private long _getClassPK(Object item) {
-		try {
-			Class<?> clazz = item.getClass();
-
-			Method method = clazz.getDeclaredMethod("getClassPK");
-
-			return GetterUtil.getLong(method.invoke(item));
-		}
-		catch (Exception exception) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(exception);
-			}
-
-			return 0L;
-		}
 	}
 
 	private String _getErrorStackTrace(Throwable throwable) {
@@ -121,6 +83,23 @@ public class ExportImportBatchEngineImportTaskExceptionHandler
 			}
 
 			return null;
+		}
+	}
+
+	private long _getId(Object item) {
+		try {
+			Class<?> clazz = item.getClass();
+
+			Method method = clazz.getDeclaredMethod("getId");
+
+			return GetterUtil.getLong(method.invoke(item));
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(exception);
+			}
+
+			return 0L;
 		}
 	}
 

--- a/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/internal/exception/handler/ImportStagedModelExceptionHandlerImpl.java
+++ b/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/internal/exception/handler/ImportStagedModelExceptionHandlerImpl.java
@@ -51,9 +51,6 @@ public class ImportStagedModelExceptionHandlerImpl
 				externalReferenceCodeModel.getExternalReferenceCode();
 		}
 
-		String modelName = ExportImportReportEntryUtil.getModelName(
-			stagedModel.getModelClass());
-
 		try {
 			long groupId = portletDataContext.getGroupId();
 
@@ -76,7 +73,9 @@ public class ImportStagedModelExceptionHandlerImpl
 					GetterUtil.getLong(
 						portletDataContext.getExportImportProcessId()),
 					portletDataException.getMessage(),
-					_getErrorStackTrace(portletDataException), modelName,
+					_getErrorStackTrace(portletDataException),
+					stagedModel.getModelClass(
+					).getName(),
 					ExportImportReportEntryUtil.getOrigin(), scope,
 					ExportImportReportEntryUtil.getScopeKey(group));
 		}
@@ -85,7 +84,10 @@ public class ImportStagedModelExceptionHandlerImpl
 				StringBundler.concat(
 					"Unable to add error export import report entry with ",
 					"external reference code \"", externalReferenceCode,
-					"\" and model name \"", modelName, "\""),
+					"\" and model name \"",
+					stagedModel.getModelClass(
+					).getName(),
+					"\""),
 				exception);
 		}
 	}

--- a/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/internal/util/ExportImportReportEntryUtil.java
+++ b/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/internal/util/ExportImportReportEntryUtil.java
@@ -8,10 +8,6 @@ package com.liferay.exportimport.report.internal.util;
 import com.liferay.batch.engine.thread.local.BatchEngineThreadLocal;
 import com.liferay.exportimport.report.constants.ExportImportReportEntryConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
-import com.liferay.object.model.ObjectDefinition;
-import com.liferay.object.model.ObjectEntry;
-import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
-import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.staging.StagingGroupHelper;
@@ -21,28 +17,6 @@ import com.liferay.staging.StagingGroupHelperUtil;
  * @author Petteri Karttunen
  */
 public class ExportImportReportEntryUtil {
-
-	public static String getModelName(Object object) {
-		if (object instanceof Class<?> clazz) {
-			return clazz.getName();
-		}
-		else if (object instanceof ObjectEntry objectEntry) {
-			ObjectDefinition objectDefinition =
-				ObjectDefinitionLocalServiceUtil.fetchObjectDefinition(
-					objectEntry.getObjectDefinitionId());
-
-			if (objectDefinition != null) {
-				return objectDefinition.getName();
-			}
-		}
-		else if (object instanceof BaseModel<?> baseModel) {
-			return baseModel.getModelClassName();
-		}
-
-		Class<?> clazz = object.getClass();
-
-		return clazz.getName();
-	}
 
 	public static int getOrigin() {
 		if (BatchEngineThreadLocal.isBatchImportInProcess()) {

--- a/modules/apps/export-import/export-import-report-test/src/testIntegration/java/com/liferay/exportimport/report/service/test/ExportImportReportEntryLocalServiceTest.java
+++ b/modules/apps/export-import/export-import-report-test/src/testIntegration/java/com/liferay/exportimport/report/service/test/ExportImportReportEntryLocalServiceTest.java
@@ -9,6 +9,9 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.exportimport.report.constants.ExportImportReportEntryConstants;
 import com.liferay.exportimport.report.model.ExportImportReportEntry;
 import com.liferay.exportimport.report.service.ExportImportReportEntryLocalService;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.test.rule.Inject;
@@ -144,47 +147,66 @@ public class ExportImportReportEntryLocalServiceTest {
 	}
 
 	@Test
-	public void testGetImportReportEntries() throws Exception {
-		long companyId = TestPropsValues.getCompanyId();
-		long exportImportConfigurationId = RandomTestUtil.randomLong();
+	public void testGetExportImportReportEntries() throws Exception {
+		Company company = CompanyTestUtil.addCompany();
 
-		List<ExportImportReportEntry> exportImportReportEntries =
-			_exportImportReportEntryLocalService.getExportImportReportEntries(
-				companyId, exportImportConfigurationId);
+		try {
+			long exportImportConfigurationId = RandomTestUtil.randomLong();
 
-		Assert.assertTrue(exportImportReportEntries.isEmpty());
+			List<ExportImportReportEntry> exportImportReportEntries =
+				_exportImportReportEntryLocalService.
+					getExportImportReportEntries(
+						TestPropsValues.getCompanyId(),
+						exportImportConfigurationId);
 
-		_exportImportReportEntryLocalService.addEmptyExportImportReportEntry(
-			RandomTestUtil.randomLong(), RandomTestUtil.randomLong(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
-			RandomTestUtil.randomLong(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomInt(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString());
-		_exportImportReportEntryLocalService.addEmptyExportImportReportEntry(
-			RandomTestUtil.randomLong(), RandomTestUtil.randomLong(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
-			exportImportConfigurationId, RandomTestUtil.randomString(),
-			RandomTestUtil.randomInt(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString());
-		_exportImportReportEntryLocalService.addEmptyExportImportReportEntry(
-			RandomTestUtil.randomLong(), companyId,
-			RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
-			RandomTestUtil.randomLong(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomInt(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString());
-		_exportImportReportEntryLocalService.addEmptyExportImportReportEntry(
-			RandomTestUtil.randomLong(), companyId,
-			RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
-			exportImportConfigurationId, RandomTestUtil.randomString(),
-			RandomTestUtil.randomInt(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString());
+			Assert.assertTrue(exportImportReportEntries.isEmpty());
 
-		exportImportReportEntries =
-			_exportImportReportEntryLocalService.getExportImportReportEntries(
-				companyId, exportImportConfigurationId);
+			_exportImportReportEntryLocalService.
+				addEmptyExportImportReportEntry(
+					RandomTestUtil.randomLong(), TestPropsValues.getCompanyId(),
+					RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
+					exportImportConfigurationId, RandomTestUtil.randomString(),
+					RandomTestUtil.randomInt(), RandomTestUtil.randomString(),
+					RandomTestUtil.randomString());
+			_exportImportReportEntryLocalService.
+				addEmptyExportImportReportEntry(
+					RandomTestUtil.randomLong(), TestPropsValues.getCompanyId(),
+					RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
+					RandomTestUtil.randomLong(), RandomTestUtil.randomString(),
+					RandomTestUtil.randomInt(), RandomTestUtil.randomString(),
+					RandomTestUtil.randomString());
+			_exportImportReportEntryLocalService.
+				addEmptyExportImportReportEntry(
+					RandomTestUtil.randomLong(), company.getCompanyId(),
+					RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
+					exportImportConfigurationId, RandomTestUtil.randomString(),
+					RandomTestUtil.randomInt(), RandomTestUtil.randomString(),
+					RandomTestUtil.randomString());
+			_exportImportReportEntryLocalService.
+				addEmptyExportImportReportEntry(
+					RandomTestUtil.randomLong(), company.getCompanyId(),
+					RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
+					RandomTestUtil.randomLong(), RandomTestUtil.randomString(),
+					RandomTestUtil.randomInt(), RandomTestUtil.randomString(),
+					RandomTestUtil.randomString());
 
-		Assert.assertTrue(exportImportReportEntries.size() == 1);
+			exportImportReportEntries =
+				_exportImportReportEntryLocalService.
+					getExportImportReportEntries(
+						TestPropsValues.getCompanyId(),
+						exportImportConfigurationId);
+
+			Assert.assertEquals(
+				exportImportReportEntries.toString(), 1,
+				exportImportReportEntries.size());
+		}
+		finally {
+			_companyLocalService.deleteCompany(company);
+		}
 	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
 
 	@Inject
 	private ExportImportReportEntryLocalService

--- a/modules/apps/export-import/export-import-report-test/src/testIntegration/java/com/liferay/exportimport/report/service/test/ExportImportReportEntryLocalServiceTest.java
+++ b/modules/apps/export-import/export-import-report-test/src/testIntegration/java/com/liferay/exportimport/report/service/test/ExportImportReportEntryLocalServiceTest.java
@@ -10,6 +10,7 @@ import com.liferay.exportimport.report.constants.ExportImportReportEntryConstant
 import com.liferay.exportimport.report.model.ExportImportReportEntry;
 import com.liferay.exportimport.report.service.ExportImportReportEntryLocalService;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -39,7 +40,7 @@ public class ExportImportReportEntryLocalServiceTest {
 				getExportImportReportEntriesCount();
 
 		long groupId = RandomTestUtil.randomLong();
-		long companyId = RandomTestUtil.randomLong();
+		long companyId = TestPropsValues.getCompanyId();
 		String classExternalReferenceCode = RandomTestUtil.randomString();
 		long classNameId = RandomTestUtil.randomLong();
 		long exportImportConfigurationId = RandomTestUtil.randomLong();
@@ -91,7 +92,7 @@ public class ExportImportReportEntryLocalServiceTest {
 				getExportImportReportEntriesCount();
 
 		long groupId = RandomTestUtil.randomLong();
-		long companyId = RandomTestUtil.randomLong();
+		long companyId = TestPropsValues.getCompanyId();
 		String classExternalReferenceCode = RandomTestUtil.randomString();
 		long classNameId = RandomTestUtil.randomLong();
 		long classPK = RandomTestUtil.randomLong();
@@ -144,7 +145,7 @@ public class ExportImportReportEntryLocalServiceTest {
 
 	@Test
 	public void testGetImportReportEntries() throws Exception {
-		long companyId = RandomTestUtil.randomLong();
+		long companyId = TestPropsValues.getCompanyId();
 		long exportImportConfigurationId = RandomTestUtil.randomLong();
 
 		List<ExportImportReportEntry> exportImportReportEntries =

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
@@ -271,6 +271,8 @@ public class BatchEnginePortletDataHandler extends BasePortletDataHandler {
 					IMPORT_STRATEGY_ON_ERROR_CONTINUE,
 				BatchEngineTaskOperation.CREATE.name(),
 				BatchEnginePortletDataHandlerUtil.buildImportParameters(
+					_exportImportVulcanBatchEngineTaskItemDelegate.
+						getExportImportDescriptor(),
 					portletDataContext),
 				_taskItemDelegateName);
 
@@ -358,19 +360,15 @@ public class BatchEnginePortletDataHandler extends BasePortletDataHandler {
 	private BatchEngineExportTaskExecutor.Result _executeExportTask(
 		int maxItems, PortletDataContext portletDataContext) {
 
-		ExportImportVulcanBatchEngineTaskItemDelegate.ExportImportDescriptor
-			exportImportDescriptor =
-				_exportImportVulcanBatchEngineTaskItemDelegate.
-					getExportImportDescriptor();
-
 		return _batchEngineExportTaskExecutor.execute(
 			_batchEngineExportTaskLocalService.createBatchEngineExportTask(
 				0L, null, portletDataContext.getCompanyId(), _getUserId(), null,
 				_className, "JSON", BatchEngineTaskExecuteStatus.INITIAL.name(),
 				Collections.emptyList(),
 				BatchEnginePortletDataHandlerUtil.buildExportParameters(
-					exportImportDescriptor.getNestedFields(),
-					exportImportDescriptor.getParameters(), portletDataContext),
+					_exportImportVulcanBatchEngineTaskItemDelegate.
+						getExportImportDescriptor(),
+					portletDataContext),
 				_taskItemDelegateName),
 			new BatchEngineExportTaskExecutor.Settings() {
 

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandlerUtil.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandlerUtil.java
@@ -10,6 +10,7 @@ import com.liferay.batch.engine.constants.CreateStrategy;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
 import com.liferay.exportimport.kernel.lar.UserIdStrategy;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
@@ -36,7 +37,8 @@ import java.util.Map;
 public class BatchEnginePortletDataHandlerUtil {
 
 	public static Map<String, Serializable> buildExportParameters(
-		List<String> nestedFields, Map<String, Serializable> parameters,
+		ExportImportVulcanBatchEngineTaskItemDelegate.ExportImportDescriptor
+			exportImportDescriptor,
 		PortletDataContext portletDataContext) {
 
 		return HashMapBuilder.<String, Serializable>put(
@@ -51,8 +53,11 @@ public class BatchEnginePortletDataHandlerUtil {
 					batchNestedFields.add("permissions");
 				}
 
-				if (ListUtil.isNotEmpty(nestedFields)) {
-					batchNestedFields.addAll(nestedFields);
+				if (ListUtil.isNotEmpty(
+						exportImportDescriptor.getNestedFields())) {
+
+					batchNestedFields.addAll(
+						exportImportDescriptor.getNestedFields());
 				}
 
 				if (batchNestedFields.isEmpty()) {
@@ -90,6 +95,10 @@ public class BatchEnginePortletDataHandlerUtil {
 				return sb.toString();
 			}
 		).put(
+			"itemClassName", exportImportDescriptor.getItemClassName()
+		).put(
+			"itemModelName", exportImportDescriptor.getItemModelName()
+		).put(
 			"siteId",
 			() -> {
 				Map<String, String[]> map =
@@ -105,11 +114,13 @@ public class BatchEnginePortletDataHandlerUtil {
 				return portletDataContext.getScopeGroupId();
 			}
 		).putAll(
-			parameters
+			exportImportDescriptor.getParameters()
 		).build();
 	}
 
 	public static Map<String, Serializable> buildImportParameters(
+		ExportImportVulcanBatchEngineTaskItemDelegate.ExportImportDescriptor
+			exportImportDescriptor,
 		PortletDataContext portletDataContext) {
 
 		return HashMapBuilder.<String, Serializable>put(
@@ -140,6 +151,10 @@ public class BatchEnginePortletDataHandlerUtil {
 				return BatchEngineImportTaskConstants.
 					IMPORT_CREATOR_STRATEGY_KEEP_CREATOR;
 			}
+		).put(
+			"itemClassName", exportImportDescriptor.getItemClassName()
+		).put(
+			"itemModelName", exportImportDescriptor.getItemModelName()
 		).put(
 			"siteId", portletDataContext.getScopeGroupId()
 		).build();

--- a/modules/apps/export-import/export-import-service/src/test/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandlerUtilTest.java
+++ b/modules/apps/export-import/export-import-service/src/test/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandlerUtilTest.java
@@ -7,7 +7,9 @@ package com.liferay.exportimport.internal.data.handler;
 
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -69,7 +71,8 @@ public class BatchEnginePortletDataHandlerUtilTest {
 
 		Map<String, Serializable> parameters =
 			BatchEnginePortletDataHandlerUtil.buildExportParameters(
-				null, null, _mockPortletDataContext(endDate, null, null));
+				_mockExportImportDescriptor(),
+				_mockPortletDataContext(endDate, null, null));
 
 		Assert.assertEquals(
 			"dateModified le " + _dateFormat.format(endDate),
@@ -83,7 +86,8 @@ public class BatchEnginePortletDataHandlerUtilTest {
 
 		Map<String, Serializable> parameters =
 			BatchEnginePortletDataHandlerUtil.buildExportParameters(
-				null, null, _mockPortletDataContext(endDate, null, startDate));
+				_mockExportImportDescriptor(),
+				_mockPortletDataContext(endDate, null, startDate));
 
 		Assert.assertEquals(
 			StringBundler.concat(
@@ -93,17 +97,43 @@ public class BatchEnginePortletDataHandlerUtilTest {
 	}
 
 	@Test
+	public void testBuildExportParametersWithItemClassName() {
+		String itemClassName = RandomTestUtil.randomString();
+
+		Map<String, Serializable> parameters =
+			BatchEnginePortletDataHandlerUtil.buildExportParameters(
+				_mockExportImportDescriptor(itemClassName, null, null, null),
+				_mockPortletDataContext());
+
+		Assert.assertEquals(itemClassName, parameters.get("itemClassName"));
+	}
+
+	@Test
+	public void testBuildExportParametersWithItemModelName() {
+		String itemModelName = RandomTestUtil.randomString();
+
+		Map<String, Serializable> parameters =
+			BatchEnginePortletDataHandlerUtil.buildExportParameters(
+				_mockExportImportDescriptor(null, itemModelName, null, null),
+				_mockPortletDataContext());
+
+		Assert.assertEquals(itemModelName, parameters.get("itemModelName"));
+	}
+
+	@Test
 	public void testBuildExportParametersWithNestedFields() {
 		Map<String, Serializable> parameters =
 			BatchEnginePortletDataHandlerUtil.buildExportParameters(
-				List.of("nestedField1", "nestedField2"), null,
-				_mockPortletDataContext(null, null, null));
+				_mockExportImportDescriptor(
+					null, null, List.of("nestedField1", "nestedField2"), null),
+				_mockPortletDataContext());
 
 		Assert.assertEquals(
 			"nestedField1,nestedField2", parameters.get("batchNestedFields"));
 
 		parameters = BatchEnginePortletDataHandlerUtil.buildExportParameters(
-			List.of("nestedField1", "nestedField2"), null,
+			_mockExportImportDescriptor(
+				null, null, List.of("nestedField1", "nestedField2"), null),
 			_mockPortletDataContext(
 				null,
 				HashMapBuilder.put(
@@ -120,7 +150,7 @@ public class BatchEnginePortletDataHandlerUtilTest {
 	public void testBuildExportParametersWithNoDates() {
 		Map<String, Serializable> parameters =
 			BatchEnginePortletDataHandlerUtil.buildExportParameters(
-				null, null, _mockPortletDataContext(null, null, null));
+				_mockExportImportDescriptor(), _mockPortletDataContext());
 
 		Assert.assertNull(parameters.get("filter"));
 	}
@@ -129,13 +159,14 @@ public class BatchEnginePortletDataHandlerUtilTest {
 	public void testBuildExportParametersWithParameters() {
 		Map<String, Serializable> parameters =
 			BatchEnginePortletDataHandlerUtil.buildExportParameters(
-				null,
-				HashMapBuilder.<String, Serializable>put(
-					"param1", "value1"
-				).put(
-					"param2", "value2"
-				).build(),
-				_mockPortletDataContext(null, null, null));
+				_mockExportImportDescriptor(
+					null, null, null,
+					HashMapBuilder.<String, Serializable>put(
+						"param1", "value1"
+					).put(
+						"param2", "value2"
+					).build()),
+				_mockPortletDataContext());
 
 		Assert.assertEquals("value1", parameters.get("param1"));
 		Assert.assertEquals("value2", parameters.get("param2"));
@@ -147,11 +178,36 @@ public class BatchEnginePortletDataHandlerUtilTest {
 
 		Map<String, Serializable> parameters =
 			BatchEnginePortletDataHandlerUtil.buildExportParameters(
-				null, null, _mockPortletDataContext(null, null, startDate));
+				_mockExportImportDescriptor(),
+				_mockPortletDataContext(null, null, startDate));
 
 		Assert.assertEquals(
 			"dateModified ge " + _dateFormat.format(startDate),
 			parameters.get("filter"));
+	}
+
+	@Test
+	public void testBuildImportParametersWithItemClassName() {
+		String itemClassName = RandomTestUtil.randomString();
+
+		Map<String, Serializable> parameters =
+			BatchEnginePortletDataHandlerUtil.buildImportParameters(
+				_mockExportImportDescriptor(itemClassName, null, null, null),
+				_mockPortletDataContext());
+
+		Assert.assertEquals(itemClassName, parameters.get("itemClassName"));
+	}
+
+	@Test
+	public void testBuildImportParametersWithItemModelName() {
+		String itemModelName = RandomTestUtil.randomString();
+
+		Map<String, Serializable> parameters =
+			BatchEnginePortletDataHandlerUtil.buildImportParameters(
+				_mockExportImportDescriptor(null, itemModelName, null, null),
+				_mockPortletDataContext());
+
+		Assert.assertEquals(itemModelName, parameters.get("itemModelName"));
 	}
 
 	private Date _getDate(int days) {
@@ -162,11 +218,57 @@ public class BatchEnginePortletDataHandlerUtilTest {
 		return calendar.getTime();
 	}
 
+	private ExportImportVulcanBatchEngineTaskItemDelegate.ExportImportDescriptor
+		_mockExportImportDescriptor() {
+
+		return Mockito.mock(
+			ExportImportVulcanBatchEngineTaskItemDelegate.
+				ExportImportDescriptor.class);
+	}
+
+	private ExportImportVulcanBatchEngineTaskItemDelegate.ExportImportDescriptor
+		_mockExportImportDescriptor(
+			String itemClassName, String itemModelName,
+			List<String> nestedFields, Map<String, Serializable> parameters) {
+
+		ExportImportVulcanBatchEngineTaskItemDelegate.ExportImportDescriptor
+			exportImportDescriptor = _mockExportImportDescriptor();
+
+		Mockito.when(
+			exportImportDescriptor.getItemClassName()
+		).thenReturn(
+			itemClassName
+		);
+
+		Mockito.when(
+			exportImportDescriptor.getItemModelName()
+		).thenReturn(
+			itemModelName
+		);
+
+		Mockito.when(
+			exportImportDescriptor.getNestedFields()
+		).thenReturn(
+			nestedFields
+		);
+
+		Mockito.when(
+			exportImportDescriptor.getParameters()
+		).thenReturn(
+			parameters
+		);
+
+		return exportImportDescriptor;
+	}
+
+	private PortletDataContext _mockPortletDataContext() {
+		return Mockito.mock(PortletDataContext.class);
+	}
+
 	private PortletDataContext _mockPortletDataContext(
 		Date endDate, Map<String, String[]> parameterMap, Date startDate) {
 
-		PortletDataContext portletDataContext = Mockito.mock(
-			PortletDataContext.class);
+		PortletDataContext portletDataContext = _mockPortletDataContext();
 
 		Mockito.when(
 			portletDataContext.getEndDate()

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -66,6 +66,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
@@ -85,6 +86,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -1270,7 +1272,7 @@ public class BatchEnginePortletDataHandlerTest {
 
 		objectEntry.setExternalReferenceCode(StringUtil.randomString());
 
-		_objectEntryLocalService.updateObjectEntry(objectEntry);
+		objectEntry = _objectEntryLocalService.updateObjectEntry(objectEntry);
 
 		ExportImportConfiguration exportImportConfiguration = _importLayouts(
 			false, true, file, group.getGroupId(), objectDefinition);
@@ -1283,15 +1285,27 @@ public class BatchEnginePortletDataHandlerTest {
 		Assert.assertEquals(
 			exportImportReportEntries.toString(), 1,
 			exportImportReportEntries.size());
-		Assert.assertTrue(
-			ListUtil.exists(
-				exportImportReportEntries,
-				exportImportReportEntry ->
-					Objects.equals(
-						exportImportReportEntry.getClassExternalReferenceCode(),
-						originalExternalReferenceCode) &&
-					(exportImportReportEntry.getType() ==
-						ExportImportReportEntryConstants.TYPE_ERROR)));
+
+		ExportImportReportEntry exportImportReportEntry =
+			exportImportReportEntries.get(0);
+
+		Assert.assertEquals(
+			originalExternalReferenceCode,
+			exportImportReportEntry.getClassExternalReferenceCode());
+		Assert.assertEquals(
+			_portal.getClassNameId(objectDefinition.getClassName()),
+			exportImportReportEntry.getClassNameId());
+		Assert.assertEquals(
+			objectEntry.getPrimaryKey(), exportImportReportEntry.getClassPK());
+		Assert.assertEquals(
+			objectEntry.getGroupId(), exportImportReportEntry.getGroupId());
+		Assert.assertEquals(
+			objectDefinition.getShortName(),
+			exportImportReportEntry.getModelName());
+		Assert.assertEquals(scope, exportImportReportEntry.getScope());
+		Assert.assertEquals(
+			ExportImportReportEntryConstants.TYPE_ERROR,
+			exportImportReportEntry.getType());
 	}
 
 	private void _testExportImportObjectEntriesWithRelatedObjectEntries(
@@ -1479,6 +1493,9 @@ public class BatchEnginePortletDataHandlerTest {
 		_batchEngineImportTaskLocalService;
 
 	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@Inject
 	private CompanyLocalService _companyLocalService;
 
 	@Inject
@@ -1503,6 +1520,9 @@ public class BatchEnginePortletDataHandlerTest {
 
 	@Inject
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	@Inject
+	private Portal _portal;
 
 	@Inject
 	private PortletDataHandlerProvider _portletDataHandlerProvider;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -366,6 +366,11 @@ public class ObjectEntryResourceImpl
 			}
 
 			@Override
+			public String getItemModelName() {
+				return _objectDefinition.getShortName();
+			}
+
+			@Override
 			public List<String> getNestedFields() {
 				return transform(
 					_objectRelationshipLocalService.


### PR DESCRIPTION
- https://liferay.atlassian.net/browse/LPD-64508

Tested [here](https://github.com/liferay-headless/liferay-portal/pull/3159). Sending directly because of unrelated stable errors.