### PR TITLE
LPD-67002 Drop permission check impl switching support. To only suppo…

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/permission/PermissionCheckerFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/PermissionCheckerFactoryImpl.java
@@ -13,7 +13,6 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.security.permission.contributor.RoleContributor;
 import com.liferay.portal.kernel.security.permission.wrapper.PermissionCheckerWrapperFactory;
-import com.liferay.portal.kernel.util.PropsValues;
 
 import org.osgi.framework.BundleContext;
 
@@ -23,14 +22,6 @@ import org.osgi.framework.BundleContext;
  * @author Shuyang Zhou
  */
 public class PermissionCheckerFactoryImpl implements PermissionCheckerFactory {
-
-	public PermissionCheckerFactoryImpl() throws Exception {
-		Class<PermissionChecker> clazz =
-			(Class<PermissionChecker>)Class.forName(
-				PropsValues.PERMISSIONS_CHECKER);
-
-		_permissionChecker = clazz.newInstance();
-	}
 
 	public void afterPropertiesSet() {
 		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
@@ -66,7 +57,9 @@ public class PermissionCheckerFactoryImpl implements PermissionCheckerFactory {
 		_roleContributors.close();
 	}
 
-	private final PermissionChecker _permissionChecker;
+	private static final PermissionChecker _permissionChecker =
+		new AdvancedPermissionChecker();
+
 	private ServiceTrackerList<PermissionCheckerWrapperFactory>
 		_permissionCheckerWrapperFactories;
 	private ServiceTrackerList<RoleContributor> _roleContributors;

--- a/portal-impl/src/com/liferay/portal/security/permission/PermissionCheckerUtil.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/PermissionCheckerUtil.java
@@ -15,7 +15,6 @@ import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.security.permission.contributor.RoleContributor;
-import com.liferay.portal.kernel.util.PropsValues;
 
 /**
  * @author Brian Wing Shun Chan
@@ -37,9 +36,7 @@ public class PermissionCheckerUtil {
 				PermissionThreadLocal.getPermissionChecker();
 
 			if (permissionChecker == null) {
-				Class<?> clazz = Class.forName(PropsValues.PERMISSIONS_CHECKER);
-
-				permissionChecker = (PermissionChecker)clazz.newInstance();
+				permissionChecker = new AdvancedPermissionChecker();
 			}
 
 			permissionChecker.init(

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -4148,18 +4148,6 @@
 ##
 
     #
-    # Set the default permission checker class used by
-    # com.liferay.portal.security.permission.PermissionCheckerFactory to check
-    # permissions for actions on objects. This class can be overriden with a
-    # custom class that implements
-    # com.liferay.portal.security.permission.PermissionChecker.
-    #
-    # Env: LIFERAY_PERMISSIONS_PERIOD_CHECKER
-    #
-    #permissions.checker=com.liferay.portal.security.permission.SimplePermissionChecker
-    permissions.checker=com.liferay.portal.security.permission.AdvancedPermissionChecker
-
-    #
     # Configure this threshold to indicate when to use the custom SQL finder to
     # check resource permissions.
     #

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2010,8 +2010,6 @@ public interface PropsKeys {
 	public static final String PERMISSIONS_CHECK_GUEST_ENABLED =
 		"permissions.check.guest.enabled";
 
-	public static final String PERMISSIONS_CHECKER = "permissions.checker";
-
 	public static final String
 		PERMISSIONS_CUSTOM_ATTRIBUTE_READ_CHECK_BY_DEFAULT =
 			"permissions.custom.attribute.read.check.by.default";

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
@@ -1695,9 +1695,6 @@ public class PropsValues {
 		GetterUtil.getBoolean(
 			PropsUtil.get(PropsKeys.PERMISSIONS_CHECK_GUEST_ENABLED));
 
-	public static final String PERMISSIONS_CHECKER = PropsUtil.get(
-		PropsKeys.PERMISSIONS_CHECKER);
-
 	public static boolean PERMISSIONS_CUSTOM_ATTRIBUTE_READ_CHECK_BY_DEFAULT =
 		GetterUtil.getBoolean(
 			PropsUtil.get(


### PR DESCRIPTION
…rt AdvancedPermissionChecker.

# breaking

## What portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java

Removed PERMISSIONS_CHECKER

## Why

Permission checker impl switching only supports shielded container shipped permission checker impl. This has limitations for customers to use. They would have to put their impl into shielded container classpath (This is no longer doable in a supported way, since we have dropped portal ext support long time ago), and the impl can not reference any module classes. We are dropping this support in favor of com.liferay.portal.kernel.security.permission.wrapper.PermissionCheckerWrapperFactory 's permission checker wrapping. A PermissionCheckerWrapperFactory impl can be registered as an osgi service from any module, at runtime it will be invoked to wrap PermissionChecker instance. PermissionCheckerWrapper can either delegate to the original PermissionChecker or take over the control to do its own permission checking. This is a more powerful and flexible way to custimize permission checking logic.

----

# breaking

## What portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java

Removed PERMISSIONS_CHECKER

## Why

Same as PropsKeys.PERMISSIONS_CHECKER removal.

----