### PR TITLE
LPD-66681 Move the logic responsible for displaying the screen navigation component to display context and fix logic to display screen navigation for descendants

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/display/context/ObjectEntryDisplayContext.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/display/context/ObjectEntryDisplayContext.java
@@ -72,6 +72,8 @@ public interface ObjectEntryDisplayContext {
 
 	public boolean isShowObjectEntryForm() throws PortalException;
 
+	public boolean isShowScreenNavigation() throws PortalException;
+
 	public String renderDDMForm(PageContext pageContext) throws PortalException;
 
 }

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/display/context/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/display/context/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/entries/display/context/test/ObjectEntryDisplayContextTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/entries/display/context/test/ObjectEntryDisplayContextTest.java
@@ -228,9 +228,44 @@ public class ObjectEntryDisplayContextTest {
 
 	@Test
 	public void testIsShowScreenNavigation() throws Exception {
-		_testIsShowScreenNavigation();
-		_testIsShowScreenNavigationWithRootObjectEntry();
-		_testIsShowScreenNavigationWithRootDescendantObjectEntry();
+		com.liferay.object.model.ObjectEntry objectEntry =
+			ObjectEntryTestUtil.addObjectEntry(_companyObjectDefinitionAA);
+
+		ObjectEntryDisplayContext objectEntryDisplayContext =
+			_objectEntryDisplayContextFactory.create(
+				_getMockHttpServletRequest(
+					objectEntry.getExternalReferenceCode(),
+					_companyObjectDefinitionAA, 0L, null));
+
+		Assert.assertFalse(objectEntryDisplayContext.isShowScreenNavigation());
+	}
+
+	@Test
+	public void testIsShowScreenNavigationWithRootDescendantObjectEntry()
+		throws Exception {
+
+		ObjectEntryDisplayContext objectEntryDisplayContext =
+			_objectEntryDisplayContextFactory.create(
+				_getMockHttpServletRequest(
+					_companyObjectEntryAA.getExternalReferenceCode(),
+					_companyObjectDefinitionAA,
+					_companyObjectRelationshipA_AA.getObjectRelationshipId(),
+					_companyObjectEntryA.getExternalReferenceCode()));
+
+		Assert.assertTrue(objectEntryDisplayContext.isShowScreenNavigation());
+	}
+
+	@Test
+	public void testIsShowScreenNavigationWithRootObjectEntry()
+		throws Exception {
+
+		ObjectEntryDisplayContext objectEntryDisplayContext =
+			_objectEntryDisplayContextFactory.create(
+				_getMockHttpServletRequest(
+					_companyObjectEntryA.getExternalReferenceCode(),
+					_companyObjectDefinitionA, 0L, null));
+
+		Assert.assertTrue(objectEntryDisplayContext.isShowScreenNavigation());
 	}
 
 	private static ObjectDefinition _addObjectDefinition(String scope)
@@ -385,45 +420,6 @@ public class ObjectEntryDisplayContextTest {
 						objectRelationship.getObjectDefinitionId2()),
 					objectRelationship.getObjectRelationshipId(),
 					parentObjectEntry.getExternalReferenceCode())));
-	}
-
-	private void _testIsShowScreenNavigation() throws Exception {
-		com.liferay.object.model.ObjectEntry objectEntry =
-			ObjectEntryTestUtil.addObjectEntry(_companyObjectDefinitionAA);
-
-		ObjectEntryDisplayContext objectEntryDisplayContext =
-			_objectEntryDisplayContextFactory.create(
-				_getMockHttpServletRequest(
-					objectEntry.getExternalReferenceCode(),
-					_companyObjectDefinitionAA, 0L, null));
-
-		Assert.assertFalse(objectEntryDisplayContext.isShowScreenNavigation());
-	}
-
-	private void _testIsShowScreenNavigationWithRootDescendantObjectEntry()
-		throws Exception {
-
-		ObjectEntryDisplayContext objectEntryDisplayContext =
-			_objectEntryDisplayContextFactory.create(
-				_getMockHttpServletRequest(
-					_companyObjectEntryAA.getExternalReferenceCode(),
-					_companyObjectDefinitionAA,
-					_companyObjectRelationshipA_AA.getObjectRelationshipId(),
-					_companyObjectEntryA.getExternalReferenceCode()));
-
-		Assert.assertTrue(objectEntryDisplayContext.isShowScreenNavigation());
-	}
-
-	private void _testIsShowScreenNavigationWithRootObjectEntry()
-		throws Exception {
-
-		ObjectEntryDisplayContext objectEntryDisplayContext =
-			_objectEntryDisplayContextFactory.create(
-				_getMockHttpServletRequest(
-					_companyObjectEntryA.getExternalReferenceCode(),
-					_companyObjectDefinitionA, 0L, null));
-
-		Assert.assertTrue(objectEntryDisplayContext.isShowScreenNavigation());
 	}
 
 	private static ObjectDefinition _companyObjectDefinitionA;

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/entries/display/context/test/ObjectEntryDisplayContextTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/entries/display/context/test/ObjectEntryDisplayContextTest.java
@@ -19,6 +19,7 @@ import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.object.test.util.ObjectEntryTestUtil;
 import com.liferay.object.test.util.TreeTestUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
@@ -225,6 +226,13 @@ public class ObjectEntryDisplayContextTest {
 			_getBackURL(mockHttpServletRequest));
 	}
 
+	@Test
+	public void testIsShowScreenNavigation() throws Exception {
+		_testIsShowScreenNavigation();
+		_testIsShowScreenNavigationWithRootObjectEntry();
+		_testIsShowScreenNavigationWithRootDescendantObjectEntry();
+	}
+
 	private static ObjectDefinition _addObjectDefinition(String scope)
 		throws Exception {
 
@@ -377,6 +385,45 @@ public class ObjectEntryDisplayContextTest {
 						objectRelationship.getObjectDefinitionId2()),
 					objectRelationship.getObjectRelationshipId(),
 					parentObjectEntry.getExternalReferenceCode())));
+	}
+
+	private void _testIsShowScreenNavigation() throws Exception {
+		com.liferay.object.model.ObjectEntry objectEntry =
+			ObjectEntryTestUtil.addObjectEntry(_companyObjectDefinitionAA);
+
+		ObjectEntryDisplayContext objectEntryDisplayContext =
+			_objectEntryDisplayContextFactory.create(
+				_getMockHttpServletRequest(
+					objectEntry.getExternalReferenceCode(),
+					_companyObjectDefinitionAA, 0L, null));
+
+		Assert.assertFalse(objectEntryDisplayContext.isShowScreenNavigation());
+	}
+
+	private void _testIsShowScreenNavigationWithRootDescendantObjectEntry()
+		throws Exception {
+
+		ObjectEntryDisplayContext objectEntryDisplayContext =
+			_objectEntryDisplayContextFactory.create(
+				_getMockHttpServletRequest(
+					_companyObjectEntryAA.getExternalReferenceCode(),
+					_companyObjectDefinitionAA,
+					_companyObjectRelationshipA_AA.getObjectRelationshipId(),
+					_companyObjectEntryA.getExternalReferenceCode()));
+
+		Assert.assertTrue(objectEntryDisplayContext.isShowScreenNavigation());
+	}
+
+	private void _testIsShowScreenNavigationWithRootObjectEntry()
+		throws Exception {
+
+		ObjectEntryDisplayContext objectEntryDisplayContext =
+			_objectEntryDisplayContextFactory.create(
+				_getMockHttpServletRequest(
+					_companyObjectEntryA.getExternalReferenceCode(),
+					_companyObjectDefinitionA, 0L, null));
+
+		Assert.assertTrue(objectEntryDisplayContext.isShowScreenNavigation());
 	}
 
 	private static ObjectDefinition _companyObjectDefinitionA;

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/display/context/ObjectEntryDisplayContextImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/display/context/ObjectEntryDisplayContextImpl.java
@@ -783,6 +783,32 @@ public class ObjectEntryDisplayContextImpl
 	}
 
 	@Override
+	public boolean isShowScreenNavigation() throws PortalException {
+		com.liferay.object.model.ObjectEntry objectEntry = getObjectEntry();
+
+		if (objectEntry == null) {
+			return false;
+		}
+
+		ObjectDefinition objectDefinition = getObjectDefinition1();
+
+		if ((getObjectLayoutTab() != null) || objectDefinition.isRootNode()) {
+			return true;
+		}
+
+		objectEntry = _objectEntryLocalService.fetchObjectEntry(
+			objectEntry.getObjectEntryId());
+
+		if ((objectEntry != null) &&
+			(objectEntry.getRootObjectEntryId() != 0)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
 	public String renderDDMForm(PageContext pageContext)
 		throws PortalException {
 

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/init.jsp
@@ -34,7 +34,6 @@ page import="com.liferay.object.model.ObjectField" %><%@
 page import="com.liferay.object.model.ObjectFolder" %><%@
 page import="com.liferay.object.model.ObjectLayout" %><%@
 page import="com.liferay.object.model.ObjectLayoutBox" %><%@
-page import="com.liferay.object.model.ObjectLayoutTab" %><%@
 page import="com.liferay.object.model.ObjectRelationship" %><%@
 page import="com.liferay.object.model.ObjectValidationRule" %><%@
 page import="com.liferay.object.model.ObjectView" %><%@

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_entries/edit_object_entry.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_entries/edit_object_entry.jsp
@@ -14,7 +14,6 @@ ObjectEntryDisplayContext objectEntryDisplayContext = (ObjectEntryDisplayContext
 
 ObjectDefinition objectDefinition = objectEntryDisplayContext.getObjectDefinition1();
 ObjectEntry objectEntry = objectEntryDisplayContext.getObjectEntry();
-ObjectLayoutTab objectLayoutTab = objectEntryDisplayContext.getObjectLayoutTab();
 ObjectRelationship objectRelationship = objectEntryDisplayContext.getObjectRelationship();
 %>
 
@@ -26,7 +25,7 @@ ObjectRelationship objectRelationship = objectEntryDisplayContext.getObjectRelat
 		/>
 	</c:when>
 	<c:otherwise>
-		<c:if test="<%= (objectEntry != null) && ((objectLayoutTab != null) || (objectDefinition.getRootObjectDefinitionId() > 0)) %>">
+		<c:if test="<%= objectEntryDisplayContext.isShowScreenNavigation() %>">
 			<liferay-frontend:screen-navigation
 				key="<%= objectDefinition.getClassName() %>"
 				navBarCssClass="container-fluid-max-xxxl"


### PR DESCRIPTION
Related: LPD-66681

Forwarding directly because the sf is broken due to unrelated issues, note that stable has no failures:

https://github.com/liferay-bpm/liferay-portal/pull/5194#issuecomment-3358012593