### PR TITLE
LPD-67111 Empty K8s TF provider on AWS Backup & Restore

### DIFF
--- a/cloud/terraform/aws/dependencies/providers.tf
+++ b/cloud/terraform/aws/dependencies/providers.tf
@@ -7,10 +7,6 @@ provider "aws" {
 	region=var.region
 }
 provider "kubernetes" {
-	config_paths=[
-		var.kube_config_path,
-		"/tmp/this-kubeconfig-file-does-not-exist",
-	]
 }
 terraform {
 	required_providers {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-67111

---

When run in-cluster, the environment variables `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` will be defined. If defined, we know we're in-cluster. So, the provider will use these environment variables as credentials. ([docs](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#in-cluster-config))

When run out-of-cluster, the provider will use the kubeconfig defined at `KUBE_CONFIG_FILE` by default. ([docs](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#file-config))

Therefore, I've added a step for users to set `KUBE_CONFIG_FILE` on their local machine in the AWS/AWSMP documentation ([here](https://liferay.atlassian.net/wiki/spaces/DET/pages/4059463783/Run+Liferay+on+AWS+via+the+Liferay+Cloud+Native+Experience+using+the+AWS+Chart#3.-Access-EKS-cluster) and [here](https://liferay.atlassian.net/wiki/spaces/DET/pages/4002873382/Run+Liferay+on+AWS+via+the+Liferay+Cloud+Native+Experience+Using+Marketplace+Artifacts#3.-Access-EKS-cluster)) prior to bootstrapping the dependencies.