### PR TITLE
LPD-60410

### DIFF
--- a/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/request/helper/InfoRequestFieldValuesProviderHelper.java
+++ b/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/request/helper/InfoRequestFieldValuesProviderHelper.java
@@ -25,6 +25,7 @@ import com.liferay.info.field.type.TextInfoFieldType;
 import com.liferay.info.form.InfoForm;
 import com.liferay.info.item.InfoItemServiceRegistry;
 import com.liferay.info.item.provider.InfoItemFormProvider;
+import com.liferay.info.item.updater.InfoItemFieldValuesUpdater;
 import com.liferay.info.localized.InfoLocalizedValue;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -102,6 +103,8 @@ public class InfoRequestFieldValuesProviderHelper {
 			ParamUtil.getLong(uploadServletRequest, "classNameId"));
 		String classTypeId = ParamUtil.getString(
 			uploadServletRequest, "classTypeId");
+		String[] deletedItemIdentifiers = ParamUtil.getStringValues(
+			uploadServletRequest, "deletedItemIdentifiers");
 		long groupId = ParamUtil.getLong(uploadServletRequest, "groupId");
 
 		Map<String, FileItem[]> multipartParameterMap =
@@ -211,6 +214,19 @@ public class InfoRequestFieldValuesProviderHelper {
 				}
 			}
 		}
+
+		InfoField<MultiselectInfoFieldType> infoField = InfoField.builder(
+		).infoFieldType(
+			MultiselectInfoFieldType.INSTANCE
+		).namespace(
+			InfoItemFieldValuesUpdater.class.getSimpleName()
+		).name(
+			"deletedItemIdentifiers"
+		).build();
+
+		infoFieldValues.put(
+			infoField.getUniqueId(),
+			new InfoFieldValue<>(infoField, deletedItemIdentifiers));
 
 		return _computeInfoFieldValues(infoFieldValues);
 	}

--- a/modules/apps/layout/layout-taglib/build.gradle
+++ b/modules/apps/layout/layout-taglib/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
 	compileOnly group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
 	compileOnly group: "jakarta.servlet.jsp", name: "jakarta.servlet.jsp-api", version: "3.1.1"
+	compileOnly group: "org.jsoup", name: "jsoup", version: "1.15.3"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:adaptive-media:adaptive-media-content-transformer-api")

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/struts/RenderFormRelationshipLayoutStructureItemStrutsAction.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/struts/RenderFormRelationshipLayoutStructureItemStrutsAction.java
@@ -1,0 +1,169 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.taglib.internal.struts;
+
+import com.liferay.fragment.constants.FragmentEntryLinkConstants;
+import com.liferay.layout.provider.LayoutStructureProvider;
+import com.liferay.layout.taglib.constants.LayoutStructureRendererConstants;
+import com.liferay.layout.taglib.servlet.taglib.renderer.LayoutStructureRenderer;
+import com.liferay.layout.util.constants.LayoutDataItemTypeConstants;
+import com.liferay.layout.util.structure.LayoutStructure;
+import com.liferay.layout.util.structure.LayoutStructureItem;
+import com.liferay.layout.util.structure.LayoutStructureItemUtil;
+import com.liferay.petra.io.unsync.UnsyncStringWriter;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
+import com.liferay.portal.kernel.servlet.PipingServletResponse;
+import com.liferay.portal.kernel.servlet.ServletResponseUtil;
+import com.liferay.portal.kernel.struts.StrutsAction;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
+import com.liferay.taglib.servlet.PageContextFactoryUtil;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Víctor Galán
+ */
+@Component(
+	property = "path=/portal/render_form_relationship_layout_structure_item",
+	service = StrutsAction.class
+)
+public class RenderFormRelationshipLayoutStructureItemStrutsAction
+	implements StrutsAction {
+
+	@Override
+	public String execute(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws Exception {
+
+		Layout layout = _layoutLocalService.fetchLayout(
+			ParamUtil.getLong(httpServletRequest, "p_l_id"));
+
+		if ((layout == null) ||
+			(!layout.isTypeContent() && !layout.isTypeAssetDisplay())) {
+
+			return null;
+		}
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		LayoutPermissionUtil.checkLayoutUpdatePermission(
+			themeDisplay.getPermissionChecker(), layout);
+
+		LayoutStructure layoutStructure =
+			_layoutStructureProvider.getLayoutStructure(
+				layout.getPlid(),
+				_getSegmentsExperienceId(httpServletRequest, layout));
+
+		if (layoutStructure == null) {
+			return null;
+		}
+
+		String formRelationshipLayoutStructureItemId = ParamUtil.getString(
+			httpServletRequest, "formRelationshipLayoutStructureItemId");
+
+		LayoutStructureItem layoutStructureItem =
+			layoutStructure.getLayoutStructureItem(
+				formRelationshipLayoutStructureItemId);
+
+		if (layoutStructureItem == null) {
+			return null;
+		}
+
+		LayoutStructureItem ancestorLayoutStructureItem =
+			LayoutStructureItemUtil.getAncestor(
+				layoutStructureItem.getItemId(),
+				LayoutDataItemTypeConstants.TYPE_FORM, layoutStructure);
+
+		if (ancestorLayoutStructureItem == null) {
+			return null;
+		}
+
+		themeDisplay.setIsolated(true);
+
+		UnsyncStringWriter unsyncStringWriter = new UnsyncStringWriter();
+
+		httpServletRequest.setAttribute(
+			LayoutStructureRendererConstants.
+				LAYOUT_PARENT_ITEM_EXTERNAL_REFERENCE_CODE +
+					formRelationshipLayoutStructureItemId,
+			ParamUtil.getString(
+				httpServletRequest, "parentItemExternalReferenceCode"));
+
+		httpServletRequest.setAttribute(
+			LayoutStructureRendererConstants.
+				LAYOUT_RELATED_ITEM_EXTERNAL_REFERENCE_CODE +
+					formRelationshipLayoutStructureItemId,
+			ParamUtil.getString(
+				httpServletRequest, "relatedItemExternalReferenceCode"));
+
+		LayoutStructureRenderer layoutStructureRenderer =
+			new LayoutStructureRenderer(
+				httpServletRequest, layoutStructure,
+				ancestorLayoutStructureItem.getParentItemId(),
+				FragmentEntryLinkConstants.VIEW,
+				PageContextFactoryUtil.create(
+					httpServletRequest,
+					new PipingServletResponse(
+						httpServletResponse, unsyncStringWriter)),
+				false, false);
+
+		layoutStructureRenderer.render();
+
+		Document document = Jsoup.parse(unsyncStringWriter.toString());
+
+		Elements elements = document.select(
+			"[data-layout-structure-item-id=\"" +
+				formRelationshipLayoutStructureItemId +
+					"\"] > [data-form-relationship-structure-item-content-id]");
+
+		Element element = elements.get(0);
+
+		ServletResponseUtil.write(httpServletResponse, element.outerHtml());
+
+		return null;
+	}
+
+	private long _getSegmentsExperienceId(
+		HttpServletRequest httpServletRequest, Layout layout) {
+
+		long segmentsExperienceId = ParamUtil.getLong(
+			httpServletRequest, "segmentsExperienceId");
+
+		if (segmentsExperienceId != 0) {
+			return segmentsExperienceId;
+		}
+
+		return _segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+			layout.getPlid());
+	}
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
+
+	@Reference
+	private LayoutStructureProvider _layoutStructureProvider;
+
+	@Reference
+	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
+
+}

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/renderer/LayoutStructureRenderer.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/renderer/LayoutStructureRenderer.java
@@ -79,6 +79,7 @@ import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -86,6 +87,7 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import com.liferay.portal.layoutconfiguration.util.RuntimePageUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -953,7 +955,11 @@ public class LayoutStructureRenderer {
 		jspWriter.write(
 			formRelationshipStyledLayoutStructureItem.getCssClass());
 		jspWriter.write("\" data-layout-structure-item-id=\"");
-		jspWriter.write(formRelationshipStyledLayoutStructureItem.getItemId());
+
+		String itemId = formRelationshipStyledLayoutStructureItem.getItemId();
+
+		jspWriter.write(itemId);
+
 		jspWriter.write("\"");
 
 		String style = _renderLayoutStructureDisplayContext.getStyle(
@@ -989,63 +995,119 @@ public class LayoutStructureRenderer {
 					LAYOUT_RELATED_ITEM_EXTERNAL_REFERENCE_CODE);
 
 		try {
+			int iterationNumber = 0;
+
+			String parentItemExternalReferenceCode = GetterUtil.getString(
+				GetterUtil.getString(
+					_httpServletRequest.getAttribute(
+						LayoutStructureRendererConstants.
+							LAYOUT_PARENT_ITEM_EXTERNAL_REFERENCE_CODE +
+								itemId),
+					currentRelatedItemExternalReferenceCode),
+				LayoutStructureRendererConstants.
+					LAYOUT_DEFAULT_EXTERNAL_REFERENCE_CODE + iterationNumber);
+			String relatedItemExternalReferenceCode = GetterUtil.getString(
+				_httpServletRequest.getAttribute(
+					LayoutStructureRendererConstants.
+						LAYOUT_RELATED_ITEM_EXTERNAL_REFERENCE_CODE + itemId),
+				LayoutStructureRendererConstants.
+					LAYOUT_DEFAULT_EXTERNAL_REFERENCE_CODE + iterationNumber);
+
 			_httpServletRequest.setAttribute(
 				LayoutStructureRendererConstants.
 					LAYOUT_PARENT_ITEM_EXTERNAL_REFERENCE_CODE,
-				LayoutStructureRendererConstants.
-					LAYOUT_DEFAULT_EXTERNAL_REFERENCE_CODE + 0);
+				parentItemExternalReferenceCode);
 			_httpServletRequest.setAttribute(
 				LayoutStructureRendererConstants.
 					LAYOUT_RELATED_ITEM_EXTERNAL_REFERENCE_CODE,
-				LayoutStructureRendererConstants.
-					LAYOUT_DEFAULT_EXTERNAL_REFERENCE_CODE + 0);
+				relatedItemExternalReferenceCode);
+
+			String formRelationshipStyledLayoutStructureItemContentId =
+				PortalUUIDUtil.generate();
 
 			if (layoutDisplayPageObjectProvider == null) {
-				_renderFormRelationshipStyledLayoutStructureItem(
-					infoForm, formRelationshipStyledLayoutStructureItem);
+				_renderFormRelationshipStyledLayoutStructureItemContent(
+					formRelationshipStyledLayoutStructureItem,
+					formRelationshipStyledLayoutStructureItemContentId,
+					infoForm);
 			}
 			else {
 				List<? extends LayoutDisplayPageObjectProvider<?>>
+					relatedLayoutDisplayPageObjectProviders = null;
+
+				if (currentRelatedLayoutDisplayPageObjectProvider != null) {
+					relatedLayoutDisplayPageObjectProviders =
+						currentRelatedLayoutDisplayPageObjectProvider.
+							getRelatedLayoutDisplayPageObjectProviders(
+								formRelationshipStyledLayoutStructureItem.
+									getContentType());
+				}
+				else {
 					relatedLayoutDisplayPageObjectProviders =
 						layoutDisplayPageObjectProvider.
 							getRelatedLayoutDisplayPageObjectProviders(
 								formRelationshipStyledLayoutStructureItem.
 									getContentType());
+				}
 
 				if (ListUtil.isEmpty(relatedLayoutDisplayPageObjectProviders)) {
-					_renderLayoutStructure(
-						formRelationshipStyledLayoutStructureItem.
-							getChildrenItemIds(),
+					_renderFormRelationshipStyledLayoutStructureItemContent(
+						formRelationshipStyledLayoutStructureItem,
+						formRelationshipStyledLayoutStructureItemContentId,
 						infoForm);
-
-					return;
 				}
+				else {
+					for (LayoutDisplayPageObjectProvider<?>
+							relatedLayoutDisplayPageObjectProvider :
+								relatedLayoutDisplayPageObjectProviders) {
 
-				for (LayoutDisplayPageObjectProvider<?>
-						relatedLayoutDisplayPageObjectProvider :
-							relatedLayoutDisplayPageObjectProviders) {
+						_httpServletRequest.setAttribute(
+							LayoutStructureRendererConstants.
+								LAYOUT_PARENT_ITEM_EXTERNAL_REFERENCE_CODE,
+							relatedLayoutDisplayPageObjectProvider.
+								getParentExternalReferenceCode());
+						_httpServletRequest.setAttribute(
+							LayoutStructureRendererConstants.
+								LAYOUT_RELATED_ITEM_DISPLAY_PAGE_OBJECT_PROVIDER,
+							relatedLayoutDisplayPageObjectProvider);
+						_httpServletRequest.setAttribute(
+							LayoutStructureRendererConstants.
+								LAYOUT_RELATED_ITEM_EXTERNAL_REFERENCE_CODE,
+							relatedLayoutDisplayPageObjectProvider.
+								getExternalReferenceCode());
 
-					_httpServletRequest.setAttribute(
-						LayoutStructureRendererConstants.
-							LAYOUT_PARENT_ITEM_EXTERNAL_REFERENCE_CODE,
-						relatedLayoutDisplayPageObjectProvider.
-							getParentExternalReferenceCode());
-					_httpServletRequest.setAttribute(
-						LayoutStructureRendererConstants.
-							LAYOUT_RELATED_ITEM_DISPLAY_PAGE_OBJECT_PROVIDER,
-						relatedLayoutDisplayPageObjectProvider);
-					_httpServletRequest.setAttribute(
-						LayoutStructureRendererConstants.
-							LAYOUT_RELATED_ITEM_EXTERNAL_REFERENCE_CODE,
-						relatedLayoutDisplayPageObjectProvider.
-							getExternalReferenceCode());
-
-					_renderLayoutStructure(
-						formRelationshipStyledLayoutStructureItem.
-							getChildrenItemIds(),
-						infoForm);
+						_renderFormRelationshipStyledLayoutStructureItemContent(
+							formRelationshipStyledLayoutStructureItem,
+							formRelationshipStyledLayoutStructureItemContentId,
+							infoForm);
+					}
 				}
 			}
+
+			_renderReactComponent(
+				"{FormRelationshipAddButton} from layout-taglib/render",
+				HashMapBuilder.<String, Object>put(
+					"contentId",
+					formRelationshipStyledLayoutStructureItemContentId
+				).put(
+					"label",
+					formRelationshipStyledLayoutStructureItem.
+						getButtonLabelJSONObject()
+				).put(
+					"renderURL",
+					HttpComponentsUtil.addParameters(
+						StringBundler.concat(
+							_themeDisplay.getPortalURL(),
+							_themeDisplay.getPathMain(), "/portal",
+							"/render_form_relationship_layout_structure_item"),
+						"formRelationshipLayoutStructureItemId",
+						formRelationshipStyledLayoutStructureItem.getItemId(),
+						"p_l_id", _themeDisplay.getPlid(),
+						"parentItemExternalReferenceCode",
+						parentItemExternalReferenceCode, "segmentsExperienceId",
+						SegmentsExperienceUtil.getSegmentsExperienceId(
+							_httpServletRequest))
+				).build());
 		}
 		finally {
 			_httpServletRequest.setAttribute(
@@ -1062,13 +1124,44 @@ public class LayoutStructureRenderer {
 				currentRelatedItemExternalReferenceCode);
 		}
 
-		_renderReactComponent(
-			"{FormRelationshipAddButton} from layout-taglib/render",
-			HashMapBuilder.<String, Object>put(
-				"label",
-				formRelationshipStyledLayoutStructureItem.
-					getButtonLabelJSONObject()
-			).build());
+		jspWriter.write("</div>");
+	}
+
+	private void _renderFormRelationshipStyledLayoutStructureItemContent(
+			FormRelationshipStyledLayoutStructureItem
+				formRelationshipStyledLayoutStructureItem,
+			String formRelationshipStyledLayoutStructureItemContentId,
+			InfoForm infoForm)
+		throws Exception {
+
+		JspWriter jspWriter = _pageContext.getOut();
+
+		jspWriter.write("<div data-form-relationship-");
+		jspWriter.write("structure-item-content-id=\"");
+		jspWriter.write(formRelationshipStyledLayoutStructureItemContentId);
+		jspWriter.write("\">");
+
+		jspWriter.write("<div class=\"d-flex justify-content-end ");
+		jspWriter.write("lfr-form-relationship-remove-button \">");
+
+		ButtonTag removeButtonTag = new ButtonTag();
+
+		removeButtonTag.setBorderless(true);
+		removeButtonTag.setCssClass("d-none lfr-portal-tooltip mt-2");
+		removeButtonTag.setDisplayType("secondary");
+		removeButtonTag.setDynamicAttribute(
+			StringPool.BLANK, "title",
+			LanguageUtil.get(_httpServletRequest, "remove"));
+		removeButtonTag.setIcon("times-circle");
+		removeButtonTag.setSmall(true);
+
+		removeButtonTag.doTag(_pageContext);
+
+		jspWriter.write("</div>");
+
+		_renderLayoutStructure(
+			formRelationshipStyledLayoutStructureItem.getChildrenItemIds(),
+			infoForm);
 
 		jspWriter.write("</div>");
 	}

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/renderer/LayoutStructureRenderer.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/renderer/LayoutStructureRenderer.java
@@ -1029,7 +1029,7 @@ public class LayoutStructureRenderer {
 				_renderFormRelationshipStyledLayoutStructureItemContent(
 					formRelationshipStyledLayoutStructureItem,
 					formRelationshipStyledLayoutStructureItemContentId,
-					infoForm);
+					infoForm, null);
 			}
 			else {
 				List<? extends LayoutDisplayPageObjectProvider<?>>
@@ -1054,7 +1054,7 @@ public class LayoutStructureRenderer {
 					_renderFormRelationshipStyledLayoutStructureItemContent(
 						formRelationshipStyledLayoutStructureItem,
 						formRelationshipStyledLayoutStructureItemContentId,
-						infoForm);
+						infoForm, null);
 				}
 				else {
 					for (LayoutDisplayPageObjectProvider<?>
@@ -1079,7 +1079,7 @@ public class LayoutStructureRenderer {
 						_renderFormRelationshipStyledLayoutStructureItemContent(
 							formRelationshipStyledLayoutStructureItem,
 							formRelationshipStyledLayoutStructureItemContentId,
-							infoForm);
+							infoForm, relatedLayoutDisplayPageObjectProvider);
 					}
 				}
 			}
@@ -1131,7 +1131,9 @@ public class LayoutStructureRenderer {
 			FormRelationshipStyledLayoutStructureItem
 				formRelationshipStyledLayoutStructureItem,
 			String formRelationshipStyledLayoutStructureItemContentId,
-			InfoForm infoForm)
+			InfoForm infoForm,
+			LayoutDisplayPageObjectProvider<?>
+				relatedLayoutDisplayPageObjectProvider)
 		throws Exception {
 
 		JspWriter jspWriter = _pageContext.getOut();
@@ -1149,9 +1151,22 @@ public class LayoutStructureRenderer {
 		removeButtonTag.setBorderless(true);
 		removeButtonTag.setCssClass("d-none lfr-portal-tooltip mt-2");
 		removeButtonTag.setDisplayType("secondary");
+
+		if (relatedLayoutDisplayPageObjectProvider != null) {
+			removeButtonTag.setDynamicAttribute(
+				StringPool.BLANK, "data-classname",
+				relatedLayoutDisplayPageObjectProvider.getClassName());
+
+			removeButtonTag.setDynamicAttribute(
+				StringPool.BLANK, "data-external-reference-code",
+				relatedLayoutDisplayPageObjectProvider.
+					getExternalReferenceCode());
+		}
+
 		removeButtonTag.setDynamicAttribute(
 			StringPool.BLANK, "title",
 			LanguageUtil.get(_httpServletRequest, "remove"));
+
 		removeButtonTag.setIcon("times-circle");
 		removeButtonTag.setSmall(true);
 

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/js/render_layout_structure/FormRelationshipAddButton.tsx
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/js/render_layout_structure/FormRelationshipAddButton.tsx
@@ -6,23 +6,80 @@
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import classNames from 'classnames';
-import React from 'react';
+import {fetch, runScriptsInElement} from 'frontend-js-web';
+import React, {useMemo, useState} from 'react';
 
 export default function FormRelationshipAddButton({
+	contentId,
 	label,
+	renderURL,
 }: {
+	contentId: string;
 	label: Record<Liferay.Language.Locale, string>;
+	renderURL: string;
 }) {
 	const value =
 		label?.[Liferay.ThemeDisplay.getLanguageId()] ??
 		label?.[Liferay.ThemeDisplay.getDefaultLanguageId()] ??
 		Liferay.Language.get('add-new');
 
+	const [disabled, setDisabled] = useState(false);
+
+	const formRelationshipElement = useMemo(
+		() =>
+			document.querySelector(
+				`[data-form-relationship-structure-item-content-id="${contentId}"]`
+			)!.parentElement!,
+		[contentId]
+	);
+
+	useEffect(() => {
+		updateRemoveButtonVisibility(formRelationshipElement);
+	}, [formRelationshipElement]);
+
+	const onClick = () => {
+		setDisabled(true);
+
+		const numberOfChildren = getNumberOfChildren(formRelationshipElement);
+
+		const url = new URL(renderURL);
+
+		url.searchParams.set(
+			'relatedItemExternalReferenceCode',
+			'LAYOUT_DEFAULT_EXTERNAL_REFERENCE_CODE' +
+				String(numberOfChildren).padStart(4, '0')
+		);
+
+		fetch(url.toString())
+			.then((response) => response.text())
+			.then((html) => {
+				setDisabled(false);
+
+				const div = document.createElement('div');
+
+				div.innerHTML = html;
+
+				if (formRelationshipElement) {
+					const lastChild = formRelationshipElement.lastElementChild;
+
+					const firstChild = div.firstElementChild as Node;
+
+					formRelationshipElement.insertBefore(firstChild, lastChild);
+
+					runScriptsInElement(firstChild as HTMLElement);
+
+					updateRemoveButtonVisibility(formRelationshipElement);
+				}
+			});
+	};
+
 	return (
 		<ClayButton
 			aria-label={value ? '' : Liferay.Language.get('add-new')}
 			borderless
+			disabled={disabled}
 			displayType="primary"
+			onClick={onClick}
 			size="sm"
 		>
 			<ClayIcon
@@ -36,4 +93,45 @@ export default function FormRelationshipAddButton({
 			{value}
 		</ClayButton>
 	);
+}
+
+function getNumberOfChildren(formRelationshipElement: HTMLElement) {
+	return formRelationshipElement.querySelectorAll(
+		':scope > [data-form-relationship-structure-item-content-id]'
+	).length;
+}
+
+const onRemoveButtonClick = (event: Event) => {
+	const removeButton = event.target as HTMLElement;
+
+	const formRelationshipContentElement = removeButton.closest(
+		'[data-form-relationship-structure-item-content-id]'
+	) as HTMLElement;
+
+	const formRelationshipElement =
+		formRelationshipContentElement.parentElement as HTMLElement;
+
+	formRelationshipContentElement.remove();
+
+	updateRemoveButtonVisibility(formRelationshipElement);
+};
+
+function updateRemoveButtonVisibility(formRelationshipElement: HTMLElement) {
+	const removeButtons = formRelationshipElement.querySelectorAll(
+		':scope > [data-form-relationship-structure-item-content-id] > .lfr-form-relationship-remove-button button'
+	);
+
+	if (getNumberOfChildren(formRelationshipElement) > 1) {
+		removeButtons.forEach((button) => {
+			button.classList.remove('d-none');
+
+			button.addEventListener('click', onRemoveButtonClick);
+		});
+	}
+	else {
+		removeButtons.forEach((button) => {
+			button.classList.add('d-none');
+			button.removeEventListener('click', onRemoveButtonClick);
+		});
+	}
 }

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/js/render_layout_structure/FormRelationshipAddButton.tsx
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/js/render_layout_structure/FormRelationshipAddButton.tsx
@@ -7,7 +7,7 @@ import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import classNames from 'classnames';
 import {fetch, runScriptsInElement} from 'frontend-js-web';
-import React, {useMemo, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 
 export default function FormRelationshipAddButton({
 	contentId,
@@ -102,7 +102,7 @@ function getNumberOfChildren(formRelationshipElement: HTMLElement) {
 }
 
 const onRemoveButtonClick = (event: Event) => {
-	const removeButton = event.target as HTMLElement;
+	const removeButton = event.currentTarget as HTMLElement;
 
 	const formRelationshipContentElement = removeButton.closest(
 		'[data-form-relationship-structure-item-content-id]'
@@ -110,11 +110,66 @@ const onRemoveButtonClick = (event: Event) => {
 
 	const formRelationshipElement =
 		formRelationshipContentElement.parentElement as HTMLElement;
+	if (
+		removeButton.dataset.classname &&
+		removeButton.dataset.externalReferenceCode
+	) {
+		updateDeletedExternalReferenceCodes(
+			removeButton.dataset.classname,
+			removeButton.dataset.externalReferenceCode,
+			formRelationshipElement
+		);
+	}
 
 	formRelationshipContentElement.remove();
 
 	updateRemoveButtonVisibility(formRelationshipElement);
 };
+
+function updateDeletedExternalReferenceCodes(
+	className: string,
+	externalReferenceCode: string,
+	formRelationshipElement: HTMLElement
+) {
+	const form = formRelationshipElement.closest('form');
+
+	if (!form) {
+		return;
+	}
+
+	const input = getOrCreateDeletedExternalReferenceCodeInput(
+		form
+	) as HTMLInputElement;
+
+	let currentValue: string[] = [];
+
+	if (input.value) {
+		currentValue = input.value.split(',');
+	}
+
+	currentValue.push(`${className}_${externalReferenceCode}`);
+
+	input.value = currentValue.join(',');
+}
+
+function getOrCreateDeletedExternalReferenceCodeInput(form: HTMLFormElement) {
+	const deletedExternalReferenceCodeInput = form.querySelector(
+		'[name="deletedItemIdentifiers"]'
+	);
+
+	if (deletedExternalReferenceCodeInput) {
+		return deletedExternalReferenceCodeInput;
+	}
+
+	const input = document.createElement('input');
+
+	input.type = 'hidden';
+	input.name = 'deletedItemIdentifiers';
+
+	form.appendChild(input);
+
+	return input;
+}
 
 function updateRemoveButtonVisibility(formRelationshipElement: HTMLElement) {
 	const removeButtons = formRelationshipElement.querySelectorAll(

--- a/modules/apps/layout/source-formatter-suppressions.xml
+++ b/modules/apps/layout/source-formatter-suppressions.xml
@@ -13,6 +13,7 @@
 		<suppress checks="VariableDeclarationAsUsedCheck" files="layout-impl/src/main/java/com/liferay/layout/internal/struts/UpdateLayoutStrutsAction\.java" />
 	</checkstyle>
 	<source-check>
+		<suppress checks="IllegalImportsCheck" files="layout-taglib/src/main/java/com/liferay/layout/taglib/internal/struts/RenderFormRelationshipLayoutStructureItemStrutsAction\.java" />
 		<suppress checks="JavaLocalServiceImplUserIdUsageCheck" files="layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryLocalServiceImpl\.java" />
 	</source-check>
 </suppressions>

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -2341,6 +2341,10 @@ public class ObjectEntryLocalServiceImpl
 				"friendlyUrlMap");
 		}
 
+		if (friendlyUrlMap == null) {
+			friendlyUrlMap = new HashMap<>();
+		}
+
 		long groupId = objectEntry.getNonzeroGroupId();
 		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
 			objectDefinition.getTitleObjectFieldId());

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/updater/ObjectEntryInfoItemFieldValuesUpdater.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/updater/ObjectEntryInfoItemFieldValuesUpdater.java
@@ -7,6 +7,7 @@ package com.liferay.object.web.internal.info.item.updater;
 
 import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.service.AssetCategoryServiceUtil;
+import com.liferay.info.field.InfoFieldValue;
 import com.liferay.info.item.InfoItemFieldValues;
 import com.liferay.info.item.provider.InfoItemFormProvider;
 import com.liferay.info.item.updater.InfoItemFieldValuesUpdater;
@@ -19,9 +20,11 @@ import com.liferay.object.rest.dto.v1_0.util.ScopeUtil;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManagerRegistry;
 import com.liferay.object.scope.ObjectScopeProviderRegistry;
+import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.web.internal.info.item.handler.ObjectEntryInfoItemExceptionRequestHandler;
 import com.liferay.object.web.internal.util.ObjectEntryUtil;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.InfoFormException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -30,7 +33,9 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 
 import java.text.DateFormat;
@@ -87,6 +92,13 @@ public class ObjectEntryInfoItemFieldValuesUpdater
 			String scopeKey = ObjectEntryInfoItemUtil.getScopeKey(
 				objectEntry.getGroupId(), _objectDefinition,
 				_objectScopeProviderRegistry);
+
+			_deleteRelatedObjectEntries(
+				themeDisplay.getCompanyId(),
+				new DefaultDTOConverterContext(
+					false, null, null, null, null, themeDisplay.getLocale(),
+					null, themeDisplay.getUser()),
+				infoItemFieldValues, scopeKey);
 
 			com.liferay.object.rest.dto.v1_0.ObjectEntry dtoObjectEntry =
 				objectEntryManager.partialUpdateObjectEntry(
@@ -173,6 +185,47 @@ public class ObjectEntryInfoItemFieldValuesUpdater
 		}
 
 		return null;
+	}
+
+	private void _deleteRelatedObjectEntries(
+			long companyId, DTOConverterContext dtoConverterContext,
+			InfoItemFieldValues infoItemFieldValues, String scopeKey)
+		throws Exception {
+
+		InfoFieldValue<Object> deletedItemIdentifiersInfoFieldValue =
+			infoItemFieldValues.getInfoFieldValue("deletedItemIdentifiers");
+
+		String[] deletedItemIdentifiers = GetterUtil.getStringValues(
+			deletedItemIdentifiersInfoFieldValue.getValue());
+
+		for (String deletedItemIdentifier : deletedItemIdentifiers) {
+			String[] split = StringUtil.split(
+				deletedItemIdentifier, StringPool.UNDERLINE);
+
+			if (split.length != 2) {
+				continue;
+			}
+
+			String className = split[0];
+
+			ObjectDefinition objectDefinition =
+				ObjectDefinitionLocalServiceUtil.
+					fetchObjectDefinitionByClassName(companyId, className);
+
+			if (objectDefinition == null) {
+				continue;
+			}
+
+			ObjectEntryManager objectEntryManager =
+				_objectEntryManagerRegistry.getObjectEntryManager(
+					objectDefinition.getStorageType());
+
+			String externalReferenceCode = split[1];
+
+			objectEntryManager.deleteObjectEntry(
+				companyId, dtoConverterContext, externalReferenceCode,
+				objectDefinition, scopeKey);
+		}
 	}
 
 	private Map<String, Object> _getProperties(


### PR DESCRIPTION
Hey Brian!

Regarding your comment in https://github.com/brianchandotcom/liferay-portal/pull/166296#issuecomment-3363713304

We cannot remove that line since otherwise it will break the SF since we are using the Jsoup library.

Currently we don't have a better option, we use this patter in several places, you can see it here:

- [JSONWebServiceStrutsAction](https://github.com/liferay/liferay-portal/blob/347e9a90170a7e8cc5f11855ed60dd784f9c6982/modules/apps/portal-remote/portal-remote-json-web-service-web/src/main/java/com/liferay/portal/remote/json/web/service/web/internal/struts/JSONWebServiceStrutsAction.java#L59-L63)
- [TermsOfUseStrutsAction](https://github.com/liferay/liferay-portal/blob/347e9a90170a7e8cc5f11855ed60dd784f9c6982/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/src/main/java/com/liferay/layout/utility/page/terms/of/use/internal/struts/TermsOfUseStrutsAction.java#L72-L76)
- [StatusStrutsAction](https://github.com/liferay/liferay-portal/blob/347e9a90170a7e8cc5f11855ed60dd784f9c6982/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/struts/StatusStrutsAction.java#L80-L84)
- [GetPagePreviewStrutsAction](https://github.com/liferay/liferay-portal/blob/347e9a90170a7e8cc5f11855ed60dd784f9c6982/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/struts/GetPagePreviewStrutsAction.java#L182-L186)
- [RenderFragmentEntryStrutsAction](https://github.com/liferay/liferay-portal/blob/347e9a90170a7e8cc5f11855ed60dd784f9c6982/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/struts/RenderFragmentEntryStrutsAction.java#L103)

We have a ticket for investigate this further in the coming months: https://liferay.atlassian.net/browse/LPD-65601