### PR TITLE
ci forward LPD 63419 pr 3176 sender DaniSzimko

### DIFF
--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -12,11 +12,8 @@ import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
-import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationParameterMapFactoryUtil;
 import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationSettingsMapFactoryUtil;
 import com.liferay.exportimport.kernel.configuration.constants.ExportImportConfigurationConstants;
-import com.liferay.exportimport.kernel.lar.ExportImportHelperUtil;
-import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
 import com.liferay.exportimport.kernel.lar.ManifestSummary;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.PortletDataContextFactoryUtil;
@@ -91,14 +88,12 @@ import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.SAXReader;
-import com.liferay.portal.kernel.zip.ZipReaderFactory;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -135,7 +130,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -366,98 +360,6 @@ public class BatchEnginePortletDataHandlerTest {
 			ObjectDefinitionConstants.SCOPE_COMPANY);
 		_testExportImportObjectEntriesWithErrorReport(
 			GroupTestUtil.addGroup(), ObjectDefinitionConstants.SCOPE_SITE);
-	}
-
-	@Test
-	@TestInfo("LPD-LPD-63419")
-	public void testExportImportObjectEntriesWithManyToManyRelationship()
-		throws Exception {
-
-		Group group = GroupTestUtil.addGroup();
-
-		ObjectDefinition objectDefinition1 = _addObjectDefinition(
-			ObjectDefinitionConstants.SCOPE_SITE);
-
-		ObjectEntry objectEntry1 = _addObjectEntry(
-			_getObjectEntryGroupId(
-				group.getGroupId(), ObjectDefinitionConstants.SCOPE_SITE),
-			objectDefinition1, RandomTestUtil.randomString());
-
-		ObjectDefinition objectDefinition2 = _addObjectDefinition(
-			ObjectDefinitionConstants.SCOPE_SITE);
-
-		ObjectEntry objectEntry2 = _addObjectEntry(
-			_getObjectEntryGroupId(
-				group.getGroupId(), ObjectDefinitionConstants.SCOPE_SITE),
-			objectDefinition2, RandomTestUtil.randomString());
-
-		ObjectRelationship objectRelationship =
-			ObjectRelationshipTestUtil.addObjectRelationship(
-				_objectRelationshipLocalService, objectDefinition1,
-				objectDefinition2,
-				ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
-				StringUtil.randomId(),
-				ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
-
-		ObjectRelationshipTestUtil.relateObjectEntries(
-			objectEntry1.getPrimaryKey(), objectEntry2.getPrimaryKey(),
-			objectRelationship, TestPropsValues.getUserId());
-
-		File larFile = _exportLayouts(
-			false, group.getGroupId(), false, new long[0], objectDefinition1,
-			objectDefinition2);
-
-		Map<String, String[]> parameterMap =
-			ExportImportConfigurationParameterMapFactoryUtil.
-				buildParameterMap();
-
-		String userIdStrategyString = MapUtil.getString(
-			parameterMap, PortletDataHandlerKeys.USER_ID_STRATEGY);
-
-		PortletDataContext portletDataContext =
-			PortletDataContextFactoryUtil.createImportPortletDataContext(
-				group.getCompanyId(), group.getGroupId(), parameterMap,
-				ExportImportHelperUtil.getUserIdStrategy(
-					TestPropsValues.getUserId(), userIdStrategyString),
-				_zipReaderFactory.getZipReader(larFile));
-
-		String objectDefinition1Path = StringPool.FORWARD_SLASH.concat(
-			objectDefinition1.getName(
-			).concat(
-				".json"
-			));
-
-		String objectEntry1Path = ExportImportPathUtil.getRootPath(
-			portletDataContext
-		).concat(
-			objectDefinition1Path
-		);
-
-		String objectDefinition2Path = StringPool.FORWARD_SLASH.concat(
-			objectDefinition2.getName(
-			).concat(
-				".json"
-			));
-
-		String objectEntry2Path = ExportImportPathUtil.getRootPath(
-			portletDataContext
-		).concat(
-			objectDefinition2Path
-		);
-
-		JSONArray objectEntry1jsonArray = JSONFactoryUtil.createJSONArray(
-			portletDataContext.getZipEntryAsString(objectEntry1Path));
-
-		_assertJSONIncludesOnlyScopeAndERCForRelationships(
-			group, objectRelationship.getName(),
-			objectEntry2.getExternalReferenceCode(), objectEntry1jsonArray);
-
-		JSONArray objectEntry2jsonArray = JSONFactoryUtil.createJSONArray(
-			portletDataContext.getZipEntryAsString(objectEntry2Path));
-
-		_assertJSONIncludesOnlyScopeAndERCForRelationships(
-			group, objectRelationship.getName(),
-			objectEntry1.getExternalReferenceCode(), objectEntry2jsonArray);
 	}
 
 	@Ignore("LPD-40798")
@@ -1108,36 +1010,6 @@ public class BatchEnginePortletDataHandlerTest {
 			ContentTypes.TEXT_PLAIN);
 	}
 
-	private void _assertJSONIncludesOnlyScopeAndERCForRelationships(
-		Group group, String relFieldName, String externalReferenceCode,
-		JSONArray jsonArray) {
-
-		for (Object entryObject : jsonArray) {
-			JSONObject entryJSONObject = (JSONObject)entryObject;
-
-			JSONArray relJSONArray = entryJSONObject.getJSONArray(relFieldName);
-
-			JSONObject relItemJSONObject = relJSONArray.getJSONObject(0);
-
-			Set<String> keys = relItemJSONObject.keySet();
-
-			Assert.assertEquals(
-				SetUtil.fromArray(
-					"scopeId", "scopeKey", "externalReferenceCode"),
-				keys);
-
-			Assert.assertEquals(
-				group.getGroupId(), relItemJSONObject.getLong("scopeId"));
-
-			Assert.assertEquals(
-				group.getGroupKey(), relItemJSONObject.getString("scopeKey"));
-
-			Assert.assertEquals(
-				externalReferenceCode,
-				relItemJSONObject.getString("externalReferenceCode"));
-		}
-	}
-
 	private void _assertNull(
 		long objectDefinitionId, ObjectEntry... objectEntries) {
 
@@ -1290,6 +1162,39 @@ public class BatchEnginePortletDataHandlerTest {
 		}
 	}
 
+	private String _getExpectedNestedRelationshipJSON(
+		Group group, ObjectEntry[] relatedObjectEntries, String scope) {
+
+		JSONArray relationshipsJSONArray = JSONFactoryUtil.createJSONArray();
+
+		for (ObjectEntry relatedObjectEntry : relatedObjectEntries) {
+			JSONArray relationshipJSONArray = JSONUtil.put(
+				JSONUtil.put(
+					"externalReferenceCode",
+					relatedObjectEntry.getExternalReferenceCode()
+				).put(
+					"scopeId",
+					(Long)_getObjectEntryGroupId(group.getGroupId(), scope)
+				).put(
+					"scopeKey",
+					() -> {
+						if (Objects.equals(
+								ObjectDefinitionConstants.SCOPE_COMPANY,
+								scope)) {
+
+							return null;
+						}
+
+						return group.getGroupKey();
+					}
+				));
+
+			relationshipsJSONArray.put(relationshipJSONArray);
+		}
+
+		return relationshipsJSONArray.toString();
+	}
+
 	private Map<String, String[]> _getExportImportParameterMap(
 		boolean deletions, boolean includeLayoutSetLayoutsPortlet,
 		List<ObjectDefinition> objectDefinitions) {
@@ -1388,6 +1293,44 @@ public class BatchEnginePortletDataHandlerTest {
 		portletDataHandler.prepareManifestSummary(portletDataContext);
 
 		return portletDataContext.getManifestSummary();
+	}
+
+	private String _getNestedRelationshipJSON(
+			String className, File file, long groupId, String relationshipName)
+		throws Exception {
+
+		try (ZipFile zipFile = new ZipFile(file)) {
+			ZipEntry zipEntry = zipFile.getEntry(
+				_getBatchFileNameWithPath(className + ".json", groupId));
+
+			if (zipEntry == null) {
+				throw new FileNotFoundException();
+			}
+
+			JSONArray nestedRelationshipsJSONArray =
+				JSONFactoryUtil.createJSONArray();
+
+			JSONArray objectEntriesJSONArray = JSONFactoryUtil.createJSONArray(
+				StringUtil.read(zipFile.getInputStream(zipEntry)));
+
+			for (int i = 0; i < objectEntriesJSONArray.length(); i++) {
+				JSONObject objectEntryJSONObject =
+					objectEntriesJSONArray.getJSONObject(i);
+
+				Object nestedObject = objectEntryJSONObject.get(
+					relationshipName);
+
+				if (nestedObject instanceof JSONObject) {
+					nestedRelationshipsJSONArray.put(
+						JSONUtil.put(nestedObject));
+				}
+				else {
+					nestedRelationshipsJSONArray.put(nestedObject);
+				}
+			}
+
+			return nestedRelationshipsJSONArray.toString();
+		}
 	}
 
 	private long _getObjectEntryGroupId(long groupId, String scope) {
@@ -1563,6 +1506,25 @@ public class BatchEnginePortletDataHandlerTest {
 		File larFile = _exportLayouts(
 			false, group.getGroupId(), false, new long[0], objectDefinition1,
 			objectDefinition2);
+
+		JSONAssert.assertEquals(
+			_getExpectedNestedRelationshipJSON(group, objectEntries1, scope),
+			_getNestedRelationshipJSON(
+				objectDefinition2.getName(), larFile, group.getGroupId(),
+				objectRelationship.getName()),
+			JSONCompareMode.STRICT);
+
+		if (Objects.equals(
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY, type)) {
+
+			JSONAssert.assertEquals(
+				_getExpectedNestedRelationshipJSON(
+					group, objectEntries2, scope),
+				_getNestedRelationshipJSON(
+					objectDefinition1.getName(), larFile, group.getGroupId(),
+					objectRelationship.getName()),
+				JSONCompareMode.STRICT);
+		}
 
 		_deleteObjectEntries(objectEntries1);
 		_deleteObjectEntries(objectEntries2);
@@ -1757,9 +1719,6 @@ public class BatchEnginePortletDataHandlerTest {
 
 	@Inject
 	private StagingLocalService _stagingLocalService;
-
-	@Inject
-	private ZipReaderFactory _zipReaderFactory;
 
 	private static class TestExportImportVulcanBatchEngineTaskItemDelegate
 		implements EntityModelResource,

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -596,8 +596,9 @@ public class BatchEnginePortletDataHandlerTest {
 			JSONUtil.putAll(
 				_getExternalReferenceCodes(objectEntries)
 			).toString(),
-			_getExternalReferenceCodesJSON(
-				objectDefinition1.getName(), file, group.getGroupId()),
+			_getExternalReferenceCodesJSONArray(
+				objectDefinition1.getName(), file, group.getGroupId()
+			).toString(),
 			JSONCompareMode.LENIENT);
 		JSONAssert.assertEquals(
 			JSONUtil.putAll(
@@ -614,8 +615,9 @@ public class BatchEnginePortletDataHandlerTest {
 			JSONUtil.putAll(
 				objectEntry.getExternalReferenceCode()
 			).toString(),
-			_getExternalReferenceCodesJSON(
-				objectDefinition2.getName(), file, group.getGroupId()),
+			_getExternalReferenceCodesJSONArray(
+				objectDefinition2.getName(), file, group.getGroupId()
+			).toString(),
 			JSONCompareMode.LENIENT);
 		JSONAssert.assertEquals(
 			JSONUtil.putAll(
@@ -633,15 +635,17 @@ public class BatchEnginePortletDataHandlerTest {
 			JSONUtil.putAll(
 				_getExternalReferenceCodes(objectEntries)
 			).toString(),
-			_getExternalReferenceCodesJSON(
-				objectDefinition1.getName(), file, group.getGroupId()),
+			_getExternalReferenceCodesJSONArray(
+				objectDefinition1.getName(), file, group.getGroupId()
+			).toString(),
 			JSONCompareMode.LENIENT);
 		JSONAssert.assertEquals(
 			JSONUtil.putAll(
 				objectEntry.getExternalReferenceCode()
 			).toString(),
-			_getExternalReferenceCodesJSON(
-				objectDefinition2.getName(), file, group.getGroupId()),
+			_getExternalReferenceCodesJSONArray(
+				objectDefinition2.getName(), file, group.getGroupId()
+			).toString(),
 			JSONCompareMode.LENIENT);
 		JSONAssert.assertEquals(
 			JSONUtil.putAll(
@@ -1146,53 +1150,15 @@ public class BatchEnginePortletDataHandlerTest {
 
 			Element rootElement = document.getRootElement();
 
-			JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
-
-			for (Element deletionSystemEventElement :
-					rootElement.elements("deletion-system-event")) {
-
-				String classExternalReferenceCode =
+			return JSONUtil.toJSONArray(
+				rootElement.elements("deletion-system-event"),
+				deletionSystemEventElement ->
 					deletionSystemEventElement.attributeValue(
-						"class-external-reference-code");
-
-				jsonArray.put(classExternalReferenceCode);
-			}
-
-			return jsonArray;
+						"class-external-reference-code"),
+				exception -> {
+					throw new RuntimeException(exception);
+				});
 		}
-	}
-
-	private String _getExpectedNestedRelationshipJSON(
-		Group group, ObjectEntry[] relatedObjectEntries, String scope) {
-
-		JSONArray relationshipsJSONArray = JSONFactoryUtil.createJSONArray();
-
-		for (ObjectEntry relatedObjectEntry : relatedObjectEntries) {
-			JSONArray relationshipJSONArray = JSONUtil.put(
-				JSONUtil.put(
-					"externalReferenceCode",
-					relatedObjectEntry.getExternalReferenceCode()
-				).put(
-					"scopeId",
-					(Long)_getObjectEntryGroupId(group.getGroupId(), scope)
-				).put(
-					"scopeKey",
-					() -> {
-						if (Objects.equals(
-								ObjectDefinitionConstants.SCOPE_COMPANY,
-								scope)) {
-
-							return null;
-						}
-
-						return group.getGroupKey();
-					}
-				));
-
-			relationshipsJSONArray.put(relationshipJSONArray);
-		}
-
-		return relationshipsJSONArray.toString();
 	}
 
 	private Map<String, String[]> _getExportImportParameterMap(
@@ -1255,7 +1221,7 @@ public class BatchEnginePortletDataHandlerTest {
 		return externalReferenceCodes;
 	}
 
-	private String _getExternalReferenceCodesJSON(
+	private JSONArray _getExternalReferenceCodesJSONArray(
 			String className, File file, long groupId)
 		throws Exception {
 
@@ -1279,7 +1245,7 @@ public class BatchEnginePortletDataHandlerTest {
 				jsonArray1.put(jsonObject.getString("externalReferenceCode"));
 			}
 
-			return jsonArray1.toString();
+			return jsonArray1;
 		}
 	}
 
@@ -1295,7 +1261,7 @@ public class BatchEnginePortletDataHandlerTest {
 		return portletDataContext.getManifestSummary();
 	}
 
-	private String _getNestedRelationshipJSON(
+	private JSONArray _getNestedRelationshipJSONArray(
 			String className, File file, long groupId, String relationshipName)
 		throws Exception {
 
@@ -1329,7 +1295,7 @@ public class BatchEnginePortletDataHandlerTest {
 				}
 			}
 
-			return nestedRelationshipsJSONArray.toString();
+			return nestedRelationshipsJSONArray;
 		}
 	}
 
@@ -1339,6 +1305,36 @@ public class BatchEnginePortletDataHandlerTest {
 		}
 
 		return groupId;
+	}
+
+	private JSONArray _getSimplifiedObjectEntriesJSONArray(
+		Group group, ObjectEntry[] objectEntries, String scope) {
+
+		return JSONUtil.toJSONArray(
+			objectEntries,
+			objectEntry -> JSONUtil.put(
+				JSONUtil.put(
+					"externalReferenceCode",
+					objectEntry.getExternalReferenceCode()
+				).put(
+					"scopeId",
+					(Long)_getObjectEntryGroupId(group.getGroupId(), scope)
+				).put(
+					"scopeKey",
+					() -> {
+						if (Objects.equals(
+								ObjectDefinitionConstants.SCOPE_COMPANY,
+								scope)) {
+
+							return null;
+						}
+
+						return group.getGroupKey();
+					}
+				)),
+			exception -> {
+				throw new RuntimeException(exception);
+			});
 	}
 
 	private ExportImportConfiguration _importLayouts(
@@ -1507,22 +1503,29 @@ public class BatchEnginePortletDataHandlerTest {
 			false, group.getGroupId(), false, new long[0], objectDefinition1,
 			objectDefinition2);
 
+		// Assert the related object entries are a simplified version
+
 		JSONAssert.assertEquals(
-			_getExpectedNestedRelationshipJSON(group, objectEntries1, scope),
-			_getNestedRelationshipJSON(
+			_getSimplifiedObjectEntriesJSONArray(
+				group, objectEntries1, scope
+			).toString(),
+			_getNestedRelationshipJSONArray(
 				objectDefinition2.getName(), larFile, group.getGroupId(),
-				objectRelationship.getName()),
+				objectRelationship.getName()
+			).toString(),
 			JSONCompareMode.STRICT);
 
 		if (Objects.equals(
 				ObjectRelationshipConstants.TYPE_MANY_TO_MANY, type)) {
 
 			JSONAssert.assertEquals(
-				_getExpectedNestedRelationshipJSON(
-					group, objectEntries2, scope),
-				_getNestedRelationshipJSON(
+				_getSimplifiedObjectEntriesJSONArray(
+					group, objectEntries2, scope
+				).toString(),
+				_getNestedRelationshipJSONArray(
 					objectDefinition1.getName(), larFile, group.getGroupId(),
-					objectRelationship.getName()),
+					objectRelationship.getName()
+				).toString(),
 				JSONCompareMode.STRICT);
 		}
 

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -1148,6 +1148,19 @@ public class BatchEnginePortletDataHandlerTest {
 		}
 	}
 
+	private JSONArray _getExportedObjectEntriesJSONArray(
+			String className, File file, long groupId)
+		throws Exception {
+
+		try (ZipFile zipFile = new ZipFile(file)) {
+			ZipEntry zipEntry = zipFile.getEntry(
+				_getBatchFileNameWithPath(className + ".json", groupId));
+
+			return JSONFactoryUtil.createJSONArray(
+				StringUtil.read(zipFile.getInputStream(zipEntry)));
+		}
+	}
+
 	private Map<String, String[]> _getExportImportParameterMap(
 		boolean deletions, boolean includeLayoutSetLayoutsPortlet,
 		List<ObjectDefinition> objectDefinitions) {
@@ -1261,44 +1274,6 @@ public class BatchEnginePortletDataHandlerTest {
 		return portletDataContext.getManifestSummary();
 	}
 
-	private JSONArray _getNestedRelationshipJSONArray(
-			String className, File file, long groupId, String relationshipName)
-		throws Exception {
-
-		try (ZipFile zipFile = new ZipFile(file)) {
-			ZipEntry zipEntry = zipFile.getEntry(
-				_getBatchFileNameWithPath(className + ".json", groupId));
-
-			if (zipEntry == null) {
-				throw new FileNotFoundException();
-			}
-
-			JSONArray nestedRelationshipsJSONArray =
-				JSONFactoryUtil.createJSONArray();
-
-			JSONArray objectEntriesJSONArray = JSONFactoryUtil.createJSONArray(
-				StringUtil.read(zipFile.getInputStream(zipEntry)));
-
-			for (int i = 0; i < objectEntriesJSONArray.length(); i++) {
-				JSONObject objectEntryJSONObject =
-					objectEntriesJSONArray.getJSONObject(i);
-
-				Object nestedObject = objectEntryJSONObject.get(
-					relationshipName);
-
-				if (nestedObject instanceof JSONObject) {
-					nestedRelationshipsJSONArray.put(
-						JSONUtil.put(nestedObject));
-				}
-				else {
-					nestedRelationshipsJSONArray.put(nestedObject);
-				}
-			}
-
-			return nestedRelationshipsJSONArray;
-		}
-	}
-
 	private long _getObjectEntryGroupId(long groupId, String scope) {
 		if (Objects.equals(ObjectDefinitionConstants.SCOPE_COMPANY, scope)) {
 			return GroupConstants.DEFAULT_PARENT_GROUP_ID;
@@ -1307,34 +1282,12 @@ public class BatchEnginePortletDataHandlerTest {
 		return groupId;
 	}
 
-	private JSONArray _getSimplifiedObjectEntriesJSONArray(
-		Group group, ObjectEntry[] objectEntries, String scope) {
+	private String _getObjectEntryScopeKey(Group group, String scope) {
+		if (Objects.equals(ObjectDefinitionConstants.SCOPE_COMPANY, scope)) {
+			return null;
+		}
 
-		return JSONUtil.toJSONArray(
-			objectEntries,
-			objectEntry -> JSONUtil.put(
-				JSONUtil.put(
-					"externalReferenceCode",
-					objectEntry.getExternalReferenceCode()
-				).put(
-					"scopeId",
-					(Long)_getObjectEntryGroupId(group.getGroupId(), scope)
-				).put(
-					"scopeKey",
-					() -> {
-						if (Objects.equals(
-								ObjectDefinitionConstants.SCOPE_COMPANY,
-								scope)) {
-
-							return null;
-						}
-
-						return group.getGroupKey();
-					}
-				)),
-			exception -> {
-				throw new RuntimeException(exception);
-			});
+		return group.getGroupKey();
 	}
 
 	private ExportImportConfiguration _importLayouts(
@@ -1503,30 +1456,85 @@ public class BatchEnginePortletDataHandlerTest {
 			false, group.getGroupId(), false, new long[0], objectDefinition1,
 			objectDefinition2);
 
-		// Assert the related object entries are a simplified version
-
-		JSONAssert.assertEquals(
-			_getSimplifiedObjectEntriesJSONArray(
-				group, objectEntries1, scope
-			).toString(),
-			_getNestedRelationshipJSONArray(
-				objectDefinition2.getName(), larFile, group.getGroupId(),
-				objectRelationship.getName()
-			).toString(),
-			JSONCompareMode.STRICT);
+		JSONArray exportedObjectEntriesJSONArray =
+			_getExportedObjectEntriesJSONArray(
+				objectDefinition2.getName(), larFile, group.getGroupId());
 
 		if (Objects.equals(
 				ObjectRelationshipConstants.TYPE_MANY_TO_MANY, type)) {
 
-			JSONAssert.assertEquals(
-				_getSimplifiedObjectEntriesJSONArray(
-					group, objectEntries2, scope
-				).toString(),
-				_getNestedRelationshipJSONArray(
-					objectDefinition1.getName(), larFile, group.getGroupId(),
-					objectRelationship.getName()
-				).toString(),
-				JSONCompareMode.STRICT);
+			for (int i = 0; i < objectEntries1.length; i++) {
+				ObjectEntry objectEntry = objectEntries1[i];
+
+				JSONAssert.assertEquals(
+					JSONUtil.put(
+						JSONUtil.put(
+							"externalReferenceCode",
+							objectEntry.getExternalReferenceCode()
+						).put(
+							"scopeId",
+							(Long)_getObjectEntryGroupId(
+								group.getGroupId(), scope)
+						).put(
+							"scopeKey", _getObjectEntryScopeKey(group, scope)
+						)
+					).toString(),
+					exportedObjectEntriesJSONArray.getJSONObject(
+						i
+					).getJSONArray(
+						objectRelationship.getName()
+					).toString(),
+					JSONCompareMode.STRICT);
+			}
+
+			exportedObjectEntriesJSONArray = _getExportedObjectEntriesJSONArray(
+				objectDefinition1.getName(), larFile, group.getGroupId());
+
+			for (int i = 0; i < objectEntries2.length; i++) {
+				ObjectEntry objectEntry = objectEntries2[i];
+
+				JSONAssert.assertEquals(
+					JSONUtil.put(
+						JSONUtil.put(
+							"externalReferenceCode",
+							objectEntry.getExternalReferenceCode()
+						).put(
+							"scopeId",
+							(Long)_getObjectEntryGroupId(
+								group.getGroupId(), scope)
+						).put(
+							"scopeKey", _getObjectEntryScopeKey(group, scope)
+						)
+					).toString(),
+					exportedObjectEntriesJSONArray.getJSONObject(
+						i
+					).getJSONArray(
+						objectRelationship.getName()
+					).toString(),
+					JSONCompareMode.STRICT);
+			}
+		}
+		else {
+			for (int i = 0; i < objectEntries1.length; i++) {
+				ObjectEntry objectEntry = objectEntries1[i];
+
+				JSONAssert.assertEquals(
+					JSONUtil.put(
+						"externalReferenceCode",
+						objectEntry.getExternalReferenceCode()
+					).put(
+						"scopeId",
+						(Long)_getObjectEntryGroupId(group.getGroupId(), scope)
+					).put(
+						"scopeKey", _getObjectEntryScopeKey(group, scope)
+					).toString(),
+					exportedObjectEntriesJSONArray.getJSONObject(
+						i
+					).getJSONObject(
+						objectRelationship.getName()
+					).toString(),
+					JSONCompareMode.STRICT);
+			}
 		}
 
 		_deleteObjectEntries(objectEntries1);

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -12,8 +12,11 @@ import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
+import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationParameterMapFactoryUtil;
 import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationSettingsMapFactoryUtil;
 import com.liferay.exportimport.kernel.configuration.constants.ExportImportConfigurationConstants;
+import com.liferay.exportimport.kernel.lar.ExportImportHelperUtil;
+import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
 import com.liferay.exportimport.kernel.lar.ManifestSummary;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.PortletDataContextFactoryUtil;
@@ -88,12 +91,14 @@ import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.SAXReader;
+import com.liferay.portal.kernel.zip.ZipReaderFactory;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -130,6 +135,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -360,6 +366,98 @@ public class BatchEnginePortletDataHandlerTest {
 			ObjectDefinitionConstants.SCOPE_COMPANY);
 		_testExportImportObjectEntriesWithErrorReport(
 			GroupTestUtil.addGroup(), ObjectDefinitionConstants.SCOPE_SITE);
+	}
+
+	@Test
+	@TestInfo("LPD-LPD-63419")
+	public void testExportImportObjectEntriesWithManyToManyRelationship()
+		throws Exception {
+
+		Group group = GroupTestUtil.addGroup();
+
+		ObjectDefinition objectDefinition1 = _addObjectDefinition(
+			ObjectDefinitionConstants.SCOPE_SITE);
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			_getObjectEntryGroupId(
+				group.getGroupId(), ObjectDefinitionConstants.SCOPE_SITE),
+			objectDefinition1, RandomTestUtil.randomString());
+
+		ObjectDefinition objectDefinition2 = _addObjectDefinition(
+			ObjectDefinitionConstants.SCOPE_SITE);
+
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			_getObjectEntryGroupId(
+				group.getGroupId(), ObjectDefinitionConstants.SCOPE_SITE),
+			objectDefinition2, RandomTestUtil.randomString());
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, objectDefinition1,
+				objectDefinition2,
+				ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+				StringUtil.randomId(),
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		ObjectRelationshipTestUtil.relateObjectEntries(
+			objectEntry1.getPrimaryKey(), objectEntry2.getPrimaryKey(),
+			objectRelationship, TestPropsValues.getUserId());
+
+		File larFile = _exportLayouts(
+			false, group.getGroupId(), false, new long[0], objectDefinition1,
+			objectDefinition2);
+
+		Map<String, String[]> parameterMap =
+			ExportImportConfigurationParameterMapFactoryUtil.
+				buildParameterMap();
+
+		String userIdStrategyString = MapUtil.getString(
+			parameterMap, PortletDataHandlerKeys.USER_ID_STRATEGY);
+
+		PortletDataContext portletDataContext =
+			PortletDataContextFactoryUtil.createImportPortletDataContext(
+				group.getCompanyId(), group.getGroupId(), parameterMap,
+				ExportImportHelperUtil.getUserIdStrategy(
+					TestPropsValues.getUserId(), userIdStrategyString),
+				_zipReaderFactory.getZipReader(larFile));
+
+		String objectDefinition1Path = StringPool.FORWARD_SLASH.concat(
+			objectDefinition1.getName(
+			).concat(
+				".json"
+			));
+
+		String objectEntry1Path = ExportImportPathUtil.getRootPath(
+			portletDataContext
+		).concat(
+			objectDefinition1Path
+		);
+
+		String objectDefinition2Path = StringPool.FORWARD_SLASH.concat(
+			objectDefinition2.getName(
+			).concat(
+				".json"
+			));
+
+		String objectEntry2Path = ExportImportPathUtil.getRootPath(
+			portletDataContext
+		).concat(
+			objectDefinition2Path
+		);
+
+		JSONArray objectEntry1jsonArray = JSONFactoryUtil.createJSONArray(
+			portletDataContext.getZipEntryAsString(objectEntry1Path));
+
+		_assertJSONIncludesOnlyScopeAndERCForRelationships(
+			group, objectRelationship.getName(),
+			objectEntry2.getExternalReferenceCode(), objectEntry1jsonArray);
+
+		JSONArray objectEntry2jsonArray = JSONFactoryUtil.createJSONArray(
+			portletDataContext.getZipEntryAsString(objectEntry2Path));
+
+		_assertJSONIncludesOnlyScopeAndERCForRelationships(
+			group, objectRelationship.getName(),
+			objectEntry1.getExternalReferenceCode(), objectEntry2jsonArray);
 	}
 
 	@Ignore("LPD-40798")
@@ -1010,6 +1108,36 @@ public class BatchEnginePortletDataHandlerTest {
 			ContentTypes.TEXT_PLAIN);
 	}
 
+	private void _assertJSONIncludesOnlyScopeAndERCForRelationships(
+		Group group, String relFieldName, String externalReferenceCode,
+		JSONArray jsonArray) {
+
+		for (Object entryObject : jsonArray) {
+			JSONObject entryJSONObject = (JSONObject)entryObject;
+
+			JSONArray relJSONArray = entryJSONObject.getJSONArray(relFieldName);
+
+			JSONObject relItemJSONObject = relJSONArray.getJSONObject(0);
+
+			Set<String> keys = relItemJSONObject.keySet();
+
+			Assert.assertEquals(
+				SetUtil.fromArray(
+					"scopeId", "scopeKey", "externalReferenceCode"),
+				keys);
+
+			Assert.assertEquals(
+				group.getGroupId(), relItemJSONObject.getLong("scopeId"));
+
+			Assert.assertEquals(
+				group.getGroupKey(), relItemJSONObject.getString("scopeKey"));
+
+			Assert.assertEquals(
+				externalReferenceCode,
+				relItemJSONObject.getString("externalReferenceCode"));
+		}
+	}
+
 	private void _assertNull(
 		long objectDefinitionId, ObjectEntry... objectEntries) {
 
@@ -1629,6 +1757,9 @@ public class BatchEnginePortletDataHandlerTest {
 
 	@Inject
 	private StagingLocalService _stagingLocalService;
+
+	@Inject
+	private ZipReaderFactory _zipReaderFactory;
 
 	private static class TestExportImportVulcanBatchEngineTaskItemDelegate
 		implements EntityModelResource,

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -1290,6 +1290,18 @@ public class BatchEnginePortletDataHandlerTest {
 		return group.getGroupKey();
 	}
 
+	private JSONObject _getSimplifiedObjectEntryJSONObject(
+		Group group, String scope, ObjectEntry objectEntry) {
+
+		return JSONUtil.put(
+			"externalReferenceCode", objectEntry.getExternalReferenceCode()
+		).put(
+			"scopeId", (Long)_getObjectEntryGroupId(group.getGroupId(), scope)
+		).put(
+			"scopeKey", _getObjectEntryScopeKey(group, scope)
+		);
+	}
+
 	private ExportImportConfiguration _importLayouts(
 			boolean deletions, boolean expectError, File file, long groupId,
 			boolean includeLayoutSetLayoutsPortlet, boolean privateLayout,
@@ -1468,16 +1480,8 @@ public class BatchEnginePortletDataHandlerTest {
 
 				JSONAssert.assertEquals(
 					JSONUtil.put(
-						JSONUtil.put(
-							"externalReferenceCode",
-							objectEntry.getExternalReferenceCode()
-						).put(
-							"scopeId",
-							(Long)_getObjectEntryGroupId(
-								group.getGroupId(), scope)
-						).put(
-							"scopeKey", _getObjectEntryScopeKey(group, scope)
-						)
+						_getSimplifiedObjectEntryJSONObject(
+							group, scope, objectEntry)
 					).toString(),
 					exportedObjectEntriesJSONArray.getJSONObject(
 						i
@@ -1495,16 +1499,8 @@ public class BatchEnginePortletDataHandlerTest {
 
 				JSONAssert.assertEquals(
 					JSONUtil.put(
-						JSONUtil.put(
-							"externalReferenceCode",
-							objectEntry.getExternalReferenceCode()
-						).put(
-							"scopeId",
-							(Long)_getObjectEntryGroupId(
-								group.getGroupId(), scope)
-						).put(
-							"scopeKey", _getObjectEntryScopeKey(group, scope)
-						)
+						_getSimplifiedObjectEntryJSONObject(
+							group, scope, objectEntry)
 					).toString(),
 					exportedObjectEntriesJSONArray.getJSONObject(
 						i
@@ -1519,14 +1515,8 @@ public class BatchEnginePortletDataHandlerTest {
 				ObjectEntry objectEntry = objectEntries1[i];
 
 				JSONAssert.assertEquals(
-					JSONUtil.put(
-						"externalReferenceCode",
-						objectEntry.getExternalReferenceCode()
-					).put(
-						"scopeId",
-						(Long)_getObjectEntryGroupId(group.getGroupId(), scope)
-					).put(
-						"scopeKey", _getObjectEntryScopeKey(group, scope)
+					_getSimplifiedObjectEntryJSONObject(
+						group, scope, objectEntry
 					).toString(),
 					exportedObjectEntriesJSONArray.getJSONObject(
 						i

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -1432,19 +1432,16 @@ public class BatchEnginePortletDataHandlerTest {
 				TestPropsValues.getUserId());
 		}
 
-		// TODO: Export both portlets at once after LPD-62165 is fixed
-
-		File larFile1 = _exportLayouts(
-			false, group.getGroupId(), false, new long[0], objectDefinition1);
-		File larFile2 = _exportLayouts(
-			false, group.getGroupId(), false, new long[0], objectDefinition2);
+		File larFile = _exportLayouts(
+			false, group.getGroupId(), false, new long[0], objectDefinition1,
+			objectDefinition2);
 
 		_deleteObjectEntries(objectEntries1);
 		_deleteObjectEntries(objectEntries2);
 
 		if (childFirst) {
 			_importLayouts(
-				false, false, larFile2, group.getGroupId(), objectDefinition2);
+				false, false, larFile, group.getGroupId(), objectDefinition2);
 
 			_assertObjectEntries(
 				true, objectDefinition1.getObjectDefinitionId(),
@@ -1454,7 +1451,7 @@ public class BatchEnginePortletDataHandlerTest {
 				objectEntries2);
 
 			_importLayouts(
-				false, false, larFile1, group.getGroupId(), objectDefinition1);
+				false, false, larFile, group.getGroupId(), objectDefinition1);
 
 			_assertObjectEntries(
 				false, objectDefinition1.getObjectDefinitionId(),
@@ -1462,7 +1459,7 @@ public class BatchEnginePortletDataHandlerTest {
 		}
 		else {
 			_importLayouts(
-				false, false, larFile1, group.getGroupId(), objectDefinition1);
+				false, false, larFile, group.getGroupId(), objectDefinition1);
 
 			_assertObjectEntries(
 				false, objectDefinition1.getObjectDefinitionId(),
@@ -1497,7 +1494,7 @@ public class BatchEnginePortletDataHandlerTest {
 			}
 
 			_importLayouts(
-				false, false, larFile2, group.getGroupId(), objectDefinition2);
+				false, false, larFile, group.getGroupId(), objectDefinition2);
 
 			_assertObjectEntries(
 				false, objectDefinition2.getObjectDefinitionId(),

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -806,19 +806,6 @@ public class BatchEnginePortletDataHandlerTest {
 
 	}
 
-	protected LogCapture getLogCapture(boolean expectError) {
-		LogCapture logCapture = null;
-
-		if (expectError) {
-			logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.exportimport.internal.lifecycle." +
-					"LoggerExportImportLifecycleListener",
-				LoggerTestUtil.ERROR);
-		}
-
-		return logCapture;
-	}
-
 	private DLFileEntry _addDLFileEntry(String content, long groupId)
 		throws Exception {
 
@@ -1249,6 +1236,19 @@ public class BatchEnginePortletDataHandlerTest {
 		}
 	}
 
+	private LogCapture _getLogCapture(boolean expectError) {
+		LogCapture logCapture = null;
+
+		if (expectError) {
+			logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.batch.engine.internal.strategy." +
+					"OnErrorContinueBatchEngineImportStrategy",
+				LoggerTestUtil.ERROR);
+		}
+
+		return logCapture;
+	}
+
 	private ManifestSummary _getManifestSummary(
 			PortletDataContext portletDataContext,
 			PortletDataHandler portletDataHandler)
@@ -1343,7 +1343,7 @@ public class BatchEnginePortletDataHandlerTest {
 			ObjectDefinition... objectDefinitions)
 		throws Exception {
 
-		try (LogCapture logCapture = getLogCapture(expectError)) {
+		try (LogCapture logCapture = _getLogCapture(expectError)) {
 			ExportImportConfiguration exportImportConfiguration =
 				_exportImportConfigurationLocalService.
 					addDraftExportImportConfiguration(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -258,6 +258,12 @@ public class ObjectEntryDTOConverter
 			contentObjectEntry, objectDefinition, objectEntryVersion,
 			serviceBuilderObjectEntry);
 
+		if (GetterUtil.getBoolean(
+				dtoConverterContext.getAttribute("simplifiedObjectEntry"))) {
+
+			return objectEntry;
+		}
+
 		TrashEntry trashEntry = null;
 
 		if (serviceBuilderObjectEntry.getStatus() ==
@@ -586,21 +592,13 @@ public class ObjectEntryDTOConverter
 										primaryKey);
 						}
 
-						if (ExportImportThreadLocal.isExportInProcess()) {
-							relatedObjectEntryAtomicReference.set(
-								_toSimplifiedDTO(
-									null, objectDefinition, null,
-									serviceBuilderObjectEntry));
-						}
-						else {
-							relatedObjectEntryAtomicReference.set(
-								toDTO(
-									_getDTOConverterContext(
-										dtoConverterContext,
-										serviceBuilderObjectEntry.
-											getObjectEntryId()),
-									serviceBuilderObjectEntry));
-						}
+						relatedObjectEntryAtomicReference.set(
+							toDTO(
+								_getDTOConverterContext(
+									dtoConverterContext,
+									serviceBuilderObjectEntry.
+										getObjectEntryId()),
+								serviceBuilderObjectEntry));
 					}
 
 					return relatedObjectEntryAtomicReference.get();
@@ -727,6 +725,11 @@ public class ObjectEntryDTOConverter
 			"preferApproved",
 			GetterUtil.getBoolean(
 				dtoConverterContext.getAttribute("preferApproved")));
+
+		if (ExportImportThreadLocal.isExportInProcess()) {
+			defaultDTOConverterContext.setAttribute(
+				"simplifiedObjectEntry", Boolean.TRUE);
+		}
 
 		return defaultDTOConverterContext;
 	}
@@ -1021,20 +1024,11 @@ public class ObjectEntryDTOConverter
 						Object.class);
 				}
 
-				boolean exportInProcess =
-					ExportImportThreadLocal.isExportInProcess();
-
 				return () -> TransformUtil.transformToArray(
 					relatedModels,
 					relatedModel -> {
 						com.liferay.object.model.ObjectEntry objectEntry =
 							(com.liferay.object.model.ObjectEntry)relatedModel;
-
-						if (exportInProcess) {
-							return _toSimplifiedDTO(
-								null, relatedObjectDefinition, null,
-								objectEntry);
-						}
 
 						return toDTO(
 							_getDTOConverterContext(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -715,12 +715,20 @@ public class ObjectEntryDTOConverter
 
 		UriInfo uriInfo = dtoConverterContext.getUriInfo();
 
-		return new DefaultDTOConverterContext(
-			dtoConverterContext.isAcceptAllLanguages(), null,
-			dtoConverterContext.getDTOConverterRegistry(),
-			dtoConverterContext.getHttpServletRequest(), objectEntryId,
-			dtoConverterContext.getLocale(), uriInfo,
-			dtoConverterContext.getUser());
+		DTOConverterContext defaultDTOConverterContext =
+			new DefaultDTOConverterContext(
+				dtoConverterContext.isAcceptAllLanguages(), null,
+				dtoConverterContext.getDTOConverterRegistry(),
+				dtoConverterContext.getHttpServletRequest(), objectEntryId,
+				dtoConverterContext.getLocale(), uriInfo,
+				dtoConverterContext.getUser());
+
+		defaultDTOConverterContext.setAttribute(
+			"preferApproved",
+			GetterUtil.getBoolean(
+				dtoConverterContext.getAttribute("preferApproved")));
+
+		return defaultDTOConverterContext;
 	}
 
 	private FileEntry _getFileEntry(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -254,6 +254,10 @@ public class ObjectEntryDTOConverter
 		ObjectEntry contentObjectEntry = (objectEntryVersion == null) ? null :
 			ObjectEntry.unsafeToDTO(objectEntryVersion.getContent());
 
+		ObjectEntry objectEntry = _toSimplifiedDTO(
+			contentObjectEntry, objectDefinition, objectEntryVersion,
+			serviceBuilderObjectEntry);
+
 		TrashEntry trashEntry = null;
 
 		if (serviceBuilderObjectEntry.getStatus() ==
@@ -266,211 +270,174 @@ public class ObjectEntryDTOConverter
 
 		TrashEntry finalTrashEntry = trashEntry;
 
-		return new ObjectEntry() {
-			{
-				setActions(dtoConverterContext::getActions);
-				setAuditEvents(
-					() -> _toAuditEvents(
+		objectEntry.setActions(dtoConverterContext::getActions);
+		objectEntry.setAuditEvents(
+			() -> _toAuditEvents(
+				dtoConverterContext, objectDefinition,
+				serviceBuilderObjectEntry));
+		objectEntry.setCreator(
+			() -> {
+				long userId = _getAttribute(
+					objectEntryVersion, ObjectEntryVersionModel::getUserId,
+					serviceBuilderObjectEntry, ObjectEntryModel::getUserId);
+
+				return CreatorUtil.toCreator(
+					_portal, dtoConverterContext.getUriInfo(),
+					_userLocalService.fetchUser(userId));
+			});
+		objectEntry.setDateCreated(
+			() -> _getAttribute(
+				objectEntryVersion, ObjectEntryVersionModel::getCreateDate,
+				serviceBuilderObjectEntry, ObjectEntryModel::getCreateDate));
+		objectEntry.setDateModified(
+			() -> _getAttribute(
+				objectEntryVersion, ObjectEntryVersionModel::getModifiedDate,
+				serviceBuilderObjectEntry, ObjectEntryModel::getModifiedDate));
+		objectEntry.setDefaultLanguageId(
+			() -> {
+				if (FeatureFlagManagerUtil.isEnabled(
+						objectDefinition.getCompanyId(), "LPD-32050")) {
+
+					return serviceBuilderObjectEntry.getDefaultLanguageId();
+				}
+
+				return null;
+			});
+		objectEntry.setDisplayDate(
+			() -> _getAttribute(
+				objectEntryVersion, ObjectEntryVersionModel::getDisplayDate,
+				serviceBuilderObjectEntry, ObjectEntryModel::getDisplayDate));
+		objectEntry.setExpirationDate(
+			() -> _getAttribute(
+				objectEntryVersion, ObjectEntryVersionModel::getExpirationDate,
+				serviceBuilderObjectEntry,
+				ObjectEntryModel::getExpirationDate));
+		objectEntry.setFriendlyUrlPath(
+			() -> serviceBuilderObjectEntry.getURLTitle(
+				dtoConverterContext.getLocale()));
+		objectEntry.setFriendlyUrlPath_i18n(
+			serviceBuilderObjectEntry::getURLTitleMap);
+		objectEntry.setId(serviceBuilderObjectEntry::getObjectEntryId);
+		objectEntry.setKeywords(
+			() -> {
+				if (objectEntryVersion != null) {
+					return contentObjectEntry.getKeywords();
+				}
+				else if (!objectDefinition.isEnableCategorization()) {
+					return null;
+				}
+
+				return ListUtil.toArray(
+					_assetTagLocalService.getTags(
+						objectDefinition.getClassName(),
+						serviceBuilderObjectEntry.getObjectEntryId()),
+					AssetTag.NAME_ACCESSOR);
+			});
+		objectEntry.setObjectEntryFolderExternalReferenceCode(
+			() -> {
+				ObjectEntryFolder objectEntryFolder =
+					_objectEntryFolderLocalService.fetchObjectEntryFolder(
+						serviceBuilderObjectEntry.getObjectEntryFolderId());
+
+				if (objectEntryFolder != null) {
+					return objectEntryFolder.getExternalReferenceCode();
+				}
+
+				return StringPool.BLANK;
+			});
+		objectEntry.setObjectEntryFolderId(
+			serviceBuilderObjectEntry::getObjectEntryFolderId);
+		objectEntry.setPermissions(
+			() -> _toPermissions(objectDefinition, serviceBuilderObjectEntry));
+		objectEntry.setProperties(
+			() -> {
+				if (objectEntryVersion == null) {
+					return _toProperties(
 						dtoConverterContext, objectDefinition,
-						serviceBuilderObjectEntry));
-				setCreator(
-					() -> _getAttribute(
-						objectEntryVersion,
-						objectEntryVersion -> CreatorUtil.toCreator(
-							_portal, dtoConverterContext.getUriInfo(),
-							_userLocalService.fetchUser(
-								objectEntryVersion.getUserId())),
-						serviceBuilderObjectEntry,
-						serviceBuilderObjectEntry -> CreatorUtil.toCreator(
-							_portal, dtoConverterContext.getUriInfo(),
-							_userLocalService.fetchUser(
-								serviceBuilderObjectEntry.getUserId()))));
-				setDateCreated(
-					() -> _getAttribute(
-						objectEntryVersion,
-						ObjectEntryVersionModel::getCreateDate,
-						serviceBuilderObjectEntry,
-						ObjectEntryModel::getCreateDate));
-				setDateModified(
-					() -> _getAttribute(
-						objectEntryVersion,
-						ObjectEntryVersionModel::getModifiedDate,
-						serviceBuilderObjectEntry,
-						ObjectEntryModel::getModifiedDate));
-				setDefaultLanguageId(
-					() -> {
-						if (FeatureFlagManagerUtil.isEnabled(
-								objectDefinition.getCompanyId(), "LPD-32050")) {
+						serviceBuilderObjectEntry);
+				}
 
-							return serviceBuilderObjectEntry.
-								getDefaultLanguageId();
-						}
+				Map<String, Object> properties =
+					contentObjectEntry.getProperties();
 
-						return null;
-					});
-				setDisplayDate(
-					() -> _getAttribute(
-						objectEntryVersion,
-						ObjectEntryVersionModel::getDisplayDate,
-						serviceBuilderObjectEntry,
-						ObjectEntryModel::getDisplayDate));
-				setExpirationDate(
-					() -> _getAttribute(
-						objectEntryVersion,
-						ObjectEntryVersionModel::getExpirationDate,
-						serviceBuilderObjectEntry,
-						ObjectEntryModel::getExpirationDate));
-				setExternalReferenceCode(
-					() -> {
-						if (objectEntryVersion != null) {
-							return contentObjectEntry.
-								getExternalReferenceCode();
-						}
+				com.liferay.object.model.ObjectEntry
+					clonedServiceBuilderObjectEntry =
+						(com.liferay.object.model.ObjectEntry)
+							serviceBuilderObjectEntry.clone();
 
-						return serviceBuilderObjectEntry.
-							getExternalReferenceCode();
-					});
-				setFriendlyUrlPath(
-					() -> serviceBuilderObjectEntry.getURLTitle(
-						dtoConverterContext.getLocale()));
-				setFriendlyUrlPath_i18n(
-					serviceBuilderObjectEntry::getURLTitleMap);
-				setId(serviceBuilderObjectEntry::getObjectEntryId);
-				setKeywords(
-					() -> {
-						if (objectEntryVersion != null) {
-							return contentObjectEntry.getKeywords();
-						}
-						else if (!objectDefinition.isEnableCategorization()) {
-							return null;
-						}
+				clonedServiceBuilderObjectEntry.setValues(
+					(Map<String, Serializable>)properties.get("properties"));
 
-						return ListUtil.toArray(
-							_assetTagLocalService.getTags(
-								objectDefinition.getClassName(),
-								serviceBuilderObjectEntry.getObjectEntryId()),
-							AssetTag.NAME_ACCESSOR);
-					});
-				setObjectEntryFolderExternalReferenceCode(
-					() -> {
-						ObjectEntryFolder objectEntryFolder =
-							_objectEntryFolderLocalService.
-								fetchObjectEntryFolder(
-									serviceBuilderObjectEntry.
-										getObjectEntryFolderId());
+				return _toProperties(
+					dtoConverterContext,
+					_objectDefinitionLocalService.getObjectDefinition(
+						clonedServiceBuilderObjectEntry.
+							getObjectDefinitionId()),
+					clonedServiceBuilderObjectEntry);
+			});
+		objectEntry.setRemovedBy(
+			() -> {
+				if (finalTrashEntry != null) {
+					return CreatorUtil.toCreator(
+						_portal, dtoConverterContext.getUriInfo(),
+						_userLocalService.fetchUser(
+							finalTrashEntry.getUserId()));
+				}
 
-						if (objectEntryFolder != null) {
-							return objectEntryFolder.getExternalReferenceCode();
-						}
+				return null;
+			});
+		objectEntry.setRemovedDate(
+			() -> {
+				if (finalTrashEntry != null) {
+					return finalTrashEntry.getCreateDate();
+				}
 
-						return StringPool.BLANK;
-					});
-				setObjectEntryFolderId(
-					serviceBuilderObjectEntry::getObjectEntryFolderId);
-				setPermissions(
-					() -> _toPermissions(
-						objectDefinition, serviceBuilderObjectEntry));
-				setProperties(
-					() -> {
-						if (objectEntryVersion == null) {
-							return _toProperties(
-								dtoConverterContext, objectDefinition,
-								serviceBuilderObjectEntry);
-						}
+				return null;
+			});
+		objectEntry.setReviewDate(
+			() -> _getAttribute(
+				objectEntryVersion, ObjectEntryVersionModel::getReviewDate,
+				serviceBuilderObjectEntry, ObjectEntryModel::getReviewDate));
+		objectEntry.setStatus(
+			() -> {
+				int status = _getAttribute(
+					objectEntryVersion, ObjectEntryVersionModel::getStatus,
+					serviceBuilderObjectEntry, ObjectEntryModel::getStatus);
 
-						Map<String, Object> properties =
-							contentObjectEntry.getProperties();
+				return _toStatus(dtoConverterContext.getLocale(), status);
+			});
+		objectEntry.setSystemProperties(
+			() -> {
+				if (objectEntryVersion != null) {
+					return _toSystemProperties(
+						dtoConverterContext.getLocale(), objectDefinition,
+						objectEntryVersion.getVersion());
+				}
 
-						com.liferay.object.model.ObjectEntry
-							clonedServiceBuilderObjectEntry =
-								(com.liferay.object.model.ObjectEntry)
-									serviceBuilderObjectEntry.clone();
+				return _toSystemProperties(
+					dtoConverterContext.getLocale(), objectDefinition,
+					serviceBuilderObjectEntry.getVersion());
+			});
+		objectEntry.setTaxonomyCategoryBriefs(
+			() -> {
+				if (objectEntryVersion != null) {
+					return contentObjectEntry.getTaxonomyCategoryBriefs();
+				}
+				else if (!objectDefinition.isEnableCategorization()) {
+					return null;
+				}
 
-						clonedServiceBuilderObjectEntry.setValues(
-							(Map<String, Serializable>)properties.get(
-								"properties"));
+				return TransformUtil.transformToArray(
+					_assetCategoryLocalService.getCategories(
+						objectDefinition.getClassName(),
+						serviceBuilderObjectEntry.getObjectEntryId()),
+					assetCategory ->
+						TaxonomyCategoryBriefUtil.toTaxonomyCategoryBrief(
+							assetCategory, dtoConverterContext),
+					TaxonomyCategoryBrief.class);
+			});
 
-						return _toProperties(
-							dtoConverterContext,
-							_objectDefinitionLocalService.getObjectDefinition(
-								clonedServiceBuilderObjectEntry.
-									getObjectDefinitionId()),
-							clonedServiceBuilderObjectEntry);
-					});
-				setRemovedBy(
-					() -> {
-						if (finalTrashEntry != null) {
-							return CreatorUtil.toCreator(
-								_portal, dtoConverterContext.getUriInfo(),
-								_userLocalService.fetchUser(
-									finalTrashEntry.getUserId()));
-						}
-
-						return null;
-					});
-				setRemovedDate(
-					() -> {
-						if (finalTrashEntry != null) {
-							return finalTrashEntry.getCreateDate();
-						}
-
-						return null;
-					});
-				setReviewDate(
-					() -> _getAttribute(
-						objectEntryVersion,
-						ObjectEntryVersionModel::getReviewDate,
-						serviceBuilderObjectEntry,
-						ObjectEntryModel::getReviewDate));
-				setScopeId(serviceBuilderObjectEntry::getGroupId);
-				setScopeKey(
-					() -> _getScopeKey(
-						objectDefinition, serviceBuilderObjectEntry));
-				setStatus(
-					() -> _getAttribute(
-						objectEntryVersion,
-						objectEntryVersion -> _toStatus(
-							dtoConverterContext.getLocale(),
-							objectEntryVersion.getStatus()),
-						serviceBuilderObjectEntry,
-						serviceBuilderObjectEntry -> _toStatus(
-							dtoConverterContext.getLocale(),
-							serviceBuilderObjectEntry.getStatus())));
-				setSystemProperties(
-					() -> {
-						if (objectEntryVersion != null) {
-							return _toSystemProperties(
-								dtoConverterContext.getLocale(),
-								objectDefinition,
-								objectEntryVersion.getVersion());
-						}
-
-						return _toSystemProperties(
-							dtoConverterContext.getLocale(), objectDefinition,
-							serviceBuilderObjectEntry.getVersion());
-					});
-				setTaxonomyCategoryBriefs(
-					() -> {
-						if (objectEntryVersion != null) {
-							return contentObjectEntry.
-								getTaxonomyCategoryBriefs();
-						}
-						else if (!objectDefinition.isEnableCategorization()) {
-							return null;
-						}
-
-						return TransformUtil.transformToArray(
-							_assetCategoryLocalService.getCategories(
-								objectDefinition.getClassName(),
-								serviceBuilderObjectEntry.getObjectEntryId()),
-							assetCategory ->
-								TaxonomyCategoryBriefUtil.
-									toTaxonomyCategoryBrief(
-										assetCategory, dtoConverterContext),
-							TaxonomyCategoryBrief.class);
-					});
-			}
-		};
+		return objectEntry;
 	}
 
 	private void _addManyToOneObjectRelationshipNames(
@@ -621,11 +588,8 @@ public class ObjectEntryDTOConverter
 
 						if (ExportImportThreadLocal.isExportInProcess()) {
 							relatedObjectEntryAtomicReference.set(
-								(Serializable)_toERCAndScope(
-									_objectDefinitionLocalService.
-										getObjectDefinition(
-											objectRelationship.
-												getObjectDefinitionId1()),
+								_toSimplifiedDTO(
+									null, objectDefinition, null,
 									serviceBuilderObjectEntry));
 						}
 						else {
@@ -1049,22 +1013,8 @@ public class ObjectEntryDTOConverter
 						Object.class);
 				}
 
-				if (!ExportImportThreadLocal.isExportInProcess()) {
-					return () -> TransformUtil.transformToArray(
-						relatedModels,
-						relatedModel -> {
-							com.liferay.object.model.ObjectEntry objectEntry =
-								(com.liferay.object.model.ObjectEntry)
-									relatedModel;
-
-							return toDTO(
-								_getDTOConverterContext(
-									dtoConverterContext,
-									objectEntry.getObjectEntryId()),
-								objectEntry);
-						},
-						ObjectEntry.class);
-				}
+				boolean exportInProcess =
+					ExportImportThreadLocal.isExportInProcess();
 
 				return () -> TransformUtil.transformToArray(
 					relatedModels,
@@ -1072,10 +1022,19 @@ public class ObjectEntryDTOConverter
 						com.liferay.object.model.ObjectEntry objectEntry =
 							(com.liferay.object.model.ObjectEntry)relatedModel;
 
-						return _toERCAndScope(
-							relatedObjectDefinition, objectEntry);
+						if (exportInProcess) {
+							return _toSimplifiedDTO(
+								null, relatedObjectDefinition, null,
+								objectEntry);
+						}
+
+						return toDTO(
+							_getDTOConverterContext(
+								dtoConverterContext,
+								objectEntry.getObjectEntryId()),
+							objectEntry);
 					},
-					Object.class);
+					ObjectEntry.class);
 			});
 	}
 
@@ -1358,21 +1317,6 @@ public class ObjectEntryDTOConverter
 			AuditFieldChange.class);
 	}
 
-	private Map<String, Object> _toERCAndScope(
-		ObjectDefinition relatedObjectDefinition,
-		com.liferay.object.model.ObjectEntry relatedObjectEntry) {
-
-		return HashMapBuilder.<String, Object>put(
-			"externalReferenceCode",
-			relatedObjectEntry.getExternalReferenceCode()
-		).put(
-			"scopeId", relatedObjectEntry.getGroupId()
-		).put(
-			"scopeKey",
-			_getScopeKey(relatedObjectDefinition, relatedObjectEntry)
-		).build();
-	}
-
 	private ExtendedEntity _toExtendedEntity(
 			BaseModel<?> baseModel, DTOConverterContext dtoConverterContext,
 			ObjectDefinition objectDefinition,
@@ -1569,6 +1513,31 @@ public class ObjectEntryDTOConverter
 		}
 
 		return (Map<String, Object>)(Map)unsafeSuppliers;
+	}
+
+	private ObjectEntry _toSimplifiedDTO(
+		ObjectEntry contentObjectEntry, ObjectDefinition objectDefinition,
+		ObjectEntryVersion objectEntryVersion,
+		com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry) {
+
+		return new ObjectEntry() {
+			{
+				setExternalReferenceCode(
+					() -> {
+						if (objectEntryVersion != null) {
+							return contentObjectEntry.
+								getExternalReferenceCode();
+						}
+
+						return serviceBuilderObjectEntry.
+							getExternalReferenceCode();
+					});
+				setScopeId(serviceBuilderObjectEntry::getGroupId);
+				setScopeKey(
+					() -> _getScopeKey(
+						objectDefinition, serviceBuilderObjectEntry));
+			}
+		};
 	}
 
 	private Status _toStatus(Locale locale, int status) {

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -1562,7 +1562,7 @@ public class ObjectEntryDTOConverter
 		Map<String, UnsafeSupplier<Object, Exception>>
 			nestedFieldsRelatedProperties = _getNestedFieldsRelatedProperties(
 				dtoConverterContext, objectEntry.getGroupId(), objectDefinition,
-				objectEntry.getObjectEntryId());
+				objectEntry.getHeadObjectEntryId());
 
 		if (nestedFieldsRelatedProperties != null) {
 			unsafeSuppliers.putAll(nestedFieldsRelatedProperties);

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -254,7 +254,7 @@ public class ObjectEntryDTOConverter
 		ObjectEntry contentObjectEntry = (objectEntryVersion == null) ? null :
 			ObjectEntry.unsafeToDTO(objectEntryVersion.getContent());
 
-		ObjectEntry objectEntry = _toSimplifiedDTO(
+		ObjectEntry objectEntry = _toSimplifiedObjectEntry(
 			contentObjectEntry, objectDefinition, objectEntryVersion,
 			serviceBuilderObjectEntry);
 
@@ -1517,7 +1517,7 @@ public class ObjectEntryDTOConverter
 		return (Map<String, Object>)(Map)unsafeSuppliers;
 	}
 
-	private ObjectEntry _toSimplifiedDTO(
+	private ObjectEntry _toSimplifiedObjectEntry(
 		ObjectEntry contentObjectEntry, ObjectDefinition objectDefinition,
 		ObjectEntryVersion objectEntryVersion,
 		com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry) {

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -16,6 +16,7 @@ import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.exportimport.attachment.ExportImportAttachmentManager;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.list.type.model.ListTypeEntry;
 import com.liferay.list.type.service.ListTypeEntryLocalService;
 import com.liferay.object.constants.ObjectActionKeys;
@@ -618,13 +619,24 @@ public class ObjectEntryDTOConverter
 										primaryKey);
 						}
 
-						relatedObjectEntryAtomicReference.set(
-							toDTO(
-								_getDTOConverterContext(
-									dtoConverterContext,
-									serviceBuilderObjectEntry.
-										getObjectEntryId()),
-								serviceBuilderObjectEntry));
+						if (ExportImportThreadLocal.isExportInProcess()) {
+							relatedObjectEntryAtomicReference.set(
+								(Serializable)_toERCAndScope(
+									_objectDefinitionLocalService.
+										getObjectDefinition(
+											objectRelationship.
+												getObjectDefinitionId1()),
+									serviceBuilderObjectEntry));
+						}
+						else {
+							relatedObjectEntryAtomicReference.set(
+								toDTO(
+									_getDTOConverterContext(
+										dtoConverterContext,
+										serviceBuilderObjectEntry.
+											getObjectEntryId()),
+									serviceBuilderObjectEntry));
+						}
 					}
 
 					return relatedObjectEntryAtomicReference.get();
@@ -739,20 +751,12 @@ public class ObjectEntryDTOConverter
 
 		UriInfo uriInfo = dtoConverterContext.getUriInfo();
 
-		DTOConverterContext defaultDTOConverterContext =
-			new DefaultDTOConverterContext(
-				dtoConverterContext.isAcceptAllLanguages(), null,
-				dtoConverterContext.getDTOConverterRegistry(),
-				dtoConverterContext.getHttpServletRequest(), objectEntryId,
-				dtoConverterContext.getLocale(), uriInfo,
-				dtoConverterContext.getUser());
-
-		defaultDTOConverterContext.setAttribute(
-			"preferApproved",
-			GetterUtil.getBoolean(
-				dtoConverterContext.getAttribute("preferApproved")));
-
-		return defaultDTOConverterContext;
+		return new DefaultDTOConverterContext(
+			dtoConverterContext.isAcceptAllLanguages(), null,
+			dtoConverterContext.getDTOConverterRegistry(),
+			dtoConverterContext.getHttpServletRequest(), objectEntryId,
+			dtoConverterContext.getLocale(), uriInfo,
+			dtoConverterContext.getUser());
 	}
 
 	private FileEntry _getFileEntry(
@@ -1045,19 +1049,33 @@ public class ObjectEntryDTOConverter
 						Object.class);
 				}
 
+				if (!ExportImportThreadLocal.isExportInProcess()) {
+					return () -> TransformUtil.transformToArray(
+						relatedModels,
+						relatedModel -> {
+							com.liferay.object.model.ObjectEntry objectEntry =
+								(com.liferay.object.model.ObjectEntry)
+									relatedModel;
+
+							return toDTO(
+								_getDTOConverterContext(
+									dtoConverterContext,
+									objectEntry.getObjectEntryId()),
+								objectEntry);
+						},
+						ObjectEntry.class);
+				}
+
 				return () -> TransformUtil.transformToArray(
 					relatedModels,
 					relatedModel -> {
 						com.liferay.object.model.ObjectEntry objectEntry =
 							(com.liferay.object.model.ObjectEntry)relatedModel;
 
-						return toDTO(
-							_getDTOConverterContext(
-								dtoConverterContext,
-								objectEntry.getObjectEntryId()),
-							objectEntry);
+						return _toERCAndScope(
+							relatedObjectDefinition, objectEntry);
 					},
-					ObjectEntry.class);
+					Object.class);
 			});
 	}
 
@@ -1340,6 +1358,21 @@ public class ObjectEntryDTOConverter
 			AuditFieldChange.class);
 	}
 
+	private Map<String, Object> _toERCAndScope(
+		ObjectDefinition relatedObjectDefinition,
+		com.liferay.object.model.ObjectEntry relatedObjectEntry) {
+
+		return HashMapBuilder.<String, Object>put(
+			"externalReferenceCode",
+			relatedObjectEntry.getExternalReferenceCode()
+		).put(
+			"scopeId", relatedObjectEntry.getGroupId()
+		).put(
+			"scopeKey",
+			_getScopeKey(relatedObjectDefinition, relatedObjectEntry)
+		).build();
+	}
+
 	private ExtendedEntity _toExtendedEntity(
 			BaseModel<?> baseModel, DTOConverterContext dtoConverterContext,
 			ObjectDefinition objectDefinition,
@@ -1529,7 +1562,7 @@ public class ObjectEntryDTOConverter
 		Map<String, UnsafeSupplier<Object, Exception>>
 			nestedFieldsRelatedProperties = _getNestedFieldsRelatedProperties(
 				dtoConverterContext, objectEntry.getGroupId(), objectDefinition,
-				objectEntry.getHeadObjectEntryId());
+				objectEntry.getObjectEntryId());
 
 		if (nestedFieldsRelatedProperties != null) {
 			unsafeSuppliers.putAll(nestedFieldsRelatedProperties);


### PR DESCRIPTION
- **LPD-62165 No longer needed, already fixed**
- **LPD-64413 return only ERC, scopeId and scopeKey when export is in process**
- **LPD-64413 add IntegrationTest**
- **LPD-64413 Follow existing pattern and integrate with existing test to test both scopes**
- **LPD-64413 undo**
- **LPD-64413 Create a method to generate a simplified DTO just with the minimum data. Then, use it from the toDTO method and also from the places where we just need to create a simplified DTO (in order to export related elements)**
- **LPD-64413 Revert this, we should leave it as it was**
- **LPD-64413 Use existing Util method and rename to match a more accurate pattern**
- **LPD-64413 Update LogCapture, we need to use a different one now, the old one does not apply anymore. And transform to a private method, we don't need it protected**
- **LPD-64413 Simplify by using a parameter in the Context, it will be filled only if the export is in progress. This will happen only for the related elements**
- **LPD-63419 SF**
- **LPD-63419 Less magic, more explicit**
- **LPD-63419 Relating implementation with test**
