### PR TITLE
LPD-68225 Improve CK Editor appearance inside CMS - sort

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-cms/src/css/_custom.scss
+++ b/modules/apps/frontend-theme/frontend-theme-cms/src/css/_custom.scss
@@ -1,4 +1,5 @@
 @import 'components/breadcrumb';
+@import 'components/ckeditor';
 @import 'components/control_menu';
 @import 'components/dropdown_menu';
 @import 'components/links';

--- a/modules/apps/frontend-theme/frontend-theme-cms/src/css/components/_ckeditor.scss
+++ b/modules/apps/frontend-theme/frontend-theme-cms/src/css/components/_ckeditor.scss
@@ -1,0 +1,27 @@
+.lfr-ck .ck.ck-editor.ck-rounded-corners {
+	> .ck.ck-editor__top {
+		> .ck.ck-sticky-panel {
+			> .ck.ck-sticky-panel__content {
+				border-color: #e7e7ed;
+				border-radius: 0.5rem;
+				border-bottom-left-radius: 0 !important;
+				border-bottom-right-radius: 0 !important;
+			}
+		}
+	}
+
+	.ck.ck-toolbar {
+		border-color: #e7e7ed;
+		border-radius: 0.5rem;
+		border-bottom-left-radius: 0 !important;
+		border-bottom-right-radius: 0 !important;
+	}
+
+	.ck.ck-editor__main > .ck-editor__editable {
+		background-color: #f1f2f5;
+		border-color: #e7e7ed;
+		border-radius: 0.5rem;
+		border-top-left-radius: 0 !important;
+		border-top-right-radius: 0 !important;
+	}
+}

--- a/modules/apps/frontend-theme/frontend-theme-cms/src/css/components/_ckeditor.scss
+++ b/modules/apps/frontend-theme/frontend-theme-cms/src/css/components/_ckeditor.scss
@@ -2,25 +2,28 @@
 	> .ck.ck-editor__top {
 		> .ck.ck-sticky-panel {
 			> .ck.ck-sticky-panel__content {
-				border-color: #e7e7ed;
-				border-radius: 0.5rem;
 				border-bottom-left-radius: 0 !important;
 				border-bottom-right-radius: 0 !important;
+				border-color: #e7e7ed;
+				border-top-left-radius: 0.5rem;
+				border-top-right-radius: 0.5rem;
 			}
 		}
 	}
 
 	.ck.ck-toolbar {
-		border-color: #e7e7ed;
-		border-radius: 0.5rem;
 		border-bottom-left-radius: 0 !important;
 		border-bottom-right-radius: 0 !important;
+		border-color: #e7e7ed;
+		border-top-left-radius: 0.5rem;
+		border-top-right-radius: 0.5rem;
 	}
 
 	.ck.ck-editor__main > .ck-editor__editable {
 		background-color: #f1f2f5;
+		border-bottom-left-radius: 0.5rem;
+		border-bottom-right-radius: 0.5rem;
 		border-color: #e7e7ed;
-		border-radius: 0.5rem;
 		border-top-left-radius: 0 !important;
 		border-top-right-radius: 0 !important;
 	}

--- a/modules/apps/frontend-theme/frontend-theme-cms/src/css/components/_ckeditor.scss
+++ b/modules/apps/frontend-theme/frontend-theme-cms/src/css/components/_ckeditor.scss
@@ -1,14 +1,11 @@
 .lfr-ck .ck.ck-editor.ck-rounded-corners {
-	> .ck.ck-editor__top {
-		> .ck.ck-sticky-panel {
-			> .ck.ck-sticky-panel__content {
-				border-bottom-left-radius: 0 !important;
-				border-bottom-right-radius: 0 !important;
-				border-color: $gray-300;
-				border-top-left-radius: $border-radius;
-				border-top-right-radius: $border-radius;
-			}
-		}
+	.ck.ck-editor__main > .ck-editor__editable {
+		background-color: $gray-200;
+		border-bottom-left-radius: $border-radius;
+		border-bottom-right-radius: $border-radius;
+		border-color: $gray-300;
+		border-top-left-radius: 0 !important;
+		border-top-right-radius: 0 !important;
 	}
 
 	.ck.ck-toolbar {
@@ -19,12 +16,15 @@
 		border-top-right-radius: $border-radius;
 	}
 
-	.ck.ck-editor__main > .ck-editor__editable {
-		background-color: $gray-200;
-		border-bottom-left-radius: $border-radius;
-		border-bottom-right-radius: $border-radius;
-		border-color: $gray-300;
-		border-top-left-radius: 0 !important;
-		border-top-right-radius: 0 !important;
+	> .ck.ck-editor__top {
+		> .ck.ck-sticky-panel {
+			> .ck.ck-sticky-panel__content {
+				border-bottom-left-radius: 0 !important;
+				border-bottom-right-radius: 0 !important;
+				border-color: $gray-300;
+				border-top-left-radius: $border-radius;
+				border-top-right-radius: $border-radius;
+			}
+		}
 	}
 }

--- a/modules/apps/frontend-theme/frontend-theme-cms/src/css/components/_ckeditor.scss
+++ b/modules/apps/frontend-theme/frontend-theme-cms/src/css/components/_ckeditor.scss
@@ -4,9 +4,9 @@
 			> .ck.ck-sticky-panel__content {
 				border-bottom-left-radius: 0 !important;
 				border-bottom-right-radius: 0 !important;
-				border-color: #e7e7ed;
-				border-top-left-radius: 0.5rem;
-				border-top-right-radius: 0.5rem;
+				border-color: $gray-300;
+				border-top-left-radius: $border-radius;
+				border-top-right-radius: $border-radius;
 			}
 		}
 	}
@@ -14,16 +14,16 @@
 	.ck.ck-toolbar {
 		border-bottom-left-radius: 0 !important;
 		border-bottom-right-radius: 0 !important;
-		border-color: #e7e7ed;
-		border-top-left-radius: 0.5rem;
-		border-top-right-radius: 0.5rem;
+		border-color: $gray-300;
+		border-top-left-radius: $border-radius;
+		border-top-right-radius: $border-radius;
 	}
 
 	.ck.ck-editor__main > .ck-editor__editable {
-		background-color: #f1f2f5;
-		border-bottom-left-radius: 0.5rem;
-		border-bottom-right-radius: 0.5rem;
-		border-color: #e7e7ed;
+		background-color: $gray-200;
+		border-bottom-left-radius: $border-radius;
+		border-bottom-right-radius: $border-radius;
+		border-color: $gray-300;
 		border-top-left-radius: 0 !important;
 		border-top-right-radius: 0 !important;
 	}

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -18198,6 +18198,7 @@ start-typing-to-find-a-page=Start typing to find a page.
 start-with=Start With
 start-with-an-object=Start With an Object
 start-with-menu-items-in=Start with Menu Items In
+start-writing-content=Start writing content...
 started=Started
 started-by=Started By
 starter-time=Starter Time

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/editor/config/RichTextFragmentCKEditor5EditorConfigContributor.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/editor/config/RichTextFragmentCKEditor5EditorConfigContributor.java
@@ -12,6 +12,7 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.language.LanguageUtil;
 
 import java.util.Map;
 
@@ -39,6 +40,10 @@ public class RichTextFragmentCKEditor5EditorConfigContributor
 			return;
 		}
 
+		String placeholder = LanguageUtil.format(
+				themeDisplay.getLocale(), "start-writing-content",
+				false);
+
 		jsonObject.put(
 			"toolbar",
 			JSONUtil.put(
@@ -54,7 +59,9 @@ public class RichTextFragmentCKEditor5EditorConfigContributor
 				}
 			).put(
 				"shouldNotGroupWhenFull", true
-			));
+			)).put(
+				"placeholder", placeholder
+			);
 	}
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/editor/config/RichTextFragmentCKEditor5EditorConfigContributor.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/editor/config/RichTextFragmentCKEditor5EditorConfigContributor.java
@@ -9,10 +9,10 @@ import com.liferay.portal.kernel.editor.configuration.BaseEditorConfigContributo
 import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.language.LanguageUtil;
 
 import java.util.Map;
 
@@ -41,10 +41,11 @@ public class RichTextFragmentCKEditor5EditorConfigContributor
 		}
 
 		String placeholder = LanguageUtil.format(
-				themeDisplay.getLocale(), "start-writing-content",
-				false);
+			themeDisplay.getLocale(), "start-writing-content", false);
 
 		jsonObject.put(
+			"placeholder", placeholder
+		).put(
 			"toolbar",
 			JSONUtil.put(
 				"items",
@@ -59,9 +60,8 @@ public class RichTextFragmentCKEditor5EditorConfigContributor
 				}
 			).put(
 				"shouldNotGroupWhenFull", true
-			)).put(
-				"placeholder", placeholder
-			);
+			)
+		);
 	}
 
 }


### PR DESCRIPTION
Follow-up of https://github.com/brianchandotcom/liferay-portal/pull/166856, I assume the CSS selectors were the not sorted thing.

I sorted the CSS selector how I assume they should be sorted, alphabetically, followed by those starting with special characters (`>` in this case). If this is wrong, please let me know.