### PR TITLE
LPD-69304

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/WidgetInstancePageElementDefinitionDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/WidgetInstancePageElementDefinitionDTOConverter.java
@@ -221,11 +221,17 @@ public class WidgetInstancePageElementDefinitionDTOConverter
 
 		return TransformUtil.transformToArray(
 			permissionsMap.entrySet(),
-			entry -> new WidgetPermission() {
-				{
-					setActionIds(entry::getValue);
-					setRoleName(entry::getKey);
+			entry -> {
+				if (ArrayUtil.isEmpty(entry.getValue())) {
+					return null;
 				}
+
+				return new WidgetPermission() {
+					{
+						setActionIds(entry::getValue);
+						setRoleName(entry::getKey);
+					}
+				};
 			},
 			WidgetPermission.class);
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/WidgetInstancePageElementDefinitionDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/WidgetInstancePageElementDefinitionDTOConverter.java
@@ -163,17 +163,15 @@ public class WidgetInstancePageElementDefinitionDTOConverter
 
 			String[] values = entrySet.getValue();
 
-			if (ArrayUtil.isNotEmpty(values)) {
-				if (values.length > 1) {
-					portletConfigurationMap.put(entrySet.getKey(), values);
-				}
-				else {
-					portletConfigurationMap.put(entrySet.getKey(), values[0]);
-				}
-			}
-			else {
+			if (values == null) {
 				portletConfigurationMap.put(
 					entrySet.getKey(), StringPool.BLANK);
+			}
+			else if (values.length == 1) {
+				portletConfigurationMap.put(entrySet.getKey(), values[0]);
+			}
+			else {
+				portletConfigurationMap.put(entrySet.getKey(), values);
 			}
 		}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/layout/structure/item/importer/WidgetInstanceLayoutStructureItemImporter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/layout/structure/item/importer/WidgetInstanceLayoutStructureItemImporter.java
@@ -102,11 +102,15 @@ public class WidgetInstanceLayoutStructureItemImporter
 		if (fragmentEntryLink == null) {
 			fragmentEntryLink = _addFragmentEntryLink(
 				widgetInstancePageElementDefinition.
+					getDraftWidgetInstanceExternalReferenceCode(),
+				widgetInstancePageElementDefinition.
 					getWidgetInstanceExternalReferenceCode(),
 				layoutStructureItemImporterContext, widgetInstance);
 		}
 		else {
 			fragmentEntryLink = _updateFragmentEntryLink(
+				widgetInstancePageElementDefinition.
+					getDraftWidgetInstanceExternalReferenceCode(),
 				fragmentEntryLink, layoutStructureItemImporterContext,
 				widgetInstance);
 		}
@@ -146,6 +150,7 @@ public class WidgetInstanceLayoutStructureItemImporter
 	}
 
 	private FragmentEntryLink _addFragmentEntryLink(
+			String draftWidgetInstanceExternalReferenceCode,
 			String externalReferenceCode,
 			LayoutStructureItemImporterContext
 				layoutStructureItemImporterContext,
@@ -160,7 +165,8 @@ public class WidgetInstanceLayoutStructureItemImporter
 		return FragmentEntryLinkLocalServiceUtil.addFragmentEntryLink(
 			externalReferenceCode,
 			layoutStructureItemImporterContext.getUserId(),
-			layoutStructureItemImporterContext.getGroupId(), null, null, null,
+			layoutStructureItemImporterContext.getGroupId(),
+			draftWidgetInstanceExternalReferenceCode, null, null,
 			layoutStructureItemImporterContext.getSegmentsExperienceId(),
 			layout.getPlid(), StringPool.BLANK, StringPool.BLANK,
 			StringPool.BLANK, StringPool.BLANK,
@@ -293,6 +299,7 @@ public class WidgetInstanceLayoutStructureItemImporter
 	}
 
 	private FragmentEntryLink _updateFragmentEntryLink(
+			String draftWidgetInstanceExternalReferenceCode,
 			FragmentEntryLink fragmentEntryLink,
 			LayoutStructureItemImporterContext
 				layoutStructureItemImporterContext,
@@ -331,10 +338,13 @@ public class WidgetInstanceLayoutStructureItemImporter
 		editableValuesJSONObject = _getEditableValuesJSONObject(
 			fragmentEntryLink, widgetInstance);
 
+		fragmentEntryLink.setOriginalFragmentEntryLinkERC(
+			draftWidgetInstanceExternalReferenceCode);
+		fragmentEntryLink.setEditableValues(
+			editableValuesJSONObject.toString());
+
 		return FragmentEntryLinkLocalServiceUtil.updateFragmentEntryLink(
-			layoutStructureItemImporterContext.getUserId(),
-			fragmentEntryLink.getFragmentEntryLinkId(),
-			editableValuesJSONObject.toString(), true);
+			fragmentEntryLink);
 	}
 
 	private static final ServiceTracker

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
@@ -646,15 +646,14 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 	}
 
 	private void _addFragmentEntryLink(
-			String externalReferenceCode, Layout layout,
-			String widgetInstanceId)
+			String externalReferenceCode, Layout layout, String namespace)
 		throws Exception {
 
 		FragmentEntryLinkLocalServiceUtil.addFragmentEntryLink(
 			externalReferenceCode, TestPropsValues.getUserId(),
 			testGroup.getGroupId(), null, null, null, 0, layout.getPlid(),
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
-			StringPool.BLANK, StringPool.BLANK, widgetInstanceId, 0, null,
+			StringPool.BLANK, StringPool.BLANK, namespace, 0, null,
 			FragmentConstants.TYPE_PORTLET, new ServiceContext());
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
@@ -9,6 +9,8 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.publisher.constants.AssetPublisherPortletKeys;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
+import com.liferay.fragment.constants.FragmentConstants;
+import com.liferay.fragment.service.FragmentEntryLinkLocalServiceUtil;
 import com.liferay.headless.admin.site.client.dto.v1_0.ContainerPageElementDefinition;
 import com.liferay.headless.admin.site.client.dto.v1_0.FragmentLink;
 import com.liferay.headless.admin.site.client.dto.v1_0.FragmentLinkInlineValue;
@@ -49,6 +51,7 @@ import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -352,14 +355,23 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 				RandomTestUtil.randomStrings(RandomTestUtil.randomInt(1, 10)),
 				null, false, false, 6, 12,
 				GridPageElementDefinition.VerticalAlignment.BOTTOM));
+
+		String draftWidgetInstanceExternalReferenceCode =
+			RandomTestUtil.randomString();
+
+		String widgetInstanceId = RandomTestUtil.randomString();
+
+		_addFragmentEntryLink(
+			draftWidgetInstanceExternalReferenceCode, layout, widgetInstanceId);
+
 		_testPostSitePageSpecificationPageExperiencePageElement(
 			_getWidgetPageElement(
 				RandomTestUtil.randomStrings(RandomTestUtil.randomInt(1, 10)),
-				RandomTestUtil.randomString(), false,
+				RandomTestUtil.randomString(),
+				draftWidgetInstanceExternalReferenceCode, false,
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				_getWidgetConfig(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(),
-				JournalContentPortletKeys.JOURNAL_CONTENT,
+				widgetInstanceId, JournalContentPortletKeys.JOURNAL_CONTENT,
 				_getWidgetPermissions()));
 	}
 
@@ -467,26 +479,33 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		_testPutSitePageSpecificationPageExperiencePageElement(
 			_getWidgetPageElement(
 				RandomTestUtil.randomStrings(RandomTestUtil.randomInt(1, 10)),
-				RandomTestUtil.randomString(), false,
+				RandomTestUtil.randomString(), null, false,
 				RandomTestUtil.randomString(), externalReferenceCode,
 				_getWidgetConfig(), widgetInstanceExternalReferenceCode,
 				RandomTestUtil.randomString(),
 				JournalContentPortletKeys.JOURNAL_CONTENT,
 				_getWidgetPermissions()));
 
+		String draftWidgetInstanceExternalReferenceCode =
+			RandomTestUtil.randomString();
+
 		String widgetInstanceId = RandomTestUtil.randomString();
+
+		_addFragmentEntryLink(
+			draftWidgetInstanceExternalReferenceCode, layout, widgetInstanceId);
 
 		_testPutSitePageSpecificationPageExperiencePageElement(
 			_getWidgetPageElement(
 				RandomTestUtil.randomStrings(RandomTestUtil.randomInt(1, 10)),
-				RandomTestUtil.randomString(), false,
+				RandomTestUtil.randomString(),
+				draftWidgetInstanceExternalReferenceCode, false,
 				RandomTestUtil.randomString(), externalReferenceCode,
 				_getWidgetConfig(), widgetInstanceExternalReferenceCode,
 				widgetInstanceId, AssetPublisherPortletKeys.ASSET_PUBLISHER,
 				_getWidgetPermissions()));
 		_testPutSitePageSpecificationPageExperiencePageElement(
 			_getWidgetPageElement(
-				null, null, false, RandomTestUtil.randomString(),
+				null, null, null, false, RandomTestUtil.randomString(),
 				externalReferenceCode, new HashMap<>(),
 				widgetInstanceExternalReferenceCode, widgetInstanceId,
 				AssetPublisherPortletKeys.ASSET_PUBLISHER,
@@ -624,6 +643,19 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 				testGroup.getExternalReferenceCode(),
 				_draftLayout.getExternalReferenceCode(),
 				segmentsExperience.getExternalReferenceCode(), pageElement);
+	}
+
+	private void _addFragmentEntryLink(
+			String externalReferenceCode, Layout layout,
+			String widgetInstanceId)
+		throws Exception {
+
+		FragmentEntryLinkLocalServiceUtil.addFragmentEntryLink(
+			externalReferenceCode, TestPropsValues.getUserId(),
+			testGroup.getGroupId(), null, null, null, 0, layout.getPlid(),
+			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
+			StringPool.BLANK, StringPool.BLANK, widgetInstanceId, 0, null,
+			FragmentConstants.TYPE_PORTLET, new ServiceContext());
 	}
 
 	private String[] _getActionIds(String roleName) {
@@ -1104,8 +1136,9 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 	}
 
 	private PageElement _getWidgetPageElement(
-			String[] cssClasses, String customCss, boolean indexed, String name,
-			String pageElementExternalReferenceCode,
+			String[] cssClasses, String customCss,
+			String draftWidgetInstanceExternalReferenceCode, boolean indexed,
+			String name, String pageElementExternalReferenceCode,
 			Map<String, Object> widgetConfig,
 			String widgetInstanceExternalReferenceCode, String widgetInstanceId,
 			String widgetName, WidgetPermission[] widgetPermissions)
@@ -1117,6 +1150,9 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 
 		widgetInstancePageElementDefinition.setCssClasses(cssClasses);
 		widgetInstancePageElementDefinition.setCustomCSS(customCss);
+		widgetInstancePageElementDefinition.
+			setDraftWidgetInstanceExternalReferenceCode(
+				draftWidgetInstanceExternalReferenceCode);
 		widgetInstancePageElementDefinition.setIndexed(indexed);
 		widgetInstancePageElementDefinition.setName(name);
 		widgetInstancePageElementDefinition.setType(


### PR DESCRIPTION
Hi @brianchandotcom ,

I am sending again in order to fix : https://github.com/brianchandotcom/liferay-portal/pull/167065#issuecomment-3450808932.

thanks

https://liferay.atlassian.net/browse/LPD-69304

# What is this solving?

Preserve draftFragmentEntryExternalReferenceCode when we are creating/updating a widget instance. I have also taken into account the  following comments:

1. https://github.com/liferay-page-management/liferay-portal/pull/17744#issuecomment-3424126918
2. https://github.com/liferay-page-management/liferay-portal/pull/17774#discussion_r2446308776

# How is it fixed?

Allowing to modify and preserve draftFragmentEntryExternalReferenceCode. Also, in case of permission issue, finally, we are not going to return an empty permissions for a role , since we can do it quickly ,because we can't create an empty action ids resource permissions because of that : https://github.com/liferay/liferay-portal/blob/b4ac2f44f4b90f25e008bfa89bc68a2166e31696/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java#L2373. So, for the moment let's go for this solution.

# How to verify?

Run included integration tests
 