### PR TITLE
LPD-69720 Removed unnecessary method which causes unwanted values

### DIFF
--- a/portal-impl/src/com/liferay/portlet/internal/PortletRequestImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/PortletRequestImpl.java
@@ -39,7 +39,6 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.servlet.NamespaceServletRequest;
@@ -814,8 +813,6 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 			dynamicServletRequest, publicRenderParametersMap,
 			portletPreferences, getLifecycle());
 
-		_processCheckbox(dynamicServletRequest);
-
 		if (!isPortletModeAllowed(portletMode)) {
 			portletMode = PortletModeFactory.getPortletMode(null, 3);
 
@@ -1229,28 +1226,6 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 			}
 			else {
 				dynamicServletRequest.setParameterValues(name, newValues);
-			}
-		}
-	}
-
-	private void _processCheckbox(DynamicServletRequest dynamicServletRequest) {
-		String checkboxNames = dynamicServletRequest.getParameter(
-			"checkboxNames");
-
-		if (Validator.isNull(checkboxNames)) {
-			return;
-		}
-
-		for (String checkboxName : StringUtil.split(checkboxNames)) {
-			String value = dynamicServletRequest.getParameter(checkboxName);
-
-			if (value == null) {
-				dynamicServletRequest.setParameter(
-					checkboxName, Boolean.FALSE.toString());
-			}
-			else if (Objects.equals(value, "on")) {
-				dynamicServletRequest.setParameter(
-					checkboxName, Boolean.TRUE.toString());
 			}
 		}
 	}


### PR DESCRIPTION
FWD: https://github.com/liferay-frontend/liferay-portal/pull/5161

https://liferay.atlassian.net/browse/LPD-69720
https://liferay.atlassian.net/browse/LPP-60890

The _processCheckbox method would give wrong values for site checkboxes when they were unchecked.
We found this legacy code no longer needed and could be removed.

Please let me know if there are any questions or comments about this.
Thank you!