### PR TITLE
LPD-69950 Prevent ExpandoAttribute to be processed

### DIFF
--- a/portal-impl/src/com/liferay/portlet/internal/PortletRequestImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/PortletRequestImpl.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.servlet.NamespaceServletRequest;
@@ -813,6 +814,8 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 			dynamicServletRequest, publicRenderParametersMap,
 			portletPreferences, getLifecycle());
 
+		_processCheckbox(dynamicServletRequest);
+
 		if (!isPortletModeAllowed(portletMode)) {
 			portletMode = PortletModeFactory.getPortletMode(null, 3);
 
@@ -1226,6 +1229,30 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 			}
 			else {
 				dynamicServletRequest.setParameterValues(name, newValues);
+			}
+		}
+	}
+
+	private void _processCheckbox(DynamicServletRequest dynamicServletRequest) {
+		String checkboxNames = dynamicServletRequest.getParameter(
+			"checkboxNames");
+
+		if (Validator.isNull(checkboxNames)) {
+			return;
+		}
+
+		for (String checkboxName : StringUtil.split(checkboxNames)) {
+			String value = dynamicServletRequest.getParameter(checkboxName);
+
+			if (!checkboxName.contains("ExpandoAttribute")) {
+				if (value == null) {
+					dynamicServletRequest.setParameter(
+						checkboxName, Boolean.FALSE.toString());
+				}
+				else if (Objects.equals(value, "on")) {
+					dynamicServletRequest.setParameter(
+						checkboxName, Boolean.TRUE.toString());
+				}
 			}
 		}
 	}


### PR DESCRIPTION
FWD: https://github.com/liferay-frontend/liferay-portal/pull/5173

https://liferay.atlassian.net/browse/LPD-69950

The _processCheckbox method is needed for checkboxes in configuations and we need to exclude any ExpandoAttribute checkboxes from being proccessed.
Each expando checkbox I found contains ExpandoAttribute in the checkboxname, which is already being handled, so there is no need to be processed in this method.

Please let me know if there are any questions or comments about this.
Thank you!