### PR TITLE
[CMS 2.0] LPD-61657 Enable download permissions for attachment fields

### DIFF
--- a/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/batch/engine/broker/test/BatchEngineBrokerTest.java
+++ b/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/batch/engine/broker/test/BatchEngineBrokerTest.java
@@ -79,6 +79,7 @@ import com.liferay.object.rest.manager.v1_0.ObjectEntryManagerRegistry;
 import com.liferay.object.service.ObjectActionLocalService;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectEntryService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.object.service.ObjectFolderItemLocalService;
@@ -99,6 +100,7 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
@@ -342,8 +344,8 @@ public class BatchEngineBrokerTest {
 				_createCSVImportFile(
 					RandomTestUtil.nextDate(), dlFileEntry,
 					_objectDefinition1.getExternalReferenceCode(),
-					_OBJECT_ENTRY_ERC_1, "object_entry.csv", null,
-					RandomTestUtil.randomLong(), RandomTestUtil.nextDate()))) {
+					"object_entry.csv", null, RandomTestUtil.randomLong(),
+					RandomTestUtil.nextDate()))) {
 
 			_executeImportTask(
 				BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
@@ -366,9 +368,12 @@ public class BatchEngineBrokerTest {
 				"C_TestObjectCSV"),
 			_getCSVString(
 				objectEntry.getCreateDate(), dlFileEntry,
-				_objectDefinition1.getExternalReferenceCode(),
-				_OBJECT_ENTRY_ERC_1, "object_entry.csv", null,
-				objectEntry.getObjectEntryId(), objectEntry.getModifiedDate()),
+				_objectDefinition1.getExternalReferenceCode(), objectEntry,
+				_objectFieldLocalService.getObjectField(
+					_OBJECT_FIELD_ERC,
+					_objectDefinition1.getObjectDefinitionId()),
+				"object_entry.csv", null, objectEntry.getObjectEntryId(),
+				objectEntry.getModifiedDate()),
 			objectEntry.getExternalReferenceCode());
 	}
 
@@ -378,11 +383,17 @@ public class BatchEngineBrokerTest {
 			"TestObject", ObjectDefinitionConstants.SCOPE_COMPANY,
 			TestPropsValues.getUser());
 
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			_OBJECT_ENTRY_ERC_1, ObjectDefinitionConstants.GROUP_ID_DEFAULT,
+			_objectDefinition1.getObjectDefinitionId());
+
 		File file = _createJSONImportFile(
 			_addDLFileEntry(
 				TestPropsValues.getGroupId(), TestPropsValues.getUserId()),
 			ObjectDefinitionConstants.GROUP_ID_DEFAULT,
-			_objectDefinition1.getExternalReferenceCode(), _OBJECT_ENTRY_ERC_1,
+			_objectDefinition1.getExternalReferenceCode(), objectEntry,
+			_objectFieldLocalService.getObjectField(
+				_OBJECT_FIELD_ERC, _objectDefinition1.getObjectDefinitionId()),
 			"object_entry_import_template.txt");
 
 		try (FileInputStream fileInputStream = new FileInputStream(file)) {
@@ -391,10 +402,6 @@ public class BatchEngineBrokerTest {
 				_objectEntryImportFieldNames, null,
 				"com.liferay.object.rest.dto.v1_0.ObjectEntry", "C_TestObject",
 				_getURIString("json", fileInputStream));
-
-			ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
-				_OBJECT_ENTRY_ERC_1, ObjectDefinitionConstants.GROUP_ID_DEFAULT,
-				_objectDefinition1.getObjectDefinitionId());
 
 			_addObjectEntryInDifferentCompany("TestObject");
 
@@ -736,17 +743,24 @@ public class BatchEngineBrokerTest {
 
 	private File _createCSVImportFile(
 			Date createDate, DLFileEntry dlFileEntry,
-			String objectDefinitionERC, String objectEntryERC, String fileName,
-			Long groupId, long id, Date modifiedDate)
+			String objectDefinitionERC, String fileName, Long groupId, long id,
+			Date modifiedDate)
 		throws Exception {
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			_OBJECT_ENTRY_ERC_1, ObjectDefinitionConstants.GROUP_ID_DEFAULT,
+			_objectDefinition1.getObjectDefinitionId());
+
+		ObjectField objectField = _objectFieldLocalService.getObjectField(
+			_OBJECT_FIELD_ERC, _objectDefinition1.getObjectDefinitionId());
 
 		File file = _file.createTempFile("csv");
 
 		_file.write(
 			file,
 			_getCSVString(
-				createDate, dlFileEntry, objectDefinitionERC, objectEntryERC,
-				fileName, groupId, id, modifiedDate));
+				createDate, dlFileEntry, objectDefinitionERC, objectEntry,
+				objectField, fileName, groupId, id, modifiedDate));
 
 		return file;
 	}
@@ -763,7 +777,8 @@ public class BatchEngineBrokerTest {
 
 	private File _createJSONImportFile(
 			DLFileEntry dlFileEntry, long groupId, String objectDefinitionERC,
-			String objectEntryERC, String templateName)
+			ObjectEntry objectEntry, ObjectField objectField,
+			String templateName)
 		throws Exception {
 
 		File file = _file.createTempFile("json");
@@ -772,7 +787,8 @@ public class BatchEngineBrokerTest {
 
 		Link link = LinkUtil.toLink(
 			_dlAppService, dlFileEntry, _dlURLHelper, groupId,
-			objectDefinitionERC, objectEntryERC, _portal);
+			objectDefinitionERC, objectEntry, _objectEntryService, objectField,
+			GuestOrUserUtil.getPermissionChecker(), _portal);
 
 		template = StringUtil.replace(
 			template,
@@ -783,7 +799,8 @@ public class BatchEngineBrokerTest {
 			},
 			new String[] {
 				link.getHref(), String.valueOf(dlFileEntry.getFileEntryId()),
-				link.getLabel(), dlFileEntry.getFileName(), objectEntryERC
+				link.getLabel(), dlFileEntry.getFileName(),
+				objectEntry.getExternalReferenceCode()
 			});
 
 		_file.write(file, template);
@@ -921,14 +938,16 @@ public class BatchEngineBrokerTest {
 
 	private String _getCSVString(
 			Date createDate, DLFileEntry dlFileEntry,
-			String objectDefinitionERC, String objectEntryERC, String fileName,
-			Long groupId, long id, Date modifiedDate)
+			String objectDefinitionERC, ObjectEntry objectEntry,
+			ObjectField objectField, String fileName, Long groupId, long id,
+			Date modifiedDate)
 		throws Exception {
 
 		Link link = LinkUtil.toLink(
 			_dlAppService, dlFileEntry, _dlURLHelper,
-			GetterUtil.getLong(groupId), objectDefinitionERC, objectEntryERC,
-			_portal);
+			GetterUtil.getLong(groupId), objectDefinitionERC, objectEntry,
+			_objectEntryService, objectField,
+			GuestOrUserUtil.getPermissionChecker(), _portal);
 
 		String scopeKey = null;
 
@@ -950,7 +969,8 @@ public class BatchEngineBrokerTest {
 				String.valueOf(dlFileEntry.getFileEntryId()), link.getHref(),
 				link.getLabel(), dlFileEntry.getFileName(),
 				_toDateString(createDate), _toDateString(modifiedDate),
-				objectEntryERC, String.valueOf(id), scopeKey
+				objectEntry.getExternalReferenceCode(), String.valueOf(id),
+				scopeKey
 			});
 	}
 
@@ -1217,6 +1237,8 @@ public class BatchEngineBrokerTest {
 				Collections.emptyList(),
 				Arrays.asList(
 					new AttachmentObjectFieldBuilder(
+					).externalReferenceCode(
+						_OBJECT_FIELD_ERC
 					).labelMap(
 						LocalizedMapUtil.getLocalizedMap(
 							RandomTestUtil.randomString())
@@ -1515,8 +1537,8 @@ public class BatchEngineBrokerTest {
 		try (FileInputStream fileInputStream = new FileInputStream(
 				_createCSVImportFile(
 					RandomTestUtil.nextDate(), dlFileEntry, objectDefinitionERC,
-					objectEntryERC, "object_entry.csv", groupId,
-					RandomTestUtil.randomLong(), RandomTestUtil.nextDate()))) {
+					"object_entry.csv", groupId, RandomTestUtil.randomLong(),
+					RandomTestUtil.nextDate()))) {
 
 			_executeImportTask(
 				BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
@@ -1539,8 +1561,12 @@ public class BatchEngineBrokerTest {
 				"C_TestObjectCSV"),
 			_getCSVString(
 				objectEntry.getCreateDate(), dlFileEntry, objectDefinitionERC,
-				objectEntryERC, "object_entry.csv", groupId,
-				objectEntry.getObjectEntryId(), objectEntry.getModifiedDate()),
+				objectEntry,
+				_objectFieldLocalService.getObjectField(
+					_OBJECT_FIELD_ERC,
+					_objectDefinition1.getObjectDefinitionId()),
+				"object_entry.csv", groupId, objectEntry.getObjectEntryId(),
+				objectEntry.getModifiedDate()),
 			objectEntry.getExternalReferenceCode());
 	}
 
@@ -1548,11 +1574,17 @@ public class BatchEngineBrokerTest {
 			long groupId, String objectEntryERC)
 		throws Exception {
 
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			objectEntryERC, groupId,
+			_objectDefinition1.getObjectDefinitionId());
+
 		File file = _createJSONImportFile(
 			_addDLFileEntry(
 				TestPropsValues.getGroupId(), TestPropsValues.getUserId()),
-			groupId, _objectDefinition1.getExternalReferenceCode(),
-			objectEntryERC, "object_entry_import_template.txt");
+			groupId, _objectDefinition1.getExternalReferenceCode(), objectEntry,
+			_objectFieldLocalService.getObjectField(
+				_OBJECT_FIELD_ERC, _objectDefinition1.getObjectDefinitionId()),
+			"object_entry_import_template.txt");
 
 		try (FileInputStream fileInputStream = new FileInputStream(file)) {
 			_executeImportTask(
@@ -1560,10 +1592,6 @@ public class BatchEngineBrokerTest {
 				_objectEntryImportFieldNames, groupId,
 				"com.liferay.object.rest.dto.v1_0.ObjectEntry", "C_TestObject",
 				_getURIString("json", fileInputStream));
-
-			ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
-				objectEntryERC, groupId,
-				_objectDefinition1.getObjectDefinitionId());
 
 			Assert.assertEquals(objectEntry.getGroupId(), groupId);
 
@@ -1617,6 +1645,8 @@ public class BatchEngineBrokerTest {
 	private static final String _OBJECT_ENTRY_ERC_2 = "TEST-OBJECT-ENTRY-2";
 
 	private static final String _OBJECT_ENTRY_ERC_3 = "TEST-OBJECT-ENTRY-3";
+
+	private static final String _OBJECT_FIELD_ERC = "TEST-OBJECT-FIELD";
 
 	private static final CSVFormat _csvFormat = CSVFormat.Builder.create(
 	).setDelimiter(
@@ -1789,6 +1819,9 @@ public class BatchEngineBrokerTest {
 
 	@Inject
 	private ObjectEntryManagerRegistry _objectEntryManagerRegistry;
+
+	@Inject
+	private ObjectEntryService _objectEntryService;
 
 	@Inject
 	private ObjectFieldLocalService _objectFieldLocalService;

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/security/permission/resource/test/DLFileEntryModelResourcePermissionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/security/permission/resource/test/DLFileEntryModelResourcePermissionTest.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -46,12 +47,15 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
 
 /**
  * @author Jürgen Kappler
@@ -71,6 +75,18 @@ public class DLFileEntryModelResourcePermissionTest {
 		_user = UserTestUtil.addUser();
 
 		_permissionChecker = PermissionCheckerFactoryUtil.create(_user);
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_group.getGroupId(), TestPropsValues.getUserId());
+
+		_serviceContext.setRequest(new MockHttpServletRequest());
+
+		ServiceContextThreadLocal.pushServiceContext(_serviceContext);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		ServiceContextThreadLocal.popServiceContext();
 	}
 
 	@Test
@@ -105,10 +121,6 @@ public class DLFileEntryModelResourcePermissionTest {
 	public void testContainsWithScheduledFileEntryAndRegularUser()
 		throws Exception {
 
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId());
-
 		DLFileEntry dlFileEntry = _dlFileEntryLocalService.addFileEntry(
 			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
@@ -118,13 +130,13 @@ public class DLFileEntryModelResourcePermissionTest {
 			new ByteArrayInputStream(new byte[0]), 0,
 			new Date(System.currentTimeMillis() + Time.MONTH),
 			new Date(System.currentTimeMillis() + Time.YEAR), new Date(),
-			serviceContext);
+			_serviceContext);
 
 		DLFileVersion dlFileVersion = dlFileEntry.getFileVersion();
 
 		_dlFileEntryLocalService.updateStatus(
 			TestPropsValues.getUserId(), dlFileVersion.getFileVersionId(),
-			WorkflowConstants.STATUS_SCHEDULED, serviceContext,
+			WorkflowConstants.STATUS_SCHEDULED, _serviceContext,
 			new HashMap<>());
 
 		Assert.assertFalse(
@@ -176,6 +188,8 @@ public class DLFileEntryModelResourcePermissionTest {
 
 	@Inject
 	private RoleLocalService _roleLocalService;
+
+	private ServiceContext _serviceContext;
 
 	@DeleteAfterTestRun
 	private User _user;

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SharedAssetDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SharedAssetDTOConverter.java
@@ -23,12 +23,14 @@ import com.liferay.object.model.ObjectField;
 import com.liferay.object.rest.dto.v1_0.util.LinkUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectEntryService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -174,8 +176,8 @@ public class SharedAssetDTOConverter
 	}
 
 	private FileEntry _getFileEntry(
-		ObjectDefinition objectDefinition, ObjectEntry objectEntry,
-		long fileEntryId) {
+		long fileEntryId, ObjectDefinition objectDefinition,
+		ObjectEntry objectEntry, ObjectField objectField) {
 
 		FileEntry fileEntry = new FileEntry();
 
@@ -188,15 +190,15 @@ public class SharedAssetDTOConverter
 
 		fileEntry.setExternalReferenceCode(
 			dlFileEntry::getExternalReferenceCode);
-
 		fileEntry.setId(dlFileEntry::getFileEntryId);
 		fileEntry.setLink(
 			() -> toLink(
 				LinkUtil.toLink(
 					_dlAppService, dlFileEntry, _dlURLHelper,
 					objectEntry.getGroupId(),
-					objectDefinition.getExternalReferenceCode(),
-					objectEntry.getExternalReferenceCode(), _portal)));
+					objectDefinition.getExternalReferenceCode(), objectEntry,
+					_objectEntryService, objectField,
+					GuestOrUserUtil.getPermissionChecker(), _portal)));
 		fileEntry.setName(dlFileEntry::getFileName);
 		fileEntry.setThumbnailURL(
 			() -> {
@@ -259,8 +261,8 @@ public class SharedAssetDTOConverter
 
 				if (serializable instanceof Long) {
 					return _getFileEntry(
-						objectDefinition, objectEntry,
-						GetterUtil.getLong(serializable));
+						GetterUtil.getLong(serializable), objectDefinition,
+						objectEntry, objectField);
 				}
 			}
 		}
@@ -366,6 +368,9 @@ public class SharedAssetDTOConverter
 
 	@Reference
 	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private ObjectEntryService _objectEntryService;
 
 	@Reference
 	private ObjectFieldLocalService _objectFieldLocalService;

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/security/permission/resource/util/ObjectDefinitionResourcePermissionUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/security/permission/resource/util/ObjectDefinitionResourcePermissionUtil.java
@@ -37,18 +37,17 @@ import java.util.concurrent.ConcurrentHashMap;
 public class ObjectDefinitionResourcePermissionUtil {
 
 	public static void populateResourceActions(
-			List<ObjectField> attachmentObjectFields,
 			ObjectActionLocalService objectActionLocalService,
-			ObjectDefinition objectDefinition,
+			List<ObjectAction> objectActions, ObjectDefinition objectDefinition,
 			ObjectFieldLocalService objectFieldLocalService,
+			List<ObjectField> objectFields,
 			PortletLocalService portletLocalService,
-			ResourceActions resourceActions,
-			List<ObjectAction> standaloneObjectActions)
+			ResourceActions resourceActions)
 		throws Exception {
 
 		Document document = _readDocument(
-			attachmentObjectFields, objectActionLocalService, objectDefinition,
-			objectFieldLocalService, standaloneObjectActions);
+			objectActionLocalService, objectActions, objectDefinition,
+			objectFieldLocalService, objectFields);
 
 		try (SafeCloseable safeCloseable = CompanyThreadLocal.lock(
 				objectDefinition.getCompanyId())) {
@@ -84,7 +83,7 @@ public class ObjectDefinitionResourcePermissionUtil {
 
 		if (document == null) {
 			document = _readDocument(
-				null, objectActionLocalService, objectDefinition,
+				objectActionLocalService, null, objectDefinition,
 				objectFieldLocalService, null);
 		}
 
@@ -95,21 +94,21 @@ public class ObjectDefinitionResourcePermissionUtil {
 
 	private static String _getObjectActionPermissionKeys(
 		ObjectActionLocalService objectActionLocalService,
-		long objectDefinitionId, List<ObjectAction> standaloneObjectActions) {
+		List<ObjectAction> objectActions, long objectDefinitionId) {
 
-		if (standaloneObjectActions == null) {
-			if (objectActionLocalService == null) {
-				return null;
-			}
-
-			standaloneObjectActions = objectActionLocalService.getObjectActions(
-				objectDefinitionId,
-				ObjectActionTriggerConstants.KEY_STANDALONE);
+		if (objectActionLocalService == null) {
+			return null;
 		}
 
 		String objectActionPermissionKeys = StringPool.BLANK;
 
-		for (ObjectAction objectAction : standaloneObjectActions) {
+		if (objectActions == null) {
+			objectActions = objectActionLocalService.getObjectActions(
+				objectDefinitionId,
+				ObjectActionTriggerConstants.KEY_STANDALONE);
+		}
+
+		for (ObjectAction objectAction : objectActions) {
 			objectActionPermissionKeys = StringBundler.concat(
 				objectActionPermissionKeys, "<action-key>",
 				objectAction.getName(), "</action-key>");
@@ -119,16 +118,17 @@ public class ObjectDefinitionResourcePermissionUtil {
 	}
 
 	private static String _getObjectFieldPermissionKeys(
-			List<ObjectField> attachmentObjectFields, long objectDefinitionId,
-			ObjectFieldLocalService objectFieldLocalService)
+			long objectDefinitionId,
+			ObjectFieldLocalService objectFieldLocalService,
+			List<ObjectField> objectFields)
 		throws Exception {
 
 		if (objectFieldLocalService == null) {
 			return null;
 		}
 
-		if (attachmentObjectFields == null) {
-			attachmentObjectFields =
+		if (objectFields == null) {
+			objectFields =
 				objectFieldLocalService.getObjectFieldsByBusinessType(
 					objectDefinitionId,
 					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT);
@@ -136,7 +136,7 @@ public class ObjectDefinitionResourcePermissionUtil {
 
 		String objectFieldPermissionKeys = StringPool.BLANK;
 
-		for (ObjectField objectField : attachmentObjectFields) {
+		for (ObjectField objectField : objectFields) {
 			objectFieldLocalService.
 				addOrUpdateObjectFieldResourceActionPLOEntries(objectField);
 
@@ -189,16 +189,15 @@ public class ObjectDefinitionResourcePermissionUtil {
 	}
 
 	private static Document _readDocument(
-			List<ObjectField> attachmentObjectFields,
 			ObjectActionLocalService objectActionLocalService,
-			ObjectDefinition objectDefinition,
+			List<ObjectAction> objectActions, ObjectDefinition objectDefinition,
 			ObjectFieldLocalService objectFieldLocalService,
-			List<ObjectAction> standaloneObjectActions)
+			List<ObjectField> objectFields)
 		throws Exception {
 
 		String objectActionPermissionKeys = _getObjectActionPermissionKeys(
-			objectActionLocalService, objectDefinition.getObjectDefinitionId(),
-			standaloneObjectActions);
+			objectActionLocalService, objectActions,
+			objectDefinition.getObjectDefinitionId());
 
 		String objectFieldPermissionKeys = StringPool.BLANK;
 
@@ -206,9 +205,8 @@ public class ObjectDefinitionResourcePermissionUtil {
 				objectDefinition.getCompanyId(), "LPD-17564")) {
 
 			objectFieldPermissionKeys = _getObjectFieldPermissionKeys(
-				attachmentObjectFields,
 				objectDefinition.getObjectDefinitionId(),
-				objectFieldLocalService);
+				objectFieldLocalService, objectFields);
 		}
 
 		String resourceActionsFileName =

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/security/permission/resource/util/ObjectDefinitionResourcePermissionUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/security/permission/resource/util/ObjectDefinitionResourcePermissionUtil.java
@@ -8,9 +8,12 @@ package com.liferay.object.definition.security.permission.resource.util;
 import com.liferay.object.constants.ObjectActionKeys;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.model.ObjectAction;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectActionLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -34,16 +37,18 @@ import java.util.concurrent.ConcurrentHashMap;
 public class ObjectDefinitionResourcePermissionUtil {
 
 	public static void populateResourceActions(
+			List<ObjectField> attachmentObjectFields,
 			ObjectActionLocalService objectActionLocalService,
 			ObjectDefinition objectDefinition,
+			ObjectFieldLocalService objectFieldLocalService,
 			PortletLocalService portletLocalService,
 			ResourceActions resourceActions,
 			List<ObjectAction> standaloneObjectActions)
 		throws Exception {
 
 		Document document = _readDocument(
-			objectActionLocalService, objectDefinition,
-			standaloneObjectActions);
+			attachmentObjectFields, objectActionLocalService, objectDefinition,
+			objectFieldLocalService, standaloneObjectActions);
 
 		try (SafeCloseable safeCloseable = CompanyThreadLocal.lock(
 				objectDefinition.getCompanyId())) {
@@ -69,7 +74,9 @@ public class ObjectDefinitionResourcePermissionUtil {
 
 	public static void removeResourceActions(
 			ObjectActionLocalService objectActionLocalService,
-			ObjectDefinition objectDefinition, ResourceActions resourceActions)
+			ObjectDefinition objectDefinition,
+			ObjectFieldLocalService objectFieldLocalService,
+			ResourceActions resourceActions)
 		throws Exception {
 
 		Document document = _objectDefinitionResourceActionDocumentsMap.remove(
@@ -77,7 +84,8 @@ public class ObjectDefinitionResourcePermissionUtil {
 
 		if (document == null) {
 			document = _readDocument(
-				objectActionLocalService, objectDefinition, null);
+				null, objectActionLocalService, objectDefinition,
+				objectFieldLocalService, null);
 		}
 
 		resourceActions.removeModelResources(document);
@@ -89,13 +97,17 @@ public class ObjectDefinitionResourcePermissionUtil {
 		ObjectActionLocalService objectActionLocalService,
 		long objectDefinitionId, List<ObjectAction> standaloneObjectActions) {
 
-		String objectActionPermissionKeys = StringPool.BLANK;
-
 		if (standaloneObjectActions == null) {
+			if (objectActionLocalService == null) {
+				return null;
+			}
+
 			standaloneObjectActions = objectActionLocalService.getObjectActions(
 				objectDefinitionId,
 				ObjectActionTriggerConstants.KEY_STANDALONE);
 		}
+
+		String objectActionPermissionKeys = StringPool.BLANK;
 
 		for (ObjectAction objectAction : standaloneObjectActions) {
 			objectActionPermissionKeys = StringBundler.concat(
@@ -104,6 +116,36 @@ public class ObjectDefinitionResourcePermissionUtil {
 		}
 
 		return objectActionPermissionKeys;
+	}
+
+	private static String _getObjectFieldPermissionKeys(
+			List<ObjectField> attachmentObjectFields, long objectDefinitionId,
+			ObjectFieldLocalService objectFieldLocalService)
+		throws Exception {
+
+		if (objectFieldLocalService == null) {
+			return null;
+		}
+
+		if (attachmentObjectFields == null) {
+			attachmentObjectFields =
+				objectFieldLocalService.getObjectFieldsByBusinessType(
+					objectDefinitionId,
+					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT);
+		}
+
+		String objectFieldPermissionKeys = StringPool.BLANK;
+
+		for (ObjectField objectField : attachmentObjectFields) {
+			objectFieldLocalService.
+				addOrUpdateObjectFieldResourceActionPLOEntries(objectField);
+
+			objectFieldPermissionKeys = StringBundler.concat(
+				objectFieldPermissionKeys, "<action-key>",
+				objectField.getAttachmentDownloadActionKey(), "</action-key>");
+		}
+
+		return objectFieldPermissionKeys;
 	}
 
 	private static String _getPermissionsGuestUnsupported(
@@ -147,14 +189,27 @@ public class ObjectDefinitionResourcePermissionUtil {
 	}
 
 	private static Document _readDocument(
+			List<ObjectField> attachmentObjectFields,
 			ObjectActionLocalService objectActionLocalService,
 			ObjectDefinition objectDefinition,
+			ObjectFieldLocalService objectFieldLocalService,
 			List<ObjectAction> standaloneObjectActions)
 		throws Exception {
 
 		String objectActionPermissionKeys = _getObjectActionPermissionKeys(
 			objectActionLocalService, objectDefinition.getObjectDefinitionId(),
 			standaloneObjectActions);
+
+		String objectFieldPermissionKeys = StringPool.BLANK;
+
+		if (FeatureFlagManagerUtil.isEnabled(
+				objectDefinition.getCompanyId(), "LPD-17564")) {
+
+			objectFieldPermissionKeys = _getObjectFieldPermissionKeys(
+				attachmentObjectFields,
+				objectDefinition.getObjectDefinitionId(),
+				objectFieldLocalService);
+		}
 
 		String resourceActionsFileName =
 			"resource-actions/resource-actions.xml.tpl";
@@ -184,7 +239,7 @@ public class ObjectDefinitionResourcePermissionUtil {
 					_getPermissionsGuestUnsupported(objectDefinition) +
 						objectActionPermissionKeys,
 					_getPermissionsSupports(objectDefinition) +
-						objectActionPermissionKeys,
+						objectActionPermissionKeys + objectFieldPermissionKeys,
 					objectDefinition.getPortletId(),
 					objectDefinition.getResourceName()
 				}));

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/security/permission/resource/util/ObjectDefinitionResourcePermissionUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/security/permission/resource/util/ObjectDefinitionResourcePermissionUtil.java
@@ -137,8 +137,8 @@ public class ObjectDefinitionResourcePermissionUtil {
 		String objectFieldPermissionKeys = StringPool.BLANK;
 
 		for (ObjectField objectField : objectFields) {
-			objectFieldLocalService.
-				addOrUpdateObjectFieldResourceActionPLOEntries(objectField);
+			objectFieldLocalService.addOrUpdateObjectFieldPLOEntries(
+				objectField);
 
 			objectFieldPermissionKeys = StringBundler.concat(
 				objectFieldPermissionKeys, "<action-key>",

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/field/util/ObjectFieldUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/field/util/ObjectFieldUtil.java
@@ -218,22 +218,23 @@ public class ObjectFieldUtil {
 			downloadURL, "objectEntryExternalReferenceCode",
 			objectEntry.getExternalReferenceCode());
 
-		if (FeatureFlagManagerUtil.isEnabled(
+		if (!FeatureFlagManagerUtil.isEnabled(
 				fileEntry.getCompanyId(), "LPD-17564")) {
 
-			if (!_hasDownloadPermission(
-					objectField.getAttachmentDownloadActionKey(), fileEntry,
-					objectEntry, objectEntryService, permissionChecker)) {
-
-				return StringPool.BLANK;
-			}
-
-			downloadURL = HttpComponentsUtil.addParameter(
-				downloadURL, "objectFieldExternalReferenceCode",
-				objectField.getExternalReferenceCode());
+			return downloadURL;
 		}
 
-		return downloadURL;
+		if (!fileEntry.containsPermission(
+				permissionChecker, ActionKeys.DOWNLOAD) ||
+			!objectEntryService.hasModelResourcePermission(
+				objectEntry, objectField.getAttachmentDownloadActionKey())) {
+
+			return StringPool.BLANK;
+		}
+
+		return HttpComponentsUtil.addParameter(
+			downloadURL, "objectFieldExternalReferenceCode",
+			objectField.getExternalReferenceCode());
 	}
 
 	public static String getCounterName(ObjectField objectField) {
@@ -452,23 +453,6 @@ public class ObjectFieldUtil {
 				_log.error(ddmExpressionException);
 			}
 		}
-	}
-
-	private static boolean _hasDownloadPermission(
-			String actionId, FileEntry fileEntry, ObjectEntry objectEntry,
-			ObjectEntryService objectEntryService,
-			PermissionChecker permissionChecker)
-		throws PortalException {
-
-		if (fileEntry.containsPermission(
-				permissionChecker, ActionKeys.DOWNLOAD) &&
-			objectEntryService.hasModelResourcePermission(
-				objectEntry, actionId)) {
-
-			return true;
-		}
-
-		return false;
 	}
 
 	private static void _validateNewValue(

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/field/util/ObjectFieldUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/field/util/ObjectFieldUtil.java
@@ -21,16 +21,20 @@ import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectFieldSetting;
 import com.liferay.object.service.ObjectEntryLocalServiceUtil;
+import com.liferay.object.service.ObjectEntryService;
 import com.liferay.object.service.ObjectFieldLocalServiceUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.DateUtil;
@@ -186,7 +190,9 @@ public class ObjectFieldUtil {
 	public static String getAttachmentDownloadURL(
 			DLURLHelper dlURLHelper, FileEntry fileEntry, long groupId,
 			String objectDefinitionExternalReferenceCode,
-			String objectEntryExternalReferenceCode, ThemeDisplay themeDisplay)
+			ObjectEntry objectEntry, ObjectEntryService objectEntryService,
+			ObjectField objectField, PermissionChecker permissionChecker,
+			ThemeDisplay themeDisplay)
 		throws PortalException {
 
 		String downloadURL = dlURLHelper.getDownloadURL(
@@ -210,7 +216,22 @@ public class ObjectFieldUtil {
 			objectDefinitionExternalReferenceCode);
 		downloadURL = HttpComponentsUtil.addParameter(
 			downloadURL, "objectEntryExternalReferenceCode",
-			objectEntryExternalReferenceCode);
+			objectEntry.getExternalReferenceCode());
+
+		if (FeatureFlagManagerUtil.isEnabled(
+				fileEntry.getCompanyId(), "LPD-17564")) {
+
+			if (!_hasDownloadPermission(
+					objectField.getAttachmentDownloadActionKey(), fileEntry,
+					objectEntry, objectEntryService, permissionChecker)) {
+
+				return StringPool.BLANK;
+			}
+
+			downloadURL = HttpComponentsUtil.addParameter(
+				downloadURL, "objectFieldExternalReferenceCode",
+				objectField.getExternalReferenceCode());
+		}
 
 		return downloadURL;
 	}
@@ -431,6 +452,23 @@ public class ObjectFieldUtil {
 				_log.error(ddmExpressionException);
 			}
 		}
+	}
+
+	private static boolean _hasDownloadPermission(
+			String actionId, FileEntry fileEntry, ObjectEntry objectEntry,
+			ObjectEntryService objectEntryService,
+			PermissionChecker permissionChecker)
+		throws PortalException {
+
+		if (fileEntry.containsPermission(
+				permissionChecker, ActionKeys.DOWNLOAD) &&
+			objectEntryService.hasModelResourcePermission(
+				objectEntry, actionId)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private static void _validateNewValue(

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectField.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectField.java
@@ -49,6 +49,8 @@ public interface ObjectField extends ObjectFieldModel, PersistedModel {
 
 	public boolean compareBusinessType(String businessType);
 
+	public String getAttachmentDownloadActionKey();
+
 	public String[] getDBColumnNames();
 
 	public String getI18nObjectFieldName();

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectFieldWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectFieldWrapper.java
@@ -245,6 +245,11 @@ public class ObjectFieldWrapper
 	}
 
 	@Override
+	public String getAttachmentDownloadActionKey() {
+		return model.getAttachmentDownloadActionKey();
+	}
+
+	@Override
 	public String[] getAvailableLanguageIds() {
 		return model.getAvailableLanguageIds();
 	}

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldLocalService.java
@@ -98,6 +98,10 @@ public interface ObjectFieldLocalService
 			List<ObjectFieldSetting> objectFieldSettings)
 		throws PortalException;
 
+	public void addOrUpdateObjectFieldResourceActionPLOEntries(
+			ObjectField objectField)
+		throws PortalException;
+
 	@Indexable(type = IndexableType.REINDEX)
 	public ObjectField addOrUpdateSystemObjectField(
 			String externalReferenceCode, long userId,
@@ -399,6 +403,10 @@ public interface ObjectFieldLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public Map<Long, List<ObjectField>> getObjectFieldsMap(long companyId);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public Map<Long, List<ObjectField>> getObjectFieldsMap(
+		long companyId, String businessType);
 
 	/**
 	 * Returns the OSGi service identifier.

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldLocalService.java
@@ -98,8 +98,7 @@ public interface ObjectFieldLocalService
 			List<ObjectFieldSetting> objectFieldSettings)
 		throws PortalException;
 
-	public void addOrUpdateObjectFieldResourceActionPLOEntries(
-			ObjectField objectField)
+	public void addOrUpdateObjectFieldPLOEntries(ObjectField objectField)
 		throws PortalException;
 
 	@Indexable(type = IndexableType.REINDEX)

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldLocalServiceUtil.java
@@ -89,6 +89,14 @@ public class ObjectFieldLocalServiceUtil {
 			readOnlyConditionExpression, required, state, objectFieldSettings);
 	}
 
+	public static void addOrUpdateObjectFieldResourceActionPLOEntries(
+			ObjectField objectField)
+		throws PortalException {
+
+		getService().addOrUpdateObjectFieldResourceActionPLOEntries(
+			objectField);
+	}
+
 	public static ObjectField addOrUpdateSystemObjectField(
 			String externalReferenceCode, long userId,
 			long listTypeDefinitionId, long objectDefinitionId,
@@ -509,6 +517,12 @@ public class ObjectFieldLocalServiceUtil {
 		long companyId) {
 
 		return getService().getObjectFieldsMap(companyId);
+	}
+
+	public static Map<Long, List<ObjectField>> getObjectFieldsMap(
+		long companyId, String businessType) {
+
+		return getService().getObjectFieldsMap(companyId, businessType);
 	}
 
 	/**

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldLocalServiceUtil.java
@@ -89,12 +89,10 @@ public class ObjectFieldLocalServiceUtil {
 			readOnlyConditionExpression, required, state, objectFieldSettings);
 	}
 
-	public static void addOrUpdateObjectFieldResourceActionPLOEntries(
-			ObjectField objectField)
+	public static void addOrUpdateObjectFieldPLOEntries(ObjectField objectField)
 		throws PortalException {
 
-		getService().addOrUpdateObjectFieldResourceActionPLOEntries(
-			objectField);
+		getService().addOrUpdateObjectFieldPLOEntries(objectField);
 	}
 
 	public static ObjectField addOrUpdateSystemObjectField(

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldLocalServiceWrapper.java
@@ -87,6 +87,15 @@ public class ObjectFieldLocalServiceWrapper
 	}
 
 	@Override
+	public void addOrUpdateObjectFieldResourceActionPLOEntries(
+			com.liferay.object.model.ObjectField objectField)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_objectFieldLocalService.addOrUpdateObjectFieldResourceActionPLOEntries(
+			objectField);
+	}
+
+	@Override
 	public com.liferay.object.model.ObjectField addOrUpdateSystemObjectField(
 			String externalReferenceCode, long userId,
 			long listTypeDefinitionId, long objectDefinitionId,
@@ -590,6 +599,15 @@ public class ObjectFieldLocalServiceWrapper
 			getObjectFieldsMap(long companyId) {
 
 		return _objectFieldLocalService.getObjectFieldsMap(companyId);
+	}
+
+	@Override
+	public java.util.Map
+		<Long, java.util.List<com.liferay.object.model.ObjectField>>
+			getObjectFieldsMap(long companyId, String businessType) {
+
+		return _objectFieldLocalService.getObjectFieldsMap(
+			companyId, businessType);
 	}
 
 	/**

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldLocalServiceWrapper.java
@@ -87,12 +87,11 @@ public class ObjectFieldLocalServiceWrapper
 	}
 
 	@Override
-	public void addOrUpdateObjectFieldResourceActionPLOEntries(
+	public void addOrUpdateObjectFieldPLOEntries(
 			com.liferay.object.model.ObjectField objectField)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
-		_objectFieldLocalService.addOrUpdateObjectFieldResourceActionPLOEntries(
-			objectField);
+		_objectFieldLocalService.addOrUpdateObjectFieldPLOEntries(objectField);
 	}
 
 	@Override

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/persistence/ObjectFieldPersistence.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/persistence/ObjectFieldPersistence.java
@@ -915,6 +915,161 @@ public interface ObjectFieldPersistence extends BasePersistence<ObjectField> {
 	public int countByC_U(long companyId, long userId);
 
 	/**
+	 * Returns all the object fields where companyId = &#63; and businessType = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @return the matching object fields
+	 */
+	public java.util.List<ObjectField> findByC_BT(
+		long companyId, String businessType);
+
+	/**
+	 * Returns a range of all the object fields where companyId = &#63; and businessType = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @return the range of matching object fields
+	 */
+	public java.util.List<ObjectField> findByC_BT(
+		long companyId, String businessType, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the object fields where companyId = &#63; and businessType = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching object fields
+	 */
+	public java.util.List<ObjectField> findByC_BT(
+		long companyId, String businessType, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<ObjectField>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the object fields where companyId = &#63; and businessType = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching object fields
+	 */
+	public java.util.List<ObjectField> findByC_BT(
+		long companyId, String businessType, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<ObjectField>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first object field in the ordered set where companyId = &#63; and businessType = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching object field
+	 * @throws NoSuchObjectFieldException if a matching object field could not be found
+	 */
+	public ObjectField findByC_BT_First(
+			long companyId, String businessType,
+			com.liferay.portal.kernel.util.OrderByComparator<ObjectField>
+				orderByComparator)
+		throws NoSuchObjectFieldException;
+
+	/**
+	 * Returns the first object field in the ordered set where companyId = &#63; and businessType = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching object field, or <code>null</code> if a matching object field could not be found
+	 */
+	public ObjectField fetchByC_BT_First(
+		long companyId, String businessType,
+		com.liferay.portal.kernel.util.OrderByComparator<ObjectField>
+			orderByComparator);
+
+	/**
+	 * Returns the last object field in the ordered set where companyId = &#63; and businessType = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching object field
+	 * @throws NoSuchObjectFieldException if a matching object field could not be found
+	 */
+	public ObjectField findByC_BT_Last(
+			long companyId, String businessType,
+			com.liferay.portal.kernel.util.OrderByComparator<ObjectField>
+				orderByComparator)
+		throws NoSuchObjectFieldException;
+
+	/**
+	 * Returns the last object field in the ordered set where companyId = &#63; and businessType = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching object field, or <code>null</code> if a matching object field could not be found
+	 */
+	public ObjectField fetchByC_BT_Last(
+		long companyId, String businessType,
+		com.liferay.portal.kernel.util.OrderByComparator<ObjectField>
+			orderByComparator);
+
+	/**
+	 * Returns the object fields before and after the current object field in the ordered set where companyId = &#63; and businessType = &#63;.
+	 *
+	 * @param objectFieldId the primary key of the current object field
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next object field
+	 * @throws NoSuchObjectFieldException if a object field with the primary key could not be found
+	 */
+	public ObjectField[] findByC_BT_PrevAndNext(
+			long objectFieldId, long companyId, String businessType,
+			com.liferay.portal.kernel.util.OrderByComparator<ObjectField>
+				orderByComparator)
+		throws NoSuchObjectFieldException;
+
+	/**
+	 * Removes all the object fields where companyId = &#63; and businessType = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 */
+	public void removeByC_BT(long companyId, String businessType);
+
+	/**
+	 * Returns the number of object fields where companyId = &#63; and businessType = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @return the number of matching object fields
+	 */
+	public int countByC_BT(long companyId, String businessType);
+
+	/**
 	 * Returns all the object fields where listTypeDefinitionId = &#63; and state = &#63;.
 	 *
 	 * @param listTypeDefinitionId the list type definition ID

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/persistence/ObjectFieldUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/persistence/ObjectFieldUtil.java
@@ -1167,6 +1167,193 @@ public class ObjectFieldUtil {
 	}
 
 	/**
+	 * Returns all the object fields where companyId = &#63; and businessType = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @return the matching object fields
+	 */
+	public static List<ObjectField> findByC_BT(
+		long companyId, String businessType) {
+
+		return getPersistence().findByC_BT(companyId, businessType);
+	}
+
+	/**
+	 * Returns a range of all the object fields where companyId = &#63; and businessType = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @return the range of matching object fields
+	 */
+	public static List<ObjectField> findByC_BT(
+		long companyId, String businessType, int start, int end) {
+
+		return getPersistence().findByC_BT(companyId, businessType, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the object fields where companyId = &#63; and businessType = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching object fields
+	 */
+	public static List<ObjectField> findByC_BT(
+		long companyId, String businessType, int start, int end,
+		OrderByComparator<ObjectField> orderByComparator) {
+
+		return getPersistence().findByC_BT(
+			companyId, businessType, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the object fields where companyId = &#63; and businessType = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching object fields
+	 */
+	public static List<ObjectField> findByC_BT(
+		long companyId, String businessType, int start, int end,
+		OrderByComparator<ObjectField> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByC_BT(
+			companyId, businessType, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first object field in the ordered set where companyId = &#63; and businessType = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching object field
+	 * @throws NoSuchObjectFieldException if a matching object field could not be found
+	 */
+	public static ObjectField findByC_BT_First(
+			long companyId, String businessType,
+			OrderByComparator<ObjectField> orderByComparator)
+		throws com.liferay.object.exception.NoSuchObjectFieldException {
+
+		return getPersistence().findByC_BT_First(
+			companyId, businessType, orderByComparator);
+	}
+
+	/**
+	 * Returns the first object field in the ordered set where companyId = &#63; and businessType = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching object field, or <code>null</code> if a matching object field could not be found
+	 */
+	public static ObjectField fetchByC_BT_First(
+		long companyId, String businessType,
+		OrderByComparator<ObjectField> orderByComparator) {
+
+		return getPersistence().fetchByC_BT_First(
+			companyId, businessType, orderByComparator);
+	}
+
+	/**
+	 * Returns the last object field in the ordered set where companyId = &#63; and businessType = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching object field
+	 * @throws NoSuchObjectFieldException if a matching object field could not be found
+	 */
+	public static ObjectField findByC_BT_Last(
+			long companyId, String businessType,
+			OrderByComparator<ObjectField> orderByComparator)
+		throws com.liferay.object.exception.NoSuchObjectFieldException {
+
+		return getPersistence().findByC_BT_Last(
+			companyId, businessType, orderByComparator);
+	}
+
+	/**
+	 * Returns the last object field in the ordered set where companyId = &#63; and businessType = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching object field, or <code>null</code> if a matching object field could not be found
+	 */
+	public static ObjectField fetchByC_BT_Last(
+		long companyId, String businessType,
+		OrderByComparator<ObjectField> orderByComparator) {
+
+		return getPersistence().fetchByC_BT_Last(
+			companyId, businessType, orderByComparator);
+	}
+
+	/**
+	 * Returns the object fields before and after the current object field in the ordered set where companyId = &#63; and businessType = &#63;.
+	 *
+	 * @param objectFieldId the primary key of the current object field
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next object field
+	 * @throws NoSuchObjectFieldException if a object field with the primary key could not be found
+	 */
+	public static ObjectField[] findByC_BT_PrevAndNext(
+			long objectFieldId, long companyId, String businessType,
+			OrderByComparator<ObjectField> orderByComparator)
+		throws com.liferay.object.exception.NoSuchObjectFieldException {
+
+		return getPersistence().findByC_BT_PrevAndNext(
+			objectFieldId, companyId, businessType, orderByComparator);
+	}
+
+	/**
+	 * Removes all the object fields where companyId = &#63; and businessType = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 */
+	public static void removeByC_BT(long companyId, String businessType) {
+		getPersistence().removeByC_BT(companyId, businessType);
+	}
+
+	/**
+	 * Returns the number of object fields where companyId = &#63; and businessType = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @return the number of matching object fields
+	 */
+	public static int countByC_BT(long companyId, String businessType) {
+		return getPersistence().countByC_BT(companyId, businessType);
+	}
+
+	/**
 	 * Returns all the object fields where listTypeDefinitionId = &#63; and state = &#63;.
 	 *
 	 * @param listTypeDefinitionId the list type definition ID

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/definition/security/permission/resource/util/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/definition/security/permission/resource/util/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 3.0.0

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/field/util/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/field/util/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 5.0.0

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/model/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/model/packageinfo
@@ -1,1 +1,1 @@
-version 12.3.0
+version 12.4.0

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/persistence/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 11.2.0
+version 11.3.0

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/attachment/AttachmentDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/attachment/AttachmentDDMFormFieldTemplateContextContributor.java
@@ -22,8 +22,6 @@ import com.liferay.object.dynamic.data.mapping.form.field.type.constants.ObjectD
 import com.liferay.object.field.attachment.AttachmentManager;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
-import com.liferay.object.model.ObjectEntry;
-import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectEntryService;
@@ -223,35 +221,32 @@ public class AttachmentDDMFormFieldTemplateContextContributor
 						return url;
 					}
 
-					String objectDefinitionERC = GetterUtil.getString(
-						ddmFormField.getProperty(
-							"objectDefinitionExternalReferenceCode"));
-
-					String objectEntryERC = GetterUtil.getString(
-						ddmFormField.getProperty(
-							"objectEntryExternalReferenceCode"));
-
 					long groupId = GetterUtil.getLong(
 						ddmFormField.getProperty("groupId"));
+
+					String objectDefinitionExternalReferenceCode =
+						GetterUtil.getString(
+							ddmFormField.getProperty(
+								"objectDefinitionExternalReferenceCode"));
 
 					ObjectDefinition objectDefinition =
 						_objectDefinitionLocalService.
 							fetchObjectDefinitionByExternalReferenceCode(
-								objectDefinitionERC, fileEntry.getCompanyId());
-
-					ObjectEntry objectEntry =
-						_objectEntryLocalService.fetchObjectEntry(
-							objectEntryERC, groupId,
-							objectDefinition.getObjectDefinitionId());
-
-					ObjectField objectField =
-						_objectFieldLocalService.fetchObjectField(
-							GetterUtil.getLong(
-								ddmFormField.getProperty("objectFieldId")));
+								objectDefinitionExternalReferenceCode,
+								fileEntry.getCompanyId());
 
 					return ObjectFieldUtil.getAttachmentDownloadURL(
-						_dlURLHelper, fileEntry, groupId, objectDefinitionERC,
-						objectEntry, _objectEntryService, objectField,
+						_dlURLHelper, fileEntry, groupId,
+						objectDefinitionExternalReferenceCode,
+						_objectEntryLocalService.fetchObjectEntry(
+							GetterUtil.getString(
+								ddmFormField.getProperty(
+									"objectEntryExternalReferenceCode")),
+							groupId, objectDefinition.getObjectDefinitionId()),
+						_objectEntryService,
+						_objectFieldLocalService.fetchObjectField(
+							GetterUtil.getLong(
+								ddmFormField.getProperty("objectFieldId"))),
 						_getPermissionChecker(themeDisplay), themeDisplay);
 				}
 			).put(

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/attachment/AttachmentDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/attachment/AttachmentDDMFormFieldTemplateContextContributor.java
@@ -21,6 +21,13 @@ import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.dynamic.data.mapping.form.field.type.constants.ObjectDDMFormFieldTypeConstants;
 import com.liferay.object.field.attachment.AttachmentManager;
 import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectEntryService;
+import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -34,6 +41,8 @@ import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.configuration.UploadServletRequestConfigurationProvider;
@@ -214,16 +223,36 @@ public class AttachmentDDMFormFieldTemplateContextContributor
 						return url;
 					}
 
+					String objectDefinitionERC = GetterUtil.getString(
+						ddmFormField.getProperty(
+							"objectDefinitionExternalReferenceCode"));
+
+					String objectEntryERC = GetterUtil.getString(
+						ddmFormField.getProperty(
+							"objectEntryExternalReferenceCode"));
+
+					long groupId = GetterUtil.getLong(
+						ddmFormField.getProperty("groupId"));
+
+					ObjectDefinition objectDefinition =
+						_objectDefinitionLocalService.
+							fetchObjectDefinitionByExternalReferenceCode(
+								objectDefinitionERC, fileEntry.getCompanyId());
+
+					ObjectEntry objectEntry =
+						_objectEntryLocalService.fetchObjectEntry(
+							objectEntryERC, groupId,
+							objectDefinition.getObjectDefinitionId());
+
+					ObjectField objectField =
+						_objectFieldLocalService.fetchObjectField(
+							GetterUtil.getLong(
+								ddmFormField.getProperty("objectFieldId")));
+
 					return ObjectFieldUtil.getAttachmentDownloadURL(
-						_dlURLHelper, fileEntry,
-						GetterUtil.getLong(ddmFormField.getProperty("groupId")),
-						GetterUtil.getString(
-							ddmFormField.getProperty(
-								"objectDefinitionExternalReferenceCode")),
-						GetterUtil.getString(
-							ddmFormField.getProperty(
-								"objectEntryExternalReferenceCode")),
-						themeDisplay);
+						_dlURLHelper, fileEntry, groupId, objectDefinitionERC,
+						objectEntry, _objectEntryService, objectField,
+						_getPermissionChecker(themeDisplay), themeDisplay);
 				}
 			).put(
 				"title", fileEntry.getFileName()
@@ -275,6 +304,17 @@ public class AttachmentDDMFormFieldTemplateContextContributor
 				_groupLocalService.fetchGroup(groupId), groupId,
 				portletNamespace + "selectAttachmentEntry",
 				fileItemSelectorCriterion));
+	}
+
+	private PermissionChecker _getPermissionChecker(ThemeDisplay themeDisplay) {
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (permissionChecker == null) {
+			permissionChecker = themeDisplay.getPermissionChecker();
+		}
+
+		return permissionChecker;
 	}
 
 	private String _getURL(
@@ -354,6 +394,18 @@ public class AttachmentDDMFormFieldTemplateContextContributor
 	private Language _language;
 
 	private volatile ObjectConfiguration _objectConfiguration;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private ObjectEntryService _objectEntryService;
+
+	@Reference
+	private ObjectFieldLocalService _objectFieldLocalService;
 
 	@Reference
 	private UploadServletRequestConfigurationProvider

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/Attachment.scss
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/Attachment.scss
@@ -30,34 +30,27 @@
 		gap: #{$gapTitleValue};
 		padding-top: #{$paddingTopTitle};
 
-		&:focus-within,
-		&:hover {
-			.lfr-objects__attachment-download {
-				color: black;
-				display: unset;
-				margin-bottom: #{$marginBottom};
-				margin-left: #{$marginLeft};
-				margin-right: #{$marginRight};
-			}
+		.lfr-objects__attachment-delete {
+			display: unset;
+			margin-bottom: #{$marginBottom};
+			margin-left: #{$marginLeft};
+			margin-right: #{$marginRight};
+		}
+
+		.lfr-objects__attachment-download {
+			display: unset;
+			margin-bottom: #{$marginBottom};
+			margin-left: #{$marginLeft};
 		}
 	}
 }
 
 .lfr-objects__attachment {
-	@include attachment(flex, 1rem, 1rem, 0, 0, 1rem, 0, 0);
+	@include attachment(flex, 1rem, 1rem, 0, 0, 5px, 0, 5px);
 }
 
 .col-ddm .col-md-4 {
 	.lfr-objects__attachment {
-		@include attachment(
-			block,
-			1rem,
-			0.2rem,
-			1rem,
-			5px,
-			0.5rem,
-			0.3rem,
-			0.5rem
-		);
+		@include attachment(block, 1rem, 0.2rem, 1rem, 5px, 0, 0.3rem, 0.5rem);
 	}
 }

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/FileContainer.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/FileContainer.tsx
@@ -4,7 +4,6 @@
  */
 
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
-import ClayIcon from '@clayui/icon';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import React from 'react';
 
@@ -35,23 +34,38 @@ export default function FileContainer({
 					<ClayButton
 						displayType="unstyled"
 						onClick={() => {
-							window.open(attachment.contentURL, '_blank');
+							if (attachment.contentURL) {
+								window.open(attachment.contentURL, '_blank');
+							}
 						}}
 					>
 						{attachment.title}
 					</ClayButton>
 
-					{Liferay.ThemeDisplay.isSignedIn() && (
-						<a
-							className="lfr-objects__attachment-download"
-							href={attachment.contentURL}
-						>
-							<ClayIcon symbol="download" />
-						</a>
-					)}
+					{Liferay.ThemeDisplay.isSignedIn() &&
+						attachment.contentURL && (
+							<div className="lfr-objects__attachment-download">
+								<ClayButtonWithIcon
+									aria-label={Liferay.Language.get(
+										'download'
+									)}
+									borderless
+									displayType="secondary"
+									monospaced
+									onClick={() =>
+										window.open(
+											attachment.contentURL,
+											'_blank'
+										)
+									}
+									symbol="download"
+									title={Liferay.Language.get('download')}
+								/>
+							</div>
+						)}
 
-					{!readOnly && (
-						<>
+					{!readOnly && attachment.title && (
+						<div className="lfr-objects__attachment-delete">
 							<ClayButtonWithIcon
 								aria-label={Liferay.Language.get('delete')}
 								borderless
@@ -61,7 +75,7 @@ export default function FileContainer({
 								symbol="times-circle-full"
 								title={Liferay.Language.get('delete')}
 							/>
-						</>
+						</div>
 					)}
 				</div>
 			</>

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/util/LinkUtil.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/util/LinkUtil.java
@@ -9,10 +9,14 @@ import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
 import com.liferay.object.rest.dto.v1_0.Link;
+import com.liferay.object.service.ObjectEntryService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.util.Portal;
 
 /**
@@ -23,8 +27,9 @@ public class LinkUtil {
 	public static Link toLink(
 		DLAppService dlAppService, DLFileEntry dlFileEntry,
 		DLURLHelper dlURLHelper, long groupId,
-		String objectDefinitionExternalReferenceCode,
-		String objectEntryExternalReferenceCode, Portal portal) {
+		String objectDefinitionExternalReferenceCode, ObjectEntry objectEntry,
+		ObjectEntryService objectEntryService, ObjectField objectField,
+		PermissionChecker permissionChecker, Portal portal) {
 
 		return new Link() {
 			{
@@ -36,7 +41,8 @@ public class LinkUtil {
 								dlAppService.getFileEntry(
 									dlFileEntry.getFileEntryId()),
 								groupId, objectDefinitionExternalReferenceCode,
-								objectEntryExternalReferenceCode, null);
+								objectEntry, objectEntryService, objectField,
+								permissionChecker, null);
 						}
 						catch (Exception exception) {
 							if (_log.isWarnEnabled()) {

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -81,6 +81,7 @@ import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.PermissionService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
@@ -837,8 +838,10 @@ public class ObjectEntryDTOConverter
 			() -> LinkUtil.toLink(
 				_dlAppService, dlFileEntry, _dlURLHelper,
 				objectEntry.getGroupId(),
-				objectDefinition.getExternalReferenceCode(),
-				objectEntry.getExternalReferenceCode(), _portal));
+				objectDefinition.getExternalReferenceCode(), objectEntry,
+				_objectEntryService, objectField,
+				GuestOrUserUtil.getPermissionChecker(), _portal));
+
 		fileEntry.setMetadata(
 			() -> NestedFieldsSupplier.supply(
 				objectFieldName + ".metadata",

--- a/modules/apps/object/object-service/service.xml
+++ b/modules/apps/object/object-service/service.xml
@@ -485,6 +485,10 @@
 			<finder-column name="companyId" />
 			<finder-column name="userId" />
 		</finder>
+		<finder name="C_BT" return-type="Collection">
+			<finder-column name="companyId" />
+			<finder-column name="businessType" />
+		</finder>
 		<finder name="LTDI_S" return-type="Collection">
 			<finder-column name="listTypeDefinitionId" />
 			<finder-column name="state" />

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -248,14 +248,14 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			serviceRegistrationsMap.put(
 				DBPartitionUtil.getPartitionKey(objectDefinitionId),
 				_deploy(
-					objectFieldsMap.getOrDefault(
+					objectActionsMap.getOrDefault(
 						objectDefinitionId, Collections.emptyList()),
 					objectDefinition,
+					objectFieldsMap.getOrDefault(
+						objectDefinitionId, Collections.emptyList()),
 					objectLayoutsMap.getOrDefault(
 						objectDefinitionId, Collections.emptyList()),
-					objectRelationshipsMap,
-					objectActionsMap.getOrDefault(
-						objectDefinitionId, Collections.emptyList())));
+					objectRelationshipsMap));
 		}
 
 		return serviceRegistrationsMap;
@@ -283,10 +283,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	}
 
 	private List<ServiceRegistration<?>> _deploy(
-		List<ObjectField> attachmentObjectFields,
-		ObjectDefinition objectDefinition, List<ObjectLayout> objectLayouts,
-		Map<Long, List<ObjectRelationship>> objectRelationshipsMap,
-		List<ObjectAction> standaloneObjectActions) {
+		List<ObjectAction> objectActions, ObjectDefinition objectDefinition,
+		List<ObjectField> objectFields, List<ObjectLayout> objectLayouts,
+		Map<Long, List<ObjectRelationship>> objectRelationshipsMap) {
 
 		if (objectDefinition.isUnmodifiableSystemObject()) {
 			return Collections.emptyList();
@@ -294,10 +293,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 		try {
 			ObjectDefinitionResourcePermissionUtil.populateResourceActions(
-				attachmentObjectFields, _objectActionLocalService,
-				objectDefinition, _objectFieldLocalService,
-				_portletLocalService, _resourceActions,
-				standaloneObjectActions);
+				_objectActionLocalService, objectActions, objectDefinition,
+				_objectFieldLocalService, objectFields, _portletLocalService,
+				_resourceActions);
 		}
 		catch (Exception exception) {
 			return ReflectionUtil.throwException(exception);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -14,6 +14,7 @@ import com.liferay.notification.handler.NotificationHandler;
 import com.liferay.notification.term.evaluator.NotificationTermEvaluator;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectDefinitionSettingConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.definition.security.permission.resource.util.ObjectDefinitionResourcePermissionUtil;
 import com.liferay.object.definition.tree.util.ObjectDefinitionTreeUtil;
 import com.liferay.object.deployer.ObjectDefinitionDeployer;
@@ -42,6 +43,7 @@ import com.liferay.object.internal.workflow.ObjectEntryWorkflowHandler;
 import com.liferay.object.model.ObjectAction;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectLayout;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.related.models.ObjectRelatedModelsPredicateProvider;
@@ -69,6 +71,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.db.partition.util.DBPartitionUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionLogic;
@@ -135,7 +138,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			dynamicQueryBatchIndexingActionableFactory,
 		GroupLocalService groupLocalService,
 		KaleoDefinitionLocalService kaleoDefinitionLocalService,
-		ListTypeLocalService listTypeLocalService,
+		Language language, ListTypeLocalService listTypeLocalService,
 		ObjectActionLocalService objectActionLocalService,
 		ObjectDefinitionLocalService objectDefinitionLocalService,
 		ObjectDefinitionSettingLocalService objectDefinitionSettingLocalService,
@@ -172,6 +175,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			dynamicQueryBatchIndexingActionableFactory;
 		_groupLocalService = groupLocalService;
 		_kaleoDefinitionLocalService = kaleoDefinitionLocalService;
+		_language = language;
 		_listTypeLocalService = listTypeLocalService;
 		_objectActionLocalService = objectActionLocalService;
 		_objectDefinitionLocalService = objectDefinitionLocalService;
@@ -216,10 +220,6 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		Map<String, List<ServiceRegistration<?>>> serviceRegistrationsMap =
 			new ConcurrentHashMap<>();
 
-		Map<Long, List<ObjectAction>> objectActionsMap =
-			_objectActionLocalService.getObjectActionsMap(
-				companyId, true, ObjectActionTriggerConstants.KEY_STANDALONE);
-
 		if (FeatureFlagManagerUtil.isEnabled(companyId, "LPD-34594")) {
 			ObjectDefinitionTreeUtil.populateRootObjectDefinitionIds(
 				objectDefinitions,
@@ -230,6 +230,12 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 							NAME_ROOT_OBJECT_DEFINITION_IDS));
 		}
 
+		Map<Long, List<ObjectAction>> objectActionsMap =
+			_objectActionLocalService.getObjectActionsMap(
+				companyId, true, ObjectActionTriggerConstants.KEY_STANDALONE);
+		Map<Long, List<ObjectField>> objectFieldsMap =
+			_objectFieldLocalService.getObjectFieldsMap(
+				companyId, ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT);
 		Map<Long, List<ObjectLayout>> objectLayoutsMap =
 			_objectLayoutLocalService.getObjectLayoutsMap(companyId);
 		Map<Long, List<ObjectRelationship>> objectRelationshipsMap =
@@ -242,6 +248,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			serviceRegistrationsMap.put(
 				DBPartitionUtil.getPartitionKey(objectDefinitionId),
 				_deploy(
+					objectFieldsMap.getOrDefault(
+						objectDefinitionId, Collections.emptyList()),
 					objectDefinition,
 					objectLayoutsMap.getOrDefault(
 						objectDefinitionId, Collections.emptyList()),
@@ -257,7 +265,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	public List<ServiceRegistration<?>> deploy(
 		ObjectDefinition objectDefinition) {
 
-		return _deploy(objectDefinition, null, null, null);
+		return _deploy(null, objectDefinition, null, null, null);
 	}
 
 	@Override
@@ -275,6 +283,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	}
 
 	private List<ServiceRegistration<?>> _deploy(
+		List<ObjectField> attachmentObjectFields,
 		ObjectDefinition objectDefinition, List<ObjectLayout> objectLayouts,
 		Map<Long, List<ObjectRelationship>> objectRelationshipsMap,
 		List<ObjectAction> standaloneObjectActions) {
@@ -285,7 +294,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 		try {
 			ObjectDefinitionResourcePermissionUtil.populateResourceActions(
-				_objectActionLocalService, objectDefinition,
+				attachmentObjectFields, _objectActionLocalService,
+				objectDefinition, _objectFieldLocalService,
 				_portletLocalService, _resourceActions,
 				standaloneObjectActions);
 		}
@@ -645,6 +655,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		_dynamicQueryBatchIndexingActionableFactory;
 	private final GroupLocalService _groupLocalService;
 	private final KaleoDefinitionLocalService _kaleoDefinitionLocalService;
+	private final Language _language;
 	private final ListTypeLocalService _listTypeLocalService;
 	private final ObjectActionLocalService _objectActionLocalService;
 	private final ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/feature/flag/AttachmentObjectFieldDownloadActionFeatureFlagListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/feature/flag/AttachmentObjectFieldDownloadActionFeatureFlagListener.java
@@ -1,0 +1,148 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.feature.flag;
+
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.definition.security.permission.resource.util.ObjectDefinitionResourcePermissionUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagListener;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
+import com.liferay.portal.kernel.security.permission.ResourceActions;
+import com.liferay.portal.kernel.service.PortletLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.language.override.service.PLOEntryLocalService;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Manuele Castro
+ */
+@Component(
+	property = "feature.flag.key=LPD-17564", service = FeatureFlagListener.class
+)
+public class AttachmentObjectFieldDownloadActionFeatureFlagListener
+	implements FeatureFlagListener {
+
+	@Override
+	public void onValue(
+		long companyId, String featureFlagKey, boolean enabled) {
+
+		if (!Objects.equals(featureFlagKey, "LPD-17564")) {
+			return;
+		}
+
+		List<ObjectDefinition> objectDefinitions =
+			_objectDefinitionLocalService.getObjectDefinitions(
+				companyId, WorkflowConstants.STATUS_APPROVED);
+
+		for (ObjectDefinition objectDefinition : objectDefinitions) {
+			List<ObjectField> objectFields =
+				_objectFieldLocalService.getObjectFieldsByBusinessType(
+					objectDefinition.getObjectDefinitionId(),
+					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT);
+
+			for (ObjectField objectField : objectFields) {
+				String actionId = objectField.getAttachmentDownloadActionKey();
+
+				if (enabled) {
+					ResourceAction resourceAction =
+						_resourceActionLocalService.fetchResourceAction(
+							objectDefinition.getClassName(), actionId);
+
+					if (resourceAction != null) {
+						continue;
+					}
+
+					try {
+						ObjectDefinitionResourcePermissionUtil.
+							populateResourceActions(
+								Collections.singletonList(objectField), null,
+								objectDefinition, _objectFieldLocalService,
+								_portletLocalService, _resourceActions, null);
+
+						_objectFieldLocalService.
+							addOrUpdateObjectFieldResourceActionPLOEntries(
+								objectField);
+
+						_updateResourcePermissions(actionId, objectDefinition);
+					}
+					catch (Exception exception) {
+						_log.error(exception);
+					}
+				}
+				else {
+					_resourceActions.removeModelResource(
+						objectDefinition.getClassName(), actionId);
+
+					_ploEntryLocalService.deletePLOEntries(
+						objectField.getCompanyId(), "action." + actionId);
+				}
+			}
+		}
+	}
+
+	private void _updateResourcePermissions(
+			String actionId, ObjectDefinition objectDefinition)
+		throws PortalException {
+
+		List<ResourcePermission> resourcePermissions =
+			_resourcePermissionLocalService.getResourcePermissions(
+				objectDefinition.getCompanyId(),
+				objectDefinition.getClassName(),
+				ResourceConstants.SCOPE_INDIVIDUAL);
+
+		for (ResourcePermission resourcePermission : resourcePermissions) {
+			if (!resourcePermission.hasActionId(actionId) &&
+				resourcePermission.isViewActionId()) {
+
+				resourcePermission.addResourceAction(actionId);
+
+				_resourcePermissionLocalService.updateResourcePermission(
+					resourcePermission);
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AttachmentObjectFieldDownloadActionFeatureFlagListener.class);
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectFieldLocalService _objectFieldLocalService;
+
+	@Reference
+	private PLOEntryLocalService _ploEntryLocalService;
+
+	@Reference
+	private PortletLocalService _portletLocalService;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourceActions _resourceActions;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/feature/flag/AttachmentObjectFieldDownloadActionFeatureFlagListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/feature/flag/AttachmentObjectFieldDownloadActionFeatureFlagListener.java
@@ -87,8 +87,7 @@ public class AttachmentObjectFieldDownloadActionFeatureFlagListener
 								_portletLocalService, _resourceActions);
 
 						_objectFieldLocalService.
-							addOrUpdateObjectFieldResourceActionPLOEntries(
-								objectField);
+							addOrUpdateObjectFieldPLOEntries(objectField);
 
 						for (ResourcePermission resourcePermission :
 								resourcePermissions) {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/feature/flag/AttachmentObjectFieldDownloadActionFeatureFlagListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/feature/flag/AttachmentObjectFieldDownloadActionFeatureFlagListener.java
@@ -11,7 +11,6 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagListener;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -59,13 +58,21 @@ public class AttachmentObjectFieldDownloadActionFeatureFlagListener
 					objectDefinition.getObjectDefinitionId(),
 					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT);
 
+			List<ResourcePermission> resourcePermissions =
+				_resourcePermissionLocalService.getResourcePermissions(
+					objectDefinition.getCompanyId(),
+					objectDefinition.getClassName(),
+					ResourceConstants.SCOPE_INDIVIDUAL);
+
 			for (ObjectField objectField : objectFields) {
-				String actionId = objectField.getAttachmentDownloadActionKey();
+				String attachmentDownloadActionKey =
+					objectField.getAttachmentDownloadActionKey();
 
 				if (enabled) {
 					ResourceAction resourceAction =
 						_resourceActionLocalService.fetchResourceAction(
-							objectDefinition.getClassName(), actionId);
+							objectDefinition.getClassName(),
+							attachmentDownloadActionKey);
 
 					if (resourceAction != null) {
 						continue;
@@ -83,41 +90,35 @@ public class AttachmentObjectFieldDownloadActionFeatureFlagListener
 							addOrUpdateObjectFieldResourceActionPLOEntries(
 								objectField);
 
-						_updateResourcePermissions(actionId, objectDefinition);
+						for (ResourcePermission resourcePermission :
+								resourcePermissions) {
+
+							if (!resourcePermission.hasActionId(
+									attachmentDownloadActionKey) &&
+								resourcePermission.isViewActionId()) {
+
+								resourcePermission.addResourceAction(
+									attachmentDownloadActionKey);
+
+								_resourcePermissionLocalService.
+									updateResourcePermission(
+										resourcePermission);
+							}
+						}
 					}
 					catch (Exception exception) {
 						_log.error(exception);
 					}
 				}
 				else {
-					_resourceActions.removeModelResource(
-						objectDefinition.getClassName(), actionId);
-
 					_ploEntryLocalService.deletePLOEntries(
-						objectField.getCompanyId(), "action." + actionId);
+						objectField.getCompanyId(),
+						"action." + attachmentDownloadActionKey);
+
+					_resourceActions.removeModelResource(
+						objectDefinition.getClassName(),
+						attachmentDownloadActionKey);
 				}
-			}
-		}
-	}
-
-	private void _updateResourcePermissions(
-			String actionId, ObjectDefinition objectDefinition)
-		throws PortalException {
-
-		List<ResourcePermission> resourcePermissions =
-			_resourcePermissionLocalService.getResourcePermissions(
-				objectDefinition.getCompanyId(),
-				objectDefinition.getClassName(),
-				ResourceConstants.SCOPE_INDIVIDUAL);
-
-		for (ResourcePermission resourcePermission : resourcePermissions) {
-			if (!resourcePermission.hasActionId(actionId) &&
-				resourcePermission.isViewActionId()) {
-
-				resourcePermission.addResourceAction(actionId);
-
-				_resourcePermissionLocalService.updateResourcePermission(
-					resourcePermission);
 			}
 		}
 	}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/feature/flag/AttachmentObjectFieldDownloadActionFeatureFlagListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/feature/flag/AttachmentObjectFieldDownloadActionFeatureFlagListener.java
@@ -74,9 +74,10 @@ public class AttachmentObjectFieldDownloadActionFeatureFlagListener
 					try {
 						ObjectDefinitionResourcePermissionUtil.
 							populateResourceActions(
-								Collections.singletonList(objectField), null,
-								objectDefinition, _objectFieldLocalService,
-								_portletLocalService, _resourceActions, null);
+								null, null, objectDefinition,
+								_objectFieldLocalService,
+								Collections.singletonList(objectField),
+								_portletLocalService, _resourceActions);
 
 						_objectFieldLocalService.
 							addOrUpdateObjectFieldResourceActionPLOEntries(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectDLFileEntryModelResourcePermissionConfigurator.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectDLFileEntryModelResourcePermissionConfigurator.java
@@ -54,8 +54,8 @@ public class ObjectDLFileEntryModelResourcePermissionConfigurator
 
 		consumer.accept(
 			(permissionChecker, name, dlFileEntry, actionId) -> {
-				if (!actionId.equals(ActionKeys.DOWNLOAD) &&
-					FeatureFlagManagerUtil.isEnabled(
+				if (!actionId.equals(ActionKeys.DOWNLOAD) ||
+					!FeatureFlagManagerUtil.isEnabled(
 						dlFileEntry.getCompanyId(), "LPD-17564")) {
 
 					return null;
@@ -65,14 +65,14 @@ public class ObjectDLFileEntryModelResourcePermissionConfigurator
 					ServiceContextThreadLocal.getServiceContext();
 
 				if (serviceContext == null) {
-					return _handleInvalidContext(dlFileEntry);
+					return _validateObjectDefinitionClassName(dlFileEntry);
 				}
 
 				HttpServletRequest httpServletRequest =
 					serviceContext.getRequest();
 
 				if (httpServletRequest == null) {
-					return _handleInvalidContext(dlFileEntry);
+					return _validateObjectDefinitionClassName(dlFileEntry);
 				}
 
 				boolean download = ParamUtil.getBoolean(
@@ -82,89 +82,88 @@ public class ObjectDLFileEntryModelResourcePermissionConfigurator
 					return null;
 				}
 
+				long companyId = PortalUtil.getCompanyId(httpServletRequest);
+
+				ObjectDefinition objectDefinition =
+					_objectDefinitionLocalService.
+						fetchObjectDefinitionByExternalReferenceCode(
+							ParamUtil.getString(
+								httpServletRequest,
+								"objectDefinitionExternalReferenceCode"),
+							companyId);
+
+				if (objectDefinition == null) {
+					return _validateObjectDefinitionClassName(dlFileEntry);
+				}
+
+				long groupId = ObjectDefinitionConstants.GROUP_ID_DEFAULT;
+
+				Group group =
+					_groupLocalService.fetchGroupByExternalReferenceCode(
+						ParamUtil.getString(
+							httpServletRequest, "groupExternalReferenceCode"),
+						companyId);
+
+				if (group != null) {
+					groupId = group.getGroupId();
+				}
+
+				ObjectEntry objectEntry =
+					_objectEntryLocalService.fetchObjectEntry(
+						ParamUtil.getString(
+							httpServletRequest,
+							"objectEntryExternalReferenceCode"),
+						groupId, objectDefinition.getObjectDefinitionId());
+
+				if (objectEntry == null) {
+					return _validateObjectDefinitionClassName(dlFileEntry);
+				}
+
 				String objectFieldExternalReferenceCode = ParamUtil.getString(
 					httpServletRequest, "objectFieldExternalReferenceCode");
 
-				if (Validator.isNotNull(objectFieldExternalReferenceCode)) {
-					long companyId = PortalUtil.getCompanyId(
-						httpServletRequest);
-
-					ObjectDefinition objectDefinition =
-						_objectDefinitionLocalService.
-							fetchObjectDefinitionByExternalReferenceCode(
-								ParamUtil.getString(
-									httpServletRequest,
-									"objectDefinitionExternalReferenceCode"),
-								companyId);
-
-					if (objectDefinition == null) {
-						return _handleInvalidContext(dlFileEntry);
-					}
-
-					long groupId = ObjectDefinitionConstants.GROUP_ID_DEFAULT;
-
-					Group group =
-						_groupLocalService.fetchGroupByExternalReferenceCode(
-							ParamUtil.getString(
-								httpServletRequest,
-								"groupExternalReferenceCode"),
-							companyId);
-
-					if (group != null) {
-						groupId = group.getGroupId();
-					}
-
-					long objectDefinitionId =
-						objectDefinition.getObjectDefinitionId();
-
-					ObjectEntry objectEntry =
-						_objectEntryLocalService.fetchObjectEntry(
-							ParamUtil.getString(
-								httpServletRequest,
-								"objectEntryExternalReferenceCode"),
-							groupId, objectDefinitionId);
-
-					if (objectEntry == null) {
-						return _handleInvalidContext(dlFileEntry);
-					}
-
-					ObjectField objectField =
-						_objectFieldLocalService.fetchObjectField(
-							objectFieldExternalReferenceCode,
-							objectDefinitionId);
-
-					if (objectField == null) {
-						return _handleInvalidContext(dlFileEntry);
-					}
-
-					ModelResourcePermission<?>
-						objectEntryModelResourcePermission =
-							ModelResourcePermissionRegistryUtil.
-								getModelResourcePermission(
-									objectDefinition.getClassName());
-
-					if ((objectEntryModelResourcePermission == null) ||
-						(objectEntryModelResourcePermission.contains(
-							permissionChecker, objectEntry.getObjectEntryId(),
-							ActionKeys.VIEW) &&
-						 objectEntryModelResourcePermission.contains(
-							 permissionChecker, objectEntry.getObjectEntryId(),
-							 objectField.getAttachmentDownloadActionKey()))) {
-
-						return null;
-					}
-
-					return false;
+				if (Validator.isNull(objectFieldExternalReferenceCode)) {
+					return _validateObjectDefinitionClassName(dlFileEntry);
 				}
 
-				return _handleInvalidContext(dlFileEntry);
+				ObjectField objectField =
+					_objectFieldLocalService.fetchObjectField(
+						objectFieldExternalReferenceCode,
+						objectDefinition.getObjectDefinitionId());
+
+				if (objectField == null) {
+					return _validateObjectDefinitionClassName(dlFileEntry);
+				}
+
+				ModelResourcePermission<?> objectEntryModelResourcePermission =
+					ModelResourcePermissionRegistryUtil.
+						getModelResourcePermission(
+							objectDefinition.getClassName());
+
+				if ((objectEntryModelResourcePermission == null) ||
+					(objectEntryModelResourcePermission.contains(
+						permissionChecker, objectEntry.getObjectEntryId(),
+						ActionKeys.VIEW) &&
+					 objectEntryModelResourcePermission.contains(
+						 permissionChecker, objectEntry.getObjectEntryId(),
+						 objectField.getAttachmentDownloadActionKey()))) {
+
+					return null;
+				}
+
+				return false;
 			});
 	}
 
-	private Boolean _handleInvalidContext(DLFileEntry dlFileEntry) {
+	private Boolean _validateObjectDefinitionClassName(
+		DLFileEntry dlFileEntry) {
+
 		String className = dlFileEntry.getClassName();
 
-		if (!className.contains("com.liferay.object.model.ObjectDefinition#")) {
+		if (!className.startsWith(
+				ObjectDefinitionConstants.
+					CLASS_NAME_PREFIX_CUSTOM_OBJECT_DEFINITION)) {
+
 			return null;
 		}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectDLFileEntryModelResourcePermissionConfigurator.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectDLFileEntryModelResourcePermissionConfigurator.java
@@ -1,0 +1,191 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.security.permission.resource;
+
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionFactory;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionLogic;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionRegistryUtil;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.function.Consumer;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Manuele Castro
+ */
+@Component(
+	property = "model.class.name=com.liferay.document.library.kernel.model.DLFileEntry",
+	service = ModelResourcePermissionFactory.ModelResourcePermissionConfigurator.class
+)
+public class ObjectDLFileEntryModelResourcePermissionConfigurator
+	implements ModelResourcePermissionFactory.
+				   ModelResourcePermissionConfigurator<DLFileEntry> {
+
+	@Override
+	public void configureModelResourcePermissionLogics(
+		ModelResourcePermission<DLFileEntry> modelResourcePermission,
+		Consumer<ModelResourcePermissionLogic<DLFileEntry>> consumer) {
+
+		consumer.accept(
+			(permissionChecker, name, dlFileEntry, actionId) -> {
+				if (!actionId.equals(ActionKeys.DOWNLOAD) &&
+					FeatureFlagManagerUtil.isEnabled(
+						dlFileEntry.getCompanyId(), "LPD-17564")) {
+
+					return null;
+				}
+
+				ServiceContext serviceContext =
+					ServiceContextThreadLocal.getServiceContext();
+
+				if (serviceContext == null) {
+					return _handleInvalidContext(dlFileEntry);
+				}
+
+				HttpServletRequest httpServletRequest =
+					serviceContext.getRequest();
+
+				if (httpServletRequest == null) {
+					return _handleInvalidContext(dlFileEntry);
+				}
+
+				boolean download = ParamUtil.getBoolean(
+					httpServletRequest, "download");
+
+				if (!download) {
+					return null;
+				}
+
+				String objectFieldExternalReferenceCode = ParamUtil.getString(
+					httpServletRequest, "objectFieldExternalReferenceCode");
+
+				if (Validator.isNotNull(objectFieldExternalReferenceCode)) {
+					long companyId = PortalUtil.getCompanyId(
+						httpServletRequest);
+
+					ObjectDefinition objectDefinition =
+						_objectDefinitionLocalService.
+							fetchObjectDefinitionByExternalReferenceCode(
+								ParamUtil.getString(
+									httpServletRequest,
+									"objectDefinitionExternalReferenceCode"),
+								companyId);
+
+					if (objectDefinition == null) {
+						return _handleInvalidContext(dlFileEntry);
+					}
+
+					long groupId = ObjectDefinitionConstants.GROUP_ID_DEFAULT;
+
+					Group group =
+						_groupLocalService.fetchGroupByExternalReferenceCode(
+							ParamUtil.getString(
+								httpServletRequest,
+								"groupExternalReferenceCode"),
+							companyId);
+
+					if (group != null) {
+						groupId = group.getGroupId();
+					}
+
+					long objectDefinitionId =
+						objectDefinition.getObjectDefinitionId();
+
+					ObjectEntry objectEntry =
+						_objectEntryLocalService.fetchObjectEntry(
+							ParamUtil.getString(
+								httpServletRequest,
+								"objectEntryExternalReferenceCode"),
+							groupId, objectDefinitionId);
+
+					if (objectEntry == null) {
+						return _handleInvalidContext(dlFileEntry);
+					}
+
+					ObjectField objectField =
+						_objectFieldLocalService.fetchObjectField(
+							objectFieldExternalReferenceCode,
+							objectDefinitionId);
+
+					if (objectField == null) {
+						return _handleInvalidContext(dlFileEntry);
+					}
+
+					ModelResourcePermission<?>
+						objectEntryModelResourcePermission =
+							ModelResourcePermissionRegistryUtil.
+								getModelResourcePermission(
+									objectDefinition.getClassName());
+
+					if ((objectEntryModelResourcePermission == null) ||
+						(objectEntryModelResourcePermission.contains(
+							permissionChecker, objectEntry.getObjectEntryId(),
+							ActionKeys.VIEW) &&
+						 objectEntryModelResourcePermission.contains(
+							 permissionChecker, objectEntry.getObjectEntryId(),
+							 objectField.getAttachmentDownloadActionKey()))) {
+
+						return null;
+					}
+
+					return false;
+				}
+
+				return _handleInvalidContext(dlFileEntry);
+			});
+	}
+
+	private Boolean _handleInvalidContext(DLFileEntry dlFileEntry) {
+		String className = dlFileEntry.getClassName();
+
+		if (!className.contains("com.liferay.object.model.ObjectDefinition#")) {
+			return null;
+		}
+
+		_log.error("Unable to verify download permission for " + className);
+
+		return false;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ObjectDLFileEntryModelResourcePermissionConfigurator.class);
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private ObjectFieldLocalService _objectFieldLocalService;
+
+}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectEntryModelResourcePermission.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectEntryModelResourcePermission.java
@@ -22,6 +22,7 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
@@ -129,7 +130,10 @@ public class ObjectEntryModelResourcePermission
 
 		if ((objectEntry.getRootObjectEntryId() != 0) &&
 			!_isObjectActionName(
-				actionId, objectEntry.getObjectDefinitionId())) {
+				actionId, objectEntry.getObjectDefinitionId()) &&
+			!_isObjectFieldName(
+				actionId, objectEntry.getCompanyId(),
+				objectEntry.getObjectDefinitionId())) {
 
 			ObjectEntry rootObjectEntry =
 				_objectEntryLocalService.fetchObjectEntry(
@@ -296,6 +300,28 @@ public class ObjectEntryModelResourcePermission
 					ObjectActionTriggerConstants.KEY_STANDALONE)) {
 
 			if (Objects.equals(objectAction.getName(), actionId)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private boolean _isObjectFieldName(
+		String actionId, long companyId, long objectDefinitionId) {
+
+		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-17564")) {
+			return false;
+		}
+
+		for (ObjectField objectField :
+				_objectFieldLocalService.getObjectFieldsByBusinessType(
+					objectDefinitionId,
+					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
+
+			if (Objects.equals(
+					objectField.getAttachmentDownloadActionKey(), actionId)) {
+
 				return true;
 			}
 		}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectFieldImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectFieldImpl.java
@@ -15,8 +15,11 @@ import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectFieldSettingLocalServiceUtil;
 import com.liferay.object.service.ObjectRelationshipLocalServiceUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -32,6 +35,16 @@ public class ObjectFieldImpl extends ObjectFieldBaseImpl {
 	@Override
 	public boolean compareBusinessType(String businessType) {
 		return Objects.equals(getBusinessType(), businessType);
+	}
+
+	@Override
+	public String getAttachmentDownloadActionKey() {
+		return StringBundler.concat(
+			ActionKeys.DOWNLOAD, StringPool.UNDERLINE,
+			getName(
+			).replaceAll(
+				"(?<!^)([A-Z])", "_$1"
+			).toUpperCase());
 	}
 
 	@Override

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectFieldImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectFieldImpl.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.List;
@@ -39,12 +40,13 @@ public class ObjectFieldImpl extends ObjectFieldBaseImpl {
 
 	@Override
 	public String getAttachmentDownloadActionKey() {
+		String name = getName();
+
+		String nameWithUnderscore = name.replaceAll("(?<!^)([A-Z])", "_$1");
+
 		return StringBundler.concat(
 			ActionKeys.DOWNLOAD, StringPool.UNDERLINE,
-			getName(
-			).replaceAll(
-				"(?<!^)([A-Z])", "_$1"
-			).toUpperCase());
+			StringUtil.toUpperCase(nameWithUnderscore));
 	}
 
 	@Override

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectActionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectActionLocalServiceImpl.java
@@ -172,7 +172,7 @@ public class ObjectActionLocalServiceImpl
 
 			try {
 				ObjectDefinitionResourcePermissionUtil.populateResourceActions(
-					objectActionLocalService, objectDefinition,
+					null, objectActionLocalService, objectDefinition, null,
 					_portletLocalService, _resourceActions, null);
 			}
 			catch (Exception exception) {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectActionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectActionLocalServiceImpl.java
@@ -172,8 +172,8 @@ public class ObjectActionLocalServiceImpl
 
 			try {
 				ObjectDefinitionResourcePermissionUtil.populateResourceActions(
-					null, objectActionLocalService, objectDefinition, null,
-					_portletLocalService, _resourceActions, null);
+					objectActionLocalService, null, objectDefinition, null,
+					null, _portletLocalService, _resourceActions);
 			}
 			catch (Exception exception) {
 				ReflectionUtil.throwException(exception);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -698,7 +698,7 @@ public class ObjectDefinitionLocalServiceImpl
 
 				ObjectDefinitionResourcePermissionUtil.removeResourceActions(
 					_objectActionLocalService, objectDefinition,
-					_resourceActions);
+					_objectFieldLocalService, _resourceActions);
 			}
 			catch (Exception exception) {
 				throw new PortalException(exception);
@@ -1060,7 +1060,7 @@ public class ObjectDefinitionLocalServiceImpl
 				_accountEntryOrganizationRelLocalService,
 				_assetEntryLocalService, _bundleContext,
 				_dynamicQueryBatchIndexingActionableFactory, _groupLocalService,
-				_kaleoDefinitionLocalService, _listTypeLocalService,
+				_kaleoDefinitionLocalService, _language, _listTypeLocalService,
 				_objectActionLocalService, objectDefinitionLocalService,
 				_objectDefinitionSettingLocalService,
 				_objectEntryFolderLocalService, _objectEntryLocalService,

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -13,6 +13,7 @@ import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.constants.ObjectValidationRuleSettingConstants;
+import com.liferay.object.definition.security.permission.resource.util.ObjectDefinitionResourcePermissionUtil;
 import com.liferay.object.definition.util.ObjectDefinitionUtil;
 import com.liferay.object.definition.util.ObjectDefinitionValidationThreadLocal;
 import com.liferay.object.exception.DuplicateObjectFieldExternalReferenceCodeException;
@@ -79,11 +80,19 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
+import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
+import com.liferay.portal.kernel.security.permission.ResourceActions;
+import com.liferay.portal.kernel.service.PortletLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.Base64;
@@ -344,6 +353,24 @@ public class ObjectFieldLocalServiceImpl
 
 				counterLocalService.reset(
 					ObjectFieldUtil.getCounterName(objectField));
+			}
+
+			if (FeatureFlagManagerUtil.isEnabled(
+					objectField.getCompanyId(), "LPD-17564") &&
+				objectField.compareBusinessType(
+					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
+
+				String actionId = objectField.getAttachmentDownloadActionKey();
+
+				_ploEntryLocalService.deletePLOEntries(
+					objectField.getCompanyId(), "action." + actionId);
+
+				ObjectDefinition objectDefinition =
+					_objectDefinitionPersistence.findByPrimaryKey(
+						objectField.getObjectDefinitionId());
+
+				_resourceActions.removeModelResource(
+					objectDefinition.getClassName(), actionId);
 			}
 
 			_objectFieldSettingLocalService.deleteObjectFieldObjectFieldSetting(
@@ -967,6 +994,25 @@ public class ObjectFieldLocalServiceImpl
 			return objectField;
 		}
 
+		if (FeatureFlagManagerUtil.isEnabled(
+				objectField.getCompanyId(), "LPD-17564") &&
+			objectField.compareBusinessType(
+				ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
+
+			try {
+				ObjectDefinitionResourcePermissionUtil.populateResourceActions(
+					null, null, objectDefinition, objectFieldLocalService,
+					_portletLocalService, _resourceActions, null);
+
+				_updateResourcePermissions(
+					objectField.getAttachmentDownloadActionKey(),
+					objectDefinition);
+			}
+			catch (Exception exception) {
+				ReflectionUtil.throwException(exception);
+			}
+		}
+
 		if (!objectField.compareBusinessType(
 				ObjectFieldConstants.BUSINESS_TYPE_AGGREGATION) &&
 			!objectField.compareBusinessType(
@@ -1205,6 +1251,19 @@ public class ObjectFieldLocalServiceImpl
 		if (Objects.equals(
 				objectField.getBusinessType(),
 				ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
+
+			if (FeatureFlagManagerUtil.isEnabled(
+					objectField.getCompanyId(), "LPD-17564") &&
+				objectDefinition.isApproved()) {
+
+				String actionId = objectField.getAttachmentDownloadActionKey();
+
+				_ploEntryLocalService.deletePLOEntries(
+					objectField.getCompanyId(), "action." + actionId);
+
+				_resourceActions.removeModelResource(
+					objectDefinition.getClassName(), actionId);
+			}
 
 			ObjectFieldSetting objectFieldSetting =
 				_objectFieldSettingPersistence.fetchByOFI_N(
@@ -1566,6 +1625,14 @@ public class ObjectFieldLocalServiceImpl
 				newObjectField, objectDefinition, objectFieldBusinessType,
 				objectFieldSettings, oldObjectField);
 
+			if (FeatureFlagManagerUtil.isEnabled(
+					newObjectField.getCompanyId(), "LPD-17564") &&
+				businessType.equals(
+					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
+
+				addOrUpdateObjectFieldResourceActionPLOEntries(newObjectField);
+			}
+
 			return newObjectField;
 		}
 
@@ -1594,6 +1661,29 @@ public class ObjectFieldLocalServiceImpl
 			objectFieldSettings, oldObjectField);
 
 		return newObjectField;
+	}
+
+	private void _updateResourcePermissions(
+			String actionId, ObjectDefinition objectDefinition)
+		throws PortalException {
+
+		Role role = _roleLocalService.getRole(
+			objectDefinition.getCompanyId(), RoleConstants.OWNER);
+
+		List<ResourcePermission> resourcePermissions =
+			_resourcePermissionLocalService.getResourcePermissions(
+				objectDefinition.getCompanyId(),
+				objectDefinition.getClassName(),
+				ResourceConstants.SCOPE_INDIVIDUAL, role.getRoleId(), true);
+
+		for (ResourcePermission resourcePermission : resourcePermissions) {
+			if (!resourcePermission.hasActionId(actionId)) {
+				resourcePermission.addResourceAction(actionId);
+
+				_resourcePermissionLocalService.updateResourcePermission(
+					resourcePermission);
+			}
+		}
 	}
 
 	private void _validateBusinessType(
@@ -2111,6 +2201,9 @@ public class ObjectFieldLocalServiceImpl
 	@Reference
 	private PLOEntryLocalService _ploEntryLocalService;
 
+	@Reference
+	private PortletLocalService _portletLocalService;
+
 	private final Set<String> _readOnlyObjectFieldNames = SetUtil.fromArray(
 		"createDate", "creator", "id", "modifiedDate", "status");
 	private final Set<String> _reservedNames = SetUtil.fromArray(
@@ -2120,6 +2213,15 @@ public class ObjectFieldLocalServiceImpl
 		"modifieddate", "reviewdate", "status", "statusbyuserid",
 		"statusbyusername", "statusdate", "taxonomycategoryids", "userid",
 		"username");
+
+	@Reference
+	private ResourceActions _resourceActions;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
 
 	@Reference
 	private SystemObjectDefinitionManagerRegistry

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -96,6 +96,7 @@ import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.language.override.service.PLOEntryLocalService;
 
 import java.io.Serializable;
 
@@ -198,6 +199,22 @@ public class ObjectFieldLocalServiceImpl
 			indexedAsKeyword, indexedLanguageId, labelMap, localized, name,
 			readOnly, readOnlyConditionExpression, required, state,
 			objectFieldSettings);
+	}
+
+	@Override
+	public void addOrUpdateObjectFieldResourceActionPLOEntries(
+			ObjectField objectField)
+		throws PortalException {
+
+		for (Locale locale : _language.getAvailableLocales()) {
+			String actionId = objectField.getAttachmentDownloadActionKey();
+
+			_ploEntryLocalService.addOrUpdatePLOEntry(
+				objectField.getCompanyId(), objectField.getUserId(),
+				"action." + actionId, LocaleUtil.toLanguageId(locale),
+				_language.format(
+					locale, "download-x", objectField.getLabel(locale)));
+		}
 	}
 
 	@Indexable(type = IndexableType.REINDEX)
@@ -2090,6 +2107,9 @@ public class ObjectFieldLocalServiceImpl
 
 	@Reference
 	private ObjectViewLocalService _objectViewLocalService;
+
+	@Reference
+	private PLOEntryLocalService _ploEntryLocalService;
 
 	private final Set<String> _readOnlyObjectFieldNames = SetUtil.fromArray(
 		"createDate", "creator", "id", "modifiedDate", "status");

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -210,17 +210,17 @@ public class ObjectFieldLocalServiceImpl
 			objectFieldSettings);
 	}
 
-	@Override
-	public void addOrUpdateObjectFieldResourceActionPLOEntries(
-			ObjectField objectField)
+	public void addOrUpdateObjectFieldPLOEntries(ObjectField objectField)
 		throws PortalException {
 
 		for (Locale locale : _language.getAvailableLocales()) {
-			String actionId = objectField.getAttachmentDownloadActionKey();
+			String attachmentDownloadActionKey =
+				objectField.getAttachmentDownloadActionKey();
 
 			_ploEntryLocalService.addOrUpdatePLOEntry(
 				objectField.getCompanyId(), objectField.getUserId(),
-				"action." + actionId, LocaleUtil.toLanguageId(locale),
+				"action." + attachmentDownloadActionKey,
+				LocaleUtil.toLanguageId(locale),
 				_language.format(
 					locale, "download-x", objectField.getLabel(locale)));
 		}
@@ -338,6 +338,9 @@ public class ObjectFieldLocalServiceImpl
 	public void deleteObjectFieldByObjectDefinitionId(Long objectDefinitionId)
 		throws PortalException {
 
+		ObjectDefinition objectDefinition =
+			_objectDefinitionPersistence.findByPrimaryKey(objectDefinitionId);
+
 		for (ObjectField objectField :
 				objectFieldPersistence.findByObjectDefinitionId(
 					objectDefinitionId)) {
@@ -348,29 +351,29 @@ public class ObjectFieldLocalServiceImpl
 
 			objectFieldPersistence.remove(objectField);
 
+			if (FeatureFlagManagerUtil.isEnabled(
+					objectField.getCompanyId(), "LPD-17564") &&
+				objectDefinition.isApproved() &&
+				objectField.compareBusinessType(
+					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
+
+				String attachmentDownloadActionKey =
+					objectField.getAttachmentDownloadActionKey();
+
+				_ploEntryLocalService.deletePLOEntries(
+					objectField.getCompanyId(),
+					"action." + attachmentDownloadActionKey);
+
+				_resourceActions.removeModelResource(
+					objectDefinition.getClassName(),
+					attachmentDownloadActionKey);
+			}
+
 			if (objectField.compareBusinessType(
 					ObjectFieldConstants.BUSINESS_TYPE_AUTO_INCREMENT)) {
 
 				counterLocalService.reset(
 					ObjectFieldUtil.getCounterName(objectField));
-			}
-
-			if (FeatureFlagManagerUtil.isEnabled(
-					objectField.getCompanyId(), "LPD-17564") &&
-				objectField.compareBusinessType(
-					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
-
-				String actionId = objectField.getAttachmentDownloadActionKey();
-
-				_ploEntryLocalService.deletePLOEntries(
-					objectField.getCompanyId(), "action." + actionId);
-
-				ObjectDefinition objectDefinition =
-					_objectDefinitionPersistence.findByPrimaryKey(
-						objectField.getObjectDefinitionId());
-
-				_resourceActions.removeModelResource(
-					objectDefinition.getClassName(), actionId);
 			}
 
 			_objectFieldSettingLocalService.deleteObjectFieldObjectFieldSetting(
@@ -1004,7 +1007,7 @@ public class ObjectFieldLocalServiceImpl
 					null, null, objectDefinition, objectFieldLocalService, null,
 					_portletLocalService, _resourceActions);
 
-				_updateResourcePermissions(
+				_updateResourcePermission(
 					objectField.getAttachmentDownloadActionKey(),
 					objectDefinition);
 			}
@@ -1256,13 +1259,16 @@ public class ObjectFieldLocalServiceImpl
 					objectField.getCompanyId(), "LPD-17564") &&
 				objectDefinition.isApproved()) {
 
-				String actionId = objectField.getAttachmentDownloadActionKey();
+				String attachmentDownloadActionKey =
+					objectField.getAttachmentDownloadActionKey();
 
 				_ploEntryLocalService.deletePLOEntries(
-					objectField.getCompanyId(), "action." + actionId);
+					objectField.getCompanyId(),
+					"action." + attachmentDownloadActionKey);
 
 				_resourceActions.removeModelResource(
-					objectDefinition.getClassName(), actionId);
+					objectDefinition.getClassName(),
+					attachmentDownloadActionKey);
 			}
 
 			ObjectFieldSetting objectFieldSetting =
@@ -1630,7 +1636,7 @@ public class ObjectFieldLocalServiceImpl
 				businessType.equals(
 					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
 
-				addOrUpdateObjectFieldResourceActionPLOEntries(newObjectField);
+				addOrUpdateObjectFieldPLOEntries(newObjectField);
 			}
 
 			return newObjectField;
@@ -1663,7 +1669,7 @@ public class ObjectFieldLocalServiceImpl
 		return newObjectField;
 	}
 
-	private void _updateResourcePermissions(
+	private void _updateResourcePermission(
 			String actionId, ObjectDefinition objectDefinition)
 		throws PortalException {
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -1001,8 +1001,8 @@ public class ObjectFieldLocalServiceImpl
 
 			try {
 				ObjectDefinitionResourcePermissionUtil.populateResourceActions(
-					null, null, objectDefinition, objectFieldLocalService,
-					_portletLocalService, _resourceActions, null);
+					null, null, objectDefinition, objectFieldLocalService, null,
+					_portletLocalService, _resourceActions);
 
 				_updateResourcePermissions(
 					objectField.getAttachmentDownloadActionKey(),

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -568,6 +568,25 @@ public class ObjectFieldLocalServiceImpl
 	}
 
 	@Override
+	public Map<Long, List<ObjectField>> getObjectFieldsMap(
+		long companyId, String businessType) {
+
+		Map<Long, List<ObjectField>> objectFieldsMap = new HashMap<>();
+
+		for (ObjectField objectField :
+				objectFieldPersistence.findByC_BT(companyId, businessType)) {
+
+			List<ObjectField> objectFields = objectFieldsMap.computeIfAbsent(
+				objectField.getObjectDefinitionId(),
+				objectDefinitionId -> new ArrayList<>());
+
+			objectFields.add(objectField);
+		}
+
+		return objectFieldsMap;
+	}
+
+	@Override
 	public Table getTable(long objectDefinitionId, String name)
 		throws PortalException {
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/persistence/impl/ObjectFieldPersistenceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/persistence/impl/ObjectFieldPersistenceImpl.java
@@ -3258,6 +3258,588 @@ public class ObjectFieldPersistenceImpl
 	private static final String _FINDER_COLUMN_C_U_USERID_2 =
 		"objectField.userId = ?";
 
+	private FinderPath _finderPathWithPaginationFindByC_BT;
+	private FinderPath _finderPathWithoutPaginationFindByC_BT;
+	private FinderPath _finderPathCountByC_BT;
+
+	/**
+	 * Returns all the object fields where companyId = &#63; and businessType = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @return the matching object fields
+	 */
+	@Override
+	public List<ObjectField> findByC_BT(long companyId, String businessType) {
+		return findByC_BT(
+			companyId, businessType, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+			null);
+	}
+
+	/**
+	 * Returns a range of all the object fields where companyId = &#63; and businessType = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @return the range of matching object fields
+	 */
+	@Override
+	public List<ObjectField> findByC_BT(
+		long companyId, String businessType, int start, int end) {
+
+		return findByC_BT(companyId, businessType, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the object fields where companyId = &#63; and businessType = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching object fields
+	 */
+	@Override
+	public List<ObjectField> findByC_BT(
+		long companyId, String businessType, int start, int end,
+		OrderByComparator<ObjectField> orderByComparator) {
+
+		return findByC_BT(
+			companyId, businessType, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the object fields where companyId = &#63; and businessType = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectFieldModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @param start the lower bound of the range of object fields
+	 * @param end the upper bound of the range of object fields (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching object fields
+	 */
+	@Override
+	public List<ObjectField> findByC_BT(
+		long companyId, String businessType, int start, int end,
+		OrderByComparator<ObjectField> orderByComparator,
+		boolean useFinderCache) {
+
+		businessType = Objects.toString(businessType, "");
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			if (useFinderCache) {
+				finderPath = _finderPathWithoutPaginationFindByC_BT;
+				finderArgs = new Object[] {companyId, businessType};
+			}
+		}
+		else if (useFinderCache) {
+			finderPath = _finderPathWithPaginationFindByC_BT;
+			finderArgs = new Object[] {
+				companyId, businessType, start, end, orderByComparator
+			};
+		}
+
+		List<ObjectField> list = null;
+
+		if (useFinderCache) {
+			list = (List<ObjectField>)finderCache.getResult(
+				finderPath, finderArgs, this);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (ObjectField objectField : list) {
+					if ((companyId != objectField.getCompanyId()) ||
+						!businessType.equals(objectField.getBusinessType())) {
+
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler sb = null;
+
+			if (orderByComparator != null) {
+				sb = new StringBundler(
+					4 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				sb = new StringBundler(4);
+			}
+
+			sb.append(_SQL_SELECT_OBJECTFIELD_WHERE);
+
+			sb.append(_FINDER_COLUMN_C_BT_COMPANYID_2);
+
+			boolean bindBusinessType = false;
+
+			if (businessType.isEmpty()) {
+				sb.append(_FINDER_COLUMN_C_BT_BUSINESSTYPE_3);
+			}
+			else {
+				bindBusinessType = true;
+
+				sb.append(_FINDER_COLUMN_C_BT_BUSINESSTYPE_2);
+			}
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else {
+				sb.append(ObjectFieldModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(companyId);
+
+				if (bindBusinessType) {
+					queryPos.add(businessType);
+				}
+
+				list = (List<ObjectField>)QueryUtil.list(
+					query, getDialect(), start, end);
+
+				cacheResult(list);
+
+				if (useFinderCache) {
+					finderCache.putResult(finderPath, finderArgs, list);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first object field in the ordered set where companyId = &#63; and businessType = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching object field
+	 * @throws NoSuchObjectFieldException if a matching object field could not be found
+	 */
+	@Override
+	public ObjectField findByC_BT_First(
+			long companyId, String businessType,
+			OrderByComparator<ObjectField> orderByComparator)
+		throws NoSuchObjectFieldException {
+
+		ObjectField objectField = fetchByC_BT_First(
+			companyId, businessType, orderByComparator);
+
+		if (objectField != null) {
+			return objectField;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("companyId=");
+		sb.append(companyId);
+
+		sb.append(", businessType=");
+		sb.append(businessType);
+
+		sb.append("}");
+
+		throw new NoSuchObjectFieldException(sb.toString());
+	}
+
+	/**
+	 * Returns the first object field in the ordered set where companyId = &#63; and businessType = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching object field, or <code>null</code> if a matching object field could not be found
+	 */
+	@Override
+	public ObjectField fetchByC_BT_First(
+		long companyId, String businessType,
+		OrderByComparator<ObjectField> orderByComparator) {
+
+		List<ObjectField> list = findByC_BT(
+			companyId, businessType, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last object field in the ordered set where companyId = &#63; and businessType = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching object field
+	 * @throws NoSuchObjectFieldException if a matching object field could not be found
+	 */
+	@Override
+	public ObjectField findByC_BT_Last(
+			long companyId, String businessType,
+			OrderByComparator<ObjectField> orderByComparator)
+		throws NoSuchObjectFieldException {
+
+		ObjectField objectField = fetchByC_BT_Last(
+			companyId, businessType, orderByComparator);
+
+		if (objectField != null) {
+			return objectField;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("companyId=");
+		sb.append(companyId);
+
+		sb.append(", businessType=");
+		sb.append(businessType);
+
+		sb.append("}");
+
+		throw new NoSuchObjectFieldException(sb.toString());
+	}
+
+	/**
+	 * Returns the last object field in the ordered set where companyId = &#63; and businessType = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching object field, or <code>null</code> if a matching object field could not be found
+	 */
+	@Override
+	public ObjectField fetchByC_BT_Last(
+		long companyId, String businessType,
+		OrderByComparator<ObjectField> orderByComparator) {
+
+		int count = countByC_BT(companyId, businessType);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<ObjectField> list = findByC_BT(
+			companyId, businessType, count - 1, count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the object fields before and after the current object field in the ordered set where companyId = &#63; and businessType = &#63;.
+	 *
+	 * @param objectFieldId the primary key of the current object field
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next object field
+	 * @throws NoSuchObjectFieldException if a object field with the primary key could not be found
+	 */
+	@Override
+	public ObjectField[] findByC_BT_PrevAndNext(
+			long objectFieldId, long companyId, String businessType,
+			OrderByComparator<ObjectField> orderByComparator)
+		throws NoSuchObjectFieldException {
+
+		businessType = Objects.toString(businessType, "");
+
+		ObjectField objectField = findByPrimaryKey(objectFieldId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			ObjectField[] array = new ObjectFieldImpl[3];
+
+			array[0] = getByC_BT_PrevAndNext(
+				session, objectField, companyId, businessType,
+				orderByComparator, true);
+
+			array[1] = objectField;
+
+			array[2] = getByC_BT_PrevAndNext(
+				session, objectField, companyId, businessType,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected ObjectField getByC_BT_PrevAndNext(
+		Session session, ObjectField objectField, long companyId,
+		String businessType, OrderByComparator<ObjectField> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				5 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(4);
+		}
+
+		sb.append(_SQL_SELECT_OBJECTFIELD_WHERE);
+
+		sb.append(_FINDER_COLUMN_C_BT_COMPANYID_2);
+
+		boolean bindBusinessType = false;
+
+		if (businessType.isEmpty()) {
+			sb.append(_FINDER_COLUMN_C_BT_BUSINESSTYPE_3);
+		}
+		else {
+			bindBusinessType = true;
+
+			sb.append(_FINDER_COLUMN_C_BT_BUSINESSTYPE_2);
+		}
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(ObjectFieldModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(companyId);
+
+		if (bindBusinessType) {
+			queryPos.add(businessType);
+		}
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(objectField)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<ObjectField> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the object fields where companyId = &#63; and businessType = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 */
+	@Override
+	public void removeByC_BT(long companyId, String businessType) {
+		for (ObjectField objectField :
+				findByC_BT(
+					companyId, businessType, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null)) {
+
+			remove(objectField);
+		}
+	}
+
+	/**
+	 * Returns the number of object fields where companyId = &#63; and businessType = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param businessType the business type
+	 * @return the number of matching object fields
+	 */
+	@Override
+	public int countByC_BT(long companyId, String businessType) {
+		businessType = Objects.toString(businessType, "");
+
+		FinderPath finderPath = _finderPathCountByC_BT;
+
+		Object[] finderArgs = new Object[] {companyId, businessType};
+
+		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
+
+		if (count == null) {
+			StringBundler sb = new StringBundler(3);
+
+			sb.append(_SQL_COUNT_OBJECTFIELD_WHERE);
+
+			sb.append(_FINDER_COLUMN_C_BT_COMPANYID_2);
+
+			boolean bindBusinessType = false;
+
+			if (businessType.isEmpty()) {
+				sb.append(_FINDER_COLUMN_C_BT_BUSINESSTYPE_3);
+			}
+			else {
+				bindBusinessType = true;
+
+				sb.append(_FINDER_COLUMN_C_BT_BUSINESSTYPE_2);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(companyId);
+
+				if (bindBusinessType) {
+					queryPos.add(businessType);
+				}
+
+				count = (Long)query.uniqueResult();
+
+				finderCache.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_C_BT_COMPANYID_2 =
+		"objectField.companyId = ? AND ";
+
+	private static final String _FINDER_COLUMN_C_BT_BUSINESSTYPE_2 =
+		"objectField.businessType = ?";
+
+	private static final String _FINDER_COLUMN_C_BT_BUSINESSTYPE_3 =
+		"(objectField.businessType IS NULL OR objectField.businessType = '')";
+
 	private FinderPath _finderPathWithPaginationFindByLTDI_S;
 	private FinderPath _finderPathWithoutPaginationFindByLTDI_S;
 	private FinderPath _finderPathCountByLTDI_S;
@@ -9017,6 +9599,25 @@ public class ObjectFieldPersistenceImpl
 			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_U",
 			new String[] {Long.class.getName(), Long.class.getName()},
 			new String[] {"companyId", "userId"}, false);
+
+		_finderPathWithPaginationFindByC_BT = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_BT",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "businessType"}, true);
+
+		_finderPathWithoutPaginationFindByC_BT = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_BT",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "businessType"}, true);
+
+		_finderPathCountByC_BT = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_BT",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"companyId", "businessType"}, false);
 
 		_finderPathWithPaginationFindByLTDI_S = new FinderPath(
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByLTDI_S",

--- a/modules/apps/object/object-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/object/object-service/src/main/resources/META-INF/sql/indexes.sql
@@ -46,6 +46,7 @@ create index IX_7D343B19 on ObjectEntryVersion (objectEntryId, status);
 create unique index IX_50DA0035 on ObjectEntryVersion (objectEntryId, version);
 create index IX_5C2CDBC9 on ObjectEntryVersion (uuid_[$COLUMN_LENGTH:75$]);
 
+create index IX_57E61DF5 on ObjectField (companyId, businessType[$COLUMN_LENGTH:75$]);
 create index IX_EAECE0E1 on ObjectField (companyId, userId);
 create index IX_6DCE835D on ObjectField (listTypeDefinitionId, state_);
 create index IX_87111650 on ObjectField (objectDefinitionId, businessType[$COLUMN_LENGTH:75$]);

--- a/modules/apps/object/object-service/src/main/resources/service.properties
+++ b/modules/apps/object/object-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.object.service
-    build.number=8
-    build.date=1758712203480
+    build.number=9
+    build.date=1761945337018

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/feature/flag/test/AttachmentObjectFieldDownloadActionFeatureFlagListenerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/feature/flag/test/AttachmentObjectFieldDownloadActionFeatureFlagListenerTest.java
@@ -67,7 +67,7 @@ public class AttachmentObjectFieldDownloadActionFeatureFlagListenerTest {
 		new LiferayIntegrationTestRule();
 
 	@Test
-	public void testOnValue() throws Exception {
+	public void test() throws Exception {
 		ObjectField objectField = ObjectFieldUtil.createObjectField(
 			ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT,
 			ObjectFieldConstants.DB_TYPE_LONG, true, false, null,
@@ -97,13 +97,6 @@ public class AttachmentObjectFieldDownloadActionFeatureFlagListenerTest {
 			ObjectDefinitionTestUtil.publishObjectDefinition(
 				Collections.singletonList(objectField));
 
-		long companyId = objectDefinition.getCompanyId();
-
-		String name = objectDefinition.getClassName();
-
-		Role powerUserRole = _roleLocalService.getRole(
-			companyId, RoleConstants.POWER_USER);
-
 		ObjectEntry objectEntry =
 			_objectEntryLocalService.addOrUpdateObjectEntry(
 				RandomTestUtil.randomString(), 0, TestPropsValues.getUserId(),
@@ -120,27 +113,35 @@ public class AttachmentObjectFieldDownloadActionFeatureFlagListenerTest {
 				).build(),
 				ServiceContextTestUtil.getServiceContext());
 
-		String primKey = String.valueOf(objectEntry.getObjectEntryId());
+		Role powerUserRole = _roleLocalService.getRole(
+			objectDefinition.getCompanyId(), RoleConstants.POWER_USER);
 
 		_resourcePermissionLocalService.setResourcePermissions(
-			companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
+			objectDefinition.getCompanyId(), objectDefinition.getClassName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(objectEntry.getObjectEntryId()),
 			powerUserRole.getRoleId(), new String[] {ActionKeys.VIEW});
 
 		FeatureFlagTestUtil.invokeFeatureFlagListeners(
-			companyId, false, "LPD-17564");
+			objectDefinition.getCompanyId(), false, "LPD-17564");
 
-		String actionId = objectField.getAttachmentDownloadActionKey();
+		String attachmentDownloadActionKey =
+			objectField.getAttachmentDownloadActionKey();
 
 		Assert.assertNull(
-			_resourceActionLocalService.fetchResourceAction(name, actionId));
+			_resourceActionLocalService.fetchResourceAction(
+				objectDefinition.getClassName(), attachmentDownloadActionKey));
 
 		Role ownerRole = _roleLocalService.getRole(
-			companyId, RoleConstants.OWNER);
+			objectDefinition.getCompanyId(), RoleConstants.OWNER);
 
 		try {
 			_resourcePermissionLocalService.hasResourcePermission(
-				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
-				ownerRole.getRoleId(), actionId);
+				objectDefinition.getCompanyId(),
+				objectDefinition.getClassName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(objectEntry.getObjectEntryId()),
+				ownerRole.getRoleId(), attachmentDownloadActionKey);
 		}
 		catch (Exception exception) {
 			Assert.assertTrue(
@@ -149,8 +150,11 @@ public class AttachmentObjectFieldDownloadActionFeatureFlagListenerTest {
 
 		try {
 			_resourcePermissionLocalService.hasResourcePermission(
-				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
-				powerUserRole.getRoleId(), actionId);
+				objectDefinition.getCompanyId(),
+				objectDefinition.getClassName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(objectEntry.getObjectEntryId()),
+				powerUserRole.getRoleId(), attachmentDownloadActionKey);
 		}
 		catch (Exception exception) {
 			Assert.assertTrue(
@@ -158,39 +162,52 @@ public class AttachmentObjectFieldDownloadActionFeatureFlagListenerTest {
 		}
 
 		FeatureFlagTestUtil.invokeFeatureFlagListeners(
-			companyId, true, "LPD-17564");
+			objectDefinition.getCompanyId(), true, "LPD-17564");
 
 		Assert.assertNotNull(
-			_resourceActionLocalService.fetchResourceAction(name, actionId));
+			_resourceActionLocalService.fetchResourceAction(
+				objectDefinition.getClassName(), attachmentDownloadActionKey));
 
 		Role guestRole = _roleLocalService.getRole(
-			companyId, RoleConstants.GUEST);
+			objectDefinition.getCompanyId(), RoleConstants.GUEST);
 
 		Assert.assertFalse(
 			_resourcePermissionLocalService.hasResourcePermission(
-				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
-				guestRole.getRoleId(), actionId));
+				objectDefinition.getCompanyId(),
+				objectDefinition.getClassName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(objectEntry.getObjectEntryId()),
+				guestRole.getRoleId(), attachmentDownloadActionKey));
 
 		Role userRole = _roleLocalService.getRole(
-			companyId, RoleConstants.USER);
+			objectDefinition.getCompanyId(), RoleConstants.USER);
 
 		Assert.assertFalse(
 			_resourcePermissionLocalService.hasResourcePermission(
-				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
-				userRole.getRoleId(), actionId));
+				objectDefinition.getCompanyId(),
+				objectDefinition.getClassName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(objectEntry.getObjectEntryId()),
+				userRole.getRoleId(), attachmentDownloadActionKey));
 
 		Assert.assertTrue(
 			_resourcePermissionLocalService.hasResourcePermission(
-				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
-				ownerRole.getRoleId(), actionId));
+				objectDefinition.getCompanyId(),
+				objectDefinition.getClassName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(objectEntry.getObjectEntryId()),
+				ownerRole.getRoleId(), attachmentDownloadActionKey));
 
 		Assert.assertTrue(
 			_resourcePermissionLocalService.hasResourcePermission(
-				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
-				powerUserRole.getRoleId(), actionId));
+				objectDefinition.getCompanyId(),
+				objectDefinition.getClassName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(objectEntry.getObjectEntryId()),
+				powerUserRole.getRoleId(), attachmentDownloadActionKey));
 
 		FeatureFlagTestUtil.invokeFeatureFlagListeners(
-			companyId, false, "LPD-17564");
+			objectDefinition.getCompanyId(), false, "LPD-17564");
 	}
 
 	private DLFileEntry _addDLFileEntry() throws Exception {

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/feature/flag/test/AttachmentObjectFieldDownloadActionFeatureFlagListenerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/feature/flag/test/AttachmentObjectFieldDownloadActionFeatureFlagListenerTest.java
@@ -1,0 +1,228 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.feature.flag.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.constants.ObjectFieldSettingConstants;
+import com.liferay.object.field.setting.builder.ObjectFieldSettingBuilder;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.NoSuchResourceActionException;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.FeatureFlagTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.TempFileEntryUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.io.ByteArrayInputStream;
+import java.io.Serializable;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Manuele Castro
+ */
+@FeatureFlag("LPD-17564")
+@RunWith(Arquillian.class)
+public class AttachmentObjectFieldDownloadActionFeatureFlagListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testOnValue() throws Exception {
+		ObjectField objectField = ObjectFieldUtil.createObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT,
+			ObjectFieldConstants.DB_TYPE_LONG, true, false, null,
+			RandomTestUtil.randomString(), "attachment",
+			Arrays.asList(
+				new ObjectFieldSettingBuilder(
+				).name(
+					ObjectFieldSettingConstants.NAME_ACCEPTED_FILE_EXTENSIONS
+				).value(
+					"jpg, jpeg, png, svg, txt"
+				).build(),
+				new ObjectFieldSettingBuilder(
+				).name(
+					ObjectFieldSettingConstants.NAME_FILE_SOURCE
+				).value(
+					ObjectFieldSettingConstants.VALUE_USER_COMPUTER
+				).build(),
+				new ObjectFieldSettingBuilder(
+				).name(
+					ObjectFieldSettingConstants.NAME_MAX_FILE_SIZE
+				).value(
+					"100"
+				).build()),
+			false);
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(objectField));
+
+		long companyId = objectDefinition.getCompanyId();
+
+		String name = objectDefinition.getClassName();
+
+		Role powerUserRole = _roleLocalService.getRole(
+			companyId, RoleConstants.POWER_USER);
+
+		ObjectEntry objectEntry =
+			_objectEntryLocalService.addOrUpdateObjectEntry(
+				RandomTestUtil.randomString(), 0, TestPropsValues.getUserId(),
+				objectDefinition.getObjectDefinitionId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				HashMapBuilder.<String, Serializable>put(
+					"attachment",
+					() -> {
+						DLFileEntry dlFileEntry = _addDLFileEntry();
+
+						return String.valueOf(dlFileEntry.getFileEntryId());
+					}
+				).build(),
+				ServiceContextTestUtil.getServiceContext());
+
+		String primKey = String.valueOf(objectEntry.getObjectEntryId());
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
+			powerUserRole.getRoleId(), new String[] {ActionKeys.VIEW});
+
+		FeatureFlagTestUtil.invokeFeatureFlagListeners(
+			companyId, false, "LPD-17564");
+
+		String actionId = objectField.getAttachmentDownloadActionKey();
+
+		Assert.assertNull(
+			_resourceActionLocalService.fetchResourceAction(name, actionId));
+
+		Role ownerRole = _roleLocalService.getRole(
+			companyId, RoleConstants.OWNER);
+
+		try {
+			_resourcePermissionLocalService.hasResourcePermission(
+				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
+				ownerRole.getRoleId(), actionId);
+		}
+		catch (Exception exception) {
+			Assert.assertTrue(
+				exception instanceof NoSuchResourceActionException);
+		}
+
+		try {
+			_resourcePermissionLocalService.hasResourcePermission(
+				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
+				powerUserRole.getRoleId(), actionId);
+		}
+		catch (Exception exception) {
+			Assert.assertTrue(
+				exception instanceof NoSuchResourceActionException);
+		}
+
+		FeatureFlagTestUtil.invokeFeatureFlagListeners(
+			companyId, true, "LPD-17564");
+
+		Assert.assertNotNull(
+			_resourceActionLocalService.fetchResourceAction(name, actionId));
+
+		Role guestRole = _roleLocalService.getRole(
+			companyId, RoleConstants.GUEST);
+
+		Assert.assertFalse(
+			_resourcePermissionLocalService.hasResourcePermission(
+				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
+				guestRole.getRoleId(), actionId));
+
+		Role userRole = _roleLocalService.getRole(
+			companyId, RoleConstants.USER);
+
+		Assert.assertFalse(
+			_resourcePermissionLocalService.hasResourcePermission(
+				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
+				userRole.getRoleId(), actionId));
+
+		Assert.assertTrue(
+			_resourcePermissionLocalService.hasResourcePermission(
+				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
+				ownerRole.getRoleId(), actionId));
+
+		Assert.assertTrue(
+			_resourcePermissionLocalService.hasResourcePermission(
+				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
+				powerUserRole.getRoleId(), actionId));
+
+		FeatureFlagTestUtil.invokeFeatureFlagListeners(
+			companyId, false, "LPD-17564");
+	}
+
+	private DLFileEntry _addDLFileEntry() throws Exception {
+		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			TempFileEntryUtil.getTempFileName("image.jpg"),
+			ContentTypes.APPLICATION_TEXT, RandomTestUtil.randomString(),
+			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
+			new ByteArrayInputStream(RandomTestUtil.randomBytes()), 67, null,
+			null, null, ServiceContextTestUtil.getServiceContext());
+
+		return _dlFileEntryLocalService.getFileEntry(
+			fileEntry.getFileEntryId());
+	}
+
+	@Inject
+	private DLAppLocalService _dlAppLocalService;
+
+	@Inject
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/security/permission/resource/test/ObjectDLFileEntryModelResourcePermissionConfiguratorTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/security/permission/resource/test/ObjectDLFileEntryModelResourcePermissionConfiguratorTest.java
@@ -32,9 +32,11 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
@@ -146,6 +148,17 @@ public class ObjectDLFileEntryModelResourcePermissionConfiguratorTest {
 
 		_themeDisplay.setCompany(_company);
 
+		_originalName = PrincipalThreadLocal.getName();
+		_originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		_user = UserLocalServiceUtil.getGuestUser(_company.getCompanyId());
+
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(_user));
+
+		PrincipalThreadLocal.setName(_user.getUserId());
+
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest(
 				HttpMethod.GET,
@@ -172,20 +185,23 @@ public class ObjectDLFileEntryModelResourcePermissionConfiguratorTest {
 
 		_role = _roleLocalService.getRole(
 			_company.getCompanyId(), RoleConstants.GUEST);
-
-		_user = UserLocalServiceUtil.getGuestUser(_company.getCompanyId());
 	}
 
 	@After
 	public void tearDown() throws PortalException {
 		_objectDefinitionLocalService.deleteObjectDefinition(_objectDefinition);
 
+		PermissionThreadLocal.setPermissionChecker(_originalPermissionChecker);
+
+		PrincipalThreadLocal.setName(_originalName);
+
 		ServiceContextThreadLocal.popServiceContext();
 	}
 
 	@Test
 	public void testContains() throws Exception {
-		String actionId = _objectField.getAttachmentDownloadActionKey();
+		String attachmentDownloadActionKey =
+			_objectField.getAttachmentDownloadActionKey();
 
 		Assert.assertFalse(
 			_dlFileEntryModelResourcePermission.contains(
@@ -193,8 +209,9 @@ public class ObjectDLFileEntryModelResourcePermissionConfiguratorTest {
 				ActionKeys.DOWNLOAD));
 
 		_testContains(new String[] {ActionKeys.VIEW}, false);
-		_testContains(new String[] {actionId}, false);
-		_testContains(new String[] {ActionKeys.VIEW, actionId}, true);
+		_testContains(new String[] {attachmentDownloadActionKey}, false);
+		_testContains(
+			new String[] {ActionKeys.VIEW, attachmentDownloadActionKey}, true);
 
 		_resourcePermissionLocalService.setResourcePermissions(
 			_company.getCompanyId(), DLFileEntry.class.getName(),
@@ -204,11 +221,11 @@ public class ObjectDLFileEntryModelResourcePermissionConfiguratorTest {
 
 		Assert.assertFalse(
 			_dlFileEntryModelResourcePermission.contains(
-				PermissionCheckerFactoryUtil.create(_user), _dlFileEntry,
+				GuestOrUserUtil.getPermissionChecker(), _dlFileEntry,
 				ActionKeys.DOWNLOAD));
 	}
 
-	private void _testContains(String[] actionIds, boolean assertTrue)
+	private void _testContains(String[] actionIds, boolean expectedResult)
 		throws Exception {
 
 		_resourcePermissionLocalService.setResourcePermissions(
@@ -217,19 +234,11 @@ public class ObjectDLFileEntryModelResourcePermissionConfiguratorTest {
 			String.valueOf(_objectEntry.getObjectEntryId()), _role.getRoleId(),
 			actionIds);
 
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_user);
-
-		if (assertTrue) {
-			Assert.assertTrue(
-				_dlFileEntryModelResourcePermission.contains(
-					permissionChecker, _dlFileEntry, ActionKeys.DOWNLOAD));
-		}
-		else {
-			Assert.assertFalse(
-				_dlFileEntryModelResourcePermission.contains(
-					permissionChecker, _dlFileEntry, ActionKeys.DOWNLOAD));
-		}
+		Assert.assertEquals(
+			expectedResult,
+			_dlFileEntryModelResourcePermission.contains(
+				GuestOrUserUtil.getPermissionChecker(), _dlFileEntry,
+				ActionKeys.DOWNLOAD));
 	}
 
 	@Inject(
@@ -268,6 +277,8 @@ public class ObjectDLFileEntryModelResourcePermissionConfiguratorTest {
 	private ObjectEntryService _objectEntryService;
 
 	private ObjectField _objectField;
+	private String _originalName;
+	private PermissionChecker _originalPermissionChecker;
 
 	@Inject
 	private ResourcePermissionLocalService _resourcePermissionLocalService;

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/security/permission/resource/test/ObjectDLFileEntryModelResourcePermissionConfiguratorTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/security/permission/resource/test/ObjectDLFileEntryModelResourcePermissionConfiguratorTest.java
@@ -1,0 +1,286 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.security.permission.resource.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.util.DLURLHelper;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.constants.ObjectFieldSettingConstants;
+import com.liferay.object.field.setting.builder.ObjectFieldSettingBuilder;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectEntryService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.TempFileEntryUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import jakarta.ws.rs.HttpMethod;
+
+import java.io.ByteArrayInputStream;
+import java.io.Serializable;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Manuele Castro
+ */
+@FeatureFlag("LPD-17564")
+@RunWith(Arquillian.class)
+public class ObjectDLFileEntryModelResourcePermissionConfiguratorTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_company = _companyLocalService.getCompany(
+			TestPropsValues.getCompanyId());
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), _company.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			TempFileEntryUtil.getTempFileName("image.jpg"),
+			ContentTypes.APPLICATION_TEXT, RandomTestUtil.randomString(),
+			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
+			new ByteArrayInputStream(RandomTestUtil.randomBytes()), 67, null,
+			null, null, serviceContext);
+
+		_dlFileEntry = _dlFileEntryLocalService.getFileEntry(
+			fileEntry.getFileEntryId());
+
+		_objectField = ObjectFieldUtil.createObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT,
+			ObjectFieldConstants.DB_TYPE_LONG, true, false, null,
+			RandomTestUtil.randomString(), "attachment",
+			Arrays.asList(
+				new ObjectFieldSettingBuilder(
+				).name(
+					ObjectFieldSettingConstants.NAME_ACCEPTED_FILE_EXTENSIONS
+				).value(
+					"jpg, jpeg, png, svg, txt"
+				).build(),
+				new ObjectFieldSettingBuilder(
+				).name(
+					ObjectFieldSettingConstants.NAME_FILE_SOURCE
+				).value(
+					ObjectFieldSettingConstants.VALUE_DOCS_AND_MEDIA
+				).build(),
+				new ObjectFieldSettingBuilder(
+				).name(
+					ObjectFieldSettingConstants.NAME_MAX_FILE_SIZE
+				).value(
+					"100"
+				).build()),
+			false);
+
+		_objectField.setExternalReferenceCode(RandomTestUtil.randomString());
+
+		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition(
+			Collections.singletonList(_objectField));
+
+		_objectEntry = _objectEntryLocalService.addOrUpdateObjectEntry(
+			RandomTestUtil.randomString(), 0, TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			HashMapBuilder.<String, Serializable>put(
+				"attachment", String.valueOf(_dlFileEntry.getFileEntryId())
+			).build(),
+			serviceContext);
+
+		_themeDisplay.setCompany(_company);
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest(
+				HttpMethod.GET,
+				ObjectFieldUtil.getAttachmentDownloadURL(
+					_dlURLHelper, fileEntry, 0,
+					_objectDefinition.getExternalReferenceCode(), _objectEntry,
+					_objectEntryService, _objectField,
+					GuestOrUserUtil.getPermissionChecker(), _themeDisplay));
+
+		mockHttpServletRequest.addParameter("download", "true");
+		mockHttpServletRequest.addParameter(
+			"objectDefinitionExternalReferenceCode",
+			_objectDefinition.getExternalReferenceCode());
+		mockHttpServletRequest.addParameter(
+			"objectEntryExternalReferenceCode",
+			_objectEntry.getExternalReferenceCode());
+		mockHttpServletRequest.addParameter(
+			"objectFieldExternalReferenceCode",
+			_objectField.getExternalReferenceCode());
+
+		serviceContext.setRequest(mockHttpServletRequest);
+
+		ServiceContextThreadLocal.pushServiceContext(serviceContext);
+
+		_role = _roleLocalService.getRole(
+			_company.getCompanyId(), RoleConstants.GUEST);
+
+		_user = UserLocalServiceUtil.getGuestUser(_company.getCompanyId());
+	}
+
+	@After
+	public void tearDown() throws PortalException {
+		_objectDefinitionLocalService.deleteObjectDefinition(_objectDefinition);
+
+		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@Test
+	public void testContains() throws Exception {
+		String actionId = _objectField.getAttachmentDownloadActionKey();
+
+		Assert.assertFalse(
+			_dlFileEntryModelResourcePermission.contains(
+				PermissionCheckerFactoryUtil.create(_user), _dlFileEntry,
+				ActionKeys.DOWNLOAD));
+
+		_testContains(new String[] {ActionKeys.VIEW}, false);
+		_testContains(new String[] {actionId}, false);
+		_testContains(new String[] {ActionKeys.VIEW, actionId}, true);
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			_company.getCompanyId(), DLFileEntry.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(_dlFileEntry.getFileEntryId()), _role.getRoleId(),
+			new String[0]);
+
+		Assert.assertFalse(
+			_dlFileEntryModelResourcePermission.contains(
+				PermissionCheckerFactoryUtil.create(_user), _dlFileEntry,
+				ActionKeys.DOWNLOAD));
+	}
+
+	private void _testContains(String[] actionIds, boolean assertTrue)
+		throws Exception {
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			_company.getCompanyId(), _objectDefinition.getClassName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(_objectEntry.getObjectEntryId()), _role.getRoleId(),
+			actionIds);
+
+		PermissionChecker permissionChecker =
+			PermissionCheckerFactoryUtil.create(_user);
+
+		if (assertTrue) {
+			Assert.assertTrue(
+				_dlFileEntryModelResourcePermission.contains(
+					permissionChecker, _dlFileEntry, ActionKeys.DOWNLOAD));
+		}
+		else {
+			Assert.assertFalse(
+				_dlFileEntryModelResourcePermission.contains(
+					permissionChecker, _dlFileEntry, ActionKeys.DOWNLOAD));
+		}
+	}
+
+	@Inject(
+		filter = "model.class.name=com.liferay.document.library.kernel.model.DLFileEntry"
+	)
+	private static ModelResourcePermission<DLFileEntry>
+		_dlFileEntryModelResourcePermission;
+
+	private Company _company;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject
+	private DLAppLocalService _dlAppLocalService;
+
+	private DLFileEntry _dlFileEntry;
+
+	@Inject
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Inject
+	private DLURLHelper _dlURLHelper;
+
+	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	private ObjectEntry _objectEntry;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private ObjectEntryService _objectEntryService;
+
+	private ObjectField _objectField;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	private Role _role;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	private final ThemeDisplay _themeDisplay = new ThemeDisplay();
+	private User _user;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectFieldPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectFieldPersistenceTest.java
@@ -291,6 +291,15 @@ public class ObjectFieldPersistenceTest {
 	}
 
 	@Test
+	public void testCountByC_BT() throws Exception {
+		_persistence.countByC_BT(RandomTestUtil.nextLong(), "");
+
+		_persistence.countByC_BT(0L, "null");
+
+		_persistence.countByC_BT(0L, (String)null);
+	}
+
+	@Test
 	public void testCountByLTDI_S() throws Exception {
 		_persistence.countByLTDI_S(
 			RandomTestUtil.nextLong(), RandomTestUtil.randomBoolean());

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
@@ -1564,7 +1564,7 @@ public class ObjectFieldLocalServiceTest {
 					).build())
 			).build());
 
-		String actionId =
+		String attachmentDownloadActionKey =
 			attachmentObjectField.getAttachmentDownloadActionKey();
 
 		ObjectDefinition objectDefinition =
@@ -1572,10 +1572,11 @@ public class ObjectFieldLocalServiceTest {
 
 		Assert.assertNotNull(
 			_resourceActionLocalService.fetchResourceAction(
-				objectDefinition.getClassName(), actionId));
+				objectDefinition.getClassName(), attachmentDownloadActionKey));
 		Assert.assertNotNull(
 			_ploEntryLocalService.fetchPLOEntry(
-				objectDefinition.getCompanyId(), "action." + actionId,
+				objectDefinition.getCompanyId(),
+				"action." + attachmentDownloadActionKey,
 				attachmentObjectField.getDefaultLanguageId()));
 
 		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
@@ -1616,10 +1617,11 @@ public class ObjectFieldLocalServiceTest {
 			() -> _dlAppLocalService.getFileEntry(persistedFileEntryId));
 		Assert.assertNull(
 			_resourceActionLocalService.fetchResourceAction(
-				objectDefinition.getClassName(), actionId));
+				objectDefinition.getClassName(), attachmentDownloadActionKey));
 		Assert.assertNull(
 			_ploEntryLocalService.fetchPLOEntry(
-				objectDefinition.getCompanyId(), "action." + actionId,
+				objectDefinition.getCompanyId(),
+				"action." + attachmentDownloadActionKey,
 				attachmentObjectField.getDefaultLanguageId()));
 
 		// Delete object field business type auto increment

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
@@ -78,6 +78,7 @@ import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -93,6 +94,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.TextFormatter;
+import com.liferay.portal.language.override.service.PLOEntryLocalService;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -1420,6 +1422,7 @@ public class ObjectFieldLocalServiceTest {
 			modifiableSystemObjectDefinition);
 	}
 
+	@FeatureFlag("LPD-17564")
 	@Test
 	public void testDeleteObjectField() throws Exception {
 
@@ -1561,6 +1564,20 @@ public class ObjectFieldLocalServiceTest {
 					).build())
 			).build());
 
+		String actionId =
+			attachmentObjectField.getAttachmentDownloadActionKey();
+
+		ObjectDefinition objectDefinition =
+			attachmentObjectField.getObjectDefinition();
+
+		Assert.assertNotNull(
+			_resourceActionLocalService.fetchResourceAction(
+				objectDefinition.getClassName(), actionId));
+		Assert.assertNotNull(
+			_ploEntryLocalService.fetchPLOEntry(
+				objectDefinition.getCompanyId(), "action." + actionId,
+				attachmentObjectField.getDefaultLanguageId()));
+
 		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
 			0, TestPropsValues.getUserId(),
 			customObjectDefinition.getObjectDefinitionId(),
@@ -1597,6 +1614,13 @@ public class ObjectFieldLocalServiceTest {
 				"No FileEntry exists with the key {fileEntryId=",
 				persistedFileEntryId, "}"),
 			() -> _dlAppLocalService.getFileEntry(persistedFileEntryId));
+		Assert.assertNull(
+			_resourceActionLocalService.fetchResourceAction(
+				objectDefinition.getClassName(), actionId));
+		Assert.assertNull(
+			_ploEntryLocalService.fetchPLOEntry(
+				objectDefinition.getCompanyId(), "action." + actionId,
+				attachmentObjectField.getDefaultLanguageId()));
 
 		// Delete object field business type auto increment
 
@@ -2999,6 +3023,9 @@ public class ObjectFieldLocalServiceTest {
 	@Inject
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;
 
+	@Inject
+	private PLOEntryLocalService _ploEntryLocalService;
+
 	private final Map<String, String> _readOnlyObjectFieldDBTypes =
 		HashMapBuilder.put(
 			"createDate", ObjectFieldConstants.DB_TYPE_DATE
@@ -3011,5 +3038,8 @@ public class ObjectFieldLocalServiceTest {
 		).put(
 			"status", ObjectFieldConstants.DB_TYPE_INTEGER
 		).build();
+
+	@Inject
+	private ResourceActionLocalService _resourceActionLocalService;
 
 }

--- a/modules/test/playwright/pages/object-web/object-entries/ViewObjectEntriesPage.ts
+++ b/modules/test/playwright/pages/object-web/object-entries/ViewObjectEntriesPage.ts
@@ -18,6 +18,7 @@ export class ViewObjectEntriesPage {
 	readonly dateTimeInput: Locator;
 	readonly deletionConfirmationModal: Locator;
 	readonly deleteFileButton: Locator;
+	readonly downloadFileButton: Locator;
 	readonly duplicateEntryErrorMessage: Locator;
 	readonly editObjectEntryForm: Locator;
 	readonly expirationDateInput: Locator;
@@ -26,6 +27,7 @@ export class ViewObjectEntriesPage {
 	readonly frontendDatasetActions: Locator;
 	readonly frontendDatasetDeleteAction: Locator;
 	readonly frontendDatasetItems: Locator;
+	readonly frontendDatasetPermissionsAction: Locator;
 	readonly frontendDatasetViewAction: Locator;
 	readonly neverExpire: Locator;
 	readonly neverReview: Locator;
@@ -61,6 +63,7 @@ export class ViewObjectEntriesPage {
 		this.deletionConfirmationModal = page
 			.getByRole('dialog')
 			.and(page.getByLabel('Delete Entry'));
+		this.downloadFileButton = page.getByRole('button', {name: 'Download'});
 		this.duplicateEntryErrorMessage = page.getByText(
 			'Error:The field values are already in use. Please choose unique values.'
 		);
@@ -82,6 +85,9 @@ export class ViewObjectEntriesPage {
 			name: 'Delete',
 		});
 		this.frontendDatasetItems = page.getByRole('cell').getByRole('link');
+		this.frontendDatasetPermissionsAction = page.getByRole('menuitem', {
+			name: 'Permissions',
+		});
 		this.frontendDatasetViewAction = page.getByRole('menuitem', {
 			name: 'View',
 		});

--- a/modules/test/playwright/tests/object-web/main/objectEntries.spec.ts
+++ b/modules/test/playwright/tests/object-web/main/objectEntries.spec.ts
@@ -77,7 +77,7 @@ const test = mergeTests(
 
 const assigneeTest = test;
 
-const scheduleTest = mergeTests(
+const cmsTest = mergeTests(
 	test,
 	featureFlagsTest({
 		'LPD-17564': {enabled: true},
@@ -1470,7 +1470,7 @@ test.describe('Manage object entries through View Object Entries', () => {
 
 		await page.getByRole('button', {name: ATTACHMENT_FILE_NAME}).hover();
 
-		await page.locator('.lexicon-icon-download').click();
+		await viewObjectEntriesPage.downloadFileButton.click();
 
 		expect((await downloadPromise).suggestedFilename()).toStrictEqual(
 			`${ATTACHMENT_FILE_NAME}`
@@ -3173,16 +3173,175 @@ test.describe('Manage object entries through Workflow', () => {
 	);
 });
 
-scheduleTest.describe('Manage object entries schedule properties', () => {
+cmsTest.describe('Manage attachment ObjectField download permission', () => {
+	cmsTest(
+		'Verify file download restrictions',
+		async ({apiHelpers, page, viewObjectEntriesPage}) => {
+			const ATTACHMENT_FILE_NAME = 'astronaut.png';
+
+			const objectFields = generateObjectFields({
+				objectFieldBusinessTypes: ['Attachment'],
+			});
+
+			const objectDefinition =
+				await apiHelpers.objectAdmin.postRandomObjectDefinition({
+					objectFields,
+					status: {code: 0},
+				});
+
+			apiHelpers.data.push({
+				id: objectDefinition.id,
+				type: 'objectDefinition',
+			});
+
+			const company =
+				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
+					'liferay.com'
+				);
+
+			const user = await createUserWithPermissions({
+				apiHelpers,
+				rolePermissions: [
+					{
+						actionIds: ['VIEW_CONTROL_PANEL'],
+						primaryKey: company.companyId,
+						resourceName: '90',
+						scope: 1,
+					},
+					{
+						actionIds: ['ACCESS_IN_CONTROL_PANEL'],
+						primaryKey: company.companyId,
+						resourceName:
+							'com_liferay_users_admin_web_portlet_UsersAdminPortlet',
+						scope: 1,
+					},
+					{
+						actionIds: ['ACCESS_IN_CONTROL_PANEL'],
+						primaryKey: company.companyId,
+						resourceName: `com_liferay_object_web_internal_object_definitions_portlet_ObjectDefinitionsPortlet_${objectDefinition.className.split('#')[1]}`,
+						scope: 1,
+					},
+					{
+						actionIds: ['VIEW'],
+						primaryKey: company.companyId,
+						resourceName: `${objectDefinition.className}`,
+						scope: 1,
+					},
+				],
+			});
+
+			let entryUrl: string;
+
+			await test.step('go to entry page, upload a file, save the entry and check download button is present', async () => {
+				await viewObjectEntriesPage.goto(objectDefinition.className);
+
+				await viewObjectEntriesPage.clickAddObjectEntry(
+					objectDefinition.label['en_US']
+				);
+
+				await viewObjectEntriesPage.selectFileButton.click();
+
+				await viewObjectEntriesPage.selectFileFromDocumentsAndMedia(
+					ATTACHMENT_FILE_NAME
+				);
+
+				await viewObjectEntriesPage.saveObjectEntryButton.click();
+
+				await expect(
+					viewObjectEntriesPage.successMessage
+				).toBeVisible();
+
+				entryUrl = page.url();
+
+				await expect(
+					viewObjectEntriesPage.downloadFileButton
+				).toBeVisible();
+			});
+
+			await test.step('login user with only view permission, then check the user is unable to perform the file download', async () => {
+				await performUserSwitch(page, user.alternateName);
+
+				await viewObjectEntriesPage.goto(objectDefinition.className);
+
+				await page
+					.getByRole('link', {name: ATTACHMENT_FILE_NAME})
+					.click();
+
+				try {
+					await page.waitForEvent('download', {timeout: 1000});
+				}
+				catch (error) {
+					expect(error.message.includes('Timeout')).toBeTruthy();
+				}
+
+				await page.goto(entryUrl);
+
+				await expect(
+					viewObjectEntriesPage.downloadFileButton
+				).not.toBeVisible();
+			});
+
+			await test.step('add download permission to the user then check the user is able to perform the file download', async () => {
+				await performUserSwitch(page, 'test');
+
+				await viewObjectEntriesPage.goto(objectDefinition.className);
+
+				await viewObjectEntriesPage.frontendDatasetActions.click();
+
+				await viewObjectEntriesPage.frontendDatasetPermissionsAction.click();
+
+				const iframeLocator = page.frameLocator(
+					'iframe[title="Permissions"]'
+				);
+
+				const objectField = objectFields[0];
+
+				const objectFieldActionCheckbox = iframeLocator.locator(
+					'#guest_ACTION_download_' + objectField.name
+				);
+
+				await objectFieldActionCheckbox.click();
+
+				await expect(objectFieldActionCheckbox).toBeChecked();
+
+				await iframeLocator.getByRole('button', {name: 'Save'}).click();
+
+				await expect(
+					iframeLocator.getByText('Success:Your request')
+				).toBeVisible();
+
+				await performUserSwitch(page, user.alternateName);
+
+				await viewObjectEntriesPage.goto(objectDefinition.className);
+
+				const downloadPromise = page.waitForEvent('download');
+
+				await page.getByRole('link', {name: 'astronaut.png'}).click();
+
+				expect(
+					(await downloadPromise).suggestedFilename()
+				).toStrictEqual(`${ATTACHMENT_FILE_NAME}`);
+
+				await page.goto(entryUrl);
+
+				await expect(
+					viewObjectEntriesPage.downloadFileButton
+				).toBeVisible();
+			});
+		}
+	);
+});
+
+cmsTest.describe('Manage object entries schedule properties', () => {
 	let _objectDefinition: ObjectDefinition;
 
-	scheduleTest.afterEach(async ({accountSettingsPage}) => {
+	cmsTest.afterEach(async ({accountSettingsPage}) => {
 		await accountSettingsPage.goToDisplaySettings();
 
 		await accountSettingsPage.setTimeZone('UTC');
 	});
 
-	scheduleTest.beforeEach(async ({accountSettingsPage, apiHelpers, page}) => {
+	cmsTest.beforeEach(async ({accountSettingsPage, apiHelpers, page}) => {
 		const objectDefinition =
 			await apiHelpers.objectAdmin.postRandomObjectDefinition({
 				status: {code: 0},
@@ -3193,7 +3352,7 @@ scheduleTest.describe('Manage object entries schedule properties', () => {
 		const objectDefinitionAPIClient =
 			await apiHelpers.buildRestClient(ObjectDefinitionAPI);
 
-		const shouldEnableConfiguration = !scheduleTest
+		const shouldEnableConfiguration = !cmsTest
 			.info()
 			.tags.includes('@enableObjectEntryScheduleFalse');
 
@@ -3227,7 +3386,7 @@ scheduleTest.describe('Manage object entries schedule properties', () => {
 		await accountSettingsPage.setTimeZone(timeZoneValue);
 	});
 
-	scheduleTest(
+	cmsTest(
 		'can create, read, update, and delete a displayDate of an object entry',
 		async ({page, viewObjectEntriesPage}) => {
 			await viewObjectEntriesPage.goto(_objectDefinition.className);
@@ -3288,7 +3447,7 @@ scheduleTest.describe('Manage object entries schedule properties', () => {
 		}
 	);
 
-	scheduleTest(
+	cmsTest(
 		'can create, read, update, and delete a expirationDate of an object entry',
 		async ({page, viewObjectEntriesPage}) => {
 			await viewObjectEntriesPage.goto(_objectDefinition.className);
@@ -3345,7 +3504,7 @@ scheduleTest.describe('Manage object entries schedule properties', () => {
 		}
 	);
 
-	scheduleTest(
+	cmsTest(
 		'can create, read, update, and delete a reviewDate of an object entry',
 		async ({page, viewObjectEntriesPage}) => {
 			await viewObjectEntriesPage.goto(_objectDefinition.className);
@@ -3396,7 +3555,7 @@ scheduleTest.describe('Manage object entries schedule properties', () => {
 		}
 	);
 
-	scheduleTest(
+	cmsTest(
 		'can see approved and scheduled labels for entry with a display date versioning enabled and at least one version approved',
 		async ({apiHelpers, page, viewObjectEntriesPage}) => {
 			const objectDefinitionAPIClient =
@@ -3459,7 +3618,7 @@ scheduleTest.describe('Manage object entries schedule properties', () => {
 		}
 	);
 
-	scheduleTest(
+	cmsTest(
 		'cannot submit an empty displayDate',
 		async ({page, viewObjectEntriesPage}) => {
 			await viewObjectEntriesPage.goto(_objectDefinition.className);
@@ -3494,7 +3653,7 @@ scheduleTest.describe('Manage object entries schedule properties', () => {
 		}
 	);
 
-	scheduleTest(
+	cmsTest(
 		'cannot submit an empty expirationDate and reviewDate when it is enabled',
 		async ({page, viewObjectEntriesPage}) => {
 			await viewObjectEntriesPage.goto(_objectDefinition.className);
@@ -3539,7 +3698,7 @@ scheduleTest.describe('Manage object entries schedule properties', () => {
 		}
 	);
 
-	scheduleTest(
+	cmsTest(
 		'cannot submit a past expirationDate',
 		async ({page, viewObjectEntriesPage}) => {
 			await viewObjectEntriesPage.goto(_objectDefinition.className);
@@ -3576,7 +3735,7 @@ scheduleTest.describe('Manage object entries schedule properties', () => {
 		}
 	);
 
-	scheduleTest(
+	cmsTest(
 		'schedule container is not visible when enableObjectEntrySchedule is disabled',
 		{tag: '@enableObjectEntryScheduleFalse'},
 		async ({viewObjectEntriesPage}) => {


### PR DESCRIPTION
##### AppSec review at: https://github.com/liferay-appsec/liferay-portal/pull/2477
##### BPM review at: https://github.com/liferay-bpm/liferay-portal/pull/5224 and https://github.com/liferay-bpm/liferay-portal/pull/5319
----
### Related stories: [LPD-61657](https://liferay.atlassian.net/browse/LPD-61657) | [LPD-61658](https://liferay.atlassian.net/browse/LPD-61658)

## Context:
Object Definitions can have Object Fields of type _Attachment_  and those attachments can be downloaded. ObjectField Attachments entries are stored as DLFileEntry, that have their own ResourcePermission which includes a _download_ ResourceAction. Currently, this action can only be configured on the _Documents and Media_ side.

## Issue:
**Attachment Object Fields have 2 types of storage:** 

1. Upload Directly from the User's Computer
2. Upload or Select from Documents and Media Item Selector

When using the first option, the creator can choose to _Show Files in Documents and Media_. If choose not to show, the file will be hidden and no download permission change will be possible on the documents and media side(the default is to allow all users to download).

Currently, for this usecase, the DLFileEntry DOWNLOAD permission is linked with its related ObjectEntry VIEW permission(if an user has view permission, they can download the attachment). While this allows admins to give some restriction, if they want users to see an ObjectEntry but don't want them to download a specific attachment from it, they cannot perform this action.

## Solution:
On this PR we're creating a new download ResourceAction for Attachment Object Fields, that will be under the ObjectEntryModel ResourcePermission. This will enable the view and download permissions to work independently, giving the admins more flexibility and power for giving resource restrictions.

How it works:

1. When adding a new attachment ObjectField to a published ObjectDefinition, it will call `ObjectDefinitionResourcePermissionUtil#populateResourceActions()`, which will be responsible for adding the new ObjectField download `ResourceAction` to the ObjectDefinition's `ObjectEntryModelResourcePermission`. After this, the admin can check the new permission was added on the permission framework for the definition entries.
2. Once the new ResourceAction is added, it will be responsible for restricting roles download access to the related attachment. If a role doesn't have the permission, the restrictions are reflected on the UI by:
    1. The _view object entries table_ no longer exposes the attachment download link. This is done by `LinkUtil#toLink()`;
    2. The download button on the ObjectEntry view is no longer available. This is done by `AttachmentDDMFormFieldTemplateContextContributor#_getFileEntryProperties()` and `FileContainer.tsx`;
    3. If somehow the user get access to the link, it will be catched by `ObjectDLFileEntryModelResourcePermissionConfigurator` which checks the permission for both VIEW and DOWNLOAD permissions, and redirects the user to either 401 or 404(if guest) pages if unauthorized.

**Additional info:** regarding the permission on the Documents and Media side, the new ObjectField download permission **will NOT** bypass that permission, there will only be a **new layer** of permission checking for the respective attachment. So, if an user has permission to download on the Object side but doesn't on the DM side, the user will still be unable to perform download. For the download action to be enabled, an user needs to have DOWNLOAD permission on **both** Object and DM side, they also need VIEW permission on the Object side as well.

## Preview:

### Download permission is available for Attachment object fields:
<img width="1914" height="808" alt="image" src="https://github.com/user-attachments/assets/21586448-62a4-4ad9-89b6-a26903be28b2" />
<img width="3819" height="2026" alt="image" src="https://github.com/user-attachments/assets/9c2f8d0d-6d42-46bd-961e-e4bdb8eae77d" />

### ObjectEntry view: download button is unavailable when permission is not granted:
<img width="1438" height="644" alt="image" src="https://github.com/user-attachments/assets/48171305-69a2-4c07-ac17-305c25972219" />

### Unauthorized user tries to access the download link:
<img width="1909" height="991" alt="image" src="https://github.com/user-attachments/assets/8ff61fac-9da0-4f23-a4ef-cb26550fca8f" />
<img width="1893" height="1723" alt="image" src="https://github.com/user-attachments/assets/4f34cb0d-02e9-486d-a163-8f3dec0255e7" />


[LPD-61657]: https://liferay.atlassian.net/browse/LPD-61657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-61658]: https://liferay.atlassian.net/browse/LPD-61658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ