### PR TITLE
LPD-70093 Differentiate object definition from CMS in item selector

### DIFF
--- a/modules/apps/fragment/fragment-collection-filter-category/src/test/java/com/liferay/fragment/collection/filter/category/display/context/FragmentCollectionFilterCategoryDisplayContextTest.java
+++ b/modules/apps/fragment/fragment-collection-filter-category/src/test/java/com/liferay/fragment/collection/filter/category/display/context/FragmentCollectionFilterCategoryDisplayContextTest.java
@@ -70,6 +70,7 @@ public class FragmentCollectionFilterCategoryDisplayContextTest {
 
 		_testGetAssetCategoryTreeNodeTitle(
 			"Category", categoryTreeNodeId, title);
+
 		_testGetAssetCategoryTreeNodeTitle(
 			"Category", RandomTestUtil.randomLong(),
 			RandomTestUtil.randomLong(), RandomTestUtil.randomString(),

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinition.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinition.java
@@ -81,6 +81,8 @@ public interface ObjectDefinition
 
 	public boolean isApproved();
 
+	public boolean isCMS();
+
 	public boolean isDefaultStorageType();
 
 	public boolean isLinkedToObjectFolder(long objectFolderId);

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinitionWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinitionWrapper.java
@@ -1069,6 +1069,11 @@ public class ObjectDefinitionWrapper
 	}
 
 	@Override
+	public boolean isCMS() {
+		return model.isCMS();
+	}
+
+	@Override
 	public boolean isDefaultStorageType() {
 		return model.isDefaultStorageType();
 	}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
@@ -7,6 +7,7 @@ package com.liferay.object.model.impl;
 
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectDefinitionSettingConstants;
+import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.constants.ObjectPortletKeys;
 import com.liferay.object.definition.setting.util.ObjectDefinitionSettingUtil;
 import com.liferay.object.definition.tree.util.ObjectDefinitionTreeUtil;
@@ -205,6 +206,26 @@ public class ObjectDefinitionImpl extends ObjectDefinitionBaseImpl {
 	@Override
 	public boolean isApproved() {
 		if (getStatus() == WorkflowConstants.STATUS_APPROVED) {
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
+	public boolean isCMS() {
+		if (!FeatureFlagManagerUtil.isEnabled(getCompanyId(), "LPD-17564")) {
+			return false;
+		}
+
+		if (Objects.equals(
+				getObjectFolderExternalReferenceCode(),
+				ObjectFolderConstants.
+					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES) ||
+			Objects.equals(
+				getObjectFolderExternalReferenceCode(),
+				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES)) {
+
 			return true;
 		}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -48,7 +48,6 @@ import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.constants.ObjectFieldValidationConstants;
 import com.liferay.object.constants.ObjectFilterConstants;
-import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.definition.setting.util.ObjectDefinitionSettingUtil;
 import com.liferay.object.definition.util.ObjectDefinitionThreadLocal;
@@ -6263,14 +6262,7 @@ public class ObjectEntryLocalServiceImpl
 			}
 		}
 
-		if (Objects.equals(
-				objectDefinition.getObjectFolderExternalReferenceCode(),
-				ObjectFolderConstants.
-					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES) ||
-			Objects.equals(
-				objectDefinition.getObjectFolderExternalReferenceCode(),
-				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES)) {
-
+		if (objectDefinition.isCMS()) {
 			Group group = _groupLocalService.fetchGroup(
 				objectEntry.getCompanyId(), GroupConstants.CMS);
 

--- a/modules/apps/object/object-service/src/test/java/com/liferay/object/model/impl/ObjectDefinitionImplTest.java
+++ b/modules/apps/object/object-service/src/test/java/com/liferay/object/model/impl/ObjectDefinitionImplTest.java
@@ -6,19 +6,26 @@
 package com.liferay.object.model.impl;
 
 import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.constants.ObjectPortletKeys;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectFolder;
+import com.liferay.object.service.ObjectFolderLocalServiceUtil;
+import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TextFormatter;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 /**
@@ -30,6 +37,11 @@ public class ObjectDefinitionImplTest {
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@AfterClass
+	public static void tearDownClass() {
+		_objectFolderLocalServiceUtilMockedStatic.close();
+	}
 
 	@Test
 	public void testGetPortletId() {
@@ -74,6 +86,27 @@ public class ObjectDefinitionImplTest {
 		}
 	}
 
+	@Test
+	public void testIsCMS() throws Exception {
+		_testIsCMS(
+			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES,
+			"false",
+			objectDefinition -> Assert.assertFalse(objectDefinition.isCMS()));
+		_testIsCMS(
+			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES,
+			"true",
+			objectDefinition -> Assert.assertTrue(objectDefinition.isCMS()));
+		_testIsCMS(
+			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES, "false",
+			objectDefinition -> Assert.assertFalse(objectDefinition.isCMS()));
+		_testIsCMS(
+			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES, "true",
+			objectDefinition -> Assert.assertTrue(objectDefinition.isCMS()));
+		_testIsCMS(
+			RandomTestUtil.randomString(), "true",
+			objectDefinition -> Assert.assertFalse(objectDefinition.isCMS()));
+	}
+
 	private ObjectDefinition _createObjectDefinition(
 		boolean modifiable, String name, boolean system) {
 
@@ -97,5 +130,48 @@ public class ObjectDefinitionImplTest {
 		Assert.assertEquals(
 			expectedRESTContextPath, objectDefinition.getRESTContextPath());
 	}
+
+	private void _testIsCMS(
+			String externalReferenceCode, String featureFlagEnabled,
+			UnsafeConsumer<ObjectDefinition, Exception> unsafeConsumer)
+		throws Exception {
+
+		long objectFolderId = RandomTestUtil.randomLong();
+
+		ObjectFolder objectFolder = Mockito.mock(ObjectFolder.class);
+
+		Mockito.when(
+			objectFolder.getExternalReferenceCode()
+		).thenReturn(
+			externalReferenceCode
+		);
+
+		_objectFolderLocalServiceUtilMockedStatic.when(
+			() -> ObjectFolderLocalServiceUtil.fetchObjectFolder(objectFolderId)
+		).thenReturn(
+			objectFolder
+		);
+
+		ObjectDefinition objectDefinition = new ObjectDefinitionImpl();
+
+		objectDefinition.setObjectFolderId(objectFolderId);
+
+		String featureFlagKey = "feature.flag.LPD-17564";
+
+		String originalValue = PropsUtil.get(featureFlagKey);
+
+		try {
+			PropsUtil.set(featureFlagKey, featureFlagEnabled);
+
+			unsafeConsumer.accept(objectDefinition);
+		}
+		finally {
+			PropsUtil.set(featureFlagKey, originalValue);
+		}
+	}
+
+	private static final MockedStatic<ObjectFolderLocalServiceUtil>
+		_objectFolderLocalServiceUtilMockedStatic = Mockito.mockStatic(
+			ObjectFolderLocalServiceUtil.class);
 
 }

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorView.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorView.java
@@ -13,13 +13,11 @@ import com.liferay.item.selector.ItemSelectorViewDescriptorRenderer;
 import com.liferay.item.selector.criteria.ActionableInfoItemItemSelectorReturnType;
 import com.liferay.item.selector.criteria.InfoItemItemSelectorReturnType;
 import com.liferay.item.selector.criteria.info.item.criterion.InfoItemItemSelectorCriterion;
-import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.related.models.ObjectRelatedModelsProviderRegistry;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.scope.ObjectScopeProviderRegistry;
-import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
@@ -37,7 +35,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 
 /**
  * @author Guilherme Camacho
@@ -67,8 +64,6 @@ public class ObjectEntryItemSelectorView
 			objectRelatedModelsProviderRegistry;
 		_objectScopeProviderRegistry = objectScopeProviderRegistry;
 		_portal = portal;
-
-		_cmsObjectDefinition = _isCMSObjectDefinition(objectDefinition);
 	}
 
 	@Override
@@ -92,7 +87,7 @@ public class ObjectEntryItemSelectorView
 	public String getTitle(Locale locale) {
 		String title = _objectDefinition.getPluralLabel(locale);
 
-		if (_cmsObjectDefinition) {
+		if (_objectDefinition.isCMS()) {
 			title = StringUtil.appendParentheticalSuffix(title, "CMS");
 		}
 
@@ -125,34 +120,12 @@ public class ObjectEntryItemSelectorView
 				_objectScopeProviderRegistry, _portal, portletURL));
 	}
 
-	private boolean _isCMSObjectDefinition(ObjectDefinition objectDefinition) {
-		if (!FeatureFlagManagerUtil.isEnabled(
-				objectDefinition.getCompanyId(), "LPD-17564")) {
-
-			return false;
-		}
-
-		if (Objects.equals(
-				objectDefinition.getObjectFolderExternalReferenceCode(),
-				ObjectFolderConstants.
-					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES) ||
-			Objects.equals(
-				objectDefinition.getObjectFolderExternalReferenceCode(),
-				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES)) {
-
-			return true;
-		}
-
-		return false;
-	}
-
 	private static final List<ItemSelectorReturnType>
 		_supportedItemSelectorReturnTypes = Arrays.asList(
 			new ActionableInfoItemItemSelectorReturnType(),
 			new InfoItemItemSelectorReturnType(),
 			new ObjectEntryItemSelectorReturnType());
 
-	private final boolean _cmsObjectDefinition;
 	private final GroupLocalService _groupLocalService;
 	private final InfoPermissionProvider<ObjectEntry> _infoPermissionProvider;
 	private final ItemSelectorViewDescriptorRenderer

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorView.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorView.java
@@ -13,14 +13,17 @@ import com.liferay.item.selector.ItemSelectorViewDescriptorRenderer;
 import com.liferay.item.selector.criteria.ActionableInfoItemItemSelectorReturnType;
 import com.liferay.item.selector.criteria.InfoItemItemSelectorReturnType;
 import com.liferay.item.selector.criteria.info.item.criterion.InfoItemItemSelectorCriterion;
+import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.related.models.ObjectRelatedModelsProviderRegistry;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.scope.ObjectScopeProviderRegistry;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import jakarta.portlet.PortletURL;
 
@@ -34,6 +37,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
 /**
  * @author Guilherme Camacho
@@ -63,6 +67,8 @@ public class ObjectEntryItemSelectorView
 			objectRelatedModelsProviderRegistry;
 		_objectScopeProviderRegistry = objectScopeProviderRegistry;
 		_portal = portal;
+
+		_cmsObjectDefinition = _isCMSObjectDefinition(objectDefinition);
 	}
 
 	@Override
@@ -84,7 +90,13 @@ public class ObjectEntryItemSelectorView
 
 	@Override
 	public String getTitle(Locale locale) {
-		return _objectDefinition.getPluralLabel(locale);
+		String title = _objectDefinition.getPluralLabel(locale);
+
+		if (_cmsObjectDefinition) {
+			title = StringUtil.appendParentheticalSuffix(title, "CMS");
+		}
+
+		return title;
 	}
 
 	@Override
@@ -113,12 +125,34 @@ public class ObjectEntryItemSelectorView
 				_objectScopeProviderRegistry, _portal, portletURL));
 	}
 
+	private boolean _isCMSObjectDefinition(ObjectDefinition objectDefinition) {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				objectDefinition.getCompanyId(), "LPD-17564")) {
+
+			return false;
+		}
+
+		if (Objects.equals(
+				objectDefinition.getObjectFolderExternalReferenceCode(),
+				ObjectFolderConstants.
+					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES) ||
+			Objects.equals(
+				objectDefinition.getObjectFolderExternalReferenceCode(),
+				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	private static final List<ItemSelectorReturnType>
 		_supportedItemSelectorReturnTypes = Arrays.asList(
 			new ActionableInfoItemItemSelectorReturnType(),
 			new InfoItemItemSelectorReturnType(),
 			new ObjectEntryItemSelectorReturnType());
 
+	private final boolean _cmsObjectDefinition;
 	private final GroupLocalService _groupLocalService;
 	private final InfoPermissionProvider<ObjectEntry> _infoPermissionProvider;
 	private final ItemSelectorViewDescriptorRenderer

--- a/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorViewTest.java
+++ b/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorViewTest.java
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.web.internal.item.selector;
+
+import com.liferay.info.permission.provider.InfoPermissionProvider;
+import com.liferay.item.selector.ItemSelectorViewDescriptorRenderer;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.related.models.ObjectRelatedModelsProviderRegistry;
+import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
+import com.liferay.object.scope.ObjectScopeProviderRegistry;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class ObjectEntryItemSelectorViewTest {
+
+	@ClassRule
+	public static LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	@TestInfo("LPD-17564")
+	public void testGetTitle() throws Exception {
+		long companyId = RandomTestUtil.randomLong();
+		Locale locale = LocaleUtil.getDefault();
+
+		String title = RandomTestUtil.randomString();
+
+		String cmsTitle = StringUtil.appendParentheticalSuffix(title, "CMS");
+
+		ObjectDefinition objectDefinition = Mockito.mock(
+			ObjectDefinition.class);
+
+		Mockito.when(
+			objectDefinition.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
+		Mockito.when(
+			objectDefinition.getPluralLabel(locale)
+		).thenReturn(
+			title
+		);
+
+		Mockito.when(
+			objectDefinition.isCMS()
+		).thenReturn(
+			false
+		);
+
+		_assertGetTitle(title, locale, objectDefinition);
+
+		Mockito.when(
+			objectDefinition.isCMS()
+		).thenReturn(
+			true
+		);
+
+		_assertGetTitle(cmsTitle, locale, objectDefinition);
+	}
+
+	private void _assertGetTitle(
+		String expectedTitle, Locale locale,
+		ObjectDefinition objectDefinition) {
+
+		ObjectEntryItemSelectorView objectEntryItemSelectorView =
+			_getObjectEntryItemSelectorView(objectDefinition);
+
+		Assert.assertEquals(
+			expectedTitle, objectEntryItemSelectorView.getTitle(locale));
+	}
+
+	private ObjectEntryItemSelectorView _getObjectEntryItemSelectorView(
+		ObjectDefinition objectDefinition) {
+
+		return new ObjectEntryItemSelectorView(
+			Mockito.mock(GroupLocalService.class),
+			Mockito.mock(InfoPermissionProvider.class),
+			Mockito.mock(ItemSelectorViewDescriptorRenderer.class),
+			objectDefinition, Mockito.mock(ObjectEntryManager.class),
+			Mockito.mock(ObjectRelatedModelsProviderRegistry.class),
+			Mockito.mock(ObjectScopeProviderRegistry.class),
+			Mockito.mock(Portal.class));
+	}
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/ObjectDefinitionModelListener.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/ObjectDefinitionModelListener.java
@@ -7,7 +7,6 @@ package com.liferay.site.cms.site.initializer.internal.model.listener;
 
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
-import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -17,8 +16,6 @@ import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.Portal;
-
-import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -34,17 +31,7 @@ public class ObjectDefinitionModelListener
 	public void onAfterRemove(ObjectDefinition objectDefinition)
 		throws ModelListenerException {
 
-		String objectFolderExternalReferenceCode =
-			objectDefinition.getObjectFolderExternalReferenceCode();
-
-		if (!Objects.equals(
-				objectFolderExternalReferenceCode,
-				ObjectFolderConstants.
-					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES) &&
-			!Objects.equals(
-				objectFolderExternalReferenceCode,
-				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES)) {
-
+		if (!objectDefinition.isCMS()) {
 			return;
 		}
 

--- a/modules/test/playwright/package-lock.json
+++ b/modules/test/playwright/package-lock.json
@@ -31,7 +31,7 @@
 		},
 		"../../apps/layout/layout-js-components-web": {
 			"name": "@liferay/layout-js-components-web",
-			"version": "1.0.47",
+			"version": "1.0.48",
 			"dev": true,
 			"dependencies": {
 				"@clayui/alert": "3.148.0",


### PR DESCRIPTION
Follow up to https://github.com/brianchandotcom/liferay-portal/pull/167300 based on https://github.com/brianchandotcom/liferay-portal/pull/167300#issuecomment-3474975733


https://liferay.atlassian.net/browse/LPD-70093

Hi Team, based on slack convo I'm sending this PR.

Basically it justs appends (CMS) to those object definitions that are from CMS, like in the screenshot

<img width="1723" height="773" alt="Screenshot from 2025-10-30 11-15-32" src="https://github.com/user-attachments/assets/0f3ddef0-48cb-4a6a-97aa-adf0156845ef" />