### PR TITLE
LPD-69685 Follow up: DBUpgrader class is owned by DB Infra team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -513,6 +513,7 @@ modules/util/portal-tools-service-builder-test-uad/    @liferay-core-infra
 modules/util/release-util/    @liferay-devtools
 modules/util/source-formatter/    @liferay-devtools
 portal-impl/src/com/liferay/portal/db/    @liferay-database-infra
+portal-impl/src/com/liferay/portal/tools/DBUpgrader.java    @liferay-database-infra
 portal-impl/src/com/liferay/portal/upgrade/    @liferay-database-infra
 portal-impl/src/com/liferay/portal/verify/    @liferay-database-infra
 portal-impl/test/unit/com/liferay/portal/upgrade/    @liferay-database-infra


### PR DESCRIPTION
In https://github.com/brianchandotcom/liferay-portal/pull/167073 I assigned in CODEOWNERS all the upgrade folders of portal-impl to DB Infra, but com.liferay.portal.tools.DBUpgrader is outside these folders, so I have to add it manually.

We need to have all our files identified in CODEOWNERS because we have an script that uses it to monitor them