### PR TITLE
LPD-70429 Add localizable configuration

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/FormContainerConfig.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/FormContainerConfig.java
@@ -157,6 +157,49 @@ public class FormContainerConfig implements Serializable {
 	@JsonIgnore
 	private Supplier<FormContainerType> _formContainerTypeSupplier;
 
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public LocalizationConfig getLocalizationConfig() {
+		if (_localizationConfigSupplier != null) {
+			localizationConfig = _localizationConfigSupplier.get();
+
+			_localizationConfigSupplier = null;
+		}
+
+		return localizationConfig;
+	}
+
+	public void setLocalizationConfig(LocalizationConfig localizationConfig) {
+		this.localizationConfig = localizationConfig;
+
+		_localizationConfigSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setLocalizationConfig(
+		UnsafeSupplier<LocalizationConfig, Exception>
+			localizationConfigUnsafeSupplier) {
+
+		_localizationConfigSupplier = () -> {
+			try {
+				return localizationConfigUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected LocalizationConfig localizationConfig;
+
+	@JsonIgnore
+	private Supplier<LocalizationConfig> _localizationConfigSupplier;
+
 	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "The form container page element's number of steps."
 	)
@@ -310,6 +353,18 @@ public class FormContainerConfig implements Serializable {
 			sb.append("\"");
 			sb.append(formContainerType);
 			sb.append("\"");
+		}
+
+		LocalizationConfig localizationConfig = getLocalizationConfig();
+
+		if (localizationConfig != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"localizationConfig\": ");
+
+			sb.append(String.valueOf(localizationConfig));
 		}
 
 		Integer numberOfSteps = getNumberOfSteps();

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/LocalizationConfig.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/LocalizationConfig.java
@@ -1,0 +1,363 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.validation.Valid;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Rubén Pulido
+ * @generated
+ */
+@Generated("")
+@GraphQLName("LocalizationConfig")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "LocalizationConfig")
+public class LocalizationConfig implements Serializable {
+
+	public static LocalizationConfig toDTO(String json) {
+		return ObjectMapperUtil.readValue(LocalizationConfig.class, json);
+	}
+
+	public static LocalizationConfig unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(LocalizationConfig.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The message displayed in the unlocalized fields."
+	)
+	@Valid
+	public FragmentInlineValue
+		getUnlocalizedFieldsMessageFragmentInlineValue() {
+
+		if (_unlocalizedFieldsMessageFragmentInlineValueSupplier != null) {
+			unlocalizedFieldsMessageFragmentInlineValue =
+				_unlocalizedFieldsMessageFragmentInlineValueSupplier.get();
+
+			_unlocalizedFieldsMessageFragmentInlineValueSupplier = null;
+		}
+
+		return unlocalizedFieldsMessageFragmentInlineValue;
+	}
+
+	public void setUnlocalizedFieldsMessageFragmentInlineValue(
+		FragmentInlineValue unlocalizedFieldsMessageFragmentInlineValue) {
+
+		this.unlocalizedFieldsMessageFragmentInlineValue =
+			unlocalizedFieldsMessageFragmentInlineValue;
+
+		_unlocalizedFieldsMessageFragmentInlineValueSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setUnlocalizedFieldsMessageFragmentInlineValue(
+		UnsafeSupplier<FragmentInlineValue, Exception>
+			unlocalizedFieldsMessageFragmentInlineValueUnsafeSupplier) {
+
+		_unlocalizedFieldsMessageFragmentInlineValueSupplier = () -> {
+			try {
+				return unlocalizedFieldsMessageFragmentInlineValueUnsafeSupplier.
+					get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The message displayed in the unlocalized fields."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected FragmentInlineValue unlocalizedFieldsMessageFragmentInlineValue;
+
+	@JsonIgnore
+	private Supplier<FragmentInlineValue>
+		_unlocalizedFieldsMessageFragmentInlineValueSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The state of the unlocalized fields."
+	)
+	@JsonGetter("unlocalizedFieldsState")
+	@Valid
+	public UnlocalizedFieldsState getUnlocalizedFieldsState() {
+		if (_unlocalizedFieldsStateSupplier != null) {
+			unlocalizedFieldsState = _unlocalizedFieldsStateSupplier.get();
+
+			_unlocalizedFieldsStateSupplier = null;
+		}
+
+		return unlocalizedFieldsState;
+	}
+
+	@JsonIgnore
+	public String getUnlocalizedFieldsStateAsString() {
+		UnlocalizedFieldsState unlocalizedFieldsState =
+			getUnlocalizedFieldsState();
+
+		if (unlocalizedFieldsState == null) {
+			return null;
+		}
+
+		return unlocalizedFieldsState.toString();
+	}
+
+	public void setUnlocalizedFieldsState(
+		UnlocalizedFieldsState unlocalizedFieldsState) {
+
+		this.unlocalizedFieldsState = unlocalizedFieldsState;
+
+		_unlocalizedFieldsStateSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setUnlocalizedFieldsState(
+		UnsafeSupplier<UnlocalizedFieldsState, Exception>
+			unlocalizedFieldsStateUnsafeSupplier) {
+
+		_unlocalizedFieldsStateSupplier = () -> {
+			try {
+				return unlocalizedFieldsStateUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The state of the unlocalized fields.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected UnlocalizedFieldsState unlocalizedFieldsState;
+
+	@JsonIgnore
+	private Supplier<UnlocalizedFieldsState> _unlocalizedFieldsStateSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof LocalizationConfig)) {
+			return false;
+		}
+
+		LocalizationConfig localizationConfig = (LocalizationConfig)object;
+
+		return Objects.equals(toString(), localizationConfig.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		FragmentInlineValue unlocalizedFieldsMessageFragmentInlineValue =
+			getUnlocalizedFieldsMessageFragmentInlineValue();
+
+		if (unlocalizedFieldsMessageFragmentInlineValue != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"unlocalizedFieldsMessageFragmentInlineValue\": ");
+
+			sb.append(
+				String.valueOf(unlocalizedFieldsMessageFragmentInlineValue));
+		}
+
+		UnlocalizedFieldsState unlocalizedFieldsState =
+			getUnlocalizedFieldsState();
+
+		if (unlocalizedFieldsState != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"unlocalizedFieldsState\": ");
+
+			sb.append("\"");
+			sb.append(unlocalizedFieldsState);
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.admin.site.dto.v1_0.LocalizationConfig",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	@GraphQLName("UnlocalizedFieldsState")
+	public static enum UnlocalizedFieldsState {
+
+		DISABLED("Disabled"), READ_ONLY("ReadOnly");
+
+		@JsonCreator
+		public static UnlocalizedFieldsState create(String value) {
+			if ((value == null) || value.equals("")) {
+				return null;
+			}
+
+			for (UnlocalizedFieldsState unlocalizedFieldsState : values()) {
+				if (Objects.equals(unlocalizedFieldsState.getValue(), value)) {
+					return unlocalizedFieldsState;
+				}
+			}
+
+			throw new IllegalArgumentException("Invalid enum value: " + value);
+		}
+
+		@JsonValue
+		public String getValue() {
+			return _value;
+		}
+
+		@Override
+		public String toString() {
+			return _value;
+		}
+
+		private UnlocalizedFieldsState(String value) {
+			_value = value;
+		}
+
+		private final String _value;
+
+	}
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/FormContainerConfig.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/FormContainerConfig.java
@@ -79,6 +79,28 @@ public class FormContainerConfig implements Cloneable, Serializable {
 
 	protected FormContainerType formContainerType;
 
+	public LocalizationConfig getLocalizationConfig() {
+		return localizationConfig;
+	}
+
+	public void setLocalizationConfig(LocalizationConfig localizationConfig) {
+		this.localizationConfig = localizationConfig;
+	}
+
+	public void setLocalizationConfig(
+		UnsafeSupplier<LocalizationConfig, Exception>
+			localizationConfigUnsafeSupplier) {
+
+		try {
+			localizationConfig = localizationConfigUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected LocalizationConfig localizationConfig;
+
 	public Integer getNumberOfSteps() {
 		return numberOfSteps;
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/LocalizationConfig.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/LocalizationConfig.java
@@ -1,0 +1,152 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.client.dto.v1_0;
+
+import com.liferay.headless.admin.site.client.function.UnsafeSupplier;
+import com.liferay.headless.admin.site.client.serdes.v1_0.LocalizationConfigSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+/**
+ * @author Rubén Pulido
+ * @generated
+ */
+@Generated("")
+public class LocalizationConfig implements Cloneable, Serializable {
+
+	public static LocalizationConfig toDTO(String json) {
+		return LocalizationConfigSerDes.toDTO(json);
+	}
+
+	public FragmentInlineValue
+		getUnlocalizedFieldsMessageFragmentInlineValue() {
+
+		return unlocalizedFieldsMessageFragmentInlineValue;
+	}
+
+	public void setUnlocalizedFieldsMessageFragmentInlineValue(
+		FragmentInlineValue unlocalizedFieldsMessageFragmentInlineValue) {
+
+		this.unlocalizedFieldsMessageFragmentInlineValue =
+			unlocalizedFieldsMessageFragmentInlineValue;
+	}
+
+	public void setUnlocalizedFieldsMessageFragmentInlineValue(
+		UnsafeSupplier<FragmentInlineValue, Exception>
+			unlocalizedFieldsMessageFragmentInlineValueUnsafeSupplier) {
+
+		try {
+			unlocalizedFieldsMessageFragmentInlineValue =
+				unlocalizedFieldsMessageFragmentInlineValueUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected FragmentInlineValue unlocalizedFieldsMessageFragmentInlineValue;
+
+	public UnlocalizedFieldsState getUnlocalizedFieldsState() {
+		return unlocalizedFieldsState;
+	}
+
+	public String getUnlocalizedFieldsStateAsString() {
+		if (unlocalizedFieldsState == null) {
+			return null;
+		}
+
+		return unlocalizedFieldsState.toString();
+	}
+
+	public void setUnlocalizedFieldsState(
+		UnlocalizedFieldsState unlocalizedFieldsState) {
+
+		this.unlocalizedFieldsState = unlocalizedFieldsState;
+	}
+
+	public void setUnlocalizedFieldsState(
+		UnsafeSupplier<UnlocalizedFieldsState, Exception>
+			unlocalizedFieldsStateUnsafeSupplier) {
+
+		try {
+			unlocalizedFieldsState = unlocalizedFieldsStateUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected UnlocalizedFieldsState unlocalizedFieldsState;
+
+	@Override
+	public LocalizationConfig clone() throws CloneNotSupportedException {
+		return (LocalizationConfig)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof LocalizationConfig)) {
+			return false;
+		}
+
+		LocalizationConfig localizationConfig = (LocalizationConfig)object;
+
+		return Objects.equals(toString(), localizationConfig.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return LocalizationConfigSerDes.toJSON(this);
+	}
+
+	public static enum UnlocalizedFieldsState {
+
+		DISABLED("Disabled"), READ_ONLY("ReadOnly");
+
+		public static UnlocalizedFieldsState create(String value) {
+			for (UnlocalizedFieldsState unlocalizedFieldsState : values()) {
+				if (Objects.equals(unlocalizedFieldsState.getValue(), value) ||
+					Objects.equals(unlocalizedFieldsState.name(), value)) {
+
+					return unlocalizedFieldsState;
+				}
+			}
+
+			return null;
+		}
+
+		public String getValue() {
+			return _value;
+		}
+
+		@Override
+		public String toString() {
+			return _value;
+		}
+
+		private UnlocalizedFieldsState(String value) {
+			_value = value;
+		}
+
+		private final String _value;
+
+	}
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/FormContainerConfigSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/FormContainerConfigSerDes.java
@@ -70,6 +70,17 @@ public class FormContainerConfigSerDes {
 			sb.append("\"");
 		}
 
+		if (formContainerConfig.getLocalizationConfig() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"localizationConfig\": ");
+
+			sb.append(
+				String.valueOf(formContainerConfig.getLocalizationConfig()));
+		}
+
 		if (formContainerConfig.getNumberOfSteps() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -135,6 +146,15 @@ public class FormContainerConfigSerDes {
 				String.valueOf(formContainerConfig.getFormContainerType()));
 		}
 
+		if (formContainerConfig.getLocalizationConfig() == null) {
+			map.put("localizationConfig", null);
+		}
+		else {
+			map.put(
+				"localizationConfig",
+				String.valueOf(formContainerConfig.getLocalizationConfig()));
+		}
+
 		if (formContainerConfig.getNumberOfSteps() == null) {
 			map.put("numberOfSteps", null);
 		}
@@ -181,6 +201,11 @@ public class FormContainerConfigSerDes {
 			else if (Objects.equals(jsonParserFieldName, "formContainerType")) {
 				return false;
 			}
+			else if (Objects.equals(
+						jsonParserFieldName, "localizationConfig")) {
+
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "numberOfSteps")) {
 				return false;
 			}
@@ -210,6 +235,15 @@ public class FormContainerConfigSerDes {
 				if (jsonParserFieldValue != null) {
 					formContainerConfig.setFormContainerType(
 						FormContainerConfig.FormContainerType.create(
+							(String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "localizationConfig")) {
+
+				if (jsonParserFieldValue != null) {
+					formContainerConfig.setLocalizationConfig(
+						LocalizationConfigSerDes.toDTO(
 							(String)jsonParserFieldValue));
 				}
 			}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/LocalizationConfigSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/LocalizationConfigSerDes.java
@@ -1,0 +1,257 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.client.serdes.v1_0;
+
+import com.liferay.headless.admin.site.client.dto.v1_0.LocalizationConfig;
+import com.liferay.headless.admin.site.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Rubén Pulido
+ * @generated
+ */
+@Generated("")
+public class LocalizationConfigSerDes {
+
+	public static LocalizationConfig toDTO(String json) {
+		LocalizationConfigJSONParser localizationConfigJSONParser =
+			new LocalizationConfigJSONParser();
+
+		return localizationConfigJSONParser.parseToDTO(json);
+	}
+
+	public static LocalizationConfig[] toDTOs(String json) {
+		LocalizationConfigJSONParser localizationConfigJSONParser =
+			new LocalizationConfigJSONParser();
+
+		return localizationConfigJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(LocalizationConfig localizationConfig) {
+		if (localizationConfig == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (localizationConfig.
+				getUnlocalizedFieldsMessageFragmentInlineValue() != null) {
+
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"unlocalizedFieldsMessageFragmentInlineValue\": ");
+
+			sb.append(
+				String.valueOf(
+					localizationConfig.
+						getUnlocalizedFieldsMessageFragmentInlineValue()));
+		}
+
+		if (localizationConfig.getUnlocalizedFieldsState() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"unlocalizedFieldsState\": ");
+
+			sb.append("\"");
+			sb.append(localizationConfig.getUnlocalizedFieldsState());
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		LocalizationConfigJSONParser localizationConfigJSONParser =
+			new LocalizationConfigJSONParser();
+
+		return localizationConfigJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(
+		LocalizationConfig localizationConfig) {
+
+		if (localizationConfig == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (localizationConfig.
+				getUnlocalizedFieldsMessageFragmentInlineValue() == null) {
+
+			map.put("unlocalizedFieldsMessageFragmentInlineValue", null);
+		}
+		else {
+			map.put(
+				"unlocalizedFieldsMessageFragmentInlineValue",
+				String.valueOf(
+					localizationConfig.
+						getUnlocalizedFieldsMessageFragmentInlineValue()));
+		}
+
+		if (localizationConfig.getUnlocalizedFieldsState() == null) {
+			map.put("unlocalizedFieldsState", null);
+		}
+		else {
+			map.put(
+				"unlocalizedFieldsState",
+				String.valueOf(localizationConfig.getUnlocalizedFieldsState()));
+		}
+
+		return map;
+	}
+
+	public static class LocalizationConfigJSONParser
+		extends BaseJSONParser<LocalizationConfig> {
+
+		@Override
+		protected LocalizationConfig createDTO() {
+			return new LocalizationConfig();
+		}
+
+		@Override
+		protected LocalizationConfig[] createDTOArray(int size) {
+			return new LocalizationConfig[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(
+					jsonParserFieldName,
+					"unlocalizedFieldsMessageFragmentInlineValue")) {
+
+				return false;
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "unlocalizedFieldsState")) {
+
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			LocalizationConfig localizationConfig, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(
+					jsonParserFieldName,
+					"unlocalizedFieldsMessageFragmentInlineValue")) {
+
+				if (jsonParserFieldValue != null) {
+					localizationConfig.
+						setUnlocalizedFieldsMessageFragmentInlineValue(
+							FragmentInlineValueSerDes.toDTO(
+								(String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "unlocalizedFieldsState")) {
+
+				if (jsonParserFieldValue != null) {
+					localizationConfig.setUnlocalizedFieldsState(
+						LocalizationConfig.UnlocalizedFieldsState.create(
+							(String)jsonParserFieldValue));
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
@@ -892,6 +892,20 @@ components:
                 formContainerType:
                     enum: [Multistep, Simple]
                     type: string
+                localizationConfig:
+                    properties:
+                        unlocalizedFieldsMessageFragmentInlineValue:
+                            $ref: "#/components/schemas/FragmentInlineValue"
+                            # @review
+                            description:
+                                The message displayed in the unlocalized fields.
+                        unlocalizedFieldsState:
+                            # @review
+                            description:
+                                The state of the unlocalized fields.
+                            enum: [Disabled, ReadOnly]
+                            type: string
+                    type: object
                 numberOfSteps:
                     # @review
                     description:

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/FormContainerPageElementDefinitionDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/FormContainerPageElementDefinitionDTOConverter.java
@@ -14,6 +14,7 @@ import com.liferay.headless.admin.site.dto.v1_0.FormContainerPageElementDefiniti
 import com.liferay.headless.admin.site.dto.v1_0.FormContainerReference;
 import com.liferay.headless.admin.site.dto.v1_0.FragmentInlineValue;
 import com.liferay.headless.admin.site.dto.v1_0.ItemExternalReference;
+import com.liferay.headless.admin.site.dto.v1_0.LocalizationConfig;
 import com.liferay.headless.admin.site.dto.v1_0.SitePageFormContainerSubmissionResult;
 import com.liferay.headless.admin.site.dto.v1_0.StayInPageFormContainerSubmissionResult;
 import com.liferay.headless.admin.site.dto.v1_0.SuccessFormContainerSubmissionResult;
@@ -145,6 +146,8 @@ public class FormContainerPageElementDefinitionDTOConverter
 
 						return FormContainerType.MULTISTEP;
 					});
+				setLocalizationConfig(
+					() -> _toLocalizationConfig(formStyledLayoutStructureItem));
 				setNumberOfSteps(
 					formStyledLayoutStructureItem::getNumberOfSteps);
 				setSuccessFormContainerSubmissionResult(
@@ -290,6 +293,38 @@ public class FormContainerPageElementDefinitionDTOConverter
 			});
 
 		return itemExternalReference;
+	}
+
+	private LocalizationConfig _toLocalizationConfig(
+		FormStyledLayoutStructureItem formStyledLayoutStructureItem) {
+
+		JSONObject jsonObject =
+			formStyledLayoutStructureItem.getLocalizationConfigJSONObject();
+
+		if (JSONUtil.isEmpty(jsonObject)) {
+			return null;
+		}
+
+		return new LocalizationConfig() {
+			{
+				setUnlocalizedFieldsMessageFragmentInlineValue(
+					() -> _toFragmentInlineValue(
+						jsonObject.getJSONObject("unlocalizedFieldsMessage")));
+				setUnlocalizedFieldsState(
+					() -> {
+						String unlocalizedFieldsState = jsonObject.getString(
+							"unlocalizedFieldsState");
+
+						if (StringUtil.equals(
+								"read-only", unlocalizedFieldsState)) {
+
+							return UnlocalizedFieldsState.READ_ONLY;
+						}
+
+						return UnlocalizedFieldsState.DISABLED;
+					});
+			}
+		};
 	}
 
 	private SuccessFormContainerSubmissionResult

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/layout/structure/item/importer/FormContainerLayoutStructureItemImporter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/layout/structure/item/importer/FormContainerLayoutStructureItemImporter.java
@@ -14,6 +14,7 @@ import com.liferay.headless.admin.site.dto.v1_0.FormContainerPageElementDefiniti
 import com.liferay.headless.admin.site.dto.v1_0.FragmentInlineValue;
 import com.liferay.headless.admin.site.dto.v1_0.ItemExternalReference;
 import com.liferay.headless.admin.site.dto.v1_0.Layout;
+import com.liferay.headless.admin.site.dto.v1_0.LocalizationConfig;
 import com.liferay.headless.admin.site.dto.v1_0.PageElement;
 import com.liferay.headless.admin.site.dto.v1_0.SitePageFormContainerSubmissionResult;
 import com.liferay.headless.admin.site.dto.v1_0.StayInPageFormContainerSubmissionResult;
@@ -176,6 +177,37 @@ public class FormContainerLayoutStructureItemImporter
 			formStyledLayoutStructureItem.setFlexWrap(null);
 			formStyledLayoutStructureItem.setJustify(null);
 			formStyledLayoutStructureItem.setWidthType(null);
+		}
+
+		LocalizationConfig localizationConfig =
+			formContainerConfig.getLocalizationConfig();
+
+		if (localizationConfig != null) {
+			formStyledLayoutStructureItem.setLocalizationConfigJSONObject(
+				JSONUtil.put(
+					"unlocalizedFieldsMessage",
+					_toFragmentInlineValueJSONObject(
+						localizationConfig.
+							getUnlocalizedFieldsMessageFragmentInlineValue())
+				).put(
+					"unlocalizedFieldsState",
+					() -> {
+						LocalizationConfig.UnlocalizedFieldsState
+							unlocalizedFieldsState =
+								localizationConfig.getUnlocalizedFieldsState();
+
+						if ((unlocalizedFieldsState == null) ||
+							Objects.equals(
+								unlocalizedFieldsState,
+								LocalizationConfig.UnlocalizedFieldsState.
+									DISABLED)) {
+
+							return "disabled";
+						}
+
+						return "read-only";
+					}
+				));
 		}
 
 		formStyledLayoutStructureItem.setNumberOfSteps(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
@@ -58,6 +58,7 @@ import com.liferay.headless.admin.site.client.dto.v1_0.HtmlProperties;
 import com.liferay.headless.admin.site.client.dto.v1_0.ItemExternalReference;
 import com.liferay.headless.admin.site.client.dto.v1_0.ListStyle;
 import com.liferay.headless.admin.site.client.dto.v1_0.ListStyleDefinition;
+import com.liferay.headless.admin.site.client.dto.v1_0.LocalizationConfig;
 import com.liferay.headless.admin.site.client.dto.v1_0.Mapping;
 import com.liferay.headless.admin.site.client.dto.v1_0.ModulePageElementDefinition;
 import com.liferay.headless.admin.site.client.dto.v1_0.ModuleViewport;
@@ -886,7 +887,8 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 	private FormContainerConfig _getFormContainerConfig(
 		String className,
 		boolean formContainerSubmissionResultDefaultDisplayPage,
-		String formContainerSubmissionResultType) {
+		String formContainerSubmissionResultType,
+		LocalizationConfig.UnlocalizedFieldsState unlocalizedFieldsState) {
 
 		FormContainerConfig formContainerConfig = new FormContainerConfig();
 
@@ -921,6 +923,8 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		formContainerConfig.setFormContainerType(
 			FormContainerConfig.FormContainerType.SIMPLE);
 		formContainerConfig.setNumberOfSteps(1);
+		formContainerConfig.setLocalizationConfig(
+			() -> _getLocalizationConfig(unlocalizedFieldsState));
 		formContainerConfig.setSuccessFormContainerSubmissionResult(
 			() -> _getSuccessFormContainerSubmissionResult(
 				className, formContainerSubmissionResultDefaultDisplayPage,
@@ -933,7 +937,8 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 			String className, String[] cssClasses, String customCss,
 			boolean formContainerSubmissionResultDefaultDisplayPage,
 			String formContainerSubmissionResultType, boolean indexed,
-			String pageElementExternalReferenceCode)
+			String pageElementExternalReferenceCode,
+			LocalizationConfig.UnlocalizedFieldsState unlocalizedFieldsState)
 		throws Exception {
 
 		FormContainerPageElementDefinition formContainerPageElementDefinition =
@@ -944,7 +949,7 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		formContainerPageElementDefinition.setFormContainerConfig(
 			_getFormContainerConfig(
 				className, formContainerSubmissionResultDefaultDisplayPage,
-				formContainerSubmissionResultType));
+				formContainerSubmissionResultType, unlocalizedFieldsState));
 		formContainerPageElementDefinition.setFragmentViewports(
 			_getFragmentViewports());
 		formContainerPageElementDefinition.setIndexed(indexed);
@@ -1260,6 +1265,23 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 
 		return LayoutStructure.of(
 			layoutPageTemplateStructure.getDefaultSegmentsExperienceData());
+	}
+
+	private LocalizationConfig _getLocalizationConfig(
+		LocalizationConfig.UnlocalizedFieldsState unlocalizedFieldsState) {
+
+		if (unlocalizedFieldsState == null) {
+			return null;
+		}
+
+		LocalizationConfig localizationConfig = new LocalizationConfig();
+
+		localizationConfig.setUnlocalizedFieldsMessageFragmentInlineValue(
+			this::_getRandomFragmentInlineValue);
+		localizationConfig.setUnlocalizedFieldsState(
+			() -> unlocalizedFieldsState);
+
+		return localizationConfig;
 	}
 
 	private PageElement _getModulePageElement(
@@ -1865,34 +1887,38 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 				objectDefinition.getClassName(),
 				RandomTestUtil.randomStrings(RandomTestUtil.randomInt(1, 10)),
 				RandomTestUtil.randomString(), true, "displayPage", true,
-				RandomTestUtil.randomString()));
+				RandomTestUtil.randomString(),
+				LocalizationConfig.UnlocalizedFieldsState.READ_ONLY));
 		_testPostSitePageSpecificationPageExperiencePageElement(
 			_getFormContainerPageElement(
 				objectDefinition.getClassName(), null, null, false,
-				"displayPage", false, RandomTestUtil.randomString()));
+				"displayPage", false, RandomTestUtil.randomString(), null));
 
 		_testPostSitePageSpecificationPageExperiencePageElement(
 			_getFormContainerPageElement(
 				null,
 				RandomTestUtil.randomStrings(RandomTestUtil.randomInt(1, 10)),
 				RandomTestUtil.randomString(), false, "embedded", false,
-				RandomTestUtil.randomString()));
+				RandomTestUtil.randomString(),
+				LocalizationConfig.UnlocalizedFieldsState.DISABLED));
 		_testPostSitePageSpecificationPageExperiencePageElement(
 			_getFormContainerPageElement(
 				objectDefinition.getClassName(), null, null, false, "none",
-				false, RandomTestUtil.randomString()));
+				false, RandomTestUtil.randomString(), null));
 		_testPostSitePageSpecificationPageExperiencePageElement(
 			_getFormContainerPageElement(
 				null,
 				RandomTestUtil.randomStrings(RandomTestUtil.randomInt(1, 10)),
 				RandomTestUtil.randomString(), false, "page", false,
-				RandomTestUtil.randomString()));
+				RandomTestUtil.randomString(),
+				LocalizationConfig.UnlocalizedFieldsState.READ_ONLY));
 		_testPostSitePageSpecificationPageExperiencePageElement(
 			_getFormContainerPageElement(
 				objectDefinition.getClassName(),
 				RandomTestUtil.randomStrings(RandomTestUtil.randomInt(1, 10)),
 				RandomTestUtil.randomString(), false, "url", false,
-				RandomTestUtil.randomString()));
+				RandomTestUtil.randomString(),
+				LocalizationConfig.UnlocalizedFieldsState.DISABLED));
 	}
 
 	private void _testPostSitePageSpecificationPageExperiencePageElementWithFragmentPageElement()
@@ -2128,33 +2154,37 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 				objectDefinition.getClassName(),
 				RandomTestUtil.randomStrings(RandomTestUtil.randomInt(1, 10)),
 				RandomTestUtil.randomString(), true, "displayPage", true,
-				externalReferenceCode));
+				externalReferenceCode,
+				LocalizationConfig.UnlocalizedFieldsState.READ_ONLY));
 		_testPutSitePageSpecificationPageExperiencePageElement(
 			_getFormContainerPageElement(
 				objectDefinition.getClassName(), null, null, false,
-				"displayPage", false, externalReferenceCode));
+				"displayPage", false, externalReferenceCode, null));
 		_testPutSitePageSpecificationPageExperiencePageElement(
 			_getFormContainerPageElement(
 				null,
 				RandomTestUtil.randomStrings(RandomTestUtil.randomInt(1, 10)),
 				RandomTestUtil.randomString(), false, "embedded", false,
-				externalReferenceCode));
+				externalReferenceCode,
+				LocalizationConfig.UnlocalizedFieldsState.DISABLED));
 		_testPutSitePageSpecificationPageExperiencePageElement(
 			_getFormContainerPageElement(
 				objectDefinition.getClassName(), null, null, false, "none",
-				false, externalReferenceCode));
+				false, externalReferenceCode,
+				LocalizationConfig.UnlocalizedFieldsState.READ_ONLY));
 		_testPutSitePageSpecificationPageExperiencePageElement(
 			_getFormContainerPageElement(
 				null,
 				RandomTestUtil.randomStrings(RandomTestUtil.randomInt(1, 10)),
 				RandomTestUtil.randomString(), false, "page", false,
-				externalReferenceCode));
+				externalReferenceCode, null));
 		_testPutSitePageSpecificationPageExperiencePageElement(
 			_getFormContainerPageElement(
 				objectDefinition.getClassName(),
 				RandomTestUtil.randomStrings(RandomTestUtil.randomInt(1, 10)),
 				RandomTestUtil.randomString(), false, "url", false,
-				externalReferenceCode));
+				externalReferenceCode,
+				LocalizationConfig.UnlocalizedFieldsState.DISABLED));
 		_testPutSitePageSpecificationPageExperiencePageElement(
 			_getPageElement(
 				new FormContainerPageElementDefinition() {


### PR DESCRIPTION
Hi @brianchandotcom ,

I am sending again in order to fix this: https://github.com/brianchandotcom/liferay-portal/pull/167610#issuecomment-3517067346.

thanks

https://liferay.atlassian.net/browse/LPD-70429

# What is this solving?

Add localizable configuration for the form container:
<img width="570" height="672" alt="image" src="https://github.com/user-attachments/assets/1f9b380c-661b-4112-b6fd-c1953b36246f" />


# How is it fixed?

Modify the yaml to map the configuration and implement the util's , the form container, the importer and the DTO .

# How to verify?

Run included integration tests


