### PR TITLE
LPD-66994 - Old staging errors not visible in the new errors UI (pr to avoid create two tx when it is not needed)

### DIFF
--- a/modules/apps/export-import/export-import-report-api/src/main/java/com/liferay/exportimport/report/service/ExportImportReportEntryLocalService.java
+++ b/modules/apps/export-import/export-import-report-api/src/main/java/com/liferay/exportimport/report/service/ExportImportReportEntryLocalService.java
@@ -59,7 +59,6 @@ public interface ExportImportReportEntryLocalService
 		int origin);
 
 	@Indexable(type = IndexableType.REINDEX)
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public ExportImportReportEntry addErrorExportImportReportEntry(
 		long groupId, long companyId, String classExternalReferenceCode,
 		long classNameId, long classPK, long exportImportConfigurationId,

--- a/modules/apps/export-import/export-import-report-api/src/main/resources/com/liferay/exportimport/report/service/packageinfo
+++ b/modules/apps/export-import/export-import-report-api/src/main/resources/com/liferay/exportimport/report/service/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.0.1

--- a/modules/apps/export-import/export-import-report-api/src/main/resources/com/liferay/exportimport/report/service/packageinfo
+++ b/modules/apps/export-import/export-import-report-api/src/main/resources/com/liferay/exportimport/report/service/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.1
+version 3.0.0

--- a/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/internal/exception/handler/ImportStagedModelExceptionHandlerImpl.java
+++ b/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/internal/exception/handler/ImportStagedModelExceptionHandlerImpl.java
@@ -87,18 +87,6 @@ public class ImportStagedModelExceptionHandlerImpl
 		return outputStream.toString();
 	}
 
-	private long _getGroupId(PortletDataContext portletDataContext) {
-		long groupId = portletDataContext.getGroupId();
-
-		if (ExportImportReportEntryUtil.isCompanyScoped(
-			groupId, _groupLocalService)) {
-
-			groupId = 0;
-		}
-
-		return groupId;
-	}
-
 	private String _getExternalReferenceCode(StagedModel stagedModel) {
 		String externalReferenceCode = null;
 
@@ -111,6 +99,18 @@ public class ImportStagedModelExceptionHandlerImpl
 		}
 
 		return externalReferenceCode;
+	}
+
+	private long _getGroupId(PortletDataContext portletDataContext) {
+		long groupId = portletDataContext.getGroupId();
+
+		if (ExportImportReportEntryUtil.isCompanyScoped(
+				groupId, _groupLocalService)) {
+
+			groupId = 0;
+		}
+
+		return groupId;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/internal/exception/handler/ImportStagedModelExceptionHandlerImpl.java
+++ b/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/internal/exception/handler/ImportStagedModelExceptionHandlerImpl.java
@@ -11,9 +11,15 @@ import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.PortletDataException;
 import com.liferay.exportimport.report.internal.util.ExportImportReportEntryUtil;
 import com.liferay.exportimport.report.service.ExportImportReportEntryLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.StagedModel;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.io.ByteArrayOutputStream;
@@ -47,22 +53,40 @@ public class ImportStagedModelExceptionHandlerImpl
 
 		Class<?> modelClass = stagedModel.getModelClass();
 
-		long groupId = portletDataContext.getGroupId();
+		try {
+			String finalExternalReferenceCode = externalReferenceCode;
 
-		if (ExportImportReportEntryUtil.isCompanyScoped(
-				groupId, _groupLocalService)) {
+			long groupId = _getGroupId(portletDataContext);
 
-			groupId = 0;
+			TransactionInvokerUtil.invoke(
+				_transactionConfig,
+				() -> {
+					_exportImportReportEntryLocalService.
+						addErrorExportImportReportEntry(
+							groupId, portletDataContext.getCompanyId(),
+							finalExternalReferenceCode,
+							ExportImportClassedModelUtil.getClassNameId(
+								stagedModel),
+							ExportImportClassedModelUtil.getClassPK(
+								stagedModel),
+							GetterUtil.getLong(
+								portletDataContext.getExportImportProcessId()),
+							portletDataException.getMessage(),
+							_getErrorStackTrace(portletDataException),
+							modelClass.getName(),
+							ExportImportReportEntryUtil.getOrigin());
+
+					return null;
+				});
 		}
-
-		_exportImportReportEntryLocalService.addErrorExportImportReportEntry(
-			groupId, portletDataContext.getCompanyId(), externalReferenceCode,
-			ExportImportClassedModelUtil.getClassNameId(stagedModel),
-			ExportImportClassedModelUtil.getClassPK(stagedModel),
-			GetterUtil.getLong(portletDataContext.getExportImportProcessId()),
-			portletDataException.getMessage(),
-			_getErrorStackTrace(portletDataException), modelClass.getName(),
-			ExportImportReportEntryUtil.getOrigin());
+		catch (Throwable throwable) {
+			_log.error(
+				StringBundler.concat(
+					"Unable to add error export import report entry with ",
+					"external reference code \"", externalReferenceCode,
+					"\" and model name \"", modelClass.getName(), "\""),
+				throwable);
+		}
 	}
 
 	private String _getErrorStackTrace(Throwable throwable) {
@@ -72,6 +96,25 @@ public class ImportStagedModelExceptionHandlerImpl
 
 		return outputStream.toString();
 	}
+
+	private long _getGroupId(PortletDataContext portletDataContext) {
+		long groupId = portletDataContext.getGroupId();
+
+		if (ExportImportReportEntryUtil.isCompanyScoped(
+				groupId, _groupLocalService)) {
+
+			groupId = 0;
+		}
+
+		return groupId;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ImportStagedModelExceptionHandlerImpl.class);
+
+	private static final TransactionConfig _transactionConfig =
+		TransactionConfig.Factory.create(
+			Propagation.REQUIRES_NEW, new Class<?>[] {Exception.class});
 
 	@Reference
 	private ExportImportReportEntryLocalService

--- a/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/internal/exception/handler/ImportStagedModelExceptionHandlerImpl.java
+++ b/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/internal/exception/handler/ImportStagedModelExceptionHandlerImpl.java
@@ -41,30 +41,20 @@ public class ImportStagedModelExceptionHandlerImpl
 		PortletDataContext portletDataContext,
 		PortletDataException portletDataException, T stagedModel) {
 
-		String externalReferenceCode = null;
-
-		if (stagedModel instanceof ExternalReferenceCodeModel) {
-			ExternalReferenceCodeModel externalReferenceCodeModel =
-				(ExternalReferenceCodeModel)stagedModel;
-
-			externalReferenceCode =
-				externalReferenceCodeModel.getExternalReferenceCode();
-		}
+		String externalReferenceCode = _getExternalReferenceCode(stagedModel);
 
 		Class<?> modelClass = stagedModel.getModelClass();
 
+		long groupId = _getGroupId(portletDataContext);
+
 		try {
-			String finalExternalReferenceCode = externalReferenceCode;
-
-			long groupId = _getGroupId(portletDataContext);
-
 			TransactionInvokerUtil.invoke(
 				_transactionConfig,
 				() -> {
 					_exportImportReportEntryLocalService.
 						addErrorExportImportReportEntry(
 							groupId, portletDataContext.getCompanyId(),
-							finalExternalReferenceCode,
+							externalReferenceCode,
 							ExportImportClassedModelUtil.getClassNameId(
 								stagedModel),
 							ExportImportClassedModelUtil.getClassPK(
@@ -101,12 +91,26 @@ public class ImportStagedModelExceptionHandlerImpl
 		long groupId = portletDataContext.getGroupId();
 
 		if (ExportImportReportEntryUtil.isCompanyScoped(
-				groupId, _groupLocalService)) {
+			groupId, _groupLocalService)) {
 
 			groupId = 0;
 		}
 
 		return groupId;
+	}
+
+	private String _getExternalReferenceCode(StagedModel stagedModel) {
+		String externalReferenceCode = null;
+
+		if (stagedModel instanceof ExternalReferenceCodeModel) {
+			ExternalReferenceCodeModel externalReferenceCodeModel =
+				(ExternalReferenceCodeModel)stagedModel;
+
+			externalReferenceCode =
+				externalReferenceCodeModel.getExternalReferenceCode();
+		}
+
+		return externalReferenceCode;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/service/impl/ExportImportReportEntryLocalServiceImpl.java
+++ b/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/service/impl/ExportImportReportEntryLocalServiceImpl.java
@@ -11,8 +11,6 @@ import com.liferay.exportimport.report.service.base.ExportImportReportEntryLocal
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
-import com.liferay.portal.kernel.transaction.Propagation;
-import com.liferay.portal.kernel.transaction.Transactional;
 
 import java.util.List;
 
@@ -58,7 +56,6 @@ public class ExportImportReportEntryLocalServiceImpl
 	}
 
 	@Indexable(type = IndexableType.REINDEX)
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public ExportImportReportEntry addErrorExportImportReportEntry(
 		long groupId, long companyId, String classExternalReferenceCode,
 		long classNameId, long classPK, long exportImportConfigurationId,

--- a/modules/apps/export-import/export-import-report-test/bnd.bnd
+++ b/modules/apps/export-import/export-import-report-test/bnd.bnd
@@ -1,3 +1,4 @@
 Bundle-Name: Liferay Export Import Report Test
 Bundle-SymbolicName: com.liferay.exportimport.report.test
 Bundle-Version: 1.0.0
+-includeresource: com.liferay.exportimport.rest.client.jar=com.liferay.exportimport.rest.client-*.jar;lib:=true

--- a/modules/apps/export-import/export-import-report-test/build.gradle
+++ b/modules/apps/export-import/export-import-report-test/build.gradle
@@ -1,8 +1,6 @@
 dependencies {
 	testIntegrationImplementation project(":apps:export-import:export-import-report-api")
-	testIntegrationImplementation project(":apps:export-import:export-import-rest-api")
-	testIntegrationImplementation project(":apps:export-import:export-import-rest-client")
 	testIntegrationImplementation project(":apps:export-import:export-import-test-util")
-	testIntegrationImplementation project(":apps:portal-background-task:portal-background-task-api")
+	testIntegrationImplementation project(":apps:portal-search:portal-search-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/export-import/export-import-report-test/build.gradle
+++ b/modules/apps/export-import/export-import-report-test/build.gradle
@@ -1,5 +1,8 @@
 dependencies {
 	testIntegrationImplementation project(":apps:export-import:export-import-report-api")
+	testIntegrationImplementation project(":apps:export-import:export-import-rest-api")
+	testIntegrationImplementation project(":apps:export-import:export-import-rest-client")
 	testIntegrationImplementation project(":apps:export-import:export-import-test-util")
+	testIntegrationImplementation project(":apps:portal-background-task:portal-background-task-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/export-import/export-import-report-test/src/testIntegration/java/com/liferay/exportimport/report/internal/exception/handler/test/ImportStagedModelExceptionHandlerTest.java
+++ b/modules/apps/export-import/export-import-report-test/src/testIntegration/java/com/liferay/exportimport/report/internal/exception/handler/test/ImportStagedModelExceptionHandlerTest.java
@@ -7,6 +7,8 @@ package com.liferay.exportimport.report.internal.exception.handler.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.expando.kernel.model.ExpandoBridge;
+import com.liferay.exportimport.kernel.background.task.BackgroundTaskExecutorNames;
+import com.liferay.exportimport.kernel.configuration.constants.ExportImportConfigurationConstants;
 import com.liferay.exportimport.kernel.lar.BaseStagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
@@ -14,30 +16,49 @@ import com.liferay.exportimport.kernel.lar.PortletDataException;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.kernel.lar.StagedModelType;
+import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
+import com.liferay.exportimport.kernel.service.ExportImportConfigurationLocalService;
 import com.liferay.exportimport.report.constants.ExportImportReportEntryConstants;
 import com.liferay.exportimport.report.model.ExportImportReportEntry;
 import com.liferay.exportimport.report.service.ExportImportReportEntryLocalService;
+import com.liferay.exportimport.rest.client.dto.v1_0.ReportEntry;
+import com.liferay.exportimport.rest.client.pagination.Page;
+import com.liferay.exportimport.rest.client.pagination.Pagination;
+import com.liferay.exportimport.rest.client.resource.v1_0.ReportEntryResource;
 import com.liferay.exportimport.test.util.ExportImportTestUtil;
+import com.liferay.portal.background.task.model.BackgroundTask;
+import com.liferay.portal.background.task.service.BackgroundTaskLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.StagedModel;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import java.io.Serializable;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -56,13 +77,16 @@ import org.osgi.framework.ServiceRegistration;
 /**
  * @author Alvaro Saugar
  */
+@FeatureFlag("LPD-35914")
 @RunWith(Arquillian.class)
 public class ImportStagedModelExceptionHandlerTest {
 
 	@ClassRule
 	@Rule
-	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
-		new LiferayIntegrationTestRule();
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {
@@ -76,6 +100,7 @@ public class ImportStagedModelExceptionHandlerTest {
 		_test(0L, _companyGroup);
 		_test(_group.getGroupId(), _group);
 	}
+	protected Group testGroup;
 
 	private void _test(long expectedGroupId, Group group) throws Exception {
 		Bundle bundle = FrameworkUtil.getBundle(
@@ -95,10 +120,16 @@ public class ImportStagedModelExceptionHandlerTest {
 			ExportImportTestUtil.getImportPortletDataContext(
 				group.getGroupId());
 
-		long exportImportProcessId = RandomTestUtil.randomLong();
+		ExportImportConfiguration exportImportConfiguration =
+			_exportImportConfigurationLocalService.
+				addDraftExportImportConfiguration(
+					group.getCreatorUserId(), RandomTestUtil.randomString(),
+					ExportImportConfigurationConstants.TYPE_IMPORT_LAYOUT,
+					Collections.emptyMap());
 
 		portletDataContext.setExportImportProcessId(
-			String.valueOf(exportImportProcessId));
+			String.valueOf(
+				exportImportConfiguration.getExportImportConfigurationId()));
 
 		long exportImportReportEntriesCount =
 			_exportImportReportEntryLocalService.
@@ -137,6 +168,41 @@ public class ImportStagedModelExceptionHandlerTest {
 			serviceRegistration.unregister();
 		}
 
+		BackgroundTask backgroundTask =
+			_backgroundTaskLocalService.addBackgroundTask(
+				TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
+				RandomTestUtil.randomString(),
+				BackgroundTaskExecutorNames.
+					LAYOUT_IMPORT_BACKGROUND_TASK_EXECUTOR,
+				HashMapBuilder.<String, Serializable>put(
+					"exportImportConfigurationId",
+					portletDataContext.getExportImportProcessId()
+				).build(),
+				null);
+
+		Company testCompany = CompanyLocalServiceUtil.getCompany(
+			group.getCompanyId());
+
+		User testCompanyAdminUser = UserTestUtil.getAdminUser(
+			testCompany.getCompanyId());
+
+		ReportEntryResource reportEntryResource = ReportEntryResource.builder(
+		).authentication(
+			testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(), 8080, "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+
+		Page<ReportEntry> importProcessErrorsPage =
+			reportEntryResource.getImportProcessReportEntriesPage(
+				backgroundTask.getBackgroundTaskId(), null, null,
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(1, importProcessErrorsPage.getTotalCount());
+
 		Assert.assertEquals(
 			exportImportReportEntriesCount + 1,
 			_exportImportReportEntryLocalService.
@@ -144,7 +210,8 @@ public class ImportStagedModelExceptionHandlerTest {
 
 		List<ExportImportReportEntry> exportImportReportEntries =
 			_exportImportReportEntryLocalService.getExportImportReportEntries(
-				TestPropsValues.getCompanyId(), exportImportProcessId);
+				TestPropsValues.getCompanyId(),
+				exportImportConfiguration.getExportImportConfigurationId());
 
 		Assert.assertEquals(
 			exportImportReportEntries.toString(), 1,
@@ -159,7 +226,7 @@ public class ImportStagedModelExceptionHandlerTest {
 			TestPropsValues.getCompanyId(),
 			exportImportReportEntry.getCompanyId());
 		Assert.assertEquals(
-			exportImportProcessId,
+			exportImportConfiguration.getExportImportConfigurationId(),
 			exportImportReportEntry.getExportImportConfigurationId());
 		Assert.assertEquals(
 			externalReferenceCode,
@@ -180,9 +247,16 @@ public class ImportStagedModelExceptionHandlerTest {
 	}
 
 	@Inject
+	private BackgroundTaskLocalService _backgroundTaskLocalService;
+
+	@Inject
 	private ClassNameLocalService _classNameLocalService;
 
 	private Group _companyGroup;
+
+	@Inject
+	private ExportImportConfigurationLocalService
+		_exportImportConfigurationLocalService;
 
 	@Inject
 	private ExportImportReportEntryLocalService

--- a/modules/apps/export-import/export-import-report-test/src/testIntegration/java/com/liferay/exportimport/report/internal/exception/handler/test/ImportStagedModelExceptionHandlerTest.java
+++ b/modules/apps/export-import/export-import-report-test/src/testIntegration/java/com/liferay/exportimport/report/internal/exception/handler/test/ImportStagedModelExceptionHandlerTest.java
@@ -7,7 +7,6 @@ package com.liferay.exportimport.report.internal.exception.handler.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.expando.kernel.model.ExpandoBridge;
-import com.liferay.exportimport.kernel.background.task.BackgroundTaskExecutorNames;
 import com.liferay.exportimport.kernel.configuration.constants.ExportImportConfigurationConstants;
 import com.liferay.exportimport.kernel.lar.BaseStagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
@@ -21,36 +20,30 @@ import com.liferay.exportimport.kernel.service.ExportImportConfigurationLocalSer
 import com.liferay.exportimport.report.constants.ExportImportReportEntryConstants;
 import com.liferay.exportimport.report.model.ExportImportReportEntry;
 import com.liferay.exportimport.report.service.ExportImportReportEntryLocalService;
-import com.liferay.exportimport.rest.client.dto.v1_0.ReportEntry;
-import com.liferay.exportimport.rest.client.pagination.Page;
-import com.liferay.exportimport.rest.client.pagination.Pagination;
-import com.liferay.exportimport.rest.client.resource.v1_0.ReportEntryResource;
 import com.liferay.exportimport.test.util.ExportImportTestUtil;
-import com.liferay.portal.background.task.model.BackgroundTask;
-import com.liferay.portal.background.task.service.BackgroundTaskLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.StagedModel;
-import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
-import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
-import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
-import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.search.document.Document;
+import com.liferay.portal.search.query.Queries;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.SearchResponse;
+import com.liferay.portal.search.searcher.Searcher;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -100,7 +93,37 @@ public class ImportStagedModelExceptionHandlerTest {
 		_test(0L, _companyGroup);
 		_test(_group.getGroupId(), _group);
 	}
+
 	protected Group testGroup;
+
+	private void _assertExportImportReportEntryIndexed(
+		long classPK, long companyId, long exportImportConfigurationId) {
+
+		SearchResponse searchResponse = _searcher.search(
+			_searchRequestBuilderFactory.builder(
+			).companyId(
+				companyId
+			).emptySearchEnabled(
+				true
+			).fields(
+				Field.CLASS_PK
+			).modelIndexerClasses(
+				ExportImportReportEntry.class
+			).query(
+				_queries.term(
+					"exportImportConfigurationId_long",
+					exportImportConfigurationId)
+			).build());
+
+		Assert.assertEquals(1, searchResponse.getCount());
+
+		List<Document> documents = searchResponse.getDocuments();
+
+		Document document = documents.get(0);
+
+		Assert.assertEquals(
+			classPK, GetterUtil.getLong(document.getValue(Field.CLASS_PK)));
+	}
 
 	private void _test(long expectedGroupId, Group group) throws Exception {
 		Bundle bundle = FrameworkUtil.getBundle(
@@ -168,41 +191,6 @@ public class ImportStagedModelExceptionHandlerTest {
 			serviceRegistration.unregister();
 		}
 
-		BackgroundTask backgroundTask =
-			_backgroundTaskLocalService.addBackgroundTask(
-				TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
-				RandomTestUtil.randomString(),
-				BackgroundTaskExecutorNames.
-					LAYOUT_IMPORT_BACKGROUND_TASK_EXECUTOR,
-				HashMapBuilder.<String, Serializable>put(
-					"exportImportConfigurationId",
-					portletDataContext.getExportImportProcessId()
-				).build(),
-				null);
-
-		Company testCompany = CompanyLocalServiceUtil.getCompany(
-			group.getCompanyId());
-
-		User testCompanyAdminUser = UserTestUtil.getAdminUser(
-			testCompany.getCompanyId());
-
-		ReportEntryResource reportEntryResource = ReportEntryResource.builder(
-		).authentication(
-			testCompanyAdminUser.getEmailAddress(),
-			PropsValues.DEFAULT_ADMIN_PASSWORD
-		).endpoint(
-			testCompany.getVirtualHostname(), 8080, "http"
-		).locale(
-			LocaleUtil.getDefault()
-		).build();
-
-		Page<ReportEntry> importProcessErrorsPage =
-			reportEntryResource.getImportProcessReportEntriesPage(
-				backgroundTask.getBackgroundTaskId(), null, null,
-				Pagination.of(1, 10), null);
-
-		Assert.assertEquals(1, importProcessErrorsPage.getTotalCount());
-
 		Assert.assertEquals(
 			exportImportReportEntriesCount + 1,
 			_exportImportReportEntryLocalService.
@@ -244,10 +232,11 @@ public class ImportStagedModelExceptionHandlerTest {
 		Assert.assertEquals(
 			ExportImportReportEntryConstants.ORIGIN_STAGING,
 			exportImportReportEntry.getOrigin());
-	}
 
-	@Inject
-	private BackgroundTaskLocalService _backgroundTaskLocalService;
+		_assertExportImportReportEntryIndexed(
+			classPK, group.getCompanyId(),
+			exportImportConfiguration.getExportImportConfigurationId());
+	}
 
 	@Inject
 	private ClassNameLocalService _classNameLocalService;
@@ -267,6 +256,15 @@ public class ImportStagedModelExceptionHandlerTest {
 
 	@Inject
 	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private Queries _queries;
+
+	@Inject
+	private Searcher _searcher;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
 
 	private class TestStagedModel
 		implements ExternalReferenceCodeModel, StagedModel {


### PR DESCRIPTION
Send pr directly because there are some error in `ci:test:stable` [are not related with these changes](https://github.com/liferay-headless/liferay-portal/pull/3265#issuecomment-3520689999). 

https://liferay.atlassian.net/browse/LPD-66994

# Problem
We have an errors framework to add the exceptions are thrown during the staging process.
It was added for the classic version of Staging but it is commited in the database but are not indexed. The problem is we request the errors from the API Headless, which search the errors in the indexer, so they are not shown, for example, in the UI.

# Solution
To fully resolve this ticket, there are two tasks to complete:
* The first is to resolve the issue when there is an indexable annotation with a transaction annotation. The buffer is not selected correctly, and the information stored in the database is not indexed. This was resolved by [Shuyang  pr](https://github.com/brianchandotcom/liferay-portal/pull/167471)
* The second. We are adding the indexable annotation to the service to store staging errors, but we have two cases in staging. The old one, where all the information is stored using a transaction and, in case of an exception, a rollback is performed (so here we need a new transaction for errors), and the Batch Engine Staging, where, in [BatchEngineImportTaskExecutorImpl](https://github.com/liferay/liferay-portal/blob/master/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java#L220-L240), we already create a transaction to store the batch exception and handle it (we need both to be in the same transaction to avoid inconsistencies, so we don't need a new transaction in the service layer).

In summary, if we add the Indexable notation in the service layer, we will use more transactions than we need. 



# Test

## Manual tests
FF needed - LPD-35914

To test both cases (classic staging and batch staging) we have imported two lars which throws exception in both cases. 
For more info take a look to the [comment](https://liferay.atlassian.net/browse/LPD-66994?focusedCommentId=3667132). 


## Integration tests
To check if the errors are indexed, we use the  same approach it  is used in the Import process (in the UI), I mean, using the API `/v1.0/import-processes/{importProcessorId}/errors`

To run the test, we have to go to:
`cd modules/apps/export-import/export-import-report-test`

and run the command 
`gw testIntegration --tests ImportStagedModelExceptionHandlerTest`

```
com.liferay.exportimport.report.internal.exception.handler.test.ImportStagedModelExceptionHandlerTest STANDARD_OUT
    Loading jar:file:/home/me/workspace/Liferay/liferay-portal/bundles/tomcat-10.1.43/webapps/ROOT/WEB-INF/shielded-container-lib/portal-impl.jar!/system.properties

com.liferay.exportimport.report.internal.exception.handler.test.ImportStagedModelExceptionHandlerTest > test STARTED

com.liferay.exportimport.report.internal.exception.handler.test.ImportStagedModelExceptionHandlerTest > test PASSED

> Task :apps:export-import:export-import-report-test:stopTestableTomcat
> Task :apps:export-import:export-import-rest-api:autoUpdateXml SKIPPED
> Task :apps:export-import:export-import-rest-client:autoUpdateXml SKIPPED
> Task :apps:export-import:export-import-test-util:autoUpdateXml SKIPPED
> Task :apps:portal-background-task:portal-background-task-api:autoUpdateXml SKIPPED


BUILD SUCCESSFUL in 15s
374 actionable tasks: 7 executed, 367 up-to-date
```