### PR TITLE
LPD-69120 Implement FragmentInstancePageElementDefinition.widgetInstances

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/FragmentInstancePageElementDefinitionDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/FragmentInstancePageElementDefinitionDTOConverter.java
@@ -7,6 +7,7 @@ package com.liferay.headless.admin.site.internal.dto.v1_0.converter;
 
 import com.liferay.fragment.entry.processor.constants.FragmentEntryProcessorConstants;
 import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.fragment.processor.PortletRegistry;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.fragment.util.configuration.FragmentConfigurationField;
 import com.liferay.fragment.util.configuration.FragmentEntryConfigurationParser;
@@ -15,19 +16,25 @@ import com.liferay.headless.admin.site.dto.v1_0.FragmentConfigurationFieldValue;
 import com.liferay.headless.admin.site.dto.v1_0.FragmentInstancePageElementDefinition;
 import com.liferay.headless.admin.site.dto.v1_0.FragmentItemExternalReference;
 import com.liferay.headless.admin.site.dto.v1_0.PageElementDefinition;
+import com.liferay.headless.admin.site.dto.v1_0.WidgetInstance;
 import com.liferay.headless.admin.site.internal.dto.v1_0.util.FragmentEditableElementUtil;
 import com.liferay.headless.admin.site.internal.dto.v1_0.util.ItemScopeUtil;
+import com.liferay.headless.admin.site.internal.dto.v1_0.util.WidgetInstanceUtil;
 import com.liferay.info.item.InfoItemServiceRegistry;
 import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
@@ -160,6 +167,8 @@ public class FragmentInstancePageElementDefinitionDTOConverter
 				setNamespace(fragmentEntryLink::getNamespace);
 				setType(PageElementDefinition.Type.FRAGMENT);
 				setUuid(fragmentEntryLink::getUuid);
+				setWidgetInstances(
+					() -> _getWidgetInstances(fragmentEntryLink));
 			}
 		};
 	}
@@ -252,6 +261,28 @@ public class FragmentInstancePageElementDefinitionDTOConverter
 		return map;
 	}
 
+	private WidgetInstance[] _getWidgetInstances(
+		FragmentEntryLink fragmentEntryLink) {
+
+		List<String> fragmentEntryLinkPortletIds =
+			_portletRegistry.getFragmentEntryLinkPortletIds(fragmentEntryLink);
+
+		if (ListUtil.isEmpty(fragmentEntryLinkPortletIds)) {
+			return null;
+		}
+
+		List<WidgetInstance> widgetInstances = new ArrayList<>();
+
+		for (String fragmentEntryLinkPortletId : fragmentEntryLinkPortletIds) {
+			widgetInstances.add(
+				WidgetInstanceUtil.getWidgetInstance(
+					PortletIdCodec.decodeInstanceId(fragmentEntryLinkPortletId),
+					fragmentEntryLink.getPlid(), fragmentEntryLinkPortletId));
+		}
+
+		return widgetInstances.toArray(new WidgetInstance[0]);
+	}
+
 	@Reference(
 		target = "(component.name=com.liferay.headless.admin.site.internal.dto.v1_0.converter.FragmentConfigurationFieldValueDTOConverter)"
 	)
@@ -267,5 +298,8 @@ public class FragmentInstancePageElementDefinitionDTOConverter
 
 	@Reference
 	private InfoItemServiceRegistry _infoItemServiceRegistry;
+
+	@Reference
+	private PortletRegistry _portletRegistry;
 
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/WidgetInstancePageElementDefinitionDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/WidgetInstancePageElementDefinitionDTOConverter.java
@@ -7,35 +7,17 @@ package com.liferay.headless.admin.site.internal.dto.v1_0.converter;
 
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
-import com.liferay.headless.admin.site.dto.v1_0.WidgetInstance;
 import com.liferay.headless.admin.site.dto.v1_0.WidgetInstancePageElementDefinition;
-import com.liferay.headless.admin.site.dto.v1_0.WidgetPermission;
 import com.liferay.headless.admin.site.internal.dto.v1_0.util.FragmentViewportUtil;
-import com.liferay.layout.exporter.PortletPermissionsExporter;
+import com.liferay.headless.admin.site.internal.dto.v1_0.util.WidgetInstanceUtil;
 import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
-import com.liferay.petra.function.transform.TransformUtil;
-import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.json.JSONUtil;
-import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.model.Portlet;
-import com.liferay.portal.kernel.portlet.PortletIdCodec;
-import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
-import com.liferay.portal.kernel.service.LayoutLocalService;
-import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.MapUtil;
-import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 
-import jakarta.portlet.PortletPreferences;
-
-import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -121,7 +103,7 @@ public class WidgetInstancePageElementDefinitionDTOConverter
 		widgetInstancePageElementDefinition.setName(
 			fragmentStyledLayoutStructureItem::getName);
 		widgetInstancePageElementDefinition.setWidgetInstance(
-			() -> _getWidgetInstance(fragmentEntryLink));
+			() -> WidgetInstanceUtil.getWidgetInstance(fragmentEntryLink));
 		widgetInstancePageElementDefinition.
 			setWidgetInstanceExternalReferenceCode(
 				fragmentEntryLink::getExternalReferenceCode);
@@ -129,121 +111,7 @@ public class WidgetInstancePageElementDefinitionDTOConverter
 		return widgetInstancePageElementDefinition;
 	}
 
-	private Map<String, Object> _getWidgetConfig(long plid, String portletId) {
-		Layout layout = _layoutLocalService.fetchLayout(plid);
-
-		if (layout == null) {
-			return null;
-		}
-
-		Portlet portlet = _portletLocalService.getPortletById(
-			PortletIdCodec.decodePortletName(portletId));
-
-		if (portlet == null) {
-			return null;
-		}
-
-		PortletPreferences portletPreferences =
-			PortletPreferencesFactoryUtil.getLayoutPortletSetup(
-				layout.getCompanyId(), PortletKeys.PREFS_OWNER_ID_DEFAULT,
-				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, layout.getPlid(),
-				portletId, portlet.getDefaultPreferences());
-
-		if (portletPreferences == null) {
-			return null;
-		}
-
-		Map<String, Object> portletConfigurationMap = new TreeMap<>();
-
-		Map<String, String[]> portletPreferencesMap =
-			portletPreferences.getMap();
-
-		for (Map.Entry<String, String[]> entrySet :
-				portletPreferencesMap.entrySet()) {
-
-			String[] values = entrySet.getValue();
-
-			if (values == null) {
-				portletConfigurationMap.put(
-					entrySet.getKey(), StringPool.BLANK);
-			}
-			else if (values.length == 1) {
-				portletConfigurationMap.put(entrySet.getKey(), values[0]);
-			}
-			else {
-				portletConfigurationMap.put(entrySet.getKey(), values);
-			}
-		}
-
-		return portletConfigurationMap;
-	}
-
-	private WidgetInstance _getWidgetInstance(
-		FragmentEntryLink fragmentEntryLink) {
-
-		JSONObject jsonObject = fragmentEntryLink.getEditableValuesJSONObject();
-
-		if (JSONUtil.isEmpty(jsonObject) || !jsonObject.has("portletId")) {
-			return null;
-		}
-
-		String instanceId = jsonObject.getString("instanceId", null);
-
-		String portletId = PortletIdCodec.encode(
-			jsonObject.getString("portletId"), instanceId);
-
-		return new WidgetInstance() {
-			{
-				setWidgetConfig(
-					() -> _getWidgetConfig(
-						fragmentEntryLink.getPlid(), portletId));
-				setWidgetInstanceId(() -> instanceId);
-				setWidgetName(
-					() -> PortletIdCodec.decodePortletName(portletId));
-				setWidgetPermissions(
-					() -> _getWidgetPermissions(
-						fragmentEntryLink.getPlid(), portletId));
-			}
-		};
-	}
-
-	private WidgetPermission[] _getWidgetPermissions(
-		long plid, String portletId) {
-
-		Map<String, String[]> permissionsMap =
-			_portletPermissionsExporter.getPortletPermissions(plid, portletId);
-
-		if (MapUtil.isEmpty(permissionsMap)) {
-			return new WidgetPermission[0];
-		}
-
-		return TransformUtil.transformToArray(
-			permissionsMap.entrySet(),
-			entry -> {
-				if (ArrayUtil.isEmpty(entry.getValue())) {
-					return null;
-				}
-
-				return new WidgetPermission() {
-					{
-						setActionIds(entry::getValue);
-						setRoleName(entry::getKey);
-					}
-				};
-			},
-			WidgetPermission.class);
-	}
-
 	@Reference
 	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
-
-	@Reference
-	private LayoutLocalService _layoutLocalService;
-
-	@Reference
-	private PortletLocalService _portletLocalService;
-
-	@Reference
-	private PortletPermissionsExporter _portletPermissionsExporter;
 
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/WidgetInstancePageElementDefinitionDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/WidgetInstancePageElementDefinitionDTOConverter.java
@@ -7,10 +7,14 @@ package com.liferay.headless.admin.site.internal.dto.v1_0.converter;
 
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
+import com.liferay.headless.admin.site.dto.v1_0.WidgetInstance;
 import com.liferay.headless.admin.site.dto.v1_0.WidgetInstancePageElementDefinition;
 import com.liferay.headless.admin.site.internal.dto.v1_0.util.FragmentViewportUtil;
 import com.liferay.headless.admin.site.internal.dto.v1_0.util.WidgetInstanceUtil;
 import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -103,12 +107,30 @@ public class WidgetInstancePageElementDefinitionDTOConverter
 		widgetInstancePageElementDefinition.setName(
 			fragmentStyledLayoutStructureItem::getName);
 		widgetInstancePageElementDefinition.setWidgetInstance(
-			() -> WidgetInstanceUtil.getWidgetInstance(fragmentEntryLink));
+			() -> _getWidgetInstance(fragmentEntryLink));
 		widgetInstancePageElementDefinition.
 			setWidgetInstanceExternalReferenceCode(
 				fragmentEntryLink::getExternalReferenceCode);
 
 		return widgetInstancePageElementDefinition;
+	}
+
+	private WidgetInstance _getWidgetInstance(
+		FragmentEntryLink fragmentEntryLink) {
+
+		JSONObject jsonObject = fragmentEntryLink.getEditableValuesJSONObject();
+
+		if (JSONUtil.isEmpty(jsonObject) || !jsonObject.has("portletId")) {
+			return null;
+		}
+
+		String instanceId = jsonObject.getString("instanceId", null);
+
+		String portletId = PortletIdCodec.encode(
+			jsonObject.getString("portletId"), instanceId);
+
+		return WidgetInstanceUtil.getWidgetInstance(
+			instanceId, fragmentEntryLink.getPlid(), portletId);
 	}
 
 	@Reference

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/WidgetInstanceUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/WidgetInstanceUtil.java
@@ -5,15 +5,12 @@
 
 package com.liferay.headless.admin.site.internal.dto.v1_0.util;
 
-import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.headless.admin.site.dto.v1_0.WidgetInstance;
 import com.liferay.headless.admin.site.dto.v1_0.WidgetPermission;
 import com.liferay.layout.exporter.PortletPermissionsExporter;
 import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
@@ -38,30 +35,16 @@ import org.osgi.util.tracker.ServiceTracker;
 public class WidgetInstanceUtil {
 
 	public static WidgetInstance getWidgetInstance(
-		FragmentEntryLink fragmentEntryLink) {
-
-		JSONObject jsonObject = fragmentEntryLink.getEditableValuesJSONObject();
-
-		if (JSONUtil.isEmpty(jsonObject) || !jsonObject.has("portletId")) {
-			return null;
-		}
-
-		String instanceId = jsonObject.getString("instanceId", null);
-
-		String portletId = PortletIdCodec.encode(
-			jsonObject.getString("portletId"), instanceId);
+		String instanceId, long plid, String portletId) {
 
 		return new WidgetInstance() {
 			{
-				setWidgetConfig(
-					() -> _getWidgetConfig(
-						fragmentEntryLink.getPlid(), portletId));
+				setWidgetConfig(() -> _getWidgetConfig(plid, portletId));
 				setWidgetInstanceId(() -> instanceId);
 				setWidgetName(
 					() -> PortletIdCodec.decodePortletName(portletId));
 				setWidgetPermissions(
-					() -> _getWidgetPermissions(
-						fragmentEntryLink.getPlid(), portletId));
+					() -> _getWidgetPermissions(plid, portletId));
 			}
 		};
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/WidgetInstanceUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/WidgetInstanceUtil.java
@@ -1,0 +1,161 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.dto.v1_0.util;
+
+import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.headless.admin.site.dto.v1_0.WidgetInstance;
+import com.liferay.headless.admin.site.dto.v1_0.WidgetPermission;
+import com.liferay.layout.exporter.PortletPermissionsExporter;
+import com.liferay.osgi.util.ServiceTrackerFactory;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.portlet.PortletIdCodec;
+import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
+import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
+import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
+
+import jakarta.portlet.PortletPreferences;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.util.tracker.ServiceTracker;
+
+/**
+ * @author Mikel Lorza
+ */
+public class WidgetInstanceUtil {
+
+	public static WidgetInstance getWidgetInstance(
+		FragmentEntryLink fragmentEntryLink) {
+
+		JSONObject jsonObject = fragmentEntryLink.getEditableValuesJSONObject();
+
+		if (JSONUtil.isEmpty(jsonObject) || !jsonObject.has("portletId")) {
+			return null;
+		}
+
+		String instanceId = jsonObject.getString("instanceId", null);
+
+		String portletId = PortletIdCodec.encode(
+			jsonObject.getString("portletId"), instanceId);
+
+		return new WidgetInstance() {
+			{
+				setWidgetConfig(
+					() -> _getWidgetConfig(
+						fragmentEntryLink.getPlid(), portletId));
+				setWidgetInstanceId(() -> instanceId);
+				setWidgetName(
+					() -> PortletIdCodec.decodePortletName(portletId));
+				setWidgetPermissions(
+					() -> _getWidgetPermissions(
+						fragmentEntryLink.getPlid(), portletId));
+			}
+		};
+	}
+
+	private static Map<String, Object> _getWidgetConfig(
+		long plid, String portletId) {
+
+		Layout layout = LayoutLocalServiceUtil.fetchLayout(plid);
+
+		if (layout == null) {
+			return null;
+		}
+
+		Portlet portlet = PortletLocalServiceUtil.getPortletById(
+			PortletIdCodec.decodePortletName(portletId));
+
+		if (portlet == null) {
+			return null;
+		}
+
+		PortletPreferences portletPreferences =
+			PortletPreferencesFactoryUtil.getLayoutPortletSetup(
+				layout.getCompanyId(), PortletKeys.PREFS_OWNER_ID_DEFAULT,
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, layout.getPlid(),
+				portletId, portlet.getDefaultPreferences());
+
+		if (portletPreferences == null) {
+			return null;
+		}
+
+		Map<String, Object> portletConfigurationMap = new TreeMap<>();
+
+		Map<String, String[]> portletPreferencesMap =
+			portletPreferences.getMap();
+
+		for (Map.Entry<String, String[]> entrySet :
+				portletPreferencesMap.entrySet()) {
+
+			String[] values = entrySet.getValue();
+
+			if (values == null) {
+				portletConfigurationMap.put(
+					entrySet.getKey(), StringPool.BLANK);
+			}
+			else if (values.length == 1) {
+				portletConfigurationMap.put(entrySet.getKey(), values[0]);
+			}
+			else {
+				portletConfigurationMap.put(entrySet.getKey(), values);
+			}
+		}
+
+		return portletConfigurationMap;
+	}
+
+	private static WidgetPermission[] _getWidgetPermissions(
+		long plid, String portletId) {
+
+		PortletPermissionsExporter portletPermissionsExporter =
+			_portletPermissionsExporterServiceTracker.getService();
+
+		if (portletPermissionsExporter == null) {
+			return null;
+		}
+
+		Map<String, String[]> permissionsMap =
+			portletPermissionsExporter.getPortletPermissions(plid, portletId);
+
+		if (MapUtil.isEmpty(permissionsMap)) {
+			return new WidgetPermission[0];
+		}
+
+		return TransformUtil.transformToArray(
+			permissionsMap.entrySet(),
+			entry -> {
+				if (ArrayUtil.isEmpty(entry.getValue())) {
+					return null;
+				}
+
+				return new WidgetPermission() {
+					{
+						setActionIds(entry::getValue);
+						setRoleName(entry::getKey);
+					}
+				};
+			},
+			WidgetPermission.class);
+	}
+
+	private static final ServiceTracker
+		<PortletPermissionsExporter, PortletPermissionsExporter>
+			_portletPermissionsExporterServiceTracker =
+				ServiceTrackerFactory.open(
+					FrameworkUtil.getBundle(WidgetInstanceUtil.class),
+					PortletPermissionsExporter.class);
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/layout/structure/item/importer/FragmentLayoutStructureItemImporter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/layout/structure/item/importer/FragmentLayoutStructureItemImporter.java
@@ -9,6 +9,7 @@ import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.contributor.util.FragmentCollectionContributorRegistryUtil;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.fragment.processor.PortletRegistry;
 import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.fragment.renderer.util.FragmentRendererRegistryUtil;
 import com.liferay.fragment.service.FragmentEntryLinkLocalServiceUtil;
@@ -18,25 +19,41 @@ import com.liferay.headless.admin.site.dto.v1_0.FragmentInstancePageElementDefin
 import com.liferay.headless.admin.site.dto.v1_0.FragmentItemExternalReference;
 import com.liferay.headless.admin.site.dto.v1_0.FragmentReference;
 import com.liferay.headless.admin.site.dto.v1_0.PageElement;
+import com.liferay.headless.admin.site.dto.v1_0.WidgetInstance;
 import com.liferay.headless.admin.site.internal.dto.v1_0.util.FragmentEditableElementUtil;
 import com.liferay.headless.admin.site.internal.dto.v1_0.util.ItemScopeUtil;
 import com.liferay.headless.admin.site.internal.resource.v1_0.layout.structure.item.importer.context.LayoutStructureItemImporterContext;
 import com.liferay.headless.admin.site.internal.resource.v1_0.layout.structure.item.importer.util.FragmentConfigurationFieldValuesUtil;
 import com.liferay.headless.admin.site.internal.resource.v1_0.util.LayoutStructureUtil;
+import com.liferay.headless.admin.site.internal.resource.v1_0.util.PortletUtil;
 import com.liferay.headless.admin.site.internal.util.LogUtil;
 import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.portlet.PortletIdCodec;
+import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Objects;
+
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.util.tracker.ServiceTracker;
 
 /**
  * @author Eudaldo Alonso
@@ -68,12 +85,23 @@ public class FragmentLayoutStructureItemImporter
 						getFragmentInstanceExternalReferenceCode(),
 					layoutStructureItemImporterContext.getGroupId());
 
+		List<String> fragmentEntryLinkPortletIds = null;
+
 		if (fragmentEntryLink == null) {
 			fragmentEntryLink = _addFragmentEntryLink(
 				fragmentInstancePageElementDefinition,
 				layoutStructureItemImporterContext);
 		}
 		else {
+			PortletRegistry portletRegistry =
+				_portletRegistryServiceTracker.getService();
+
+			if (portletRegistry != null) {
+				fragmentEntryLinkPortletIds =
+					portletRegistry.getFragmentEntryLinkPortletIds(
+						fragmentEntryLink);
+			}
+
 			fragmentEntryLink = _updateFragmentEntryLink(
 				fragmentEntryLink, fragmentInstancePageElementDefinition,
 				layoutStructureItemImporterContext);
@@ -81,6 +109,53 @@ public class FragmentLayoutStructureItemImporter
 
 		if (fragmentEntryLink == null) {
 			return null;
+		}
+
+		Layout layout = layoutStructureItemImporterContext.getLayout();
+
+		if (ArrayUtil.isNotEmpty(
+				fragmentInstancePageElementDefinition.getWidgetInstances())) {
+
+			for (WidgetInstance widgetInstance :
+					fragmentInstancePageElementDefinition.
+						getWidgetInstances()) {
+
+				if (Validator.isNull(widgetInstance.getWidgetName())) {
+					continue;
+				}
+
+				String portletId = PortletIdCodec.encode(
+					widgetInstance.getWidgetName(),
+					widgetInstance.getWidgetInstanceId());
+
+				PortletUtil.importPortletPreferences(
+					layout, portletId, widgetInstance.getWidgetConfig());
+
+				PortletUtil.importPortletPermissions(
+					layout, portletId, widgetInstance.getWidgetName(),
+					widgetInstance.getWidgetPermissions());
+			}
+		}
+
+		if (ListUtil.isNotEmpty(fragmentEntryLinkPortletIds)) {
+			for (String fragmentEntryLinkPortletId :
+					SetUtil.asymmetricDifference(
+						fragmentEntryLinkPortletIds,
+						_getPortletIds(
+							fragmentInstancePageElementDefinition.
+								getWidgetInstances()))) {
+
+				PortletPreferencesLocalServiceUtil.deletePortletPreferences(
+					PortletKeys.PREFS_OWNER_ID_DEFAULT,
+					PortletKeys.PREFS_OWNER_TYPE_LAYOUT, layout.getPlid(),
+					fragmentEntryLinkPortletId);
+
+				ResourcePermissionLocalServiceUtil.deleteResourcePermissions(
+					layout.getCompanyId(), fragmentEntryLinkPortletId,
+					ResourceConstants.SCOPE_INDIVIDUAL,
+					PortletPermissionUtil.getPrimaryKey(
+						layout.getPlid(), fragmentEntryLinkPortletId));
+			}
 		}
 
 		FragmentStyledLayoutStructureItem fragmentStyledLayoutStructureItem =
@@ -300,6 +375,23 @@ public class FragmentLayoutStructureItemImporter
 		return fragmentEntryLink.getExternalReferenceCode();
 	}
 
+	private List<String> _getPortletIds(WidgetInstance[] widgetInstances) {
+		List<String> portletIds = new ArrayList<>();
+
+		if (ArrayUtil.isEmpty(widgetInstances)) {
+			return portletIds;
+		}
+
+		for (WidgetInstance widgetInstance : widgetInstances) {
+			portletIds.add(
+				PortletIdCodec.encode(
+					widgetInstance.getWidgetName(),
+					widgetInstance.getWidgetInstanceId()));
+		}
+
+		return portletIds;
+	}
+
 	private int _getType(
 		FragmentInstancePageElementDefinition
 			fragmentInstancePageElementDefinition) {
@@ -375,6 +467,11 @@ public class FragmentLayoutStructureItemImporter
 		return FragmentEntryLinkLocalServiceUtil.updateFragmentEntryLink(
 			fragmentEntryLink);
 	}
+
+	private static final ServiceTracker<PortletRegistry, PortletRegistry>
+		_portletRegistryServiceTracker = ServiceTrackerFactory.open(
+			FrameworkUtil.getBundle(FragmentLayoutStructureItemImporter.class),
+			PortletRegistry.class);
 
 	private static class FragmentEntryReference {
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/layout/structure/item/importer/FragmentLayoutStructureItemImporter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/layout/structure/item/importer/FragmentLayoutStructureItemImporter.java
@@ -128,12 +128,12 @@ public class FragmentLayoutStructureItemImporter
 					widgetInstance.getWidgetName(),
 					widgetInstance.getWidgetInstanceId());
 
-				PortletUtil.importPortletPreferences(
-					layout, portletId, widgetInstance.getWidgetConfig());
-
 				PortletUtil.importPortletPermissions(
 					layout, portletId, widgetInstance.getWidgetName(),
 					widgetInstance.getWidgetPermissions());
+
+				PortletUtil.importPortletPreferences(
+					layout, portletId, widgetInstance.getWidgetConfig());
 			}
 		}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/layout/structure/item/importer/FragmentLayoutStructureItemImporter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/layout/structure/item/importer/FragmentLayoutStructureItemImporter.java
@@ -78,14 +78,14 @@ public class FragmentLayoutStructureItemImporter
 			return null;
 		}
 
+		List<String> fragmentEntryLinkPortletIds = null;
+
 		FragmentEntryLink fragmentEntryLink =
 			FragmentEntryLinkLocalServiceUtil.
 				fetchFragmentEntryLinkByExternalReferenceCode(
 					fragmentInstancePageElementDefinition.
 						getFragmentInstanceExternalReferenceCode(),
 					layoutStructureItemImporterContext.getGroupId());
-
-		List<String> fragmentEntryLinkPortletIds = null;
 
 		if (fragmentEntryLink == null) {
 			fragmentEntryLink = _addFragmentEntryLink(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/layout/structure/item/importer/WidgetInstanceLayoutStructureItemImporter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/layout/structure/item/importer/WidgetInstanceLayoutStructureItemImporter.java
@@ -79,12 +79,12 @@ public class WidgetInstanceLayoutStructureItemImporter
 			widgetInstance.getWidgetName(),
 			widgetInstance.getWidgetInstanceId());
 
-		PortletUtil.importPortletPreferences(
-			layout, portletId, widgetInstance.getWidgetConfig());
-
 		PortletUtil.importPortletPermissions(
 			layout, portletId, widgetInstance.getWidgetName(),
 			widgetInstance.getWidgetPermissions());
+
+		PortletUtil.importPortletPreferences(
+			layout, portletId, widgetInstance.getWidgetConfig());
 
 		FragmentEntryLink fragmentEntryLink =
 			FragmentEntryLinkLocalServiceUtil.

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/layout/structure/item/importer/WidgetInstanceLayoutStructureItemImporter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/layout/structure/item/importer/WidgetInstanceLayoutStructureItemImporter.java
@@ -12,12 +12,10 @@ import com.liferay.fragment.service.FragmentEntryLinkLocalServiceUtil;
 import com.liferay.headless.admin.site.dto.v1_0.PageElement;
 import com.liferay.headless.admin.site.dto.v1_0.WidgetInstance;
 import com.liferay.headless.admin.site.dto.v1_0.WidgetInstancePageElementDefinition;
-import com.liferay.headless.admin.site.dto.v1_0.WidgetPermission;
 import com.liferay.headless.admin.site.internal.dto.v1_0.util.FragmentViewportUtil;
 import com.liferay.headless.admin.site.internal.resource.v1_0.layout.structure.item.importer.context.LayoutStructureItemImporterContext;
 import com.liferay.headless.admin.site.internal.resource.v1_0.util.LayoutStructureUtil;
-import com.liferay.layout.importer.PortletPermissionsImporter;
-import com.liferay.layout.importer.PortletPreferencesPortletConfigurationImporter;
+import com.liferay.headless.admin.site.internal.resource.v1_0.util.PortletUtil;
 import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
@@ -34,19 +32,13 @@ import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
 
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.util.tracker.ServiceTracker;
@@ -87,10 +79,10 @@ public class WidgetInstanceLayoutStructureItemImporter
 			widgetInstance.getWidgetName(),
 			widgetInstance.getWidgetInstanceId());
 
-		_importPortletPreferences(
+		PortletUtil.importPortletPreferences(
 			layout, portletId, widgetInstance.getWidgetConfig());
 
-		_importPortletPermissions(
+		PortletUtil.importPortletPermissions(
 			layout, portletId, widgetInstance.getWidgetName(),
 			widgetInstance.getWidgetPermissions());
 
@@ -246,72 +238,6 @@ public class WidgetInstanceLayoutStructureItemImporter
 		return namespace;
 	}
 
-	private List<Map<String, Object>> _getWidgetPermissionsMaps(
-		WidgetPermission[] widgetPermissions) {
-
-		if (ArrayUtil.isEmpty(widgetPermissions)) {
-			return new ArrayList<>();
-		}
-
-		List<Map<String, Object>> widgetPermissionsMaps = new ArrayList<>();
-
-		for (WidgetPermission widgetPermission : widgetPermissions) {
-			widgetPermissionsMaps.add(
-				HashMapBuilder.<String, Object>put(
-					"actionKeys", Arrays.asList(widgetPermission.getActionIds())
-				).put(
-					"roleKey", widgetPermission.getRoleName()
-				).build());
-		}
-
-		return widgetPermissionsMaps;
-	}
-
-	private void _importPortletPermissions(
-			Layout layout, String portletId, String portletName,
-			WidgetPermission[] widgetPermissions)
-		throws Exception {
-
-		PortletPermissionsImporter portletPermissionsImporter =
-			_portletPermissionsImporterServiceTracker.getService();
-
-		if (portletPermissionsImporter == null) {
-			return;
-		}
-
-		if ((widgetPermissions != null) && (widgetPermissions.length == 0)) {
-			ResourcePermissionLocalServiceUtil.deleteResourcePermissions(
-				layout.getCompanyId(), portletName,
-				ResourceConstants.SCOPE_INDIVIDUAL,
-				PortletPermissionUtil.getPrimaryKey(
-					layout.getPlid(), portletId));
-
-			return;
-		}
-
-		portletPermissionsImporter.importPortletPermissions(
-			layout.getPlid(), portletId, Collections.emptySet(),
-			_getWidgetPermissionsMaps(widgetPermissions));
-	}
-
-	private void _importPortletPreferences(
-			Layout layout, String portletId, Map<String, Object> widgetConfig)
-		throws Exception {
-
-		PortletPreferencesPortletConfigurationImporter
-			portletPreferencesPortletConfigurationImporter =
-				_portletPreferencesPortletConfigurationImporterServiceTracker.
-					getService();
-
-		if (portletPreferencesPortletConfigurationImporter == null) {
-			return;
-		}
-
-		portletPreferencesPortletConfigurationImporter.
-			importPortletConfiguration(
-				layout.getPlid(), portletId, widgetConfig);
-	}
-
 	private FragmentEntryLink _updateFragmentEntryLink(
 			String draftWidgetInstanceExternalReferenceCode,
 			FragmentEntryLink fragmentEntryLink,
@@ -368,20 +294,5 @@ public class WidgetInstanceLayoutStructureItemImporter
 					FrameworkUtil.getBundle(
 						WidgetInstanceLayoutStructureItemImporter.class),
 					FragmentEntryProcessorRegistry.class);
-	private static final ServiceTracker
-		<PortletPermissionsImporter, PortletPermissionsImporter>
-			_portletPermissionsImporterServiceTracker =
-				ServiceTrackerFactory.open(
-					FrameworkUtil.getBundle(
-						WidgetInstanceLayoutStructureItemImporter.class),
-					PortletPermissionsImporter.class);
-	private static final ServiceTracker
-		<PortletPreferencesPortletConfigurationImporter,
-		 PortletPreferencesPortletConfigurationImporter>
-			_portletPreferencesPortletConfigurationImporterServiceTracker =
-				ServiceTrackerFactory.open(
-					FrameworkUtil.getBundle(
-						WidgetInstanceLayoutStructureItemImporter.class),
-					PortletPreferencesPortletConfigurationImporter.class);
 
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PortletUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PortletUtil.java
@@ -1,0 +1,116 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.resource.v1_0.util;
+
+import com.liferay.headless.admin.site.dto.v1_0.WidgetPermission;
+import com.liferay.headless.admin.site.internal.resource.v1_0.layout.structure.item.importer.WidgetInstanceLayoutStructureItemImporter;
+import com.liferay.layout.importer.PortletPermissionsImporter;
+import com.liferay.layout.importer.PortletPreferencesPortletConfigurationImporter;
+import com.liferay.osgi.util.ServiceTrackerFactory;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
+import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.util.tracker.ServiceTracker;
+
+/**
+ * @author Mikel Lorza
+ */
+public class PortletUtil {
+
+	public static void importPortletPermissions(
+			Layout layout, String portletId, String portletName,
+			WidgetPermission[] widgetPermissions)
+		throws Exception {
+
+		PortletPermissionsImporter portletPermissionsImporter =
+			_portletPermissionsImporterServiceTracker.getService();
+
+		if (portletPermissionsImporter == null) {
+			return;
+		}
+
+		if ((widgetPermissions != null) && (widgetPermissions.length == 0)) {
+			ResourcePermissionLocalServiceUtil.deleteResourcePermissions(
+				layout.getCompanyId(), portletName,
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				PortletPermissionUtil.getPrimaryKey(
+					layout.getPlid(), portletId));
+
+			return;
+		}
+
+		portletPermissionsImporter.importPortletPermissions(
+			layout.getPlid(), portletId, Collections.emptySet(),
+			_getWidgetPermissionsMaps(widgetPermissions));
+	}
+
+	public static void importPortletPreferences(
+			Layout layout, String portletId, Map<String, Object> widgetConfig)
+		throws Exception {
+
+		PortletPreferencesPortletConfigurationImporter
+			portletPreferencesPortletConfigurationImporter =
+				_portletPreferencesPortletConfigurationImporterServiceTracker.
+					getService();
+
+		if (portletPreferencesPortletConfigurationImporter == null) {
+			return;
+		}
+
+		portletPreferencesPortletConfigurationImporter.
+			importPortletConfiguration(
+				layout.getPlid(), portletId, widgetConfig);
+	}
+
+	private static List<Map<String, Object>> _getWidgetPermissionsMaps(
+		WidgetPermission[] widgetPermissions) {
+
+		if (ArrayUtil.isEmpty(widgetPermissions)) {
+			return new ArrayList<>();
+		}
+
+		List<Map<String, Object>> widgetPermissionsMaps = new ArrayList<>();
+
+		for (WidgetPermission widgetPermission : widgetPermissions) {
+			widgetPermissionsMaps.add(
+				HashMapBuilder.<String, Object>put(
+					"actionKeys", Arrays.asList(widgetPermission.getActionIds())
+				).put(
+					"roleKey", widgetPermission.getRoleName()
+				).build());
+		}
+
+		return widgetPermissionsMaps;
+	}
+
+	private static final ServiceTracker
+		<PortletPermissionsImporter, PortletPermissionsImporter>
+			_portletPermissionsImporterServiceTracker =
+				ServiceTrackerFactory.open(
+					FrameworkUtil.getBundle(
+						WidgetInstanceLayoutStructureItemImporter.class),
+					PortletPermissionsImporter.class);
+	private static final ServiceTracker
+		<PortletPreferencesPortletConfigurationImporter,
+		 PortletPreferencesPortletConfigurationImporter>
+			_portletPreferencesPortletConfigurationImporterServiceTracker =
+				ServiceTrackerFactory.open(
+					FrameworkUtil.getBundle(
+						WidgetInstanceLayoutStructureItemImporter.class),
+					PortletPreferencesPortletConfigurationImporter.class);
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
@@ -113,6 +113,7 @@ import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -565,6 +566,20 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 			String configuration, long groupId, ServiceContext serviceContext)
 		throws Exception {
 
+		return _addFragmentEntry(
+			configuration, groupId,
+			StringBundler.concat(
+				"<h1 data-lfr-editable-id=\"element-text\" ",
+				"data-lfr-editable-type=\"text\">",
+				RandomTestUtil.randomString(), "</h1>"),
+			serviceContext);
+	}
+
+	private FragmentEntry _addFragmentEntry(
+			String configuration, long groupId, String html,
+			ServiceContext serviceContext)
+		throws Exception {
+
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
 				null, TestPropsValues.getUserId(), groupId,
@@ -574,13 +589,8 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 			null, TestPropsValues.getUserId(), groupId,
 			fragmentCollection.getFragmentCollectionId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			StringPool.BLANK,
-			StringBundler.concat(
-				"<h1 data-lfr-editable-id=\"element-text\" ",
-				"data-lfr-editable-type=\"text\">",
-				RandomTestUtil.randomString(), "</h1>"),
-			StringPool.BLANK, false, configuration, null, 0, false, false,
-			FragmentConstants.TYPE_COMPONENT, null,
+			StringPool.BLANK, html, StringPool.BLANK, false, configuration,
+			null, 0, false, false, FragmentConstants.TYPE_COMPONENT, null,
 			WorkflowConstants.STATUS_APPROVED, serviceContext);
 	}
 
@@ -2270,6 +2280,56 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 					_addFragmentEntry(
 						null, testGroup.getGroupId(), serviceContext),
 					testGroup.getGroupId())));
+		_testPutSitePageSpecificationPageExperiencePageElement(
+			_getFragmentInstancePageElement(
+				externalReferenceCode,
+				PageElementsTestUtil.getFragmentInstancePageElementDefinition(
+					Collections.emptyMap(), new FragmentEditableElement[0],
+					_addFragmentEntry(
+						null, testGroup.getGroupId(), serviceContext),
+					testGroup.getGroupId())));
+
+		FragmentEntry fragmentEntry = _addFragmentEntry(
+			null, testGroup.getGroupId(),
+			"<lfr-widget-web-content></lfr-widget-web-content>",
+			serviceContext);
+
+		externalReferenceCode = RandomTestUtil.randomString();
+
+		String fragmentInstanceExternalReferenceCode =
+			RandomTestUtil.randomString();
+
+		String namespace = RandomTestUtil.randomString();
+
+		String uuid = RandomTestUtil.randomString();
+
+		_testPutSitePageSpecificationPageExperiencePageElement(
+			_getFragmentInstancePageElement(
+				externalReferenceCode,
+				PageElementsTestUtil.getFragmentInstancePageElementDefinition(
+					Collections.emptyMap(), new FragmentEditableElement[0],
+					fragmentEntry, fragmentInstanceExternalReferenceCode,
+					testGroup.getGroupId(), namespace, uuid,
+					new WidgetInstance[] {
+						_getWidgetInstance(
+							_getWidgetConfig(), namespace,
+							JournalContentPortletKeys.JOURNAL_CONTENT,
+							_getWidgetPermissions())
+					})));
+
+		_testPutSitePageSpecificationPageExperiencePageElement(
+			_getFragmentInstancePageElement(
+				externalReferenceCode,
+				PageElementsTestUtil.getFragmentInstancePageElementDefinition(
+					Collections.emptyMap(), new FragmentEditableElement[0],
+					fragmentEntry, fragmentInstanceExternalReferenceCode,
+					testGroup.getGroupId(), namespace, uuid,
+					new WidgetInstance[] {
+						_getWidgetInstance(
+							new HashMap<>(), namespace,
+							JournalContentPortletKeys.JOURNAL_CONTENT,
+							new WidgetPermission[0])
+					})));
 
 		_testPutSitePageSpecificationPageExperiencePageElementWithFragmentPageElementWithConfiguration();
 		_testPutSitePageSpecificationPageExperiencePageElementWithFragmentPageElementWithFragmentEditableElements();
@@ -2732,6 +2792,9 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 
 	@Inject
 	private Portal _portal;
+
+	@Inject
+	private PortletPreferencesLocalService _portletPreferencesLocalService;
 
 	private int _position;
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
@@ -352,11 +352,8 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		_testPutSitePageSpecificationPageExperiencePageElementWithCollectionDisplayPageElement();
 		_testPutSitePageSpecificationPageExperiencePageElementWithContainerPageElement();
 		_testPutSitePageSpecificationPageExperiencePageElementWithFormContainerPageElement();
-
 		_testPutSitePageSpecificationPageExperiencePageElementWithFragmentPageElement();
-
 		_testPutSitePageSpecificationPageExperiencePageElementWithGridPageElement();
-
 		_testPutSitePageSpecificationPageExperiencePageElementWithWidgetPageElement();
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageElementsTestUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageElementsTestUtil.java
@@ -65,64 +65,91 @@ public class PageElementsTestUtil {
 			FragmentEditableElement[] curFragmentEditableElements,
 			FragmentEntry fragmentEntry, long scopeGroupId) {
 
-		return new FragmentInstancePageElementDefinition() {
-			{
-				setConfiguration(fragmentEntry::getConfiguration);
-				setCss(fragmentEntry::getCss);
-				setCssClasses(
-					() -> new String[] {RandomTestUtil.randomString()});
-				setCustomCSS(RandomTestUtil::randomString);
-				setDatePropagated(RandomTestUtil::nextDate);
-				setFragmentConfigurationFieldValues(
-					() ->
-						FragmentConfigurationFieldValueTestUtil.
-							getFragmentConfigurationFieldValuesMap(
-								JSONFactoryUtil.createJSONObject(
-									fragmentEntry.getConfiguration()),
-								configurationValuesMap, scopeGroupId));
-				setFragmentEditableElements(() -> curFragmentEditableElements);
-				setFragmentInstanceExternalReferenceCode(
-					RandomTestUtil::randomString);
-				setFragmentReference(
-					() -> {
-						if (fragmentEntry.getFragmentEntryId() == 0) {
-							return new DefaultFragmentReference() {
-								{
-									setDefaultFragmentKey(
-										fragmentEntry::getFragmentEntryKey);
-									setFragmentReferenceType(
-										() ->
-											FragmentReferenceType.
-												DEFAULT_FRAGMENT_REFERENCE);
-								}
-							};
-						}
+		return getFragmentInstancePageElementDefinition(
+			configurationValuesMap, curFragmentEditableElements, fragmentEntry,
+			RandomTestUtil.randomString(), scopeGroupId,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null);
+	}
 
-						return new FragmentItemExternalReference() {
-							{
-								setExternalReferenceCode(
-									fragmentEntry::getExternalReferenceCode);
-								setFragmentReferenceType(
-									() ->
-										FragmentReferenceType.
-											FRAGMENT_ITEM_EXTERNAL_REFERENCE);
-								setScope(
-									() -> ScopeTestUtil.getItemScope(
-										fragmentEntry.getGroupId(),
-										scopeGroupId));
-							}
-						};
-					});
-				setFragmentType(FragmentType.BASIC);
-				setHtml(fragmentEntry::getHtml);
-				setIndexed(RandomTestUtil::randomBoolean);
-				setJs(fragmentEntry::getJs);
-				setName(RandomTestUtil::randomString);
-				setNamespace(RandomTestUtil::randomString);
-				setType(Type.FRAGMENT);
-				setUuid(RandomTestUtil::randomString);
-			}
-		};
+	public static FragmentInstancePageElementDefinition
+		getFragmentInstancePageElementDefinition(
+			Map<String, Object> configurationValuesMap,
+			FragmentEditableElement[] curFragmentEditableElements,
+			FragmentEntry fragmentEntry,
+			String fragmentInstanceExternalReferenceCode, long scopeGroupId,
+			String namespace, String uuid, WidgetInstance[] widgetInstances) {
+
+		FragmentInstancePageElementDefinition
+			fragmentInstancePageElementDefinition =
+				new FragmentInstancePageElementDefinition();
+
+		fragmentInstancePageElementDefinition.setConfiguration(
+			fragmentEntry::getConfiguration);
+		fragmentInstancePageElementDefinition.
+			setFragmentConfigurationFieldValues(
+				() ->
+					FragmentConfigurationFieldValueTestUtil.
+						getFragmentConfigurationFieldValuesMap(
+							JSONFactoryUtil.createJSONObject(
+								fragmentEntry.getConfiguration()),
+							configurationValuesMap, scopeGroupId));
+		fragmentInstancePageElementDefinition.setFragmentEditableElements(
+			() -> curFragmentEditableElements);
+		fragmentInstancePageElementDefinition.setCss(fragmentEntry::getCss);
+		fragmentInstancePageElementDefinition.setCssClasses(
+			() -> new String[] {RandomTestUtil.randomString()});
+		fragmentInstancePageElementDefinition.setCustomCSS(
+			RandomTestUtil::randomString);
+		fragmentInstancePageElementDefinition.setDatePropagated(
+			RandomTestUtil::nextDate);
+		fragmentInstancePageElementDefinition.
+			setFragmentInstanceExternalReferenceCode(
+				fragmentInstanceExternalReferenceCode);
+		fragmentInstancePageElementDefinition.setFragmentReference(
+			() -> {
+				if (fragmentEntry.getFragmentEntryId() == 0) {
+					return new DefaultFragmentReference() {
+						{
+							setDefaultFragmentKey(
+								fragmentEntry::getFragmentEntryKey);
+							setFragmentReferenceType(
+								() ->
+									FragmentReferenceType.
+										DEFAULT_FRAGMENT_REFERENCE);
+						}
+					};
+				}
+
+				return new FragmentItemExternalReference() {
+					{
+						setExternalReferenceCode(
+							fragmentEntry::getExternalReferenceCode);
+						setFragmentReferenceType(
+							() ->
+								FragmentReferenceType.
+									FRAGMENT_ITEM_EXTERNAL_REFERENCE);
+						setScope(
+							() -> ScopeTestUtil.getItemScope(
+								fragmentEntry.getGroupId(), scopeGroupId));
+					}
+				};
+			});
+		fragmentInstancePageElementDefinition.setFragmentType(
+			FragmentInstancePageElementDefinition.FragmentType.BASIC);
+		fragmentInstancePageElementDefinition.setHtml(fragmentEntry::getHtml);
+		fragmentInstancePageElementDefinition.setIndexed(
+			RandomTestUtil::randomBoolean);
+		fragmentInstancePageElementDefinition.setJs(fragmentEntry::getJs);
+		fragmentInstancePageElementDefinition.setName(
+			RandomTestUtil::randomString);
+		fragmentInstancePageElementDefinition.setNamespace(namespace);
+		fragmentInstancePageElementDefinition.setType(
+			PageElementDefinition.Type.FRAGMENT);
+		fragmentInstancePageElementDefinition.setUuid(uuid);
+		fragmentInstancePageElementDefinition.setWidgetInstances(
+			() -> widgetInstances);
+
+		return fragmentInstancePageElementDefinition;
 	}
 
 	public static FragmentInstancePageElementDefinition

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageElementsTestUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageElementsTestUtil.java
@@ -62,11 +62,11 @@ public class PageElementsTestUtil {
 	public static FragmentInstancePageElementDefinition
 		getFragmentInstancePageElementDefinition(
 			Map<String, Object> configurationValuesMap,
-			FragmentEditableElement[] curFragmentEditableElements,
+			FragmentEditableElement[] fragmentEditableElements,
 			FragmentEntry fragmentEntry, long scopeGroupId) {
 
 		return getFragmentInstancePageElementDefinition(
-			configurationValuesMap, curFragmentEditableElements, fragmentEntry,
+			configurationValuesMap, fragmentEditableElements, fragmentEntry,
 			RandomTestUtil.randomString(), scopeGroupId,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null);
 	}
@@ -74,7 +74,7 @@ public class PageElementsTestUtil {
 	public static FragmentInstancePageElementDefinition
 		getFragmentInstancePageElementDefinition(
 			Map<String, Object> configurationValuesMap,
-			FragmentEditableElement[] curFragmentEditableElements,
+			FragmentEditableElement[] fragmentEditableElements,
 			FragmentEntry fragmentEntry,
 			String fragmentInstanceExternalReferenceCode, long scopeGroupId,
 			String namespace, String uuid, WidgetInstance[] widgetInstances) {
@@ -94,7 +94,7 @@ public class PageElementsTestUtil {
 								fragmentEntry.getConfiguration()),
 							configurationValuesMap, scopeGroupId));
 		fragmentInstancePageElementDefinition.setFragmentEditableElements(
-			() -> curFragmentEditableElements);
+			() -> fragmentEditableElements);
 		fragmentInstancePageElementDefinition.setCss(fragmentEntry::getCss);
 		fragmentInstancePageElementDefinition.setCssClasses(
 			() -> new String[] {RandomTestUtil.randomString()});


### PR DESCRIPTION
Hi @brianchandotcom ,

I am sending again to fix this : https://github.com/brianchandotcom/liferay-portal/pull/167797#issuecomment-3542776768. You can see a sort and as used in the last two commits .

If I'm not mistaken, this is already sorted by the class:

```
PortletPreferencesLocalServiceUtil.deletePortletPreferences(
					PortletKeys.PREFS_OWNER_ID_DEFAULT,
					PortletKeys.PREFS_OWNER_TYPE_LAYOUT, layout.getPlid(),
					fragmentEntryLinkPortletId);

				ResourcePermissionLocalServiceUtil.deleteResourcePermissions(
					layout.getCompanyId(), fragmentEntryLinkPortletId,
					ResourceConstants.SCOPE_INDIVIDUAL,
					PortletPermissionUtil.getPrimaryKey(
						layout.getPlid(), fragmentEntryLinkPortletId));
```

Regards

https://liferay.atlassian.net/browse/LPD-69120

# What is this solving?

Add implementation for the widget instances embedded in the custom fragment entries.

# How is it fixed?

Refactor widget instance code  to use it for the widget custom fragment entries.

# How to verify?

Run included integration tests
