### PR TITLE
LPD-57934 Use DualListBoxes with consistency, keeping the available items on the left side

### DIFF
--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/configuration.jsp
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/configuration.jsp
@@ -131,20 +131,16 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 
 							<%
 							List<KeyValuePair> leftList = new ArrayList<KeyValuePair>();
-
-							for (Organization organization : organizations) {
-								if (!announcementsDisplayContext.isScopeOrganizationSelected(organization)) {
-									leftList.add(new KeyValuePair(HtmlUtil.escape(organization.getExternalReferenceCode()), organization.getName()));
-								}
-							}
-
 							List<KeyValuePair> rightList = new ArrayList<KeyValuePair>();
 
 							for (Organization organization : organizations) {
-								KeyValuePair tempKeyValuePair = new KeyValuePair(HtmlUtil.escape(organization.getExternalReferenceCode()), organization.getName());
+								KeyValuePair keyValuePair = new KeyValuePair(HtmlUtil.escape(organization.getExternalReferenceCode()), organization.getName());
 
-								if (!leftList.contains(tempKeyValuePair)) {
-									rightList.add(tempKeyValuePair);
+								if (!announcementsDisplayContext.isScopeOrganizationSelected(organization)) {
+									leftList.add(keyValuePair);
+								}
+								else {
+									rightList.add(keyValuePair);
 								}
 							}
 							%>
@@ -170,20 +166,16 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 
 							<%
 							List<KeyValuePair> leftList = new ArrayList<KeyValuePair>();
-
-							for (UserGroup userGroup : userGroups) {
-								if (!announcementsDisplayContext.isScopeUserGroupSelected(userGroup)) {
-									leftList.add(new KeyValuePair(HtmlUtil.escape(userGroup.getExternalReferenceCode()), userGroup.getName()));
-								}
-							}
-
 							List<KeyValuePair> rightList = new ArrayList<KeyValuePair>();
 
 							for (UserGroup userGroup : userGroups) {
-								KeyValuePair tempKeyValuePair = new KeyValuePair(HtmlUtil.escape(userGroup.getExternalReferenceCode()), userGroup.getName());
+								KeyValuePair keyValuePair = new KeyValuePair(HtmlUtil.escape(userGroup.getExternalReferenceCode()), userGroup.getName());
 
-								if (!leftList.contains(tempKeyValuePair)) {
-									rightList.add(tempKeyValuePair);
+								if (!announcementsDisplayContext.isScopeUserGroupSelected(userGroup)) {
+									leftList.add(keyValuePair);
+								}
+								else {
+									rightList.add(keyValuePair);
 								}
 							}
 							%>
@@ -209,20 +201,16 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 
 							<%
 							List<KeyValuePair> leftList = new ArrayList<KeyValuePair>();
-
-							for (Role role : roles) {
-								if (!announcementsDisplayContext.isScopeRoleSelected(role)) {
-									leftList.add(new KeyValuePair(HtmlUtil.escape(role.getExternalReferenceCode()), role.getTitle(locale)));
-								}
-							}
-
 							List<KeyValuePair> rightList = new ArrayList<KeyValuePair>();
 
 							for (Role role : roles) {
-								KeyValuePair tempKeyValuePair = new KeyValuePair(HtmlUtil.escape(role.getExternalReferenceCode()), role.getTitle(locale));
+								KeyValuePair keyValuePair = new KeyValuePair(HtmlUtil.escape(role.getExternalReferenceCode()), role.getTitle(locale));
 
-								if (!leftList.contains(tempKeyValuePair)) {
-									rightList.add(tempKeyValuePair);
+								if (!announcementsDisplayContext.isScopeRoleSelected(role)) {
+									leftList.add(keyValuePair);
+								}
+								else {
+									rightList.add(keyValuePair);
 								}
 							}
 							%>

--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/configuration.jsp
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/configuration.jsp
@@ -120,7 +120,7 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 									rightBoxName="currentScopeGroupExternalReferenceCodes"
 									rightList="<%= leftList %>"
 									rightReorder="<%= Boolean.TRUE.toString() %>"
-									rightTitle="current"
+									rightTitle="in-use"
 								/>
 							</div>
 						</liferay-ui:section>
@@ -159,7 +159,7 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 									rightBoxName="currentScopeOrganizationExternalReferenceCodes"
 									rightList="<%= leftList %>"
 									rightReorder="<%= Boolean.TRUE.toString() %>"
-									rightTitle="current"
+									rightTitle="in-use"
 								/>
 							</div>
 						</liferay-ui:section>
@@ -198,7 +198,7 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 									rightBoxName="currentScopeUserGroupExternalReferenceCodes"
 									rightList="<%= leftList %>"
 									rightReorder="<%= Boolean.TRUE.toString() %>"
-									rightTitle="current"
+									rightTitle="in-use"
 								/>
 							</div>
 						</liferay-ui:section>
@@ -237,7 +237,7 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 									rightBoxName="currentScopeRoleExternalReferenceCodes"
 									rightList="<%= leftList %>"
 									rightReorder="<%= Boolean.TRUE.toString() %>"
-									rightTitle="current"
+									rightTitle="in-use"
 								/>
 							</div>
 						</liferay-ui:section>

--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/configuration.jsp
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/configuration.jsp
@@ -101,7 +101,7 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 
 								KeyValuePair keyValuePair = new KeyValuePair(HtmlUtil.escape(curGroup.getExternalReferenceCode()), descriptiveName);
 
-								if (announcementsDisplayContext.isScopeGroupSelected(curGroup)) {
+								if (!announcementsDisplayContext.isScopeGroupSelected(curGroup)) {
 									leftList.add(keyValuePair);
 								}
 								else {
@@ -115,10 +115,10 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 							<div id="<portlet:namespace />ScopeGroupExternalReferenceCodesBoxes">
 								<liferay-ui:input-move-boxes
 									leftBoxName="availableScopeGroupExternalReferenceCodes"
-									leftList="<%= rightList %>"
+									leftList="<%= leftList %>"
 									leftTitle="available"
 									rightBoxName="currentScopeGroupExternalReferenceCodes"
-									rightList="<%= leftList %>"
+									rightList="<%= rightList %>"
 									rightReorder="<%= Boolean.TRUE.toString() %>"
 									rightTitle="in-use"
 								/>
@@ -133,7 +133,7 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 							List<KeyValuePair> leftList = new ArrayList<KeyValuePair>();
 
 							for (Organization organization : organizations) {
-								if (announcementsDisplayContext.isScopeOrganizationSelected(organization)) {
+								if (!announcementsDisplayContext.isScopeOrganizationSelected(organization)) {
 									leftList.add(new KeyValuePair(HtmlUtil.escape(organization.getExternalReferenceCode()), organization.getName()));
 								}
 							}
@@ -154,10 +154,10 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 							<div id="<portlet:namespace />ScopeOrganizationExternalReferenceCodesBoxes">
 								<liferay-ui:input-move-boxes
 									leftBoxName="availableScopeOrganizationExternalReferenceCodes"
-									leftList="<%= rightList %>"
+									leftList="<%= leftList %>"
 									leftTitle="available"
 									rightBoxName="currentScopeOrganizationExternalReferenceCodes"
-									rightList="<%= leftList %>"
+									rightList="<%= rightList %>"
 									rightReorder="<%= Boolean.TRUE.toString() %>"
 									rightTitle="in-use"
 								/>
@@ -172,7 +172,7 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 							List<KeyValuePair> leftList = new ArrayList<KeyValuePair>();
 
 							for (UserGroup userGroup : userGroups) {
-								if (announcementsDisplayContext.isScopeUserGroupSelected(userGroup)) {
+								if (!announcementsDisplayContext.isScopeUserGroupSelected(userGroup)) {
 									leftList.add(new KeyValuePair(HtmlUtil.escape(userGroup.getExternalReferenceCode()), userGroup.getName()));
 								}
 							}
@@ -193,10 +193,10 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 							<div id="<portlet:namespace />ScopeUserGroupExternalReferenceCodesBoxes">
 								<liferay-ui:input-move-boxes
 									leftBoxName="availableScopeUserGroupExternalReferenceCodes"
-									leftList="<%= rightList %>"
+									leftList="<%= leftList %>"
 									leftTitle="available"
 									rightBoxName="currentScopeUserGroupExternalReferenceCodes"
-									rightList="<%= leftList %>"
+									rightList="<%= rightList %>"
 									rightReorder="<%= Boolean.TRUE.toString() %>"
 									rightTitle="in-use"
 								/>
@@ -211,7 +211,7 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 							List<KeyValuePair> leftList = new ArrayList<KeyValuePair>();
 
 							for (Role role : roles) {
-								if (announcementsDisplayContext.isScopeRoleSelected(role)) {
+								if (!announcementsDisplayContext.isScopeRoleSelected(role)) {
 									leftList.add(new KeyValuePair(HtmlUtil.escape(role.getExternalReferenceCode()), role.getTitle(locale)));
 								}
 							}
@@ -232,10 +232,10 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 							<div id="<portlet:namespace />ScopeRoleExternalReferenceCodesBoxes">
 								<liferay-ui:input-move-boxes
 									leftBoxName="availableScopeRoleExternalReferenceCodes"
-									leftList="<%= rightList %>"
+									leftList="<%= leftList %>"
 									leftTitle="available"
 									rightBoxName="currentScopeRoleExternalReferenceCodes"
-									rightList="<%= leftList %>"
+									rightList="<%= rightList %>"
 									rightReorder="<%= Boolean.TRUE.toString() %>"
 									rightTitle="in-use"
 								/>

--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/configuration.jsp
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/configuration.jsp
@@ -114,13 +114,13 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 
 							<div id="<portlet:namespace />ScopeGroupExternalReferenceCodesBoxes">
 								<liferay-ui:input-move-boxes
-									leftBoxName="currentScopeGroupExternalReferenceCodes"
-									leftList="<%= leftList %>"
-									leftReorder="<%= Boolean.TRUE.toString() %>"
-									leftTitle="current"
-									rightBoxName="availableScopeGroupExternalReferenceCodes"
-									rightList="<%= rightList %>"
-									rightTitle="available"
+									leftBoxName="availableScopeGroupExternalReferenceCodes"
+									leftList="<%= rightList %>"
+									leftTitle="available"
+									rightBoxName="currentScopeGroupExternalReferenceCodes"
+									rightList="<%= leftList %>"
+									rightReorder="<%= Boolean.TRUE.toString() %>"
+									rightTitle="current"
 								/>
 							</div>
 						</liferay-ui:section>
@@ -153,13 +153,13 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 
 							<div id="<portlet:namespace />ScopeOrganizationExternalReferenceCodesBoxes">
 								<liferay-ui:input-move-boxes
-									leftBoxName="currentScopeOrganizationExternalReferenceCodes"
-									leftList="<%= leftList %>"
-									leftReorder="<%= Boolean.TRUE.toString() %>"
-									leftTitle="current"
-									rightBoxName="availableScopeOrganizationExternalReferenceCodes"
-									rightList="<%= rightList %>"
-									rightTitle="available"
+									leftBoxName="availableScopeOrganizationExternalReferenceCodes"
+									leftList="<%= rightList %>"
+									leftTitle="available"
+									rightBoxName="currentScopeOrganizationExternalReferenceCodes"
+									rightList="<%= leftList %>"
+									rightReorder="<%= Boolean.TRUE.toString() %>"
+									rightTitle="current"
 								/>
 							</div>
 						</liferay-ui:section>
@@ -192,13 +192,13 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 
 							<div id="<portlet:namespace />ScopeUserGroupExternalReferenceCodesBoxes">
 								<liferay-ui:input-move-boxes
-									leftBoxName="currentScopeUserGroupExternalReferenceCodes"
-									leftList="<%= leftList %>"
-									leftReorder="<%= Boolean.TRUE.toString() %>"
-									leftTitle="current"
-									rightBoxName="availableScopeUserGroupExternalReferenceCodes"
-									rightList="<%= rightList %>"
-									rightTitle="available"
+									leftBoxName="availableScopeUserGroupExternalReferenceCodes"
+									leftList="<%= rightList %>"
+									leftTitle="available"
+									rightBoxName="currentScopeUserGroupExternalReferenceCodes"
+									rightList="<%= leftList %>"
+									rightReorder="<%= Boolean.TRUE.toString() %>"
+									rightTitle="current"
 								/>
 							</div>
 						</liferay-ui:section>
@@ -231,13 +231,13 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 
 							<div id="<portlet:namespace />ScopeRoleExternalReferenceCodesBoxes">
 								<liferay-ui:input-move-boxes
-									leftBoxName="currentScopeRoleExternalReferenceCodes"
-									leftList="<%= leftList %>"
-									leftReorder="<%= Boolean.TRUE.toString() %>"
-									leftTitle="current"
-									rightBoxName="availableScopeRoleExternalReferenceCodes"
-									rightList="<%= rightList %>"
-									rightTitle="available"
+									leftBoxName="availableScopeRoleExternalReferenceCodes"
+									leftList="<%= rightList %>"
+									leftTitle="available"
+									rightBoxName="currentScopeRoleExternalReferenceCodes"
+									rightList="<%= leftList %>"
+									rightReorder="<%= Boolean.TRUE.toString() %>"
+									rightTitle="current"
 								/>
 							</div>
 						</liferay-ui:section>

--- a/modules/apps/asset/asset-categories-navigation-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/asset/asset-categories-navigation-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -41,13 +41,13 @@
 
 			<div class="<%= assetCategoriesNavigationPortletInstanceConfiguration.allAssetVocabularies() ? "hide" : "" %>" id="<portlet:namespace />assetVocabulariesBoxes">
 				<liferay-ui:input-move-boxes
-					leftBoxName="currentAssetVocabularyIds"
-					leftList="<%= assetCategoriesNavigationDisplayContext.getCurrentVocabularyNames() %>"
-					leftReorder="<%= Boolean.TRUE.toString() %>"
-					leftTitle="current"
-					rightBoxName="availableAssetVocabularyIds"
-					rightList="<%= assetCategoriesNavigationDisplayContext.getAvailableVocabularyNames() %>"
-					rightTitle="available"
+					leftBoxName="availableAssetVocabularyIds"
+					leftList="<%= assetCategoriesNavigationDisplayContext.getAvailableVocabularyNames() %>"
+					leftTitle="available"
+					rightBoxName="currentAssetVocabularyIds"
+					rightList="<%= assetCategoriesNavigationDisplayContext.getCurrentVocabularyNames() %>"
+					rightReorder="<%= Boolean.TRUE.toString() %>"
+					rightTitle="current"
 				/>
 			</div>
 		</liferay-frontend:fieldset>

--- a/modules/apps/asset/asset-categories-navigation-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/asset/asset-categories-navigation-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -47,7 +47,7 @@
 					rightBoxName="currentAssetVocabularyIds"
 					rightList="<%= assetCategoriesNavigationDisplayContext.getCurrentVocabularyNames() %>"
 					rightReorder="<%= Boolean.TRUE.toString() %>"
-					rightTitle="current"
+					rightTitle="in-use"
 				/>
 			</div>
 		</liferay-frontend:fieldset>

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
@@ -78,7 +78,7 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 			rightBoxName="currentClassNameIds"
 			rightList="<%= typesLeftList %>"
 			rightReorder="<%= Boolean.TRUE.toString() %>"
-			rightTitle="selected"
+			rightTitle="in-use"
 		/>
 	</div>
 
@@ -223,7 +223,7 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 					rightBoxName='<%= className + "currentClassTypeIds" %>'
 					rightList="<%= subtypesLeftList %>"
 					rightReorder="<%= Boolean.TRUE.toString() %>"
-					rightTitle="selected"
+					rightTitle="in-use"
 				/>
 			</div>
 		</div>

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
@@ -72,13 +72,13 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 
 	<div class="<%= editAssetListDisplayContext.isAnyAssetType() ? "hide" : "" %>" id="<portlet:namespace />classNamesBoxes">
 		<liferay-ui:input-move-boxes
-			leftBoxName="currentClassNameIds"
-			leftList="<%= typesLeftList %>"
-			leftReorder="<%= Boolean.TRUE.toString() %>"
-			leftTitle="selected"
-			rightBoxName="availableClassNameIds"
-			rightList="<%= typesRightList %>"
-			rightTitle="available"
+			leftBoxName="availableClassNameIds"
+			leftList="<%= typesRightList %>"
+			leftTitle="available"
+			rightBoxName="currentClassNameIds"
+			rightList="<%= typesLeftList %>"
+			rightReorder="<%= Boolean.TRUE.toString() %>"
+			rightTitle="selected"
 		/>
 	</div>
 
@@ -217,13 +217,13 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 
 			<div class="<%= (assetSelectedClassTypeIds.length > 1) ? StringPool.BLANK : "hide" %>" id="<portlet:namespace /><%= className %>Boxes">
 				<liferay-ui:input-move-boxes
-					leftBoxName='<%= className + "currentClassTypeIds" %>'
-					leftList="<%= subtypesLeftList %>"
-					leftReorder="<%= Boolean.TRUE.toString() %>"
-					leftTitle="selected"
-					rightBoxName='<%= className + "availableClassTypeIds" %>'
-					rightList="<%= subtypesRightList %>"
-					rightTitle="available"
+					leftBoxName='<%= className + "availableClassTypeIds" %>'
+					leftList="<%= subtypesRightList %>"
+					leftTitle="available"
+					rightBoxName='<%= className + "currentClassTypeIds" %>'
+					rightList="<%= subtypesLeftList %>"
+					rightReorder="<%= Boolean.TRUE.toString() %>"
+					rightTitle="selected"
 				/>
 			</div>
 		</div>

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
@@ -19,19 +19,19 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 
 	<%
 
-	// Left list
+	// Right list
 
-	List<KeyValuePair> typesLeftList = new ArrayList<KeyValuePair>();
+	List<KeyValuePair> typesRightList = new ArrayList<KeyValuePair>();
 
 	long[] classNameIds = editAssetListDisplayContext.getClassNameIds();
 
 	for (long classNameId : classNameIds) {
-		typesLeftList.add(new KeyValuePair(String.valueOf(classNameId), ResourceActionsUtil.getModelResource(locale, PortalUtil.getClassName(classNameId))));
+		typesRightList.add(new KeyValuePair(String.valueOf(classNameId), ResourceActionsUtil.getModelResource(locale, PortalUtil.getClassName(classNameId))));
 	}
 
-	// Right list
+	// Left list
 
-	List<KeyValuePair> typesRightList = new ArrayList<KeyValuePair>();
+	List<KeyValuePair> typesLeftList = new ArrayList<KeyValuePair>();
 
 	Arrays.sort(classNameIds);
 	%>
@@ -46,7 +46,7 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 				ClassName className = ClassNameLocalServiceUtil.getClassName(classNameId);
 
 				if (Arrays.binarySearch(classNameIds, classNameId) < 0) {
-					typesRightList.add(new KeyValuePair(String.valueOf(classNameId), ResourceActionsUtil.getModelResource(locale, className.getValue())));
+					typesLeftList.add(new KeyValuePair(String.valueOf(classNameId), ResourceActionsUtil.getModelResource(locale, className.getValue())));
 				}
 			%>
 
@@ -67,16 +67,16 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 	<aui:input name="TypeSettingsProperties--classNameIds--" type="hidden" />
 
 	<%
-	typesRightList = ListUtil.sort(typesRightList, new KeyValuePairComparator(false, true));
+	typesLeftList = ListUtil.sort(typesLeftList, new KeyValuePairComparator(false, true));
 	%>
 
 	<div class="<%= editAssetListDisplayContext.isAnyAssetType() ? "hide" : "" %>" id="<portlet:namespace />classNamesBoxes">
 		<liferay-ui:input-move-boxes
 			leftBoxName="availableClassNameIds"
-			leftList="<%= typesRightList %>"
+			leftList="<%= typesLeftList %>"
 			leftTitle="available"
 			rightBoxName="currentClassNameIds"
-			rightList="<%= typesLeftList %>"
+			rightList="<%= typesRightList %>"
 			rightReorder="<%= Boolean.TRUE.toString() %>"
 			rightTitle="in-use"
 		/>
@@ -104,15 +104,15 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 
 		Long[] assetSelectedClassTypeIds = editAssetListDisplayContext.getClassTypeIds(unicodeProperties, className, classTypes);
 
-		// Left list
+		// Right list
 
-		List<KeyValuePair> subtypesLeftList = new ArrayList<KeyValuePair>();
+		List<KeyValuePair> subtypesRightList = new ArrayList<KeyValuePair>();
 
 		for (long subtypeId : assetSelectedClassTypeIds) {
 			try {
 				ClassType classType = classTypeReader.getClassType(subtypeId, locale);
 
-				subtypesLeftList.add(new KeyValuePair(String.valueOf(subtypeId), HtmlUtil.escape(classType.getName())));
+				subtypesRightList.add(new KeyValuePair(String.valueOf(subtypeId), HtmlUtil.escape(classType.getName())));
 			}
 			catch (NoSuchModelException nsme) {
 			}
@@ -120,9 +120,9 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 
 		Arrays.sort(assetSelectedClassTypeIds);
 
-		// Right list
+		// Left list
 
-		List<KeyValuePair> subtypesRightList = new ArrayList<KeyValuePair>();
+		List<KeyValuePair> subtypesLeftList = new ArrayList<KeyValuePair>();
 
 		boolean noAssetSubtypeSelected = false;
 
@@ -146,7 +146,7 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 					<%
 					for (ClassType classType : classTypes) {
 						if (Arrays.binarySearch(assetSelectedClassTypeIds, classType.getClassTypeId()) < 0) {
-							subtypesRightList.add(new KeyValuePair(String.valueOf(classType.getClassTypeId()), HtmlUtil.escape(classType.getName())));
+							subtypesLeftList.add(new KeyValuePair(String.valueOf(classType.getClassTypeId()), HtmlUtil.escape(classType.getName())));
 						}
 					%>
 
@@ -209,7 +209,7 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 					<%
 					}
 
-					typesRightList = ListUtil.sort(typesRightList, new KeyValuePairComparator(false, true));
+					typesLeftList = ListUtil.sort(typesLeftList, new KeyValuePairComparator(false, true));
 					%>
 
 				</div>
@@ -218,10 +218,10 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 			<div class="<%= (assetSelectedClassTypeIds.length > 1) ? StringPool.BLANK : "hide" %>" id="<portlet:namespace /><%= className %>Boxes">
 				<liferay-ui:input-move-boxes
 					leftBoxName='<%= className + "availableClassTypeIds" %>'
-					leftList="<%= subtypesRightList %>"
+					leftList="<%= subtypesLeftList %>"
 					leftTitle="available"
 					rightBoxName='<%= className + "currentClassTypeIds" %>'
-					rightList="<%= subtypesLeftList %>"
+					rightList="<%= subtypesRightList %>"
 					rightReorder="<%= Boolean.TRUE.toString() %>"
 					rightTitle="in-use"
 				/>

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/metadata.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/metadata.jsp
@@ -11,21 +11,12 @@
 
 <%
 
-// Right list
-
-List<KeyValuePair> rightList = new ArrayList<>();
-
-String[] metadataFields = assetPublisherDisplayContext.getMetadataFields();
-
-for (String metadataField : metadataFields) {
-	rightList.add(new KeyValuePair(metadataField, LanguageUtil.get(request, metadataField)));
-}
-
 // Left list
 
 List<KeyValuePair> leftList = new ArrayList<>();
 
 String[] allMetadataFields = {"author", "categories", "create-date", "expiration-date", "modified-date", "priority", "publish-date", "tags", "view-count"};
+String[] metadataFields = assetPublisherDisplayContext.getMetadataFields();
 
 for (String metadataField : allMetadataFields) {
 	if (!ArrayUtil.contains(metadataFields, metadataField)) {
@@ -34,6 +25,14 @@ for (String metadataField : allMetadataFields) {
 }
 
 leftList = ListUtil.sort(leftList, new KeyValuePairComparator(false, true));
+
+// Right list
+
+List<KeyValuePair> rightList = new ArrayList<>();
+
+for (String metadataField : metadataFields) {
+	rightList.add(new KeyValuePair(metadataField, LanguageUtil.get(request, metadataField)));
+}
 %>
 
 <liferay-ui:input-move-boxes

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/metadata.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/metadata.jsp
@@ -37,10 +37,10 @@ rightList = ListUtil.sort(rightList, new KeyValuePairComparator(false, true));
 %>
 
 <liferay-ui:input-move-boxes
-	leftBoxName="currentMetadataFields"
-	leftList="<%= leftList %>"
-	leftTitle="current"
-	rightBoxName="availableMetadataFields"
-	rightList="<%= rightList %>"
-	rightTitle="available"
+	leftBoxName="availableMetadataFields"
+	leftList="<%= rightList %>"
+	leftTitle="available"
+	rightBoxName="currentMetadataFields"
+	rightList="<%= leftList %>"
+	rightTitle="current"
 />

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/metadata.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/metadata.jsp
@@ -11,36 +11,36 @@
 
 <%
 
-// Left list
+// Right list
 
-List<KeyValuePair> leftList = new ArrayList<>();
+List<KeyValuePair> rightList = new ArrayList<>();
 
 String[] metadataFields = assetPublisherDisplayContext.getMetadataFields();
 
 for (String metadataField : metadataFields) {
-	leftList.add(new KeyValuePair(metadataField, LanguageUtil.get(request, metadataField)));
+	rightList.add(new KeyValuePair(metadataField, LanguageUtil.get(request, metadataField)));
 }
 
-// Right list
+// Left list
 
-List<KeyValuePair> rightList = new ArrayList<>();
+List<KeyValuePair> leftList = new ArrayList<>();
 
 String[] allMetadataFields = {"author", "categories", "create-date", "expiration-date", "modified-date", "priority", "publish-date", "tags", "view-count"};
 
 for (String metadataField : allMetadataFields) {
 	if (!ArrayUtil.contains(metadataFields, metadataField)) {
-		rightList.add(new KeyValuePair(metadataField, LanguageUtil.get(request, metadataField)));
+		leftList.add(new KeyValuePair(metadataField, LanguageUtil.get(request, metadataField)));
 	}
 }
 
-rightList = ListUtil.sort(rightList, new KeyValuePairComparator(false, true));
+leftList = ListUtil.sort(leftList, new KeyValuePairComparator(false, true));
 %>
 
 <liferay-ui:input-move-boxes
 	leftBoxName="availableMetadataFields"
-	leftList="<%= rightList %>"
+	leftList="<%= leftList %>"
 	leftTitle="available"
 	rightBoxName="currentMetadataFields"
-	rightList="<%= leftList %>"
+	rightList="<%= rightList %>"
 	rightTitle="in-use"
 />

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/metadata.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/metadata.jsp
@@ -42,5 +42,5 @@ rightList = ListUtil.sort(rightList, new KeyValuePairComparator(false, true));
 	leftTitle="available"
 	rightBoxName="currentMetadataFields"
 	rightList="<%= leftList %>"
-	rightTitle="current"
+	rightTitle="in-use"
 />

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
@@ -19,19 +19,19 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 	<%
 	Set<Long> availableClassNameIdsSet = SetUtil.fromArray(assetPublisherDisplayContext.getAvailableClassNameIds());
 
-	// Left list
+	// Right list
 
-	List<KeyValuePair> typesLeftList = new ArrayList<KeyValuePair>();
+	List<KeyValuePair> typesRightList = new ArrayList<KeyValuePair>();
 
 	long[] classNameIds = assetPublisherDisplayContext.getClassNameIds();
 
 	for (long classNameId : classNameIds) {
-		typesLeftList.add(new KeyValuePair(String.valueOf(classNameId), ResourceActionsUtil.getModelResource(locale, PortalUtil.getClassName(classNameId))));
+		typesRightList.add(new KeyValuePair(String.valueOf(classNameId), ResourceActionsUtil.getModelResource(locale, PortalUtil.getClassName(classNameId))));
 	}
 
-	// Right list
+	// Left list
 
-	List<KeyValuePair> typesRightList = new ArrayList<KeyValuePair>();
+	List<KeyValuePair> typesLeftList = new ArrayList<KeyValuePair>();
 
 	Arrays.sort(classNameIds);
 	%>
@@ -47,7 +47,7 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 				ClassName className = ClassNameLocalServiceUtil.getClassName(classNameId);
 
 				if (Arrays.binarySearch(classNameIds, classNameId) < 0) {
-					typesRightList.add(new KeyValuePair(String.valueOf(classNameId), ResourceActionsUtil.getModelResource(locale, className.getValue())));
+					typesLeftList.add(new KeyValuePair(String.valueOf(classNameId), ResourceActionsUtil.getModelResource(locale, className.getValue())));
 				}
 			%>
 
@@ -63,16 +63,16 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 	<aui:input name="preferences--classNameIds--" type="hidden" />
 
 	<%
-	typesRightList = ListUtil.sort(typesRightList, new KeyValuePairComparator(false, true));
+	typesLeftList = ListUtil.sort(typesLeftList, new KeyValuePairComparator(false, true));
 	%>
 
 	<div class="<%= assetPublisherDisplayContext.isAnyAssetType() ? "hide" : "" %>" id="<portlet:namespace />classNamesBoxes">
 		<liferay-ui:input-move-boxes
 			leftBoxName="availableClassNameIds"
-			leftList="<%= typesRightList %>"
+			leftList="<%= typesLeftList %>"
 			leftTitle="available"
 			rightBoxName="currentClassNameIds"
-			rightList="<%= typesLeftList %>"
+			rightList="<%= typesRightList %>"
 			rightReorder="<%= Boolean.TRUE.toString() %>"
 			rightTitle="in-use"
 		/>
@@ -96,23 +96,23 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 
 		Long[] assetSelectedClassTypeIds = assetPublisherWebHelper.getClassTypeIds(portletPreferences, className, classTypes);
 
-		// Left list
+		// Right list
 
-		List<KeyValuePair> subtypesLeftList = new ArrayList<KeyValuePair>();
+		List<KeyValuePair> subtypesRightList = new ArrayList<KeyValuePair>();
 
 		for (long subtypeId : assetSelectedClassTypeIds) {
 			try {
 				ClassType classType = classTypeReader.getClassType(subtypeId, locale);
 
-				subtypesLeftList.add(new KeyValuePair(String.valueOf(subtypeId), HtmlUtil.escape(classType.getName())));
+				subtypesRightList.add(new KeyValuePair(String.valueOf(subtypeId), HtmlUtil.escape(classType.getName())));
 			}
 			catch (NoSuchModelException nsme) {
 			}
 		}
 
-		// Right list
+		// Left list
 
-		List<KeyValuePair> subtypesRightList = new ArrayList<KeyValuePair>();
+		List<KeyValuePair> subtypesLeftList = new ArrayList<KeyValuePair>();
 
 		boolean anyAssetSubtype = GetterUtil.getBoolean(portletPreferences.getValue("anyClassType" + className, Boolean.TRUE.toString()));
 	%>
@@ -127,7 +127,7 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 					<%
 					for (ClassType classType : classTypes) {
 						if (Arrays.binarySearch(assetSelectedClassTypeIds, classType.getClassTypeId()) < 0) {
-							subtypesRightList.add(new KeyValuePair(String.valueOf(classType.getClassTypeId()), HtmlUtil.escape(classType.getName())));
+							subtypesLeftList.add(new KeyValuePair(String.valueOf(classType.getClassTypeId()), HtmlUtil.escape(classType.getName())));
 						}
 					%>
 
@@ -184,7 +184,7 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 					<%
 					}
 
-					typesRightList = ListUtil.sort(typesRightList, new KeyValuePairComparator(false, true));
+					typesLeftList = ListUtil.sort(typesLeftList, new KeyValuePairComparator(false, true));
 					%>
 
 				</div>
@@ -193,10 +193,10 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 			<div class="<%= (assetSelectedClassTypeIds.length > 1) ? StringPool.BLANK : "hide" %>" id="<portlet:namespace /><%= className %>Boxes">
 				<liferay-ui:input-move-boxes
 					leftBoxName='<%= className + "availableClassTypeIds" %>'
-					leftList="<%= subtypesRightList %>"
+					leftList="<%= subtypesLeftList %>"
 					leftTitle="available"
 					rightBoxName='<%= className + "currentClassTypeIds" %>'
-					rightList="<%= subtypesLeftList %>"
+					rightList="<%= subtypesRightList %>"
 					rightReorder="<%= Boolean.TRUE.toString() %>"
 					rightTitle="in-use"
 				/>

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
@@ -74,7 +74,7 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 			rightBoxName="currentClassNameIds"
 			rightList="<%= typesLeftList %>"
 			rightReorder="<%= Boolean.TRUE.toString() %>"
-			rightTitle="selected"
+			rightTitle="in-use"
 		/>
 	</div>
 
@@ -198,7 +198,7 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 					rightBoxName='<%= className + "currentClassTypeIds" %>'
 					rightList="<%= subtypesLeftList %>"
 					rightReorder="<%= Boolean.TRUE.toString() %>"
-					rightTitle="selected"
+					rightTitle="in-use"
 				/>
 			</div>
 		</div>

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
@@ -115,6 +115,8 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 		List<KeyValuePair> subtypesLeftList = new ArrayList<KeyValuePair>();
 
 		boolean anyAssetSubtype = GetterUtil.getBoolean(portletPreferences.getValue("anyClassType" + className, Boolean.TRUE.toString()));
+
+		Arrays.sort(assetSelectedClassTypeIds);
 	%>
 
 		<div class='asset-subtype <%= (assetSelectedClassTypeIds.length < 1) ? StringPool.BLANK : "hide" %>' id="<portlet:namespace /><%= className %>Options">

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
@@ -68,13 +68,13 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 
 	<div class="<%= assetPublisherDisplayContext.isAnyAssetType() ? "hide" : "" %>" id="<portlet:namespace />classNamesBoxes">
 		<liferay-ui:input-move-boxes
-			leftBoxName="currentClassNameIds"
-			leftList="<%= typesLeftList %>"
-			leftReorder="<%= Boolean.TRUE.toString() %>"
-			leftTitle="selected"
-			rightBoxName="availableClassNameIds"
-			rightList="<%= typesRightList %>"
-			rightTitle="available"
+			leftBoxName="availableClassNameIds"
+			leftList="<%= typesRightList %>"
+			leftTitle="available"
+			rightBoxName="currentClassNameIds"
+			rightList="<%= typesLeftList %>"
+			rightReorder="<%= Boolean.TRUE.toString() %>"
+			rightTitle="selected"
 		/>
 	</div>
 
@@ -192,13 +192,13 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 
 			<div class="<%= (assetSelectedClassTypeIds.length > 1) ? StringPool.BLANK : "hide" %>" id="<portlet:namespace /><%= className %>Boxes">
 				<liferay-ui:input-move-boxes
-					leftBoxName='<%= className + "currentClassTypeIds" %>'
-					leftList="<%= subtypesLeftList %>"
-					leftReorder="<%= Boolean.TRUE.toString() %>"
-					leftTitle="selected"
-					rightBoxName='<%= className + "availableClassTypeIds" %>'
-					rightList="<%= subtypesRightList %>"
-					rightTitle="available"
+					leftBoxName='<%= className + "availableClassTypeIds" %>'
+					leftList="<%= subtypesRightList %>"
+					leftTitle="available"
+					rightBoxName='<%= className + "currentClassTypeIds" %>'
+					rightList="<%= subtypesLeftList %>"
+					rightReorder="<%= Boolean.TRUE.toString() %>"
+					rightTitle="selected"
 				/>
 			</div>
 		</div>

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/js/blogs/AssetCategoriesSelectionBox.tsx
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/js/blogs/AssetCategoriesSelectionBox.tsx
@@ -164,7 +164,7 @@ export default function AssetCategoriesSelectionBox({
 				onItemsChange={setCategories}
 				right={{
 					id: `${portletNamespace}current`,
-					label: Liferay.Language.get('current'),
+					label: Liferay.Language.get('in-use'),
 				}}
 				size={3}
 			/>

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks_admin/configuration_browse.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks_admin/configuration_browse.jsp
@@ -140,13 +140,13 @@ portletDisplay.setURLBackTitle("bookmarks");
 									%>
 
 									<liferay-ui:input-move-boxes
-										leftBoxName="currentFolderColumns"
-										leftList="<%= leftList %>"
-										leftReorder="<%= Boolean.TRUE.toString() %>"
-										leftTitle="current"
-										rightBoxName="availableFolderColumns"
-										rightList="<%= rightList %>"
-										rightTitle="available"
+										leftBoxName="availableFolderColumns"
+										leftList="<%= rightList %>"
+										leftTitle="available"
+										rightBoxName="currentFolderColumns"
+										rightList="<%= leftList %>"
+										rightReorder="<%= Boolean.TRUE.toString() %>"
+										rightTitle="current"
 									/>
 								</aui:field-wrapper>
 							</div>
@@ -239,13 +239,13 @@ portletDisplay.setURLBackTitle("bookmarks");
 								%>
 
 								<liferay-ui:input-move-boxes
-									leftBoxName="currentEntryColumns"
-									leftList="<%= leftList %>"
-									leftReorder="<%= Boolean.TRUE.toString() %>"
-									leftTitle="current"
-									rightBoxName="availableEntryColumns"
-									rightList="<%= rightList %>"
-									rightTitle="available"
+									leftBoxName="availableEntryColumns"
+									leftList="<%= rightList %>"
+									leftTitle="available"
+									rightBoxName="currentEntryColumns"
+									rightList="<%= leftList %>"
+									rightReorder="<%= Boolean.TRUE.toString() %>"
+									rightTitle="current"
 								/>
 							</aui:field-wrapper>
 						</div>

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks_admin/configuration_browse.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks_admin/configuration_browse.jsp
@@ -146,7 +146,7 @@ portletDisplay.setURLBackTitle("bookmarks");
 										rightBoxName="currentFolderColumns"
 										rightList="<%= leftList %>"
 										rightReorder="<%= Boolean.TRUE.toString() %>"
-										rightTitle="current"
+										rightTitle="in-use"
 									/>
 								</aui:field-wrapper>
 							</div>
@@ -245,7 +245,7 @@ portletDisplay.setURLBackTitle("bookmarks");
 									rightBoxName="currentEntryColumns"
 									rightList="<%= leftList %>"
 									rightReorder="<%= Boolean.TRUE.toString() %>"
-									rightTitle="current"
+									rightTitle="in-use"
 								/>
 							</aui:field-wrapper>
 						</div>

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks_admin/configuration_browse.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks_admin/configuration_browse.jsp
@@ -116,35 +116,35 @@ portletDisplay.setURLBackTitle("bookmarks");
 									<%
 									Set<String> availableFolderColumns = SetUtil.fromArray(StringUtil.split(allFolderColumns));
 
-									// Left list
-
-									List<KeyValuePair> leftList = new ArrayList<>();
-
-									for (String folderColumn : folderColumns) {
-										leftList.add(new KeyValuePair(folderColumn, LanguageUtil.get(request, folderColumn)));
-									}
-
 									// Right list
 
 									List<KeyValuePair> rightList = new ArrayList<>();
+
+									for (String folderColumn : folderColumns) {
+										rightList.add(new KeyValuePair(folderColumn, LanguageUtil.get(request, folderColumn)));
+									}
+
+									// Left list
+
+									List<KeyValuePair> leftList = new ArrayList<>();
 
 									Arrays.sort(folderColumns);
 
 									for (String folderColumn : availableFolderColumns) {
 										if (Arrays.binarySearch(folderColumns, folderColumn) < 0) {
-											rightList.add(new KeyValuePair(folderColumn, LanguageUtil.get(request, folderColumn)));
+											leftList.add(new KeyValuePair(folderColumn, LanguageUtil.get(request, folderColumn)));
 										}
 									}
 
-									rightList = ListUtil.sort(rightList, new KeyValuePairComparator(false, true));
+									leftList = ListUtil.sort(leftList, new KeyValuePairComparator(false, true));
 									%>
 
 									<liferay-ui:input-move-boxes
 										leftBoxName="availableFolderColumns"
-										leftList="<%= rightList %>"
+										leftList="<%= leftList %>"
 										leftTitle="available"
 										rightBoxName="currentFolderColumns"
-										rightList="<%= leftList %>"
+										rightList="<%= rightList %>"
 										rightReorder="<%= Boolean.TRUE.toString() %>"
 										rightTitle="in-use"
 									/>
@@ -213,37 +213,37 @@ portletDisplay.setURLBackTitle("bookmarks");
 								<%
 								Set<String> availableEntryColumns = SetUtil.fromArray(StringUtil.split(allEntryColumns));
 
-								// Left list
+								// Right list
 
-								List<KeyValuePair> leftList = new ArrayList<>();
+								List<KeyValuePair> rightList = new ArrayList<>();
 
 								for (int i = 0; i < entryColumns.length; i++) {
 									String entryColumn = entryColumns[i];
 
-									leftList.add(new KeyValuePair(entryColumn, LanguageUtil.get(request, entryColumn)));
+									rightList.add(new KeyValuePair(entryColumn, LanguageUtil.get(request, entryColumn)));
 								}
 
-								// Right list
+								// Left list
 
-								List<KeyValuePair> rightList = new ArrayList<>();
+								List<KeyValuePair> leftList = new ArrayList<>();
 
 								Arrays.sort(entryColumns);
 
 								for (String entryColumn : availableEntryColumns) {
 									if (Arrays.binarySearch(entryColumns, entryColumn) < 0) {
-										rightList.add(new KeyValuePair(entryColumn, LanguageUtil.get(request, entryColumn)));
+										leftList.add(new KeyValuePair(entryColumn, LanguageUtil.get(request, entryColumn)));
 									}
 								}
 
-								rightList = ListUtil.sort(rightList, new KeyValuePairComparator(false, true));
+								leftList = ListUtil.sort(leftList, new KeyValuePairComparator(false, true));
 								%>
 
 								<liferay-ui:input-move-boxes
 									leftBoxName="availableEntryColumns"
-									leftList="<%= rightList %>"
+									leftList="<%= leftList %>"
 									leftTitle="available"
 									rightBoxName="currentEntryColumns"
-									rightList="<%= leftList %>"
+									rightList="<%= rightList %>"
 									rightReorder="<%= Boolean.TRUE.toString() %>"
 									rightTitle="in-use"
 								/>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
@@ -69,7 +69,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 					rightBoxName="currentDisplayViews"
 					rightList="<%= dlPortletInstanceSettingsHelper.getCurrentDisplayViews() %>"
 					rightReorder="<%= Boolean.TRUE.toString() %>"
-					rightTitle="current"
+					rightTitle="in-use"
 				/>
 			</aui:field-wrapper>
 		</liferay-frontend:fieldset>
@@ -118,7 +118,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 						rightBoxName="currentEntryColumns"
 						rightList="<%= dlPortletInstanceSettingsHelper.getCurrentEntryColumns() %>"
 						rightReorder="<%= Boolean.TRUE.toString() %>"
-						rightTitle="current"
+						rightTitle="in-use"
 					/>
 				</aui:field-wrapper>
 			</liferay-frontend:fieldset>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
@@ -63,13 +63,13 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 
 			<aui:field-wrapper label="display-style-views">
 				<liferay-ui:input-move-boxes
-					leftBoxName="currentDisplayViews"
-					leftList="<%= dlPortletInstanceSettingsHelper.getCurrentDisplayViews() %>"
-					leftReorder="<%= Boolean.TRUE.toString() %>"
-					leftTitle="current"
-					rightBoxName="availableDisplayViews"
-					rightList="<%= dlPortletInstanceSettingsHelper.getAvailableDisplayViews() %>"
-					rightTitle="available"
+					leftBoxName="availableDisplayViews"
+					leftList="<%= dlPortletInstanceSettingsHelper.getAvailableDisplayViews() %>"
+					leftTitle="available"
+					rightBoxName="currentDisplayViews"
+					rightList="<%= dlPortletInstanceSettingsHelper.getCurrentDisplayViews() %>"
+					rightReorder="<%= Boolean.TRUE.toString() %>"
+					rightTitle="current"
 				/>
 			</aui:field-wrapper>
 		</liferay-frontend:fieldset>
@@ -112,13 +112,13 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 			<liferay-frontend:fieldset>
 				<aui:field-wrapper label="show-columns">
 					<liferay-ui:input-move-boxes
-						leftBoxName="currentEntryColumns"
-						leftList="<%= dlPortletInstanceSettingsHelper.getCurrentEntryColumns() %>"
-						leftReorder="<%= Boolean.TRUE.toString() %>"
-						leftTitle="current"
-						rightBoxName="availableEntryColumns"
-						rightList="<%= dlPortletInstanceSettingsHelper.getAvailableEntryColumns() %>"
-						rightTitle="available"
+						leftBoxName="availableEntryColumns"
+						leftList="<%= dlPortletInstanceSettingsHelper.getAvailableEntryColumns() %>"
+						leftTitle="available"
+						rightBoxName="currentEntryColumns"
+						rightList="<%= dlPortletInstanceSettingsHelper.getCurrentEntryColumns() %>"
+						rightReorder="<%= Boolean.TRUE.toString() %>"
+						rightTitle="current"
 					/>
 				</aui:field-wrapper>
 			</liferay-frontend:fieldset>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/configuration.jsp
@@ -44,7 +44,7 @@ IGConfigurationDisplayContext igConfigurationDisplayContext = (IGConfigurationDi
 					rightBoxName="currentMimeTypes"
 					rightList="<%= igConfigurationDisplayContext.getCurrentMimeTypes() %>"
 					rightReorder="<%= Boolean.TRUE.toString() %>"
-					rightTitle="current"
+					rightTitle="in-use"
 				/>
 			</aui:field-wrapper>
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/configuration.jsp
@@ -38,13 +38,13 @@ IGConfigurationDisplayContext igConfigurationDisplayContext = (IGConfigurationDi
 
 			<aui:field-wrapper label="show-media-type">
 				<liferay-ui:input-move-boxes
-					leftBoxName="currentMimeTypes"
-					leftList="<%= igConfigurationDisplayContext.getCurrentMimeTypes() %>"
-					leftReorder="<%= Boolean.TRUE.toString() %>"
-					leftTitle="current"
-					rightBoxName="availableMimeTypes"
-					rightList="<%= igConfigurationDisplayContext.getAvailableMimeTypes() %>"
-					rightTitle="available"
+					leftBoxName="availableMimeTypes"
+					leftList="<%= igConfigurationDisplayContext.getAvailableMimeTypes() %>"
+					leftTitle="available"
+					rightBoxName="currentMimeTypes"
+					rightList="<%= igConfigurationDisplayContext.getCurrentMimeTypes() %>"
+					rightReorder="<%= Boolean.TRUE.toString() %>"
+					rightTitle="current"
 				/>
 			</aui:field-wrapper>
 

--- a/modules/apps/portal-rules-engine/portal-rules-engine-sample-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/portal-rules-engine/portal-rules-engine-sample-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -37,19 +37,9 @@ long[] classNameIdValues = StringUtil.split(ParamUtil.getString(request, "classN
 
 			<%
 
-			// Right list
+			// Left list
 
 			MethodKey methodKey = new MethodKey(ClassResolverUtil.resolve("com.liferay.portal.kernel.security.permission.ResourceActionsUtil", PortalClassLoaderUtil.getClassLoader()), "getModelResource", HttpServletRequest.class, String.class);
-
-			List<KeyValuePair> rightList = new ArrayList<KeyValuePair>();
-
-			for (long classNameId : classNameIdValues) {
-				String value = (String)PortalClassInvoker.invoke(methodKey, request, PortalUtil.getClassName(classNameId));
-
-				rightList.add(new KeyValuePair(String.valueOf(classNameId), value));
-			}
-
-			// Left list
 
 			List<KeyValuePair> leftList = new ArrayList<KeyValuePair>();
 
@@ -59,6 +49,16 @@ long[] classNameIdValues = StringUtil.split(ParamUtil.getString(request, "classN
 
 					leftList.add(new KeyValuePair(String.valueOf(classNameId), value));
 				}
+			}
+
+			// Right list
+
+			List<KeyValuePair> rightList = new ArrayList<KeyValuePair>();
+
+			for (long classNameId : classNameIdValues) {
+				String value = (String)PortalClassInvoker.invoke(methodKey, request, PortalUtil.getClassName(classNameId));
+
+				rightList.add(new KeyValuePair(String.valueOf(classNameId), value));
 			}
 			%>
 

--- a/modules/apps/portal-rules-engine/portal-rules-engine-sample-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/portal-rules-engine/portal-rules-engine-sample-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -37,27 +37,27 @@ long[] classNameIdValues = StringUtil.split(ParamUtil.getString(request, "classN
 
 			<%
 
-			// Left list
+			// Right list
 
 			MethodKey methodKey = new MethodKey(ClassResolverUtil.resolve("com.liferay.portal.kernel.security.permission.ResourceActionsUtil", PortalClassLoaderUtil.getClassLoader()), "getModelResource", HttpServletRequest.class, String.class);
 
-			List<KeyValuePair> leftList = new ArrayList<KeyValuePair>();
+			List<KeyValuePair> rightList = new ArrayList<KeyValuePair>();
 
 			for (long classNameId : classNameIdValues) {
 				String value = (String)PortalClassInvoker.invoke(methodKey, request, PortalUtil.getClassName(classNameId));
 
-				leftList.add(new KeyValuePair(String.valueOf(classNameId), value));
+				rightList.add(new KeyValuePair(String.valueOf(classNameId), value));
 			}
 
-			// Right list
+			// Left list
 
-			List<KeyValuePair> rightList = new ArrayList<KeyValuePair>();
+			List<KeyValuePair> leftList = new ArrayList<KeyValuePair>();
 
 			for (long classNameId : AssetRendererFactoryRegistryUtil.getClassNameIds(company.getCompanyId())) {
 				if (!ArrayUtil.contains(classNameIdValues, classNameId)) {
 					String value = (String)PortalClassInvoker.invoke(methodKey, request, PortalUtil.getClassName(classNameId));
 
-					rightList.add(new KeyValuePair(String.valueOf(classNameId), value));
+					leftList.add(new KeyValuePair(String.valueOf(classNameId), value));
 				}
 			}
 			%>
@@ -66,10 +66,10 @@ long[] classNameIdValues = StringUtil.split(ParamUtil.getString(request, "classN
 
 			<liferay-ui:input-move-boxes
 				leftBoxName="availableClassNameIds"
-				leftList="<%= ListUtil.sort(rightList, new KeyValuePairComparator(false, true)) %>"
+				leftList="<%= ListUtil.sort(leftList, new KeyValuePairComparator(false, true)) %>"
 				leftTitle="available"
 				rightBoxName="currentClassNameIds"
-				rightList="<%= ListUtil.sort(leftList, new KeyValuePairComparator(false, true)) %>"
+				rightList="<%= ListUtil.sort(rightList, new KeyValuePairComparator(false, true)) %>"
 				rightTitle="in-use"
 			/>
 

--- a/modules/apps/portal-rules-engine/portal-rules-engine-sample-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/portal-rules-engine/portal-rules-engine-sample-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -65,12 +65,12 @@ long[] classNameIdValues = StringUtil.split(ParamUtil.getString(request, "classN
 			<aui:input name="userCustomAttributeNames" value='<%= ParamUtil.getString(request, "userCustomAttributeNamesValue", userCustomAttributeNames) %>' wrapperCssClass="lfr-input-text-container" />
 
 			<liferay-ui:input-move-boxes
-				leftBoxName="currentClassNameIds"
-				leftList="<%= ListUtil.sort(leftList, new KeyValuePairComparator(false, true)) %>"
-				leftTitle="current"
-				rightBoxName="availableClassNameIds"
-				rightList="<%= ListUtil.sort(rightList, new KeyValuePairComparator(false, true)) %>"
-				rightTitle="available"
+				leftBoxName="availableClassNameIds"
+				leftList="<%= ListUtil.sort(rightList, new KeyValuePairComparator(false, true)) %>"
+				leftTitle="available"
+				rightBoxName="currentClassNameIds"
+				rightList="<%= ListUtil.sort(leftList, new KeyValuePairComparator(false, true)) %>"
+				rightTitle="current"
 			/>
 
 			<aui:button-row>

--- a/modules/apps/portal-rules-engine/portal-rules-engine-sample-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/portal-rules-engine/portal-rules-engine-sample-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -70,7 +70,7 @@ long[] classNameIdValues = StringUtil.split(ParamUtil.getString(request, "classN
 				leftTitle="available"
 				rightBoxName="currentClassNameIds"
 				rightList="<%= ListUtil.sort(leftList, new KeyValuePairComparator(false, true)) %>"
-				rightTitle="current"
+				rightTitle="in-use"
 			/>
 
 			<aui:button-row>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/configuration/asset_entries.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/configuration/asset_entries.jsp
@@ -16,7 +16,9 @@ int frequencyThreshold = dataJSONObject.getInt("frequencyThreshold");
 
 String[] assetTypes = new String[0];
 
-List<KeyValuePair> currentAssetTypes = new ArrayList<KeyValuePair>();
+// Right list
+
+List<KeyValuePair> rightList = new ArrayList<KeyValuePair>();
 
 if (dataJSONObject.has("values")) {
 	JSONArray valuesJSONArray = dataJSONObject.getJSONArray("values");
@@ -26,17 +28,19 @@ if (dataJSONObject.has("values")) {
 	for (int i = 0; i < valuesJSONArray.length(); i++) {
 		assetTypes[i] = valuesJSONArray.getString(i);
 
-		currentAssetTypes.add(new KeyValuePair(assetTypes[i], ResourceActionsUtil.getModelResource(locale, assetTypes[i])));
+		rightList.add(new KeyValuePair(assetTypes[i], ResourceActionsUtil.getModelResource(locale, assetTypes[i])));
 	}
 }
 
-List<KeyValuePair> availableAssetTypes = new ArrayList<KeyValuePair>();
+// Left list
+
+List<KeyValuePair> leftList = new ArrayList<KeyValuePair>();
 
 for (AssetRendererFactory<?> assetRendererFactory : assetEntriesSearchFacet.getAssetRendererFactories(company.getCompanyId())) {
 	String className = assetRendererFactory.getClassName();
 
 	if (assetRendererFactory.isSearchable() && !ArrayUtil.contains(assetTypes, className)) {
-		availableAssetTypes.add(new KeyValuePair(className, ResourceActionsUtil.getModelResource(locale, className)));
+		leftList.add(new KeyValuePair(className, ResourceActionsUtil.getModelResource(locale, className)));
 	}
 }
 %>
@@ -47,10 +51,10 @@ for (AssetRendererFactory<?> assetRendererFactory : assetEntriesSearchFacet.getA
 
 <liferay-ui:input-move-boxes
 	leftBoxName="availableAssetTypes"
-	leftList="<%= availableAssetTypes %>"
+	leftList="<%= leftList %>"
 	leftTitle="available"
 	rightBoxName="currentAssetTypes"
-	rightList="<%= currentAssetTypes %>"
+	rightList="<%= rightList %>"
 	rightTitle="in-use"
 />
 

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/configuration/asset_entries.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/configuration/asset_entries.jsp
@@ -16,6 +16,18 @@ int frequencyThreshold = dataJSONObject.getInt("frequencyThreshold");
 
 String[] assetTypes = new String[0];
 
+// Left list
+
+List<KeyValuePair> leftList = new ArrayList<KeyValuePair>();
+
+for (AssetRendererFactory<?> assetRendererFactory : assetEntriesSearchFacet.getAssetRendererFactories(company.getCompanyId())) {
+	String className = assetRendererFactory.getClassName();
+
+	if (assetRendererFactory.isSearchable() && !ArrayUtil.contains(assetTypes, className)) {
+		leftList.add(new KeyValuePair(className, ResourceActionsUtil.getModelResource(locale, className)));
+	}
+}
+
 // Right list
 
 List<KeyValuePair> rightList = new ArrayList<KeyValuePair>();
@@ -29,18 +41,6 @@ if (dataJSONObject.has("values")) {
 		assetTypes[i] = valuesJSONArray.getString(i);
 
 		rightList.add(new KeyValuePair(assetTypes[i], ResourceActionsUtil.getModelResource(locale, assetTypes[i])));
-	}
-}
-
-// Left list
-
-List<KeyValuePair> leftList = new ArrayList<KeyValuePair>();
-
-for (AssetRendererFactory<?> assetRendererFactory : assetEntriesSearchFacet.getAssetRendererFactories(company.getCompanyId())) {
-	String className = assetRendererFactory.getClassName();
-
-	if (assetRendererFactory.isSearchable() && !ArrayUtil.contains(assetTypes, className)) {
-		leftList.add(new KeyValuePair(className, ResourceActionsUtil.getModelResource(locale, className)));
 	}
 }
 %>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/configuration/asset_entries.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/configuration/asset_entries.jsp
@@ -51,7 +51,7 @@ for (AssetRendererFactory<?> assetRendererFactory : assetEntriesSearchFacet.getA
 	leftTitle="available"
 	rightBoxName="currentAssetTypes"
 	rightList="<%= currentAssetTypes %>"
-	rightTitle="current"
+	rightTitle="in-use"
 />
 
 <aui:script>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/configuration/asset_entries.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/configuration/asset_entries.jsp
@@ -46,12 +46,12 @@ for (AssetRendererFactory<?> assetRendererFactory : assetEntriesSearchFacet.getA
 <aui:input name='<%= assetEntriesSearchFacet.getClassName() + "assetTypes" %>' type="hidden" />
 
 <liferay-ui:input-move-boxes
-	leftBoxName="currentAssetTypes"
-	leftList="<%= currentAssetTypes %>"
-	leftTitle="current"
-	rightBoxName="availableAssetTypes"
-	rightList="<%= availableAssetTypes %>"
-	rightTitle="available"
+	leftBoxName="availableAssetTypes"
+	leftList="<%= availableAssetTypes %>"
+	leftTitle="available"
+	rightBoxName="currentAssetTypes"
+	rightList="<%= currentAssetTypes %>"
+	rightTitle="current"
 />
 
 <aui:script>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/type/facet/configuration.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/type/facet/configuration.jsp
@@ -91,12 +91,12 @@ TypeFacetPortletPreferences typeFacetPortletPreferences = new com.liferay.portal
 			<aui:input name="<%= PortletPreferencesJspUtil.getInputName(TypeFacetPortletPreferences.PREFERENCE_KEY_ASSET_TYPES) %>" type="hidden" value="<%= typeFacetPortletPreferences.getAssetTypes() %>" />
 
 			<liferay-ui:input-move-boxes
-				leftBoxName="currentAssetTypes"
-				leftList="<%= typeFacetPortletPreferences.getCurrentAssetTypes(themeDisplay.getCompanyId(), themeDisplay.getLocale()) %>"
-				leftTitle="current"
-				rightBoxName="availableAssetTypes"
-				rightList="<%= typeFacetPortletPreferences.getAvailableAssetTypes(themeDisplay.getCompanyId(), themeDisplay.getLocale()) %>"
-				rightTitle="available"
+				leftBoxName="availableAssetTypes"
+				leftList="<%= typeFacetPortletPreferences.getAvailableAssetTypes(themeDisplay.getCompanyId(), themeDisplay.getLocale()) %>"
+				leftTitle="available"
+				rightBoxName="currentAssetTypes"
+				rightList="<%= typeFacetPortletPreferences.getCurrentAssetTypes(themeDisplay.getCompanyId(), themeDisplay.getLocale()) %>"
+				rightTitle="current"
 			/>
 		</liferay-frontend:fieldset>
 	</liferay-frontend:edit-form-body>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/type/facet/configuration.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/type/facet/configuration.jsp
@@ -96,7 +96,7 @@ TypeFacetPortletPreferences typeFacetPortletPreferences = new com.liferay.portal
 				leftTitle="available"
 				rightBoxName="currentAssetTypes"
 				rightList="<%= typeFacetPortletPreferences.getCurrentAssetTypes(themeDisplay.getCompanyId(), themeDisplay.getLocale()) %>"
-				rightTitle="current"
+				rightTitle="in-use"
 			/>
 		</liferay-frontend:fieldset>
 	</liferay-frontend:edit-form-body>

--- a/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/language.jsp
+++ b/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/language.jsp
@@ -97,7 +97,7 @@
 			leftTitle="available"
 			rightBoxName="currentLanguageIds"
 			rightList="<%= rightList %>"
-			rightTitle="current"
+			rightTitle="in-use"
 		/>
 	</aui:fieldset>
 </aui:fieldset>

--- a/modules/apps/site-navigation/site-navigation-language-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/site-navigation/site-navigation-language-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -46,13 +46,13 @@
 			<aui:input name="preferences--languageIds--" type="hidden" />
 
 			<liferay-ui:input-move-boxes
-				leftBoxName="currentLanguageIds"
-				leftList="<%= siteNavigationLanguageDisplayContext.getCurrentLanguageIdKVPs() %>"
-				leftReorder="<%= Boolean.TRUE.toString() %>"
-				leftTitle="current"
-				rightBoxName="availableLanguageIds"
-				rightList="<%= siteNavigationLanguageDisplayContext.getAvailableLanguageIdKVPs() %>"
-				rightTitle="available"
+				leftBoxName="availableLanguageIds"
+				leftList="<%= siteNavigationLanguageDisplayContext.getAvailableLanguageIdKVPs() %>"
+				leftTitle="available"
+				rightBoxName="currentLanguageIds"
+				rightList="<%= siteNavigationLanguageDisplayContext.getCurrentLanguageIdKVPs() %>"
+				rightReorder="<%= Boolean.TRUE.toString() %>"
+				rightTitle="current"
 			/>
 		</liferay-frontend:fieldset>
 	</liferay-frontend:edit-form-body>

--- a/modules/apps/site-navigation/site-navigation-language-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/site-navigation/site-navigation-language-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -52,7 +52,7 @@
 				rightBoxName="currentLanguageIds"
 				rightList="<%= siteNavigationLanguageDisplayContext.getCurrentLanguageIdKVPs() %>"
 				rightReorder="<%= Boolean.TRUE.toString() %>"
-				rightTitle="current"
+				rightTitle="in-use"
 			/>
 		</liferay-frontend:fieldset>
 	</liferay-frontend:edit-form-body>

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/js/SiteLanguageConfiguration.js
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/js/SiteLanguageConfiguration.js
@@ -203,7 +203,7 @@ export default function SiteLanguageConfiguration({
 						}}
 						onItemsChange={handleItemsChange}
 						right={{
-							label: Liferay.Language.get('current'),
+							label: Liferay.Language.get('in-use'),
 						}}
 						size={10}
 					/>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceLanguageSettings.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceLanguageSettings.tsx
@@ -254,7 +254,7 @@ export default function SpaceLanguageSettings({
 								onItemsChange={handleItemsChange}
 								right={{
 									id: 'selectedLanguages',
-									label: Liferay.Language.get('selected'),
+									label: Liferay.Language.get('in-use'),
 								}}
 								size={10}
 							/>

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceLanguageSettings.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceLanguageSettings.test.tsx
@@ -207,7 +207,7 @@ describe('SpaceLanguageSettings', () => {
 
 			const selectedLanguages = screen
 				.getByRole('listbox', {
-					name: 'selected',
+					name: 'in-use',
 				})
 				.querySelectorAll('option');
 
@@ -223,7 +223,7 @@ describe('SpaceLanguageSettings', () => {
 			});
 
 			const selectedLanguagesSelect = screen.getByRole('listbox', {
-				name: 'selected',
+				name: 'in-use',
 			});
 
 			const ltrButton = screen.getByRole('button', {
@@ -250,7 +250,7 @@ describe('SpaceLanguageSettings', () => {
 			});
 
 			const selectedLanguagesSelect = screen.getByRole('listbox', {
-				name: 'selected',
+				name: 'in-use',
 			});
 
 			const ltrButton = screen.getByRole('button', {
@@ -281,7 +281,7 @@ describe('SpaceLanguageSettings', () => {
 			});
 
 			const selectedLanguagesSelect = screen.getByRole('listbox', {
-				name: 'selected',
+				name: 'in-use',
 			});
 
 			const rtlButton = screen.getByRole('button', {
@@ -309,7 +309,7 @@ describe('SpaceLanguageSettings', () => {
 			});
 
 			const selectedLanguagesSelect = screen.getByRole('listbox', {
-				name: 'selected',
+				name: 'in-use',
 			});
 
 			const rtlButton = screen.getByRole('button', {

--- a/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks_settings/page.jsp
+++ b/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks_settings/page.jsp
@@ -17,18 +17,6 @@ if (Validator.isNull(displayStyle)) {
 	displayStyle = displayStyles[0];
 }
 
-// Right list
-
-List<KeyValuePair> rightList = new ArrayList<>();
-
-for (int i = 0; i < types.length; i++) {
-	SocialBookmark socialBookmark = SocialBookmarksRegistryUtil.getSocialBookmark(types[i]);
-
-	if (socialBookmark != null) {
-		rightList.add(new KeyValuePair(types[i], socialBookmark.getName(locale)));
-	}
-}
-
 // Left list
 
 List<KeyValuePair> leftList = new ArrayList<>();
@@ -44,6 +32,18 @@ for (String curType : SocialBookmarksRegistryUtil.getSocialBookmarksTypes()) {
 }
 
 leftList = ListUtil.sort(leftList, new KeyValuePairComparator(false, true));
+
+// Right list
+
+List<KeyValuePair> rightList = new ArrayList<>();
+
+for (int i = 0; i < types.length; i++) {
+	SocialBookmark socialBookmark = SocialBookmarksRegistryUtil.getSocialBookmark(types[i]);
+
+	if (socialBookmark != null) {
+		rightList.add(new KeyValuePair(types[i], socialBookmark.getName(locale)));
+	}
+}
 %>
 
 <aui:input name="preferences--socialBookmarksTypes--" type="hidden" value="<%= StringUtil.merge(types) %>" />

--- a/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks_settings/page.jsp
+++ b/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks_settings/page.jsp
@@ -49,13 +49,13 @@ rightList = ListUtil.sort(rightList, new KeyValuePairComparator(false, true));
 <aui:input name="preferences--socialBookmarksTypes--" type="hidden" value="<%= StringUtil.merge(types) %>" />
 
 <liferay-ui:input-move-boxes
-	leftBoxName="currentTypes"
-	leftList="<%= leftList %>"
-	leftReorder="<%= Boolean.TRUE.toString() %>"
-	leftTitle="current"
-	rightBoxName="availableTypes"
-	rightList="<%= rightList %>"
-	rightTitle="available"
+	leftBoxName="availableTypes"
+	leftList="<%= rightList %>"
+	leftTitle="available"
+	rightBoxName="currentTypes"
+	rightList="<%= leftList %>"
+	rightReorder="<%= Boolean.TRUE.toString() %>"
+	rightTitle="current"
 />
 
 <label class="control-label" for="<portlet:namespace />typesOptions">

--- a/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks_settings/page.jsp
+++ b/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks_settings/page.jsp
@@ -55,7 +55,7 @@ rightList = ListUtil.sort(rightList, new KeyValuePairComparator(false, true));
 	rightBoxName="currentTypes"
 	rightList="<%= leftList %>"
 	rightReorder="<%= Boolean.TRUE.toString() %>"
-	rightTitle="current"
+	rightTitle="in-use"
 />
 
 <label class="control-label" for="<portlet:namespace />typesOptions">

--- a/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks_settings/page.jsp
+++ b/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks_settings/page.jsp
@@ -17,21 +17,21 @@ if (Validator.isNull(displayStyle)) {
 	displayStyle = displayStyles[0];
 }
 
-// Left list
+// Right list
 
-List<KeyValuePair> leftList = new ArrayList<>();
+List<KeyValuePair> rightList = new ArrayList<>();
 
 for (int i = 0; i < types.length; i++) {
 	SocialBookmark socialBookmark = SocialBookmarksRegistryUtil.getSocialBookmark(types[i]);
 
 	if (socialBookmark != null) {
-		leftList.add(new KeyValuePair(types[i], socialBookmark.getName(locale)));
+		rightList.add(new KeyValuePair(types[i], socialBookmark.getName(locale)));
 	}
 }
 
-// Right list
+// Left list
 
-List<KeyValuePair> rightList = new ArrayList<>();
+List<KeyValuePair> leftList = new ArrayList<>();
 
 Set<String> typesSet = new HashSet<>(Arrays.asList(types));
 
@@ -39,21 +39,21 @@ for (String curType : SocialBookmarksRegistryUtil.getSocialBookmarksTypes()) {
 	SocialBookmark socialBookmark = SocialBookmarksRegistryUtil.getSocialBookmark(curType);
 
 	if (!typesSet.contains(curType)) {
-		rightList.add(new KeyValuePair(curType, socialBookmark.getName(locale)));
+		leftList.add(new KeyValuePair(curType, socialBookmark.getName(locale)));
 	}
 }
 
-rightList = ListUtil.sort(rightList, new KeyValuePairComparator(false, true));
+leftList = ListUtil.sort(leftList, new KeyValuePairComparator(false, true));
 %>
 
 <aui:input name="preferences--socialBookmarksTypes--" type="hidden" value="<%= StringUtil.merge(types) %>" />
 
 <liferay-ui:input-move-boxes
 	leftBoxName="availableTypes"
-	leftList="<%= rightList %>"
+	leftList="<%= leftList %>"
 	leftTitle="available"
 	rightBoxName="currentTypes"
-	rightList="<%= leftList %>"
+	rightList="<%= rightList %>"
 	rightReorder="<%= Boolean.TRUE.toString() %>"
 	rightTitle="in-use"
 />

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/configuration.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/configuration.jsp
@@ -58,15 +58,15 @@
 			<%
 			Set<String> currentVisibleNodes = new HashSet<String>(wikiPortletInstanceSettingsHelper.getAllNodeNames());
 
-			// Left list
+			// Right list
 
-			List<KeyValuePair> leftList = new ArrayList<KeyValuePair>();
+			List<KeyValuePair> rightList = new ArrayList<KeyValuePair>();
 
 			String[] visibleNodeNames = wikiPortletInstanceSettingsHelper.getVisibleNodeNames();
 
 			for (String folderColumn : visibleNodeNames) {
 				if (currentVisibleNodes.contains(folderColumn)) {
-					leftList.add(new KeyValuePair(folderColumn, HtmlUtil.escape(LanguageUtil.get(request, folderColumn))));
+					rightList.add(new KeyValuePair(folderColumn, HtmlUtil.escape(LanguageUtil.get(request, folderColumn))));
 				}
 			}
 
@@ -78,29 +78,29 @@
 
 			for (String folderColumn : currentVisibleNodes) {
 				if ((Arrays.binarySearch(hiddenNodes, folderColumn) < 0) && (Arrays.binarySearch(visibleNodeNames, folderColumn) < 0)) {
-					leftList.add(new KeyValuePair(folderColumn, HtmlUtil.escape(LanguageUtil.get(request, folderColumn))));
-				}
-			}
-
-			// Right list
-
-			List<KeyValuePair> rightList = new ArrayList<KeyValuePair>();
-
-			for (String folderColumn : hiddenNodes) {
-				if (currentVisibleNodes.contains(folderColumn) && (Arrays.binarySearch(visibleNodeNames, folderColumn) < 0)) {
 					rightList.add(new KeyValuePair(folderColumn, HtmlUtil.escape(LanguageUtil.get(request, folderColumn))));
 				}
 			}
 
-			rightList = ListUtil.sort(rightList, new KeyValuePairComparator(false, true));
+			// Left list
+
+			List<KeyValuePair> leftList = new ArrayList<KeyValuePair>();
+
+			for (String folderColumn : hiddenNodes) {
+				if (currentVisibleNodes.contains(folderColumn) && (Arrays.binarySearch(visibleNodeNames, folderColumn) < 0)) {
+					leftList.add(new KeyValuePair(folderColumn, HtmlUtil.escape(LanguageUtil.get(request, folderColumn))));
+				}
+			}
+
+			leftList = ListUtil.sort(leftList, new KeyValuePairComparator(false, true));
 			%>
 
 			<liferay-ui:input-move-boxes
 				leftBoxName="availableVisibleNodes"
-				leftList="<%= rightList %>"
+				leftList="<%= leftList %>"
 				leftTitle="hidden"
 				rightBoxName="currentVisibleNodes"
-				rightList="<%= leftList %>"
+				rightList="<%= rightList %>"
 				rightReorder="<%= Boolean.TRUE.toString() %>"
 				rightTitle="visible"
 			/>

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/configuration.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/configuration.jsp
@@ -96,13 +96,13 @@
 			%>
 
 			<liferay-ui:input-move-boxes
-				leftBoxName="currentVisibleNodes"
-				leftList="<%= leftList %>"
-				leftReorder="<%= Boolean.TRUE.toString() %>"
-				leftTitle="visible"
-				rightBoxName="availableVisibleNodes"
-				rightList="<%= rightList %>"
-				rightTitle="hidden"
+				leftBoxName="availableVisibleNodes"
+				leftList="<%= rightList %>"
+				leftTitle="hidden"
+				rightBoxName="currentVisibleNodes"
+				rightList="<%= leftList %>"
+				rightReorder="<%= Boolean.TRUE.toString() %>"
+				rightTitle="visible"
 			/>
 		</liferay-frontend:fieldset>
 	</liferay-frontend:edit-form-body>

--- a/modules/test/playwright/tests/announcements-web/main/pages/AnnouncementsWidgetConfigurationPage.ts
+++ b/modules/test/playwright/tests/announcements-web/main/pages/AnnouncementsWidgetConfigurationPage.ts
@@ -70,7 +70,7 @@ export class AnnouncementsWidgetConfigurationPage {
 
 		await this.configurationIframe
 			.getByRole('button', {
-				name: 'Transfer Item Right to Left',
+				name: 'Move selected items from Available to In Use',
 			})
 			.click();
 	}

--- a/modules/test/playwright/tests/blogs-web/main/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/main/blogEntry.spec.ts
@@ -323,7 +323,7 @@ test(
 			title,
 		});
 
-		await page.getByLabel('Current').selectOption('category-1');
+		await page.getByLabel('In Use').selectOption('category-1');
 		await page.getByLabel('Reorder Down').click();
 		await page.getByLabel('Reorder Down').click();
 
@@ -387,7 +387,7 @@ test(
 		});
 
 		await page.getByLabel('Remove category-1').click();
-		await page.getByLabel('Current').selectOption('category-2');
+		await page.getByLabel('In Use').selectOption('category-2');
 		await page.getByLabel('Reorder Down').click();
 
 		const expectedCategoriesPartialURL = 'category-3/category-2';

--- a/modules/test/playwright/tests/site-admin-web/main/siteLanguagesConfiguration.spec.ts
+++ b/modules/test/playwright/tests/site-admin-web/main/siteLanguagesConfiguration.spec.ts
@@ -53,11 +53,11 @@ test(
 		await page.waitForTimeout(500);
 
 		await page
-			.getByLabel('Current', {exact: true})
+			.getByLabel('In Use', {exact: true})
 			.selectOption(removedLanguage);
 		await page
 			.getByRole('button', {
-				name: 'Move selected items from Current to Available',
+				name: 'Move selected items from In Use to Available',
 			})
 			.click({force: true});
 
@@ -92,7 +92,7 @@ test(
 			.selectOption(removedLanguage);
 		await page
 			.getByRole('button', {
-				name: 'Move selected items from Available to Current',
+				name: 'Move selected items from Available to In Use',
 			})
 			.click({force: true});
 
@@ -161,11 +161,11 @@ test('Cannot remove the site default language in instance settings', async ({
 
 	await page.waitForTimeout(500);
 	await page
-		.getByLabel('Current', {exact: true})
+		.getByLabel('In Use', {exact: true})
 		.selectOption('Spanish (Spain)');
 	await page
 		.getByRole('button', {
-			name: 'Move selected items from Current to Available',
+			name: 'Move selected items from In Use to Available',
 		})
 		.click({force: true});
 

--- a/modules/test/playwright/tests/site-navigation-language-web/main/languageWidget.spec.ts
+++ b/modules/test/playwright/tests/site-navigation-language-web/main/languageWidget.spec.ts
@@ -146,13 +146,13 @@ test('The user can choose which languages will be available to site via language
 	await leftSelector.selectOption(allOptions);
 
 	await configurationIFrame
-		.getByLabel('Move selected items from Current to Available.')
+		.getByLabel('Move selected items from In Use to Available.')
 		.click();
 
 	await rightSelector.selectOption(['de_DE', 'en_US', 'es_ES']);
 
 	await configurationIFrame
-		.getByLabel('Move selected items from Available to Current.')
+		.getByLabel('Move selected items from Available to In Use.')
 		.click();
 
 	await configurationIFrame.getByRole('button', {name: 'Save'}).click();


### PR DESCRIPTION
# Original description

Ticket: https://liferay.atlassian.net/browse/LPD-57934

## Motivation
DualListBox components were being used without consistency. Some pages were using this to display the available items with the left box, while others were using the right box for the same purpose. So, the presentation of data wasn´t consistent over the platform.

## Proposed Solution
This solution goes over some of its usage to keep available items on the left side as defined by the Lexicon team.

## Steps to Verify
You might want to go over all the occurrences and check if the left side for this component is used for items that are available (not selected) and the right side for items in use (selected). Here is the list of the modules that were changed:

1. Announcements module (on the configuration page for the "Announcements" widget)
2. Asset categories module (on the configuration page for the "Category Filter" widget)
3. Asset list module (go to asset libraries > select an existing library > edit an existing dynamic collection)
4. Asset publisher module (on the configuration page for the "Asset Publisher" widget)
5. Blogs module (go to site > Content & Data > Blogs > Create a new entry > On the friendly URL section)
6. Bookmarks module (go to site > Content & Data > Bookmarks > Configuration on the top right next to the Liferay menu)
7. Document library module (on the configuration page for both the "Documents and Media" and "Media Gallery" widgets)
8. Portal search module (on the configuration page for the "Type Facet" widget)
9. Portal settings module (go to Menu > Control Panel > Instance Settings > Localization)
10. Site Navigation Language module (on the configuration page for the "Language Selector" widget)
11. Site admin module (go to site > Site configuration > Site settings > Localization)
12. Social bookmarks taglib (this one is reused by other modules. For example, there is a social bookmark usage in the configuration page for the Asset Publisher module)
13. Wiki module (on the configuration page for the "Wiki" widget)

P.S.: There is also a reference for this component on the osb-patcher module, but we decided to keep it unchanged.

## Screenshots

P.S.: These screenshots don't cover all the changes, they are simply illustrative to show the expected behavior for these components.

<img width="704" height="934" alt="image" src="https://github.com/user-attachments/assets/e50fcb48-1b2e-4e4b-9e54-fb8dc886fd32" />

<img width="1136" height="500" alt="image" src="https://github.com/user-attachments/assets/1a51d75d-1fb5-4070-a08b-74f0b61c45d7" />

<img width="1152" height="532" alt="image" src="https://github.com/user-attachments/assets/0e31910b-5d40-416f-a084-4ea34ff5635e" />
