### PR TITLE
LPD-69556 Even non-shared mode would never have concurrent access to …

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/search/ReindexCacheThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/ReindexCacheThreadLocal.java
@@ -10,8 +10,8 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsUtil;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.IntFunction;
 import java.util.function.Supplier;
 
@@ -104,7 +104,7 @@ public class ReindexCacheThreadLocal {
 	}
 
 	public static SafeCloseable openReindexMode() {
-		return _reindexCacheMap.setWithSafeCloseable(new HashMap<>());
+		return _reindexCacheMap.setWithSafeCloseable(new ConcurrentHashMap<>());
 	}
 
 	public static SafeCloseable openReindexMode(


### PR DESCRIPTION
…the reindex cache, as we apply more usages of reindex cache, it is becoming possible to have nested reindex cache lookup. To avoid the nested Map.computeIfAbsent() caused ConcurrentModificationException, switch to use ConcurrentHashMap for non-shared mode too.