### PR TITLE
LPD-73598 When booting from existing db + dl without osgi/state (the …

### DIFF
--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/model/listener/AddRepositoryIdInitialRequestPortalInstanceLifecycleListener.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/model/listener/AddRepositoryIdInitialRequestPortalInstanceLifecycleListener.java
@@ -109,13 +109,20 @@ public class AddRepositoryIdInitialRequestPortalInstanceLifecycleListener
 
 				serviceContext.setUserId(user.getCompanyId());
 
-				Repository repository = _repositoryLocalService.addRepository(
-					null, user.getUserId(), company.getGroupId(),
-					_portal.getClassNameId(PortletRepository.class.getName()),
-					DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-					PropsKeys.IMAGE_DEFAULT_COMPANY_LOGO, null,
-					CPConstants.SERVICE_NAME_PRODUCT, new UnicodeProperties(),
-					true, serviceContext);
+				Repository repository = _repositoryLocalService.fetchRepository(
+					company.getGroupId(), PropsKeys.IMAGE_DEFAULT_COMPANY_LOGO,
+					CPConstants.SERVICE_NAME_PRODUCT);
+
+				if (repository == null) {
+					repository = _repositoryLocalService.addRepository(
+						null, user.getUserId(), company.getGroupId(),
+						_portal.getClassNameId(
+							PortletRepository.class.getName()),
+						DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+						PropsKeys.IMAGE_DEFAULT_COMPANY_LOGO, null,
+						CPConstants.SERVICE_NAME_PRODUCT,
+						new UnicodeProperties(), true, serviceContext);
+				}
 
 				Image image = ImageToolUtil.getDefaultCompanyLogo();
 


### PR DESCRIPTION
…typical post-upgrade startup scenario), if a company does not have its logo file, AddRepositoryIdInitialRequestPortalInstanceLifecycleListener will try to recreate it. But the logic has a major flaw, when you don't have the logo file, you may still have the dl reposistory. Blindly trying to create a new repository to hold the logo file could lead to "A folder already exists with name image.default.company.logo

com.liferay.document.library.kernel.exception.DuplicateFolderNameException: A folder already exists with name image.default.company.logo". Check repository existence before creating.