### PR TITLE
[FE] Create Playwright to test Scoping intersection

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/UQBEditSXPBlueprintForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/UQBEditSXPBlueprintForm.js
@@ -477,7 +477,7 @@ function UQBEditSXPBlueprintForm({
 					// Enable Feature Flag LPD-41306 to use the new Headless API
 
 					const response = await fetch(
-						`/o/headless-admin-site/v1.0/sites/by-external-reference-code/${externalReferenceCode}`,
+						`/o/headless-admin-site/v1.0/sites/${externalReferenceCode}`,
 						{
 							headers: new Headers({
 								'Accept-Language':

--- a/modules/test/playwright/pages/search-experiences-web/EditSXPBlueprintPage.ts
+++ b/modules/test/playwright/pages/search-experiences-web/EditSXPBlueprintPage.ts
@@ -5,6 +5,8 @@
 
 import {Locator, Page, expect} from '@playwright/test';
 
+import {clickAndExpectToBeHidden} from '../../utils/clickAndExpectToBeHidden';
+
 export class EditSXPBlueprintPage {
 	readonly addSXPElementSidebar: Locator;
 	readonly cancelButton: Locator;
@@ -318,5 +320,50 @@ export class EditSXPBlueprintPage {
 				}
 			}
 		}
+	}
+
+	async selectScope({
+		label,
+		tab,
+	}: {
+		label: string;
+		tab?: 'Recent' | 'My Sites' | 'Asset Libraries' | 'Spaces';
+	}) {
+		const scopeSelector = this.page.locator('.scope-selector');
+
+		await scopeSelector.getByRole('button', {name: 'Select Scope'}).click();
+
+		const scopeModal = this.page.frameLocator(
+			'iframe[title="Select Scope"]'
+		);
+
+		if (tab) {
+			await scopeModal
+				.locator('.navbar-nav')
+				.getByRole('link', {name: tab})
+				.click();
+		}
+
+		await clickAndExpectToBeHidden({
+			target: this.page.locator('.modal-dialog'),
+			trigger: scopeModal.getByRole('link', {exact: true, name: label}),
+		});
+
+		await expect(
+			scopeSelector
+				.locator('tr')
+				.filter({has: this.page.getByRole('cell', {name: label})})
+		).toBeVisible();
+	}
+
+	async removeScope({label}: {label: string}) {
+		const scopeSelector = this.page.locator('.scope-selector');
+
+		await clickAndExpectToBeHidden({
+			target: scopeSelector.getByRole('cell', {name: label}),
+			trigger: scopeSelector
+				.getByRole('row', {name: label})
+				.getByLabel('Remove'),
+		});
 	}
 }

--- a/modules/test/playwright/tests/search-experiences-web/main/unifiedQueryBuilder.spec.ts
+++ b/modules/test/playwright/tests/search-experiences-web/main/unifiedQueryBuilder.spec.ts
@@ -1,0 +1,211 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {isolatedLayoutTest} from '../../../fixtures/isolatedLayoutTest';
+import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
+import {searchExperiencesPagesTest} from '../../../fixtures/searchExperiencesPageTest';
+import {searchPageTest} from '../../../fixtures/searchPageTest';
+import {DEFAULT_SXP_BLUEPRINT_CONFIGURATION} from '../../../helpers/SearchExperiencesApiHelper';
+import {getRandomInt} from '../../../utils/getRandomInt';
+import getBasicWebContentStructureId from '../../../utils/structured-content/getBasicWebContentStructureId';
+
+export const test = mergeTests(
+	isolatedLayoutTest({type: 'portlet'}),
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-37320': {enabled: true}, // Unified Query Builder
+		'LPD-41306': {enabled: true}, // Headless Site API
+		'LPS-129412': {enabled: true}, // Collection Providers for Blueprint
+		'LPS-178052': {enabled: true}, // Headless Site Page API
+	}),
+	isolatedSiteTest,
+	pageEditorPagesTest,
+	loginTest(),
+	searchPageTest,
+	searchExperiencesPagesTest
+);
+
+test.describe('Data Persists', () => {
+	let site1: any;
+	let sxpBlueprintId: string;
+	const sxpBlueprintTitle = `Blueprint${getRandomInt()}`;
+
+	test.beforeEach(
+		async ({
+			apiHelpers,
+			editSXPBlueprintPage,
+			sxpBlueprintsAndElementsViewPage,
+		}) => {
+			await test.step('Create site via API', async () => {
+				site1 = await apiHelpers.headlessSite.createSite({
+					name: `Site1 ${getRandomInt()}`,
+				});
+			});
+
+			await test.step('Create blueprint manually', async () => {
+				await sxpBlueprintsAndElementsViewPage.goto();
+
+				await sxpBlueprintsAndElementsViewPage.createBlueprint(
+					sxpBlueprintTitle
+				);
+			});
+
+			await test.step('Save ID for created blueprint', async () => {
+				await expect(editSXPBlueprintPage.editTitleButton).toHaveText(
+					sxpBlueprintTitle
+				);
+
+				sxpBlueprintId = await editSXPBlueprintPage.getSXPBlueprintId();
+			});
+		}
+	);
+
+	test.afterEach(async ({apiHelpers}) => {
+		await test.step('Delete created site and blueprint', async () => {
+			if (site1.id) {
+				await apiHelpers.headlessSite.deleteSite(site1.id);
+			}
+
+			await apiHelpers.searchExperiences.deleteSXPBlueprint(
+				sxpBlueprintId
+			);
+		});
+	});
+
+	test('Scope selection persists after saving blueprint', async ({
+		editSXPBlueprintPage,
+		page,
+		sxpBlueprintsAndElementsViewPage,
+	}) => {
+		await test.step('Select site1 for the scope', async () => {
+			await editSXPBlueprintPage.selectScope({
+				label: site1.name,
+				tab: 'My Sites',
+			});
+		});
+
+		await test.step('Save blueprint and redirect back to it', async () => {
+			await editSXPBlueprintPage.saveBlueprint();
+
+			await sxpBlueprintsAndElementsViewPage.selectTableLink(
+				sxpBlueprintTitle
+			);
+		});
+
+		await test.step('Assert the scope selections saved', async () => {
+			await expect(
+				page
+					.locator('.scope-selector tr')
+					.filter({has: page.getByRole('cell', {name: site1.name})})
+			).toBeVisible();
+		});
+	});
+});
+
+test.describe('Scope Selection', () => {
+	let site1: any;
+	let site2: any;
+
+	test.beforeEach(async ({apiHelpers}) => {
+		site1 = await apiHelpers.headlessSite.createSite({
+			name: `Site1 ${getRandomInt()}`,
+		});
+
+		site2 = await apiHelpers.headlessSite.createSite({
+			name: `Site2 ${getRandomInt()}`,
+		});
+	});
+
+	test.afterEach(async ({apiHelpers}) => {
+		if (site1.id) {
+			await apiHelpers.headlessSite.deleteSite(site1.id);
+		}
+
+		if (site2.id) {
+			await apiHelpers.headlessSite.deleteSite(site2.id);
+		}
+	});
+
+	test('Sites with content are shown in blueprint preview', async ({
+		apiHelpers,
+		editSXPBlueprintPage,
+		sxpBlueprintsAndElementsViewPage,
+	}) => {
+		let sxpBlueprint: SXPBlueprint;
+
+		await test.step('Create content for two sites', async () => {
+			const basicWebContentStructureId =
+				await getBasicWebContentStructureId(apiHelpers);
+
+			await apiHelpers.jsonWebServicesJournal.addWebContent({
+				ddmStructureId: basicWebContentStructureId,
+				groupId: site1.id,
+				titleMap: {en_US: `Web Content for ${site1.name}`},
+			});
+		});
+
+		await test.step('Create blueprint with API scoped to the first site', async () => {
+			sxpBlueprint =
+				await apiHelpers.searchExperiences.createSXPBlueprint({
+					configuration: {
+						...DEFAULT_SXP_BLUEPRINT_CONFIGURATION,
+						generalConfiguration: {
+							...DEFAULT_SXP_BLUEPRINT_CONFIGURATION.generalConfiguration,
+							scope: [
+								site1.externalReferenceCode,
+								site2.externalReferenceCode,
+							],
+						},
+					},
+				});
+		});
+
+		await test.step('Navigate to created blueprint', async () => {
+			await sxpBlueprintsAndElementsViewPage.goto();
+
+			await sxpBlueprintsAndElementsViewPage.selectTableLink(
+				sxpBlueprint.title
+			);
+		});
+
+		await test.step('Verify web content is shown in blueprint preview', async () => {
+			await editSXPBlueprintPage.openPreviewSidebar();
+
+			await editSXPBlueprintPage.searchInPreviewSidebar(site1.name);
+
+			await editSXPBlueprintPage.assertPreviewSidebarSearchResult(
+				`Web Content for ${site1.name}`,
+				[
+					{
+						label: 'entryClassName',
+						value: 'com.liferay.journal.model.JournalArticle',
+					},
+				]
+			);
+		});
+
+		await test.step('Remove first site from blueprint scope', async () => {
+			await editSXPBlueprintPage.removeScope({label: site1.name});
+		});
+
+		await test.step('Verify web content is no longer shown in blueprint preview', async () => {
+			await editSXPBlueprintPage.previewSidebar
+				.getByLabel('Refresh')
+				.click();
+
+			await expect(
+				editSXPBlueprintPage.previewSidebar.getByText(
+					'No Results Found'
+				)
+			).toBeVisible();
+		});
+	});
+});

--- a/modules/test/playwright/tests/search-experiences-web/main/unified_query_builder/scopeSelection.spec.ts
+++ b/modules/test/playwright/tests/search-experiences-web/main/unified_query_builder/scopeSelection.spec.ts
@@ -5,17 +5,17 @@
 
 import {expect, mergeTests} from '@playwright/test';
 
-import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
-import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
-import {isolatedLayoutTest} from '../../../fixtures/isolatedLayoutTest';
-import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
-import {loginTest} from '../../../fixtures/loginTest';
-import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
-import {searchExperiencesPagesTest} from '../../../fixtures/searchExperiencesPageTest';
-import {searchPageTest} from '../../../fixtures/searchPageTest';
-import {DEFAULT_SXP_BLUEPRINT_CONFIGURATION} from '../../../helpers/SearchExperiencesApiHelper';
-import {getRandomInt} from '../../../utils/getRandomInt';
-import getBasicWebContentStructureId from '../../../utils/structured-content/getBasicWebContentStructureId';
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedLayoutTest} from '../../../../fixtures/isolatedLayoutTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
+import {searchExperiencesPagesTest} from '../../../../fixtures/searchExperiencesPageTest';
+import {searchPageTest} from '../../../../fixtures/searchPageTest';
+import {DEFAULT_SXP_BLUEPRINT_CONFIGURATION} from '../../../../helpers/SearchExperiencesApiHelper';
+import {getRandomInt} from '../../../../utils/getRandomInt';
+import getBasicWebContentStructureId from '../../../../utils/structured-content/getBasicWebContentStructureId';
 
 export const test = mergeTests(
 	isolatedLayoutTest({type: 'portlet'}),
@@ -33,84 +33,7 @@ export const test = mergeTests(
 	searchExperiencesPagesTest
 );
 
-test.describe('Data Persists', () => {
-	let site1: any;
-	let sxpBlueprintId: string;
-	const sxpBlueprintTitle = `Blueprint${getRandomInt()}`;
-
-	test.beforeEach(
-		async ({
-			apiHelpers,
-			editSXPBlueprintPage,
-			sxpBlueprintsAndElementsViewPage,
-		}) => {
-			await test.step('Create site via API', async () => {
-				site1 = await apiHelpers.headlessSite.createSite({
-					name: `Site1 ${getRandomInt()}`,
-				});
-			});
-
-			await test.step('Create blueprint manually', async () => {
-				await sxpBlueprintsAndElementsViewPage.goto();
-
-				await sxpBlueprintsAndElementsViewPage.createBlueprint(
-					sxpBlueprintTitle
-				);
-			});
-
-			await test.step('Save ID for created blueprint', async () => {
-				await expect(editSXPBlueprintPage.editTitleButton).toHaveText(
-					sxpBlueprintTitle
-				);
-
-				sxpBlueprintId = await editSXPBlueprintPage.getSXPBlueprintId();
-			});
-		}
-	);
-
-	test.afterEach(async ({apiHelpers}) => {
-		await test.step('Delete created site and blueprint', async () => {
-			if (site1.id) {
-				await apiHelpers.headlessSite.deleteSite(site1.id);
-			}
-
-			await apiHelpers.searchExperiences.deleteSXPBlueprint(
-				sxpBlueprintId
-			);
-		});
-	});
-
-	test('Scope selection persists after saving blueprint', async ({
-		editSXPBlueprintPage,
-		page,
-		sxpBlueprintsAndElementsViewPage,
-	}) => {
-		await test.step('Select site1 for the scope', async () => {
-			await editSXPBlueprintPage.selectScope({
-				label: site1.name,
-				tab: 'My Sites',
-			});
-		});
-
-		await test.step('Save blueprint and redirect back to it', async () => {
-			await editSXPBlueprintPage.saveBlueprint();
-
-			await sxpBlueprintsAndElementsViewPage.selectTableLink(
-				sxpBlueprintTitle
-			);
-		});
-
-		await test.step('Assert the scope selections saved', async () => {
-			await expect(
-				page
-					.locator('.scope-selector tr')
-					.filter({has: page.getByRole('cell', {name: site1.name})})
-			).toBeVisible();
-		});
-	});
-});
-
-test.describe('Scope Selection', () => {
+test.describe('Site Scope', () => {
 	let site1: any;
 	let site2: any;
 
@@ -132,6 +55,51 @@ test.describe('Scope Selection', () => {
 		if (site2.id) {
 			await apiHelpers.headlessSite.deleteSite(site2.id);
 		}
+	});
+
+	test('Scope selection persists after saving blueprint', async ({
+		apiHelpers,
+		editSXPBlueprintPage,
+		page,
+		sxpBlueprintsAndElementsViewPage,
+	}) => {
+		let sxpBlueprint: SXPBlueprint;
+
+		await test.step('Create blueprint with API scoped to the first site', async () => {
+			sxpBlueprint =
+				await apiHelpers.searchExperiences.createSXPBlueprint();
+		});
+
+		await test.step('Navigate to created blueprint', async () => {
+			await sxpBlueprintsAndElementsViewPage.goto();
+
+			await sxpBlueprintsAndElementsViewPage.selectTableLink(
+				sxpBlueprint.title
+			);
+		});
+
+		await test.step('Select site1 for the scope', async () => {
+			await editSXPBlueprintPage.selectScope({
+				label: site1.name,
+				tab: 'My Sites',
+			});
+		});
+
+		await test.step('Save blueprint and redirect back to it', async () => {
+			await editSXPBlueprintPage.saveBlueprint();
+
+			await sxpBlueprintsAndElementsViewPage.selectTableLink(
+				sxpBlueprint.title
+			);
+		});
+
+		await test.step('Assert the scope selections saved', async () => {
+			await expect(
+				page
+					.locator('.scope-selector tr')
+					.filter({has: page.getByRole('cell', {name: site1.name})})
+			).toBeVisible();
+		});
 	});
 
 	test('Sites with content are shown in blueprint preview', async ({


### PR DESCRIPTION
Manually forwarded from https://github.com/liferay-search/liferay-portal/pull/1776
Failures look unrelated

https://liferay.atlassian.net/browse/LPD-71496 - [FE] Create Playwright to test Scoping intersection

Test coverage includes:
- Scope can be saved to a created blueprint
- Blueprint preview will alter its search results depending on whether Sites 1 and 2 are selected. If both are selected, content from site1 is shown. If only site2 is selected and has no content, no content is shown.