### PR TITLE
Revert "LPD-73738 Simplify"

### DIFF
--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseState.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseState.java
@@ -267,14 +267,21 @@ public class PreupgradeVerifyDatabaseState extends PreupgradeVerifyProcess {
 	private static final Log _log = LogFactoryUtil.getLog(
 		PreupgradeVerifyDatabaseState.class);
 
-	private static final Set<String> _falsePositive74UpgradeDroppedTableNames =
-		Set.of(
-			"Account_", "AccountGroupAccountEntryRel",
-			"AssetEntries_AssetCategories", "BlogsStatsUser",
-			"CAccountGroupCAccountRel", "CommerceAccount",
-			"CommerceAccountGroup", "CommerceAccountGroupRel",
-			"CommerceAccountOrganizationRel", "CommerceAccountUserRel",
-			"CommerceAddress", "CommerceCountry", "CommerceRegion",
-			"MBStatsUser", "OrgGroupRole", "RemoteAppEntry");
+	private static final Set<String> _falsePositive74UpgradeDroppedTableNames;
+
+	static {
+		_falsePositive74UpgradeDroppedTableNames = new TreeSet<>(
+			String.CASE_INSENSITIVE_ORDER);
+
+		_falsePositive74UpgradeDroppedTableNames.addAll(
+			Set.of(
+				"Account_", "AccountGroupAccountEntryRel",
+				"AssetEntries_AssetCategories", "BlogsStatsUser",
+				"CAccountGroupCAccountRel", "CommerceAccount",
+				"CommerceAccountGroup", "CommerceAccountGroupRel",
+				"CommerceAccountOrganizationRel", "CommerceAccountUserRel",
+				"CommerceAddress", "CommerceCountry", "CommerceRegion",
+				"MBStatsUser", "OrgGroupRole", "RemoteAppEntry"));
+	}
 
 }


### PR DESCRIPTION
This reverts commit 94f7e4aaac66fe70322561304e3a9f3f6cbfabf0.

We cannot just use `Set.of`, we have to create a `TreeSet<>(String.CASE_INSENSITIVE_ORDER);`

Postgresql database stores the table names in lowecase and oracle or DB2 database in UPPERCASE, so when ignoring these false positive table names, we have to do all the checks ignoring the case, that is the reason I used **TreeSet<>(String.CASE_INSENSITIVE_ORDER);** 
