### PR TITLE
LPD-73375 The spaces in the selectors do not reflect the color chosen during creation

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/Breadcrumb.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/Breadcrumb.tsx
@@ -14,6 +14,7 @@ import React, {ComponentProps} from 'react';
 import DefaultPermissionModalContent from '../../main_view/default_permission/DefaultPermissionModalContent';
 import {DefaultPermissionModalContentProps} from '../../main_view/default_permission/DefaultPermissionTypes';
 import ApiHelper from '../services/ApiHelper';
+import {LogoColor} from '../types/Space';
 import {displayErrorToast} from '../utils/toastUtil';
 import SpaceSticker from './SpaceSticker';
 
@@ -28,14 +29,11 @@ export interface ActionDropdownItemProps {
 	target?: 'asyncDelete' | 'defaultPermissionsModal' | 'link' | 'modal';
 }
 
-interface Props
-	extends Pick<
-		React.ComponentProps<typeof ClaySticker>,
-		'displayType' | 'size'
-	> {
+interface Props extends Pick<React.ComponentProps<typeof ClaySticker>, 'size'> {
 	actionItems?: ComponentProps<typeof ClayDropDownWithItems>['items'] &
 		ActionDropdownItemProps;
 	breadcrumbItems: BreadcrumbItem[];
+	displayType?: LogoColor;
 	hideSpace?: boolean;
 }
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/SpaceSelector.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/SpaceSelector.tsx
@@ -10,16 +10,17 @@ import {
 } from '@liferay/frontend-js-item-selector-web';
 import React from 'react';
 
-import {Space} from '../types/Space';
+import {LogoColor, Space} from '../types/Space';
 import SpaceSticker from './SpaceSticker';
 
 interface ISpaceInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+	spaceLogoColor?: LogoColor;
 	spaceName?: string;
 	value?: string;
 }
 
 export const SpaceInput = React.forwardRef<HTMLInputElement, ISpaceInputProps>(
-	({spaceName, value, ...otherProps}, ref) => {
+	({spaceLogoColor, spaceName, value, ...otherProps}, ref) => {
 		const showSticker = !!spaceName && !!value && !!value.length;
 
 		return (
@@ -36,7 +37,12 @@ export const SpaceInput = React.forwardRef<HTMLInputElement, ISpaceInputProps>(
 
 					{showSticker && (
 						<ClayInput.GroupInsetItem before>
-							<SpaceSticker hideName name={spaceName} size="sm" />
+							<SpaceSticker
+								displayType={spaceLogoColor}
+								hideName
+								name={spaceName}
+								size="sm"
+							/>
 						</ClayInput.GroupInsetItem>
 					)}
 				</ClayInput.GroupItem>
@@ -85,7 +91,11 @@ export default function SpaceSelector({
 					key={space.externalReferenceCode}
 					textValue={space.name}
 				>
-					<SpaceSticker name={space.name} size="sm" />
+					<SpaceSticker
+						displayType={space.settings?.logoColor}
+						name={space.name}
+						size="sm"
+					/>
 				</ItemSelector.Item>
 			)}
 		</ItemSelector>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/SpaceSelector.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/SpaceSelector.tsx
@@ -83,6 +83,7 @@ export default function SpaceSelector({
 					event.preventDefault();
 				}
 			}}
+			spaceLogoColor={space?.settings?.logoColor}
 			spaceName={space?.name}
 			{...otherProps}
 		>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/SpaceSticker.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/SpaceSticker.tsx
@@ -23,14 +23,8 @@ export const logoColors: Record<LogoColor, string> = {
 	'outline-9': Liferay.Language.get('white'),
 };
 
-function getDisplayType(char: string): LogoColor {
-	const displayTypes = Object.keys(logoColors);
-
-	return displayTypes[char.charCodeAt(0) % displayTypes.length] as LogoColor;
-}
-
 export default function SpaceSticker({
-	displayType,
+	displayType = 'outline-0',
 	hideName,
 	href,
 	name,
@@ -49,11 +43,7 @@ export default function SpaceSticker({
 
 	return (
 		<div className={wrapperClasses}>
-			<ClaySticker
-				displayType={displayType || getDisplayType(name)}
-				size={size}
-				{...otherProps}
-			>
+			<ClaySticker displayType={displayType} size={size} {...otherProps}>
 				{name.charAt(0).toUpperCase()}
 			</ClaySticker>
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/FolderService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/FolderService.ts
@@ -9,6 +9,9 @@ export type TFolder = {
 	description: string;
 	externalReferenceCode?: string;
 	id: number;
+	scope?: {
+		externalReferenceCode: string;
+	};
 	scopeKey?: string;
 	title: string;
 };

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/components/CategorizationSpaces.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/components/CategorizationSpaces.tsx
@@ -12,9 +12,10 @@ import React, {ChangeEvent, useEffect, useState} from 'react';
 
 import SpaceSticker from '../../../common/components/SpaceSticker';
 import SpaceService from '../../../common/services/SpaceService';
+import {LogoColor} from '../../../common/types/Space';
 
 type Space = {
-	displayType?: string;
+	displayType?: LogoColor;
 	label: string;
 	value: any;
 };
@@ -163,11 +164,11 @@ export default function CategorizationSpaces({
 							key={item.value}
 							textValue={item.label}
 						>
-							<div className="autofit-row autofit-row-center">
-								<span className="align-items-center d-flex space-renderer-sticker">
-									<SpaceSticker name={item.label} />
-								</span>
-							</div>
+							<SpaceSticker
+								displayType={item.displayType}
+								name={item.label}
+								size="sm"
+							/>
 						</ClayMultiSelect.Item>
 					)}
 				</ClayMultiSelect>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/tags/MergeTagsModal.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/tags/MergeTagsModal.tsx
@@ -208,7 +208,7 @@ export default function MergeTagsModalContent({
 						(
 							assetLibrary: {
 								name: string;
-								settings?: {logoColor: string};
+								settings?: {logoColor: LogoColor};
 							},
 							index: number
 						) => (
@@ -218,8 +218,7 @@ export default function MergeTagsModalContent({
 							>
 								<SpaceSticker
 									displayType={
-										assetLibrary.settings
-											?.logoColor as LogoColor
+										assetLibrary.settings?.logoColor
 									}
 									name={assetLibrary.name}
 									size="sm"

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/folders/EditFolder.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/folders/EditFolder.tsx
@@ -16,6 +16,8 @@ import {SpaceInput} from '../../common/components/SpaceSelector';
 import {FieldText} from '../../common/components/forms';
 import {required, validate} from '../../common/components/forms/validations';
 import FolderService, {TFolder} from '../../common/services/FolderService';
+import SpaceService from '../../common/services/SpaceService';
+import {Space} from '../../common/types/Space';
 
 interface EditFolderProps {
 	backURL: string;
@@ -24,8 +26,20 @@ interface EditFolderProps {
 
 const EditFolder: React.FC<EditFolderProps> = ({backURL, folderId}) => {
 	const [folderData, setFolderData] = useState<
-		Pick<TFolder, 'description' | 'scopeKey' | 'title'>
-	>({description: '', scopeKey: '', title: ''});
+		Pick<TFolder, 'description' | 'scopeKey' | 'title'> & {
+			space: Pick<Space, 'name' | 'settings'>;
+		}
+	>({
+		description: '',
+		scopeKey: '',
+		space: {
+			name: '',
+			settings: {
+				logoColor: 'outline-0',
+			},
+		},
+		title: '',
+	});
 	const [isLoading, setIsLoading] = useState<boolean>(true);
 
 	const folderSpaceInputId = `${uuidv4()}folderSpace`;
@@ -35,8 +49,11 @@ const EditFolder: React.FC<EditFolderProps> = ({backURL, folderId}) => {
 			setIsLoading(true);
 			try {
 				const response = await FolderService.getFolder(folderId);
+				const space = await SpaceService.getSpace(
+					response.scope?.externalReferenceCode!
+				);
 
-				setFolderData(response);
+				setFolderData({...response, space});
 			}
 			catch (error: any) {
 				throw new Error(
@@ -62,7 +79,7 @@ const EditFolder: React.FC<EditFolderProps> = ({backURL, folderId}) => {
 		initialValues: {
 			folderDescription: folderData.description,
 			folderName: folderData.title,
-			folderSpace: folderData.scopeKey,
+			folderSpace: folderData.space,
 		},
 		onSubmit: async (formValues) => {
 			const newFolderValues: TFolder = {
@@ -105,7 +122,7 @@ const EditFolder: React.FC<EditFolderProps> = ({backURL, folderId}) => {
 			setValues({
 				folderDescription: folderData.description,
 				folderName: folderData.title,
-				folderSpace: folderData.scopeKey,
+				folderSpace: folderData.space,
 			});
 		}
 	}, [folderData, setValues]);
@@ -195,8 +212,11 @@ const EditFolder: React.FC<EditFolderProps> = ({backURL, folderId}) => {
 							aria-readonly
 							id={folderSpaceInputId}
 							readOnly
-							spaceName={values.folderSpace}
-							value={values.folderSpace}
+							spaceLogoColor={
+								values.folderSpace.settings?.logoColor
+							}
+							spaceName={values.folderSpace.name}
+							value={values.folderSpace.name}
 						/>
 					</FieldBase>
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/folders/EditFolder.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/folders/EditFolder.tsx
@@ -26,12 +26,11 @@ interface EditFolderProps {
 
 const EditFolder: React.FC<EditFolderProps> = ({backURL, folderId}) => {
 	const [folderData, setFolderData] = useState<
-		Pick<TFolder, 'description' | 'scopeKey' | 'title'> & {
+		Pick<TFolder, 'description' | 'title'> & {
 			space: Pick<Space, 'name' | 'settings'>;
 		}
 	>({
 		description: '',
-		scopeKey: '',
 		space: {
 			name: '',
 			settings: {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/folders/EditFolder.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/folders/EditFolder.tsx
@@ -32,7 +32,7 @@ const EditFolder: React.FC<EditFolderProps> = ({backURL, folderId}) => {
 	>({
 		description: '',
 		space: {
-			name: '',
+			name: 'Default',
 			settings: {
 				logoColor: 'outline-0',
 			},

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/SpaceRenderer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/SpaceRenderer.tsx
@@ -8,6 +8,7 @@ import classNames from 'classnames';
 import React from 'react';
 
 import SpaceSticker from '../../../common/components/SpaceSticker';
+import {LogoColor} from '../../../common/types/Space';
 
 const SpaceRenderer = ({
 	href,
@@ -16,7 +17,7 @@ const SpaceRenderer = ({
 	value,
 }: {
 	href?: string;
-	logoColor: IClayStickerProps['displayType'];
+	logoColor?: LogoColor;
 	size?: IClayStickerProps['size'];
 	value: string;
 }) => {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/components/SpacesSelector.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/components/SpacesSelector.tsx
@@ -126,7 +126,11 @@ export default function SpacesSelector({
 								key={item.externalReferenceCode}
 								textValue={item.name}
 							>
-								<SpaceSticker name={item.name} size="sm" />
+								<SpaceSticker
+									displayType={item.settings?.logoColor}
+									name={item.name}
+									size="sm"
+								/>
 							</ItemSelector.Item>
 						)}
 					</ItemSelector>

--- a/modules/apps/site/site-cms-site-initializer/test/js/common/components/SpaceSticker.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/common/components/SpaceSticker.test.tsx
@@ -8,33 +8,55 @@ import {render, screen} from '@testing-library/react';
 import React from 'react';
 
 import SpaceSticker from '../../../../src/main/resources/META-INF/resources/js/common/components/SpaceSticker';
+import {LogoColor} from '../../../../src/main/resources/META-INF/resources/js/common/types/Space';
 
-const spaceTitle = 'First space';
+const space = {
+	name: 'First space',
+	settings: {
+		logoColor: 'outline-1' as LogoColor,
+	},
+};
 
 describe('SpaceSticker', () => {
 	it('renders the first letter of the name in uppercase', () => {
-		render(<SpaceSticker name={spaceTitle} />);
+		render(
+			<SpaceSticker
+				displayType={space.settings.logoColor}
+				name={space.name}
+			/>
+		);
 
 		expect(
-			screen.getByText(spaceTitle.charAt(0).toUpperCase())
+			screen.getByText(space.name.charAt(0).toUpperCase())
 		).toBeInTheDocument();
 	});
 
 	it('renders the full name next to the sticker', () => {
-		render(<SpaceSticker name={spaceTitle} />);
+		render(
+			<SpaceSticker
+				displayType={space.settings.logoColor}
+				name={space.name}
+			/>
+		);
 
-		expect(screen.getByText(spaceTitle)).toBeInTheDocument();
+		expect(screen.getByText(space.name)).toBeInTheDocument();
 	});
 
 	it('render component without name if "hideName" is true', () => {
-		render(<SpaceSticker hideName name={spaceTitle} />);
+		render(
+			<SpaceSticker
+				displayType={space.settings.logoColor}
+				hideName
+				name={space.name}
+			/>
+		);
 
-		expect(screen.queryByText(spaceTitle)).not.toBeInTheDocument();
+		expect(screen.queryByText(space.name)).not.toBeInTheDocument();
 	});
 
 	it('applies the provided style to the ClaySticker', () => {
 		const {container} = render(
-			<SpaceSticker displayType="outline-3" name={spaceTitle} />
+			<SpaceSticker displayType="outline-3" name={space.name} />
 		);
 
 		expect(container.getElementsByClassName('sticker')[0]).toHaveClass(
@@ -44,7 +66,11 @@ describe('SpaceSticker', () => {
 
 	it('applies the provided size prop to the ClaySticker', () => {
 		const {container} = render(
-			<SpaceSticker name={spaceTitle} size="sm" />
+			<SpaceSticker
+				displayType={space.settings.logoColor}
+				name={space.name}
+				size="sm"
+			/>
 		);
 
 		expect(container.getElementsByClassName('sticker')[0]).toHaveClass(

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/default_permission/BulkDefaultPermissionModalContent.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/default_permission/BulkDefaultPermissionModalContent.test.tsx
@@ -83,6 +83,7 @@ describe('BulkDefaultPermissionModalContent', () => {
 			externalReferenceCode: 'ERC2',
 			id: 1,
 			name: 'Test Space',
+			settings: {logoColor: 'outline-0'},
 			siteId: 20203,
 		});
 

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/folders/EditFolder.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/folders/EditFolder.test.tsx
@@ -89,7 +89,9 @@ describe('EditFolder', () => {
 		);
 
 		const combobox = screen.getByRole('textbox', {name: /space/i});
-		expect(combobox).toHaveValue(mockFolder.scopeKey);
+		await waitFor(() => {
+			expect(combobox).toHaveValue(mockFolder.scopeKey);
+		});
 		expect(combobox).toHaveAttribute('aria-readonly', 'true');
 	});
 


### PR DESCRIPTION
Resent from https://github.com/brianchandotcom/liferay-portal/pull/168721 due to rebase errors

**JIRA Ticket**: https://liferay.atlassian.net/browse/LPD-73375

This fixes a wrong behavior where the color of the Space logo was not correctly displayed in UI selections, such as the Item Selector.

**How to verify:**

1. Go to the CMS site and configure a few Asset Libraries/Spaces, ensuring they have different logo colors set in their respective configurations.
2. Navigate to the context where the selector is used (e.g., Asset Creation, Content Structure definition).
3. Click the Space selector to view the list of available Libraries/Spaces.

**Expected Result (After Fix):** Each listed Space accurately reflects its corresponding configured logo color.

**Actual Result (Before Fix):** All Space logos appeared with incorrect color

Sent manually as was just a rebase error
SF and stable run: https://github.com/liferay-platform-experience/liferay-portal/pull/1592

cc @ethib137