### PR TITLE
LPD-72787 Add 'parentTaxonomyCategory' and 'parentTaxonomyVocabulary' to objectEntry's 'taxonomyCategoryBriefs' response

### DIFF
--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/TaxonomyCategoryBrief.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/TaxonomyCategoryBrief.java
@@ -138,7 +138,7 @@ public class TaxonomyCategoryBrief implements Serializable {
 	}
 
 	@GraphQLField(description = "The category's parent category.")
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected ParentTaxonomyCategory parentTaxonomyCategory;
 
 	@JsonIgnore
@@ -185,7 +185,7 @@ public class TaxonomyCategoryBrief implements Serializable {
 	}
 
 	@GraphQLField(description = "The parent category's `TaxonomyVocabulary`.")
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected ParentTaxonomyVocabulary parentTaxonomyVocabulary;
 
 	@JsonIgnore

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/TaxonomyCategoryBrief.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/TaxonomyCategoryBrief.java
@@ -138,7 +138,7 @@ public class TaxonomyCategoryBrief implements Serializable {
 	}
 
 	@GraphQLField(description = "The category's parent category.")
-	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected ParentTaxonomyCategory parentTaxonomyCategory;
 
 	@JsonIgnore
@@ -185,7 +185,7 @@ public class TaxonomyCategoryBrief implements Serializable {
 	}
 
 	@GraphQLField(description = "The parent category's `TaxonomyVocabulary`.")
-	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected ParentTaxonomyVocabulary parentTaxonomyVocabulary;
 
 	@JsonIgnore

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/dto/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 4.0.1

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -282,7 +282,6 @@ components:
                                 The parent taxonomy category's external reference code.
                             type: string
                     type: object
-                    writeOnly: true
                 parentTaxonomyVocabulary:
                     description:
                         The parent category's `TaxonomyVocabulary`.
@@ -293,7 +292,6 @@ components:
                                 The parent category's `TaxonomyVocabulary` external reference code.
                             type: string
                     type: object
-                    writeOnly: true
                 scope:
                     type: scope
                 taxonomyCategoryExternalReferenceCode:

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -281,6 +281,7 @@ components:
                             description:
                                 The parent taxonomy category's external reference code.
                             type: string
+                    readOnly: true
                     type: object
                 parentTaxonomyVocabulary:
                     description:
@@ -291,6 +292,7 @@ components:
                             description:
                                 The parent category's `TaxonomyVocabulary` external reference code.
                             type: string
+                    readOnly: true
                     type: object
                 scope:
                     type: scope

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/util/TaxonomyCategoryBriefUtil.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/util/TaxonomyCategoryBriefUtil.java
@@ -6,6 +6,7 @@
 package com.liferay.object.rest.internal.dto.v1_0.util;
 
 import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.object.rest.dto.v1_0.ParentTaxonomyCategory;
 import com.liferay.object.rest.dto.v1_0.TaxonomyCategoryBrief;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
@@ -35,6 +36,20 @@ public class TaxonomyCategoryBriefUtil {
 				setEmbeddedTaxonomyCategory(
 					() -> _toTaxonomyCategory(
 						assetCategory.getCategoryId(), dtoConverterContext));
+				setParentTaxonomyCategory(
+					() -> {
+						AssetCategory parentAssetCategory =
+							assetCategory.getParentCategory();
+
+						return new ParentTaxonomyCategory() {
+							{
+								setExternalReferenceCode(
+									() ->
+										parentAssetCategory.
+											getExternalReferenceCode());
+							}
+						};
+					});
 				setScope(
 					() -> Scope.of(
 						assetCategory.getGroupId(),

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/util/TaxonomyCategoryBriefUtil.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/util/TaxonomyCategoryBriefUtil.java
@@ -51,9 +51,8 @@ public class TaxonomyCategoryBriefUtil {
 						return new ParentTaxonomyCategory() {
 							{
 								setExternalReferenceCode(
-									() ->
-										parentAssetCategory.
-											getExternalReferenceCode());
+									parentAssetCategory::
+										getExternalReferenceCode);
 							}
 						};
 					});
@@ -66,9 +65,8 @@ public class TaxonomyCategoryBriefUtil {
 						return new ParentTaxonomyVocabulary() {
 							{
 								setExternalReferenceCode(
-									() ->
-										parentAssetVocabulary.
-											getExternalReferenceCode());
+									parentAssetVocabulary::
+										getExternalReferenceCode);
 							}
 						};
 					});

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/util/TaxonomyCategoryBriefUtil.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/util/TaxonomyCategoryBriefUtil.java
@@ -6,7 +6,10 @@
 package com.liferay.object.rest.internal.dto.v1_0.util;
 
 import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
 import com.liferay.object.rest.dto.v1_0.ParentTaxonomyCategory;
+import com.liferay.object.rest.dto.v1_0.ParentTaxonomyVocabulary;
 import com.liferay.object.rest.dto.v1_0.TaxonomyCategoryBrief;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
@@ -46,6 +49,21 @@ public class TaxonomyCategoryBriefUtil {
 								setExternalReferenceCode(
 									() ->
 										parentAssetCategory.
+											getExternalReferenceCode());
+							}
+						};
+					});
+				setParentTaxonomyVocabulary(
+					() -> {
+						AssetVocabulary parentAssetVocabulary =
+							AssetVocabularyLocalServiceUtil.getAssetVocabulary(
+								assetCategory.getVocabularyId());
+
+						return new ParentTaxonomyVocabulary() {
+							{
+								setExternalReferenceCode(
+									() ->
+										parentAssetVocabulary.
 											getExternalReferenceCode());
 							}
 						};

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/util/TaxonomyCategoryBriefUtil.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/util/TaxonomyCategoryBriefUtil.java
@@ -44,6 +44,10 @@ public class TaxonomyCategoryBriefUtil {
 						AssetCategory parentAssetCategory =
 							assetCategory.getParentCategory();
 
+						if (parentAssetCategory == null) {
+							return null;
+						}
+
 						return new ParentTaxonomyCategory() {
 							{
 								setExternalReferenceCode(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -6848,9 +6848,12 @@ public class ObjectEntryResourceTest {
 	public void testGetObjectEntryFilteredByTaxonomyCategories()
 		throws Exception {
 
-		TaxonomyCategory taxonomyCategory1 = _addTaxonomyCategory();
-		TaxonomyCategory taxonomyCategory2 = _addTaxonomyCategory();
-		TaxonomyCategory taxonomyCategory3 = _addTaxonomyCategory();
+		TaxonomyCategory taxonomyCategory1 =
+			_addTaxonomyVocabularyTaxonomyCategory();
+		TaxonomyCategory taxonomyCategory2 =
+			_addTaxonomyVocabularyTaxonomyCategory();
+		TaxonomyCategory taxonomyCategory3 =
+			_addTaxonomyVocabularyTaxonomyCategory();
 
 		_postObjectEntryWithTaxonomyCategories();
 		_postObjectEntryWithTaxonomyCategories(taxonomyCategory1);
@@ -8260,8 +8263,9 @@ public class ObjectEntryResourceTest {
 				group1.getGroupId(), RandomTestUtil.randomString(),
 				new ServiceContext());
 
-		TaxonomyCategory taxonomyCategory1 = _addTaxonomyCategory(
-			group1.getGroupId(), assetVocabulary1.getVocabularyId());
+		TaxonomyCategory taxonomyCategory1 =
+			_addTaxonomyVocabularyTaxonomyCategory(
+				group1.getGroupId(), assetVocabulary1.getVocabularyId());
 
 		Group group2 = _groupLocalService.getGroup(
 			TestPropsValues.getCompanyId(), GroupConstants.CMS);
@@ -8273,13 +8277,19 @@ public class ObjectEntryResourceTest {
 				group2.getGroupId(), RandomTestUtil.randomString(),
 				new ServiceContext());
 
-		TaxonomyCategory taxonomyCategory2 = _addTaxonomyCategory(
-			group2.getGroupId(), assetVocabulary2.getVocabularyId());
+		TaxonomyCategory taxonomyCategory2 =
+			_addTaxonomyVocabularyTaxonomyCategory(
+				group2.getGroupId(), assetVocabulary2.getVocabularyId());
 
 		Group group3 = _groupLocalService.fetchGroup(_testGroupId);
 
-		TaxonomyCategory taxonomyCategory3 = _addTaxonomyCategory(
-			group3.getGroupId(), _assetVocabulary.getVocabularyId());
+		TaxonomyCategory taxonomyCategory3 =
+			_addTaxonomyVocabularyTaxonomyCategory(
+				group3.getGroupId(), _assetVocabulary.getVocabularyId());
+
+		TaxonomyCategory taxonomyCategory4 =
+			_addTaxonomyCategoryTaxonomyCategory(
+				group3.getGroupId(), taxonomyCategory3.getId());
 
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
@@ -8288,7 +8298,7 @@ public class ObjectEntryResourceTest {
 				"taxonomyCategoryIds",
 				JSONUtil.putAll(
 					taxonomyCategory1.getId(), taxonomyCategory2.getId(),
-					taxonomyCategory3.getId())
+					taxonomyCategory3.getId(), taxonomyCategory4.getId())
 			).toString(),
 			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
 
@@ -8300,15 +8310,18 @@ public class ObjectEntryResourceTest {
 
 		_assertTaxonomyCategories(
 			jsonObject.getJSONArray("taxonomyCategoryBriefs"), false,
-			taxonomyCategory1, taxonomyCategory2, taxonomyCategory3);
+			taxonomyCategory1, taxonomyCategory2, taxonomyCategory3,
+			taxonomyCategory4);
 	}
 
 	@Test
 	public void testGetObjectEntryWithTaxonomyCategoriesAndEmbeddedTaxonomyCategory()
 		throws Exception {
 
-		TaxonomyCategory taxonomyCategory1 = _addTaxonomyCategory();
-		TaxonomyCategory taxonomyCategory2 = _addTaxonomyCategory();
+		TaxonomyCategory taxonomyCategory1 =
+			_addTaxonomyVocabularyTaxonomyCategory();
+		TaxonomyCategory taxonomyCategory2 =
+			_addTaxonomyVocabularyTaxonomyCategory();
 
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
@@ -8808,8 +8821,10 @@ public class ObjectEntryResourceTest {
 
 	@Test
 	public void testPatchObjectEntryWithTaxonomyCategories() throws Exception {
-		TaxonomyCategory taxonomyCategory1 = _addTaxonomyCategory();
-		TaxonomyCategory taxonomyCategory2 = _addTaxonomyCategory();
+		TaxonomyCategory taxonomyCategory1 =
+			_addTaxonomyVocabularyTaxonomyCategory();
+		TaxonomyCategory taxonomyCategory2 =
+			_addTaxonomyVocabularyTaxonomyCategory();
 
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
@@ -8821,7 +8836,8 @@ public class ObjectEntryResourceTest {
 			).toString(),
 			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
 
-		TaxonomyCategory taxonomyCategory3 = _addTaxonomyCategory();
+		TaxonomyCategory taxonomyCategory3 =
+			_addTaxonomyVocabularyTaxonomyCategory();
 
 		jsonObject = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
@@ -10692,7 +10708,8 @@ public class ObjectEntryResourceTest {
 				_objectDefinition1);
 
 		try {
-			TaxonomyCategory taxonomyCategory = _addTaxonomyCategory();
+			TaxonomyCategory taxonomyCategory =
+				_addTaxonomyVocabularyTaxonomyCategory();
 
 			JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
 				JSONUtil.put(
@@ -10774,10 +10791,14 @@ public class ObjectEntryResourceTest {
 			).toString(),
 			JSONCompareMode.STRICT);
 
-		TaxonomyCategory taxonomyCategory1 = _addTaxonomyCategory(
-			assetVocabulary.getGroupId(), assetVocabulary.getVocabularyId());
-		TaxonomyCategory taxonomyCategory2 = _addTaxonomyCategory(
-			assetVocabulary.getGroupId(), assetVocabulary.getVocabularyId());
+		TaxonomyCategory taxonomyCategory1 =
+			_addTaxonomyVocabularyTaxonomyCategory(
+				assetVocabulary.getGroupId(),
+				assetVocabulary.getVocabularyId());
+		TaxonomyCategory taxonomyCategory2 =
+			_addTaxonomyVocabularyTaxonomyCategory(
+				assetVocabulary.getGroupId(),
+				assetVocabulary.getVocabularyId());
 
 		JSONAssert.assertEquals(
 			JSONUtil.put(
@@ -15318,34 +15339,27 @@ public class ObjectEntryResourceTest {
 			actionId);
 	}
 
-	private TaxonomyCategory _addTaxonomyCategory() throws Exception {
-		return _addTaxonomyCategory(
+	private TaxonomyCategory _addTaxonomyCategoryTaxonomyCategory(
+			long groupId, String taxonomyCategoryId)
+		throws Exception {
+
+		return _taxonomyCategoryResource.postTaxonomyCategoryTaxonomyCategory(
+			taxonomyCategoryId, _randomTaxonomyCategory(groupId));
+	}
+
+	private TaxonomyCategory _addTaxonomyVocabularyTaxonomyCategory()
+		throws Exception {
+
+		return _addTaxonomyVocabularyTaxonomyCategory(
 			_testGroupId, _assetVocabulary.getVocabularyId());
 	}
 
-	private TaxonomyCategory _addTaxonomyCategory(
+	private TaxonomyCategory _addTaxonomyVocabularyTaxonomyCategory(
 			long groupId, long taxonomyVocabularyId)
 		throws Exception {
 
 		return _taxonomyCategoryResource.postTaxonomyVocabularyTaxonomyCategory(
-			taxonomyVocabularyId,
-			new TaxonomyCategory() {
-				{
-					dateCreated = RandomTestUtil.nextDate();
-					dateModified = RandomTestUtil.nextDate();
-					description = StringUtil.toLowerCase(
-						RandomTestUtil.randomString());
-					externalReferenceCode = StringUtil.toLowerCase(
-						RandomTestUtil.randomString());
-					id = StringUtil.toLowerCase(RandomTestUtil.randomString());
-					name = StringUtil.toLowerCase(
-						RandomTestUtil.randomString());
-					numberOfTaxonomyCategories = RandomTestUtil.randomInt();
-					siteId = groupId;
-					taxonomyCategoryUsageCount = RandomTestUtil.randomInt();
-					taxonomyVocabularyId = RandomTestUtil.randomLong();
-				}
-			});
+			taxonomyVocabularyId, _randomTaxonomyCategory(groupId));
 	}
 
 	private FileEntry _addTempFileEntry(
@@ -16518,6 +16532,25 @@ public class ObjectEntryResourceTest {
 				_getEndpoint(_objectDefinition1, _testGroupId),
 				StringPool.SLASH, id, "/permissions"),
 			Http.Method.PUT);
+	}
+
+	private TaxonomyCategory _randomTaxonomyCategory(long groupId) {
+		return new TaxonomyCategory() {
+			{
+				dateCreated = RandomTestUtil.nextDate();
+				dateModified = RandomTestUtil.nextDate();
+				description = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				externalReferenceCode = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				id = StringUtil.toLowerCase(RandomTestUtil.randomString());
+				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
+				numberOfTaxonomyCategories = RandomTestUtil.randomInt();
+				siteId = groupId;
+				taxonomyCategoryUsageCount = RandomTestUtil.randomInt();
+				taxonomyVocabularyId = RandomTestUtil.randomLong();
+			}
+		};
 	}
 
 	private void _registerUnsafeSupplierInvocations(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -8264,8 +8264,9 @@ public class ObjectEntryResourceTest {
 				new ServiceContext());
 
 		TaxonomyCategory taxonomyCategory1 =
-			_addTaxonomyVocabularyTaxonomyCategory(
-				group1.getGroupId(), assetVocabulary1.getVocabularyId());
+			_taxonomyCategoryResource.postTaxonomyVocabularyTaxonomyCategory(
+				assetVocabulary1.getVocabularyId(),
+				_randomTaxonomyCategory(group1.getGroupId()));
 
 		Group group2 = _groupLocalService.getGroup(
 			TestPropsValues.getCompanyId(), GroupConstants.CMS);
@@ -8278,18 +8279,21 @@ public class ObjectEntryResourceTest {
 				new ServiceContext());
 
 		TaxonomyCategory taxonomyCategory2 =
-			_addTaxonomyVocabularyTaxonomyCategory(
-				group2.getGroupId(), assetVocabulary2.getVocabularyId());
+			_taxonomyCategoryResource.postTaxonomyVocabularyTaxonomyCategory(
+				assetVocabulary2.getVocabularyId(),
+				_randomTaxonomyCategory(group2.getGroupId()));
 
 		Group group3 = _groupLocalService.fetchGroup(_testGroupId);
 
 		TaxonomyCategory taxonomyCategory3 =
-			_addTaxonomyVocabularyTaxonomyCategory(
-				group3.getGroupId(), _assetVocabulary.getVocabularyId());
+			_taxonomyCategoryResource.postTaxonomyVocabularyTaxonomyCategory(
+				_assetVocabulary.getVocabularyId(),
+				_randomTaxonomyCategory(group3.getGroupId()));
 
 		TaxonomyCategory taxonomyCategory4 =
-			_addTaxonomyCategoryTaxonomyCategory(
-				group3.getGroupId(), taxonomyCategory3.getId());
+			_taxonomyCategoryResource.postTaxonomyCategoryTaxonomyCategory(
+				taxonomyCategory3.getId(),
+				_randomTaxonomyCategory(group3.getGroupId()));
 
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
@@ -10792,13 +10796,14 @@ public class ObjectEntryResourceTest {
 			JSONCompareMode.STRICT);
 
 		TaxonomyCategory taxonomyCategory1 =
-			_addTaxonomyVocabularyTaxonomyCategory(
-				assetVocabulary.getGroupId(),
-				assetVocabulary.getVocabularyId());
+			_taxonomyCategoryResource.postTaxonomyVocabularyTaxonomyCategory(
+				assetVocabulary.getVocabularyId(),
+				_randomTaxonomyCategory(assetVocabulary.getGroupId()));
+
 		TaxonomyCategory taxonomyCategory2 =
-			_addTaxonomyVocabularyTaxonomyCategory(
-				assetVocabulary.getGroupId(),
-				assetVocabulary.getVocabularyId());
+			_taxonomyCategoryResource.postTaxonomyVocabularyTaxonomyCategory(
+				assetVocabulary.getVocabularyId(),
+				_randomTaxonomyCategory(assetVocabulary.getGroupId()));
 
 		JSONAssert.assertEquals(
 			JSONUtil.put(
@@ -15339,27 +15344,13 @@ public class ObjectEntryResourceTest {
 			actionId);
 	}
 
-	private TaxonomyCategory _addTaxonomyCategoryTaxonomyCategory(
-			long groupId, String taxonomyCategoryId)
-		throws Exception {
-
-		return _taxonomyCategoryResource.postTaxonomyCategoryTaxonomyCategory(
-			taxonomyCategoryId, _randomTaxonomyCategory(groupId));
-	}
-
 	private TaxonomyCategory _addTaxonomyVocabularyTaxonomyCategory()
 		throws Exception {
 
-		return _addTaxonomyVocabularyTaxonomyCategory(
-			_testGroupId, _assetVocabulary.getVocabularyId());
-	}
-
-	private TaxonomyCategory _addTaxonomyVocabularyTaxonomyCategory(
-			long groupId, long taxonomyVocabularyId)
-		throws Exception {
+		long taxonomyVocabularyId = _assetVocabulary.getVocabularyId();
 
 		return _taxonomyCategoryResource.postTaxonomyVocabularyTaxonomyCategory(
-			taxonomyVocabularyId, _randomTaxonomyCategory(groupId));
+			taxonomyVocabularyId, _randomTaxonomyCategory(_testGroupId));
 	}
 
 	private FileEntry _addTempFileEntry(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -20383,17 +20383,19 @@ public class ObjectEntryResourceTest {
 			boolean withEmbeddedTaxonomyCategory)
 		throws Exception {
 
-		ParentTaxonomyVocabulary parentTaxonomyVocabulary =
-			taxonomyCategory.getParentTaxonomyVocabulary();
-
 		Scope scope = Scope.of(
 			taxonomyCategory.getSiteId(), LocaleUtil.getDefault());
 
 		JSONObject jsonObject = JSONUtil.put(
 			"parentTaxonomyVocabulary",
-			JSONUtil.put(
-				"externalReferenceCode",
-				parentTaxonomyVocabulary.getExternalReferenceCode())
+			() -> {
+				ParentTaxonomyVocabulary parentTaxonomyVocabulary =
+					taxonomyCategory.getParentTaxonomyVocabulary();
+
+				return JSONUtil.put(
+					"externalReferenceCode",
+					parentTaxonomyVocabulary.getExternalReferenceCode());
+			}
 		).put(
 			"scope",
 			JSONUtil.put(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -32,6 +32,8 @@ import com.liferay.expando.kernel.model.ExpandoColumn;
 import com.liferay.expando.kernel.model.ExpandoColumnConstants;
 import com.liferay.expando.kernel.model.ExpandoTableConstants;
 import com.liferay.expando.test.util.ExpandoTestUtil;
+import com.liferay.headless.admin.taxonomy.client.dto.v1_0.ParentTaxonomyCategory;
+import com.liferay.headless.admin.taxonomy.client.dto.v1_0.ParentTaxonomyVocabulary;
 import com.liferay.headless.admin.taxonomy.client.dto.v1_0.TaxonomyCategory;
 import com.liferay.headless.admin.taxonomy.client.resource.v1_0.TaxonomyCategoryResource;
 import com.liferay.headless.delivery.dto.v1_0.Creator;
@@ -20357,10 +20359,18 @@ public class ObjectEntryResourceTest {
 			boolean withEmbeddedTaxonomyCategory)
 		throws Exception {
 
+		ParentTaxonomyVocabulary parentTaxonomyVocabulary =
+			taxonomyCategory.getParentTaxonomyVocabulary();
+
 		Scope scope = Scope.of(
 			taxonomyCategory.getSiteId(), LocaleUtil.getDefault());
 
 		JSONObject jsonObject = JSONUtil.put(
+			"parentTaxonomyVocabulary",
+			JSONUtil.put(
+				"externalReferenceCode",
+				parentTaxonomyVocabulary.getExternalReferenceCode())
+		).put(
 			"scope",
 			JSONUtil.put(
 				"externalReferenceCode", scope.getExternalReferenceCode()
@@ -20375,6 +20385,17 @@ public class ObjectEntryResourceTest {
 		).put(
 			"taxonomyCategoryName", taxonomyCategory.getName()
 		);
+
+		ParentTaxonomyCategory parentTaxonomyCategory =
+			taxonomyCategory.getParentTaxonomyCategory();
+
+		if (parentTaxonomyCategory != null) {
+			jsonObject.put(
+				"parentTaxonomyCategory",
+				JSONUtil.put(
+					"externalReferenceCode",
+					parentTaxonomyCategory.getExternalReferenceCode()));
+		}
 
 		if (!withEmbeddedTaxonomyCategory) {
 			return jsonObject;

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -20387,6 +20387,20 @@ public class ObjectEntryResourceTest {
 			taxonomyCategory.getSiteId(), LocaleUtil.getDefault());
 
 		JSONObject jsonObject = JSONUtil.put(
+			"parentTaxonomyCategory",
+			() -> {
+				ParentTaxonomyCategory parentTaxonomyCategory =
+					taxonomyCategory.getParentTaxonomyCategory();
+
+				if (parentTaxonomyCategory == null) {
+					return null;
+				}
+
+				return JSONUtil.put(
+					"externalReferenceCode",
+					parentTaxonomyCategory.getExternalReferenceCode());
+			}
+		).put(
 			"parentTaxonomyVocabulary",
 			() -> {
 				ParentTaxonomyVocabulary parentTaxonomyVocabulary =
@@ -20411,17 +20425,6 @@ public class ObjectEntryResourceTest {
 		).put(
 			"taxonomyCategoryName", taxonomyCategory.getName()
 		);
-
-		ParentTaxonomyCategory parentTaxonomyCategory =
-			taxonomyCategory.getParentTaxonomyCategory();
-
-		if (parentTaxonomyCategory != null) {
-			jsonObject.put(
-				"parentTaxonomyCategory",
-				JSONUtil.put(
-					"externalReferenceCode",
-					parentTaxonomyCategory.getExternalReferenceCode()));
-		}
 
 		if (!withEmbeddedTaxonomyCategory) {
 			return jsonObject;

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
@@ -2412,6 +2412,7 @@
 				}
 			},
 			"ParentTaxonomyCategory": {
+				"description": "The category's parent category.",
 				"properties": {
 					"externalReferenceCode": {
 						"description": "The parent taxonomy category's external reference code.",
@@ -2431,6 +2432,7 @@
 				}
 			},
 			"ParentTaxonomyVocabulary": {
+				"description": "The parent category's `TaxonomyVocabulary`.",
 				"properties": {
 					"externalReferenceCode": {
 						"description": "The parent category's `TaxonomyVocabulary` external reference code.",

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
@@ -963,6 +963,7 @@
 				}
 			},
 			"ParentTaxonomyCategory": {
+				"description": "The category's parent category.",
 				"properties": {
 					"externalReferenceCode": {
 						"description": "The parent taxonomy category's external reference code.",
@@ -982,6 +983,7 @@
 				}
 			},
 			"ParentTaxonomyVocabulary": {
+				"description": "The parent category's `TaxonomyVocabulary`.",
 				"properties": {
 					"externalReferenceCode": {
 						"description": "The parent category's `TaxonomyVocabulary` external reference code.",

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
@@ -987,6 +987,7 @@
 				}
 			},
 			"ParentTaxonomyCategory": {
+				"description": "The category's parent category.",
 				"properties": {
 					"externalReferenceCode": {
 						"description": "The parent taxonomy category's external reference code.",
@@ -1006,6 +1007,7 @@
 				}
 			},
 			"ParentTaxonomyVocabulary": {
+				"description": "The parent category's `TaxonomyVocabulary`.",
 				"properties": {
 					"externalReferenceCode": {
 						"description": "The parent category's `TaxonomyVocabulary` external reference code.",

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_categorization_disabled.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_categorization_disabled.json
@@ -666,6 +666,7 @@
 				}
 			},
 			"ParentTaxonomyCategory": {
+				"description": "The category's parent category.",
 				"properties": {
 					"externalReferenceCode": {
 						"description": "The parent taxonomy category's external reference code.",
@@ -685,6 +686,7 @@
 				}
 			},
 			"ParentTaxonomyVocabulary": {
+				"description": "The parent category's `TaxonomyVocabulary`.",
 				"properties": {
 					"externalReferenceCode": {
 						"description": "The parent category's `TaxonomyVocabulary` external reference code.",

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
@@ -3481,6 +3481,7 @@
 				}
 			},
 			"ParentTaxonomyCategory": {
+				"description": "The category's parent category.",
 				"properties": {
 					"externalReferenceCode": {
 						"description": "The parent taxonomy category's external reference code.",
@@ -3500,6 +3501,7 @@
 				}
 			},
 			"ParentTaxonomyVocabulary": {
+				"description": "The parent category's `TaxonomyVocabulary`.",
 				"properties": {
 					"externalReferenceCode": {
 						"description": "The parent category's `TaxonomyVocabulary` external reference code.",

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_site.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_site.json
@@ -692,6 +692,7 @@
 				}
 			},
 			"ParentTaxonomyCategory": {
+				"description": "The category's parent category.",
 				"properties": {
 					"externalReferenceCode": {
 						"description": "The parent taxonomy category's external reference code.",
@@ -711,6 +712,7 @@
 				}
 			},
 			"ParentTaxonomyVocabulary": {
+				"description": "The parent category's `TaxonomyVocabulary`.",
 				"properties": {
 					"externalReferenceCode": {
 						"description": "The parent category's `TaxonomyVocabulary` external reference code.",


### PR DESCRIPTION
**What's new?**
- Now the `parentTaxonomyCategory` and `parentTaxonomyVocabulary` are returned in the `taxonomyCategoryBriefs` JSON Object of the ObjectEntry response instead of being `writeOnly` Objects

**What's changed?**
- The already existing tests related to taxonomy categories have been updated to assert the new `taxonomyCategoryBriefs` structure

For more details please refer to the following **Jira tickets**: [LPD-72787](https://liferay.atlassian.net/browse/LPD-72787), [LPD-70649](https://liferay.atlassian.net/browse/LPD-70649)

Manually forwarded from https://github.com/liferay-headless/liferay-portal/pull/3321

Changes from https://github.com/brianchandotcom/liferay-portal/pull/168776#issuecomment-3668873869 applied