### PR TITLE
LPD-74809 Missing baselines in Content Management

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Delivery API
 Bundle-SymbolicName: com.liferay.headless.delivery.api
-Bundle-Version: 55.1.1
+Bundle-Version: 55.2.0
 Export-Package:\
 	com.liferay.headless.delivery.dto.v1_0,\
 	com.liferay.headless.delivery.dto.v1_0.util,\

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 35.3.0
+version 35.4.0

--- a/modules/apps/item-selector/item-selector-taglib/bnd.bnd
+++ b/modules/apps/item-selector/item-selector-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Item Selector Taglib
 Bundle-SymbolicName: com.liferay.item.selector.taglib
-Bundle-Version: 7.0.10
+Bundle-Version: 8.0.0
 Export-Package:\
 	com.liferay.item.selector.taglib,\
 	com.liferay.item.selector.taglib.servlet.taglib,\

--- a/modules/apps/item-selector/item-selector-taglib/package.json
+++ b/modules/apps/item-selector/item-selector-taglib/package.json
@@ -28,5 +28,5 @@
 		"format": "node-scripts format",
 		"test": "node-scripts test"
 	},
-	"version": "7.0.10"
+	"version": "8.0.0"
 }

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/com/liferay/item/selector/taglib/packageinfo
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/com/liferay/item/selector/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-74809

Test failures show missing version increase. Running `gw baseline` on affected modules + Breaking change message:

* `item-selector/item-selector-taglib`
* `headless/headless-delivery/headless-delivery-api`