### PR TITLE
LPD-74343 Restore loading variable as it's used in more places

### DIFF
--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/multiselector-dropdown/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/multiselector-dropdown/index.html
@@ -14,13 +14,14 @@
 
 		<div class="d-flex">
 			<div class="form-control form-control-tag-group input-group">
+				[#assign options=(input.attributes.options)![]]
+				[#assign values=((input.value!"")?has_content)?then((input.value?split(",")), [])]
+				[#assign loading=(options?size == 0)]
+
 				<div class="input-group-item">
 					<div class="input-group">
 						<div aria-hidden="true" class="d-contents input-group-item input-group-item-shrink input-group-prepend" id="${fragmentElementId}-label-container" role="grid">
-							[#assign options=(input.attributes.options)![]]
-							[#assign values=((input.value!"")?has_content)?then((input.value?split(",")), [])]
-
-							[#if (options?size == 0)]
+							[#if loading]
 								[#assign labels=((input.attributes.selectedOptionLabel!"")?has_content)?then((input.attributes.selectedOptionLabel?split(",")), [])]
 
 								[#list labels as label]


### PR DESCRIPTION
Hi @brianchandotcom, this is a follow-up of https://github.com/brianchandotcom/liferay-portal/pull/168895. 

I'm restoring `loading` variable since ist's used also [here](https://github.com/brianchandotcom/liferay-portal/blob/master/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/multiselector-dropdown/index.html#L78) and [here](https://github.com/brianchandotcom/liferay-portal/blob/master/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/multiselector-dropdown/index.html#L82). I'm creating the variable so we don't have to repeat `options?size == 0`. Let me know what you think, thanks!