### PR TITLE
LPD-75053 Fix Array query parameter serialization in GraphQL

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/data/processor/LiferayMethodDataFetchingProcessor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/data/processor/LiferayMethodDataFetchingProcessor.java
@@ -261,8 +261,7 @@ public class LiferayMethodDataFetchingProcessor {
 					(Object[])Array.newInstance(
 						parameterType.getComponentType(), 0));
 			}
-
-			if (argument instanceof Map) {
+			else if (argument instanceof Map) {
 				ObjectMapper objectMapper = ObjectMapperHolder._objectMapper;
 
 				argument = objectMapper.convertValue(

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/data/processor/LiferayMethodDataFetchingProcessor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/data/processor/LiferayMethodDataFetchingProcessor.java
@@ -262,11 +262,7 @@ public class LiferayMethodDataFetchingProcessor {
 						parameterType.getComponentType(), 0));
 			}
 
-			Class<? extends Parameter> parameterClass = parameter.getClass();
-
-			if ((argument instanceof Map) &&
-				!parameterClass.isAssignableFrom(Map.class)) {
-
+			if (argument instanceof Map) {
 				ObjectMapper objectMapper = ObjectMapperHolder._objectMapper;
 
 				argument = objectMapper.convertValue(

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/data/processor/LiferayMethodDataFetchingProcessor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/data/processor/LiferayMethodDataFetchingProcessor.java
@@ -66,12 +66,14 @@ import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.UriInfo;
 
+import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -248,6 +250,17 @@ public class LiferayMethodDataFetchingProcessor {
 						binaryFiles, __ -> ObjectMapperHolder._objectMapper,
 						values);
 				}
+			}
+
+			Class<?> parameterType = parameter.getType();
+
+			if ((argument instanceof ArrayList<?> listArgument) &&
+				parameterType.isArray()) {
+
+				Object array = Array.newInstance(
+					parameterType.getComponentType(), listArgument.size());
+
+				argument = listArgument.toArray((Object[])array);
 			}
 
 			Class<? extends Parameter> parameterClass = parameter.getClass();

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/data/processor/LiferayMethodDataFetchingProcessor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/data/processor/LiferayMethodDataFetchingProcessor.java
@@ -252,14 +252,14 @@ public class LiferayMethodDataFetchingProcessor {
 				}
 			}
 
-			Class<?> parameterType = parameter.getType();
+			Class<?> parameterClass = parameter.getType();
 
 			if ((argument instanceof ArrayList<?> listArgument) &&
-				parameterType.isArray()) {
+				parameterClass.isArray()) {
 
 				argument = listArgument.toArray(
 					(Object[])Array.newInstance(
-						parameterType.getComponentType(), 0));
+						parameterClass.getComponentType(), 0));
 			}
 			else if (argument instanceof Map) {
 				ObjectMapper objectMapper = ObjectMapperHolder._objectMapper;

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/data/processor/LiferayMethodDataFetchingProcessor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/data/processor/LiferayMethodDataFetchingProcessor.java
@@ -257,10 +257,9 @@ public class LiferayMethodDataFetchingProcessor {
 			if ((argument instanceof ArrayList<?> listArgument) &&
 				parameterType.isArray()) {
 
-				Object array = Array.newInstance(
-					parameterType.getComponentType(), listArgument.size());
-
-				argument = listArgument.toArray((Object[])array);
+				argument = listArgument.toArray(
+					(Object[])Array.newInstance(
+						parameterType.getComponentType(), 0));
 			}
 
 			Class<? extends Parameter> parameterClass = parameter.getClass();

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
@@ -98,7 +98,7 @@ public class GraphQLServletTest {
 		Assert.assertArrayEquals(
 			integers,
 			JSONUtil.toIntegerArray(
-				JSONUtil.getValueAsJSONObject(
+				JSONUtil.getValueAsJSONArray(
 					_invoke(
 						new GraphQLField(
 							"testDTO1Page",
@@ -107,10 +107,8 @@ public class GraphQLServletTest {
 							).build(),
 							new GraphQLField("integers")),
 						"query"),
-					"JSONObject/data", "JSONObject/testDTO1Page"
-				).getJSONArray(
-					"integers"
-				)));
+					"JSONObject/data", "JSONObject/testDTO1Page",
+					"JSONArray/integers")));
 	}
 
 	@Test

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
@@ -91,9 +91,7 @@ public class GraphQLServletTest {
 
 	@Test
 	public void testArrayQueryParameter() throws Exception {
-		Integer[] types = {
-			RandomTestUtil.randomInt(), RandomTestUtil.randomInt()
-		};
+		int[] types = {RandomTestUtil.randomInt(), RandomTestUtil.randomInt()};
 
 		JSONObject jsonObject = JSONUtil.getValueAsJSONObject(
 			_invoke(
@@ -106,10 +104,11 @@ public class GraphQLServletTest {
 				"query"),
 			"JSONObject/data", "JSONObject/testDTO1Page");
 
-		Assert.assertArrayEquals(
-			types,
-			ArrayUtil.toArray(
-				JSONUtil.toIntegerArray(jsonObject.getJSONArray("types"))));
+		JSONArray typesJSONArray = jsonObject.getJSONArray("types");
+
+		Assert.assertEquals(2, typesJSONArray.length());
+		Assert.assertEquals(types[0], typesJSONArray.getInt(0));
+		Assert.assertEquals(types[1], typesJSONArray.getInt(1));
 	}
 
 	@Test

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
@@ -93,23 +93,22 @@ public class GraphQLServletTest {
 	public void testArrayQueryParameter() throws Exception {
 		int[] types = {RandomTestUtil.randomInt(), RandomTestUtil.randomInt()};
 
-		JSONArray typesJSONArray = JSONUtil.getValueAsJSONObject(
-			_invoke(
-				new GraphQLField(
-					"testDTO1Page",
-					HashMapBuilder.put(
-						"types", (Object)types
-					).build(),
-					new GraphQLField("types")),
-				"query"),
-			"JSONObject/data", "JSONObject/testDTO1Page"
-		).getJSONArray(
-			"types"
-		);
-
-		Assert.assertEquals(2, typesJSONArray.length());
-		Assert.assertEquals(types[0], typesJSONArray.getInt(0));
-		Assert.assertEquals(types[1], typesJSONArray.getInt(1));
+		Assert.assertArrayEquals(
+			types,
+			JSONUtil.toIntegerArray(
+				JSONUtil.getValueAsJSONObject(
+					_invoke(
+						new GraphQLField(
+							"testDTO1Page",
+							HashMapBuilder.put(
+								"types", (Object)types
+							).build(),
+							new GraphQLField("types")),
+						"query"),
+					"JSONObject/data", "JSONObject/testDTO1Page"
+				).getJSONArray(
+					"types"
+				)));
 	}
 
 	@Test

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
@@ -30,6 +30,7 @@ import com.liferay.portal.vulcan.internal.test.util.PaginationConfigurationTestU
 
 import jakarta.ws.rs.NotFoundException;
 
+import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 
 import java.util.Arrays;
@@ -86,6 +87,29 @@ public class GraphQLServletTest {
 	@After
 	public void tearDown() {
 		_serviceRegistration.unregister();
+	}
+
+	@Test
+	public void testArrayQueryParameter() throws Exception {
+		Integer[] types = {
+			RandomTestUtil.randomInt(), RandomTestUtil.randomInt()
+		};
+
+		JSONObject jsonObject = JSONUtil.getValueAsJSONObject(
+			_invoke(
+				new GraphQLField(
+					"testDTO1Page",
+					HashMapBuilder.put(
+						"types", (Object)types
+					).build(),
+					new GraphQLField("types")),
+				"query"),
+			"JSONObject/data", "JSONObject/testDTO1Page");
+
+		Assert.assertArrayEquals(
+			types,
+			ArrayUtil.toArray(
+				JSONUtil.toIntegerArray(jsonObject.getJSONArray("types"))));
 	}
 
 	@Test
@@ -601,9 +625,10 @@ public class GraphQLServletTest {
 
 	public static class TestDTO1Page {
 
-		public TestDTO1Page(int page, int pageSize) {
+		public TestDTO1Page(int page, int pageSize, Integer[] types) {
 			this.page = page;
 			this.pageSize = pageSize;
+			this.types = types;
 		}
 
 		public int getPage() {
@@ -614,11 +639,18 @@ public class GraphQLServletTest {
 			return pageSize;
 		}
 
+		public Integer[] getTypes() {
+			return types;
+		}
+
 		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
 		protected int page;
 
 		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
 		protected int pageSize;
+
+		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+		protected Integer[] types;
 
 	}
 
@@ -659,9 +691,10 @@ public class GraphQLServletTest {
 		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
 		public GraphQLServletTest.TestDTO1Page testDTO1Page(
 			@GraphQLName("page") int page,
+			@GraphQLName("types") Integer[] types,
 			@GraphQLName("pageSize") int pageSize) {
 
-			return new TestDTO1Page(page, pageSize);
+			return new TestDTO1Page(page, pageSize, types);
 		}
 
 		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
@@ -738,7 +771,7 @@ public class GraphQLServletTest {
 
 					sb.append(entry.getKey());
 					sb.append(": ");
-					sb.append(entry.getValue());
+					sb.append(_serializeValue(entry.getValue()));
 					sb.append(", ");
 				}
 
@@ -761,6 +794,41 @@ public class GraphQLServletTest {
 			}
 
 			return sb.toString();
+		}
+
+		private String _serializeArray(Object array) {
+			StringBuilder sb = new StringBuilder("[");
+			int length = Array.getLength(array);
+
+			for (int i = 0; i < length; i++) {
+				sb.append(_serializeValue(Array.get(array, i)));
+
+				if (i < (length - 1)) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		private String _serializeValue(Object value) {
+			if (value == null) {
+				return "null";
+			}
+
+			if (value instanceof String) {
+				return "\"" + value + "\"";
+			}
+
+			if (value.getClass(
+				).isArray()) {
+
+				return _serializeArray(value);
+			}
+
+			return value.toString();
 		}
 
 		private final List<GraphQLField> _graphQLFields;

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
@@ -91,23 +91,25 @@ public class GraphQLServletTest {
 
 	@Test
 	public void testArrayQueryParameter() throws Exception {
-		int[] types = {RandomTestUtil.randomInt(), RandomTestUtil.randomInt()};
+		int[] integers = {
+			RandomTestUtil.randomInt(), RandomTestUtil.randomInt()
+		};
 
 		Assert.assertArrayEquals(
-			types,
+			integers,
 			JSONUtil.toIntegerArray(
 				JSONUtil.getValueAsJSONObject(
 					_invoke(
 						new GraphQLField(
 							"testDTO1Page",
 							HashMapBuilder.put(
-								"types", (Object)types
+								"integers", (Object)integers
 							).build(),
-							new GraphQLField("types")),
+							new GraphQLField("integers")),
 						"query"),
 					"JSONObject/data", "JSONObject/testDTO1Page"
 				).getJSONArray(
-					"types"
+					"integers"
 				)));
 	}
 
@@ -624,10 +626,14 @@ public class GraphQLServletTest {
 
 	public static class TestDTO1Page {
 
-		public TestDTO1Page(int page, int pageSize, Integer[] types) {
+		public TestDTO1Page(Integer[] integers, int page, int pageSize) {
+			this.integers = integers;
 			this.page = page;
 			this.pageSize = pageSize;
-			this.types = types;
+		}
+
+		public Integer[] getIntegers() {
+			return integers;
 		}
 
 		public int getPage() {
@@ -638,18 +644,14 @@ public class GraphQLServletTest {
 			return pageSize;
 		}
 
-		public Integer[] getTypes() {
-			return types;
-		}
+		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+		protected Integer[] integers;
 
 		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
 		protected int page;
 
 		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
 		protected int pageSize;
-
-		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		protected Integer[] types;
 
 	}
 
@@ -688,12 +690,12 @@ public class GraphQLServletTest {
 		}
 
 		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		public GraphQLServletTest.TestDTO1Page testDTO1Page(
+		public TestDTO1Page testDTO1Page(
+			@GraphQLName("integers") Integer[] integers,
 			@GraphQLName("page") int page,
-			@GraphQLName("types") Integer[] types,
 			@GraphQLName("pageSize") int pageSize) {
 
-			return new TestDTO1Page(page, pageSize, types);
+			return new TestDTO1Page(integers, page, pageSize);
 		}
 
 		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
@@ -812,22 +812,18 @@ public class GraphQLServletTest {
 			return sb.toString();
 		}
 
-		private String _serializeValue(Object value) {
+		private Object _serializeValue(Object value) {
 			if (value == null) {
-				return "null";
+				return null;
 			}
 
-			if (value instanceof String) {
-				return "\"" + value + "\"";
-			}
+			Class<?> clazz = value.getClass();
 
-			if (value.getClass(
-				).isArray()) {
-
+			if (clazz.isArray()) {
 				return _serializeArray(value);
 			}
 
-			return value.toString();
+			return value;
 		}
 
 		private final List<GraphQLField> _graphQLFields;

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
@@ -90,28 +90,6 @@ public class GraphQLServletTest {
 	}
 
 	@Test
-	public void testArrayQueryParameter() throws Exception {
-		int[] integers = {
-			RandomTestUtil.randomInt(), RandomTestUtil.randomInt()
-		};
-
-		Assert.assertArrayEquals(
-			integers,
-			JSONUtil.toIntegerArray(
-				JSONUtil.getValueAsJSONArray(
-					_invoke(
-						new GraphQLField(
-							"testDTO1Page",
-							HashMapBuilder.put(
-								"integers", (Object)integers
-							).build(),
-							new GraphQLField("integers")),
-						"query"),
-					"JSONObject/data", "JSONObject/testDTO1Page",
-					"JSONArray/integers")));
-	}
-
-	@Test
 	public void testGraphQLNameConflict() throws Exception {
 
 		// TestDTO2 has the GraphQL name "FileEntry" which is already
@@ -375,6 +353,28 @@ public class GraphQLServletTest {
 			0, () -> _test(-1, -1, null, -1));
 		PaginationConfigurationTestUtil.withPageSizeLimit(
 			0, () -> _test(-1, -1, null, 0));
+	}
+
+	@Test
+	public void testQueryWithArrayParameter() throws Exception {
+		int[] integers = {
+			RandomTestUtil.randomInt(), RandomTestUtil.randomInt()
+		};
+
+		Assert.assertArrayEquals(
+			integers,
+			JSONUtil.toIntegerArray(
+				JSONUtil.getValueAsJSONArray(
+					_invoke(
+						new GraphQLField(
+							"testDTO1Page",
+							HashMapBuilder.put(
+								"integers", (Object)integers
+							).build(),
+							new GraphQLField("integers")),
+						"query"),
+					"JSONObject/data", "JSONObject/testDTO1Page",
+					"JSONArray/integers")));
 	}
 
 	@Test

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
@@ -93,7 +93,7 @@ public class GraphQLServletTest {
 	public void testArrayQueryParameter() throws Exception {
 		int[] types = {RandomTestUtil.randomInt(), RandomTestUtil.randomInt()};
 
-		JSONObject jsonObject = JSONUtil.getValueAsJSONObject(
+		JSONArray typesJSONArray = JSONUtil.getValueAsJSONObject(
 			_invoke(
 				new GraphQLField(
 					"testDTO1Page",
@@ -102,9 +102,10 @@ public class GraphQLServletTest {
 					).build(),
 					new GraphQLField("types")),
 				"query"),
-			"JSONObject/data", "JSONObject/testDTO1Page");
-
-		JSONArray typesJSONArray = jsonObject.getJSONArray("types");
+			"JSONObject/data", "JSONObject/testDTO1Page"
+		).getJSONArray(
+			"types"
+		);
 
 		Assert.assertEquals(2, typesJSONArray.length());
 		Assert.assertEquals(types[0], typesJSONArray.getInt(0));


### PR DESCRIPTION
**Original pull request comment:**
**What's changed?**
- Now during the processing of the arguments returned by the GraphQL Java library so that the array query parameters are translated to regular arrays instead of the ArrayLists managed by the library

More details in the following **Jira Ticket:** [LPD-75053](https://liferay.atlassian.net/browse/LPD-75053)

Original Liferay Headless pull request: https://github.com/liferay-headless/liferay-portal/pull/3359

Sent with the changes suggested in https://github.com/brianchandotcom/liferay-portal/pull/168936#issuecomment-3686695756