### PR TITLE
LPD-70661 Exclude object entries from Staging

### DIFF
--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/vulcan/batch/engine/ExportImportVulcanBatchEngineTaskItemDelegate.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/vulcan/batch/engine/ExportImportVulcanBatchEngineTaskItemDelegate.java
@@ -65,6 +65,9 @@ public interface ExportImportVulcanBatchEngineTaskItemDelegate<T>
 			return false;
 		}
 
+		public default boolean isStagingSupported() {
+			return getScope() == Scope.SITE || getScope() == Scope.DEPOT;
+		}
 	}
 
 	public enum Scope {

--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/vulcan/batch/engine/ExportImportVulcanBatchEngineTaskItemDelegate.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/vulcan/batch/engine/ExportImportVulcanBatchEngineTaskItemDelegate.java
@@ -66,10 +66,6 @@ public interface ExportImportVulcanBatchEngineTaskItemDelegate<T>
 		}
 
 		public default boolean isStagingSupported() {
-			if ((getScope() == Scope.SITE) || (getScope() == Scope.DEPOT)) {
-				return true;
-			}
-
 			return false;
 		}
 

--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/vulcan/batch/engine/ExportImportVulcanBatchEngineTaskItemDelegate.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/vulcan/batch/engine/ExportImportVulcanBatchEngineTaskItemDelegate.java
@@ -66,8 +66,13 @@ public interface ExportImportVulcanBatchEngineTaskItemDelegate<T>
 		}
 
 		public default boolean isStagingSupported() {
-			return getScope() == Scope.SITE || getScope() == Scope.DEPOT;
+			if ((getScope() == Scope.SITE) || (getScope() == Scope.DEPOT)) {
+				return true;
+			}
+
+			return false;
 		}
+
 	}
 
 	public enum Scope {

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
@@ -170,12 +170,12 @@ public class BatchEnginePortletDataHandler extends BasePortletDataHandler {
 				exportImportDescriptor =
 					registration.getExportImportDescriptor();
 
-			if (!exportImportDescriptor.isStagingSupported()) {
-				return false;
+			if (exportImportDescriptor.isStagingSupported()) {
+				return true;
 			}
 		}
 
-		return true;
+		return false;
 	}
 
 	@Override

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
@@ -15,6 +15,7 @@ import com.liferay.batch.engine.model.BatchEngineExportTask;
 import com.liferay.batch.engine.model.BatchEngineImportTask;
 import com.liferay.batch.engine.service.BatchEngineExportTaskLocalService;
 import com.liferay.batch.engine.service.BatchEngineImportTaskService;
+import com.liferay.exportimport.internal.lar.PortletDataContextImpl;
 import com.liferay.exportimport.internal.lar.PortletDataContextThreadLocal;
 import com.liferay.exportimport.kernel.lar.BasePortletDataHandler;
 import com.liferay.exportimport.kernel.lar.DataLevel;
@@ -33,7 +34,9 @@ import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -139,6 +142,39 @@ public class BatchEnginePortletDataHandler extends BasePortletDataHandler {
 
 	@Override
 	public boolean isBatch() {
+		return true;
+	}
+
+	@Override
+	public boolean isConfigurationEnabled() {
+		long companyId = CompanyThreadLocal.getCompanyId();
+
+		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-41367")) {
+			return false;
+		}
+
+		PortletDataContext portletDataContext = new PortletDataContextImpl(
+			null, false);
+
+		portletDataContext.setCompanyId(companyId);
+
+		List<Registration> activeRegistrations = _getActiveRegistrations(
+			portletDataContext);
+
+		if (activeRegistrations.isEmpty()) {
+			return false;
+		}
+
+		for (Registration registration : activeRegistrations) {
+			ExportImportVulcanBatchEngineTaskItemDelegate.ExportImportDescriptor
+				exportImportDescriptor =
+					registration.getExportImportDescriptor();
+
+			if (!exportImportDescriptor.isStagingSupported()) {
+				return false;
+			}
+		}
+
 		return true;
 	}
 

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
@@ -20,6 +20,7 @@ import com.liferay.exportimport.internal.lar.PortletDataContextThreadLocal;
 import com.liferay.exportimport.kernel.lar.BasePortletDataHandler;
 import com.liferay.exportimport.kernel.lar.DataLevel;
 import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.lar.ManifestSummary;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.PortletDataException;
@@ -158,24 +159,9 @@ public class BatchEnginePortletDataHandler extends BasePortletDataHandler {
 
 		portletDataContext.setCompanyId(companyId);
 
-		List<Registration> activeRegistrations = _getActiveRegistrations(
-			portletDataContext);
-
-		if (activeRegistrations.isEmpty()) {
-			return false;
-		}
-
-		for (Registration registration : activeRegistrations) {
-			ExportImportVulcanBatchEngineTaskItemDelegate.ExportImportDescriptor
-				exportImportDescriptor =
-					registration.getExportImportDescriptor();
-
-			if (exportImportDescriptor.isStagingSupported()) {
-				return true;
-			}
-		}
-
-		return false;
+		return !_getActiveRegistrations(
+			portletDataContext, true
+		).isEmpty();
 	}
 
 	@Override
@@ -569,6 +555,13 @@ public class BatchEnginePortletDataHandler extends BasePortletDataHandler {
 	private List<Registration> _getActiveRegistrations(
 		PortletDataContext portletDataContext) {
 
+		return _getActiveRegistrations(
+			portletDataContext, ExportImportThreadLocal.isStagingInProcess());
+	}
+
+	private List<Registration> _getActiveRegistrations(
+		PortletDataContext portletDataContext, boolean stagingSupportedOnly) {
+
 		return ListUtil.filter(
 			_registrations,
 			registration -> {
@@ -576,7 +569,14 @@ public class BatchEnginePortletDataHandler extends BasePortletDataHandler {
 					ExportImportDescriptor exportImportDescriptor =
 						registration.getExportImportDescriptor();
 
-				return exportImportDescriptor.isActive(portletDataContext);
+				if (!exportImportDescriptor.isActive(portletDataContext) ||
+					(stagingSupportedOnly &&
+					 !exportImportDescriptor.isStagingSupported())) {
+
+					return false;
+				}
+
+				return true;
 			});
 	}
 

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -913,6 +913,15 @@ public class BatchEnginePortletDataHandlerTest {
 			objectEntries[1]);
 	}
 
+	@FeatureFlag("LPD-41367")
+	@Test
+	@TestInfo("LPD-70661")
+	public void testIsConfigurationEnabled() throws Exception {
+		_testIsConfigurationEnabled(false);
+
+		_testIsConfigurationEnabled(true);
+	}
+
 	@Test
 	@TestInfo("LPD-73132")
 	public void testIsStagedWithObjectDefinitions() throws Exception {
@@ -1944,6 +1953,46 @@ public class BatchEnginePortletDataHandlerTest {
 					portletDataHandler)));
 	}
 
+	private void _testIsConfigurationEnabled(boolean stagingSupported)
+		throws Exception {
+
+		String portletId = RandomTestUtil.randomString();
+
+		try (SafeCloseable safeCloseable1 = _registerServiceWithSafeCloseable(
+				Portlet.class,
+				new GenericPortlet() {
+				},
+				MapUtil.singletonDictionary("jakarta.portlet.name", portletId));
+			SafeCloseable safeCloseable2 = _registerServiceWithSafeCloseable(
+				VulcanBatchEngineTaskItemDelegate.class,
+				new TestExportImportVulcanBatchEngineTaskItemDelegate(
+					filter -> null, portletId, stagingSupported),
+				HashMapDictionaryBuilder.put(
+					"batch.engine.task.item.delegate", "true"
+				).put(
+					"batch.engine.task.item.delegate.class.name",
+					TestItem.class.getName()
+				).put(
+					"batch.engine.task.item.delegate.name",
+					RandomTestUtil.randomString()
+				).put(
+					"companyId", String.valueOf(TestPropsValues.getCompanyId())
+				).put(
+					"export.import.vulcan.batch.engine.task.item.delegate",
+					"true"
+				).build())) {
+
+			Thread.sleep(1000);
+
+			PortletDataHandler portletDataHandler =
+				_portletDataHandlerProvider.provide(
+					TestPropsValues.getCompanyId(), portletId);
+
+			Assert.assertEquals(
+				stagingSupported, portletDataHandler.isConfigurationEnabled());
+		}
+	}
+
 	/**
 	 * @see com.liferay.object.rest.internal.dto.v1_0.converter.ObjectEntryDTOConverter#_toSimplifiedObjectEntry(
 	 *      com.liferay.object.rest.dto.v1_0.ObjectEntry, ObjectDefinition,
@@ -2059,6 +2108,15 @@ public class BatchEnginePortletDataHandlerTest {
 			_portletId = portletId;
 		}
 
+		public TestExportImportVulcanBatchEngineTaskItemDelegate(
+			Function<Filter, Page<TestItem>> function, String portletId,
+			boolean stagingSupported) {
+
+			_function = function;
+			_portletId = portletId;
+			_stagingSupported = stagingSupported;
+		}
+
 		@Override
 		public void create(
 			Collection<TestItem> items, Map<String, Serializable> parameters) {
@@ -2110,6 +2168,11 @@ public class BatchEnginePortletDataHandlerTest {
 				@Override
 				public Scope getScope() {
 					return Scope.COMPANY;
+				}
+
+				@Override
+				public boolean isStagingSupported() {
+					return _stagingSupported;
 				}
 
 			};
@@ -2195,6 +2258,7 @@ public class BatchEnginePortletDataHandlerTest {
 		private static String _modelClassName = RandomTestUtil.randomString();
 		private static String _resourceClassName =
 			RandomTestUtil.randomString();
+		private static boolean _stagingSupported = true;
 
 		private final Function<Filter, Page<TestItem>> _function;
 		private final String _portletId;

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -2106,6 +2106,8 @@ public class BatchEnginePortletDataHandlerTest {
 
 			_function = function;
 			_portletId = portletId;
+
+			_stagingSupported = true;
 		}
 
 		public TestExportImportVulcanBatchEngineTaskItemDelegate(
@@ -2255,13 +2257,11 @@ public class BatchEnginePortletDataHandlerTest {
 			};
 		}
 
-		private static String _modelClassName = RandomTestUtil.randomString();
-		private static String _resourceClassName =
-			RandomTestUtil.randomString();
-		private static boolean _stagingSupported = true;
-
 		private final Function<Filter, Page<TestItem>> _function;
+		private final String _modelClassName = RandomTestUtil.randomString();
 		private final String _portletId;
+		private final String _resourceClassName = RandomTestUtil.randomString();
+		private final boolean _stagingSupported;
 
 	}
 

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -1618,6 +1618,14 @@ public class BatchEnginePortletDataHandlerTest {
 			Function<Filter, Page<TestItem>> function, String portletId)
 		throws Exception {
 
+		return _register(function, portletId, false);
+	}
+
+	private SafeCloseable _register(
+			Function<Filter, Page<TestItem>> function, String portletId,
+			boolean stagingSupported)
+		throws Exception {
+
 		SafeCloseable safeCloseable1 = _registerServiceWithSafeCloseable(
 			Portlet.class,
 			new GenericPortlet() {
@@ -1626,7 +1634,7 @@ public class BatchEnginePortletDataHandlerTest {
 		SafeCloseable safeCloseable2 = _registerServiceWithSafeCloseable(
 			VulcanBatchEngineTaskItemDelegate.class,
 			new TestExportImportVulcanBatchEngineTaskItemDelegate(
-				function, portletId),
+				function, portletId, stagingSupported),
 			HashMapDictionaryBuilder.put(
 				"batch.engine.task.item.delegate", "true"
 			).put(
@@ -1958,29 +1966,8 @@ public class BatchEnginePortletDataHandlerTest {
 
 		String portletId = RandomTestUtil.randomString();
 
-		try (SafeCloseable safeCloseable1 = _registerServiceWithSafeCloseable(
-				Portlet.class,
-				new GenericPortlet() {
-				},
-				MapUtil.singletonDictionary("jakarta.portlet.name", portletId));
-			SafeCloseable safeCloseable2 = _registerServiceWithSafeCloseable(
-				VulcanBatchEngineTaskItemDelegate.class,
-				new TestExportImportVulcanBatchEngineTaskItemDelegate(
-					filter -> null, portletId, stagingSupported),
-				HashMapDictionaryBuilder.put(
-					"batch.engine.task.item.delegate", "true"
-				).put(
-					"batch.engine.task.item.delegate.class.name",
-					TestItem.class.getName()
-				).put(
-					"batch.engine.task.item.delegate.name",
-					RandomTestUtil.randomString()
-				).put(
-					"companyId", String.valueOf(TestPropsValues.getCompanyId())
-				).put(
-					"export.import.vulcan.batch.engine.task.item.delegate",
-					"true"
-				).build())) {
+		try (SafeCloseable safeCloseable = _register(
+				null, portletId, stagingSupported)) {
 
 			Thread.sleep(1000);
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateFolderResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateFolderResourceImpl.java
@@ -108,6 +108,11 @@ public class DisplayPageTemplateFolderResourceImpl
 				return FeatureFlagManagerUtil.isEnabled("LPD-35443");
 			}
 
+			@Override
+			public boolean isStagingSupported() {
+				return true;
+			}
+
 		};
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateResourceImpl.java
@@ -151,6 +151,11 @@ public class DisplayPageTemplateResourceImpl
 				return FeatureFlagManagerUtil.isEnabled("LPD-35443");
 			}
 
+			@Override
+			public boolean isStagingSupported() {
+				return true;
+			}
+
 		};
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/MasterPageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/MasterPageResourceImpl.java
@@ -129,6 +129,11 @@ public class MasterPageResourceImpl
 				return FeatureFlagManagerUtil.isEnabled("LPD-35443");
 			}
 
+			@Override
+			public boolean isStagingSupported() {
+				return true;
+			}
+
 		};
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/NavigationMenuResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/NavigationMenuResourceImpl.java
@@ -138,6 +138,11 @@ public class NavigationMenuResourceImpl
 				return Scope.SITE;
 			}
 
+			@Override
+			public boolean isStagingSupported() {
+				return true;
+			}
+
 		};
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/NavigationMenuResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/NavigationMenuResourceImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.admin.site.internal.resource.v1_0;
 
 import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
 import com.liferay.headless.admin.site.dto.v1_0.NavigationMenu;
 import com.liferay.headless.admin.site.dto.v1_0.NavigationMenuItem;
@@ -136,6 +137,12 @@ public class NavigationMenuResourceImpl
 			@Override
 			public Scope getScope() {
 				return Scope.SITE;
+			}
+
+			@Override
+			public boolean isActive(PortletDataContext portletDataContext) {
+				return FeatureFlagManagerUtil.isEnabled(
+					portletDataContext.getCompanyId(), "LPD-66179");
 			}
 
 			@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateResourceImpl.java
@@ -149,6 +149,11 @@ public class PageTemplateResourceImpl
 				return FeatureFlagManagerUtil.isEnabled("LPD-35443");
 			}
 
+			@Override
+			public boolean isStagingSupported() {
+				return true;
+			}
+
 		};
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateSetResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateSetResourceImpl.java
@@ -105,6 +105,11 @@ public class PageTemplateSetResourceImpl
 				return FeatureFlagManagerUtil.isEnabled("LPD-35443");
 			}
 
+			@Override
+			public boolean isStagingSupported() {
+				return true;
+			}
+
 		};
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
@@ -225,6 +225,11 @@ public class SitePageResourceImpl
 				return true;
 			}
 
+			@Override
+			public boolean isStagingSupported() {
+				return true;
+			}
+
 		};
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/UtilityPageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/UtilityPageResourceImpl.java
@@ -130,6 +130,11 @@ public class UtilityPageResourceImpl
 				return FeatureFlagManagerUtil.isEnabled("LPD-35443");
 			}
 
+			@Override
+			public boolean isStagingSupported() {
+				return true;
+			}
+
 		};
 	}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
@@ -183,6 +183,11 @@ public class KeywordResourceImpl
 				return Scope.SITE;
 			}
 
+			@Override
+			public boolean isStagingSupported() {
+				return true;
+			}
+
 		};
 	}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
@@ -164,6 +164,11 @@ public class TaxonomyCategoryResourceImpl
 				return Scope.SITE;
 			}
 
+			@Override
+			public boolean isStagingSupported() {
+				return true;
+			}
+
 		};
 	}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -171,6 +171,11 @@ public class TaxonomyVocabularyResourceImpl
 				return ExportImportVulcanBatchEngineTaskItemDelegate.Scope.SITE;
 			}
 
+			@Override
+			public boolean isStagingSupported() {
+				return true;
+			}
+
 		};
 	}
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -577,6 +577,11 @@ public class ObjectEntryResourceImpl
 				return "root-object";
 			}
 
+			@Override
+			public boolean isStagingSupported() {
+				return false;
+			}
+
 		};
 	}
 

--- a/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/init.jsp
@@ -35,7 +35,6 @@ page import="com.liferay.portal.kernel.dao.search.SearchContainer" %><%@
 page import="com.liferay.portal.kernel.exception.LocaleException" %><%@
 page import="com.liferay.portal.kernel.exception.RemoteOptionsException" %><%@
 page import="com.liferay.portal.kernel.exception.SystemException" %><%@
-page import="com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil" %><%@
 page import="com.liferay.portal.kernel.group.capability.GroupCapabilityUtil" %><%@
 page import="com.liferay.portal.kernel.json.JSONArray" %><%@
 page import="com.liferay.portal.kernel.json.JSONFactoryUtil" %><%@

--- a/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/staging_configuration_staged_portlets.jspf
+++ b/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/staging_configuration_staged_portlets.jspf
@@ -107,7 +107,7 @@
 			for (Portlet curPortlet : dataSiteLevelPortlets) {
 				PortletDataHandler portletDataHandler = curPortlet.getPortletDataHandlerInstance();
 
-				if (!portletDataHandler.isConfigurationEnabled() || !portletDataHandler.isEnabled(company.getCompanyId()) || !GroupCapabilityUtil.isSupportsPortlet(liveGroup, curPortlet)) {
+				if (!portletDataHandler.isConfigurationEnabled() || !portletDataHandler.isEnabled(company.getCompanyId()) || portletDataHandler.isHidden() || !GroupCapabilityUtil.isSupportsPortlet(liveGroup, curPortlet)) {
 					continue;
 				}
 

--- a/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/staging_configuration_staged_portlets.jspf
+++ b/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/staging_configuration_staged_portlets.jspf
@@ -107,7 +107,7 @@
 			for (Portlet curPortlet : dataSiteLevelPortlets) {
 				PortletDataHandler portletDataHandler = curPortlet.getPortletDataHandlerInstance();
 
-				if ((!FeatureFlagManagerUtil.isEnabled("LPD-41367") && portletDataHandler.isBatch()) || !portletDataHandler.isConfigurationEnabled() || !portletDataHandler.isEnabled(company.getCompanyId()) || !GroupCapabilityUtil.isSupportsPortlet(liveGroup, curPortlet)) {
+				if (!portletDataHandler.isConfigurationEnabled() || !portletDataHandler.isEnabled(company.getCompanyId()) || !GroupCapabilityUtil.isSupportsPortlet(liveGroup, curPortlet)) {
 					continue;
 				}
 

--- a/modules/test/playwright/tests/export-import-web/main/pages/StagingPage.ts
+++ b/modules/test/playwright/tests/export-import-web/main/pages/StagingPage.ts
@@ -8,10 +8,12 @@ import {Locator, Page, expect} from '@playwright/test';
 import getRandomString from '../../../../utils/getRandomString';
 
 export class StagingPage {
+	readonly localStagingButton: Locator;
 	readonly page: Page;
 	readonly stagedPortletCheckbox: (stagedPortletName: string) => Locator;
 
 	constructor(page: Page) {
+		this.localStagingButton = page.getByTestId('stagingType_local');
 		this.page = page;
 		this.stagedPortletCheckbox = (stagedPortletName: string) =>
 			this.page
@@ -21,7 +23,7 @@ export class StagingPage {
 	}
 
 	async enableLocalStaging(stagedPortlets?: string[]) {
-		await this.page.getByTestId('stagingType_local').check();
+		await this.localStagingButton.check();
 
 		this.page.once('dialog', async (dialog) => {
 			expect(dialog.message()).toContain(

--- a/modules/test/playwright/tests/export-import-web/main/stagingUseCase.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/stagingUseCase.spec.ts
@@ -69,8 +69,8 @@ const testWithBatchStagingFF = mergeTests(
 );
 
 testWithBatchStagingFF(
-	'Object entries can be staged through batch',
-	{tag: ['@LPD-72343']},
+	'Object entries can not be staged through batch',
+	{tag: ['@LPD-70661', '@LPD-72343']},
 	async ({apiHelpers, stagingPage}) => {
 		const objectActionAPIClient =
 			await apiHelpers.buildRestClient(ObjectDefinitionAPI);
@@ -94,84 +94,19 @@ testWithBatchStagingFF(
 			type: 'site',
 		});
 
-		const initialObjectEntry = await apiHelpers.objectEntry.postObjectEntry(
+		await apiHelpers.objectEntry.postObjectEntry(
 			{externalReferenceCode: getRandomString(), name: getRandomString()},
 			`c/tests/scopes/${site.name}`
 		);
 
 		await stagingPage.goto(site.name);
-		await stagingPage.enableLocalStaging([
-			objectDefinition.pluralLabel.en_US,
-		]);
+		await stagingPage.localStagingButton.click();
 
-		expect(
-			await apiHelpers.objectEntry.getObjectEntryByExternalReferenceCode({
-				applicationName: `c/tests/scopes/${site.name}`,
-				externalReferenceCode: initialObjectEntry.externalReferenceCode,
-			})
-		).toMatchObject({
-			externalReferenceCode: initialObjectEntry.externalReferenceCode,
-			name: initialObjectEntry.name,
-			scopeKey: site.name,
-		});
-
-		const stagingSite =
-			await apiHelpers.headlessAdminUser.getSiteByFriendlyUrlPath(
-				`${site.friendlyUrlPath}-staging`
-			);
-
-		expect(
-			await apiHelpers.objectEntry.getObjectEntryByExternalReferenceCode({
-				applicationName: `c/tests/scopes/${stagingSite.key}`,
-				externalReferenceCode: initialObjectEntry.externalReferenceCode,
-			})
-		).toMatchObject({
-			externalReferenceCode: initialObjectEntry.externalReferenceCode,
-			name: initialObjectEntry.name,
-			scopeKey: stagingSite.key,
-		});
-
-		const objectEntry = await apiHelpers.objectEntry.postObjectEntry(
-			{externalReferenceCode: getRandomString(), name: getRandomString()},
-			`c/tests/scopes/${stagingSite.key}`
-		);
-
-		expect(
-			await apiHelpers.objectEntry.getObjectEntryByExternalReferenceCode({
-				applicationName: `c/tests/scopes/${stagingSite.key}`,
-				externalReferenceCode: objectEntry.externalReferenceCode,
-			})
-		).toMatchObject({
-			externalReferenceCode: objectEntry.externalReferenceCode,
-			name: objectEntry.name,
-			scopeKey: stagingSite.key,
-		});
-
-		expect(
-			await apiHelpers.objectEntry.getObjectEntryByExternalReferenceCode({
-				applicationName: `c/tests/scopes/${site.name}`,
-				externalReferenceCode: objectEntry.externalReferenceCode,
-			})
-		).toEqual({
-			status: 'NOT_FOUND',
-		});
-
-		await stagingPage.goto(stagingSite.key);
-		await stagingPage.publish({
-			rangeAll: true,
-			selectedEntities: [objectDefinition.pluralLabel.en_US],
-		});
-
-		expect(
-			await apiHelpers.objectEntry.getObjectEntryByExternalReferenceCode({
-				applicationName: `c/tests/scopes/${site.name}`,
-				externalReferenceCode: objectEntry.externalReferenceCode,
-			})
-		).toMatchObject({
-			externalReferenceCode: objectEntry.externalReferenceCode,
-			name: objectEntry.name,
-			scopeKey: site.name,
-		});
+		await expect(
+			stagingPage.stagedPortletCheckbox(
+				objectDefinition.pluralLabel.en_US
+			)
+		).toHaveCount(0);
 	}
 );
 


### PR DESCRIPTION
Forwarded manually from: https://github.com/liferay-headless/liferay-portal/pull/3354

---

Story: [LPD-64439](https://liferay.atlassian.net/browse/LPD-64439)
Technical task: [LPD-70661](https://liferay.atlassian.net/browse/LPD-70661)

### Purpose of the change:
When the feature flag `LPD-41367` is active, we want to be able to use batch-enabled entities in staging (implemented under [LPD-72342](https://liferay.atlassian.net/browse/LPD-72342)). However, at this moment, we still want to exclude object entries from staging.

The commit https://github.com/liferay-headless/liferay-portal/pull/3354/commits/3637f5e6930e0efe3626d9ef8dadde79ef2ec73a adds `isStagingSupported()` method to `ExportImportDescriptor`. This way all batch-enabled APIs can decide whether they support staging or not.

On the `PortletDataHandler` level I reused the `isConfigurationEnabled()` method, which was originally created for this purpose: https://github.com/liferay/liferay-portal/commit/6e1832711767656009b65cbb9da1de73afc58d91

At [this point](https://github.com/liferay-headless/liferay-portal/pull/3354/changes#diff-9ff3830a345368b9db9e8430d271f3228c3b16a0ac03566658168bcf72549650R156-R157) I need to create a "mock" `PortletDataContext`, since the `ExportImportDescriptor.isActive()` methods need one, but we don't have it. It's only created when we have an actual export/import process (or ManifestSummary calculation).
For example, `PortletDataContext` is needed [here](https://github.com/liferay/liferay-portal/blob/540670e2ce025f0d06bf5d1cfe8bfa21a189eb9b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java#L213-L221).