### PR TITLE
LPD-75475 Prevent the appearance of the scope for taxonomyCategories when the object is in the same scope as the category

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -463,7 +463,8 @@ public class ObjectEntryDTOConverter
 						serviceBuilderObjectEntry.getObjectEntryId()),
 					assetCategory ->
 						TaxonomyCategoryBriefUtil.toTaxonomyCategoryBrief(
-							assetCategory, dtoConverterContext),
+							assetCategory, dtoConverterContext,
+							serviceBuilderObjectEntry.getGroupId()),
 					TaxonomyCategoryBrief.class);
 			});
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/util/TaxonomyCategoryBriefUtil.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/util/TaxonomyCategoryBriefUtil.java
@@ -31,7 +31,7 @@ public class TaxonomyCategoryBriefUtil {
 
 	public static TaxonomyCategoryBrief toTaxonomyCategoryBrief(
 			AssetCategory assetCategory,
-			DTOConverterContext dtoConverterContext)
+			DTOConverterContext dtoConverterContext, long groupId)
 		throws Exception {
 
 		return new TaxonomyCategoryBrief() {
@@ -71,9 +71,15 @@ public class TaxonomyCategoryBriefUtil {
 						};
 					});
 				setScope(
-					() -> Scope.of(
-						assetCategory.getGroupId(),
-						dtoConverterContext.getLocale()));
+					() -> {
+						if (groupId == assetCategory.getGroupId()) {
+							return null;
+						}
+
+						return Scope.of(
+							assetCategory.getGroupId(),
+							dtoConverterContext.getLocale());
+					});
 				setTaxonomyCategoryExternalReferenceCode(
 					assetCategory::getExternalReferenceCode);
 				setTaxonomyCategoryId(assetCategory::getCategoryId);

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -354,23 +354,6 @@ public class ObjectEntryResourceTest {
 				LocaleUtil.US, RandomTestUtil.randomString()),
 			_listTypeDefinition.isSystem());
 
-		_depotScopedObjectDefinition =
-			ObjectDefinitionTestUtil.publishObjectDefinition(
-				Collections.singletonList(
-					new TextObjectFieldBuilder(
-					).labelMap(
-						RandomTestUtil.randomLocaleStringMap()
-					).name(
-						StringUtil.randomId()
-					).build()),
-				ObjectDefinitionConstants.SCOPE_DEPOT);
-
-		_objectDefinitionSettingLocalService.addObjectDefinitionSetting(
-			_depotScopedObjectDefinition.getUserId(),
-			_depotScopedObjectDefinition.getObjectDefinitionId(),
-			ObjectDefinitionSettingConstants.NAME_ACCEPT_ALL_GROUPS,
-			StringPool.TRUE);
-
 		String objectDefinitionName = ObjectDefinitionTestUtil.getRandomName();
 
 		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition(
@@ -8392,8 +8375,25 @@ public class ObjectEntryResourceTest {
 
 		// Depot scope
 
+		ObjectDefinition depotScopedObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						RandomTestUtil.randomLocaleStringMap()
+					).name(
+						StringUtil.randomId()
+					).build()),
+				ObjectDefinitionConstants.SCOPE_DEPOT);
+
+		_objectDefinitionSettingLocalService.addObjectDefinitionSetting(
+			depotScopedObjectDefinition.getUserId(),
+			depotScopedObjectDefinition.getObjectDefinitionId(),
+			ObjectDefinitionSettingConstants.NAME_ACCEPT_ALL_GROUPS,
+			StringPool.TRUE);
+
 		_testGetObjectEntryWithTaxonomyCategories(
-			depotEntry.getGroupId(), _depotScopedObjectDefinition,
+			depotEntry.getGroupId(), depotScopedObjectDefinition,
 			taxonomyCategory1, taxonomyCategory2, taxonomyCategory3,
 			taxonomyCategory4);
 
@@ -8567,6 +8567,23 @@ public class ObjectEntryResourceTest {
 
 		// Depot scope group ID
 
+		ObjectDefinition depotScopedObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						RandomTestUtil.randomLocaleStringMap()
+					).name(
+						StringUtil.randomId()
+					).build()),
+				ObjectDefinitionConstants.SCOPE_DEPOT);
+
+		_objectDefinitionSettingLocalService.addObjectDefinitionSetting(
+			depotScopedObjectDefinition.getUserId(),
+			depotScopedObjectDefinition.getObjectDefinitionId(),
+			ObjectDefinitionSettingConstants.NAME_ACCEPT_ALL_GROUPS,
+			StringPool.TRUE);
+
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
 					"WebApplicationExceptionMapper",
@@ -8576,7 +8593,7 @@ public class ObjectEntryResourceTest {
 				HTTPTestUtil.invokeToJSONObject(
 					null,
 					_getEndpoint(
-						_depotScopedObjectDefinition,
+						depotScopedObjectDefinition,
 						RandomTestUtil.randomLong()),
 					Http.Method.GET));
 		}
@@ -8588,12 +8605,12 @@ public class ObjectEntryResourceTest {
 			ServiceContextTestUtil.getServiceContext());
 
 		ObjectEntry depotScopedObjectEntry = ObjectEntryTestUtil.addObjectEntry(
-			depotEntry.getGroupId(), _depotScopedObjectDefinition,
+			depotEntry.getGroupId(), depotScopedObjectDefinition,
 			Collections.emptyMap());
 
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
 			null,
-			_getEndpoint(_depotScopedObjectDefinition, depotEntry.getGroupId()),
+			_getEndpoint(depotScopedObjectDefinition, depotEntry.getGroupId()),
 			Http.Method.GET);
 
 		_assertItem(
@@ -20738,8 +20755,6 @@ public class ObjectEntryResourceTest {
 
 	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;
-
-	private ObjectDefinition _depotScopedObjectDefinition;
 
 	@Inject
 	private DLAppLocalService _dlAppLocalService;

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -16991,17 +16991,13 @@ public class ObjectEntryResourceTest {
 			TaxonomyCategory... taxonomyCategories)
 		throws Exception {
 
-		JSONArray jsonArray = _jsonFactory.createJSONArray();
-
-		for (TaxonomyCategory taxonomyCategory : taxonomyCategories) {
-			jsonArray.put(taxonomyCategory.getId());
-		}
-
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
 				_OBJECT_FIELD_NAME_1, "value"
 			).put(
-				"taxonomyCategoryIds", jsonArray
+				"taxonomyCategoryIds",
+				JSONUtil.toJSONArray(
+					taxonomyCategories, TaxonomyCategory::getId)
 			).toString(),
 			_getEndpoint(objectDefinition, groupId), Http.Method.POST);
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -8432,7 +8432,7 @@ public class ObjectEntryResourceTest {
 			Http.Method.GET);
 
 		_assertTaxonomyCategories(
-			jsonObject.getLong("scopeKey"),
+			jsonObject.getLong("scopeId"),
 			jsonObject.getJSONArray("taxonomyCategoryBriefs"), true,
 			taxonomyCategory1, taxonomyCategory2);
 	}
@@ -8925,7 +8925,7 @@ public class ObjectEntryResourceTest {
 			Http.Method.PATCH);
 
 		_assertTaxonomyCategories(
-			jsonObject.getLong("scopeKey"),
+			jsonObject.getLong("scopeId"),
 			jsonObject.getJSONArray("taxonomyCategoryBriefs"), false,
 			taxonomyCategory1, taxonomyCategory2, taxonomyCategory3);
 	}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -354,6 +354,23 @@ public class ObjectEntryResourceTest {
 				LocaleUtil.US, RandomTestUtil.randomString()),
 			_listTypeDefinition.isSystem());
 
+		_depotScopedObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						RandomTestUtil.randomLocaleStringMap()
+					).name(
+						StringUtil.randomId()
+					).build()),
+				ObjectDefinitionConstants.SCOPE_DEPOT);
+
+		_objectDefinitionSettingLocalService.addObjectDefinitionSetting(
+			_depotScopedObjectDefinition.getUserId(),
+			_depotScopedObjectDefinition.getObjectDefinitionId(),
+			ObjectDefinitionSettingConstants.NAME_ACCEPT_ALL_GROUPS,
+			StringPool.TRUE);
+
 		String objectDefinitionName = ObjectDefinitionTestUtil.getRandomName();
 
 		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition(
@@ -8367,30 +8384,23 @@ public class ObjectEntryResourceTest {
 				group3.getGroupId(), taxonomyCategory3.getId(),
 				taxonomyCategory3.getTaxonomyVocabularyId());
 
-		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
-			JSONUtil.put(
-				_OBJECT_FIELD_NAME_1, "value"
-			).put(
-				"taxonomyCategoryIds",
-				JSONUtil.putAll(
-					taxonomyCategory1.getId(), taxonomyCategory2.getId(),
-					taxonomyCategory3.getId(), taxonomyCategory4.getId())
-			).toString(),
-			StringBundler.concat(
-				_siteScopedObjectDefinition1.getRESTContextPath(), "/scopes/",
-				_testGroupId),
-			Http.Method.POST);
+		// Company scope
 
-		jsonObject = HTTPTestUtil.invokeToJSONObject(
-			null,
-			StringBundler.concat(
-				_siteScopedObjectDefinition1.getRESTContextPath(),
-				StringPool.SLASH, jsonObject.getString("id")),
-			Http.Method.GET);
+		_testGetObjectEntryWithTaxonomyCategories(
+			0, _objectDefinition1, taxonomyCategory1, taxonomyCategory2,
+			taxonomyCategory3, taxonomyCategory4);
 
-		_assertTaxonomyCategories(
-			_testGroupId, jsonObject.getJSONArray("taxonomyCategoryBriefs"),
-			false, taxonomyCategory1, taxonomyCategory2, taxonomyCategory3,
+		// Site scope
+
+		_testGetObjectEntryWithTaxonomyCategories(
+			_testGroupId, _siteScopedObjectDefinition1, taxonomyCategory1,
+			taxonomyCategory2, taxonomyCategory3, taxonomyCategory4);
+
+		// Depot scope
+
+		_testGetObjectEntryWithTaxonomyCategories(
+			depotEntry.getGroupId(), _depotScopedObjectDefinition,
+			taxonomyCategory1, taxonomyCategory2, taxonomyCategory3,
 			taxonomyCategory4);
 	}
 
@@ -8557,23 +8567,6 @@ public class ObjectEntryResourceTest {
 
 		// Depot scope group ID
 
-		ObjectDefinition depotScopedObjectDefinition =
-			ObjectDefinitionTestUtil.publishObjectDefinition(
-				Collections.singletonList(
-					new TextObjectFieldBuilder(
-					).labelMap(
-						RandomTestUtil.randomLocaleStringMap()
-					).name(
-						StringUtil.randomId()
-					).build()),
-				ObjectDefinitionConstants.SCOPE_DEPOT);
-
-		_objectDefinitionSettingLocalService.addObjectDefinitionSetting(
-			depotScopedObjectDefinition.getUserId(),
-			depotScopedObjectDefinition.getObjectDefinitionId(),
-			ObjectDefinitionSettingConstants.NAME_ACCEPT_ALL_GROUPS,
-			StringPool.TRUE);
-
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
 					"WebApplicationExceptionMapper",
@@ -8583,7 +8576,7 @@ public class ObjectEntryResourceTest {
 				HTTPTestUtil.invokeToJSONObject(
 					null,
 					_getEndpoint(
-						depotScopedObjectDefinition,
+						_depotScopedObjectDefinition,
 						RandomTestUtil.randomLong()),
 					Http.Method.GET));
 		}
@@ -8595,12 +8588,12 @@ public class ObjectEntryResourceTest {
 			ServiceContextTestUtil.getServiceContext());
 
 		ObjectEntry depotScopedObjectEntry = ObjectEntryTestUtil.addObjectEntry(
-			depotEntry.getGroupId(), depotScopedObjectDefinition,
+			depotEntry.getGroupId(), _depotScopedObjectDefinition,
 			Collections.emptyMap());
 
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
 			null,
-			_getEndpoint(depotScopedObjectDefinition, depotEntry.getGroupId()),
+			_getEndpoint(_depotScopedObjectDefinition, depotEntry.getGroupId()),
 			Http.Method.GET);
 
 		_assertItem(
@@ -16993,6 +16986,51 @@ public class ObjectEntryResourceTest {
 		unsafeTriConsumer.accept(actionJSONObject, jsonObject, objectAction);
 	}
 
+	private void _testGetObjectEntryWithTaxonomyCategories(
+			long groupId, ObjectDefinition objectDefinition,
+			TaxonomyCategory... taxonomyCategories)
+		throws Exception {
+
+		String endpoint = null;
+
+		ObjectScopeProvider objectScopeProvider =
+			_objectScopeProviderRegistry.getObjectScopeProvider(
+				objectDefinition.getScope());
+
+		if (objectScopeProvider.isGroupAware()) {
+			endpoint = StringBundler.concat(
+				objectDefinition.getRESTContextPath(), "/scopes/", groupId);
+		}
+		else {
+			endpoint = objectDefinition.getRESTContextPath();
+		}
+
+		JSONArray jsonArray = _jsonFactory.createJSONArray();
+
+		for (TaxonomyCategory taxonomyCategory : taxonomyCategories) {
+			jsonArray.put(taxonomyCategory.getId());
+		}
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_OBJECT_FIELD_NAME_1, "value"
+			).put(
+				"taxonomyCategoryIds", jsonArray
+			).toString(),
+			endpoint, Http.Method.POST);
+
+		jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			objectDefinition.getRESTContextPath() + StringPool.SLASH +
+				jsonObject.getString("id"),
+			Http.Method.GET);
+
+		_assertTaxonomyCategories(
+			jsonObject.getLong("scopeId"),
+			jsonObject.getJSONArray("taxonomyCategoryBriefs"), false,
+			taxonomyCategories);
+	}
+
 	private void _testPatchCustomObjectEntry(
 			Function<JSONObject, String> endpointFunction,
 			ObjectDefinition objectDefinition1,
@@ -20718,6 +20756,8 @@ public class ObjectEntryResourceTest {
 
 	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;
+
+	private ObjectDefinition _depotScopedObjectDefinition;
 
 	@Inject
 	private DLAppLocalService _dlAppLocalService;

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -8390,18 +8390,18 @@ public class ObjectEntryResourceTest {
 			0, _objectDefinition1, taxonomyCategory1, taxonomyCategory2,
 			taxonomyCategory3, taxonomyCategory4);
 
-		// Site scope
-
-		_testGetObjectEntryWithTaxonomyCategories(
-			_testGroupId, _siteScopedObjectDefinition1, taxonomyCategory1,
-			taxonomyCategory2, taxonomyCategory3, taxonomyCategory4);
-
 		// Depot scope
 
 		_testGetObjectEntryWithTaxonomyCategories(
 			depotEntry.getGroupId(), _depotScopedObjectDefinition,
 			taxonomyCategory1, taxonomyCategory2, taxonomyCategory3,
 			taxonomyCategory4);
+
+		// Site scope
+
+		_testGetObjectEntryWithTaxonomyCategories(
+			_testGroupId, _siteScopedObjectDefinition1, taxonomyCategory1,
+			taxonomyCategory2, taxonomyCategory3, taxonomyCategory4);
 	}
 
 	@Test

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -16991,20 +16991,6 @@ public class ObjectEntryResourceTest {
 			TaxonomyCategory... taxonomyCategories)
 		throws Exception {
 
-		String endpoint = null;
-
-		ObjectScopeProvider objectScopeProvider =
-			_objectScopeProviderRegistry.getObjectScopeProvider(
-				objectDefinition.getScope());
-
-		if (objectScopeProvider.isGroupAware()) {
-			endpoint = StringBundler.concat(
-				objectDefinition.getRESTContextPath(), "/scopes/", groupId);
-		}
-		else {
-			endpoint = objectDefinition.getRESTContextPath();
-		}
-
 		JSONArray jsonArray = _jsonFactory.createJSONArray();
 
 		for (TaxonomyCategory taxonomyCategory : taxonomyCategories) {
@@ -17017,7 +17003,7 @@ public class ObjectEntryResourceTest {
 			).put(
 				"taxonomyCategoryIds", jsonArray
 			).toString(),
-			endpoint, Http.Method.POST);
+			_getEndpoint(objectDefinition, groupId), Http.Method.POST);
 
 		jsonObject = HTTPTestUtil.invokeToJSONObject(
 			null,

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -8376,17 +8376,21 @@ public class ObjectEntryResourceTest {
 					taxonomyCategory1.getId(), taxonomyCategory2.getId(),
 					taxonomyCategory3.getId(), taxonomyCategory4.getId())
 			).toString(),
-			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
+			StringBundler.concat(
+				_siteScopedObjectDefinition1.getRESTContextPath(), "/scopes/",
+				_testGroupId),
+			Http.Method.POST);
 
 		jsonObject = HTTPTestUtil.invokeToJSONObject(
 			null,
-			_objectDefinition1.getRESTContextPath() + StringPool.SLASH +
-				jsonObject.getString("id"),
+			StringBundler.concat(
+				_siteScopedObjectDefinition1.getRESTContextPath(),
+				StringPool.SLASH, jsonObject.getString("id")),
 			Http.Method.GET);
 
 		_assertTaxonomyCategories(
-			jsonObject.getJSONArray("taxonomyCategoryBriefs"), false,
-			taxonomyCategory1, taxonomyCategory2, taxonomyCategory3,
+			_testGroupId, jsonObject.getJSONArray("taxonomyCategoryBriefs"),
+			false, taxonomyCategory1, taxonomyCategory2, taxonomyCategory3,
 			taxonomyCategory4);
 	}
 
@@ -8418,6 +8422,7 @@ public class ObjectEntryResourceTest {
 			Http.Method.GET);
 
 		_assertTaxonomyCategories(
+			jsonObject.getLong("scopeKey"),
 			jsonObject.getJSONArray("taxonomyCategoryBriefs"), true,
 			taxonomyCategory1, taxonomyCategory2);
 	}
@@ -8927,6 +8932,7 @@ public class ObjectEntryResourceTest {
 			Http.Method.PATCH);
 
 		_assertTaxonomyCategories(
+			jsonObject.getLong("scopeKey"),
 			jsonObject.getJSONArray("taxonomyCategoryBriefs"), false,
 			taxonomyCategory1, taxonomyCategory2, taxonomyCategory3);
 	}
@@ -15775,7 +15781,8 @@ public class ObjectEntryResourceTest {
 	}
 
 	private void _assertTaxonomyCategories(
-			JSONArray jsonArray1, boolean withEmbeddedTaxonomyCategory,
+			long groupId, JSONArray jsonArray1,
+			boolean withEmbeddedTaxonomyCategory,
 			TaxonomyCategory... taxonomyCategories)
 		throws Exception {
 
@@ -15784,7 +15791,7 @@ public class ObjectEntryResourceTest {
 		for (TaxonomyCategory taxonomyCategory : taxonomyCategories) {
 			jsonArray2.put(
 				_toTaxonomyCategoryJSONObject(
-					taxonomyCategory, withEmbeddedTaxonomyCategory));
+					groupId, taxonomyCategory, withEmbeddedTaxonomyCategory));
 		}
 
 		JSONAssert.assertEquals(
@@ -20485,12 +20492,9 @@ public class ObjectEntryResourceTest {
 	}
 
 	private JSONObject _toTaxonomyCategoryJSONObject(
-			TaxonomyCategory taxonomyCategory,
+			long groupId, TaxonomyCategory taxonomyCategory,
 			boolean withEmbeddedTaxonomyCategory)
 		throws Exception {
-
-		Scope scope = Scope.of(
-			taxonomyCategory.getSiteId(), LocaleUtil.getDefault());
 
 		JSONObject jsonObject = JSONUtil.put(
 			"parentTaxonomyCategory",
@@ -20518,11 +20522,20 @@ public class ObjectEntryResourceTest {
 			}
 		).put(
 			"scope",
-			JSONUtil.put(
-				"externalReferenceCode", scope.getExternalReferenceCode()
-			).put(
-				"type", scope.getTypeAsString()
-			)
+			() -> {
+				if (groupId == taxonomyCategory.getSiteId()) {
+					return null;
+				}
+
+				Scope scope = Scope.of(
+					taxonomyCategory.getSiteId(), LocaleUtil.getDefault());
+
+				return JSONUtil.put(
+					"externalReferenceCode", scope.getExternalReferenceCode()
+				).put(
+					"type", scope.getTypeAsString()
+				);
+			}
 		).put(
 			"taxonomyCategoryExternalReferenceCode",
 			taxonomyCategory.getExternalReferenceCode()

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -8376,21 +8376,7 @@ public class ObjectEntryResourceTest {
 		// Depot scope
 
 		ObjectDefinition depotScopedObjectDefinition =
-			ObjectDefinitionTestUtil.publishObjectDefinition(
-				Collections.singletonList(
-					new TextObjectFieldBuilder(
-					).labelMap(
-						RandomTestUtil.randomLocaleStringMap()
-					).name(
-						StringUtil.randomId()
-					).build()),
-				ObjectDefinitionConstants.SCOPE_DEPOT);
-
-		_objectDefinitionSettingLocalService.addObjectDefinitionSetting(
-			depotScopedObjectDefinition.getUserId(),
-			depotScopedObjectDefinition.getObjectDefinitionId(),
-			ObjectDefinitionSettingConstants.NAME_ACCEPT_ALL_GROUPS,
-			StringPool.TRUE);
+			_addDepotScopedObjectDefinition();
 
 		_testGetObjectEntryWithTaxonomyCategories(
 			depotEntry.getGroupId(), depotScopedObjectDefinition,
@@ -8568,21 +8554,7 @@ public class ObjectEntryResourceTest {
 		// Depot scope group ID
 
 		ObjectDefinition depotScopedObjectDefinition =
-			ObjectDefinitionTestUtil.publishObjectDefinition(
-				Collections.singletonList(
-					new TextObjectFieldBuilder(
-					).labelMap(
-						RandomTestUtil.randomLocaleStringMap()
-					).name(
-						StringUtil.randomId()
-					).build()),
-				ObjectDefinitionConstants.SCOPE_DEPOT);
-
-		_objectDefinitionSettingLocalService.addObjectDefinitionSetting(
-			depotScopedObjectDefinition.getUserId(),
-			depotScopedObjectDefinition.getObjectDefinitionId(),
-			ObjectDefinitionSettingConstants.NAME_ACCEPT_ALL_GROUPS,
-			StringPool.TRUE);
+			_addDepotScopedObjectDefinition();
 
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
@@ -15241,6 +15213,29 @@ public class ObjectEntryResourceTest {
 		GroupTestUtil.addGroup(
 			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
 			GroupConstants.DEFAULT_PARENT_GROUP_ID, GroupConstants.CMS);
+	}
+
+	private ObjectDefinition _addDepotScopedObjectDefinition()
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						RandomTestUtil.randomLocaleStringMap()
+					).name(
+						StringUtil.randomId()
+					).build()),
+				ObjectDefinitionConstants.SCOPE_DEPOT);
+
+		_objectDefinitionSettingLocalService.addObjectDefinitionSetting(
+			objectDefinition.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			ObjectDefinitionSettingConstants.NAME_ACCEPT_ALL_GROUPS,
+			StringPool.TRUE);
+
+		return objectDefinition;
 	}
 
 	private DLFileEntry _addDLFileEntry(String content, long folderId)


### PR DESCRIPTION
Manually forwarded from https://github.com/liferay-headless/liferay-portal/pull/3379

**Original description:**

More details in the following **Jira ticket**: [LPD-75475](https://liferay.atlassian.net/browse/LPD-75475)