### PR TITLE
LPD-65187 database.indexes.update.on.startup must be executed independently of the value of upgrade.database.auto.run

### DIFF
--- a/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
+++ b/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
@@ -385,8 +385,9 @@ public class MainServlet extends HttpServlet {
 		if (DBUpgrader.isUpgradeDatabaseAutoRunEnabled()) {
 			DBUpgrader.upgradeModules();
 		}
-		else if (PropsValues.DATABASE_INDEXES_UPDATE_ON_STARTUP &&
-				 !StartupHelperUtil.isDBNew()) {
+
+		if (PropsValues.DATABASE_INDEXES_UPDATE_ON_STARTUP &&
+			!StartupHelperUtil.isDBNew()) {
 
 			IndexUpdaterUtil.updateAllIndexes();
 		}


### PR DESCRIPTION
Tests run here: https://github.com/liferay-database-infra/liferay-portal/pull/3217