### PR TITLE
LPD-72328 RawMetadataProcessor class not renamed by com.liferay.portal.upgrade.v7_0_1.UpgradeDocumentLibrary (2nd part)

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/ClassNameUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/ClassNameUpgradeProcessTest.java
@@ -277,15 +277,16 @@ public class ClassNameUpgradeProcessTest {
 
 		try (PreparedStatement preparedStatement = _connection.prepareStatement(
 				"insert into DDMStructure (mvccVersion, ctCollectionId, " +
-					"structureId, companyId, classNameId, structureKey) " +
-						"values (?, ?, ?, ?, ?, ?)")) {
+					"uuid_, structureId, companyId, classNameId, " +
+						"structureKey) values (?, ?, ?, ?, ?, ?, ?)")) {
 
 			preparedStatement.setLong(1, 0);
 			preparedStatement.setLong(2, 0);
-			preparedStatement.setLong(3, structureId);
-			preparedStatement.setLong(4, _companyId);
-			preparedStatement.setLong(5, classNameId);
-			preparedStatement.setString(6, RandomTestUtil.randomString());
+			preparedStatement.setString(3, RandomTestUtil.randomString());
+			preparedStatement.setLong(4, structureId);
+			preparedStatement.setLong(5, _companyId);
+			preparedStatement.setLong(6, classNameId);
+			preparedStatement.setString(7, RandomTestUtil.randomString());
 
 			preparedStatement.executeUpdate();
 		}
@@ -298,14 +299,15 @@ public class ClassNameUpgradeProcessTest {
 
 		try (PreparedStatement preparedStatement = _connection.prepareStatement(
 				"insert into DDMStructureLink (mvccVersion, ctCollectionId, " +
-					"structureLinkId, companyId, structureId) values (?, ?, " +
-						"?, ?, ?)")) {
+					"structureLinkId, companyId, classPK, structureId) " +
+						"values (?, ?, ?, ?, ?, ?)")) {
 
 			preparedStatement.setLong(1, 0);
 			preparedStatement.setLong(2, 0);
 			preparedStatement.setLong(3, RandomTestUtil.nextLong());
 			preparedStatement.setLong(4, _companyId);
-			preparedStatement.setLong(5, structureId);
+			preparedStatement.setLong(5, RandomTestUtil.randomLong());
+			preparedStatement.setLong(6, structureId);
 
 			preparedStatement.executeUpdate();
 		}
@@ -328,42 +330,49 @@ public class ClassNameUpgradeProcessTest {
 
 		try (PreparedStatement preparedStatement = _connection.prepareStatement(
 				"insert into DDMStorageLink (mvccVersion, ctCollectionId, " +
-					"storageLinkId, companyId, structureId, " +
-						"structureVersionId) values (?, ?, ?, ?, ?, ?)")) {
+					"storageLinkId, companyId, classPK, structureId, " +
+						"structureVersionId) values (?, ?, ?, ?, ?, ?, ?)")) {
 
 			preparedStatement.setLong(1, 0);
 			preparedStatement.setLong(2, 0);
 			preparedStatement.setLong(3, RandomTestUtil.nextLong());
 			preparedStatement.setLong(4, _companyId);
-			preparedStatement.setLong(5, structureId);
-			preparedStatement.setLong(6, structureVersionId);
+			preparedStatement.setLong(5, RandomTestUtil.randomLong());
+			preparedStatement.setLong(6, structureId);
+			preparedStatement.setLong(7, structureVersionId);
 
 			preparedStatement.executeUpdate();
 		}
 
 		try (PreparedStatement preparedStatement = _connection.prepareStatement(
 				"insert into DDMField (mvccVersion, ctCollectionId, fieldId, " +
-					"companyId, structureVersionId) values (?, ?, ?, ?, ?)")) {
+					"companyId, storageId, structureVersionId) values (?, ?, " +
+						"?, ?, ?, ?)")) {
 
 			preparedStatement.setLong(1, 0);
 			preparedStatement.setLong(2, 0);
 			preparedStatement.setLong(3, RandomTestUtil.nextLong());
 			preparedStatement.setLong(4, _companyId);
-			preparedStatement.setLong(5, structureVersionId);
+			preparedStatement.setLong(5, RandomTestUtil.randomLong());
+			preparedStatement.setLong(6, structureVersionId);
 
 			preparedStatement.executeUpdate();
 		}
 
 		try (PreparedStatement preparedStatement = _connection.prepareStatement(
-				"insert into DDMStructureLayout (mvccVersion, " +
-					"ctCollectionId, structureLayoutId, companyId, " +
-						"structureVersionId) values (?, ?, ?, ?, ?)")) {
+				StringBundler.concat(
+					"insert into DDMStructureLayout (mvccVersion, ",
+					"ctCollectionId, uuid_, structureLayoutId, companyId, ",
+					"structureLayoutKey, structureVersionId) values (?, ?, ?, ",
+					"?, ?, ?, ?)"))) {
 
 			preparedStatement.setLong(1, 0);
 			preparedStatement.setLong(2, 0);
-			preparedStatement.setLong(3, RandomTestUtil.nextLong());
-			preparedStatement.setLong(4, _companyId);
-			preparedStatement.setLong(5, structureVersionId);
+			preparedStatement.setString(3, RandomTestUtil.randomString());
+			preparedStatement.setLong(4, RandomTestUtil.nextLong());
+			preparedStatement.setLong(5, _companyId);
+			preparedStatement.setString(6, RandomTestUtil.randomString());
+			preparedStatement.setLong(7, structureVersionId);
 
 			preparedStatement.executeUpdate();
 		}
@@ -375,15 +384,19 @@ public class ClassNameUpgradeProcessTest {
 		long fileEntryMetadataId = RandomTestUtil.nextLong();
 
 		try (PreparedStatement preparedStatement = _connection.prepareStatement(
-				"insert into DLFileEntryMetadata (mvccVersion, " +
-					"ctCollectionId, fileEntryMetadataId, companyId, " +
-						"DDMStructureId) values (?, ?, ?, ?, ?)")) {
+				StringBundler.concat(
+					"insert into DLFileEntryMetadata (mvccVersion, ",
+					"ctCollectionId, fileEntryMetadataId, companyId, ",
+					"DDMStructureId, fileVersionId, externalReferenceCode) ",
+					"values (?, ?, ?, ?, ?, ?, ?)"))) {
 
 			preparedStatement.setLong(1, 0);
 			preparedStatement.setLong(2, 0);
 			preparedStatement.setLong(3, fileEntryMetadataId);
 			preparedStatement.setLong(4, _companyId);
 			preparedStatement.setLong(5, structureId);
+			preparedStatement.setLong(6, RandomTestUtil.randomLong());
+			preparedStatement.setString(7, RandomTestUtil.randomString());
 
 			preparedStatement.executeUpdate();
 		}

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/ClassNameUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/ClassNameUpgradeProcessTest.java
@@ -7,9 +7,12 @@ package com.liferay.portal.upgrade.v7_4_x.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.processor.RawMetadataProcessor;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.cache.MultiVMPool;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
@@ -21,7 +24,10 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
+import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -38,53 +44,178 @@ public class ClassNameUpgradeProcessTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_connection = DataAccess.getConnection();
+
+		_companyId = _addCompanyId();
+
+		_originalCacheEnabled = ReflectionTestUtil.getAndSetFieldValue(
+			PortalInstancePool.class, "_cacheEnabled", false);
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		ReflectionTestUtil.setFieldValue(
+			PortalInstancePool.class, "_cacheEnabled", _originalCacheEnabled);
+
+		_delete("Company");
+
+		DataAccess.cleanUp(_connection);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_delete(
+			"DLFileEntryMetadata", "DDMField", "DDMStorageLink", "DDMStructure",
+			"DDMStructureLayout", "DDMStructureLink", "DDMStructureVersion");
+		_deleteClassName();
+	}
+
+	@Test
+	public void testDeleteAndUpdateDDMStructure() throws Exception {
+		long newClassNameId = _getClassNameId(_NEW_CLASS_NAME);
+		long oldClassNameId = _addClassName(_OLD_CLASS_NAME);
+
+		long newStructureId = _addDDMStructure(newClassNameId);
+
+		long oldStructureId = _addDDMStructure(oldClassNameId);
+
+		_addDLFileEntryMetadata(oldStructureId);
+
+		runUpgrade();
+
+		Assert.assertEquals(0, _getDDMStructureClassNameId(newStructureId));
+
+		Assert.assertEquals(
+			newClassNameId, _getDDMStructureClassNameId(oldStructureId));
+	}
+
 	@Test
 	public void testDeleteClassName() throws Exception {
-		try (Connection connection = DataAccess.getConnection()) {
-			long classNameId = _addClassName(_CLASS_NAME, connection);
+		_addClassName(_OLD_CLASS_NAME);
 
-			long structureId = _addDDMStructure(classNameId, connection);
+		runUpgrade();
 
-			try {
-				runUpgrade();
+		Assert.assertEquals(0, _getClassNameId(_OLD_CLASS_NAME));
+	}
 
-				Assert.assertEquals(
-					0, _getClassNameId(_CLASS_NAME, connection));
+	@Test
+	public void testDeleteDDMStructure() throws Exception {
+		long newClassNameId = _getClassNameId(_NEW_CLASS_NAME);
+		long oldClassNameId = _addClassName(_OLD_CLASS_NAME);
 
-				Assert.assertEquals(
-					_getClassNameId(
-						RawMetadataProcessor.class.getName(), connection),
-					_getDDMStructureClassNameId(structureId, connection));
-			}
-			finally {
-				_deleteDDMStructure(structureId, connection);
-				_deleteClassName(classNameId, connection);
-			}
-		}
+		long newStructureId = _addDDMStructure(newClassNameId);
+		long oldStructureId = _addDDMStructure(oldClassNameId);
+
+		runUpgrade();
+
+		Assert.assertEquals(
+			newClassNameId, _getDDMStructureClassNameId(newStructureId));
+
+		Assert.assertEquals(0, _getDDMStructureClassNameId(oldStructureId));
 	}
 
 	@Test
 	public void testUpdateClassName() throws Exception {
-		try (Connection connection = DataAccess.getConnection()) {
-			long classNameId = _getClassNameId(
-				RawMetadataProcessor.class.getName(), connection);
+		long classNameId = _getClassNameId(_NEW_CLASS_NAME);
 
-			_updateClassNameValue(
-				classNameId, RawMetadataProcessor.class.getName(), connection);
+		Assert.assertNotEquals(0, classNameId);
 
-			try {
-				runUpgrade();
+		_updateClassNameValue(classNameId, _OLD_CLASS_NAME);
 
-				Assert.assertEquals(
-					RawMetadataProcessor.class.getName(),
-					_getClassNameValue(classNameId, connection));
-			}
-			finally {
-				_updateClassNameValue(
-					classNameId, RawMetadataProcessor.class.getName(),
-					connection);
-			}
+		try {
+			runUpgrade();
+
+			Assert.assertEquals(
+				_NEW_CLASS_NAME, _getClassNameValue(classNameId));
 		}
+		finally {
+			_updateClassNameValue(classNameId, _NEW_CLASS_NAME);
+		}
+	}
+
+	@Test
+	public void testUpdateDDMStructure() throws Exception {
+		long classNameId = _addClassName(_OLD_CLASS_NAME);
+
+		long structureId = _addDDMStructure(classNameId);
+
+		runUpgrade();
+
+		Assert.assertEquals(
+			_getClassNameId(_NEW_CLASS_NAME),
+			_getDDMStructureClassNameId(structureId));
+	}
+
+	@Test
+	public void testUpdateDDMStructureRelatedTables1() throws Exception {
+		long newClassNameId = _getClassNameId(_NEW_CLASS_NAME);
+		long oldClassNameId = _addClassName(_OLD_CLASS_NAME);
+
+		long newStructureId = _addDDMStructure(newClassNameId);
+		long oldStructureId = _addDDMStructure(oldClassNameId);
+
+		_addDLFileEntryMetadata(newStructureId);
+		_addDLFileEntryMetadata(newStructureId);
+		_addDLFileEntryMetadata(oldStructureId);
+
+		long newStructureVersionId = _addDDMStructureRelatedTables(
+			newStructureId);
+		long oldStructureVersionId = _addDDMStructureRelatedTables(
+			oldStructureId);
+
+		runUpgrade();
+
+		Assert.assertEquals(
+			12,
+			_getDDMStructureRelatedTablesCount(
+				newStructureId, newStructureVersionId));
+
+		Assert.assertEquals(
+			0,
+			_getDDMStructureRelatedTablesCount(
+				oldStructureId, oldStructureVersionId));
+
+		Assert.assertEquals(
+			newClassNameId, _getDDMStructureClassNameId(newStructureId));
+
+		Assert.assertEquals(0, _getDDMStructureClassNameId(oldStructureId));
+	}
+
+	@Test
+	public void testUpdateDDMStructureRelatedTables2() throws Exception {
+		long newClassNameId = _getClassNameId(_NEW_CLASS_NAME);
+		long oldClassNameId = _addClassName(_OLD_CLASS_NAME);
+
+		long newStructureId = _addDDMStructure(newClassNameId);
+		long oldStructureId = _addDDMStructure(oldClassNameId);
+
+		_addDLFileEntryMetadata(newStructureId);
+		_addDLFileEntryMetadata(oldStructureId);
+		_addDLFileEntryMetadata(oldStructureId);
+
+		long newStructureVersionId = _addDDMStructureRelatedTables(
+			newStructureId);
+		long oldStructureVersionId = _addDDMStructureRelatedTables(
+			oldStructureId);
+
+		runUpgrade();
+
+		Assert.assertEquals(
+			0,
+			_getDDMStructureRelatedTablesCount(
+				newStructureId, newStructureVersionId));
+
+		Assert.assertEquals(
+			12,
+			_getDDMStructureRelatedTablesCount(
+				oldStructureId, oldStructureVersionId));
+
+		Assert.assertEquals(0, _getDDMStructureClassNameId(newStructureId));
+
+		Assert.assertEquals(
+			newClassNameId, _getDDMStructureClassNameId(oldStructureId));
 	}
 
 	protected void runUpgrade() throws Exception {
@@ -96,12 +227,38 @@ public class ClassNameUpgradeProcessTest {
 		_multiVMPool.clear();
 	}
 
-	private long _addClassName(String className, Connection connection)
-		throws Exception {
+	private static long _addCompanyId() throws Exception {
+		long companyId = RandomTestUtil.nextLong();
 
+		try (PreparedStatement preparedStatement = _connection.prepareStatement(
+				"insert into Company (mvccVersion, companyId) values (?, ?)")) {
+
+			preparedStatement.setLong(1, 0);
+			preparedStatement.setLong(2, companyId);
+
+			preparedStatement.executeUpdate();
+		}
+
+		return companyId;
+	}
+
+	private static void _delete(String... tables) throws Exception {
+		for (String table : tables) {
+			try (PreparedStatement preparedStatement =
+					_connection.prepareStatement(
+						"delete from " + table + " where companyId = ?")) {
+
+				preparedStatement.setLong(1, _companyId);
+
+				preparedStatement.execute();
+			}
+		}
+	}
+
+	private long _addClassName(String className) throws Exception {
 		long classNameId = RandomTestUtil.nextLong();
 
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
+		try (PreparedStatement preparedStatement = _connection.prepareStatement(
 				"insert into ClassName_ (mvccVersion, classNameId, value) " +
 					"values (?, ?, ?)")) {
 
@@ -115,21 +272,20 @@ public class ClassNameUpgradeProcessTest {
 		return classNameId;
 	}
 
-	private long _addDDMStructure(long classNameId, Connection connection)
-		throws Exception {
-
+	private long _addDDMStructure(long classNameId) throws Exception {
 		long structureId = RandomTestUtil.nextLong();
 
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				"insert into DDMStructure (mvccVersion, ctcollectionid, " +
-					"structureid, classNameId, structurekey) values (?, ?, " +
-						"?, ?, ?)")) {
+		try (PreparedStatement preparedStatement = _connection.prepareStatement(
+				"insert into DDMStructure (mvccVersion, ctCollectionId, " +
+					"structureId, companyId, classNameId, structureKey) " +
+						"values (?, ?, ?, ?, ?, ?)")) {
 
 			preparedStatement.setLong(1, 0);
 			preparedStatement.setLong(2, 0);
 			preparedStatement.setLong(3, structureId);
-			preparedStatement.setLong(4, classNameId);
-			preparedStatement.setString(5, RandomTestUtil.randomString());
+			preparedStatement.setLong(4, _companyId);
+			preparedStatement.setLong(5, classNameId);
+			preparedStatement.setString(6, RandomTestUtil.randomString());
 
 			preparedStatement.executeUpdate();
 		}
@@ -137,34 +293,136 @@ public class ClassNameUpgradeProcessTest {
 		return structureId;
 	}
 
-	private void _deleteClassName(long classNameId, Connection connection)
+	private long _addDDMStructureRelatedTables(long structureId)
 		throws Exception {
 
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				"delete from ClassName_ where classNameId = ?")) {
+		try (PreparedStatement preparedStatement = _connection.prepareStatement(
+				"insert into DDMStructureLink (mvccVersion, ctCollectionId, " +
+					"structureLinkId, companyId, structureId) values (?, ?, " +
+						"?, ?, ?)")) {
 
-			preparedStatement.setLong(1, classNameId);
+			preparedStatement.setLong(1, 0);
+			preparedStatement.setLong(2, 0);
+			preparedStatement.setLong(3, RandomTestUtil.nextLong());
+			preparedStatement.setLong(4, _companyId);
+			preparedStatement.setLong(5, structureId);
 
-			preparedStatement.execute();
+			preparedStatement.executeUpdate();
 		}
+
+		long structureVersionId = RandomTestUtil.nextLong();
+
+		try (PreparedStatement preparedStatement = _connection.prepareStatement(
+				"insert into DDMStructureVersion (mvccVersion, " +
+					"ctCollectionId, structureVersionId, companyId, " +
+						"structureId) values (?, ?, ?, ?, ?)")) {
+
+			preparedStatement.setLong(1, 0);
+			preparedStatement.setLong(2, 0);
+			preparedStatement.setLong(3, structureVersionId);
+			preparedStatement.setLong(4, _companyId);
+			preparedStatement.setLong(5, structureId);
+
+			preparedStatement.executeUpdate();
+		}
+
+		try (PreparedStatement preparedStatement = _connection.prepareStatement(
+				"insert into DDMStorageLink (mvccVersion, ctCollectionId, " +
+					"storageLinkId, companyId, structureId, " +
+						"structureVersionId) values (?, ?, ?, ?, ?, ?)")) {
+
+			preparedStatement.setLong(1, 0);
+			preparedStatement.setLong(2, 0);
+			preparedStatement.setLong(3, RandomTestUtil.nextLong());
+			preparedStatement.setLong(4, _companyId);
+			preparedStatement.setLong(5, structureId);
+			preparedStatement.setLong(6, structureVersionId);
+
+			preparedStatement.executeUpdate();
+		}
+
+		try (PreparedStatement preparedStatement = _connection.prepareStatement(
+				"insert into DDMField (mvccVersion, ctCollectionId, fieldId, " +
+					"companyId, structureVersionId) values (?, ?, ?, ?, ?)")) {
+
+			preparedStatement.setLong(1, 0);
+			preparedStatement.setLong(2, 0);
+			preparedStatement.setLong(3, RandomTestUtil.nextLong());
+			preparedStatement.setLong(4, _companyId);
+			preparedStatement.setLong(5, structureVersionId);
+
+			preparedStatement.executeUpdate();
+		}
+
+		try (PreparedStatement preparedStatement = _connection.prepareStatement(
+				"insert into DDMStructureLayout (mvccVersion, " +
+					"ctCollectionId, structureLayoutId, companyId, " +
+						"structureVersionId) values (?, ?, ?, ?, ?)")) {
+
+			preparedStatement.setLong(1, 0);
+			preparedStatement.setLong(2, 0);
+			preparedStatement.setLong(3, RandomTestUtil.nextLong());
+			preparedStatement.setLong(4, _companyId);
+			preparedStatement.setLong(5, structureVersionId);
+
+			preparedStatement.executeUpdate();
+		}
+
+		return structureVersionId;
 	}
 
-	private void _deleteDDMStructure(long structureId, Connection connection)
+	private long _addDLFileEntryMetadata(long structureId) throws Exception {
+		long fileEntryMetadataId = RandomTestUtil.nextLong();
+
+		try (PreparedStatement preparedStatement = _connection.prepareStatement(
+				"insert into DLFileEntryMetadata (mvccVersion, " +
+					"ctCollectionId, fileEntryMetadataId, companyId, " +
+						"DDMStructureId) values (?, ?, ?, ?, ?)")) {
+
+			preparedStatement.setLong(1, 0);
+			preparedStatement.setLong(2, 0);
+			preparedStatement.setLong(3, fileEntryMetadataId);
+			preparedStatement.setLong(4, _companyId);
+			preparedStatement.setLong(5, structureId);
+
+			preparedStatement.executeUpdate();
+		}
+
+		return fileEntryMetadataId;
+	}
+
+	private int _count(String table, String column, long structureId)
 		throws Exception {
 
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				"delete from DDMStructure where structureId = ?")) {
+		try (PreparedStatement preparedStatement = _connection.prepareStatement(
+				StringBundler.concat(
+					"select count(*) from ", table, " where ", column,
+					" = ?"))) {
 
 			preparedStatement.setLong(1, structureId);
 
+			ResultSet resultSet = preparedStatement.executeQuery();
+
+			if (resultSet.next()) {
+				return resultSet.getInt(1);
+			}
+		}
+
+		return 0;
+	}
+
+	private void _deleteClassName() throws Exception {
+		try (PreparedStatement preparedStatement = _connection.prepareStatement(
+				"delete from ClassName_ where value = ?")) {
+
+			preparedStatement.setString(1, _OLD_CLASS_NAME);
+
 			preparedStatement.execute();
 		}
 	}
 
-	private long _getClassNameId(String value, Connection connection)
-		throws Exception {
-
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
+	private long _getClassNameId(String value) throws Exception {
+		try (PreparedStatement preparedStatement = _connection.prepareStatement(
 				"select classNameId from ClassName_ where value = ?")) {
 
 			preparedStatement.setString(1, value);
@@ -179,10 +437,8 @@ public class ClassNameUpgradeProcessTest {
 		return 0;
 	}
 
-	private String _getClassNameValue(long classNameId, Connection connection)
-		throws Exception {
-
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
+	private String _getClassNameValue(long classNameId) throws Exception {
+		try (PreparedStatement preparedStatement = _connection.prepareStatement(
 				"select value from ClassName_ where classNameId = ?")) {
 
 			preparedStatement.setLong(1, classNameId);
@@ -197,11 +453,10 @@ public class ClassNameUpgradeProcessTest {
 		return null;
 	}
 
-	private long _getDDMStructureClassNameId(
-			long structureId, Connection connection)
+	private long _getDDMStructureClassNameId(long structureId)
 		throws Exception {
 
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
+		try (PreparedStatement preparedStatement = _connection.prepareStatement(
 				"select classNameId from DDMStructure where structureId = ?")) {
 
 			preparedStatement.setLong(1, structureId);
@@ -216,11 +471,32 @@ public class ClassNameUpgradeProcessTest {
 		return 0;
 	}
 
-	private void _updateClassNameValue(
-			long classNameId, String value, Connection connection)
+	private int _getDDMStructureRelatedTablesCount(
+			long structureId, long structureVersionId)
 		throws Exception {
 
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
+		int dlFileEntryMetadataCount = _count(
+			"DLFileEntryMetadata", "DDMStructureId", structureId);
+		int ddmFieldCount = _count(
+			"DDMField", "structureVersionId", structureVersionId);
+		int ddmStorageLinkCount = _count(
+			"DDMStorageLink", "structureId", structureId);
+		int ddmStructureLayoutCount = _count(
+			"DDMStructureLayout", "structureVersionId", structureVersionId);
+		int ddmStructureLinkCount = _count(
+			"DDMStructureLink", "structureId", structureId);
+		int ddmStructureVersionCount = _count(
+			"DDMStructureVersion", "structureId", structureId);
+
+		return dlFileEntryMetadataCount + ddmFieldCount + ddmStorageLinkCount +
+			ddmStructureLayoutCount + ddmStructureLinkCount +
+				ddmStructureVersionCount;
+	}
+
+	private void _updateClassNameValue(long classNameId, String value)
+		throws Exception {
+
+		try (PreparedStatement preparedStatement = _connection.prepareStatement(
 				"update ClassName_ set value = ? where classNameId = ? ")) {
 
 			preparedStatement.setString(1, value);
@@ -230,8 +506,15 @@ public class ClassNameUpgradeProcessTest {
 		}
 	}
 
-	private static final String _CLASS_NAME =
+	private static final String _NEW_CLASS_NAME =
+		RawMetadataProcessor.class.getName();
+
+	private static final String _OLD_CLASS_NAME =
 		"com.liferay.document.library.kernel.util.RawMetadataProcessor";
+
+	private static long _companyId;
+	private static Connection _connection;
+	private static boolean _originalCacheEnabled;
 
 	@Inject
 	private EntityCache _entityCache;

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/ClassNameUpgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/ClassNameUpgradeProcess.java
@@ -6,7 +6,9 @@
 package com.liferay.portal.upgrade.v7_4_x;
 
 import com.liferay.document.library.kernel.processor.RawMetadataProcessor;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.StringBundler;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -30,11 +32,55 @@ public class ClassNameUpgradeProcess extends UpgradeProcess {
 
 		if (newClassNameId == 0) {
 			_updateValue(oldClassNameId);
-		}
-		else {
-			_updateDDMStructureClassNameId(newClassNameId, oldClassNameId);
 
-			_deleteClassName(oldClassNameId);
+			return;
+		}
+
+		_deleteClassName(oldClassNameId);
+
+		for (long companyId : PortalInstancePool.getCompanyIds()) {
+			long oldStructureId = _getDDMStructureId(oldClassNameId, companyId);
+
+			if (oldStructureId == 0) {
+				continue;
+			}
+
+			long newStructureId = _getDDMStructureId(newClassNameId, companyId);
+
+			if (newStructureId == 0) {
+				_updateDDMStructureClassNameId(newClassNameId, oldStructureId);
+
+				continue;
+			}
+
+			int oldCount = _getDLFileEntryMetadataCount(oldStructureId);
+
+			if (oldCount == 0) {
+				_deleteDDMStructure(oldStructureId);
+
+				continue;
+			}
+
+			int newCount = _getDLFileEntryMetadataCount(newStructureId);
+
+			if (newCount == 0) {
+				_deleteDDMStructure(newStructureId);
+				_updateDDMStructureClassNameId(newClassNameId, oldStructureId);
+
+				continue;
+			}
+
+			if (newCount >= oldCount) {
+				_updateDDMStructureRelatedTables(
+					newStructureId, oldStructureId);
+				_deleteDDMStructure(oldStructureId);
+			}
+			else {
+				_updateDDMStructureRelatedTables(
+					oldStructureId, newStructureId);
+				_deleteDDMStructure(newStructureId);
+				_updateDDMStructureClassNameId(newClassNameId, oldStructureId);
+			}
 		}
 	}
 
@@ -43,6 +89,24 @@ public class ClassNameUpgradeProcess extends UpgradeProcess {
 				"delete from ClassName_ where classNameId = ?")) {
 
 			preparedStatement.setLong(1, classNameId);
+
+			preparedStatement.execute();
+		}
+	}
+
+	private void _deleteDDMStructure(long structureId) throws Exception {
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"delete from DDMStructureVersion where structureId = ?")) {
+
+			preparedStatement.setLong(1, structureId);
+
+			preparedStatement.execute();
+		}
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"delete from DDMStructure where structureId = ?")) {
+
+			preparedStatement.setLong(1, structureId);
 
 			preparedStatement.execute();
 		}
@@ -64,19 +128,117 @@ public class ClassNameUpgradeProcess extends UpgradeProcess {
 		return 0;
 	}
 
-	private void _updateDDMStructureClassNameId(
-			long newClassNameId, long oldClassNameId)
+	private long _getDDMStructureId(long classNameId, long companyId)
 		throws Exception {
 
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				"update DDMStructure set classNameId = ? where classNameId = " +
-					"?")) {
+				"select structureId from DDMStructure where classNameId = ? " +
+					"and companyId = ?")) {
 
-			preparedStatement.setLong(1, newClassNameId);
-			preparedStatement.setLong(2, oldClassNameId);
+			preparedStatement.setLong(1, classNameId);
+			preparedStatement.setLong(2, companyId);
+
+			ResultSet resultSet = preparedStatement.executeQuery();
+
+			if (resultSet.next()) {
+				return resultSet.getLong("structureId");
+			}
+		}
+
+		return 0;
+	}
+
+	private long _getDDMStructureVersionId(long structureId) throws Exception {
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select structureVersionId from DDMStructureVersion where " +
+					"structureId = ?")) {
+
+			preparedStatement.setLong(1, structureId);
+
+			ResultSet resultSet = preparedStatement.executeQuery();
+
+			if (resultSet.next()) {
+				return resultSet.getLong("structureVersionId");
+			}
+		}
+
+		return 0;
+	}
+
+	private int _getDLFileEntryMetadataCount(long structureId)
+		throws Exception {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select count(*) from DLFileEntryMetadata where " +
+					"DDMStructureId = ?")) {
+
+			preparedStatement.setLong(1, structureId);
+
+			ResultSet resultSet = preparedStatement.executeQuery();
+
+			if (resultSet.next()) {
+				return resultSet.getInt(1);
+			}
+		}
+
+		return 0;
+	}
+
+	private void _update(
+			String table, String column, long newValue, long oldValue)
+		throws Exception {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"update ", table, " set ", column, " = ? where ", column,
+					" = ?"))) {
+
+			preparedStatement.setLong(1, newValue);
+			preparedStatement.setLong(2, oldValue);
 
 			preparedStatement.execute();
 		}
+	}
+
+	private void _updateDDMStructureClassNameId(
+			long classNameId, long structureId)
+		throws Exception {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"update DDMStructure set classNameId = ? where structureId = " +
+					"?")) {
+
+			preparedStatement.setLong(1, classNameId);
+			preparedStatement.setLong(2, structureId);
+
+			preparedStatement.execute();
+		}
+	}
+
+	private void _updateDDMStructureRelatedTables(
+			long newStructureId, long oldStructureId)
+		throws Exception {
+
+		_update(
+			"DDMStorageLink", "structureId", newStructureId, oldStructureId);
+		_update(
+			"DDMStructureLink", "structureId", newStructureId, oldStructureId);
+		_update(
+			"DLFileEntryMetadata", "DDMStructureId", newStructureId,
+			oldStructureId);
+
+		long newStructureVersionId = _getDDMStructureVersionId(newStructureId);
+		long oldStructureVersionId = _getDDMStructureVersionId(oldStructureId);
+
+		_update(
+			"DDMField", "structureVersionId", newStructureVersionId,
+			oldStructureVersionId);
+		_update(
+			"DDMStorageLink", "structureVersionId", newStructureVersionId,
+			oldStructureVersionId);
+		_update(
+			"DDMStructureLayout", "structureVersionId", newStructureVersionId,
+			oldStructureVersionId);
 	}
 
 	private void _updateValue(long classNameId) throws Exception {


### PR DESCRIPTION
:warning: This PR has already passed the SF and CI Testing [here](https://github.com/liferay-content-management/liferay-portal/pull/7644). Just creating directly here because we don't want to wait more (CI needs to execute the relevant suite again before forwarding)

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-72328

The upgrade was failing because I was not handling the case where a DDM Structure exists for both old and new class name.

# How am I fixing it?

Handle the case where both class names have a DDM structure and/or entries in DLFileEntryMetadata (and related tables).

Also:
* Taking into account multiple companies
* Improve performance when data exists in DLFileEntryMetadata for both class names: change structureId in related tables for the class name with fewer entries.

# How can you verify that it works?

Run updated integration test:

`cd modules/apps/portal/portal-upgrade-test`
`gw tI --tests ClassNameUpgradeProcessTest`