### PR TITLE
LPD-76151 Stop unnecessary searches with Allow Empty Searches is configured

### DIFF
--- a/modules/apps/portal-search/portal-search-api/bnd.bnd
+++ b/modules/apps/portal-search/portal-search-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Search API
 Bundle-SymbolicName: com.liferay.portal.search.api
-Bundle-Version: 20.0.1
+Bundle-Version: 20.1.0
 Export-Package:\
 	com.liferay.portal.search.aggregation,\
 	com.liferay.portal.search.aggregation.bucket,\

--- a/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/constants/SearchContextAttributes.java
+++ b/modules/apps/portal-search/portal-search-api/src/main/java/com/liferay/portal/search/constants/SearchContextAttributes.java
@@ -19,6 +19,9 @@ public class SearchContextAttributes {
 	public static final String ATTRIBUTE_KEY_EMPTY_SEARCH =
 		"search.empty.search";
 
+	public static final String ATTRIBUTE_KEY_EXECUTE_SEARCH =
+		"search.execute.search";
+
 	public static final String ATTRIBUTE_KEY_LUCENE_SYNTAX =
 		"search.lucene.syntax";
 

--- a/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/constants/packageinfo
+++ b/modules/apps/portal-search/portal-search-api/src/main/resources/com/liferay/portal/search/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/shared/search/SearchBarPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/shared/search/SearchBarPortletSharedSearchContributor.java
@@ -59,6 +59,19 @@ public class SearchBarPortletSharedSearchContributor
 		if (!_shouldContributeToCurrentPageSearch(
 				searchBarPortletPreferences, portletSharedSearchSettings)) {
 
+			searchRequestBuilder.withSearchContext(
+				searchContext -> {
+					Object executeSearch = searchContext.getAttribute(
+						SearchContextAttributes.ATTRIBUTE_KEY_EXECUTE_SEARCH);
+
+					if (executeSearch == null) {
+						searchContext.setAttribute(
+							SearchContextAttributes.
+								ATTRIBUTE_KEY_EXECUTE_SEARCH,
+							Boolean.FALSE);
+					}
+				});
+
 			return;
 		}
 
@@ -67,6 +80,9 @@ public class SearchBarPortletSharedSearchContributor
 				searchContext.setAttribute(
 					SearchContextAttributes.
 						ATTRIBUTE_KEY_CONTRIBUTE_TUNING_RANKINGS,
+					Boolean.TRUE);
+				searchContext.setAttribute(
+					SearchContextAttributes.ATTRIBUTE_KEY_EXECUTE_SEARCH,
 					Boolean.TRUE);
 				searchContext.setIncludeAttachments(
 					searchBarPortletPreferences.isIncludeAttachments());

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/shared/search/SearchResultsPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/shared/search/SearchResultsPortletSharedSearchContributor.java
@@ -8,6 +8,7 @@ package com.liferay.portal.search.web.internal.search.results.portlet.shared.sea
 import com.liferay.portal.kernel.dao.search.SearchPaginationUtil;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.search.constants.SearchContextAttributes;
 import com.liferay.portal.search.searcher.SearchRequestBuilder;
 import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.web.constants.SearchResultsPortletKeys;
@@ -56,6 +57,11 @@ public class SearchResultsPortletSharedSearchContributor
 
 			searchRequestBuilder.highlightFields(fieldsToDisplay);
 		}
+
+		searchRequestBuilder.withSearchContext(
+			searchContext -> searchContext.setAttribute(
+				SearchContextAttributes.ATTRIBUTE_KEY_EXECUTE_SEARCH,
+				Boolean.TRUE));
 	}
 
 	@Reference

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/searcher/SearcherImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/searcher/SearcherImpl.java
@@ -76,10 +76,14 @@ public class SearcherImpl implements Searcher {
 
 		SearchContext searchContext = searchRequestImpl.getSearchContext();
 
-		if (Validator.isBlank(StringUtil.trim(searchContext.getKeywords())) &&
+		if ((Validator.isBlank(StringUtil.trim(searchContext.getKeywords())) &&
+			 !GetterUtil.getBoolean(
+				 searchContext.getAttribute(
+					 SearchContextAttributes.ATTRIBUTE_KEY_EMPTY_SEARCH))) ||
 			!GetterUtil.getBoolean(
 				searchContext.getAttribute(
-					SearchContextAttributes.ATTRIBUTE_KEY_EMPTY_SEARCH))) {
+					SearchContextAttributes.ATTRIBUTE_KEY_EXECUTE_SEARCH),
+				true)) {
 
 			searchResponseBuilder.hits(new HitsImpl());
 		}

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/searcher/SearcherImplTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/searcher/SearcherImplTest.java
@@ -86,7 +86,28 @@ public class SearcherImplTest {
 	}
 
 	@Test
-	public void testSearchExcludeContributrosAndIncludeContributors()
+	public void testExecuteSearchAttribute() throws Exception {
+		SearchContext searchContext = new SearchContext();
+
+		searchContext.setKeywords("keyword");
+
+		SearchResponse searchResponse = _searcherImpl.doSearch(
+			_createSearchRequestImpl(searchContext));
+
+		_assertDocumentReturned(searchResponse, 1);
+
+		searchContext.setAttribute(
+			SearchContextAttributes.ATTRIBUTE_KEY_EXECUTE_SEARCH,
+			Boolean.FALSE);
+
+		searchResponse = _searcherImpl.doSearch(
+			_createSearchRequestImpl(searchContext));
+
+		_assertDocumentReturned(searchResponse, 0);
+	}
+
+	@Test
+	public void testSearchExcludeContributorsAndIncludeContributors()
 		throws Exception {
 
 		SearchContext searchContext = new SearchContext();


### PR DESCRIPTION
Reviewed and tested here: https://github.com/liferay-search/liferay-portal/pull/1800

Original PR Comment:

> https://liferay.atlassian.net/browse/LPD-76151
> 
> **Author:** @joshuacords 
> **Reviewer:** @bryanengler
> 
> **Issue:** The presence of a Search Bar on a page triggers a search through the Search Bar's render method. This search is not needed if the search bar's destination is a different page. Usually this search is aborted because "Allow Empty Searches" is not set. But when it is set through a Search Options portlet on the page, then a search is performed usually with an excessive size causing performance issues for portals with many contents.
> 
> **Solution:** Originally I tried to simply stop the search happening from the render method. But there was an unintended side effect. The Search Bar is looking for the Allow Empty Search property to enable it's ability to search with no keyword. When the search is aborted before the contributors are called, then the Allow Empty Search configuration on a Search Options widget is never seen by the Search Bar render method and therefore empty searches were not possible. I experimented with adding an Allow Empty Search configuration to the Search Bar to allow empty searches. This works, but in some ways conflicts with the Search Options widget on the pages with the search bar. You can see my experimental branch here: https://github.com/joshuacords/liferay-portal/tree/LPD-76151-allow-empty-results
> 
> So instead I am triggering the search framework and aborting the search in the SearcherImpl (the same place the Allow Empty Searches attribute is checked). I do this by adding a new attribute ATTRIBUTE_KEY_EXECUTE_SEARCH. When this attribute is not set or set to TRUE, the search will continue as usual, but when set to FALSE, the search will abort. Since the SearchResults portlet and SearchBar portlet render methods are what trigger searches, I set the attribute in their contribute methods in such a way that if any of them are contributing a valid search, then the search continues, otherwise it will be aborted. (Note: a Search Bar with no destination or destination being the same page is sufficient to trigger a search on a page.)