### PR TITLE
LPD-73437 AI Task list should retrieves the latest versions

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/bnd.bnd
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Workflow Kaleo API
 Bundle-SymbolicName: com.liferay.portal.workflow.kaleo.api
-Bundle-Version: 19.3.1
+Bundle-Version: 19.4.0
 Export-Package:\
 	com.liferay.portal.workflow.kaleo,\
 	com.liferay.portal.workflow.kaleo.constants,\

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoDefinitionVersion.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoDefinitionVersion.java
@@ -53,6 +53,9 @@ public interface KaleoDefinitionVersion
 
 	public String getContentAsXML();
 
+	public boolean isLatest()
+		throws com.liferay.portal.kernel.exception.PortalException;
+
 	public KaleoDefinition getKaleoDefinition()
 		throws com.liferay.portal.kernel.exception.PortalException;
 

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoDefinitionVersionWrapper.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoDefinitionVersionWrapper.java
@@ -576,6 +576,13 @@ public class KaleoDefinitionVersionWrapper
 		return model.isIncomplete();
 	}
 
+	@Override
+	public boolean isLatest()
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return model.isLatest();
+	}
+
 	/**
 	 * Returns <code>true</code> if this kaleo definition version is pending.
 	 *

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/resources/com/liferay/portal/workflow/kaleo/model/packageinfo
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/resources/com/liferay/portal/workflow/kaleo/model/packageinfo
@@ -1,1 +1,1 @@
-version 5.9.0
+version 5.10.0

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/search/spi/model/index/contributor/KaleoDefinitionVersionModelDocumentContributor.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/search/spi/model/index/contributor/KaleoDefinitionVersionModelDocumentContributor.java
@@ -41,6 +41,9 @@ public class KaleoDefinitionVersionModelDocumentContributor
 				kaleoDefinitionVersion.getKaleoDefinition();
 
 			document.addNumber("active", kaleoDefinition.isActive() ? 1 : 0);
+
+			document.addKeyword("latest", kaleoDefinitionVersion.isLatest());
+
 			document.addKeyword("scope", kaleoDefinition.getScope());
 		}
 		catch (PortalException portalException) {

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/model/impl/KaleoDefinitionVersionImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/model/impl/KaleoDefinitionVersionImpl.java
@@ -13,8 +13,10 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowException;
 import com.liferay.portal.workflow.kaleo.definition.util.WorkflowDefinitionContentUtil;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinition;
+import com.liferay.portal.workflow.kaleo.model.KaleoDefinitionVersion;
 import com.liferay.portal.workflow.kaleo.model.KaleoNode;
 import com.liferay.portal.workflow.kaleo.service.KaleoDefinitionLocalServiceUtil;
+import com.liferay.portal.workflow.kaleo.service.KaleoDefinitionVersionLocalServiceUtil;
 import com.liferay.portal.workflow.kaleo.service.KaleoNodeLocalServiceUtil;
 
 /**
@@ -49,6 +51,21 @@ public class KaleoDefinitionVersionImpl extends KaleoDefinitionVersionBaseImpl {
 	@Override
 	public KaleoNode getKaleoStartNode() throws PortalException {
 		return KaleoNodeLocalServiceUtil.getKaleoNode(getStartKaleoNodeId());
+	}
+
+	@Override
+	public boolean isLatest() throws PortalException {
+		KaleoDefinitionVersion kaleoDefinitionVersion =
+			KaleoDefinitionVersionLocalServiceUtil.
+				getLatestKaleoDefinitionVersion(getCompanyId(), getName());
+
+		if (kaleoDefinitionVersion.getKaleoDefinitionVersionId() ==
+				getKaleoDefinitionVersionId()) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	@Override

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/TaskDefinitionResourceImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/TaskDefinitionResourceImpl.java
@@ -9,21 +9,20 @@ import com.liferay.ai.hub.rest.dto.v1_0.TaskDefinition;
 import com.liferay.ai.hub.rest.resource.v1_0.TaskDefinitionResource;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
-import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
-import com.liferay.portal.kernel.search.filter.TermFilter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.workflow.WorkflowDefinition;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.SearchUtil;
-import com.liferay.portal.workflow.kaleo.model.KaleoDefinition;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinitionVersion;
-import com.liferay.portal.workflow.kaleo.service.KaleoDefinitionVersionLocalService;
+import com.liferay.portal.workflow.manager.WorkflowDefinitionManager;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -60,39 +59,35 @@ public class TaskDefinitionResourceImpl extends BaseTaskDefinitionResourceImpl {
 				BooleanFilter booleanFilter =
 					booleanQuery.getPreBooleanFilter();
 
-				booleanFilter.add(
-					new TermFilter("scope", "ai"), BooleanClauseOccur.MUST);
+				booleanFilter.addRequiredTerm("latest", Boolean.TRUE);
+				booleanFilter.addRequiredTerm("scope", "ai");
 			},
 			filter, KaleoDefinitionVersion.class.getName(), search, pagination,
-			queryConfig -> queryConfig.setSelectedFieldNames(Field.NAME),
+			queryConfig -> queryConfig.setSelectedFieldNames(
+				Field.NAME, Field.VERSION),
 			searchContext -> searchContext.setCompanyId(
 				contextCompany.getCompanyId()),
 			sorts,
 			document -> _toTaskDefinition(
-				_kaleoDefinitionVersionLocalService.
-					getLatestKaleoDefinitionVersion(
-						contextCompany.getCompanyId(),
-						document.get(Field.NAME))));
+				_workflowDefinitionManager.getWorkflowDefinition(
+					contextCompany.getCompanyId(), document.get(Field.NAME),
+					GetterUtil.getInteger(document.get(Field.VERSION)))));
 	}
 
 	private TaskDefinition _toTaskDefinition(
-			KaleoDefinitionVersion kaleoDefinitionVersion)
+			WorkflowDefinition workflowDefinition)
 		throws PortalException {
-
-		KaleoDefinition kaleoDefinition =
-			kaleoDefinitionVersion.getKaleoDefinition();
 
 		return new TaskDefinition() {
 			{
-				setDescription(kaleoDefinition::getDescription);
-				setName(kaleoDefinition::getName);
-				setVersion(kaleoDefinition::getVersion);
+				setDescription(workflowDefinition::getDescription);
+				setName(workflowDefinition::getName);
+				setVersion(workflowDefinition::getVersion);
 			}
 		};
 	}
 
 	@Reference
-	private KaleoDefinitionVersionLocalService
-		_kaleoDefinitionVersionLocalService;
+	private WorkflowDefinitionManager _workflowDefinitionManager;
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/TaskDefinitionResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/TaskDefinitionResourceTest.java
@@ -9,13 +9,11 @@ import com.liferay.ai.hub.rest.client.dto.v1_0.TaskDefinition;
 import com.liferay.ai.hub.rest.client.pagination.Page;
 import com.liferay.ai.hub.rest.client.pagination.Pagination;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.test.rule.FeatureFlag;
@@ -78,21 +76,60 @@ public class TaskDefinitionResourceTest
 			taskDefinitionResource.getTaskDefinitionsPage(
 				null, null, Pagination.of(1, 10), null);
 
-		AssertUtils.assertEquals(
+		assertEquals(
 			List.of(
-				WorkflowDefinitionConstants.NAME_CHANGE_TONE,
-				WorkflowDefinitionConstants.NAME_CHAT_MESSAGE_PIPELINE,
-				WorkflowDefinitionConstants.NAME_FIX_SPELLING_AND_GRAMMAR,
-				WorkflowDefinitionConstants.NAME_IMPROVE_WRITING,
-				WorkflowDefinitionConstants.NAME_MAKE_LONGER,
-				WorkflowDefinitionConstants.NAME_MAKE_SHORTER),
-			TransformUtil.transform(page.getItems(), TaskDefinition::getName));
+				new TaskDefinition() {
+					{
+						name = WorkflowDefinitionConstants.NAME_CHANGE_TONE;
+						version = 1;
+					}
+				},
+				new TaskDefinition() {
+					{
+						name =
+							WorkflowDefinitionConstants.
+								NAME_CHAT_MESSAGE_PIPELINE;
+						version = 1;
+					}
+				},
+				new TaskDefinition() {
+					{
+						name =
+							WorkflowDefinitionConstants.
+								NAME_FIX_SPELLING_AND_GRAMMAR;
+						version = 1;
+					}
+				},
+				new TaskDefinition() {
+					{
+						name = WorkflowDefinitionConstants.NAME_IMPROVE_WRITING;
+						version = 1;
+					}
+				},
+				new TaskDefinition() {
+					{
+						name = WorkflowDefinitionConstants.NAME_MAKE_LONGER;
+						version = 1;
+					}
+				},
+				new TaskDefinition() {
+					{
+						name = WorkflowDefinitionConstants.NAME_MAKE_SHORTER;
+						version = 1;
+					}
+				}),
+			(List<TaskDefinition>)page.getItems());
 	}
 
 	@Ignore
 	@Override
 	@Test
 	public void testGetTaskDefinitionsPageWithPagination() {
+	}
+
+	@Override
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[] {"name", "version"};
 	}
 
 	@Override


### PR DESCRIPTION
- **LPD-73437 feat: index a flag to know if the kaleo definition version is the latest**
- **LPD-73437 fix: only retrieve the latest versions of the workflow definitions**
- **LPD-73437 test: ensure the version is being retrieved in the dto**
- **LPD-73437 generated: gradlew baseline**
- **LPD-73437 generated: gradlew buildService**
