### PR TITLE
LPD-75672 Add REST Builder support for 'delete[parentSchema][schema]ByExternalReferenceCode' pattern in batch delete method

### DIFF
--- a/modules/apps/change-tracking/change-tracking-rest-impl/rest-openapi.yaml
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/rest-openapi.yaml
@@ -229,7 +229,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.change.tracking.rest.client', and version '5.0.3'."
+        'com.liferay.change.tracking.rest.client', and version '6.0.0'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.change.tracking.rest.client', and version '5.0.3'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.change.tracking.rest.client', and version '6.0.0'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
@@ -1579,9 +1579,49 @@ public abstract class BaseKeywordResourceImpl
 
 		UnsafeFunction<Keyword, Keyword, Exception> keywordUnsafeFunction =
 			keyword -> {
-				deleteKeyword(keyword.getId());
+				if (keyword.getId() != null) {
+					try {
+						deleteKeyword(keyword.getId());
 
-				return keyword;
+						return keyword;
+					}
+					catch (Exception exception) {
+						if (keyword.getExternalReferenceCode() != null) {
+							if (parameters.containsKey("assetLibraryId")) {
+								deleteAssetLibraryKeywordByExternalReferenceCode(
+									(Long)parameters.get("assetLibraryId"),
+									keyword.getExternalReferenceCode());
+
+								return keyword;
+							}
+
+							if (parameters.containsKey("siteId")) {
+								deleteSiteKeywordByExternalReferenceCode(
+									(Long)parameters.get("siteId"),
+									keyword.getExternalReferenceCode());
+
+								return keyword;
+							}
+						}
+					}
+				}
+				else if (parameters.containsKey("assetLibraryId")) {
+					deleteAssetLibraryKeywordByExternalReferenceCode(
+						(Long)parameters.get("assetLibraryId"),
+						keyword.getExternalReferenceCode());
+
+					return keyword;
+				}
+				else if (parameters.containsKey("siteId")) {
+					deleteSiteKeywordByExternalReferenceCode(
+						(Long)parameters.get("siteId"),
+						keyword.getExternalReferenceCode());
+
+					return keyword;
+				}
+
+				throw new UnsupportedOperationException(
+					"Unable to delete by external reference code or ID");
 			};
 
 		if (contextBatchUnsafeBiConsumer != null) {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
@@ -2494,9 +2494,53 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 
 		UnsafeFunction<TaxonomyCategory, TaxonomyCategory, Exception>
 			taxonomyCategoryUnsafeFunction = taxonomyCategory -> {
-				deleteTaxonomyCategory(taxonomyCategory.getId());
+				if (taxonomyCategory.getId() != null) {
+					try {
+						deleteTaxonomyCategory(taxonomyCategory.getId());
 
-				return taxonomyCategory;
+						return taxonomyCategory;
+					}
+					catch (Exception exception) {
+						if (taxonomyCategory.getExternalReferenceCode() !=
+								null) {
+
+							if (parameters.containsKey("assetLibraryId")) {
+								deleteAssetLibraryTaxonomyCategoryByExternalReferenceCode(
+									(Long)parameters.get("assetLibraryId"),
+									taxonomyCategory.
+										getExternalReferenceCode());
+
+								return taxonomyCategory;
+							}
+
+							if (parameters.containsKey("siteId")) {
+								deleteSiteTaxonomyCategoryByExternalReferenceCode(
+									(Long)parameters.get("siteId"),
+									taxonomyCategory.
+										getExternalReferenceCode());
+
+								return taxonomyCategory;
+							}
+						}
+					}
+				}
+				else if (parameters.containsKey("assetLibraryId")) {
+					deleteAssetLibraryTaxonomyCategoryByExternalReferenceCode(
+						(Long)parameters.get("assetLibraryId"),
+						taxonomyCategory.getExternalReferenceCode());
+
+					return taxonomyCategory;
+				}
+				else if (parameters.containsKey("siteId")) {
+					deleteSiteTaxonomyCategoryByExternalReferenceCode(
+						(Long)parameters.get("siteId"),
+						taxonomyCategory.getExternalReferenceCode());
+
+					return taxonomyCategory;
+				}
+
+				throw new UnsupportedOperationException(
+					"Unable to delete by external reference code or ID");
 			};
 
 		if (contextBatchUnsafeBiConsumer != null) {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
@@ -2082,9 +2082,53 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 
 		UnsafeFunction<TaxonomyVocabulary, TaxonomyVocabulary, Exception>
 			taxonomyVocabularyUnsafeFunction = taxonomyVocabulary -> {
-				deleteTaxonomyVocabulary(taxonomyVocabulary.getId());
+				if (taxonomyVocabulary.getId() != null) {
+					try {
+						deleteTaxonomyVocabulary(taxonomyVocabulary.getId());
 
-				return taxonomyVocabulary;
+						return taxonomyVocabulary;
+					}
+					catch (Exception exception) {
+						if (taxonomyVocabulary.getExternalReferenceCode() !=
+								null) {
+
+							if (parameters.containsKey("assetLibraryId")) {
+								deleteAssetLibraryTaxonomyVocabularyByExternalReferenceCode(
+									(Long)parameters.get("assetLibraryId"),
+									taxonomyVocabulary.
+										getExternalReferenceCode());
+
+								return taxonomyVocabulary;
+							}
+
+							if (parameters.containsKey("siteId")) {
+								deleteSiteTaxonomyVocabularyByExternalReferenceCode(
+									(Long)parameters.get("siteId"),
+									taxonomyVocabulary.
+										getExternalReferenceCode());
+
+								return taxonomyVocabulary;
+							}
+						}
+					}
+				}
+				else if (parameters.containsKey("assetLibraryId")) {
+					deleteAssetLibraryTaxonomyVocabularyByExternalReferenceCode(
+						(Long)parameters.get("assetLibraryId"),
+						taxonomyVocabulary.getExternalReferenceCode());
+
+					return taxonomyVocabulary;
+				}
+				else if (parameters.containsKey("siteId")) {
+					deleteSiteTaxonomyVocabularyByExternalReferenceCode(
+						(Long)parameters.get("siteId"),
+						taxonomyVocabulary.getExternalReferenceCode());
+
+					return taxonomyVocabulary;
+				}
+
+				throw new UnsupportedOperationException(
+					"Unable to delete by external reference code or ID");
 			};
 
 		if (contextBatchUnsafeBiConsumer != null) {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -2894,19 +2894,93 @@ public abstract class BaseKeywordResourceTestCase {
 
 	@Test
 	public void testBatchEngineDeleteImportTask() throws Exception {
-		Keyword keyword1 = testBatchEngineDeleteImportTask_addKeyword();
+		Keyword keyword1 =
+			testBatchEngineDeleteImportTask_addAssetLibraryKeyword();
+
+		testBatchEngineDeleteImportTask_deleteKeyword(
+			200, keyword1.getExternalReferenceCode(), null, "assetLibraryId",
+			String.valueOf(testDepotEntryGroup.getGroupId()));
+
+		keyword1 = testBatchEngineDeleteImportTask_addKeyword();
 
 		testBatchEngineDeleteImportTask_deleteKeyword(
 			200, null, keyword1.getId());
 
 		assertHttpResponseStatusCode(
 			404, keywordResource.getKeywordHttpResponse(keyword1.getId()));
+
+		keyword1 = testBatchEngineDeleteImportTask_addSiteKeyword();
+
+		testBatchEngineDeleteImportTask_deleteKeyword(
+			200, keyword1.getExternalReferenceCode(), null, "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		keyword1 = testBatchEngineDeleteImportTask_addAssetLibraryKeyword();
+		Keyword keyword2 =
+			testBatchEngineDeleteImportTask_addAssetLibraryKeyword();
+
+		testBatchEngineDeleteImportTask_deleteKeyword(
+			200, keyword2.getExternalReferenceCode(), keyword1.getId(),
+			"assetLibraryId", String.valueOf(testDepotEntryGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404, keywordResource.getKeywordHttpResponse(keyword1.getId()));
+		assertHttpResponseStatusCode(
+			200, keywordResource.getKeywordHttpResponse(keyword2.getId()));
+
+		testBatchEngineDeleteImportTask_deleteKeyword(
+			200, keyword2.getExternalReferenceCode(), keyword1.getId(),
+			"assetLibraryId", String.valueOf(testDepotEntryGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404, keywordResource.getKeywordHttpResponse(keyword2.getId()));
+
+		keyword1 = testBatchEngineDeleteImportTask_addSiteKeyword();
+		keyword2 = testBatchEngineDeleteImportTask_addSiteKeyword();
+
+		testBatchEngineDeleteImportTask_deleteKeyword(
+			200, keyword2.getExternalReferenceCode(), keyword1.getId(),
+			"siteId", String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404, keywordResource.getKeywordHttpResponse(keyword1.getId()));
+		assertHttpResponseStatusCode(
+			200, keywordResource.getKeywordHttpResponse(keyword2.getId()));
+
+		testBatchEngineDeleteImportTask_deleteKeyword(
+			200, keyword2.getExternalReferenceCode(), keyword1.getId(),
+			"siteId", String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404, keywordResource.getKeywordHttpResponse(keyword2.getId()));
+
+		keyword1 = testBatchEngineDeleteImportTask_addSiteKeyword();
+
+		testBatchEngineDeleteImportTask_deleteKeyword(
+			400, keyword1.getExternalReferenceCode(), keyword1.getId(),
+			"assetLibraryId", String.valueOf(testDepotEntryGroup.getGroupId()),
+			"siteId", String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			200, keywordResource.getKeywordHttpResponse(keyword1.getId()));
 	}
 
 	protected Keyword testBatchEngineDeleteImportTask_addKeyword()
 		throws Exception {
 
 		return testDeleteKeyword_addKeyword();
+	}
+
+	protected Keyword testBatchEngineDeleteImportTask_addAssetLibraryKeyword()
+		throws Exception {
+
+		return testDeleteAssetLibraryKeywordByExternalReferenceCode_addKeyword();
+	}
+
+	protected Keyword testBatchEngineDeleteImportTask_addSiteKeyword()
+		throws Exception {
+
+		return testDeleteSiteKeywordByExternalReferenceCode_addKeyword();
 	}
 
 	protected void testBatchEngineDeleteImportTask_deleteKeyword(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -4803,6 +4803,13 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 	@Test
 	public void testBatchEngineDeleteImportTask() throws Exception {
 		TaxonomyCategory taxonomyCategory1 =
+			testBatchEngineDeleteImportTask_addAssetLibraryTaxonomyCategory();
+
+		testBatchEngineDeleteImportTask_deleteTaxonomyCategory(
+			200, taxonomyCategory1.getExternalReferenceCode(), null,
+			"assetLibraryId", String.valueOf(testDepotEntryGroup.getGroupId()));
+
+		taxonomyCategory1 =
 			testBatchEngineDeleteImportTask_addTaxonomyCategory();
 
 		testBatchEngineDeleteImportTask_deleteTaxonomyCategory(
@@ -4812,6 +4819,85 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 			404,
 			taxonomyCategoryResource.getTaxonomyCategoryHttpResponse(
 				taxonomyCategory1.getId()));
+
+		taxonomyCategory1 =
+			testBatchEngineDeleteImportTask_addSiteTaxonomyCategory();
+
+		testBatchEngineDeleteImportTask_deleteTaxonomyCategory(
+			200, taxonomyCategory1.getExternalReferenceCode(), null, "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		taxonomyCategory1 =
+			testBatchEngineDeleteImportTask_addAssetLibraryTaxonomyCategory();
+		TaxonomyCategory taxonomyCategory2 =
+			testBatchEngineDeleteImportTask_addAssetLibraryTaxonomyCategory();
+
+		testBatchEngineDeleteImportTask_deleteTaxonomyCategory(
+			200, taxonomyCategory2.getExternalReferenceCode(),
+			taxonomyCategory1.getId(), "assetLibraryId",
+			String.valueOf(testDepotEntryGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			taxonomyCategoryResource.getTaxonomyCategoryHttpResponse(
+				taxonomyCategory1.getId()));
+		assertHttpResponseStatusCode(
+			200,
+			taxonomyCategoryResource.getTaxonomyCategoryHttpResponse(
+				taxonomyCategory2.getId()));
+
+		testBatchEngineDeleteImportTask_deleteTaxonomyCategory(
+			200, taxonomyCategory2.getExternalReferenceCode(),
+			taxonomyCategory1.getId(), "assetLibraryId",
+			String.valueOf(testDepotEntryGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			taxonomyCategoryResource.getTaxonomyCategoryHttpResponse(
+				taxonomyCategory2.getId()));
+
+		taxonomyCategory1 =
+			testBatchEngineDeleteImportTask_addSiteTaxonomyCategory();
+		taxonomyCategory2 =
+			testBatchEngineDeleteImportTask_addSiteTaxonomyCategory();
+
+		testBatchEngineDeleteImportTask_deleteTaxonomyCategory(
+			200, taxonomyCategory2.getExternalReferenceCode(),
+			taxonomyCategory1.getId(), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			taxonomyCategoryResource.getTaxonomyCategoryHttpResponse(
+				taxonomyCategory1.getId()));
+		assertHttpResponseStatusCode(
+			200,
+			taxonomyCategoryResource.getTaxonomyCategoryHttpResponse(
+				taxonomyCategory2.getId()));
+
+		testBatchEngineDeleteImportTask_deleteTaxonomyCategory(
+			200, taxonomyCategory2.getExternalReferenceCode(),
+			taxonomyCategory1.getId(), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			taxonomyCategoryResource.getTaxonomyCategoryHttpResponse(
+				taxonomyCategory2.getId()));
+
+		taxonomyCategory1 =
+			testBatchEngineDeleteImportTask_addSiteTaxonomyCategory();
+
+		testBatchEngineDeleteImportTask_deleteTaxonomyCategory(
+			400, taxonomyCategory1.getExternalReferenceCode(),
+			taxonomyCategory1.getId(), "assetLibraryId",
+			String.valueOf(testDepotEntryGroup.getGroupId()), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			200,
+			taxonomyCategoryResource.getTaxonomyCategoryHttpResponse(
+				taxonomyCategory1.getId()));
 	}
 
 	protected TaxonomyCategory
@@ -4819,6 +4905,20 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		throws Exception {
 
 		return testDeleteTaxonomyCategory_addTaxonomyCategory();
+	}
+
+	protected TaxonomyCategory
+			testBatchEngineDeleteImportTask_addAssetLibraryTaxonomyCategory()
+		throws Exception {
+
+		return testDeleteAssetLibraryTaxonomyCategoryByExternalReferenceCode_addTaxonomyCategory();
+	}
+
+	protected TaxonomyCategory
+			testBatchEngineDeleteImportTask_addSiteTaxonomyCategory()
+		throws Exception {
+
+		return testDeleteSiteTaxonomyCategoryByExternalReferenceCode_addTaxonomyCategory();
 	}
 
 	protected void testBatchEngineDeleteImportTask_deleteTaxonomyCategory(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -3323,6 +3323,13 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 	@Test
 	public void testBatchEngineDeleteImportTask() throws Exception {
 		TaxonomyVocabulary taxonomyVocabulary1 =
+			testBatchEngineDeleteImportTask_addAssetLibraryTaxonomyVocabulary();
+
+		testBatchEngineDeleteImportTask_deleteTaxonomyVocabulary(
+			200, taxonomyVocabulary1.getExternalReferenceCode(), null,
+			"assetLibraryId", String.valueOf(testDepotEntryGroup.getGroupId()));
+
+		taxonomyVocabulary1 =
 			testBatchEngineDeleteImportTask_addTaxonomyVocabulary();
 
 		testBatchEngineDeleteImportTask_deleteTaxonomyVocabulary(
@@ -3332,6 +3339,85 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 			404,
 			taxonomyVocabularyResource.getTaxonomyVocabularyHttpResponse(
 				taxonomyVocabulary1.getId()));
+
+		taxonomyVocabulary1 =
+			testBatchEngineDeleteImportTask_addSiteTaxonomyVocabulary();
+
+		testBatchEngineDeleteImportTask_deleteTaxonomyVocabulary(
+			200, taxonomyVocabulary1.getExternalReferenceCode(), null, "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		taxonomyVocabulary1 =
+			testBatchEngineDeleteImportTask_addAssetLibraryTaxonomyVocabulary();
+		TaxonomyVocabulary taxonomyVocabulary2 =
+			testBatchEngineDeleteImportTask_addAssetLibraryTaxonomyVocabulary();
+
+		testBatchEngineDeleteImportTask_deleteTaxonomyVocabulary(
+			200, taxonomyVocabulary2.getExternalReferenceCode(),
+			taxonomyVocabulary1.getId(), "assetLibraryId",
+			String.valueOf(testDepotEntryGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			taxonomyVocabularyResource.getTaxonomyVocabularyHttpResponse(
+				taxonomyVocabulary1.getId()));
+		assertHttpResponseStatusCode(
+			200,
+			taxonomyVocabularyResource.getTaxonomyVocabularyHttpResponse(
+				taxonomyVocabulary2.getId()));
+
+		testBatchEngineDeleteImportTask_deleteTaxonomyVocabulary(
+			200, taxonomyVocabulary2.getExternalReferenceCode(),
+			taxonomyVocabulary1.getId(), "assetLibraryId",
+			String.valueOf(testDepotEntryGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			taxonomyVocabularyResource.getTaxonomyVocabularyHttpResponse(
+				taxonomyVocabulary2.getId()));
+
+		taxonomyVocabulary1 =
+			testBatchEngineDeleteImportTask_addSiteTaxonomyVocabulary();
+		taxonomyVocabulary2 =
+			testBatchEngineDeleteImportTask_addSiteTaxonomyVocabulary();
+
+		testBatchEngineDeleteImportTask_deleteTaxonomyVocabulary(
+			200, taxonomyVocabulary2.getExternalReferenceCode(),
+			taxonomyVocabulary1.getId(), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			taxonomyVocabularyResource.getTaxonomyVocabularyHttpResponse(
+				taxonomyVocabulary1.getId()));
+		assertHttpResponseStatusCode(
+			200,
+			taxonomyVocabularyResource.getTaxonomyVocabularyHttpResponse(
+				taxonomyVocabulary2.getId()));
+
+		testBatchEngineDeleteImportTask_deleteTaxonomyVocabulary(
+			200, taxonomyVocabulary2.getExternalReferenceCode(),
+			taxonomyVocabulary1.getId(), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			taxonomyVocabularyResource.getTaxonomyVocabularyHttpResponse(
+				taxonomyVocabulary2.getId()));
+
+		taxonomyVocabulary1 =
+			testBatchEngineDeleteImportTask_addSiteTaxonomyVocabulary();
+
+		testBatchEngineDeleteImportTask_deleteTaxonomyVocabulary(
+			400, taxonomyVocabulary1.getExternalReferenceCode(),
+			taxonomyVocabulary1.getId(), "assetLibraryId",
+			String.valueOf(testDepotEntryGroup.getGroupId()), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			200,
+			taxonomyVocabularyResource.getTaxonomyVocabularyHttpResponse(
+				taxonomyVocabulary1.getId()));
 	}
 
 	protected TaxonomyVocabulary
@@ -3339,6 +3425,20 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		throws Exception {
 
 		return testDeleteTaxonomyVocabulary_addTaxonomyVocabulary();
+	}
+
+	protected TaxonomyVocabulary
+			testBatchEngineDeleteImportTask_addAssetLibraryTaxonomyVocabulary()
+		throws Exception {
+
+		return testDeleteAssetLibraryTaxonomyVocabularyByExternalReferenceCode_addTaxonomyVocabulary();
+	}
+
+	protected TaxonomyVocabulary
+			testBatchEngineDeleteImportTask_addSiteTaxonomyVocabulary()
+		throws Exception {
+
+		return testDeleteSiteTaxonomyVocabularyByExternalReferenceCode_addTaxonomyVocabulary();
 	}
 
 	protected void testBatchEngineDeleteImportTask_deleteTaxonomyVocabulary(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
@@ -588,6 +588,27 @@ public class TaxonomyCategoryResourceTest
 	}
 
 	@Override
+	protected TaxonomyCategory
+			testBatchEngineDeleteImportTask_addAssetLibraryTaxonomyCategory()
+		throws Exception {
+
+		_scopeType = Scope.Type.ASSET_LIBRARY;
+
+		return super.
+			testBatchEngineDeleteImportTask_addAssetLibraryTaxonomyCategory();
+	}
+
+	@Override
+	protected TaxonomyCategory
+			testBatchEngineDeleteImportTask_addSiteTaxonomyCategory()
+		throws Exception {
+
+		_scopeType = Scope.Type.SITE;
+
+		return super.testBatchEngineDeleteImportTask_addSiteTaxonomyCategory();
+	}
+
+	@Override
 	protected Long
 		testDeleteAssetLibraryTaxonomyCategoryByExternalReferenceCode_getAssetLibraryId() {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
@@ -616,9 +616,37 @@ public abstract class BaseBlogPostingImageResourceImpl
 
 		UnsafeFunction<BlogPostingImage, BlogPostingImage, Exception>
 			blogPostingImageUnsafeFunction = blogPostingImage -> {
-				deleteBlogPostingImage(blogPostingImage.getId());
+				if (blogPostingImage.getId() != null) {
+					try {
+						deleteBlogPostingImage(blogPostingImage.getId());
 
-				return blogPostingImage;
+						return blogPostingImage;
+					}
+					catch (Exception exception) {
+						if (blogPostingImage.getExternalReferenceCode() !=
+								null) {
+
+							if (parameters.containsKey("siteId")) {
+								deleteSiteBlogPostingImageByExternalReferenceCode(
+									(Long)parameters.get("siteId"),
+									blogPostingImage.
+										getExternalReferenceCode());
+
+								return blogPostingImage;
+							}
+						}
+					}
+				}
+				else if (parameters.containsKey("siteId")) {
+					deleteSiteBlogPostingImageByExternalReferenceCode(
+						(Long)parameters.get("siteId"),
+						blogPostingImage.getExternalReferenceCode());
+
+					return blogPostingImage;
+				}
+
+				throw new UnsupportedOperationException(
+					"Unable to delete by external reference code or ID");
 			};
 
 		if (contextBatchUnsafeBiConsumer != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
@@ -1450,9 +1450,34 @@ public abstract class BaseBlogPostingResourceImpl
 
 		UnsafeFunction<BlogPosting, BlogPosting, Exception>
 			blogPostingUnsafeFunction = blogPosting -> {
-				deleteBlogPosting(blogPosting.getId());
+				if (blogPosting.getId() != null) {
+					try {
+						deleteBlogPosting(blogPosting.getId());
 
-				return blogPosting;
+						return blogPosting;
+					}
+					catch (Exception exception) {
+						if (blogPosting.getExternalReferenceCode() != null) {
+							if (parameters.containsKey("siteId")) {
+								deleteSiteBlogPostingByExternalReferenceCode(
+									(Long)parameters.get("siteId"),
+									blogPosting.getExternalReferenceCode());
+
+								return blogPosting;
+							}
+						}
+					}
+				}
+				else if (parameters.containsKey("siteId")) {
+					deleteSiteBlogPostingByExternalReferenceCode(
+						(Long)parameters.get("siteId"),
+						blogPosting.getExternalReferenceCode());
+
+					return blogPosting;
+				}
+
+				throw new UnsupportedOperationException(
+					"Unable to delete by external reference code or ID");
 			};
 
 		if (contextBatchUnsafeBiConsumer != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentMetadataSetResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentMetadataSetResourceImpl.java
@@ -1047,9 +1047,53 @@ public abstract class BaseDocumentMetadataSetResourceImpl
 
 		UnsafeFunction<DocumentMetadataSet, DocumentMetadataSet, Exception>
 			documentMetadataSetUnsafeFunction = documentMetadataSet -> {
-				deleteDocumentMetadataSet(documentMetadataSet.getId());
+				if (documentMetadataSet.getId() != null) {
+					try {
+						deleteDocumentMetadataSet(documentMetadataSet.getId());
 
-				return documentMetadataSet;
+						return documentMetadataSet;
+					}
+					catch (Exception exception) {
+						if (documentMetadataSet.getExternalReferenceCode() !=
+								null) {
+
+							if (parameters.containsKey("assetLibraryId")) {
+								deleteAssetLibraryDocumentMetadataSetByExternalReferenceCode(
+									(Long)parameters.get("assetLibraryId"),
+									documentMetadataSet.
+										getExternalReferenceCode());
+
+								return documentMetadataSet;
+							}
+
+							if (parameters.containsKey("siteId")) {
+								deleteSiteDocumentMetadataSetByExternalReferenceCode(
+									(Long)parameters.get("siteId"),
+									documentMetadataSet.
+										getExternalReferenceCode());
+
+								return documentMetadataSet;
+							}
+						}
+					}
+				}
+				else if (parameters.containsKey("assetLibraryId")) {
+					deleteAssetLibraryDocumentMetadataSetByExternalReferenceCode(
+						(Long)parameters.get("assetLibraryId"),
+						documentMetadataSet.getExternalReferenceCode());
+
+					return documentMetadataSet;
+				}
+				else if (parameters.containsKey("siteId")) {
+					deleteSiteDocumentMetadataSetByExternalReferenceCode(
+						(Long)parameters.get("siteId"),
+						documentMetadataSet.getExternalReferenceCode());
+
+					return documentMetadataSet;
+				}
+
+				throw new UnsupportedOperationException(
+					"Unable to delete by external reference code or ID");
 			};
 
 		if (contextBatchUnsafeBiConsumer != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
@@ -2293,9 +2293,49 @@ public abstract class BaseDocumentResourceImpl
 
 		UnsafeFunction<Document, Document, Exception> documentUnsafeFunction =
 			document -> {
-				deleteDocument(document.getId());
+				if (document.getId() != null) {
+					try {
+						deleteDocument(document.getId());
 
-				return document;
+						return document;
+					}
+					catch (Exception exception) {
+						if (document.getExternalReferenceCode() != null) {
+							if (parameters.containsKey("assetLibraryId")) {
+								deleteAssetLibraryDocumentByExternalReferenceCode(
+									(Long)parameters.get("assetLibraryId"),
+									document.getExternalReferenceCode());
+
+								return document;
+							}
+
+							if (parameters.containsKey("siteId")) {
+								deleteSiteDocumentByExternalReferenceCode(
+									(Long)parameters.get("siteId"),
+									document.getExternalReferenceCode());
+
+								return document;
+							}
+						}
+					}
+				}
+				else if (parameters.containsKey("assetLibraryId")) {
+					deleteAssetLibraryDocumentByExternalReferenceCode(
+						(Long)parameters.get("assetLibraryId"),
+						document.getExternalReferenceCode());
+
+					return document;
+				}
+				else if (parameters.containsKey("siteId")) {
+					deleteSiteDocumentByExternalReferenceCode(
+						(Long)parameters.get("siteId"),
+						document.getExternalReferenceCode());
+
+					return document;
+				}
+
+				throw new UnsupportedOperationException(
+					"Unable to delete by external reference code or ID");
 			};
 
 		if (contextBatchUnsafeBiConsumer != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentShortcutResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentShortcutResourceImpl.java
@@ -1025,9 +1025,37 @@ public abstract class BaseDocumentShortcutResourceImpl
 
 		UnsafeFunction<DocumentShortcut, DocumentShortcut, Exception>
 			documentShortcutUnsafeFunction = documentShortcut -> {
-				deleteDocumentShortcut(documentShortcut.getId());
+				if (documentShortcut.getId() != null) {
+					try {
+						deleteDocumentShortcut(documentShortcut.getId());
 
-				return documentShortcut;
+						return documentShortcut;
+					}
+					catch (Exception exception) {
+						if (documentShortcut.getExternalReferenceCode() !=
+								null) {
+
+							if (parameters.containsKey("siteId")) {
+								deleteSiteDocumentShortcutByExternalReferenceCode(
+									(Long)parameters.get("siteId"),
+									documentShortcut.
+										getExternalReferenceCode());
+
+								return documentShortcut;
+							}
+						}
+					}
+				}
+				else if (parameters.containsKey("siteId")) {
+					deleteSiteDocumentShortcutByExternalReferenceCode(
+						(Long)parameters.get("siteId"),
+						documentShortcut.getExternalReferenceCode());
+
+					return documentShortcut;
+				}
+
+				throw new UnsupportedOperationException(
+					"Unable to delete by external reference code or ID");
 			};
 
 		if (contextBatchUnsafeBiConsumer != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
@@ -2038,9 +2038,38 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 
 		UnsafeFunction<KnowledgeBaseArticle, KnowledgeBaseArticle, Exception>
 			knowledgeBaseArticleUnsafeFunction = knowledgeBaseArticle -> {
-				deleteKnowledgeBaseArticle(knowledgeBaseArticle.getId());
+				if (knowledgeBaseArticle.getId() != null) {
+					try {
+						deleteKnowledgeBaseArticle(
+							knowledgeBaseArticle.getId());
 
-				return knowledgeBaseArticle;
+						return knowledgeBaseArticle;
+					}
+					catch (Exception exception) {
+						if (knowledgeBaseArticle.getExternalReferenceCode() !=
+								null) {
+
+							if (parameters.containsKey("siteId")) {
+								deleteSiteKnowledgeBaseArticleByExternalReferenceCode(
+									(Long)parameters.get("siteId"),
+									knowledgeBaseArticle.
+										getExternalReferenceCode());
+
+								return knowledgeBaseArticle;
+							}
+						}
+					}
+				}
+				else if (parameters.containsKey("siteId")) {
+					deleteSiteKnowledgeBaseArticleByExternalReferenceCode(
+						(Long)parameters.get("siteId"),
+						knowledgeBaseArticle.getExternalReferenceCode());
+
+					return knowledgeBaseArticle;
+				}
+
+				throw new UnsupportedOperationException(
+					"Unable to delete by external reference code or ID");
 			};
 
 		if (contextBatchUnsafeBiConsumer != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
@@ -1318,9 +1318,37 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 
 		UnsafeFunction<KnowledgeBaseFolder, KnowledgeBaseFolder, Exception>
 			knowledgeBaseFolderUnsafeFunction = knowledgeBaseFolder -> {
-				deleteKnowledgeBaseFolder(knowledgeBaseFolder.getId());
+				if (knowledgeBaseFolder.getId() != null) {
+					try {
+						deleteKnowledgeBaseFolder(knowledgeBaseFolder.getId());
 
-				return knowledgeBaseFolder;
+						return knowledgeBaseFolder;
+					}
+					catch (Exception exception) {
+						if (knowledgeBaseFolder.getExternalReferenceCode() !=
+								null) {
+
+							if (parameters.containsKey("siteId")) {
+								deleteSiteKnowledgeBaseFolderByExternalReferenceCode(
+									(Long)parameters.get("siteId"),
+									knowledgeBaseFolder.
+										getExternalReferenceCode());
+
+								return knowledgeBaseFolder;
+							}
+						}
+					}
+				}
+				else if (parameters.containsKey("siteId")) {
+					deleteSiteKnowledgeBaseFolderByExternalReferenceCode(
+						(Long)parameters.get("siteId"),
+						knowledgeBaseFolder.getExternalReferenceCode());
+
+					return knowledgeBaseFolder;
+				}
+
+				throw new UnsupportedOperationException(
+					"Unable to delete by external reference code or ID");
 			};
 
 		if (contextBatchUnsafeBiConsumer != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
@@ -2048,9 +2048,37 @@ public abstract class BaseMessageBoardMessageResourceImpl
 
 		UnsafeFunction<MessageBoardMessage, MessageBoardMessage, Exception>
 			messageBoardMessageUnsafeFunction = messageBoardMessage -> {
-				deleteMessageBoardMessage(messageBoardMessage.getId());
+				if (messageBoardMessage.getId() != null) {
+					try {
+						deleteMessageBoardMessage(messageBoardMessage.getId());
 
-				return messageBoardMessage;
+						return messageBoardMessage;
+					}
+					catch (Exception exception) {
+						if (messageBoardMessage.getExternalReferenceCode() !=
+								null) {
+
+							if (parameters.containsKey("siteId")) {
+								deleteSiteMessageBoardMessageByExternalReferenceCode(
+									(Long)parameters.get("siteId"),
+									messageBoardMessage.
+										getExternalReferenceCode());
+
+								return messageBoardMessage;
+							}
+						}
+					}
+				}
+				else if (parameters.containsKey("siteId")) {
+					deleteSiteMessageBoardMessageByExternalReferenceCode(
+						(Long)parameters.get("siteId"),
+						messageBoardMessage.getExternalReferenceCode());
+
+					return messageBoardMessage;
+				}
+
+				throw new UnsupportedOperationException(
+					"Unable to delete by external reference code or ID");
 			};
 
 		if (contextBatchUnsafeBiConsumer != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
@@ -1125,9 +1125,34 @@ public abstract class BaseNavigationMenuResourceImpl
 
 		UnsafeFunction<NavigationMenu, NavigationMenu, Exception>
 			navigationMenuUnsafeFunction = navigationMenu -> {
-				deleteNavigationMenu(navigationMenu.getId());
+				if (navigationMenu.getId() != null) {
+					try {
+						deleteNavigationMenu(navigationMenu.getId());
 
-				return navigationMenu;
+						return navigationMenu;
+					}
+					catch (Exception exception) {
+						if (navigationMenu.getExternalReferenceCode() != null) {
+							if (parameters.containsKey("siteId")) {
+								deleteSiteNavigationMenuByExternalReferenceCode(
+									(Long)parameters.get("siteId"),
+									navigationMenu.getExternalReferenceCode());
+
+								return navigationMenu;
+							}
+						}
+					}
+				}
+				else if (parameters.containsKey("siteId")) {
+					deleteSiteNavigationMenuByExternalReferenceCode(
+						(Long)parameters.get("siteId"),
+						navigationMenu.getExternalReferenceCode());
+
+					return navigationMenu;
+				}
+
+				throw new UnsupportedOperationException(
+					"Unable to delete by external reference code or ID");
 			};
 
 		if (contextBatchUnsafeBiConsumer != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
@@ -2125,10 +2125,59 @@ public abstract class BaseStructuredContentFolderResourceImpl
 			<StructuredContentFolder, StructuredContentFolder, Exception>
 				structuredContentFolderUnsafeFunction =
 					structuredContentFolder -> {
-						deleteStructuredContentFolder(
-							structuredContentFolder.getId());
+						if (structuredContentFolder.getId() != null) {
+							try {
+								deleteStructuredContentFolder(
+									structuredContentFolder.getId());
 
-						return structuredContentFolder;
+								return structuredContentFolder;
+							}
+							catch (Exception exception) {
+								if (structuredContentFolder.
+										getExternalReferenceCode() != null) {
+
+									if (parameters.containsKey(
+											"assetLibraryId")) {
+
+										deleteAssetLibraryStructuredContentFolderByExternalReferenceCode(
+											(Long)parameters.get(
+												"assetLibraryId"),
+											structuredContentFolder.
+												getExternalReferenceCode());
+
+										return structuredContentFolder;
+									}
+
+									if (parameters.containsKey("siteId")) {
+										deleteSiteStructuredContentFolderByExternalReferenceCode(
+											(Long)parameters.get("siteId"),
+											structuredContentFolder.
+												getExternalReferenceCode());
+
+										return structuredContentFolder;
+									}
+								}
+							}
+						}
+						else if (parameters.containsKey("assetLibraryId")) {
+							deleteAssetLibraryStructuredContentFolderByExternalReferenceCode(
+								(Long)parameters.get("assetLibraryId"),
+								structuredContentFolder.
+									getExternalReferenceCode());
+
+							return structuredContentFolder;
+						}
+						else if (parameters.containsKey("siteId")) {
+							deleteSiteStructuredContentFolderByExternalReferenceCode(
+								(Long)parameters.get("siteId"),
+								structuredContentFolder.
+									getExternalReferenceCode());
+
+							return structuredContentFolder;
+						}
+
+						throw new UnsupportedOperationException(
+							"Unable to delete by external reference code or ID");
 					};
 
 		if (contextBatchUnsafeBiConsumer != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
@@ -2803,9 +2803,53 @@ public abstract class BaseStructuredContentResourceImpl
 
 		UnsafeFunction<StructuredContent, StructuredContent, Exception>
 			structuredContentUnsafeFunction = structuredContent -> {
-				deleteStructuredContent(structuredContent.getId());
+				if (structuredContent.getId() != null) {
+					try {
+						deleteStructuredContent(structuredContent.getId());
 
-				return structuredContent;
+						return structuredContent;
+					}
+					catch (Exception exception) {
+						if (structuredContent.getExternalReferenceCode() !=
+								null) {
+
+							if (parameters.containsKey("assetLibraryId")) {
+								deleteAssetLibraryStructuredContentByExternalReferenceCode(
+									(Long)parameters.get("assetLibraryId"),
+									structuredContent.
+										getExternalReferenceCode());
+
+								return structuredContent;
+							}
+
+							if (parameters.containsKey("siteId")) {
+								deleteSiteStructuredContentByExternalReferenceCode(
+									(Long)parameters.get("siteId"),
+									structuredContent.
+										getExternalReferenceCode());
+
+								return structuredContent;
+							}
+						}
+					}
+				}
+				else if (parameters.containsKey("assetLibraryId")) {
+					deleteAssetLibraryStructuredContentByExternalReferenceCode(
+						(Long)parameters.get("assetLibraryId"),
+						structuredContent.getExternalReferenceCode());
+
+					return structuredContent;
+				}
+				else if (parameters.containsKey("siteId")) {
+					deleteSiteStructuredContentByExternalReferenceCode(
+						(Long)parameters.get("siteId"),
+						structuredContent.getExternalReferenceCode());
+
+					return structuredContent;
+				}
+
+				throw new UnsupportedOperationException(
+					"Unable to delete by external reference code or ID");
 			};
 
 		if (contextBatchUnsafeBiConsumer != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
@@ -1116,9 +1116,34 @@ public abstract class BaseWikiNodeResourceImpl
 
 		UnsafeFunction<WikiNode, WikiNode, Exception> wikiNodeUnsafeFunction =
 			wikiNode -> {
-				deleteWikiNode(wikiNode.getId());
+				if (wikiNode.getId() != null) {
+					try {
+						deleteWikiNode(wikiNode.getId());
 
-				return wikiNode;
+						return wikiNode;
+					}
+					catch (Exception exception) {
+						if (wikiNode.getExternalReferenceCode() != null) {
+							if (parameters.containsKey("siteId")) {
+								deleteSiteWikiNodeByExternalReferenceCode(
+									(Long)parameters.get("siteId"),
+									wikiNode.getExternalReferenceCode());
+
+								return wikiNode;
+							}
+						}
+					}
+				}
+				else if (parameters.containsKey("siteId")) {
+					deleteSiteWikiNodeByExternalReferenceCode(
+						(Long)parameters.get("siteId"),
+						wikiNode.getExternalReferenceCode());
+
+					return wikiNode;
+				}
+
+				throw new UnsupportedOperationException(
+					"Unable to delete by external reference code or ID");
 			};
 
 		if (contextBatchUnsafeBiConsumer != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
@@ -1047,9 +1047,34 @@ public abstract class BaseWikiPageResourceImpl
 
 		UnsafeFunction<WikiPage, WikiPage, Exception> wikiPageUnsafeFunction =
 			wikiPage -> {
-				deleteWikiPage(wikiPage.getId());
+				if (wikiPage.getId() != null) {
+					try {
+						deleteWikiPage(wikiPage.getId());
 
-				return wikiPage;
+						return wikiPage;
+					}
+					catch (Exception exception) {
+						if (wikiPage.getExternalReferenceCode() != null) {
+							if (parameters.containsKey("siteId")) {
+								deleteSiteWikiPageByExternalReferenceCode(
+									(Long)parameters.get("siteId"),
+									wikiPage.getExternalReferenceCode());
+
+								return wikiPage;
+							}
+						}
+					}
+				}
+				else if (parameters.containsKey("siteId")) {
+					deleteSiteWikiPageByExternalReferenceCode(
+						(Long)parameters.get("siteId"),
+						wikiPage.getExternalReferenceCode());
+
+					return wikiPage;
+				}
+
+				throw new UnsupportedOperationException(
+					"Unable to delete by external reference code or ID");
 			};
 
 		if (contextBatchUnsafeBiConsumer != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
@@ -1610,6 +1610,42 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 			404,
 			blogPostingImageResource.getBlogPostingImageHttpResponse(
 				blogPostingImage1.getId()));
+
+		blogPostingImage1 =
+			testBatchEngineDeleteImportTask_addSiteBlogPostingImage();
+
+		testBatchEngineDeleteImportTask_deleteBlogPostingImage(
+			200, blogPostingImage1.getExternalReferenceCode(), null, "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		blogPostingImage1 =
+			testBatchEngineDeleteImportTask_addSiteBlogPostingImage();
+		BlogPostingImage blogPostingImage2 =
+			testBatchEngineDeleteImportTask_addSiteBlogPostingImage();
+
+		testBatchEngineDeleteImportTask_deleteBlogPostingImage(
+			200, blogPostingImage2.getExternalReferenceCode(),
+			blogPostingImage1.getId(), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			blogPostingImageResource.getBlogPostingImageHttpResponse(
+				blogPostingImage1.getId()));
+		assertHttpResponseStatusCode(
+			200,
+			blogPostingImageResource.getBlogPostingImageHttpResponse(
+				blogPostingImage2.getId()));
+
+		testBatchEngineDeleteImportTask_deleteBlogPostingImage(
+			200, blogPostingImage2.getExternalReferenceCode(),
+			blogPostingImage1.getId(), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			blogPostingImageResource.getBlogPostingImageHttpResponse(
+				blogPostingImage2.getId()));
 	}
 
 	protected BlogPostingImage
@@ -1617,6 +1653,13 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 		throws Exception {
 
 		return testDeleteBlogPostingImage_addBlogPostingImage();
+	}
+
+	protected BlogPostingImage
+			testBatchEngineDeleteImportTask_addSiteBlogPostingImage()
+		throws Exception {
+
+		return testDeleteSiteBlogPostingImageByExternalReferenceCode_addBlogPostingImage();
 	}
 
 	protected void testBatchEngineDeleteImportTask_deleteBlogPostingImage(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
@@ -1967,12 +1967,50 @@ public abstract class BaseBlogPostingResourceTestCase {
 			404,
 			blogPostingResource.getBlogPostingHttpResponse(
 				blogPosting1.getId()));
+
+		blogPosting1 = testBatchEngineDeleteImportTask_addSiteBlogPosting();
+
+		testBatchEngineDeleteImportTask_deleteBlogPosting(
+			200, blogPosting1.getExternalReferenceCode(), null, "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		blogPosting1 = testBatchEngineDeleteImportTask_addSiteBlogPosting();
+		BlogPosting blogPosting2 =
+			testBatchEngineDeleteImportTask_addSiteBlogPosting();
+
+		testBatchEngineDeleteImportTask_deleteBlogPosting(
+			200, blogPosting2.getExternalReferenceCode(), blogPosting1.getId(),
+			"siteId", String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			blogPostingResource.getBlogPostingHttpResponse(
+				blogPosting1.getId()));
+		assertHttpResponseStatusCode(
+			200,
+			blogPostingResource.getBlogPostingHttpResponse(
+				blogPosting2.getId()));
+
+		testBatchEngineDeleteImportTask_deleteBlogPosting(
+			200, blogPosting2.getExternalReferenceCode(), blogPosting1.getId(),
+			"siteId", String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			blogPostingResource.getBlogPostingHttpResponse(
+				blogPosting2.getId()));
 	}
 
 	protected BlogPosting testBatchEngineDeleteImportTask_addBlogPosting()
 		throws Exception {
 
 		return testDeleteBlogPosting_addBlogPosting();
+	}
+
+	protected BlogPosting testBatchEngineDeleteImportTask_addSiteBlogPosting()
+		throws Exception {
+
+		return testDeleteSiteBlogPostingByExternalReferenceCode_addBlogPosting();
 	}
 
 	protected void testBatchEngineDeleteImportTask_deleteBlogPosting(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentMetadataSetResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentMetadataSetResourceTestCase.java
@@ -2185,6 +2185,13 @@ public abstract class BaseDocumentMetadataSetResourceTestCase {
 	@Test
 	public void testBatchEngineDeleteImportTask() throws Exception {
 		DocumentMetadataSet documentMetadataSet1 =
+			testBatchEngineDeleteImportTask_addAssetLibraryDocumentMetadataSet();
+
+		testBatchEngineDeleteImportTask_deleteDocumentMetadataSet(
+			200, documentMetadataSet1.getExternalReferenceCode(), null,
+			"assetLibraryId", String.valueOf(testDepotEntryGroup.getGroupId()));
+
+		documentMetadataSet1 =
 			testBatchEngineDeleteImportTask_addDocumentMetadataSet();
 
 		testBatchEngineDeleteImportTask_deleteDocumentMetadataSet(
@@ -2194,6 +2201,85 @@ public abstract class BaseDocumentMetadataSetResourceTestCase {
 			404,
 			documentMetadataSetResource.getDocumentMetadataSetHttpResponse(
 				documentMetadataSet1.getId()));
+
+		documentMetadataSet1 =
+			testBatchEngineDeleteImportTask_addSiteDocumentMetadataSet();
+
+		testBatchEngineDeleteImportTask_deleteDocumentMetadataSet(
+			200, documentMetadataSet1.getExternalReferenceCode(), null,
+			"siteId", String.valueOf(testGroup.getGroupId()));
+
+		documentMetadataSet1 =
+			testBatchEngineDeleteImportTask_addAssetLibraryDocumentMetadataSet();
+		DocumentMetadataSet documentMetadataSet2 =
+			testBatchEngineDeleteImportTask_addAssetLibraryDocumentMetadataSet();
+
+		testBatchEngineDeleteImportTask_deleteDocumentMetadataSet(
+			200, documentMetadataSet2.getExternalReferenceCode(),
+			documentMetadataSet1.getId(), "assetLibraryId",
+			String.valueOf(testDepotEntryGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			documentMetadataSetResource.getDocumentMetadataSetHttpResponse(
+				documentMetadataSet1.getId()));
+		assertHttpResponseStatusCode(
+			200,
+			documentMetadataSetResource.getDocumentMetadataSetHttpResponse(
+				documentMetadataSet2.getId()));
+
+		testBatchEngineDeleteImportTask_deleteDocumentMetadataSet(
+			200, documentMetadataSet2.getExternalReferenceCode(),
+			documentMetadataSet1.getId(), "assetLibraryId",
+			String.valueOf(testDepotEntryGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			documentMetadataSetResource.getDocumentMetadataSetHttpResponse(
+				documentMetadataSet2.getId()));
+
+		documentMetadataSet1 =
+			testBatchEngineDeleteImportTask_addSiteDocumentMetadataSet();
+		documentMetadataSet2 =
+			testBatchEngineDeleteImportTask_addSiteDocumentMetadataSet();
+
+		testBatchEngineDeleteImportTask_deleteDocumentMetadataSet(
+			200, documentMetadataSet2.getExternalReferenceCode(),
+			documentMetadataSet1.getId(), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			documentMetadataSetResource.getDocumentMetadataSetHttpResponse(
+				documentMetadataSet1.getId()));
+		assertHttpResponseStatusCode(
+			200,
+			documentMetadataSetResource.getDocumentMetadataSetHttpResponse(
+				documentMetadataSet2.getId()));
+
+		testBatchEngineDeleteImportTask_deleteDocumentMetadataSet(
+			200, documentMetadataSet2.getExternalReferenceCode(),
+			documentMetadataSet1.getId(), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			documentMetadataSetResource.getDocumentMetadataSetHttpResponse(
+				documentMetadataSet2.getId()));
+
+		documentMetadataSet1 =
+			testBatchEngineDeleteImportTask_addSiteDocumentMetadataSet();
+
+		testBatchEngineDeleteImportTask_deleteDocumentMetadataSet(
+			400, documentMetadataSet1.getExternalReferenceCode(),
+			documentMetadataSet1.getId(), "assetLibraryId",
+			String.valueOf(testDepotEntryGroup.getGroupId()), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			200,
+			documentMetadataSetResource.getDocumentMetadataSetHttpResponse(
+				documentMetadataSet1.getId()));
 	}
 
 	protected DocumentMetadataSet
@@ -2201,6 +2287,20 @@ public abstract class BaseDocumentMetadataSetResourceTestCase {
 		throws Exception {
 
 		return testDeleteDocumentMetadataSet_addDocumentMetadataSet();
+	}
+
+	protected DocumentMetadataSet
+			testBatchEngineDeleteImportTask_addAssetLibraryDocumentMetadataSet()
+		throws Exception {
+
+		return testDeleteAssetLibraryDocumentMetadataSetByExternalReferenceCode_addDocumentMetadataSet();
+	}
+
+	protected DocumentMetadataSet
+			testBatchEngineDeleteImportTask_addSiteDocumentMetadataSet()
+		throws Exception {
+
+		return testDeleteSiteDocumentMetadataSetByExternalReferenceCode_addDocumentMetadataSet();
 	}
 
 	protected void testBatchEngineDeleteImportTask_deleteDocumentMetadataSet(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -3938,19 +3938,93 @@ public abstract class BaseDocumentResourceTestCase {
 
 	@Test
 	public void testBatchEngineDeleteImportTask() throws Exception {
-		Document document1 = testBatchEngineDeleteImportTask_addDocument();
+		Document document1 =
+			testBatchEngineDeleteImportTask_addAssetLibraryDocument();
+
+		testBatchEngineDeleteImportTask_deleteDocument(
+			200, document1.getExternalReferenceCode(), null, "assetLibraryId",
+			String.valueOf(testDepotEntryGroup.getGroupId()));
+
+		document1 = testBatchEngineDeleteImportTask_addDocument();
 
 		testBatchEngineDeleteImportTask_deleteDocument(
 			200, null, document1.getId());
 
 		assertHttpResponseStatusCode(
 			404, documentResource.getDocumentHttpResponse(document1.getId()));
+
+		document1 = testBatchEngineDeleteImportTask_addSiteDocument();
+
+		testBatchEngineDeleteImportTask_deleteDocument(
+			200, document1.getExternalReferenceCode(), null, "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		document1 = testBatchEngineDeleteImportTask_addAssetLibraryDocument();
+		Document document2 =
+			testBatchEngineDeleteImportTask_addAssetLibraryDocument();
+
+		testBatchEngineDeleteImportTask_deleteDocument(
+			200, document2.getExternalReferenceCode(), document1.getId(),
+			"assetLibraryId", String.valueOf(testDepotEntryGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404, documentResource.getDocumentHttpResponse(document1.getId()));
+		assertHttpResponseStatusCode(
+			200, documentResource.getDocumentHttpResponse(document2.getId()));
+
+		testBatchEngineDeleteImportTask_deleteDocument(
+			200, document2.getExternalReferenceCode(), document1.getId(),
+			"assetLibraryId", String.valueOf(testDepotEntryGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404, documentResource.getDocumentHttpResponse(document2.getId()));
+
+		document1 = testBatchEngineDeleteImportTask_addSiteDocument();
+		document2 = testBatchEngineDeleteImportTask_addSiteDocument();
+
+		testBatchEngineDeleteImportTask_deleteDocument(
+			200, document2.getExternalReferenceCode(), document1.getId(),
+			"siteId", String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404, documentResource.getDocumentHttpResponse(document1.getId()));
+		assertHttpResponseStatusCode(
+			200, documentResource.getDocumentHttpResponse(document2.getId()));
+
+		testBatchEngineDeleteImportTask_deleteDocument(
+			200, document2.getExternalReferenceCode(), document1.getId(),
+			"siteId", String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404, documentResource.getDocumentHttpResponse(document2.getId()));
+
+		document1 = testBatchEngineDeleteImportTask_addSiteDocument();
+
+		testBatchEngineDeleteImportTask_deleteDocument(
+			400, document1.getExternalReferenceCode(), document1.getId(),
+			"assetLibraryId", String.valueOf(testDepotEntryGroup.getGroupId()),
+			"siteId", String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			200, documentResource.getDocumentHttpResponse(document1.getId()));
 	}
 
 	protected Document testBatchEngineDeleteImportTask_addDocument()
 		throws Exception {
 
 		return testDeleteDocument_addDocument();
+	}
+
+	protected Document testBatchEngineDeleteImportTask_addAssetLibraryDocument()
+		throws Exception {
+
+		return testDeleteAssetLibraryDocumentByExternalReferenceCode_addDocument();
+	}
+
+	protected Document testBatchEngineDeleteImportTask_addSiteDocument()
+		throws Exception {
+
+		return testDeleteSiteDocumentByExternalReferenceCode_addDocument();
 	}
 
 	protected void testBatchEngineDeleteImportTask_deleteDocument(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentShortcutResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentShortcutResourceTestCase.java
@@ -1789,6 +1789,42 @@ public abstract class BaseDocumentShortcutResourceTestCase {
 			404,
 			documentShortcutResource.getDocumentShortcutHttpResponse(
 				documentShortcut1.getId()));
+
+		documentShortcut1 =
+			testBatchEngineDeleteImportTask_addSiteDocumentShortcut();
+
+		testBatchEngineDeleteImportTask_deleteDocumentShortcut(
+			200, documentShortcut1.getExternalReferenceCode(), null, "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		documentShortcut1 =
+			testBatchEngineDeleteImportTask_addSiteDocumentShortcut();
+		DocumentShortcut documentShortcut2 =
+			testBatchEngineDeleteImportTask_addSiteDocumentShortcut();
+
+		testBatchEngineDeleteImportTask_deleteDocumentShortcut(
+			200, documentShortcut2.getExternalReferenceCode(),
+			documentShortcut1.getId(), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			documentShortcutResource.getDocumentShortcutHttpResponse(
+				documentShortcut1.getId()));
+		assertHttpResponseStatusCode(
+			200,
+			documentShortcutResource.getDocumentShortcutHttpResponse(
+				documentShortcut2.getId()));
+
+		testBatchEngineDeleteImportTask_deleteDocumentShortcut(
+			200, documentShortcut2.getExternalReferenceCode(),
+			documentShortcut1.getId(), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			documentShortcutResource.getDocumentShortcutHttpResponse(
+				documentShortcut2.getId()));
 	}
 
 	protected DocumentShortcut
@@ -1796,6 +1832,13 @@ public abstract class BaseDocumentShortcutResourceTestCase {
 		throws Exception {
 
 		return testDeleteDocumentShortcut_addDocumentShortcut();
+	}
+
+	protected DocumentShortcut
+			testBatchEngineDeleteImportTask_addSiteDocumentShortcut()
+		throws Exception {
+
+		return testDeleteSiteDocumentShortcutByExternalReferenceCode_addDocumentShortcut();
 	}
 
 	protected void testBatchEngineDeleteImportTask_deleteDocumentShortcut(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
@@ -3485,6 +3485,42 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 			404,
 			knowledgeBaseArticleResource.getKnowledgeBaseArticleHttpResponse(
 				knowledgeBaseArticle1.getId()));
+
+		knowledgeBaseArticle1 =
+			testBatchEngineDeleteImportTask_addSiteKnowledgeBaseArticle();
+
+		testBatchEngineDeleteImportTask_deleteKnowledgeBaseArticle(
+			200, knowledgeBaseArticle1.getExternalReferenceCode(), null,
+			"siteId", String.valueOf(testGroup.getGroupId()));
+
+		knowledgeBaseArticle1 =
+			testBatchEngineDeleteImportTask_addSiteKnowledgeBaseArticle();
+		KnowledgeBaseArticle knowledgeBaseArticle2 =
+			testBatchEngineDeleteImportTask_addSiteKnowledgeBaseArticle();
+
+		testBatchEngineDeleteImportTask_deleteKnowledgeBaseArticle(
+			200, knowledgeBaseArticle2.getExternalReferenceCode(),
+			knowledgeBaseArticle1.getId(), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			knowledgeBaseArticleResource.getKnowledgeBaseArticleHttpResponse(
+				knowledgeBaseArticle1.getId()));
+		assertHttpResponseStatusCode(
+			200,
+			knowledgeBaseArticleResource.getKnowledgeBaseArticleHttpResponse(
+				knowledgeBaseArticle2.getId()));
+
+		testBatchEngineDeleteImportTask_deleteKnowledgeBaseArticle(
+			200, knowledgeBaseArticle2.getExternalReferenceCode(),
+			knowledgeBaseArticle1.getId(), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			knowledgeBaseArticleResource.getKnowledgeBaseArticleHttpResponse(
+				knowledgeBaseArticle2.getId()));
 	}
 
 	protected KnowledgeBaseArticle
@@ -3492,6 +3528,13 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		throws Exception {
 
 		return testDeleteKnowledgeBaseArticle_addKnowledgeBaseArticle();
+	}
+
+	protected KnowledgeBaseArticle
+			testBatchEngineDeleteImportTask_addSiteKnowledgeBaseArticle()
+		throws Exception {
+
+		return testDeleteSiteKnowledgeBaseArticleByExternalReferenceCode_addKnowledgeBaseArticle();
 	}
 
 	protected void testBatchEngineDeleteImportTask_deleteKnowledgeBaseArticle(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
@@ -2046,6 +2046,42 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 			404,
 			knowledgeBaseFolderResource.getKnowledgeBaseFolderHttpResponse(
 				knowledgeBaseFolder1.getId()));
+
+		knowledgeBaseFolder1 =
+			testBatchEngineDeleteImportTask_addSiteKnowledgeBaseFolder();
+
+		testBatchEngineDeleteImportTask_deleteKnowledgeBaseFolder(
+			200, knowledgeBaseFolder1.getExternalReferenceCode(), null,
+			"siteId", String.valueOf(testGroup.getGroupId()));
+
+		knowledgeBaseFolder1 =
+			testBatchEngineDeleteImportTask_addSiteKnowledgeBaseFolder();
+		KnowledgeBaseFolder knowledgeBaseFolder2 =
+			testBatchEngineDeleteImportTask_addSiteKnowledgeBaseFolder();
+
+		testBatchEngineDeleteImportTask_deleteKnowledgeBaseFolder(
+			200, knowledgeBaseFolder2.getExternalReferenceCode(),
+			knowledgeBaseFolder1.getId(), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			knowledgeBaseFolderResource.getKnowledgeBaseFolderHttpResponse(
+				knowledgeBaseFolder1.getId()));
+		assertHttpResponseStatusCode(
+			200,
+			knowledgeBaseFolderResource.getKnowledgeBaseFolderHttpResponse(
+				knowledgeBaseFolder2.getId()));
+
+		testBatchEngineDeleteImportTask_deleteKnowledgeBaseFolder(
+			200, knowledgeBaseFolder2.getExternalReferenceCode(),
+			knowledgeBaseFolder1.getId(), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			knowledgeBaseFolderResource.getKnowledgeBaseFolderHttpResponse(
+				knowledgeBaseFolder2.getId()));
 	}
 
 	protected KnowledgeBaseFolder
@@ -2053,6 +2089,13 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		throws Exception {
 
 		return testDeleteKnowledgeBaseFolder_addKnowledgeBaseFolder();
+	}
+
+	protected KnowledgeBaseFolder
+			testBatchEngineDeleteImportTask_addSiteKnowledgeBaseFolder()
+		throws Exception {
+
+		return testDeleteSiteKnowledgeBaseFolderByExternalReferenceCode_addKnowledgeBaseFolder();
 	}
 
 	protected void testBatchEngineDeleteImportTask_deleteKnowledgeBaseFolder(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
@@ -3549,6 +3549,42 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 			404,
 			messageBoardMessageResource.getMessageBoardMessageHttpResponse(
 				messageBoardMessage1.getId()));
+
+		messageBoardMessage1 =
+			testBatchEngineDeleteImportTask_addSiteMessageBoardMessage();
+
+		testBatchEngineDeleteImportTask_deleteMessageBoardMessage(
+			200, messageBoardMessage1.getExternalReferenceCode(), null,
+			"siteId", String.valueOf(testGroup.getGroupId()));
+
+		messageBoardMessage1 =
+			testBatchEngineDeleteImportTask_addSiteMessageBoardMessage();
+		MessageBoardMessage messageBoardMessage2 =
+			testBatchEngineDeleteImportTask_addSiteMessageBoardMessage();
+
+		testBatchEngineDeleteImportTask_deleteMessageBoardMessage(
+			200, messageBoardMessage2.getExternalReferenceCode(),
+			messageBoardMessage1.getId(), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			messageBoardMessageResource.getMessageBoardMessageHttpResponse(
+				messageBoardMessage1.getId()));
+		assertHttpResponseStatusCode(
+			200,
+			messageBoardMessageResource.getMessageBoardMessageHttpResponse(
+				messageBoardMessage2.getId()));
+
+		testBatchEngineDeleteImportTask_deleteMessageBoardMessage(
+			200, messageBoardMessage2.getExternalReferenceCode(),
+			messageBoardMessage1.getId(), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			messageBoardMessageResource.getMessageBoardMessageHttpResponse(
+				messageBoardMessage2.getId()));
 	}
 
 	protected MessageBoardMessage
@@ -3556,6 +3592,13 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		throws Exception {
 
 		return testDeleteMessageBoardMessage_addMessageBoardMessage();
+	}
+
+	protected MessageBoardMessage
+			testBatchEngineDeleteImportTask_addSiteMessageBoardMessage()
+		throws Exception {
+
+		return testDeleteSiteMessageBoardMessageByExternalReferenceCode_addMessageBoardMessage();
 	}
 
 	protected void testBatchEngineDeleteImportTask_deleteMessageBoardMessage(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
@@ -1838,12 +1838,55 @@ public abstract class BaseNavigationMenuResourceTestCase {
 			404,
 			navigationMenuResource.getNavigationMenuHttpResponse(
 				navigationMenu1.getId()));
+
+		navigationMenu1 =
+			testBatchEngineDeleteImportTask_addSiteNavigationMenu();
+
+		testBatchEngineDeleteImportTask_deleteNavigationMenu(
+			200, navigationMenu1.getExternalReferenceCode(), null, "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		navigationMenu1 =
+			testBatchEngineDeleteImportTask_addSiteNavigationMenu();
+		NavigationMenu navigationMenu2 =
+			testBatchEngineDeleteImportTask_addSiteNavigationMenu();
+
+		testBatchEngineDeleteImportTask_deleteNavigationMenu(
+			200, navigationMenu2.getExternalReferenceCode(),
+			navigationMenu1.getId(), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			navigationMenuResource.getNavigationMenuHttpResponse(
+				navigationMenu1.getId()));
+		assertHttpResponseStatusCode(
+			200,
+			navigationMenuResource.getNavigationMenuHttpResponse(
+				navigationMenu2.getId()));
+
+		testBatchEngineDeleteImportTask_deleteNavigationMenu(
+			200, navigationMenu2.getExternalReferenceCode(),
+			navigationMenu1.getId(), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			navigationMenuResource.getNavigationMenuHttpResponse(
+				navigationMenu2.getId()));
 	}
 
 	protected NavigationMenu testBatchEngineDeleteImportTask_addNavigationMenu()
 		throws Exception {
 
 		return testDeleteNavigationMenu_addNavigationMenu();
+	}
+
+	protected NavigationMenu
+			testBatchEngineDeleteImportTask_addSiteNavigationMenu()
+		throws Exception {
+
+		return testDeleteSiteNavigationMenuByExternalReferenceCode_addNavigationMenu();
 	}
 
 	protected void testBatchEngineDeleteImportTask_deleteNavigationMenu(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
@@ -3914,6 +3914,13 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 	@Test
 	public void testBatchEngineDeleteImportTask() throws Exception {
 		StructuredContentFolder structuredContentFolder1 =
+			testBatchEngineDeleteImportTask_addAssetLibraryStructuredContentFolder();
+
+		testBatchEngineDeleteImportTask_deleteStructuredContentFolder(
+			200, structuredContentFolder1.getExternalReferenceCode(), null,
+			"assetLibraryId", String.valueOf(testDepotEntryGroup.getGroupId()));
+
+		structuredContentFolder1 =
 			testBatchEngineDeleteImportTask_addStructuredContentFolder();
 
 		testBatchEngineDeleteImportTask_deleteStructuredContentFolder(
@@ -3924,6 +3931,92 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 			structuredContentFolderResource.
 				getStructuredContentFolderHttpResponse(
 					structuredContentFolder1.getId()));
+
+		structuredContentFolder1 =
+			testBatchEngineDeleteImportTask_addSiteStructuredContentFolder();
+
+		testBatchEngineDeleteImportTask_deleteStructuredContentFolder(
+			200, structuredContentFolder1.getExternalReferenceCode(), null,
+			"siteId", String.valueOf(testGroup.getGroupId()));
+
+		structuredContentFolder1 =
+			testBatchEngineDeleteImportTask_addAssetLibraryStructuredContentFolder();
+		StructuredContentFolder structuredContentFolder2 =
+			testBatchEngineDeleteImportTask_addAssetLibraryStructuredContentFolder();
+
+		testBatchEngineDeleteImportTask_deleteStructuredContentFolder(
+			200, structuredContentFolder2.getExternalReferenceCode(),
+			structuredContentFolder1.getId(), "assetLibraryId",
+			String.valueOf(testDepotEntryGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			structuredContentFolderResource.
+				getStructuredContentFolderHttpResponse(
+					structuredContentFolder1.getId()));
+		assertHttpResponseStatusCode(
+			200,
+			structuredContentFolderResource.
+				getStructuredContentFolderHttpResponse(
+					structuredContentFolder2.getId()));
+
+		testBatchEngineDeleteImportTask_deleteStructuredContentFolder(
+			200, structuredContentFolder2.getExternalReferenceCode(),
+			structuredContentFolder1.getId(), "assetLibraryId",
+			String.valueOf(testDepotEntryGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			structuredContentFolderResource.
+				getStructuredContentFolderHttpResponse(
+					structuredContentFolder2.getId()));
+
+		structuredContentFolder1 =
+			testBatchEngineDeleteImportTask_addSiteStructuredContentFolder();
+		structuredContentFolder2 =
+			testBatchEngineDeleteImportTask_addSiteStructuredContentFolder();
+
+		testBatchEngineDeleteImportTask_deleteStructuredContentFolder(
+			200, structuredContentFolder2.getExternalReferenceCode(),
+			structuredContentFolder1.getId(), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			structuredContentFolderResource.
+				getStructuredContentFolderHttpResponse(
+					structuredContentFolder1.getId()));
+		assertHttpResponseStatusCode(
+			200,
+			structuredContentFolderResource.
+				getStructuredContentFolderHttpResponse(
+					structuredContentFolder2.getId()));
+
+		testBatchEngineDeleteImportTask_deleteStructuredContentFolder(
+			200, structuredContentFolder2.getExternalReferenceCode(),
+			structuredContentFolder1.getId(), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			structuredContentFolderResource.
+				getStructuredContentFolderHttpResponse(
+					structuredContentFolder2.getId()));
+
+		structuredContentFolder1 =
+			testBatchEngineDeleteImportTask_addSiteStructuredContentFolder();
+
+		testBatchEngineDeleteImportTask_deleteStructuredContentFolder(
+			400, structuredContentFolder1.getExternalReferenceCode(),
+			structuredContentFolder1.getId(), "assetLibraryId",
+			String.valueOf(testDepotEntryGroup.getGroupId()), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			200,
+			structuredContentFolderResource.
+				getStructuredContentFolderHttpResponse(
+					structuredContentFolder1.getId()));
 	}
 
 	protected StructuredContentFolder
@@ -3931,6 +4024,20 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		throws Exception {
 
 		return testDeleteStructuredContentFolder_addStructuredContentFolder();
+	}
+
+	protected StructuredContentFolder
+			testBatchEngineDeleteImportTask_addAssetLibraryStructuredContentFolder()
+		throws Exception {
+
+		return testDeleteAssetLibraryStructuredContentFolderByExternalReferenceCode_addStructuredContentFolder();
+	}
+
+	protected StructuredContentFolder
+			testBatchEngineDeleteImportTask_addSiteStructuredContentFolder()
+		throws Exception {
+
+		return testDeleteSiteStructuredContentFolderByExternalReferenceCode_addStructuredContentFolder();
 	}
 
 	protected void

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -4656,6 +4656,13 @@ public abstract class BaseStructuredContentResourceTestCase {
 	@Test
 	public void testBatchEngineDeleteImportTask() throws Exception {
 		StructuredContent structuredContent1 =
+			testBatchEngineDeleteImportTask_addAssetLibraryStructuredContent();
+
+		testBatchEngineDeleteImportTask_deleteStructuredContent(
+			200, structuredContent1.getExternalReferenceCode(), null,
+			"assetLibraryId", String.valueOf(testDepotEntryGroup.getGroupId()));
+
+		structuredContent1 =
 			testBatchEngineDeleteImportTask_addStructuredContent();
 
 		testBatchEngineDeleteImportTask_deleteStructuredContent(
@@ -4665,6 +4672,85 @@ public abstract class BaseStructuredContentResourceTestCase {
 			404,
 			structuredContentResource.getStructuredContentHttpResponse(
 				structuredContent1.getId()));
+
+		structuredContent1 =
+			testBatchEngineDeleteImportTask_addSiteStructuredContent();
+
+		testBatchEngineDeleteImportTask_deleteStructuredContent(
+			200, structuredContent1.getExternalReferenceCode(), null, "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		structuredContent1 =
+			testBatchEngineDeleteImportTask_addAssetLibraryStructuredContent();
+		StructuredContent structuredContent2 =
+			testBatchEngineDeleteImportTask_addAssetLibraryStructuredContent();
+
+		testBatchEngineDeleteImportTask_deleteStructuredContent(
+			200, structuredContent2.getExternalReferenceCode(),
+			structuredContent1.getId(), "assetLibraryId",
+			String.valueOf(testDepotEntryGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			structuredContentResource.getStructuredContentHttpResponse(
+				structuredContent1.getId()));
+		assertHttpResponseStatusCode(
+			200,
+			structuredContentResource.getStructuredContentHttpResponse(
+				structuredContent2.getId()));
+
+		testBatchEngineDeleteImportTask_deleteStructuredContent(
+			200, structuredContent2.getExternalReferenceCode(),
+			structuredContent1.getId(), "assetLibraryId",
+			String.valueOf(testDepotEntryGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			structuredContentResource.getStructuredContentHttpResponse(
+				structuredContent2.getId()));
+
+		structuredContent1 =
+			testBatchEngineDeleteImportTask_addSiteStructuredContent();
+		structuredContent2 =
+			testBatchEngineDeleteImportTask_addSiteStructuredContent();
+
+		testBatchEngineDeleteImportTask_deleteStructuredContent(
+			200, structuredContent2.getExternalReferenceCode(),
+			structuredContent1.getId(), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			structuredContentResource.getStructuredContentHttpResponse(
+				structuredContent1.getId()));
+		assertHttpResponseStatusCode(
+			200,
+			structuredContentResource.getStructuredContentHttpResponse(
+				structuredContent2.getId()));
+
+		testBatchEngineDeleteImportTask_deleteStructuredContent(
+			200, structuredContent2.getExternalReferenceCode(),
+			structuredContent1.getId(), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			structuredContentResource.getStructuredContentHttpResponse(
+				structuredContent2.getId()));
+
+		structuredContent1 =
+			testBatchEngineDeleteImportTask_addSiteStructuredContent();
+
+		testBatchEngineDeleteImportTask_deleteStructuredContent(
+			400, structuredContent1.getExternalReferenceCode(),
+			structuredContent1.getId(), "assetLibraryId",
+			String.valueOf(testDepotEntryGroup.getGroupId()), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			200,
+			structuredContentResource.getStructuredContentHttpResponse(
+				structuredContent1.getId()));
 	}
 
 	protected StructuredContent
@@ -4672,6 +4758,20 @@ public abstract class BaseStructuredContentResourceTestCase {
 		throws Exception {
 
 		return testDeleteStructuredContent_addStructuredContent();
+	}
+
+	protected StructuredContent
+			testBatchEngineDeleteImportTask_addAssetLibraryStructuredContent()
+		throws Exception {
+
+		return testDeleteAssetLibraryStructuredContentByExternalReferenceCode_addStructuredContent();
+	}
+
+	protected StructuredContent
+			testBatchEngineDeleteImportTask_addSiteStructuredContent()
+		throws Exception {
+
+		return testDeleteSiteStructuredContentByExternalReferenceCode_addStructuredContent();
 	}
 
 	protected void testBatchEngineDeleteImportTask_deleteStructuredContent(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
@@ -1726,12 +1726,43 @@ public abstract class BaseWikiNodeResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			404, wikiNodeResource.getWikiNodeHttpResponse(wikiNode1.getId()));
+
+		wikiNode1 = testBatchEngineDeleteImportTask_addSiteWikiNode();
+
+		testBatchEngineDeleteImportTask_deleteWikiNode(
+			200, wikiNode1.getExternalReferenceCode(), null, "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		wikiNode1 = testBatchEngineDeleteImportTask_addSiteWikiNode();
+		WikiNode wikiNode2 = testBatchEngineDeleteImportTask_addSiteWikiNode();
+
+		testBatchEngineDeleteImportTask_deleteWikiNode(
+			200, wikiNode2.getExternalReferenceCode(), wikiNode1.getId(),
+			"siteId", String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404, wikiNodeResource.getWikiNodeHttpResponse(wikiNode1.getId()));
+		assertHttpResponseStatusCode(
+			200, wikiNodeResource.getWikiNodeHttpResponse(wikiNode2.getId()));
+
+		testBatchEngineDeleteImportTask_deleteWikiNode(
+			200, wikiNode2.getExternalReferenceCode(), wikiNode1.getId(),
+			"siteId", String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404, wikiNodeResource.getWikiNodeHttpResponse(wikiNode2.getId()));
 	}
 
 	protected WikiNode testBatchEngineDeleteImportTask_addWikiNode()
 		throws Exception {
 
 		return testDeleteWikiNode_addWikiNode();
+	}
+
+	protected WikiNode testBatchEngineDeleteImportTask_addSiteWikiNode()
+		throws Exception {
+
+		return testDeleteSiteWikiNodeByExternalReferenceCode_addWikiNode();
 	}
 
 	protected void testBatchEngineDeleteImportTask_deleteWikiNode(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
@@ -1729,12 +1729,43 @@ public abstract class BaseWikiPageResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			404, wikiPageResource.getWikiPageHttpResponse(wikiPage1.getId()));
+
+		wikiPage1 = testBatchEngineDeleteImportTask_addSiteWikiPage();
+
+		testBatchEngineDeleteImportTask_deleteWikiPage(
+			200, wikiPage1.getExternalReferenceCode(), null, "siteId",
+			String.valueOf(testGroup.getGroupId()));
+
+		wikiPage1 = testBatchEngineDeleteImportTask_addSiteWikiPage();
+		WikiPage wikiPage2 = testBatchEngineDeleteImportTask_addSiteWikiPage();
+
+		testBatchEngineDeleteImportTask_deleteWikiPage(
+			200, wikiPage2.getExternalReferenceCode(), wikiPage1.getId(),
+			"siteId", String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404, wikiPageResource.getWikiPageHttpResponse(wikiPage1.getId()));
+		assertHttpResponseStatusCode(
+			200, wikiPageResource.getWikiPageHttpResponse(wikiPage2.getId()));
+
+		testBatchEngineDeleteImportTask_deleteWikiPage(
+			200, wikiPage2.getExternalReferenceCode(), wikiPage1.getId(),
+			"siteId", String.valueOf(testGroup.getGroupId()));
+
+		assertHttpResponseStatusCode(
+			404, wikiPageResource.getWikiPageHttpResponse(wikiPage2.getId()));
 	}
 
 	protected WikiPage testBatchEngineDeleteImportTask_addWikiPage()
 		throws Exception {
 
 		return testDeleteWikiPage_addWikiPage();
+	}
+
+	protected WikiPage testBatchEngineDeleteImportTask_addSiteWikiPage()
+		throws Exception {
+
+		return testDeleteSiteWikiPageByExternalReferenceCode_addWikiPage();
 	}
 
 	protected void testBatchEngineDeleteImportTask_deleteWikiPage(

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseAssetLibraryTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseAssetLibraryTestEntityResourceImpl.java
@@ -240,8 +240,40 @@ public abstract class BaseAssetLibraryTestEntityResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
+		UnsafeFunction
+			<AssetLibraryTestEntity, AssetLibraryTestEntity, Exception>
+				assetLibraryTestEntityUnsafeFunction =
+					assetLibraryTestEntity -> {
+						if (parameters.containsKey("assetLibraryId")) {
+							deleteAssetLibraryAssetLibraryTestEntityByExternalReferenceCode(
+								(Long)parameters.get("assetLibraryId"),
+								assetLibraryTestEntity.
+									getExternalReferenceCode());
+
+							return assetLibraryTestEntity;
+						}
+
+						throw new UnsupportedOperationException(
+							"Unable to delete by external reference code or ID");
+					};
+
+		if (contextBatchUnsafeBiConsumer != null) {
+			contextBatchUnsafeBiConsumer.accept(
+				assetLibraryTestEntities, assetLibraryTestEntityUnsafeFunction);
+		}
+		else if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				assetLibraryTestEntities,
+				assetLibraryTestEntityUnsafeFunction::apply);
+		}
+		else {
+			for (AssetLibraryTestEntity assetLibraryTestEntity :
+					assetLibraryTestEntities) {
+
+				assetLibraryTestEntityUnsafeFunction.apply(
+					assetLibraryTestEntity);
+			}
+		}
 	}
 
 	public Set<String> getAvailableCreateStrategies() {

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseScopedTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseScopedTestEntityResourceImpl.java
@@ -957,8 +957,40 @@ public abstract class BaseScopedTestEntityResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
+		UnsafeFunction<ScopedTestEntity, ScopedTestEntity, Exception>
+			scopedTestEntityUnsafeFunction = scopedTestEntity -> {
+				if (parameters.containsKey("assetLibraryId")) {
+					deleteAssetLibraryScopedTestEntityByExternalReferenceCode(
+						(Long)parameters.get("assetLibraryId"),
+						scopedTestEntity.getExternalReferenceCode());
+
+					return scopedTestEntity;
+				}
+				else if (parameters.containsKey("siteId")) {
+					deleteSiteScopedTestEntityByExternalReferenceCode(
+						(Long)parameters.get("siteId"),
+						scopedTestEntity.getExternalReferenceCode());
+
+					return scopedTestEntity;
+				}
+
+				throw new UnsupportedOperationException(
+					"Unable to delete by external reference code or ID");
+			};
+
+		if (contextBatchUnsafeBiConsumer != null) {
+			contextBatchUnsafeBiConsumer.accept(
+				scopedTestEntities, scopedTestEntityUnsafeFunction);
+		}
+		else if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				scopedTestEntities, scopedTestEntityUnsafeFunction::apply);
+		}
+		else {
+			for (ScopedTestEntity scopedTestEntity : scopedTestEntities) {
+				scopedTestEntityUnsafeFunction.apply(scopedTestEntity);
+			}
+		}
 	}
 
 	public Set<String> getAvailableCreateStrategies() {

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseSiteTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseSiteTestEntityResourceImpl.java
@@ -998,8 +998,33 @@ public abstract class BaseSiteTestEntityResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
+		UnsafeFunction<SiteTestEntity, SiteTestEntity, Exception>
+			siteTestEntityUnsafeFunction = siteTestEntity -> {
+				if (parameters.containsKey("siteId")) {
+					deleteSiteSiteTestEntityByExternalReferenceCode(
+						(Long)parameters.get("siteId"),
+						siteTestEntity.getExternalReferenceCode());
+
+					return siteTestEntity;
+				}
+
+				throw new UnsupportedOperationException(
+					"Unable to delete by external reference code or ID");
+			};
+
+		if (contextBatchUnsafeBiConsumer != null) {
+			contextBatchUnsafeBiConsumer.accept(
+				siteTestEntities, siteTestEntityUnsafeFunction);
+		}
+		else if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				siteTestEntities, siteTestEntityUnsafeFunction::apply);
+		}
+		else {
+			for (SiteTestEntity siteTestEntity : siteTestEntities) {
+				siteTestEntityUnsafeFunction.apply(siteTestEntity);
+			}
+		}
 	}
 
 	public Set<String> getAvailableCreateStrategies() {

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseAssetLibraryTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseAssetLibraryTestEntityResourceTestCase.java
@@ -16,6 +16,9 @@ import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
+import com.liferay.headless.batch.engine.client.dto.v1_0.ImportTask;
+import com.liferay.headless.batch.engine.client.http.HttpInvoker.HttpResponse;
+import com.liferay.headless.batch.engine.client.resource.v1_0.ImportTaskResource;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -128,6 +131,16 @@ public abstract class BaseAssetLibraryTestEntityResourceTestCase {
 			testCompany.getCompanyId());
 
 		assetLibraryTestEntityResource = AssetLibraryTestEntityResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(), 8080, "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+
+		importTaskResource = ImportTaskResource.builder(
 		).authentication(
 			_testCompanyAdminUser.getEmailAddress(),
 			PropsValues.DEFAULT_ADMIN_PASSWORD
@@ -423,7 +436,51 @@ public abstract class BaseAssetLibraryTestEntityResourceTestCase {
 
 	@Test
 	public void testBatchEngineDeleteImportTask() throws Exception {
-		Assert.assertTrue(true);
+		AssetLibraryTestEntity assetLibraryTestEntity1 =
+			testBatchEngineDeleteImportTask_addAssetLibraryAssetLibraryTestEntity();
+
+		testBatchEngineDeleteImportTask_deleteAssetLibraryTestEntity(
+			200, assetLibraryTestEntity1.getExternalReferenceCode(),
+			"assetLibraryId", String.valueOf(testDepotEntryGroup.getGroupId()));
+	}
+
+	protected AssetLibraryTestEntity
+			testBatchEngineDeleteImportTask_addAssetLibraryAssetLibraryTestEntity()
+		throws Exception {
+
+		return testDeleteAssetLibraryAssetLibraryTestEntityByExternalReferenceCode_addAssetLibraryTestEntity();
+	}
+
+	protected void testBatchEngineDeleteImportTask_deleteAssetLibraryTestEntity(
+			int expectedStatusCode, String externalReferenceCode,
+			String... parameters)
+		throws Exception {
+
+		ImportTaskResource importTaskResource = ImportTaskResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(), 8080, "http"
+		).parameters(
+			parameters
+		).build();
+
+		HttpResponse httpResponse =
+			importTaskResource.deleteImportTaskHttpResponse(
+				"com.liferay.portal.tools.rest.builder.test.dto.v1_0.AssetLibraryTestEntity",
+				null, null, null, null,
+				JSONUtil.putAll(
+					JSONUtil.put(
+						"externalReferenceCode", () -> externalReferenceCode)));
+
+		Assert.assertEquals(expectedStatusCode, httpResponse.getStatusCode());
+
+		if (expectedStatusCode == 200) {
+			waitForFinish(
+				"COMPLETED",
+				JSONFactoryUtil.createJSONObject(httpResponse.getContent()));
+		}
 	}
 
 	protected AssetLibraryTestEntity
@@ -1136,7 +1193,30 @@ public abstract class BaseAssetLibraryTestEntityResourceTestCase {
 		return randomAssetLibraryTestEntity();
 	}
 
+	protected final JSONObject waitForFinish(
+			String expectedExecuteStatus, JSONObject jsonObject)
+		throws Exception {
+
+		while (true) {
+			ImportTask importTask = importTaskResource.getImportTask(
+				jsonObject.getLong("id"));
+
+			ImportTask.ExecuteStatus executeStatus =
+				importTask.getExecuteStatus();
+
+			if (StringUtil.equals(executeStatus.getValue(), "COMPLETED") ||
+				StringUtil.equals(executeStatus.getValue(), "FAILED")) {
+
+				Assert.assertEquals(
+					expectedExecuteStatus, executeStatus.getValue());
+
+				return jsonObject;
+			}
+		}
+	}
+
 	protected AssetLibraryTestEntityResource assetLibraryTestEntityResource;
+	protected ImportTaskResource importTaskResource;
 	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
 	protected com.liferay.portal.kernel.model.Company testCompany;
 	protected DepotEntry irrelevantDepotEntry;

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseScopedTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseScopedTestEntityResourceTestCase.java
@@ -16,6 +16,9 @@ import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
+import com.liferay.headless.batch.engine.client.dto.v1_0.ImportTask;
+import com.liferay.headless.batch.engine.client.http.HttpInvoker.HttpResponse;
+import com.liferay.headless.batch.engine.client.resource.v1_0.ImportTaskResource;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -132,6 +135,16 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 			testCompany.getCompanyId());
 
 		scopedTestEntityResource = ScopedTestEntityResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(), 8080, "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+
+		importTaskResource = ImportTaskResource.builder(
 		).authentication(
 			_testCompanyAdminUser.getEmailAddress(),
 			PropsValues.DEFAULT_ADMIN_PASSWORD
@@ -1491,7 +1504,65 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 
 	@Test
 	public void testBatchEngineDeleteImportTask() throws Exception {
-		Assert.assertTrue(true);
+		ScopedTestEntity scopedTestEntity1 =
+			testBatchEngineDeleteImportTask_addAssetLibraryScopedTestEntity();
+
+		testBatchEngineDeleteImportTask_deleteScopedTestEntity(
+			200, scopedTestEntity1.getExternalReferenceCode(), "assetLibraryId",
+			String.valueOf(testDepotEntryGroup.getGroupId()));
+
+		scopedTestEntity1 =
+			testBatchEngineDeleteImportTask_addSiteScopedTestEntity();
+
+		testBatchEngineDeleteImportTask_deleteScopedTestEntity(
+			200, scopedTestEntity1.getExternalReferenceCode(), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+	}
+
+	protected ScopedTestEntity
+			testBatchEngineDeleteImportTask_addAssetLibraryScopedTestEntity()
+		throws Exception {
+
+		return testDeleteAssetLibraryScopedTestEntityByExternalReferenceCode_addScopedTestEntity();
+	}
+
+	protected ScopedTestEntity
+			testBatchEngineDeleteImportTask_addSiteScopedTestEntity()
+		throws Exception {
+
+		return testDeleteSiteScopedTestEntityByExternalReferenceCode_addScopedTestEntity();
+	}
+
+	protected void testBatchEngineDeleteImportTask_deleteScopedTestEntity(
+			int expectedStatusCode, String externalReferenceCode,
+			String... parameters)
+		throws Exception {
+
+		ImportTaskResource importTaskResource = ImportTaskResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(), 8080, "http"
+		).parameters(
+			parameters
+		).build();
+
+		HttpResponse httpResponse =
+			importTaskResource.deleteImportTaskHttpResponse(
+				"com.liferay.portal.tools.rest.builder.test.dto.v1_0.ScopedTestEntity",
+				null, null, null, null,
+				JSONUtil.putAll(
+					JSONUtil.put(
+						"externalReferenceCode", () -> externalReferenceCode)));
+
+		Assert.assertEquals(expectedStatusCode, httpResponse.getStatusCode());
+
+		if (expectedStatusCode == 200) {
+			waitForFinish(
+				"COMPLETED",
+				JSONFactoryUtil.createJSONObject(httpResponse.getContent()));
+		}
 	}
 
 	protected ScopedTestEntity
@@ -2397,7 +2468,30 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 		return randomScopedTestEntity();
 	}
 
+	protected final JSONObject waitForFinish(
+			String expectedExecuteStatus, JSONObject jsonObject)
+		throws Exception {
+
+		while (true) {
+			ImportTask importTask = importTaskResource.getImportTask(
+				jsonObject.getLong("id"));
+
+			ImportTask.ExecuteStatus executeStatus =
+				importTask.getExecuteStatus();
+
+			if (StringUtil.equals(executeStatus.getValue(), "COMPLETED") ||
+				StringUtil.equals(executeStatus.getValue(), "FAILED")) {
+
+				Assert.assertEquals(
+					expectedExecuteStatus, executeStatus.getValue());
+
+				return jsonObject;
+			}
+		}
+	}
+
 	protected ScopedTestEntityResource scopedTestEntityResource;
+	protected ImportTaskResource importTaskResource;
 	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
 	protected com.liferay.portal.kernel.model.Company testCompany;
 	protected DepotEntry irrelevantDepotEntry;

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseSiteTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseSiteTestEntityResourceTestCase.java
@@ -13,6 +13,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.headless.batch.engine.client.dto.v1_0.ImportTask;
+import com.liferay.headless.batch.engine.client.http.HttpInvoker.HttpResponse;
+import com.liferay.headless.batch.engine.client.resource.v1_0.ImportTaskResource;
 import com.liferay.oauth2.provider.scope.ScopeChecker;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -132,6 +135,16 @@ public abstract class BaseSiteTestEntityResourceTestCase {
 			testCompany.getCompanyId());
 
 		siteTestEntityResource = SiteTestEntityResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(), 8080, "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+
+		importTaskResource = ImportTaskResource.builder(
 		).authentication(
 			_testCompanyAdminUser.getEmailAddress(),
 			PropsValues.DEFAULT_ADMIN_PASSWORD
@@ -1341,7 +1354,51 @@ public abstract class BaseSiteTestEntityResourceTestCase {
 
 	@Test
 	public void testBatchEngineDeleteImportTask() throws Exception {
-		Assert.assertTrue(true);
+		SiteTestEntity siteTestEntity1 =
+			testBatchEngineDeleteImportTask_addSiteSiteTestEntity();
+
+		testBatchEngineDeleteImportTask_deleteSiteTestEntity(
+			200, siteTestEntity1.getExternalReferenceCode(), "siteId",
+			String.valueOf(testGroup.getGroupId()));
+	}
+
+	protected SiteTestEntity
+			testBatchEngineDeleteImportTask_addSiteSiteTestEntity()
+		throws Exception {
+
+		return testDeleteSiteSiteTestEntityByExternalReferenceCode_addSiteTestEntity();
+	}
+
+	protected void testBatchEngineDeleteImportTask_deleteSiteTestEntity(
+			int expectedStatusCode, String externalReferenceCode,
+			String... parameters)
+		throws Exception {
+
+		ImportTaskResource importTaskResource = ImportTaskResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(), 8080, "http"
+		).parameters(
+			parameters
+		).build();
+
+		HttpResponse httpResponse =
+			importTaskResource.deleteImportTaskHttpResponse(
+				"com.liferay.portal.tools.rest.builder.test.dto.v1_0.SiteTestEntity",
+				null, null, null, null,
+				JSONUtil.putAll(
+					JSONUtil.put(
+						"externalReferenceCode", () -> externalReferenceCode)));
+
+		Assert.assertEquals(expectedStatusCode, httpResponse.getStatusCode());
+
+		if (expectedStatusCode == 200) {
+			waitForFinish(
+				"COMPLETED",
+				JSONFactoryUtil.createJSONObject(httpResponse.getContent()));
+		}
 	}
 
 	protected SiteTestEntity testGraphQLSiteSiteTestEntity_addSiteTestEntity()
@@ -2192,7 +2249,30 @@ public abstract class BaseSiteTestEntityResourceTestCase {
 		return siteTestEntity;
 	}
 
+	protected final JSONObject waitForFinish(
+			String expectedExecuteStatus, JSONObject jsonObject)
+		throws Exception {
+
+		while (true) {
+			ImportTask importTask = importTaskResource.getImportTask(
+				jsonObject.getLong("id"));
+
+			ImportTask.ExecuteStatus executeStatus =
+				importTask.getExecuteStatus();
+
+			if (StringUtil.equals(executeStatus.getValue(), "COMPLETED") ||
+				StringUtil.equals(executeStatus.getValue(), "FAILED")) {
+
+				Assert.assertEquals(
+					expectedExecuteStatus, executeStatus.getValue());
+
+				return jsonObject;
+			}
+		}
+	}
+
 	protected SiteTestEntityResource siteTestEntityResource;
+	protected ImportTaskResource importTaskResource;
 	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
 	protected SiteTestEntityResource permissionsSiteTestEntityResource;
 	protected com.liferay.portal.kernel.model.Company testCompany;

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -1164,6 +1164,17 @@ public class FreeMarkerTool {
 			configYAML, propertyName, schema, schemas);
 	}
 
+	public boolean isExternalReferenceCodeExclusiveMethod(
+		String httpMethod, JavaMethodSignature javaMethodSignature) {
+
+		return StringUtil.equals(
+			StringBundler.concat(
+				httpMethod,
+				GetterUtil.getString(javaMethodSignature.getParentSchemaName()),
+				GetterUtil.getString(javaMethodSignature.getSchemaName())),
+			javaMethodSignature.getMethodName());
+	}
+
 	public boolean isExternalReferenceCodeMethod(
 		String httpMethod, JavaMethodSignature javaMethodSignature) {
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -174,10 +174,14 @@ public abstract class Base${schemaName}ResourceImpl
 			</#if>
 		<#elseif stringUtil.equals(javaMethodSignature.methodName, "deleteAssetLibrary" + schemaName)>
 			<#assign deleteAssetLibraryBatchJavaMethodSignature = javaMethodSignature />
+		<#elseif stringUtil.equals(javaMethodSignature.methodName, "deleteAssetLibrary" + schemaName + "ByExternalReferenceCode")>
+			<#assign deleteAssetLibraryByExternalReferenceCodeBatchJavaMethodSignature = javaMethodSignature />
 		<#elseif stringUtil.equals(javaMethodSignature.methodName, "delete" + schemaName) && !freeMarkerTool.isExternalReferenceCodeMethod("delete", javaMethodSignature)>
 			<#assign deleteByIdBatchJavaMethodSignature = javaMethodSignature />
 		<#elseif stringUtil.equals(javaMethodSignature.methodName, "deleteSite" + schemaName)>
 			<#assign deleteSiteBatchJavaMethodSignature = javaMethodSignature />
+		<#elseif stringUtil.equals(javaMethodSignature.methodName, "deleteSite" + schemaName + "ByExternalReferenceCode")>
+			<#assign deleteSiteByExternalReferenceCodeBatchJavaMethodSignature = javaMethodSignature />
 		<#elseif stringUtil.equals(javaMethodSignature.methodName, "get" + schemaName)>
 			<#assign getByIdJavaMethodSignature = javaMethodSignature />
 		<#elseif stringUtil.equals(javaMethodSignature.methodName, "get" + parentSchemaName + schemaNames + "Page")>
@@ -1013,17 +1017,19 @@ public abstract class Base${schemaName}ResourceImpl
 		public void delete(Collection<${javaDataType}> ${schemaVarNames}, Map<String, Serializable> parameters) throws Exception {
 			<#assign
 				useDeleteAssetLibrary = deleteAssetLibraryBatchJavaMethodSignature?? && properties?keys?seq_contains("externalReferenceCode")
+				useDeleteAssetLibraryByExternalReferenceCode = deleteAssetLibraryByExternalReferenceCodeBatchJavaMethodSignature?? && properties?keys?seq_contains("externalReferenceCode")
 				useDeleteByExternalReferenceCode = deleteByExternalReferenceCodeBatchJavaMethodSignature?? && properties?keys?seq_contains("externalReferenceCode")
 				useDeleteById = deleteByIdBatchJavaMethodSignature?? && (properties?keys?seq_contains("id") || properties?keys?seq_contains(schemaVarName + "Id"))
 				useDeleteSite = deleteSiteBatchJavaMethodSignature?? && properties?keys?seq_contains("externalReferenceCode")
+				useDeleteSiteByExternalReferenceCode = deleteSiteByExternalReferenceCodeBatchJavaMethodSignature?? && properties?keys?seq_contains("externalReferenceCode")
 			/>
 
-			<#if useDeleteAssetLibrary || useDeleteByExternalReferenceCode || useDeleteById || useDeleteSite>
+			<#if useDeleteAssetLibrary || useDeleteByExternalReferenceCode || useDeleteById || useDeleteSite || useDeleteSiteByExternalReferenceCode>
 				UnsafeFunction<${javaDataType}, ${javaDataType}, Exception> ${schemaVarName}UnsafeFunction = ${schemaVarName} -> {
 					<#if useDeleteById>
 						<#assign getterMethodName = properties?keys?seq_contains("id")?then("getId", "get" + schemaName + "Id") />
 
-						<#if useDeleteAssetLibrary || useDeleteByExternalReferenceCode || useDeleteSite>
+						<#if useDeleteAssetLibrary || useDeleteByExternalReferenceCode || useDeleteSite || useDeleteSiteByExternalReferenceCode>
 							if (${schemaVarName}.${getterMethodName}() != null) {
 								try {
 						</#if>
@@ -1045,7 +1051,7 @@ public abstract class Base${schemaName}ResourceImpl
 
 						return ${schemaVarName};
 
-						<#if useDeleteAssetLibrary || useDeleteByExternalReferenceCode || useDeleteSite>
+						<#if useDeleteAssetLibrary || useDeleteAssetLibraryByExternalReferenceCode || useDeleteByExternalReferenceCode || useDeleteSite || useDeleteSiteByExternalReferenceCode>
 							}
 							catch (Exception exception) {
 								if (${schemaVarName}.getExternalReferenceCode() != null) {
@@ -1066,6 +1072,16 @@ public abstract class Base${schemaName}ResourceImpl
 											}
 										</#if>
 
+										<#if useDeleteAssetLibraryByExternalReferenceCode>
+											if (parameters.containsKey("assetLibraryId")) {
+												${deleteAssetLibraryByExternalReferenceCodeBatchJavaMethodSignature.methodName}(
+													<@getDeleteBatchJavaMethodParameters javaMethodParameters = deleteAssetLibraryByExternalReferenceCodeBatchJavaMethodSignature.javaMethodParameters />
+												);
+
+												return ${schemaVarName};
+											}
+										</#if>
+
 										<#if useDeleteSite>
 											if (parameters.containsKey("siteExternalReferenceCode")) {
 												${deleteSiteBatchJavaMethodSignature.methodName}(
@@ -1076,9 +1092,20 @@ public abstract class Base${schemaName}ResourceImpl
 											}
 										</#if>
 
+										<#if useDeleteSiteByExternalReferenceCode>
+											if (parameters.containsKey("siteId")) {
+												${deleteSiteByExternalReferenceCodeBatchJavaMethodSignature.methodName}(
+													<@getDeleteBatchJavaMethodParameters javaMethodParameters = deleteSiteByExternalReferenceCodeBatchJavaMethodSignature.javaMethodParameters />
+												);
+
+												return ${schemaVarName};
+											}
+										</#if>
+
 										}
+									}
 									</#if>
-								}
+							}
 						</#if>
 					</#if>
 
@@ -1094,8 +1121,20 @@ public abstract class Base${schemaName}ResourceImpl
 						}
 					</#if>
 
+					<#if useDeleteAssetLibraryByExternalReferenceCode>
+						<#if useDeleteAssetLibrary || useDeleteById >else</#if>
+
+						if (parameters.containsKey("assetLibraryId")) {
+							${deleteAssetLibraryByExternalReferenceCodeBatchJavaMethodSignature.methodName}(
+								<@getDeleteBatchJavaMethodParameters javaMethodParameters = deleteAssetLibraryByExternalReferenceCodeBatchJavaMethodSignature.javaMethodParameters />
+							);
+
+							return ${schemaVarName};
+						}
+					</#if>
+
 					<#if useDeleteByExternalReferenceCode>
-						<#if useDeleteAssetLibrary || useDeleteById>else</#if>
+						<#if useDeleteAssetLibrary || useDeleteAssetLibraryByExternalReferenceCode || useDeleteById>else</#if>
 
 						if (${schemaVarName}.getExternalReferenceCode() != null) {
 							${deleteByExternalReferenceCodeBatchJavaMethodSignature.methodName}(${schemaVarName}.getExternalReferenceCode());
@@ -1105,7 +1144,7 @@ public abstract class Base${schemaName}ResourceImpl
 					</#if>
 
 					<#if useDeleteSite>
-						<#if useDeleteAssetLibrary || useDeleteByExternalReferenceCode || useDeleteById>else</#if>
+						<#if useDeleteAssetLibrary || useDeleteAssetLibraryByExternalReferenceCode || useDeleteByExternalReferenceCode || useDeleteById>else</#if>
 
 						if (parameters.containsKey("siteExternalReferenceCode")) {
 							${deleteSiteBatchJavaMethodSignature.methodName}(
@@ -1116,7 +1155,19 @@ public abstract class Base${schemaName}ResourceImpl
 						}
 					</#if>
 
-					<#if useDeleteAssetLibrary || useDeleteByExternalReferenceCode || useDeleteSite>
+					<#if useDeleteSiteByExternalReferenceCode>
+						<#if useDeleteAssetLibrary || useDeleteAssetLibraryByExternalReferenceCode || useDeleteByExternalReferenceCode || useDeleteById || useDeleteSite>else</#if>
+
+						if (parameters.containsKey("siteId")) {
+							${deleteSiteByExternalReferenceCodeBatchJavaMethodSignature.methodName}(
+								<@getDeleteBatchJavaMethodParameters javaMethodParameters = deleteSiteByExternalReferenceCodeBatchJavaMethodSignature.javaMethodParameters />
+							);
+
+							return ${schemaVarName};
+						}
+					</#if>
+
+					<#if useDeleteAssetLibrary || useDeleteAssetLibraryByExternalReferenceCode || useDeleteByExternalReferenceCode || useDeleteSite || useDeleteSiteByExternalReferenceCode>
 						throw new UnsupportedOperationException("Unable to delete by external reference code or ID");
 					</#if>
 				};

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -172,16 +172,12 @@ public abstract class Base${schemaName}ResourceImpl
 			<#else>
 				<#assign putByExternalReferenceCodeBatchJavaMethodSignature = javaMethodSignature />
 			</#if>
-		<#elseif stringUtil.equals(javaMethodSignature.methodName, "deleteAssetLibrary" + schemaName)>
+		<#elseif stringUtil.equals(javaMethodSignature.methodName, "deleteAssetLibrary" + schemaName) || stringUtil.equals(javaMethodSignature.methodName, "deleteAssetLibrary" + schemaName + "ByExternalReferenceCode")>
 			<#assign deleteAssetLibraryBatchJavaMethodSignature = javaMethodSignature />
-		<#elseif stringUtil.equals(javaMethodSignature.methodName, "deleteAssetLibrary" + schemaName + "ByExternalReferenceCode")>
-			<#assign deleteAssetLibraryByExternalReferenceCodeBatchJavaMethodSignature = javaMethodSignature />
 		<#elseif stringUtil.equals(javaMethodSignature.methodName, "delete" + schemaName) && !freeMarkerTool.isExternalReferenceCodeMethod("delete", javaMethodSignature)>
 			<#assign deleteByIdBatchJavaMethodSignature = javaMethodSignature />
-		<#elseif stringUtil.equals(javaMethodSignature.methodName, "deleteSite" + schemaName)>
+		<#elseif stringUtil.equals(javaMethodSignature.methodName, "deleteSite" + schemaName) || stringUtil.equals(javaMethodSignature.methodName, "deleteSite" + schemaName + "ByExternalReferenceCode")>
 			<#assign deleteSiteBatchJavaMethodSignature = javaMethodSignature />
-		<#elseif stringUtil.equals(javaMethodSignature.methodName, "deleteSite" + schemaName + "ByExternalReferenceCode")>
-			<#assign deleteSiteByExternalReferenceCodeBatchJavaMethodSignature = javaMethodSignature />
 		<#elseif stringUtil.equals(javaMethodSignature.methodName, "get" + schemaName)>
 			<#assign getByIdJavaMethodSignature = javaMethodSignature />
 		<#elseif stringUtil.equals(javaMethodSignature.methodName, "get" + parentSchemaName + schemaNames + "Page")>
@@ -1017,19 +1013,17 @@ public abstract class Base${schemaName}ResourceImpl
 		public void delete(Collection<${javaDataType}> ${schemaVarNames}, Map<String, Serializable> parameters) throws Exception {
 			<#assign
 				useDeleteAssetLibrary = deleteAssetLibraryBatchJavaMethodSignature?? && properties?keys?seq_contains("externalReferenceCode")
-				useDeleteAssetLibraryByExternalReferenceCode = deleteAssetLibraryByExternalReferenceCodeBatchJavaMethodSignature?? && properties?keys?seq_contains("externalReferenceCode")
 				useDeleteByExternalReferenceCode = deleteByExternalReferenceCodeBatchJavaMethodSignature?? && properties?keys?seq_contains("externalReferenceCode")
 				useDeleteById = deleteByIdBatchJavaMethodSignature?? && (properties?keys?seq_contains("id") || properties?keys?seq_contains(schemaVarName + "Id"))
 				useDeleteSite = deleteSiteBatchJavaMethodSignature?? && properties?keys?seq_contains("externalReferenceCode")
-				useDeleteSiteByExternalReferenceCode = deleteSiteByExternalReferenceCodeBatchJavaMethodSignature?? && properties?keys?seq_contains("externalReferenceCode")
 			/>
 
-			<#if useDeleteAssetLibrary || useDeleteByExternalReferenceCode || useDeleteById || useDeleteSite || useDeleteSiteByExternalReferenceCode>
+			<#if useDeleteAssetLibrary || useDeleteByExternalReferenceCode || useDeleteById || useDeleteSite>
 				UnsafeFunction<${javaDataType}, ${javaDataType}, Exception> ${schemaVarName}UnsafeFunction = ${schemaVarName} -> {
 					<#if useDeleteById>
 						<#assign getterMethodName = properties?keys?seq_contains("id")?then("getId", "get" + schemaName + "Id") />
 
-						<#if useDeleteAssetLibrary || useDeleteByExternalReferenceCode || useDeleteSite || useDeleteSiteByExternalReferenceCode>
+						<#if useDeleteAssetLibrary || useDeleteByExternalReferenceCode || useDeleteSite>
 							if (${schemaVarName}.${getterMethodName}() != null) {
 								try {
 						</#if>
@@ -1051,7 +1045,7 @@ public abstract class Base${schemaName}ResourceImpl
 
 						return ${schemaVarName};
 
-						<#if useDeleteAssetLibrary || useDeleteAssetLibraryByExternalReferenceCode || useDeleteByExternalReferenceCode || useDeleteSite || useDeleteSiteByExternalReferenceCode>
+						<#if useDeleteAssetLibrary || useDeleteByExternalReferenceCode || useDeleteSite>
 							}
 							catch (Exception exception) {
 								if (${schemaVarName}.getExternalReferenceCode() != null) {
@@ -1062,8 +1056,11 @@ public abstract class Base${schemaName}ResourceImpl
 											}
 										}
 									<#else>
+
 										<#if useDeleteAssetLibrary>
-											if (parameters.containsKey("assetLibraryExternalReferenceCode")) {
+											<#assign assetLibraryParameter = freeMarkerTool.isExternalReferenceCodeExclusiveMethod("delete", deleteAssetLibraryBatchJavaMethodSignature)?then("assetLibraryExternalReferenceCode", "assetLibraryId") />
+
+											if (parameters.containsKey("${assetLibraryParameter}")) {
 												${deleteAssetLibraryBatchJavaMethodSignature.methodName}(
 													<@getDeleteBatchJavaMethodParameters javaMethodParameters = deleteAssetLibraryBatchJavaMethodSignature.javaMethodParameters />
 												);
@@ -1072,30 +1069,12 @@ public abstract class Base${schemaName}ResourceImpl
 											}
 										</#if>
 
-										<#if useDeleteAssetLibraryByExternalReferenceCode>
-											if (parameters.containsKey("assetLibraryId")) {
-												${deleteAssetLibraryByExternalReferenceCodeBatchJavaMethodSignature.methodName}(
-													<@getDeleteBatchJavaMethodParameters javaMethodParameters = deleteAssetLibraryByExternalReferenceCodeBatchJavaMethodSignature.javaMethodParameters />
-												);
-
-												return ${schemaVarName};
-											}
-										</#if>
-
 										<#if useDeleteSite>
-											if (parameters.containsKey("siteExternalReferenceCode")) {
+											<#assign siteParameter = freeMarkerTool.isExternalReferenceCodeExclusiveMethod("delete", deleteSiteBatchJavaMethodSignature)?then("siteExternalReferenceCode", "siteId") />
+
+											if (parameters.containsKey("${siteParameter}")) {
 												${deleteSiteBatchJavaMethodSignature.methodName}(
 													<@getDeleteBatchJavaMethodParameters javaMethodParameters = deleteSiteBatchJavaMethodSignature.javaMethodParameters />
-												);
-
-												return ${schemaVarName};
-											}
-										</#if>
-
-										<#if useDeleteSiteByExternalReferenceCode>
-											if (parameters.containsKey("siteId")) {
-												${deleteSiteByExternalReferenceCodeBatchJavaMethodSignature.methodName}(
-													<@getDeleteBatchJavaMethodParameters javaMethodParameters = deleteSiteByExternalReferenceCodeBatchJavaMethodSignature.javaMethodParameters />
 												);
 
 												return ${schemaVarName};
@@ -1110,9 +1089,11 @@ public abstract class Base${schemaName}ResourceImpl
 					</#if>
 
 					<#if useDeleteAssetLibrary>
+						<#assign assetLibraryParameter = freeMarkerTool.isExternalReferenceCodeExclusiveMethod("delete", deleteAssetLibraryBatchJavaMethodSignature)?then("assetLibraryExternalReferenceCode", "assetLibraryId") />
+
 						<#if useDeleteById>else</#if>
 
-						if (parameters.containsKey("assetLibraryExternalReferenceCode")) {
+						if (parameters.containsKey("${assetLibraryParameter}")) {
 							${deleteAssetLibraryBatchJavaMethodSignature.methodName}(
 								<@getDeleteBatchJavaMethodParameters javaMethodParameters = deleteAssetLibraryBatchJavaMethodSignature.javaMethodParameters />
 							);
@@ -1121,20 +1102,8 @@ public abstract class Base${schemaName}ResourceImpl
 						}
 					</#if>
 
-					<#if useDeleteAssetLibraryByExternalReferenceCode>
-						<#if useDeleteAssetLibrary || useDeleteById >else</#if>
-
-						if (parameters.containsKey("assetLibraryId")) {
-							${deleteAssetLibraryByExternalReferenceCodeBatchJavaMethodSignature.methodName}(
-								<@getDeleteBatchJavaMethodParameters javaMethodParameters = deleteAssetLibraryByExternalReferenceCodeBatchJavaMethodSignature.javaMethodParameters />
-							);
-
-							return ${schemaVarName};
-						}
-					</#if>
-
 					<#if useDeleteByExternalReferenceCode>
-						<#if useDeleteAssetLibrary || useDeleteAssetLibraryByExternalReferenceCode || useDeleteById>else</#if>
+						<#if useDeleteAssetLibrary || useDeleteById>else</#if>
 
 						if (${schemaVarName}.getExternalReferenceCode() != null) {
 							${deleteByExternalReferenceCodeBatchJavaMethodSignature.methodName}(${schemaVarName}.getExternalReferenceCode());
@@ -1144,9 +1113,11 @@ public abstract class Base${schemaName}ResourceImpl
 					</#if>
 
 					<#if useDeleteSite>
-						<#if useDeleteAssetLibrary || useDeleteAssetLibraryByExternalReferenceCode || useDeleteByExternalReferenceCode || useDeleteById>else</#if>
+						<#if useDeleteAssetLibrary || useDeleteByExternalReferenceCode || useDeleteById>else</#if>
 
-						if (parameters.containsKey("siteExternalReferenceCode")) {
+						<#assign siteParameter = freeMarkerTool.isExternalReferenceCodeExclusiveMethod("delete", deleteSiteBatchJavaMethodSignature)?then("siteExternalReferenceCode", "siteId") />
+
+						if (parameters.containsKey("${siteParameter}")) {
 							${deleteSiteBatchJavaMethodSignature.methodName}(
 								<@getDeleteBatchJavaMethodParameters javaMethodParameters = deleteSiteBatchJavaMethodSignature.javaMethodParameters />
 							);
@@ -1155,19 +1126,7 @@ public abstract class Base${schemaName}ResourceImpl
 						}
 					</#if>
 
-					<#if useDeleteSiteByExternalReferenceCode>
-						<#if useDeleteAssetLibrary || useDeleteAssetLibraryByExternalReferenceCode || useDeleteByExternalReferenceCode || useDeleteById || useDeleteSite>else</#if>
-
-						if (parameters.containsKey("siteId")) {
-							${deleteSiteByExternalReferenceCodeBatchJavaMethodSignature.methodName}(
-								<@getDeleteBatchJavaMethodParameters javaMethodParameters = deleteSiteByExternalReferenceCodeBatchJavaMethodSignature.javaMethodParameters />
-							);
-
-							return ${schemaVarName};
-						}
-					</#if>
-
-					<#if useDeleteAssetLibrary || useDeleteAssetLibraryByExternalReferenceCode || useDeleteByExternalReferenceCode || useDeleteSite || useDeleteSiteByExternalReferenceCode>
+					<#if useDeleteAssetLibrary || useDeleteByExternalReferenceCode || useDeleteSite>
 						throw new UnsupportedOperationException("Unable to delete by external reference code or ID");
 					</#if>
 				};

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -2920,7 +2920,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 				<#if useDeleteAssetLibrary>
 					protected ${schemaName} testBatchEngineDeleteImportTask_addAssetLibrary${schemaName}() throws Exception {
-						<#if (hasExternalReferenceCodeProperty || hasIdProperty) && (freeMarkerTool.hasJavaMethodSignature(javaMethodSignatures, "deleteAssetLibrary" + schemaName) || freeMarkerTool.hasJavaMethodSignature(javaMethodSignatures, "deleteAssetLibrary" + schemaName + "ByExternalReferenceCode"))>
+						<#if hasExternalReferenceCodeProperty || hasIdProperty>
 							return test${deleteAssetLibraryBatchJavaMethodSignature.methodName?cap_first}_add${schemaName}();
 						<#else>
 							throw new UnsupportedOperationException("This method needs to be implemented");
@@ -2930,7 +2930,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 				<#if useDeleteSite>
 					protected ${schemaName} testBatchEngineDeleteImportTask_addSite${schemaName}() throws Exception {
-						<#if (hasExternalReferenceCodeProperty || hasIdProperty) && (freeMarkerTool.hasJavaMethodSignature(javaMethodSignatures, "deleteSite" + schemaName) || freeMarkerTool.hasJavaMethodSignature(javaMethodSignatures, "deleteSite" + schemaName + "ByExternalReferenceCode"))>
+						<#if hasExternalReferenceCodeProperty || hasIdProperty>
 							return test${deleteSiteBatchJavaMethodSignature.methodName?cap_first}_add${schemaName}();
 						<#else>
 							throw new UnsupportedOperationException("This method needs to be implemented");

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -42,9 +42,11 @@ import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 	javaMethodSignatures = freeMarkerTool.getResourceTestCaseJavaMethodSignatures(configYAML, openAPIYAML, schemaName)
 	properties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema, allSchemas)
 	useDeleteAssetLibrary = false
+	useDeleteAssetLibraryByExternalReferenceCode = false
 	useDeleteByExternalReferenceCode = false
 	useDeleteById = false
 	useDeleteSite = false
+	useDeleteSiteByExternalReferenceCode = false
 
 	hasExternalReferenceCodeProperty = properties?keys?seq_contains("externalReferenceCode")
 	hasIdProperty = properties?keys?seq_contains("id") || properties?keys?seq_contains(schemaVarName + "Id")
@@ -55,9 +57,11 @@ import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 		generateDepotEntry = generateDepotEntry || javaMethodSignature.methodName?contains("AssetLibrary")
 		generatePermissionsJavaMethodSignatures = generatePermissionsJavaMethodSignatures + (isPermissionsCompatibleMethod(configYAML, javaMethodSignature, javaMethodSignatures, schema, schemaName)?then([javaMethodSignature], []))
 		useDeleteAssetLibrary = useDeleteAssetLibrary || (hasExternalReferenceCodeProperty && stringUtil.equals(javaMethodSignature.methodName, "deleteAssetLibrary" + schemaName))
+		useDeleteAssetLibraryByExternalReferenceCode = useDeleteAssetLibraryByExternalReferenceCode || (hasExternalReferenceCodeProperty && stringUtil.equals(javaMethodSignature.methodName, "deleteAssetLibrary" + schemaName + "ByExternalReferenceCode"))
 		useDeleteByExternalReferenceCode = useDeleteByExternalReferenceCode || (freeMarkerTool.isExternalReferenceCodeMethod("delete", javaMethodSignature) && hasExternalReferenceCodeProperty && !javaMethodSignature.parentSchemaName?has_content)
 		useDeleteById = useDeleteById || (stringUtil.equals(javaMethodSignature.methodName, "delete" + schemaName) && (freeMarkerTool.hasPathParameter(javaMethodSignature, "id") || freeMarkerTool.hasPathParameter(javaMethodSignature, schemaVarName + "Id")) && hasIdProperty)
 		useDeleteSite = useDeleteSite || (hasExternalReferenceCodeProperty && stringUtil.equals(javaMethodSignature.methodName, "deleteSite" + schemaName))
+		useDeleteSiteByExternalReferenceCode = useDeleteSiteByExternalReferenceCode || (hasExternalReferenceCodeProperty && stringUtil.equals(javaMethodSignature.methodName, "deleteSite" + schemaName + "ByExternalReferenceCode"))
 	/>
 </#list>
 
@@ -2697,8 +2701,25 @@ public abstract class Base${schemaName}ResourceTestCase {
 					</#if>
 				</#if>
 
+				<#if useDeleteAssetLibraryByExternalReferenceCode>
+					<#if !useDeleteAssetLibrary>${schemaName}</#if> ${schemaVarName}1 = testBatchEngineDeleteImportTask_addAssetLibrary${schemaName}();
+
+					testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}1.getExternalReferenceCode(),<#if useDeleteById> null,</#if> "assetLibraryId", String.valueOf(testDepotEntryGroup.getGroupId()));
+
+					<#if getAssetLibraryJavaMethodSignature?has_content>
+						assertHttpResponseStatusCode(
+							404,
+							${schemaVarName}Resource.${getAssetLibraryJavaMethodSignature.methodName}HttpResponse(
+								<@getRESTMethodParameters
+									javaMethodSignature = getAssetLibraryJavaMethodSignature
+									testJavaMethodName = "batchEngineDeleteImportTask"
+									varName = schemaVarName + "1"
+								/>));
+					</#if>
+				</#if>
+
 				<#if useDeleteByExternalReferenceCode>
-					<#if !useDeleteAssetLibrary>${schemaName}</#if> ${schemaVarName}1 = testBatchEngineDeleteImportTask_add${schemaName}();
+					<#if !useDeleteAssetLibrary && !useDeleteAssetLibraryByExternalReferenceCode>${schemaName}</#if> ${schemaVarName}1 = testBatchEngineDeleteImportTask_add${schemaName}();
 
 					testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}1.getExternalReferenceCode()<#if useDeleteById>, null</#if>);
 
@@ -2715,7 +2736,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 				</#if>
 
 				<#if useDeleteById>
-					<#if !useDeleteAssetLibrary && !useDeleteByExternalReferenceCode>${schemaName}</#if> ${schemaVarName}1 = testBatchEngineDeleteImportTask_add${schemaName}();
+					<#if !useDeleteAssetLibrary && !useDeleteAssetLibraryByExternalReferenceCode && !useDeleteByExternalReferenceCode>${schemaName}</#if> ${schemaVarName}1 = testBatchEngineDeleteImportTask_add${schemaName}();
 
 					testBatchEngineDeleteImportTask_delete${schemaName}(200, null, ${schemaVarName}1.${getIdMethodName}());
 
@@ -2732,7 +2753,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 				</#if>
 
 				<#if useDeleteSite>
-					<#if !useDeleteAssetLibrary && !useDeleteByExternalReferenceCode && !useDeleteById>${schemaName}</#if> ${schemaVarName}1 = testBatchEngineDeleteImportTask_addSite${schemaName}();
+					<#if !useDeleteAssetLibrary && !useDeleteAssetLibraryByExternalReferenceCode && !useDeleteByExternalReferenceCode && !useDeleteById>${schemaName}</#if> ${schemaVarName}1 = testBatchEngineDeleteImportTask_addSite${schemaName}();
 
 					testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}1.getExternalReferenceCode(),<#if useDeleteById> null,</#if> "siteExternalReferenceCode", testGroup.getExternalReferenceCode());
 
@@ -2748,7 +2769,24 @@ public abstract class Base${schemaName}ResourceTestCase {
 					</#if>
 				</#if>
 
-				<#if (useDeleteAssetLibrary || useDeleteSite) && useDeleteById>
+				<#if useDeleteSiteByExternalReferenceCode>
+					<#if !useDeleteAssetLibrary && !useDeleteAssetLibraryByExternalReferenceCode && !useDeleteByExternalReferenceCode && !useDeleteById && !useDeleteSite>${schemaName}</#if> ${schemaVarName}1 = testBatchEngineDeleteImportTask_addSite${schemaName}();
+
+					testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}1.getExternalReferenceCode(),<#if useDeleteById> null,</#if> "siteId", String.valueOf(testGroup.getGroupId()));
+
+					<#if getSiteJavaMethodSignature?has_content>
+						assertHttpResponseStatusCode(
+							404,
+							${schemaVarName}Resource.${getSiteJavaMethodSignature.methodName}HttpResponse(
+								<@getRESTMethodParameters
+									javaMethodSignature = getSiteJavaMethodSignature
+									testJavaMethodName = "batchEngineDeleteImportTask"
+									varName = schemaVarName + "1"
+								/>));
+					</#if>
+				</#if>
+
+				<#if (useDeleteAssetLibrary || useDeleteAssetLibraryByExternalReferenceCode || useDeleteSite || useDeleteSiteByExternalReferenceCode) && useDeleteById>
 					<#if useDeleteAssetLibrary>
 						${schemaVarName}1 = testBatchEngineDeleteImportTask_addAssetLibrary${schemaName}();
 						${schemaName} ${schemaVarName}2 = testBatchEngineDeleteImportTask_addAssetLibrary${schemaName}();
@@ -2788,9 +2826,48 @@ public abstract class Base${schemaName}ResourceTestCase {
 						</#if>
 					</#if>
 
+					<#if useDeleteAssetLibraryByExternalReferenceCode>
+						${schemaVarName}1 = testBatchEngineDeleteImportTask_addAssetLibrary${schemaName}();
+						<#if !useDeleteAssetLibrary>${schemaName}</#if> ${schemaVarName}2 = testBatchEngineDeleteImportTask_addAssetLibrary${schemaName}();
+
+						testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}2.getExternalReferenceCode(), ${schemaVarName}1.${getIdMethodName}(), "assetLibraryId", String.valueOf(testDepotEntryGroup.getGroupId()));
+
+						<#if getJavaMethodSignature?has_content>
+							assertHttpResponseStatusCode(
+								404,
+								${schemaVarName}Resource.${getJavaMethodSignature.methodName}HttpResponse(
+									<@getRESTMethodParameters
+										javaMethodSignature = getJavaMethodSignature
+										testJavaMethodName = "batchEngineDeleteImportTask"
+										varName = schemaVarName + "1"
+									/>));
+							assertHttpResponseStatusCode(
+								200,
+								${schemaVarName}Resource.${getJavaMethodSignature.methodName}HttpResponse(
+									<@getRESTMethodParameters
+										javaMethodSignature = getJavaMethodSignature
+										testJavaMethodName = "batchEngineDeleteImportTask"
+										varName = schemaVarName + "2"
+									/>));
+						</#if>
+
+						testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}2.getExternalReferenceCode(), ${schemaVarName}1.${getIdMethodName}(), "assetLibraryId", String.valueOf(testDepotEntryGroup.getGroupId()));
+
+						<#if getJavaMethodSignature?has_content>
+							assertHttpResponseStatusCode(
+								404,
+								${schemaVarName}Resource.${getJavaMethodSignature.methodName}HttpResponse(
+									<@getRESTMethodParameters
+										javaMethodSignature = getJavaMethodSignature
+										testJavaMethodName = "batchEngineDeleteImportTask"
+										varName = schemaVarName + "2"
+									/>));
+						</#if>
+					</#if>
+
 					<#if useDeleteSite>
 						${schemaVarName}1 = testBatchEngineDeleteImportTask_addSite${schemaName}();
-						<#if !useDeleteAssetLibrary>${schemaName}</#if> ${schemaVarName}2 = testBatchEngineDeleteImportTask_addSite${schemaName}();
+						<#if !useDeleteAssetLibrary && !useDeleteAssetLibraryByExternalReferenceCode>${schemaName}</#if> ${schemaVarName}2 = testBatchEngineDeleteImportTask_addSite${schemaName}();
 
 						testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}2.getExternalReferenceCode(), ${schemaVarName}1.${getIdMethodName}(), "siteExternalReferenceCode", testGroup.getExternalReferenceCode());
 
@@ -2814,6 +2891,45 @@ public abstract class Base${schemaName}ResourceTestCase {
 						</#if>
 
 						testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}2.getExternalReferenceCode(), ${schemaVarName}1.${getIdMethodName}(), "siteExternalReferenceCode", testGroup.getExternalReferenceCode());
+
+						<#if getJavaMethodSignature?has_content>
+							assertHttpResponseStatusCode(
+								404,
+								${schemaVarName}Resource.${getJavaMethodSignature.methodName}HttpResponse(
+									<@getRESTMethodParameters
+										javaMethodSignature = getJavaMethodSignature
+										testJavaMethodName = "batchEngineDeleteImportTask"
+										varName = schemaVarName + "2"
+									/>));
+						</#if>
+					</#if>
+
+					<#if useDeleteSiteByExternalReferenceCode>
+						${schemaVarName}1 = testBatchEngineDeleteImportTask_addSite${schemaName}();
+						<#if !useDeleteAssetLibrary && !useDeleteAssetLibraryByExternalReferenceCode && !useDeleteSite>${schemaName}</#if> ${schemaVarName}2 = testBatchEngineDeleteImportTask_addSite${schemaName}();
+
+						testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}2.getExternalReferenceCode(), ${schemaVarName}1.${getIdMethodName}(), "siteId", String.valueOf(testGroup.getGroupId()));
+
+						<#if getJavaMethodSignature?has_content>
+							assertHttpResponseStatusCode(
+								404,
+								${schemaVarName}Resource.${getJavaMethodSignature.methodName}HttpResponse(
+									<@getRESTMethodParameters
+										javaMethodSignature = getJavaMethodSignature
+										testJavaMethodName = "batchEngineDeleteImportTask"
+										varName = schemaVarName + "1"
+									/>));
+							assertHttpResponseStatusCode(
+								200,
+								${schemaVarName}Resource.${getJavaMethodSignature.methodName}HttpResponse(
+									<@getRESTMethodParameters
+										javaMethodSignature = getJavaMethodSignature
+										testJavaMethodName = "batchEngineDeleteImportTask"
+										varName = schemaVarName + "2"
+									/>));
+						</#if>
+
+						testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}2.getExternalReferenceCode(), ${schemaVarName}1.${getIdMethodName}(), "siteId", String.valueOf(testGroup.getGroupId()));
 
 						<#if getJavaMethodSignature?has_content>
 							assertHttpResponseStatusCode(
@@ -2906,10 +3022,30 @@ public abstract class Base${schemaName}ResourceTestCase {
 					}
 				</#if>
 
+				<#if useDeleteAssetLibraryByExternalReferenceCode>
+					protected ${schemaName} testBatchEngineDeleteImportTask_addAssetLibrary${schemaName}() throws Exception {
+						<#if (hasExternalReferenceCodeProperty || hasIdProperty) && freeMarkerTool.hasJavaMethodSignature(javaMethodSignatures, "deleteAssetLibrary" + schemaName + "ByExternalReferenceCode")>
+							return testDeleteAssetLibrary${schemaName}ByExternalReferenceCode_add${schemaName}();
+						<#else>
+							throw new UnsupportedOperationException("This method needs to be implemented");
+						</#if>
+					}
+				</#if>
+
 				<#if useDeleteSite>
 					protected ${schemaName} testBatchEngineDeleteImportTask_addSite${schemaName}() throws Exception {
 						<#if (hasExternalReferenceCodeProperty || hasIdProperty) && freeMarkerTool.hasJavaMethodSignature(javaMethodSignatures, "deleteSite" + schemaName)>
 							return testDeleteSite${schemaName}_add${schemaName}();
+						<#else>
+							throw new UnsupportedOperationException("This method needs to be implemented");
+						</#if>
+					}
+				</#if>
+
+				<#if useDeleteSiteByExternalReferenceCode>
+					protected ${schemaName} testBatchEngineDeleteImportTask_addSite${schemaName}() throws Exception {
+						<#if (hasExternalReferenceCodeProperty || hasIdProperty) && freeMarkerTool.hasJavaMethodSignature(javaMethodSignatures, "deleteSite" + schemaName + "ByExternalReferenceCode")>
+							return testDeleteSite${schemaName}ByExternalReferenceCode_add${schemaName}();
 						<#else>
 							throw new UnsupportedOperationException("This method needs to be implemented");
 						</#if>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -42,11 +42,9 @@ import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 	javaMethodSignatures = freeMarkerTool.getResourceTestCaseJavaMethodSignatures(configYAML, openAPIYAML, schemaName)
 	properties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema, allSchemas)
 	useDeleteAssetLibrary = false
-	useDeleteAssetLibraryByExternalReferenceCode = false
 	useDeleteByExternalReferenceCode = false
 	useDeleteById = false
 	useDeleteSite = false
-	useDeleteSiteByExternalReferenceCode = false
 
 	hasExternalReferenceCodeProperty = properties?keys?seq_contains("externalReferenceCode")
 	hasIdProperty = properties?keys?seq_contains("id") || properties?keys?seq_contains(schemaVarName + "Id")
@@ -56,13 +54,21 @@ import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 	<#assign
 		generateDepotEntry = generateDepotEntry || javaMethodSignature.methodName?contains("AssetLibrary")
 		generatePermissionsJavaMethodSignatures = generatePermissionsJavaMethodSignatures + (isPermissionsCompatibleMethod(configYAML, javaMethodSignature, javaMethodSignatures, schema, schemaName)?then([javaMethodSignature], []))
-		useDeleteAssetLibrary = useDeleteAssetLibrary || (hasExternalReferenceCodeProperty && stringUtil.equals(javaMethodSignature.methodName, "deleteAssetLibrary" + schemaName))
-		useDeleteAssetLibraryByExternalReferenceCode = useDeleteAssetLibraryByExternalReferenceCode || (hasExternalReferenceCodeProperty && stringUtil.equals(javaMethodSignature.methodName, "deleteAssetLibrary" + schemaName + "ByExternalReferenceCode"))
 		useDeleteByExternalReferenceCode = useDeleteByExternalReferenceCode || (freeMarkerTool.isExternalReferenceCodeMethod("delete", javaMethodSignature) && hasExternalReferenceCodeProperty && !javaMethodSignature.parentSchemaName?has_content)
 		useDeleteById = useDeleteById || (stringUtil.equals(javaMethodSignature.methodName, "delete" + schemaName) && (freeMarkerTool.hasPathParameter(javaMethodSignature, "id") || freeMarkerTool.hasPathParameter(javaMethodSignature, schemaVarName + "Id")) && hasIdProperty)
-		useDeleteSite = useDeleteSite || (hasExternalReferenceCodeProperty && stringUtil.equals(javaMethodSignature.methodName, "deleteSite" + schemaName))
-		useDeleteSiteByExternalReferenceCode = useDeleteSiteByExternalReferenceCode || (hasExternalReferenceCodeProperty && stringUtil.equals(javaMethodSignature.methodName, "deleteSite" + schemaName + "ByExternalReferenceCode"))
 	/>
+
+	<#if hasExternalReferenceCodeProperty && (stringUtil.equals(javaMethodSignature.methodName, "deleteAssetLibrary" + schemaName) || stringUtil.equals(javaMethodSignature.methodName, "deleteAssetLibrary" + schemaName + "ByExternalReferenceCode"))>
+		<#assign
+			deleteAssetLibraryBatchJavaMethodSignature = javaMethodSignature
+			useDeleteAssetLibrary = true
+		/>
+	<#elseif hasExternalReferenceCodeProperty && (stringUtil.equals(javaMethodSignature.methodName, "deleteSite" + schemaName) || stringUtil.equals(javaMethodSignature.methodName, "deleteSite" + schemaName + "ByExternalReferenceCode"))>
+		<#assign
+			deleteSiteBatchJavaMethodSignature = javaMethodSignature
+			useDeleteSite = true
+		/>
+	</#if>
 </#list>
 
 <#assign
@@ -2687,24 +2693,9 @@ public abstract class Base${schemaName}ResourceTestCase {
 				<#if useDeleteAssetLibrary>
 					${schemaName} ${schemaVarName}1 = testBatchEngineDeleteImportTask_addAssetLibrary${schemaName}();
 
-					testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}1.getExternalReferenceCode(),<#if useDeleteById> null,</#if> "assetLibraryExternalReferenceCode", testDepotEntryGroup.getExternalReferenceCode());
+					<#assign isExternalReferenceCodeExclusiveMethod = freeMarkerTool.isExternalReferenceCodeExclusiveMethod("delete", deleteAssetLibraryBatchJavaMethodSignature) />
 
-					<#if getAssetLibraryJavaMethodSignature?has_content>
-						assertHttpResponseStatusCode(
-							404,
-							${schemaVarName}Resource.${getAssetLibraryJavaMethodSignature.methodName}HttpResponse(
-								<@getRESTMethodParameters
-									javaMethodSignature = getAssetLibraryJavaMethodSignature
-									testJavaMethodName = "batchEngineDeleteImportTask"
-									varName = schemaVarName + "1"
-								/>));
-					</#if>
-				</#if>
-
-				<#if useDeleteAssetLibraryByExternalReferenceCode>
-					<#if !useDeleteAssetLibrary>${schemaName}</#if> ${schemaVarName}1 = testBatchEngineDeleteImportTask_addAssetLibrary${schemaName}();
-
-					testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}1.getExternalReferenceCode(),<#if useDeleteById> null,</#if> "assetLibraryId", String.valueOf(testDepotEntryGroup.getGroupId()));
+					testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}1.getExternalReferenceCode(),<#if useDeleteById> null,</#if> "${isExternalReferenceCodeExclusiveMethod?then("assetLibraryExternalReferenceCode", "assetLibraryId")}", ${isExternalReferenceCodeExclusiveMethod?then("testDepotEntryGroup.getExternalReferenceCode()", "String.valueOf(testDepotEntryGroup.getGroupId())")});
 
 					<#if getAssetLibraryJavaMethodSignature?has_content>
 						assertHttpResponseStatusCode(
@@ -2719,7 +2710,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 				</#if>
 
 				<#if useDeleteByExternalReferenceCode>
-					<#if !useDeleteAssetLibrary && !useDeleteAssetLibraryByExternalReferenceCode>${schemaName}</#if> ${schemaVarName}1 = testBatchEngineDeleteImportTask_add${schemaName}();
+					<#if !useDeleteAssetLibrary>${schemaName}</#if> ${schemaVarName}1 = testBatchEngineDeleteImportTask_add${schemaName}();
 
 					testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}1.getExternalReferenceCode()<#if useDeleteById>, null</#if>);
 
@@ -2736,7 +2727,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 				</#if>
 
 				<#if useDeleteById>
-					<#if !useDeleteAssetLibrary && !useDeleteAssetLibraryByExternalReferenceCode && !useDeleteByExternalReferenceCode>${schemaName}</#if> ${schemaVarName}1 = testBatchEngineDeleteImportTask_add${schemaName}();
+					<#if !useDeleteAssetLibrary && !useDeleteByExternalReferenceCode>${schemaName}</#if> ${schemaVarName}1 = testBatchEngineDeleteImportTask_add${schemaName}();
 
 					testBatchEngineDeleteImportTask_delete${schemaName}(200, null, ${schemaVarName}1.${getIdMethodName}());
 
@@ -2753,26 +2744,11 @@ public abstract class Base${schemaName}ResourceTestCase {
 				</#if>
 
 				<#if useDeleteSite>
-					<#if !useDeleteAssetLibrary && !useDeleteAssetLibraryByExternalReferenceCode && !useDeleteByExternalReferenceCode && !useDeleteById>${schemaName}</#if> ${schemaVarName}1 = testBatchEngineDeleteImportTask_addSite${schemaName}();
+					<#if !useDeleteAssetLibrary && !useDeleteByExternalReferenceCode && !useDeleteById>${schemaName}</#if> ${schemaVarName}1 = testBatchEngineDeleteImportTask_addSite${schemaName}();
 
-					testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}1.getExternalReferenceCode(),<#if useDeleteById> null,</#if> "siteExternalReferenceCode", testGroup.getExternalReferenceCode());
+					<#assign isExternalReferenceCodeExclusiveMethod = freeMarkerTool.isExternalReferenceCodeExclusiveMethod("delete", deleteSiteBatchJavaMethodSignature) />
 
-					<#if getSiteJavaMethodSignature?has_content>
-						assertHttpResponseStatusCode(
-							404,
-							${schemaVarName}Resource.${getSiteJavaMethodSignature.methodName}HttpResponse(
-								<@getRESTMethodParameters
-									javaMethodSignature = getSiteJavaMethodSignature
-									testJavaMethodName = "batchEngineDeleteImportTask"
-									varName = schemaVarName + "1"
-								/>));
-					</#if>
-				</#if>
-
-				<#if useDeleteSiteByExternalReferenceCode>
-					<#if !useDeleteAssetLibrary && !useDeleteAssetLibraryByExternalReferenceCode && !useDeleteByExternalReferenceCode && !useDeleteById && !useDeleteSite>${schemaName}</#if> ${schemaVarName}1 = testBatchEngineDeleteImportTask_addSite${schemaName}();
-
-					testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}1.getExternalReferenceCode(),<#if useDeleteById> null,</#if> "siteId", String.valueOf(testGroup.getGroupId()));
+					testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}1.getExternalReferenceCode(),<#if useDeleteById> null,</#if> "${isExternalReferenceCodeExclusiveMethod?then("siteExternalReferenceCode", "siteId")}", ${isExternalReferenceCodeExclusiveMethod?then("testGroup.getExternalReferenceCode()", "String.valueOf(testGroup.getGroupId())")});
 
 					<#if getSiteJavaMethodSignature?has_content>
 						assertHttpResponseStatusCode(
@@ -2786,12 +2762,14 @@ public abstract class Base${schemaName}ResourceTestCase {
 					</#if>
 				</#if>
 
-				<#if (useDeleteAssetLibrary || useDeleteAssetLibraryByExternalReferenceCode || useDeleteSite || useDeleteSiteByExternalReferenceCode) && useDeleteById>
+				<#if (useDeleteAssetLibrary || useDeleteSite) && useDeleteById>
 					<#if useDeleteAssetLibrary>
 						${schemaVarName}1 = testBatchEngineDeleteImportTask_addAssetLibrary${schemaName}();
 						${schemaName} ${schemaVarName}2 = testBatchEngineDeleteImportTask_addAssetLibrary${schemaName}();
 
-						testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}2.getExternalReferenceCode(), ${schemaVarName}1.${getIdMethodName}(), "assetLibraryExternalReferenceCode", testDepotEntryGroup.getExternalReferenceCode());
+						<#assign isExternalReferenceCodeExclusiveMethod = freeMarkerTool.isExternalReferenceCodeExclusiveMethod("delete", deleteAssetLibraryBatchJavaMethodSignature) />
+
+						testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}2.getExternalReferenceCode(), ${schemaVarName}1.${getIdMethodName}(), "${isExternalReferenceCodeExclusiveMethod?then("assetLibraryExternalReferenceCode", "assetLibraryId")}", ${isExternalReferenceCodeExclusiveMethod?then("testDepotEntryGroup.getExternalReferenceCode()", "String.valueOf(testDepotEntryGroup.getGroupId())")});
 
 						<#if getJavaMethodSignature?has_content>
 							assertHttpResponseStatusCode(
@@ -2812,46 +2790,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 									/>));
 						</#if>
 
-						testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}2.getExternalReferenceCode(), ${schemaVarName}1.${getIdMethodName}(), "assetLibraryExternalReferenceCode", testDepotEntryGroup.getExternalReferenceCode());
-
-						<#if getJavaMethodSignature?has_content>
-							assertHttpResponseStatusCode(
-								404,
-								${schemaVarName}Resource.${getJavaMethodSignature.methodName}HttpResponse(
-									<@getRESTMethodParameters
-										javaMethodSignature = getJavaMethodSignature
-										testJavaMethodName = "batchEngineDeleteImportTask"
-										varName = schemaVarName + "2"
-									/>));
-						</#if>
-					</#if>
-
-					<#if useDeleteAssetLibraryByExternalReferenceCode>
-						${schemaVarName}1 = testBatchEngineDeleteImportTask_addAssetLibrary${schemaName}();
-						<#if !useDeleteAssetLibrary>${schemaName}</#if> ${schemaVarName}2 = testBatchEngineDeleteImportTask_addAssetLibrary${schemaName}();
-
-						testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}2.getExternalReferenceCode(), ${schemaVarName}1.${getIdMethodName}(), "assetLibraryId", String.valueOf(testDepotEntryGroup.getGroupId()));
-
-						<#if getJavaMethodSignature?has_content>
-							assertHttpResponseStatusCode(
-								404,
-								${schemaVarName}Resource.${getJavaMethodSignature.methodName}HttpResponse(
-									<@getRESTMethodParameters
-										javaMethodSignature = getJavaMethodSignature
-										testJavaMethodName = "batchEngineDeleteImportTask"
-										varName = schemaVarName + "1"
-									/>));
-							assertHttpResponseStatusCode(
-								200,
-								${schemaVarName}Resource.${getJavaMethodSignature.methodName}HttpResponse(
-									<@getRESTMethodParameters
-										javaMethodSignature = getJavaMethodSignature
-										testJavaMethodName = "batchEngineDeleteImportTask"
-										varName = schemaVarName + "2"
-									/>));
-						</#if>
-
-						testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}2.getExternalReferenceCode(), ${schemaVarName}1.${getIdMethodName}(), "assetLibraryId", String.valueOf(testDepotEntryGroup.getGroupId()));
+						testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}2.getExternalReferenceCode(), ${schemaVarName}1.${getIdMethodName}(), "${isExternalReferenceCodeExclusiveMethod?then("assetLibraryExternalReferenceCode", "assetLibraryId")}", ${isExternalReferenceCodeExclusiveMethod?then("testDepotEntryGroup.getExternalReferenceCode()", "String.valueOf(testDepotEntryGroup.getGroupId())")});
 
 						<#if getJavaMethodSignature?has_content>
 							assertHttpResponseStatusCode(
@@ -2867,48 +2806,11 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 					<#if useDeleteSite>
 						${schemaVarName}1 = testBatchEngineDeleteImportTask_addSite${schemaName}();
-						<#if !useDeleteAssetLibrary && !useDeleteAssetLibraryByExternalReferenceCode>${schemaName}</#if> ${schemaVarName}2 = testBatchEngineDeleteImportTask_addSite${schemaName}();
+						<#if !useDeleteAssetLibrary>${schemaName}</#if> ${schemaVarName}2 = testBatchEngineDeleteImportTask_addSite${schemaName}();
 
-						testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}2.getExternalReferenceCode(), ${schemaVarName}1.${getIdMethodName}(), "siteExternalReferenceCode", testGroup.getExternalReferenceCode());
+						<#assign isExternalReferenceCodeExclusiveMethod = freeMarkerTool.isExternalReferenceCodeExclusiveMethod("delete", deleteSiteBatchJavaMethodSignature) />
 
-						<#if getJavaMethodSignature?has_content>
-							assertHttpResponseStatusCode(
-								404,
-								${schemaVarName}Resource.${getJavaMethodSignature.methodName}HttpResponse(
-									<@getRESTMethodParameters
-										javaMethodSignature = getJavaMethodSignature
-										testJavaMethodName = "batchEngineDeleteImportTask"
-										varName = schemaVarName + "1"
-									/>));
-							assertHttpResponseStatusCode(
-								200,
-								${schemaVarName}Resource.${getJavaMethodSignature.methodName}HttpResponse(
-									<@getRESTMethodParameters
-										javaMethodSignature = getJavaMethodSignature
-										testJavaMethodName = "batchEngineDeleteImportTask"
-										varName = schemaVarName + "2"
-									/>));
-						</#if>
-
-						testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}2.getExternalReferenceCode(), ${schemaVarName}1.${getIdMethodName}(), "siteExternalReferenceCode", testGroup.getExternalReferenceCode());
-
-						<#if getJavaMethodSignature?has_content>
-							assertHttpResponseStatusCode(
-								404,
-								${schemaVarName}Resource.${getJavaMethodSignature.methodName}HttpResponse(
-									<@getRESTMethodParameters
-										javaMethodSignature = getJavaMethodSignature
-										testJavaMethodName = "batchEngineDeleteImportTask"
-										varName = schemaVarName + "2"
-									/>));
-						</#if>
-					</#if>
-
-					<#if useDeleteSiteByExternalReferenceCode>
-						${schemaVarName}1 = testBatchEngineDeleteImportTask_addSite${schemaName}();
-						<#if !useDeleteAssetLibrary && !useDeleteAssetLibraryByExternalReferenceCode && !useDeleteSite>${schemaName}</#if> ${schemaVarName}2 = testBatchEngineDeleteImportTask_addSite${schemaName}();
-
-						testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}2.getExternalReferenceCode(), ${schemaVarName}1.${getIdMethodName}(), "siteId", String.valueOf(testGroup.getGroupId()));
+						testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}2.getExternalReferenceCode(), ${schemaVarName}1.${getIdMethodName}(), "${isExternalReferenceCodeExclusiveMethod?then("siteExternalReferenceCode", "siteId")}", ${isExternalReferenceCodeExclusiveMethod?then("testGroup.getExternalReferenceCode()", "String.valueOf(testGroup.getGroupId())")});
 
 						<#if getJavaMethodSignature?has_content>
 							assertHttpResponseStatusCode(
@@ -2929,7 +2831,9 @@ public abstract class Base${schemaName}ResourceTestCase {
 									/>));
 						</#if>
 
-						testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}2.getExternalReferenceCode(), ${schemaVarName}1.${getIdMethodName}(), "siteId", String.valueOf(testGroup.getGroupId()));
+						<#assign isExternalReferenceCodeExclusiveMethod = freeMarkerTool.isExternalReferenceCodeExclusiveMethod("delete", deleteSiteBatchJavaMethodSignature) />
+
+						testBatchEngineDeleteImportTask_delete${schemaName}(200, ${schemaVarName}2.getExternalReferenceCode(), ${schemaVarName}1.${getIdMethodName}(), "${isExternalReferenceCodeExclusiveMethod?then("siteExternalReferenceCode", "siteId")}", ${isExternalReferenceCodeExclusiveMethod?then("testGroup.getExternalReferenceCode()", "String.valueOf(testGroup.getGroupId())")});
 
 						<#if getJavaMethodSignature?has_content>
 							assertHttpResponseStatusCode(
@@ -2946,7 +2850,9 @@ public abstract class Base${schemaName}ResourceTestCase {
 					<#if useDeleteAssetLibrary && useDeleteSite>
 						${schemaVarName}1 = testBatchEngineDeleteImportTask_addSite${schemaName}();
 
-						testBatchEngineDeleteImportTask_delete${schemaName}(400, ${schemaVarName}1.getExternalReferenceCode(), ${schemaVarName}1.${getIdMethodName}(), "assetLibraryExternalReferenceCode", testDepotEntryGroup.getExternalReferenceCode(), "siteExternalReferenceCode", testGroup.getExternalReferenceCode());
+						<#assign isExternalReferenceCodeExclusiveMethod = freeMarkerTool.isExternalReferenceCodeExclusiveMethod("delete", deleteAssetLibraryBatchJavaMethodSignature) && freeMarkerTool.isExternalReferenceCodeExclusiveMethod("delete", deleteSiteBatchJavaMethodSignature) />
+
+						testBatchEngineDeleteImportTask_delete${schemaName}(400, ${schemaVarName}1.getExternalReferenceCode(), ${schemaVarName}1.${getIdMethodName}(), "${isExternalReferenceCodeExclusiveMethod?then("assetLibraryExternalReferenceCode", "assetLibraryId")}", ${isExternalReferenceCodeExclusiveMethod?then("testDepotEntryGroup.getExternalReferenceCode()", "String.valueOf(testDepotEntryGroup.getGroupId())")}, "${isExternalReferenceCodeExclusiveMethod?then("siteExternalReferenceCode", "siteId")}", ${isExternalReferenceCodeExclusiveMethod?then("testGroup.getExternalReferenceCode()", "String.valueOf(testGroup.getGroupId())")});
 
 						<#if getJavaMethodSignature?has_content>
 							assertHttpResponseStatusCode(
@@ -3014,18 +2920,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 				<#if useDeleteAssetLibrary>
 					protected ${schemaName} testBatchEngineDeleteImportTask_addAssetLibrary${schemaName}() throws Exception {
-						<#if (hasExternalReferenceCodeProperty || hasIdProperty) && freeMarkerTool.hasJavaMethodSignature(javaMethodSignatures, "deleteAssetLibrary" + schemaName)>
-							return testDeleteAssetLibrary${schemaName}_add${schemaName}();
-						<#else>
-							throw new UnsupportedOperationException("This method needs to be implemented");
-						</#if>
-					}
-				</#if>
-
-				<#if useDeleteAssetLibraryByExternalReferenceCode>
-					protected ${schemaName} testBatchEngineDeleteImportTask_addAssetLibrary${schemaName}() throws Exception {
-						<#if (hasExternalReferenceCodeProperty || hasIdProperty) && freeMarkerTool.hasJavaMethodSignature(javaMethodSignatures, "deleteAssetLibrary" + schemaName + "ByExternalReferenceCode")>
-							return testDeleteAssetLibrary${schemaName}ByExternalReferenceCode_add${schemaName}();
+						<#if (hasExternalReferenceCodeProperty || hasIdProperty) && (freeMarkerTool.hasJavaMethodSignature(javaMethodSignatures, "deleteAssetLibrary" + schemaName) || freeMarkerTool.hasJavaMethodSignature(javaMethodSignatures, "deleteAssetLibrary" + schemaName + "ByExternalReferenceCode"))>
+							return test${deleteAssetLibraryBatchJavaMethodSignature.methodName?cap_first}_add${schemaName}();
 						<#else>
 							throw new UnsupportedOperationException("This method needs to be implemented");
 						</#if>
@@ -3034,18 +2930,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 				<#if useDeleteSite>
 					protected ${schemaName} testBatchEngineDeleteImportTask_addSite${schemaName}() throws Exception {
-						<#if (hasExternalReferenceCodeProperty || hasIdProperty) && freeMarkerTool.hasJavaMethodSignature(javaMethodSignatures, "deleteSite" + schemaName)>
-							return testDeleteSite${schemaName}_add${schemaName}();
-						<#else>
-							throw new UnsupportedOperationException("This method needs to be implemented");
-						</#if>
-					}
-				</#if>
-
-				<#if useDeleteSiteByExternalReferenceCode>
-					protected ${schemaName} testBatchEngineDeleteImportTask_addSite${schemaName}() throws Exception {
-						<#if (hasExternalReferenceCodeProperty || hasIdProperty) && freeMarkerTool.hasJavaMethodSignature(javaMethodSignatures, "deleteSite" + schemaName + "ByExternalReferenceCode")>
-							return testDeleteSite${schemaName}ByExternalReferenceCode_add${schemaName}();
+						<#if (hasExternalReferenceCodeProperty || hasIdProperty) && (freeMarkerTool.hasJavaMethodSignature(javaMethodSignatures, "deleteSite" + schemaName) || freeMarkerTool.hasJavaMethodSignature(javaMethodSignatures, "deleteSite" + schemaName + "ByExternalReferenceCode"))>
+							return test${deleteSiteBatchJavaMethodSignature.methodName?cap_first}_add${schemaName}();
 						<#else>
 							throw new UnsupportedOperationException("This method needs to be implemented");
 						</#if>


### PR DESCRIPTION
Original description:

For more information please take a look at the following Jira Tickets: [LPD-75530](https://liferay.atlassian.net/browse/LPD-75530), [LPD-75672](https://liferay.atlassian.net/browse/LPD-75672)

Manually forwarded from: https://github.com/liferay-headless/liferay-portal/pull/3392

Resent after https://github.com/brianchandotcom/liferay-portal/pull/169457 since I believe no `freeMarkerTool.isVersionCompatible` is needed since batch Delete method already existed within the system, we just cover more of the already existing Liferay patterns.