### PR TITLE
LPD-76578 ObjectEntryFolder does not need a taskItemDelegateName

### DIFF
--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
@@ -69,10 +69,7 @@ import org.osgi.service.component.annotations.ServiceScope;
  */
 @Component(
 	properties = "OSGI-INF/liferay/rest/v1_0/object-entry-folder.properties",
-	property = {
-		"batch.engine.task.item.delegate.name=depot-object-entry-folder",
-		"export.import.vulcan.batch.engine.task.item.delegate=true"
-	},
+	property = "export.import.vulcan.batch.engine.task.item.delegate=true",
 	scope = ServiceScope.PROTOTYPE, service = ObjectEntryFolderResource.class
 )
 public class ObjectEntryFolderResourceImpl


### PR DESCRIPTION
This was done after a conversation I had with @jkappler.

For more details please refer to the following Jira ticket: [LPD-76578](https://liferay.atlassian.net/browse/LPD-76578)