### PR TITLE
LPD-75527 Add uuid to the page experience schema

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageExperience.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageExperience.java
@@ -415,6 +415,49 @@ public class PageExperience implements Serializable {
 	private Supplier<ItemExternalReference>
 		_segmentItemExternalReferenceSupplier;
 
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "A valid external identifier to reference this page experience."
+	)
+	public String getUuid() {
+		if (_uuidSupplier != null) {
+			uuid = _uuidSupplier.get();
+
+			_uuidSupplier = null;
+		}
+
+		return uuid;
+	}
+
+	public void setUuid(String uuid) {
+		this.uuid = uuid;
+
+		_uuidSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setUuid(UnsafeSupplier<String, Exception> uuidUnsafeSupplier) {
+		_uuidSupplier = () -> {
+			try {
+				return uuidUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "A valid external identifier to reference this page experience."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String uuid;
+
+	@JsonIgnore
+	private Supplier<String> _uuidSupplier;
+
 	@Override
 	public boolean equals(Object object) {
 		if (this == object) {
@@ -570,6 +613,22 @@ public class PageExperience implements Serializable {
 			sb.append("\"segmentItemExternalReference\": ");
 
 			sb.append(String.valueOf(segmentItemExternalReference));
+		}
+
+		String uuid = getUuid();
+
+		if (uuid != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"uuid\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(uuid));
+
+			sb.append("\"");
 		}
 
 		sb.append("}");

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageExperience.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageExperience.java
@@ -202,6 +202,25 @@ public class PageExperience implements Cloneable, Serializable {
 
 	protected ItemExternalReference segmentItemExternalReference;
 
+	public String getUuid() {
+		return uuid;
+	}
+
+	public void setUuid(String uuid) {
+		this.uuid = uuid;
+	}
+
+	public void setUuid(UnsafeSupplier<String, Exception> uuidUnsafeSupplier) {
+		try {
+			uuid = uuidUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String uuid;
+
 	@Override
 	public PageExperience clone() throws CloneNotSupportedException {
 		return (PageExperience)super.clone();

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageExperienceSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageExperienceSerDes.java
@@ -167,6 +167,20 @@ public class PageExperienceSerDes {
 					pageExperience.getSegmentItemExternalReference()));
 		}
 
+		if (pageExperience.getUuid() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"uuid\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(pageExperience.getUuid()));
+
+			sb.append("\"");
+		}
+
 		sb.append("}");
 
 		return sb.toString();
@@ -255,6 +269,13 @@ public class PageExperienceSerDes {
 					pageExperience.getSegmentItemExternalReference()));
 		}
 
+		if (pageExperience.getUuid() == null) {
+			map.put("uuid", null);
+		}
+		else {
+			map.put("uuid", String.valueOf(pageExperience.getUuid()));
+		}
+
 		return map;
 	}
 
@@ -300,6 +321,9 @@ public class PageExperienceSerDes {
 			else if (Objects.equals(
 						jsonParserFieldName, "segmentItemExternalReference")) {
 
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "uuid")) {
 				return false;
 			}
 
@@ -382,6 +406,11 @@ public class PageExperienceSerDes {
 					pageExperience.setSegmentItemExternalReference(
 						ItemExternalReferenceSerDes.toDTO(
 							(String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "uuid")) {
+				if (jsonParserFieldValue != null) {
+					pageExperience.setUuid((String)jsonParserFieldValue);
 				}
 			}
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
@@ -2757,6 +2757,11 @@ components:
                     # @review
                     description:
                         The segment's item external reference.
+                uuid:
+                    # @review
+                    description:
+                        A valid external identifier to reference this page experience.
+                    type: string
             type: object
         PageNavigationMenuItemSettings:
             description:

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageExperienceDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageExperienceDTOConverter.java
@@ -94,6 +94,7 @@ public class PageExperienceDTOConverter
 							}
 						};
 					});
+				setUuid(segmentsExperience::getUuid);
 			}
 		};
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageExperienceResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageExperienceResourceImpl.java
@@ -239,7 +239,7 @@ public abstract class BasePageExperienceResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-experiences/{pageExperienceExternalReferenceCode}' -d $'{"externalReferenceCode": ___, "key": ___, "name_i18n": ___, "pageElements": ___, "pageRules": ___, "pageSpecificationExternalReferenceCode": ___, "priority": ___, "segmentItemExternalReference": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-experiences/{pageExperienceExternalReferenceCode}' -d $'{"externalReferenceCode": ___, "key": ___, "name_i18n": ___, "pageElements": ___, "pageRules": ___, "pageSpecificationExternalReferenceCode": ___, "priority": ___, "segmentItemExternalReference": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates an experience of a specific page specification of a site page within a site. Updates only the fields received in the request body, leaving any other fields untouched."
@@ -319,6 +319,10 @@ public abstract class BasePageExperienceResourceImpl
 			existingPageExperience.setPriority(pageExperience.getPriority());
 		}
 
+		if (pageExperience.getUuid() != null) {
+			existingPageExperience.setUuid(pageExperience.getUuid());
+		}
+
 		preparePatch(pageExperience, existingPageExperience);
 
 		return putSitePageExperience(
@@ -329,7 +333,7 @@ public abstract class BasePageExperienceResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-specifications/{pageSpecificationExternalReferenceCode}/page-experiences' -d $'{"externalReferenceCode": ___, "key": ___, "name_i18n": ___, "pageElements": ___, "pageRules": ___, "pageSpecificationExternalReferenceCode": ___, "priority": ___, "segmentItemExternalReference": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-specifications/{pageSpecificationExternalReferenceCode}/page-experiences' -d $'{"externalReferenceCode": ___, "key": ___, "name_i18n": ___, "pageElements": ___, "pageRules": ___, "pageSpecificationExternalReferenceCode": ___, "priority": ___, "segmentItemExternalReference": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Adds a new experience to a page specification of a site page."
@@ -388,7 +392,7 @@ public abstract class BasePageExperienceResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-experiences/{pageExperienceExternalReferenceCode}' -d $'{"externalReferenceCode": ___, "key": ___, "name_i18n": ___, "pageElements": ___, "pageRules": ___, "pageSpecificationExternalReferenceCode": ___, "priority": ___, "segmentItemExternalReference": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-experiences/{pageExperienceExternalReferenceCode}' -d $'{"externalReferenceCode": ___, "key": ___, "name_i18n": ___, "pageElements": ___, "pageRules": ___, "pageSpecificationExternalReferenceCode": ___, "priority": ___, "segmentItemExternalReference": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates an experience of a specific page specification of a site page within a site."

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageExperienceResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageExperienceResourceImpl.java
@@ -234,7 +234,7 @@ public class PageExperienceResourceImpl extends BasePageExperienceResourceImpl {
 					GetterUtil.getInteger(pageExperience.getPriority()),
 					ServiceContextUtil.createServiceContext(
 						groupId, contextHttpServletRequest,
-						contextUser.getUserId())));
+						contextUser.getUserId(), pageExperience.getUuid())));
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
@@ -227,7 +227,7 @@ public class LayoutUtil {
 		}
 
 		PageExperience defaultPageExperience =
-			SegmentsExperienceUtil.getDefaultPageExperience(
+			PageExperienceUtil.getDefaultPageExperience(
 				publishedContentPageSpecification.getPageExperiences());
 
 		serviceContext.setAttribute(
@@ -236,7 +236,7 @@ public class LayoutUtil {
 		serviceContext.setAttribute(
 			"defaultSegmentsExperienceUuid", defaultPageExperience.getUuid());
 
-		defaultPageExperience = SegmentsExperienceUtil.getDefaultPageExperience(
+		defaultPageExperience = PageExperienceUtil.getDefaultPageExperience(
 			draftContentPageSpecification.getPageExperiences());
 
 		serviceContext.setAttribute(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
@@ -226,16 +226,26 @@ public class LayoutUtil {
 			}
 		}
 
+		PageExperience defaultPageExperience =
+			SegmentsExperienceUtil.getDefaultPageExperience(
+				publishedContentPageSpecification.getPageExperiences());
+
 		serviceContext.setAttribute(
 			"defaultSegmentsExperienceExternalReferenceCode",
-			SegmentsExperienceUtil.
-				getDefaultSegmentsExperienceExternalReferenceCode(
-					publishedContentPageSpecification.getPageExperiences()));
+			defaultPageExperience.getExternalReferenceCode());
+		serviceContext.setAttribute(
+			"defaultSegmentsExperienceUuid", defaultPageExperience.getUuid());
+
+		defaultPageExperience = SegmentsExperienceUtil.getDefaultPageExperience(
+			draftContentPageSpecification.getPageExperiences());
+
 		serviceContext.setAttribute(
 			"draftLayoutDefaultSegmentsExperienceExternalReferenceCode",
-			SegmentsExperienceUtil.
-				getDefaultSegmentsExperienceExternalReferenceCode(
-					draftContentPageSpecification.getPageExperiences()));
+			defaultPageExperience.getExternalReferenceCode());
+		serviceContext.setAttribute(
+			"draftLayoutDefaultSegmentsExperienceUuid",
+			defaultPageExperience.getUuid());
+
 		serviceContext.setAttribute(
 			"draftLayoutExternalReferenceCode",
 			draftContentPageSpecification.getExternalReferenceCode());

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageExperienceUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageExperienceUtil.java
@@ -20,6 +20,25 @@ import java.util.Set;
  */
 public class PageExperienceUtil {
 
+	public static PageExperience getDefaultPageExperience(
+		PageExperience[] pageExperiences) {
+
+		if (ArrayUtil.isEmpty(pageExperiences)) {
+			throw new UnsupportedOperationException();
+		}
+
+		for (PageExperience pageExperience : pageExperiences) {
+			if (Objects.equals(
+					pageExperience.getKey(),
+					SegmentsExperienceConstants.KEY_DEFAULT)) {
+
+				return pageExperience;
+			}
+		}
+
+		throw new UnsupportedOperationException();
+	}
+
 	public static void validatePageExperiences(
 		SegmentsExperience defaultSegmentsExperience,
 		PageExperience[] pageExperiences) {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/SegmentsExperienceUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/SegmentsExperienceUtil.java
@@ -22,7 +22,6 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
-import com.liferay.segments.constants.SegmentsExperienceConstants;
 import com.liferay.segments.model.SegmentsEntry;
 import com.liferay.segments.model.SegmentsExperience;
 import com.liferay.segments.service.SegmentsEntryLocalServiceUtil;
@@ -67,25 +66,6 @@ public class SegmentsExperienceUtil {
 			layout, segmentsExperience.getSegmentsExperienceId());
 
 		return segmentsExperience;
-	}
-
-	public static PageExperience getDefaultPageExperience(
-		PageExperience[] pageExperiences) {
-
-		if (ArrayUtil.isEmpty(pageExperiences)) {
-			throw new UnsupportedOperationException();
-		}
-
-		for (PageExperience pageExperience : pageExperiences) {
-			if (Objects.equals(
-					pageExperience.getKey(),
-					SegmentsExperienceConstants.KEY_DEFAULT)) {
-
-				return pageExperience;
-			}
-		}
-
-		throw new UnsupportedOperationException();
 	}
 
 	public static SegmentsExperience updateSegmentsExperience(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/SegmentsExperienceUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/SegmentsExperienceUtil.java
@@ -54,7 +54,10 @@ public class SegmentsExperienceUtil {
 				UnicodePropertiesBuilder.create(
 					true
 				).build(),
-				new ServiceContext());
+				ServiceContextUtil.createServiceContext(
+					serviceContext.getScopeGroupId(),
+					serviceContext.getRequest(), serviceContext.getUserId(),
+					pageExperience.getUuid()));
 
 		LayoutLocalServiceUtil.updateLayoutContent(
 			_getData(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/SegmentsExperienceUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/SegmentsExperienceUtil.java
@@ -69,7 +69,7 @@ public class SegmentsExperienceUtil {
 		return segmentsExperience;
 	}
 
-	public static String getDefaultSegmentsExperienceExternalReferenceCode(
+	public static PageExperience getDefaultPageExperience(
 		PageExperience[] pageExperiences) {
 
 		if (ArrayUtil.isEmpty(pageExperiences)) {
@@ -81,7 +81,7 @@ public class SegmentsExperienceUtil {
 					pageExperience.getKey(),
 					SegmentsExperienceConstants.KEY_DEFAULT)) {
 
-				return pageExperience.getExternalReferenceCode();
+				return pageExperience;
 			}
 		}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/ServiceContextUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/ServiceContextUtil.java
@@ -130,6 +130,18 @@ public class ServiceContextUtil {
 		return serviceContext;
 	}
 
+	public static ServiceContext createServiceContext(
+		long groupId, HttpServletRequest httpServletRequest, long userId,
+		String uuid) {
+
+		ServiceContext serviceContext = createServiceContext(
+			groupId, httpServletRequest, userId);
+
+		serviceContext.setUuid(uuid);
+
+		return serviceContext;
+	}
+
 	public static void setLayoutSetPrototypeLayoutERC(
 			long groupId, PageSpecification pageSpecification,
 			ServiceContext serviceContext)

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BasePageExperienceResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BasePageExperienceResourceTestCase.java
@@ -181,6 +181,7 @@ public abstract class BasePageExperienceResourceTestCase {
 		pageExperience.setExternalReferenceCode(regex);
 		pageExperience.setKey(regex);
 		pageExperience.setPageSpecificationExternalReferenceCode(regex);
+		pageExperience.setUuid(regex);
 
 		String json = PageExperienceSerDes.toJSON(pageExperience);
 
@@ -192,6 +193,7 @@ public abstract class BasePageExperienceResourceTestCase {
 		Assert.assertEquals(regex, pageExperience.getKey());
 		Assert.assertEquals(
 			regex, pageExperience.getPageSpecificationExternalReferenceCode());
+		Assert.assertEquals(regex, pageExperience.getUuid());
 	}
 
 	@Test
@@ -686,6 +688,14 @@ public abstract class BasePageExperienceResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("uuid", additionalAssertFieldName)) {
+				if (pageExperience.getUuid() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			throw new IllegalArgumentException(
 				"Invalid additional assert field name " +
 					additionalAssertFieldName);
@@ -897,6 +907,16 @@ public abstract class BasePageExperienceResourceTestCase {
 				if (!Objects.deepEquals(
 						pageExperience1.getSegmentItemExternalReference(),
 						pageExperience2.getSegmentItemExternalReference())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("uuid", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						pageExperience1.getUuid(), pageExperience2.getUuid())) {
 
 					return false;
 				}
@@ -1177,6 +1197,52 @@ public abstract class BasePageExperienceResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
+		if (entityFieldName.equals("uuid")) {
+			Object object = pageExperience.getUuid();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
 		throw new IllegalArgumentException(
 			"Invalid entity field " + entityFieldName);
 	}
@@ -1228,6 +1294,7 @@ public abstract class BasePageExperienceResourceTestCase {
 				pageSpecificationExternalReferenceCode = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				priority = RandomTestUtil.randomInt();
+				uuid = StringUtil.toLowerCase(RandomTestUtil.randomString());
 			}
 		};
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageExperienceResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageExperienceResourceTest.java
@@ -269,6 +269,14 @@ public class PageExperienceResourceTest
 				continue;
 			}
 
+			if (Objects.equals(additionalAssertFieldName, "uuid")) {
+				if (pageExperience.getUuid() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			throw new IllegalArgumentException(
 				"Invalid additional assert field name " +
 					additionalAssertFieldName);
@@ -282,7 +290,7 @@ public class PageExperienceResourceTest
 		return new String[] {
 			"externalReferenceCode", "key", "name_i18n", "pageElements",
 			"pageSpecificationExternalReferenceCode", "priority",
-			"segmentItemExternalReference"
+			"segmentItemExternalReference", "uuid"
 		};
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageExperiencesTestUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageExperiencesTestUtil.java
@@ -57,6 +57,9 @@ public class PageExperiencesTestUtil {
 		Assert.assertEquals(
 			segmentsExperience.getExternalReferenceCode(),
 			pageExperience.getExternalReferenceCode());
+
+		Assert.assertEquals(
+			expectedPageExperience.getUuid(), pageExperience.getUuid());
 	}
 
 	public static PageExperience getDefaultPageExperience(
@@ -87,6 +90,7 @@ public class PageExperiencesTestUtil {
 		pageExperience.setPageElements(pageElements);
 		pageExperience.setPageSpecificationExternalReferenceCode(
 			pageSpecificationExternalReferenceCode);
+		pageExperience.setUuid(RandomTestUtil::randomString);
 
 		return new PageExperience[] {pageExperience};
 	}
@@ -98,6 +102,7 @@ public class PageExperiencesTestUtil {
 		pageExperience.setKey(RandomTestUtil.randomString());
 		pageExperience.setName_i18n(
 			Collections.singletonMap("en-US", RandomTestUtil.randomString()));
+		pageExperience.setUuid(RandomTestUtil::randomString);
 
 		return pageExperience;
 	}

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/model/listener/LayoutModelListener.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/model/listener/LayoutModelListener.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.segments.constants.SegmentsExperienceConstants;
 import com.liferay.segments.model.SegmentsExperience;
@@ -176,6 +177,13 @@ public class LayoutModelListener extends BaseModelListener<Layout> {
 
 		if (segmentsExperience != null) {
 			return segmentsExperience;
+		}
+
+		String defaultSegmentsExperienceUuid = GetterUtil.getString(
+			serviceContext.getAttribute("defaultSegmentsExperienceUuid"));
+
+		if (Validator.isNotNull(defaultSegmentsExperienceUuid)) {
+			serviceContext.setUuid(defaultSegmentsExperienceUuid);
 		}
 
 		return _segmentsExperienceLocalService.addDefaultSegmentsExperience(

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
@@ -466,6 +466,10 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 					"draftLayoutDefaultSegmentsExperienceExternalReference" +
 						"Code"));
 			serviceContext.setAttribute(
+				"defaultSegmentsExperienceUuid",
+				serviceContext.getAttribute(
+					"draftLayoutDefaultSegmentsExperienceUuid"));
+			serviceContext.setAttribute(
 				"layoutSetPrototypeLayoutERC",
 				serviceContext.getAttribute(
 					"draftLayoutLayoutSetPrototypeLayoutERC"));


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-75250

# What is this solving?

Add uuid to the page experience schema to ensure  that the export/import functionality with legacy staging environment remains compatible with page experiences created with the API.

# How is it fixed?

Exporting and importing UUID and taking it int account when we are creating the default experience for a content page in the layout model listener.

# How to verify?

Run included integration tests
