### PR TITLE
LPD-75687 At import time, set the order of the Batch Executions

### DIFF
--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/vulcan/batch/engine/ExportImportVulcanBatchEngineTaskItemDelegate.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/vulcan/batch/engine/ExportImportVulcanBatchEngineTaskItemDelegate.java
@@ -44,6 +44,10 @@ public interface ExportImportVulcanBatchEngineTaskItemDelegate<T>
 
 		public String getPortletId();
 
+		public default int getRank() {
+			return 100;
+		}
+
 		public default Map<String, String[]> getReferences() {
 			return null;
 		}

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
@@ -147,6 +147,27 @@ public class BatchEnginePortletDataHandler extends BasePortletDataHandler {
 	}
 
 	@Override
+	public int getRank() {
+		if (_registrations.isEmpty()) {
+			return super.getRank();
+		}
+
+		int rank = Integer.MAX_VALUE;
+
+		for (Registration registration : _registrations) {
+			ExportImportVulcanBatchEngineTaskItemDelegate.ExportImportDescriptor
+				exportImportDescriptor =
+					registration.getExportImportDescriptor();
+
+			if (exportImportDescriptor.getRank() < rank) {
+				rank = exportImportDescriptor.getRank();
+			}
+		}
+
+		return rank;
+	}
+
+	@Override
 	public String getSchemaVersion() {
 		return SCHEMA_VERSION;
 	}

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -3413,7 +3413,7 @@ public class BatchEnginePortletDataHandlerTest {
 		public TestExportImportVulcanBatchEngineTaskItemDelegate build() {
 			if (_portletId == null) {
 				throw new IllegalArgumentException(
-					"portletId must be not null");
+					"portletId must not be null");
 			}
 
 			return new TestExportImportVulcanBatchEngineTaskItemDelegate(

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -52,6 +52,7 @@ import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.constants.ObjectPortletKeys;
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.exception.NoSuchObjectEntryException;
+import com.liferay.object.field.builder.PicklistObjectFieldBuilder;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
 import com.liferay.object.field.setting.builder.ObjectFieldSettingBuilder;
 import com.liferay.object.field.util.ObjectFieldUtil;
@@ -1672,6 +1673,106 @@ public class BatchEnginePortletDataHandlerTest {
 		_assertNull(
 			objectDefinition.getObjectDefinitionId(), objectEntries[0],
 			objectEntries[1]);
+	}
+
+	@Test
+	@TestInfo("LPD-75687")
+	public void testImportOrderByRank() throws Exception {
+		Group group = _stagingGroupHelper.fetchCompanyGroup(
+			TestPropsValues.getCompanyId());
+
+		// First: list type definition
+
+		ListTypeDefinition listTypeDefinition = _addListTypeDefinition();
+
+		ListTypeEntry[] listTypeEntries = _addListTypeEntries(
+			3, listTypeDefinition);
+
+		// Second: object definition
+
+		String picklistName = StringUtil.randomId();
+		String textFieldName = StringUtil.randomId();
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Arrays.asList(
+					new PicklistObjectFieldBuilder(
+					).externalReferenceCode(
+						picklistName
+					).labelMap(
+						RandomTestUtil.randomLocaleStringMap()
+					).name(
+						picklistName
+					).listTypeDefinitionId(
+						listTypeDefinition.getListTypeDefinitionId()
+					).build(),
+					new TextObjectFieldBuilder(
+					).labelMap(
+						RandomTestUtil.randomLocaleStringMap()
+					).name(
+						StringUtil.randomId()
+					).required(
+						false
+					).build()));
+
+		// Third: object entries
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			GroupConstants.DEFAULT_PARENT_GROUP_ID, objectDefinition,
+			(Map)HashMapBuilder.<String, Serializable>put(
+				picklistName, listTypeEntries[0].getKey()
+			).put(
+				textFieldName, RandomTestUtil.randomString()
+			).build());
+
+		File larFile = new ExportImportExecutor(
+		).withGroupId(
+			group.getGroupId()
+		).withIncludeListTypeDefinitions(
+		).withObjectDefinition(
+			objectDefinition
+		).executeExport();
+
+		_objectEntryLocalService.deleteObjectEntry(objectEntry);
+
+		_objectFieldLocalService.deleteObjectField(
+			_objectFieldLocalService.fetchObjectField(
+				picklistName, objectDefinition.getObjectDefinitionId()));
+
+		_listTypeDefinitionLocalService.deleteListTypeDefinition(
+			listTypeDefinition);
+
+		new ExportImportExecutor(
+		).withGroupId(
+			group.getGroupId()
+		).withIncludeListTypeDefinitions(
+		).withLARFile(
+			larFile
+		).withObjectDefinition(
+			objectDefinition
+		).executeImport();
+
+		_assertListTypeDefinition(
+			listTypeDefinition, listTypeEntries.length, listTypeEntries);
+
+		Assert.assertNotNull(
+			_objectFieldLocalService.fetchObjectField(
+				picklistName, objectDefinition.getObjectDefinitionId()));
+
+		List<ObjectEntry> importedObjectEntries =
+			_objectEntryLocalService.getObjectEntries(
+				GroupConstants.DEFAULT_PARENT_GROUP_ID,
+				objectDefinition.getObjectDefinitionId(), QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS);
+
+		Assert.assertEquals(
+			importedObjectEntries.toString(), 1, importedObjectEntries.size());
+
+		ObjectEntry importedObjectEntry = importedObjectEntries.get(0);
+
+		Assert.assertEquals(
+			listTypeEntries[0].getKey(),
+			MapUtil.getString(importedObjectEntry.getValues(), picklistName));
 	}
 
 	@FeatureFlag("LPD-41367")

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -3411,6 +3411,11 @@ public class BatchEnginePortletDataHandlerTest {
 		TestExportImportVulcanBatchEngineTaskItemDelegateBuilder {
 
 		public TestExportImportVulcanBatchEngineTaskItemDelegate build() {
+			if (_portletId == null) {
+				throw new IllegalArgumentException(
+					"portletId must be not null");
+			}
+
 			return new TestExportImportVulcanBatchEngineTaskItemDelegate(
 				_function, _portletId, _rank, _stagingSupported);
 		}

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -1432,16 +1432,21 @@ public class BatchEnginePortletDataHandlerTest {
 				TestPropsValues.getCompanyId(), portletId));
 
 		try (SafeCloseable safeCloseable = _register(
-				filter -> {
-					if (filter != null) {
-						return Page.of(Arrays.asList(new TestItem(1)));
-					}
+				new TestExportImportVulcanBatchEngineTaskItemDelegateBuilder(
+				).withFunction(
+					filter -> {
+						if (filter != null) {
+							return Page.of(Arrays.asList(new TestItem(1)));
+						}
 
-					return Page.of(
-						Arrays.asList(
-							new TestItem(1), new TestItem(2), new TestItem(3)));
-				},
-				portletId)) {
+						return Page.of(
+							Arrays.asList(
+								new TestItem(1), new TestItem(2),
+								new TestItem(3)));
+					}
+				).withPortletId(
+					portletId
+				).build())) {
 
 			PortletDataHandler portletDataHandler =
 				_portletDataHandlerProvider.provide(
@@ -1575,7 +1580,12 @@ public class BatchEnginePortletDataHandlerTest {
 			_portletDataHandlerProvider.provide(
 				TestPropsValues.getCompanyId(), portletId));
 
-		try (SafeCloseable safeCloseable = _register(null, portletId)) {
+		try (SafeCloseable safeCloseable = _register(
+				new TestExportImportVulcanBatchEngineTaskItemDelegateBuilder(
+				).withPortletId(
+					portletId
+				).build())) {
+
 			PortletDataHandler portletDataHandler =
 				_portletDataHandlerProvider.provide(
 					TestPropsValues.getCompanyId(), portletId);
@@ -2292,26 +2302,20 @@ public class BatchEnginePortletDataHandlerTest {
 	}
 
 	private SafeCloseable _register(
-			Function<Filter, Page<TestItem>> function, String portletId)
-		throws Exception {
-
-		return _register(function, portletId, false);
-	}
-
-	private SafeCloseable _register(
-			Function<Filter, Page<TestItem>> function, String portletId,
-			boolean stagingSupported)
+			TestExportImportVulcanBatchEngineTaskItemDelegate
+				testExportImportVulcanBatchEngineTaskItemDelegate)
 		throws Exception {
 
 		SafeCloseable safeCloseable1 = _registerServiceWithSafeCloseable(
 			Portlet.class,
 			new GenericPortlet() {
 			},
-			MapUtil.singletonDictionary("jakarta.portlet.name", portletId));
+			MapUtil.singletonDictionary(
+				"jakarta.portlet.name",
+				testExportImportVulcanBatchEngineTaskItemDelegate._portletId));
 		SafeCloseable safeCloseable2 = _registerServiceWithSafeCloseable(
 			VulcanBatchEngineTaskItemDelegate.class,
-			new TestExportImportVulcanBatchEngineTaskItemDelegate(
-				function, portletId, stagingSupported),
+			testExportImportVulcanBatchEngineTaskItemDelegate,
 			HashMapDictionaryBuilder.put(
 				"batch.engine.task.item.delegate", "true"
 			).put(
@@ -2864,7 +2868,12 @@ public class BatchEnginePortletDataHandlerTest {
 		String portletId = RandomTestUtil.randomString();
 
 		try (SafeCloseable safeCloseable = _register(
-				null, portletId, stagingSupported)) {
+				new TestExportImportVulcanBatchEngineTaskItemDelegateBuilder(
+				).withPortletId(
+					portletId
+				).withStagingSupported(
+					stagingSupported
+				).build())) {
 
 			Thread.sleep(1000);
 
@@ -3009,20 +3018,12 @@ public class BatchEnginePortletDataHandlerTest {
 				   VulcanBatchEngineTaskItemDelegate<TestItem> {
 
 		public TestExportImportVulcanBatchEngineTaskItemDelegate(
-			Function<Filter, Page<TestItem>> function, String portletId) {
-
-			_function = function;
-			_portletId = portletId;
-
-			_stagingSupported = true;
-		}
-
-		public TestExportImportVulcanBatchEngineTaskItemDelegate(
 			Function<Filter, Page<TestItem>> function, String portletId,
-			boolean stagingSupported) {
+			Integer rank, boolean stagingSupported) {
 
 			_function = function;
 			_portletId = portletId;
+			_rank = rank;
 			_stagingSupported = stagingSupported;
 		}
 
@@ -3067,6 +3068,15 @@ public class BatchEnginePortletDataHandlerTest {
 				@Override
 				public String getPortletId() {
 					return _portletId;
+				}
+
+				@Override
+				public int getRank() {
+					if (_rank != null) {
+						return _rank;
+					}
+
+					return ExportImportDescriptor.super.getRank();
 				}
 
 				@Override
@@ -3167,8 +3177,56 @@ public class BatchEnginePortletDataHandlerTest {
 		private final Function<Filter, Page<TestItem>> _function;
 		private final String _modelClassName = RandomTestUtil.randomString();
 		private final String _portletId;
+		private final Integer _rank;
 		private final String _resourceClassName = RandomTestUtil.randomString();
 		private final boolean _stagingSupported;
+
+	}
+
+	private static class
+		TestExportImportVulcanBatchEngineTaskItemDelegateBuilder {
+
+		public TestExportImportVulcanBatchEngineTaskItemDelegate build() {
+			return new TestExportImportVulcanBatchEngineTaskItemDelegate(
+				_function, _portletId, _rank, _stagingSupported);
+		}
+
+		public TestExportImportVulcanBatchEngineTaskItemDelegateBuilder
+			withFunction(Function<Filter, Page<TestItem>> function) {
+
+			_function = function;
+
+			return this;
+		}
+
+		public TestExportImportVulcanBatchEngineTaskItemDelegateBuilder
+			withPortletId(String portletId) {
+
+			_portletId = portletId;
+
+			return this;
+		}
+
+		public TestExportImportVulcanBatchEngineTaskItemDelegateBuilder
+			withRank(int rank) {
+
+			_rank = rank;
+
+			return this;
+		}
+
+		public TestExportImportVulcanBatchEngineTaskItemDelegateBuilder
+			withStagingSupported(boolean stagingSupported) {
+
+			_stagingSupported = stagingSupported;
+
+			return this;
+		}
+
+		private Function<Filter, Page<TestItem>> _function;
+		private String _portletId;
+		private Integer _rank;
+		private boolean _stagingSupported;
 
 	}
 

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -202,6 +202,11 @@ public class BatchEnginePortletDataHandlerTest {
 	public static void setUpClass() throws PortalException {
 		FeatureFlagTestUtil.invokeFeatureFlagListeners(
 			TestPropsValues.getCompanyId(), true, "LPD-35914");
+
+		Bundle bundle = FrameworkUtil.getBundle(
+			BatchEnginePortletDataHandlerTest.class);
+
+		_bundleContext = bundle.getBundleContext();
 	}
 
 	@AfterClass
@@ -856,12 +861,8 @@ public class BatchEnginePortletDataHandlerTest {
 
 		Group group2 = GroupTestUtil.addGroup();
 
-		Bundle bundle = FrameworkUtil.getBundle(getClass());
-
-		BundleContext bundleContext = bundle.getBundleContext();
-
 		ServiceRegistration<?> serviceRegistration =
-			bundleContext.registerService(
+			_bundleContext.registerService(
 				StagedModelDataHandler.class,
 				new BaseStagedModelDataHandler<Layout>() {
 
@@ -1487,6 +1488,118 @@ public class BatchEnginePortletDataHandlerTest {
 		_testGetExportModelCount(
 			TestPropsValues.getGroupId(),
 			_addObjectDefinition(ObjectDefinitionConstants.SCOPE_SITE));
+	}
+
+	@Test
+	@TestInfo("LPD-75687")
+	public void testGetRank() throws Exception {
+		String portletId = RandomTestUtil.randomString();
+
+		try (SafeCloseable safeCloseable = _register(
+				new TestExportImportVulcanBatchEngineTaskItemDelegateBuilder(
+				).withPortletId(
+					portletId
+				).build())) {
+
+			PortletDataHandler portletDataHandler =
+				_portletDataHandlerProvider.provide(
+					TestPropsValues.getCompanyId(), portletId);
+
+			Assert.assertEquals(100, portletDataHandler.getRank());
+		}
+
+		int rank1 = 101;
+
+		try (SafeCloseable safeCloseable = _register(
+				new TestExportImportVulcanBatchEngineTaskItemDelegateBuilder(
+				).withPortletId(
+					portletId
+				).withRank(
+					rank1
+				).build())) {
+
+			PortletDataHandler portletDataHandler =
+				_portletDataHandlerProvider.provide(
+					TestPropsValues.getCompanyId(), portletId);
+
+			Assert.assertEquals(rank1, portletDataHandler.getRank());
+		}
+
+		int rank2 = 99;
+
+		try (SafeCloseable safeCloseable = _register(
+				new TestExportImportVulcanBatchEngineTaskItemDelegateBuilder(
+				).withPortletId(
+					portletId
+				).withRank(
+					rank2
+				).build())) {
+
+			PortletDataHandler portletDataHandler =
+				_portletDataHandlerProvider.provide(
+					TestPropsValues.getCompanyId(), portletId);
+
+			Assert.assertEquals(rank2, portletDataHandler.getRank());
+		}
+
+		try (SafeCloseable safeCloseable1 = _register(
+				new TestExportImportVulcanBatchEngineTaskItemDelegateBuilder(
+				).withPortletId(
+					portletId
+				).build())) {
+
+			try (SafeCloseable safeCloseable2 = _register(
+					new TestExportImportVulcanBatchEngineTaskItemDelegateBuilder(
+					).withPortletId(
+						portletId
+					).withRank(
+						rank1
+					).build())) {
+
+				PortletDataHandler portletDataHandler =
+					_portletDataHandlerProvider.provide(
+						TestPropsValues.getCompanyId(), portletId);
+
+				Assert.assertEquals(100, portletDataHandler.getRank());
+			}
+
+			try (SafeCloseable safeCloseable2 = _register(
+					new TestExportImportVulcanBatchEngineTaskItemDelegateBuilder(
+					).withPortletId(
+						portletId
+					).withRank(
+						rank2
+					).build())) {
+
+				PortletDataHandler portletDataHandler =
+					_portletDataHandlerProvider.provide(
+						TestPropsValues.getCompanyId(), portletId);
+
+				Assert.assertEquals(rank2, portletDataHandler.getRank());
+			}
+
+			try (SafeCloseable safeCloseable3 = _register(
+					new TestExportImportVulcanBatchEngineTaskItemDelegateBuilder(
+					).withPortletId(
+						portletId
+					).withRank(
+						rank1
+					).build());
+				SafeCloseable safeCloseable4 = _register(
+					new TestExportImportVulcanBatchEngineTaskItemDelegateBuilder(
+					).withPortletId(
+						portletId
+					).withRank(
+						rank2
+					).build())) {
+
+				PortletDataHandler portletDataHandler =
+					_portletDataHandlerProvider.provide(
+						TestPropsValues.getCompanyId(), portletId);
+
+				Assert.assertEquals(rank2, portletDataHandler.getRank());
+			}
+		}
 	}
 
 	@Test
@@ -2306,13 +2419,25 @@ public class BatchEnginePortletDataHandlerTest {
 				testExportImportVulcanBatchEngineTaskItemDelegate)
 		throws Exception {
 
-		SafeCloseable safeCloseable1 = _registerServiceWithSafeCloseable(
-			Portlet.class,
-			new GenericPortlet() {
-			},
-			MapUtil.singletonDictionary(
-				"jakarta.portlet.name",
-				testExportImportVulcanBatchEngineTaskItemDelegate._portletId));
+		String portletId =
+			testExportImportVulcanBatchEngineTaskItemDelegate._portletId;
+
+		SafeCloseable safeCloseable1 = () -> {
+		};
+
+		if (ArrayUtil.isEmpty(
+				_bundleContext.getServiceReferences(
+					Portlet.class.getName(),
+					StringBundler.concat(
+						"(jakarta.portlet.name=", portletId, ")")))) {
+
+			safeCloseable1 = _registerServiceWithSafeCloseable(
+				Portlet.class,
+				new GenericPortlet() {
+				},
+				MapUtil.singletonDictionary("jakarta.portlet.name", portletId));
+		}
+
 		SafeCloseable safeCloseable2 = _registerServiceWithSafeCloseable(
 			VulcanBatchEngineTaskItemDelegate.class,
 			testExportImportVulcanBatchEngineTaskItemDelegate,
@@ -2330,12 +2455,14 @@ public class BatchEnginePortletDataHandlerTest {
 				"export.import.vulcan.batch.engine.task.item.delegate", "true"
 			).build());
 
+		SafeCloseable finalSafeCloseable = safeCloseable1;
+
 		return () -> {
 			try {
 				safeCloseable2.close();
 			}
 			finally {
-				safeCloseable1.close();
+				finalSafeCloseable.close();
 			}
 		};
 	}
@@ -2343,13 +2470,8 @@ public class BatchEnginePortletDataHandlerTest {
 	private <S> SafeCloseable _registerServiceWithSafeCloseable(
 		Class<S> clazz, S service, Dictionary<String, ?> properties) {
 
-		Bundle bundle = FrameworkUtil.getBundle(
-			BatchEnginePortletDataHandlerTest.class);
-
-		BundleContext bundleContext = bundle.getBundleContext();
-
 		ServiceRegistration<S> serviceRegistration =
-			bundleContext.registerService(clazz, service, properties);
+			_bundleContext.registerService(clazz, service, properties);
 
 		return serviceRegistration::unregister;
 	}
@@ -2929,6 +3051,7 @@ public class BatchEnginePortletDataHandlerTest {
 	private static final String _OBJECT_FIELD_VALUE_ATTACHMENT_USER_COMPUTER =
 		RandomTestUtil.randomString();
 
+	private static BundleContext _bundleContext;
 	private static final BiFunction
 		<FileEntry, Group, ObjectValuePair<String, Long>>
 			_defaultReportEntryBiFunction =

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/ListTypeDefinitionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/ListTypeDefinitionResourceImpl.java
@@ -106,6 +106,11 @@ public class ListTypeDefinitionResourceImpl
 			}
 
 			@Override
+			public int getRank() {
+				return 98;
+			}
+
+			@Override
 			public String getResourceClassName() {
 				return ListTypeDefinitionResourceImpl.class.getName();
 			}

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
@@ -204,6 +204,11 @@ public class ObjectDefinitionResourceImpl
 			}
 
 			@Override
+			public int getRank() {
+				return 99;
+			}
+
+			@Override
 			public String getResourceClassName() {
 				return ObjectDefinitionResourceImpl.class.getName();
 			}

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/exportimport/data/handler/StagedGroupStagedModelDataHandler.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/exportimport/data/handler/StagedGroupStagedModelDataHandler.java
@@ -55,6 +55,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -491,8 +492,9 @@ public class StagedGroupStagedModelDataHandler
 
 		_permissionImporter.clearCache();
 
-		List<Element> batchPortletElements = new ArrayList<>();
 		List<Element> nonbatchPortletElements = new ArrayList<>();
+		Map<Integer, List<Element>> rankedBatchPortletElements =
+			new TreeMap<>();
 
 		for (Element portletElement : sitePortletElements) {
 			String portletId = portletElement.attributeValue("portlet-id");
@@ -508,7 +510,17 @@ public class StagedGroupStagedModelDataHandler
 				portlet.getPortletDataHandlerInstance();
 
 			if (portletDataHandler.isBatch()) {
-				batchPortletElements.add(portletElement);
+				rankedBatchPortletElements.compute(
+					portletDataHandler.getRank(),
+					(priority, portletElements) -> {
+						if (portletElements == null) {
+							portletElements = new ArrayList<>();
+						}
+
+						portletElements.add(portletElement);
+
+						return portletElements;
+					});
 			}
 			else {
 				nonbatchPortletElements.add(portletElement);
@@ -517,7 +529,10 @@ public class StagedGroupStagedModelDataHandler
 
 		List<Element> orderedPortletElements = new ArrayList<>();
 
-		orderedPortletElements.addAll(batchPortletElements);
+		for (List<Element> elements : rankedBatchPortletElements.values()) {
+			orderedPortletElements.addAll(elements);
+		}
+
 		orderedPortletElements.addAll(nonbatchPortletElements);
 
 		for (Element portletElement : orderedPortletElements) {

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/exportimport/data/handler/StagedGroupStagedModelDataHandler.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/exportimport/data/handler/StagedGroupStagedModelDataHandler.java
@@ -510,17 +510,11 @@ public class StagedGroupStagedModelDataHandler
 				portlet.getPortletDataHandlerInstance();
 
 			if (portletDataHandler.isBatch()) {
-				rankedBatchPortletElements.compute(
-					portletDataHandler.getRank(),
-					(priority, portletElements) -> {
-						if (portletElements == null) {
-							portletElements = new ArrayList<>();
-						}
-
-						portletElements.add(portletElement);
-
-						return portletElements;
-					});
+				rankedBatchPortletElements.computeIfAbsent(
+					portletDataHandler.getRank(), __ -> new ArrayList<>()
+				).add(
+					portletElement
+				);
 			}
 			else {
 				nonbatchPortletElements.add(portletElement);


### PR DESCRIPTION
Forwarded manually from: https://github.com/liferay-headless/liferay-portal/pull/3417
Related ticket: https://liferay.atlassian.net/browse/LPD-75687

---

The purpose of this story is to set the order of the Batch executions for the given imports, sorted by priority desc:

- List Type Definitions
- Object Definitions
- Object Entries

That is, if the LAR file contains (and the user selects) a subset of the previous items, the List Type Definitions must be imported before the Object Definitions, and the Object Definitions must be imported before the Object Entries.

The lower value of the rank integer value, the higher priority it has, so the import will be processed before. For example, the value of the rank is:

`Rank (List Type Definitions) = 98` < `Rank (Object Definitions) = 99` < `Priority (Object Entries) = 100`