### PR TITLE
LPD-76007 Allow permissions actionId through stagingPermissions check

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/permission/StagingPermissionImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/permission/StagingPermissionImpl.java
@@ -73,6 +73,7 @@ public class StagingPermissionImpl implements StagingPermission {
 			!actionId.equals(ActionKeys.DELETE) &&
 			!actionId.equals(ActionKeys.DELETE_DISCUSSION) &&
 			!actionId.equals(ActionKeys.DOWNLOAD) &&
+			!actionId.equals(ActionKeys.PERMISSIONS) &&
 			!actionId.equals(ActionKeys.UPDATE_DISCUSSION) &&
 			!actionId.equals(ActionKeys.VIEW) &&
 			group.hasLocalOrRemoteStagingGroup() &&

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/permission/StagingPermissionImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/permission/StagingPermissionImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.exportimport.internal.staging.permission;
 
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.staging.permission.StagingPermission;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -59,7 +60,12 @@ public class StagingPermissionImpl implements StagingPermission {
 			Group group, String portletId, String actionId)
 		throws Exception {
 
-		if (!PropsValues.STAGING_LIVE_GROUP_LOCKING_ENABLED) {
+		if (!PropsValues.STAGING_LIVE_GROUP_LOCKING_ENABLED ||
+			ExportImportThreadLocal.isExportInProcess() ||
+			ExportImportThreadLocal.isImportInProcess() ||
+			ExportImportThreadLocal.isInitialLayoutStagingInProcess() ||
+			ExportImportThreadLocal.isStagingInProcess()) {
+
 			return null;
 		}
 
@@ -73,7 +79,6 @@ public class StagingPermissionImpl implements StagingPermission {
 			!actionId.equals(ActionKeys.DELETE) &&
 			!actionId.equals(ActionKeys.DELETE_DISCUSSION) &&
 			!actionId.equals(ActionKeys.DOWNLOAD) &&
-			!actionId.equals(ActionKeys.PERMISSIONS) &&
 			!actionId.equals(ActionKeys.UPDATE_DISCUSSION) &&
 			!actionId.equals(ActionKeys.VIEW) &&
 			group.hasLocalOrRemoteStagingGroup() &&

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/node-scripts.config.js
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/node-scripts.config.js
@@ -1,0 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+module.exports = {
+	main: './src/index.ts',
+};

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/package.json
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/package.json
@@ -1,0 +1,13 @@
+{
+	"dependencies": {
+	},
+	"devDependencies": {
+		"@types/node": "^12",
+		"typescript": "^4.0 || ^5.0"
+	},
+	"main": "src/index.ts",
+	"name": "@liferay/headless-admin-taxonomy-client-js",
+	"private": true,
+	"type": "commonjs",
+	"version": "1.0.0"
+}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/apis/KeywordAPI.ts
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/apis/KeywordAPI.ts
@@ -1,0 +1,1643 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ObjectSerializer} from '../utils/SerDes';
+
+		import {Keyword} from '../models/Keyword';
+		import {PageKeyword} from '../models/PageKeyword';
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+
+export class KeywordAPI {
+	protected _basePath: string;
+	protected _defaultHeaders: any = {};
+
+	constructor(basePath?: string) {
+		if (basePath) {
+			this._basePath = basePath;
+		}
+	}
+
+	set defaultHeaders(defaultHeaders: any) {
+		this._defaultHeaders = defaultHeaders;
+	}
+
+		/**
+		 * Deletes the asset library's keyword by external reference code.
+				 * @param assetLibraryId
+				 * @param externalReferenceCode
+		 * @param headers Optional custom request headers
+		 */
+		public async deleteAssetLibraryKeywordByExternalReferenceCode(
+						assetLibraryId: number,
+						externalReferenceCode: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/keywords/by-external-reference-code/{externalReferenceCode}"
+						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
+										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
+				;
+
+			const queryParameters: any = {};
+
+						if (assetLibraryId === null || assetLibraryId === undefined) {
+							throw new Error("Required parameter assetLibraryId was null or undefined when calling deleteAssetLibraryKeywordByExternalReferenceCode.");
+						}
+
+						if (externalReferenceCode === null || externalReferenceCode === undefined) {
+							throw new Error("Required parameter externalReferenceCode was null or undefined when calling deleteAssetLibraryKeywordByExternalReferenceCode.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "DELETE",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Deletes the keyword and returns a 204 if the operation succeeds.
+				 * @param keywordId
+		 * @param headers Optional custom request headers
+		 */
+		public async deleteKeyword(
+						keywordId: number,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/keywords/{keywordId}"
+						.replace("{keywordId}",encodeURIComponent(keywordId))
+				;
+
+			const queryParameters: any = {};
+
+						if (keywordId === null || keywordId === undefined) {
+							throw new Error("Required parameter keywordId was null or undefined when calling deleteKeyword.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "DELETE",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Deletes the site's keyword by external reference code.
+				 * @param siteId
+				 * @param externalReferenceCode
+		 * @param headers Optional custom request headers
+		 */
+		public async deleteSiteKeywordByExternalReferenceCode(
+						siteId: number,
+						externalReferenceCode: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/sites/{siteId}/keywords/by-external-reference-code/{externalReferenceCode}"
+						.replace("{siteId}",encodeURIComponent(siteId))
+										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
+				;
+
+			const queryParameters: any = {};
+
+						if (siteId === null || siteId === undefined) {
+							throw new Error("Required parameter siteId was null or undefined when calling deleteSiteKeywordByExternalReferenceCode.");
+						}
+
+						if (externalReferenceCode === null || externalReferenceCode === undefined) {
+							throw new Error("Required parameter externalReferenceCode was null or undefined when calling deleteSiteKeywordByExternalReferenceCode.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "DELETE",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Retrieves the asset library's keyword by external reference code.
+				 * @param assetLibraryId
+				 * @param externalReferenceCode
+				 * @param fields
+				 * @param restrictFields
+		 * @param headers Optional custom request headers
+		 */
+		public async getAssetLibraryKeywordByExternalReferenceCode(
+						assetLibraryId: number,
+						externalReferenceCode: string,
+						fields?: string,
+						restrictFields?: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: Keyword;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/keywords/by-external-reference-code/{externalReferenceCode}"
+						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
+										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
+												;
+
+			const queryParameters: any = {};
+
+						if (assetLibraryId === null || assetLibraryId === undefined) {
+							throw new Error("Required parameter assetLibraryId was null or undefined when calling getAssetLibraryKeywordByExternalReferenceCode.");
+						}
+
+						if (externalReferenceCode === null || externalReferenceCode === undefined) {
+							throw new Error("Required parameter externalReferenceCode was null or undefined when calling getAssetLibraryKeywordByExternalReferenceCode.");
+						}
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "Keyword"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * 
+				 * @param assetLibraryId
+				 * @param fields
+				 * @param restrictFields
+				 * @param roleNames
+		 * @param headers Optional custom request headers
+		 */
+		public async getAssetLibraryKeywordPermissionsPage(
+						assetLibraryId: number,
+						fields?: string,
+						restrictFields?: string,
+						roleNames?: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/keywords/permissions"
+						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
+																;
+
+			const queryParameters: any = {};
+
+						if (assetLibraryId === null || assetLibraryId === undefined) {
+							throw new Error("Required parameter assetLibraryId was null or undefined when calling getAssetLibraryKeywordPermissionsPage.");
+						}
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+						if (roleNames !== undefined) {
+							queryParameters["roleNames"] = ObjectSerializer.serialize(roleNames, "string");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * 
+				 * @param assetLibraryId
+				 * @param aggregationTerms
+				 * @param fields
+				 * @param filter
+				 * @param page
+				 * @param pageSize
+				 * @param restrictFields
+				 * @param search
+				 * @param sort
+		 * @param headers Optional custom request headers
+		 */
+		public async getAssetLibraryKeywordsPage(
+						assetLibraryId: number,
+						aggregationTerms?: Array<string>,
+						fields?: string,
+						filter?: string,
+						page?: number,
+						pageSize?: number,
+						restrictFields?: string,
+						search?: string,
+						sort?: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: PageKeyword;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/keywords"
+						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
+																																				;
+
+			const queryParameters: any = {};
+
+						if (assetLibraryId === null || assetLibraryId === undefined) {
+							throw new Error("Required parameter assetLibraryId was null or undefined when calling getAssetLibraryKeywordsPage.");
+						}
+
+						if (aggregationTerms !== undefined) {
+							queryParameters["aggregationTerms"] = ObjectSerializer.serialize(aggregationTerms, "Array<string>");
+						}
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (filter !== undefined) {
+							queryParameters["filter"] = ObjectSerializer.serialize(filter, "string");
+						}
+
+						if (page !== undefined) {
+							queryParameters["page"] = ObjectSerializer.serialize(page, "number");
+						}
+
+						if (pageSize !== undefined) {
+							queryParameters["pageSize"] = ObjectSerializer.serialize(pageSize, "number");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+						if (search !== undefined) {
+							queryParameters["search"] = ObjectSerializer.serialize(search, "string");
+						}
+
+						if (sort !== undefined) {
+							queryParameters["sort"] = ObjectSerializer.serialize(sort, "string");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "PageKeyword"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Retrieves a keyword.
+				 * @param keywordId
+				 * @param fields
+				 * @param restrictFields
+		 * @param headers Optional custom request headers
+		 */
+		public async getKeyword(
+						keywordId: number,
+						fields?: string,
+						restrictFields?: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: Keyword;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/keywords/{keywordId}"
+						.replace("{keywordId}",encodeURIComponent(keywordId))
+												;
+
+			const queryParameters: any = {};
+
+						if (keywordId === null || keywordId === undefined) {
+							throw new Error("Required parameter keywordId was null or undefined when calling getKeyword.");
+						}
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "Keyword"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * 
+				 * @param fields
+				 * @param page
+				 * @param pageSize
+				 * @param restrictFields
+				 * @param search
+				 * @param siteId
+		 * @param headers Optional custom request headers
+		 */
+		public async getKeywordsRankedPage(
+						fields?: string,
+						page?: number,
+						pageSize?: number,
+						restrictFields?: string,
+						search?: string,
+						siteId?: number,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: PageKeyword;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/keywords/ranked"
+																								;
+
+			const queryParameters: any = {};
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (page !== undefined) {
+							queryParameters["page"] = ObjectSerializer.serialize(page, "number");
+						}
+
+						if (pageSize !== undefined) {
+							queryParameters["pageSize"] = ObjectSerializer.serialize(pageSize, "number");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+						if (search !== undefined) {
+							queryParameters["search"] = ObjectSerializer.serialize(search, "string");
+						}
+
+						if (siteId !== undefined) {
+							queryParameters["siteId"] = ObjectSerializer.serialize(siteId, "number");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "PageKeyword"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Retrieves the site's keyword by external reference code.
+				 * @param siteId
+				 * @param externalReferenceCode
+				 * @param fields
+				 * @param restrictFields
+		 * @param headers Optional custom request headers
+		 */
+		public async getSiteKeywordByExternalReferenceCode(
+						siteId: number,
+						externalReferenceCode: string,
+						fields?: string,
+						restrictFields?: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: Keyword;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/sites/{siteId}/keywords/by-external-reference-code/{externalReferenceCode}"
+						.replace("{siteId}",encodeURIComponent(siteId))
+										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
+												;
+
+			const queryParameters: any = {};
+
+						if (siteId === null || siteId === undefined) {
+							throw new Error("Required parameter siteId was null or undefined when calling getSiteKeywordByExternalReferenceCode.");
+						}
+
+						if (externalReferenceCode === null || externalReferenceCode === undefined) {
+							throw new Error("Required parameter externalReferenceCode was null or undefined when calling getSiteKeywordByExternalReferenceCode.");
+						}
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "Keyword"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * 
+				 * @param siteId
+				 * @param fields
+				 * @param restrictFields
+				 * @param roleNames
+		 * @param headers Optional custom request headers
+		 */
+		public async getSiteKeywordPermissionsPage(
+						siteId: number,
+						fields?: string,
+						restrictFields?: string,
+						roleNames?: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/sites/{siteId}/keywords/permissions"
+						.replace("{siteId}",encodeURIComponent(siteId))
+																;
+
+			const queryParameters: any = {};
+
+						if (siteId === null || siteId === undefined) {
+							throw new Error("Required parameter siteId was null or undefined when calling getSiteKeywordPermissionsPage.");
+						}
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+						if (roleNames !== undefined) {
+							queryParameters["roleNames"] = ObjectSerializer.serialize(roleNames, "string");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Retrieves a Site's keywords. Results can be paginated, filtered, searched, and sorted.
+				 * @param siteId
+				 * @param aggregationTerms
+				 * @param fields
+				 * @param filter
+				 * @param page
+				 * @param pageSize
+				 * @param restrictFields
+				 * @param search
+				 * @param sort
+		 * @param headers Optional custom request headers
+		 */
+		public async getSiteKeywordsPage(
+						siteId: number,
+						aggregationTerms?: Array<string>,
+						fields?: string,
+						filter?: string,
+						page?: number,
+						pageSize?: number,
+						restrictFields?: string,
+						search?: string,
+						sort?: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: PageKeyword;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/sites/{siteId}/keywords"
+						.replace("{siteId}",encodeURIComponent(siteId))
+																																				;
+
+			const queryParameters: any = {};
+
+						if (siteId === null || siteId === undefined) {
+							throw new Error("Required parameter siteId was null or undefined when calling getSiteKeywordsPage.");
+						}
+
+						if (aggregationTerms !== undefined) {
+							queryParameters["aggregationTerms"] = ObjectSerializer.serialize(aggregationTerms, "Array<string>");
+						}
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (filter !== undefined) {
+							queryParameters["filter"] = ObjectSerializer.serialize(filter, "string");
+						}
+
+						if (page !== undefined) {
+							queryParameters["page"] = ObjectSerializer.serialize(page, "number");
+						}
+
+						if (pageSize !== undefined) {
+							queryParameters["pageSize"] = ObjectSerializer.serialize(pageSize, "number");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+						if (search !== undefined) {
+							queryParameters["search"] = ObjectSerializer.serialize(search, "string");
+						}
+
+						if (sort !== undefined) {
+							queryParameters["sort"] = ObjectSerializer.serialize(sort, "string");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "PageKeyword"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * 
+				 * @param assetLibraryId
+		 		* @param requestBody Request body that can be one of multiple content types
+		 * @param headers Optional custom request headers
+		 */
+		public async postAssetLibraryKeywordWithContentType(
+						assetLibraryId: number,
+					requestBody:
+							{
+								parameters: {
+										keyword?: Keyword
+								},
+								type: "application/json"
+							}
+								|
+							{
+								parameters: {
+										keyword?: Keyword
+								},
+								type: "application/xml"
+							}
+								,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: Keyword;
+			response: Response;
+		}> {
+				let body;
+						if (requestBody.type === "application/json") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.keyword, "Keyword"));
+						}
+						if (requestBody.type === "application/xml") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.keyword, "Keyword"));
+						}
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/keywords"
+						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
+				;
+
+			const queryParameters: any = {};
+
+						if (assetLibraryId === null || assetLibraryId === undefined) {
+							throw new Error("Required parameter assetLibraryId was null or undefined when calling postAssetLibraryKeyword.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+					body: body,
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+								,{"Content-Type": requestBody.type}
+					,headers || {}
+					),
+				method: "POST",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "Keyword"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+					/**
+					 *  - Default method for JSON body
+							 * @param assetLibraryId
+						 * @param keyword
+					 */
+					public async postAssetLibraryKeyword(
+									assetLibraryId: number,
+							keyword?: Keyword,
+						headers?: {[name: string]: string}
+					): Promise<{
+							body: Keyword;
+						response: Response;
+					}> {
+						return this.postAssetLibraryKeywordWithContentType(
+										assetLibraryId,
+							{
+								parameters: {
+										keyword: keyword
+								},
+								type: "application/json"
+							},
+							headers
+						);
+					}
+		/**
+		 * Inserts a new keyword in a Site.
+				 * @param siteId
+		 		* @param requestBody Request body that can be one of multiple content types
+		 * @param headers Optional custom request headers
+		 */
+		public async postSiteKeywordWithContentType(
+						siteId: number,
+					requestBody:
+							{
+								parameters: {
+										keyword?: Keyword
+								},
+								type: "application/json"
+							}
+								|
+							{
+								parameters: {
+										keyword?: Keyword
+								},
+								type: "application/xml"
+							}
+								,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: Keyword;
+			response: Response;
+		}> {
+				let body;
+						if (requestBody.type === "application/json") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.keyword, "Keyword"));
+						}
+						if (requestBody.type === "application/xml") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.keyword, "Keyword"));
+						}
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/sites/{siteId}/keywords"
+						.replace("{siteId}",encodeURIComponent(siteId))
+				;
+
+			const queryParameters: any = {};
+
+						if (siteId === null || siteId === undefined) {
+							throw new Error("Required parameter siteId was null or undefined when calling postSiteKeyword.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+					body: body,
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+								,{"Content-Type": requestBody.type}
+					,headers || {}
+					),
+				method: "POST",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "Keyword"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+					/**
+					 * Inserts a new keyword in a Site. - Default method for JSON body
+							 * @param siteId
+						 * @param keyword
+					 */
+					public async postSiteKeyword(
+									siteId: number,
+							keyword?: Keyword,
+						headers?: {[name: string]: string}
+					): Promise<{
+							body: Keyword;
+						response: Response;
+					}> {
+						return this.postSiteKeywordWithContentType(
+										siteId,
+							{
+								parameters: {
+										keyword: keyword
+								},
+								type: "application/json"
+							},
+							headers
+						);
+					}
+		/**
+		 * Updates the asset library's keyword with the given external reference code, or creates it if it not exists.
+				 * @param assetLibraryId
+				 * @param externalReferenceCode
+		 		* @param requestBody Request body that can be one of multiple content types
+		 * @param headers Optional custom request headers
+		 */
+		public async putAssetLibraryKeywordByExternalReferenceCodeWithContentType(
+						assetLibraryId: number,
+						externalReferenceCode: string,
+					requestBody:
+							{
+								parameters: {
+										keyword?: Keyword
+								},
+								type: "application/json"
+							}
+								|
+							{
+								parameters: {
+										keyword?: Keyword
+								},
+								type: "application/xml"
+							}
+								,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: Keyword;
+			response: Response;
+		}> {
+				let body;
+						if (requestBody.type === "application/json") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.keyword, "Keyword"));
+						}
+						if (requestBody.type === "application/xml") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.keyword, "Keyword"));
+						}
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/keywords/by-external-reference-code/{externalReferenceCode}"
+						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
+										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
+				;
+
+			const queryParameters: any = {};
+
+						if (assetLibraryId === null || assetLibraryId === undefined) {
+							throw new Error("Required parameter assetLibraryId was null or undefined when calling putAssetLibraryKeywordByExternalReferenceCode.");
+						}
+
+						if (externalReferenceCode === null || externalReferenceCode === undefined) {
+							throw new Error("Required parameter externalReferenceCode was null or undefined when calling putAssetLibraryKeywordByExternalReferenceCode.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+					body: body,
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+								,{"Content-Type": requestBody.type}
+					,headers || {}
+					),
+				method: "PUT",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "Keyword"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+					/**
+					 * Updates the asset library's keyword with the given external reference code, or creates it if it not exists. - Default method for JSON body
+							 * @param assetLibraryId
+							 * @param externalReferenceCode
+						 * @param keyword
+					 */
+					public async putAssetLibraryKeywordByExternalReferenceCode(
+									assetLibraryId: number,
+									externalReferenceCode: string,
+							keyword?: Keyword,
+						headers?: {[name: string]: string}
+					): Promise<{
+							body: Keyword;
+						response: Response;
+					}> {
+						return this.putAssetLibraryKeywordByExternalReferenceCodeWithContentType(
+										assetLibraryId,
+										externalReferenceCode,
+							{
+								parameters: {
+										keyword: keyword
+								},
+								type: "application/json"
+							},
+							headers
+						);
+					}
+		/**
+		 * 
+				 * @param assetLibraryId
+		 * @param headers Optional custom request headers
+		 */
+		public async putAssetLibraryKeywordPermissionsPage(
+						assetLibraryId: number,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/keywords/permissions"
+						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
+				;
+
+			const queryParameters: any = {};
+
+						if (assetLibraryId === null || assetLibraryId === undefined) {
+							throw new Error("Required parameter assetLibraryId was null or undefined when calling putAssetLibraryKeywordPermissionsPage.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "PUT",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Replaces the keyword with the information sent in the request body. Any missing fields are deleted, unless required.
+				 * @param keywordId
+		 		* @param requestBody Request body that can be one of multiple content types
+		 * @param headers Optional custom request headers
+		 */
+		public async putKeywordWithContentType(
+						keywordId: number,
+					requestBody:
+							{
+								parameters: {
+										keyword?: Keyword
+								},
+								type: "application/json"
+							}
+								|
+							{
+								parameters: {
+										keyword?: Keyword
+								},
+								type: "application/xml"
+							}
+								,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: Keyword;
+			response: Response;
+		}> {
+				let body;
+						if (requestBody.type === "application/json") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.keyword, "Keyword"));
+						}
+						if (requestBody.type === "application/xml") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.keyword, "Keyword"));
+						}
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/keywords/{keywordId}"
+						.replace("{keywordId}",encodeURIComponent(keywordId))
+				;
+
+			const queryParameters: any = {};
+
+						if (keywordId === null || keywordId === undefined) {
+							throw new Error("Required parameter keywordId was null or undefined when calling putKeyword.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+					body: body,
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+								,{"Content-Type": requestBody.type}
+					,headers || {}
+					),
+				method: "PUT",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "Keyword"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+					/**
+					 * Replaces the keyword with the information sent in the request body. Any missing fields are deleted, unless required. - Default method for JSON body
+							 * @param keywordId
+						 * @param keyword
+					 */
+					public async putKeyword(
+									keywordId: number,
+							keyword?: Keyword,
+						headers?: {[name: string]: string}
+					): Promise<{
+							body: Keyword;
+						response: Response;
+					}> {
+						return this.putKeywordWithContentType(
+										keywordId,
+							{
+								parameters: {
+										keyword: keyword
+								},
+								type: "application/json"
+							},
+							headers
+						);
+					}
+		/**
+		 * 
+				 * @param toKeywordId
+				 * @param fromKeywordIds
+		 * @param headers Optional custom request headers
+		 */
+		public async putKeywordMerge(
+						toKeywordId: number,
+						fromKeywordIds: Array<number>,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/keywords/{toKeywordId}/merge"
+						.replace("{toKeywordId}",encodeURIComponent(toKeywordId))
+								;
+
+			const queryParameters: any = {};
+
+						if (toKeywordId === null || toKeywordId === undefined) {
+							throw new Error("Required parameter toKeywordId was null or undefined when calling putKeywordMerge.");
+						}
+
+						if (fromKeywordIds === null || fromKeywordIds === undefined) {
+							throw new Error("Required parameter fromKeywordIds was null or undefined when calling putKeywordMerge.");
+						}
+
+						if (fromKeywordIds !== undefined) {
+							queryParameters["fromKeywordIds"] = ObjectSerializer.serialize(fromKeywordIds, "Array<number>");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "PUT",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * 
+				 * @param keywordId
+		 * @param headers Optional custom request headers
+		 */
+		public async putKeywordSubscribe(
+						keywordId: number,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/keywords/{keywordId}/subscribe"
+						.replace("{keywordId}",encodeURIComponent(keywordId))
+				;
+
+			const queryParameters: any = {};
+
+						if (keywordId === null || keywordId === undefined) {
+							throw new Error("Required parameter keywordId was null or undefined when calling putKeywordSubscribe.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "PUT",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * 
+				 * @param keywordId
+		 * @param headers Optional custom request headers
+		 */
+		public async putKeywordUnsubscribe(
+						keywordId: number,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/keywords/{keywordId}/unsubscribe"
+						.replace("{keywordId}",encodeURIComponent(keywordId))
+				;
+
+			const queryParameters: any = {};
+
+						if (keywordId === null || keywordId === undefined) {
+							throw new Error("Required parameter keywordId was null or undefined when calling putKeywordUnsubscribe.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "PUT",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Updates the site's keyword with the given external reference code, or creates it if it not exists.
+				 * @param siteId
+				 * @param externalReferenceCode
+		 		* @param requestBody Request body that can be one of multiple content types
+		 * @param headers Optional custom request headers
+		 */
+		public async putSiteKeywordByExternalReferenceCodeWithContentType(
+						siteId: number,
+						externalReferenceCode: string,
+					requestBody:
+							{
+								parameters: {
+										keyword?: Keyword
+								},
+								type: "application/json"
+							}
+								|
+							{
+								parameters: {
+										keyword?: Keyword
+								},
+								type: "application/xml"
+							}
+								,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: Keyword;
+			response: Response;
+		}> {
+				let body;
+						if (requestBody.type === "application/json") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.keyword, "Keyword"));
+						}
+						if (requestBody.type === "application/xml") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.keyword, "Keyword"));
+						}
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/sites/{siteId}/keywords/by-external-reference-code/{externalReferenceCode}"
+						.replace("{siteId}",encodeURIComponent(siteId))
+										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
+				;
+
+			const queryParameters: any = {};
+
+						if (siteId === null || siteId === undefined) {
+							throw new Error("Required parameter siteId was null or undefined when calling putSiteKeywordByExternalReferenceCode.");
+						}
+
+						if (externalReferenceCode === null || externalReferenceCode === undefined) {
+							throw new Error("Required parameter externalReferenceCode was null or undefined when calling putSiteKeywordByExternalReferenceCode.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+					body: body,
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+								,{"Content-Type": requestBody.type}
+					,headers || {}
+					),
+				method: "PUT",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "Keyword"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+					/**
+					 * Updates the site's keyword with the given external reference code, or creates it if it not exists. - Default method for JSON body
+							 * @param siteId
+							 * @param externalReferenceCode
+						 * @param keyword
+					 */
+					public async putSiteKeywordByExternalReferenceCode(
+									siteId: number,
+									externalReferenceCode: string,
+							keyword?: Keyword,
+						headers?: {[name: string]: string}
+					): Promise<{
+							body: Keyword;
+						response: Response;
+					}> {
+						return this.putSiteKeywordByExternalReferenceCodeWithContentType(
+										siteId,
+										externalReferenceCode,
+							{
+								parameters: {
+										keyword: keyword
+								},
+								type: "application/json"
+							},
+							headers
+						);
+					}
+		/**
+		 * 
+				 * @param siteId
+		 * @param headers Optional custom request headers
+		 */
+		public async putSiteKeywordPermissionsPage(
+						siteId: number,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/sites/{siteId}/keywords/permissions"
+						.replace("{siteId}",encodeURIComponent(siteId))
+				;
+
+			const queryParameters: any = {};
+
+						if (siteId === null || siteId === undefined) {
+							throw new Error("Required parameter siteId was null or undefined when calling putSiteKeywordPermissionsPage.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "PUT",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/apis/TaxonomyCategoryAPI.ts
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/apis/TaxonomyCategoryAPI.ts
@@ -1,0 +1,2102 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ObjectSerializer} from '../utils/SerDes';
+
+		import {PageTaxonomyCategory} from '../models/PageTaxonomyCategory';
+		import {TaxonomyCategory} from '../models/TaxonomyCategory';
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+
+export class TaxonomyCategoryAPI {
+	protected _basePath: string;
+	protected _defaultHeaders: any = {};
+
+	constructor(basePath?: string) {
+		if (basePath) {
+			this._basePath = basePath;
+		}
+	}
+
+	set defaultHeaders(defaultHeaders: any) {
+		this._defaultHeaders = defaultHeaders;
+	}
+
+		/**
+		 * Deletes the asset library's taxonomy category by external reference code.
+				 * @param assetLibraryId
+				 * @param externalReferenceCode
+		 * @param headers Optional custom request headers
+		 */
+		public async deleteAssetLibraryTaxonomyCategoryByExternalReferenceCode(
+						assetLibraryId: number,
+						externalReferenceCode: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-categories/by-external-reference-code/{externalReferenceCode}"
+						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
+										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
+				;
+
+			const queryParameters: any = {};
+
+						if (assetLibraryId === null || assetLibraryId === undefined) {
+							throw new Error("Required parameter assetLibraryId was null or undefined when calling deleteAssetLibraryTaxonomyCategoryByExternalReferenceCode.");
+						}
+
+						if (externalReferenceCode === null || externalReferenceCode === undefined) {
+							throw new Error("Required parameter externalReferenceCode was null or undefined when calling deleteAssetLibraryTaxonomyCategoryByExternalReferenceCode.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "DELETE",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Deletes the site's taxonomy category by external reference code.
+				 * @param siteId
+				 * @param externalReferenceCode
+		 * @param headers Optional custom request headers
+		 */
+		public async deleteSiteTaxonomyCategoryByExternalReferenceCode(
+						siteId: number,
+						externalReferenceCode: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-categories/by-external-reference-code/{externalReferenceCode}"
+						.replace("{siteId}",encodeURIComponent(siteId))
+										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
+				;
+
+			const queryParameters: any = {};
+
+						if (siteId === null || siteId === undefined) {
+							throw new Error("Required parameter siteId was null or undefined when calling deleteSiteTaxonomyCategoryByExternalReferenceCode.");
+						}
+
+						if (externalReferenceCode === null || externalReferenceCode === undefined) {
+							throw new Error("Required parameter externalReferenceCode was null or undefined when calling deleteSiteTaxonomyCategoryByExternalReferenceCode.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "DELETE",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Deletes the taxonomy category and returns a 204 if the operation succeeds.
+				 * @param taxonomyCategoryId
+		 * @param headers Optional custom request headers
+		 */
+		public async deleteTaxonomyCategory(
+						taxonomyCategoryId: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/taxonomy-categories/{taxonomyCategoryId}"
+						.replace("{taxonomyCategoryId}",encodeURIComponent(taxonomyCategoryId))
+				;
+
+			const queryParameters: any = {};
+
+						if (taxonomyCategoryId === null || taxonomyCategoryId === undefined) {
+							throw new Error("Required parameter taxonomyCategoryId was null or undefined when calling deleteTaxonomyCategory.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "DELETE",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Deletes the site's taxonomy category by external reference code.
+				 * @param taxonomyVocabularyId
+				 * @param externalReferenceCode
+		 * @param headers Optional custom request headers
+		 */
+		public async deleteTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode(
+						taxonomyVocabularyId: number,
+						externalReferenceCode: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories/by-external-reference-code/{externalReferenceCode}"
+						.replace("{taxonomyVocabularyId}",encodeURIComponent(taxonomyVocabularyId))
+										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
+				;
+
+			const queryParameters: any = {};
+
+						if (taxonomyVocabularyId === null || taxonomyVocabularyId === undefined) {
+							throw new Error("Required parameter taxonomyVocabularyId was null or undefined when calling deleteTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode.");
+						}
+
+						if (externalReferenceCode === null || externalReferenceCode === undefined) {
+							throw new Error("Required parameter externalReferenceCode was null or undefined when calling deleteTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "DELETE",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Retrieves the asset library's taxonomy categories.
+				 * @param assetLibraryId
+				 * @param aggregationTerms
+				 * @param fields
+				 * @param filter
+				 * @param page
+				 * @param pageSize
+				 * @param restrictFields
+				 * @param search
+				 * @param sort
+		 * @param headers Optional custom request headers
+		 */
+		public async getAssetLibraryTaxonomyCategoriesPage(
+						assetLibraryId: number,
+						aggregationTerms?: Array<string>,
+						fields?: string,
+						filter?: string,
+						page?: number,
+						pageSize?: number,
+						restrictFields?: string,
+						search?: string,
+						sort?: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: PageTaxonomyCategory;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-categories"
+						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
+																																				;
+
+			const queryParameters: any = {};
+
+						if (assetLibraryId === null || assetLibraryId === undefined) {
+							throw new Error("Required parameter assetLibraryId was null or undefined when calling getAssetLibraryTaxonomyCategoriesPage.");
+						}
+
+						if (aggregationTerms !== undefined) {
+							queryParameters["aggregationTerms"] = ObjectSerializer.serialize(aggregationTerms, "Array<string>");
+						}
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (filter !== undefined) {
+							queryParameters["filter"] = ObjectSerializer.serialize(filter, "string");
+						}
+
+						if (page !== undefined) {
+							queryParameters["page"] = ObjectSerializer.serialize(page, "number");
+						}
+
+						if (pageSize !== undefined) {
+							queryParameters["pageSize"] = ObjectSerializer.serialize(pageSize, "number");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+						if (search !== undefined) {
+							queryParameters["search"] = ObjectSerializer.serialize(search, "string");
+						}
+
+						if (sort !== undefined) {
+							queryParameters["sort"] = ObjectSerializer.serialize(sort, "string");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "PageTaxonomyCategory"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Retrieves the asset library's taxonomy category by external reference code.
+				 * @param assetLibraryId
+				 * @param externalReferenceCode
+				 * @param fields
+				 * @param restrictFields
+		 * @param headers Optional custom request headers
+		 */
+		public async getAssetLibraryTaxonomyCategoryByExternalReferenceCode(
+						assetLibraryId: number,
+						externalReferenceCode: string,
+						fields?: string,
+						restrictFields?: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: TaxonomyCategory;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-categories/by-external-reference-code/{externalReferenceCode}"
+						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
+										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
+												;
+
+			const queryParameters: any = {};
+
+						if (assetLibraryId === null || assetLibraryId === undefined) {
+							throw new Error("Required parameter assetLibraryId was null or undefined when calling getAssetLibraryTaxonomyCategoryByExternalReferenceCode.");
+						}
+
+						if (externalReferenceCode === null || externalReferenceCode === undefined) {
+							throw new Error("Required parameter externalReferenceCode was null or undefined when calling getAssetLibraryTaxonomyCategoryByExternalReferenceCode.");
+						}
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "TaxonomyCategory"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Retrieves the site's taxonomy categories.
+				 * @param siteId
+				 * @param aggregationTerms
+				 * @param fields
+				 * @param filter
+				 * @param page
+				 * @param pageSize
+				 * @param restrictFields
+				 * @param search
+				 * @param sort
+		 * @param headers Optional custom request headers
+		 */
+		public async getSiteTaxonomyCategoriesPage(
+						siteId: number,
+						aggregationTerms?: Array<string>,
+						fields?: string,
+						filter?: string,
+						page?: number,
+						pageSize?: number,
+						restrictFields?: string,
+						search?: string,
+						sort?: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: PageTaxonomyCategory;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-categories"
+						.replace("{siteId}",encodeURIComponent(siteId))
+																																				;
+
+			const queryParameters: any = {};
+
+						if (siteId === null || siteId === undefined) {
+							throw new Error("Required parameter siteId was null or undefined when calling getSiteTaxonomyCategoriesPage.");
+						}
+
+						if (aggregationTerms !== undefined) {
+							queryParameters["aggregationTerms"] = ObjectSerializer.serialize(aggregationTerms, "Array<string>");
+						}
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (filter !== undefined) {
+							queryParameters["filter"] = ObjectSerializer.serialize(filter, "string");
+						}
+
+						if (page !== undefined) {
+							queryParameters["page"] = ObjectSerializer.serialize(page, "number");
+						}
+
+						if (pageSize !== undefined) {
+							queryParameters["pageSize"] = ObjectSerializer.serialize(pageSize, "number");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+						if (search !== undefined) {
+							queryParameters["search"] = ObjectSerializer.serialize(search, "string");
+						}
+
+						if (sort !== undefined) {
+							queryParameters["sort"] = ObjectSerializer.serialize(sort, "string");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "PageTaxonomyCategory"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Retrieves the site's taxonomy category by external reference code.
+				 * @param siteId
+				 * @param externalReferenceCode
+				 * @param fields
+				 * @param restrictFields
+		 * @param headers Optional custom request headers
+		 */
+		public async getSiteTaxonomyCategoryByExternalReferenceCode(
+						siteId: number,
+						externalReferenceCode: string,
+						fields?: string,
+						restrictFields?: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: TaxonomyCategory;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-categories/by-external-reference-code/{externalReferenceCode}"
+						.replace("{siteId}",encodeURIComponent(siteId))
+										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
+												;
+
+			const queryParameters: any = {};
+
+						if (siteId === null || siteId === undefined) {
+							throw new Error("Required parameter siteId was null or undefined when calling getSiteTaxonomyCategoryByExternalReferenceCode.");
+						}
+
+						if (externalReferenceCode === null || externalReferenceCode === undefined) {
+							throw new Error("Required parameter externalReferenceCode was null or undefined when calling getSiteTaxonomyCategoryByExternalReferenceCode.");
+						}
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "TaxonomyCategory"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * 
+				 * @param fields
+				 * @param page
+				 * @param pageSize
+				 * @param restrictFields
+				 * @param siteId
+		 * @param headers Optional custom request headers
+		 */
+		public async getTaxonomyCategoriesRankedPage(
+						fields?: string,
+						page?: number,
+						pageSize?: number,
+						restrictFields?: string,
+						siteId?: number,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: PageTaxonomyCategory;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/taxonomy-categories/ranked"
+																				;
+
+			const queryParameters: any = {};
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (page !== undefined) {
+							queryParameters["page"] = ObjectSerializer.serialize(page, "number");
+						}
+
+						if (pageSize !== undefined) {
+							queryParameters["pageSize"] = ObjectSerializer.serialize(pageSize, "number");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+						if (siteId !== undefined) {
+							queryParameters["siteId"] = ObjectSerializer.serialize(siteId, "number");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "PageTaxonomyCategory"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Retrieves a taxonomy category.
+				 * @param taxonomyCategoryId
+				 * @param fields
+				 * @param restrictFields
+		 * @param headers Optional custom request headers
+		 */
+		public async getTaxonomyCategory(
+						taxonomyCategoryId: string,
+						fields?: string,
+						restrictFields?: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: TaxonomyCategory;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/taxonomy-categories/{taxonomyCategoryId}"
+						.replace("{taxonomyCategoryId}",encodeURIComponent(taxonomyCategoryId))
+												;
+
+			const queryParameters: any = {};
+
+						if (taxonomyCategoryId === null || taxonomyCategoryId === undefined) {
+							throw new Error("Required parameter taxonomyCategoryId was null or undefined when calling getTaxonomyCategory.");
+						}
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "TaxonomyCategory"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * 
+				 * @param taxonomyCategoryId
+				 * @param fields
+				 * @param restrictFields
+				 * @param roleNames
+		 * @param headers Optional custom request headers
+		 */
+		public async getTaxonomyCategoryPermissionsPage(
+						taxonomyCategoryId: string,
+						fields?: string,
+						restrictFields?: string,
+						roleNames?: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/taxonomy-categories/{taxonomyCategoryId}/permissions"
+						.replace("{taxonomyCategoryId}",encodeURIComponent(taxonomyCategoryId))
+																;
+
+			const queryParameters: any = {};
+
+						if (taxonomyCategoryId === null || taxonomyCategoryId === undefined) {
+							throw new Error("Required parameter taxonomyCategoryId was null or undefined when calling getTaxonomyCategoryPermissionsPage.");
+						}
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+						if (roleNames !== undefined) {
+							queryParameters["roleNames"] = ObjectSerializer.serialize(roleNames, "string");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Retrieves a taxonomy category's child taxonomy categories. Results can be paginated, filtered, searched, and sorted.
+				 * @param parentTaxonomyCategoryId
+				 * @param aggregationTerms
+				 * @param fields
+				 * @param filter
+				 * @param page
+				 * @param pageSize
+				 * @param restrictFields
+				 * @param search
+				 * @param sort
+		 * @param headers Optional custom request headers
+		 */
+		public async getTaxonomyCategoryTaxonomyCategoriesPage(
+						parentTaxonomyCategoryId: string,
+						aggregationTerms?: Array<string>,
+						fields?: string,
+						filter?: string,
+						page?: number,
+						pageSize?: number,
+						restrictFields?: string,
+						search?: string,
+						sort?: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: PageTaxonomyCategory;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/taxonomy-categories/{parentTaxonomyCategoryId}/taxonomy-categories"
+						.replace("{parentTaxonomyCategoryId}",encodeURIComponent(parentTaxonomyCategoryId))
+																																				;
+
+			const queryParameters: any = {};
+
+						if (parentTaxonomyCategoryId === null || parentTaxonomyCategoryId === undefined) {
+							throw new Error("Required parameter parentTaxonomyCategoryId was null or undefined when calling getTaxonomyCategoryTaxonomyCategoriesPage.");
+						}
+
+						if (aggregationTerms !== undefined) {
+							queryParameters["aggregationTerms"] = ObjectSerializer.serialize(aggregationTerms, "Array<string>");
+						}
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (filter !== undefined) {
+							queryParameters["filter"] = ObjectSerializer.serialize(filter, "string");
+						}
+
+						if (page !== undefined) {
+							queryParameters["page"] = ObjectSerializer.serialize(page, "number");
+						}
+
+						if (pageSize !== undefined) {
+							queryParameters["pageSize"] = ObjectSerializer.serialize(pageSize, "number");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+						if (search !== undefined) {
+							queryParameters["search"] = ObjectSerializer.serialize(search, "string");
+						}
+
+						if (sort !== undefined) {
+							queryParameters["sort"] = ObjectSerializer.serialize(sort, "string");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "PageTaxonomyCategory"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Retrieves a vocabulary's taxonomy categories. Results can be paginated, filtered, searched, and sorted.
+				 * @param taxonomyVocabularyId
+				 * @param aggregationTerms
+				 * @param fields
+				 * @param filter
+				 * @param flatten
+				 * @param page
+				 * @param pageSize
+				 * @param restrictFields
+				 * @param search
+				 * @param sort
+		 * @param headers Optional custom request headers
+		 */
+		public async getTaxonomyVocabularyTaxonomyCategoriesPage(
+						taxonomyVocabularyId: number,
+						aggregationTerms?: Array<string>,
+						fields?: string,
+						filter?: string,
+						flatten?: boolean,
+						page?: number,
+						pageSize?: number,
+						restrictFields?: string,
+						search?: string,
+						sort?: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: PageTaxonomyCategory;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories"
+						.replace("{taxonomyVocabularyId}",encodeURIComponent(taxonomyVocabularyId))
+																																								;
+
+			const queryParameters: any = {};
+
+						if (taxonomyVocabularyId === null || taxonomyVocabularyId === undefined) {
+							throw new Error("Required parameter taxonomyVocabularyId was null or undefined when calling getTaxonomyVocabularyTaxonomyCategoriesPage.");
+						}
+
+						if (aggregationTerms !== undefined) {
+							queryParameters["aggregationTerms"] = ObjectSerializer.serialize(aggregationTerms, "Array<string>");
+						}
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (filter !== undefined) {
+							queryParameters["filter"] = ObjectSerializer.serialize(filter, "string");
+						}
+
+						if (flatten !== undefined) {
+							queryParameters["flatten"] = ObjectSerializer.serialize(flatten, "boolean");
+						}
+
+						if (page !== undefined) {
+							queryParameters["page"] = ObjectSerializer.serialize(page, "number");
+						}
+
+						if (pageSize !== undefined) {
+							queryParameters["pageSize"] = ObjectSerializer.serialize(pageSize, "number");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+						if (search !== undefined) {
+							queryParameters["search"] = ObjectSerializer.serialize(search, "string");
+						}
+
+						if (sort !== undefined) {
+							queryParameters["sort"] = ObjectSerializer.serialize(sort, "string");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "PageTaxonomyCategory"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Retrieves the site's taxonomy category by external reference code.
+				 * @param taxonomyVocabularyId
+				 * @param externalReferenceCode
+				 * @param fields
+				 * @param restrictFields
+		 * @param headers Optional custom request headers
+		 */
+		public async getTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode(
+						taxonomyVocabularyId: number,
+						externalReferenceCode: string,
+						fields?: string,
+						restrictFields?: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: TaxonomyCategory;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories/by-external-reference-code/{externalReferenceCode}"
+						.replace("{taxonomyVocabularyId}",encodeURIComponent(taxonomyVocabularyId))
+										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
+												;
+
+			const queryParameters: any = {};
+
+						if (taxonomyVocabularyId === null || taxonomyVocabularyId === undefined) {
+							throw new Error("Required parameter taxonomyVocabularyId was null or undefined when calling getTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode.");
+						}
+
+						if (externalReferenceCode === null || externalReferenceCode === undefined) {
+							throw new Error("Required parameter externalReferenceCode was null or undefined when calling getTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode.");
+						}
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "TaxonomyCategory"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Updates only the fields received in the request body. Other fields are left untouched.
+				 * @param taxonomyCategoryId
+		 		* @param requestBody Request body that can be one of multiple content types
+		 * @param headers Optional custom request headers
+		 */
+		public async patchTaxonomyCategoryWithContentType(
+						taxonomyCategoryId: string,
+					requestBody:
+							{
+								parameters: {
+										taxonomyCategory?: TaxonomyCategory
+								},
+								type: "application/json"
+							}
+								|
+							{
+								parameters: {
+										taxonomyCategory?: TaxonomyCategory
+								},
+								type: "application/xml"
+							}
+								,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: TaxonomyCategory;
+			response: Response;
+		}> {
+				let body;
+						if (requestBody.type === "application/json") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyCategory, "TaxonomyCategory"));
+						}
+						if (requestBody.type === "application/xml") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyCategory, "TaxonomyCategory"));
+						}
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/taxonomy-categories/{taxonomyCategoryId}"
+						.replace("{taxonomyCategoryId}",encodeURIComponent(taxonomyCategoryId))
+				;
+
+			const queryParameters: any = {};
+
+						if (taxonomyCategoryId === null || taxonomyCategoryId === undefined) {
+							throw new Error("Required parameter taxonomyCategoryId was null or undefined when calling patchTaxonomyCategory.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+					body: body,
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+								,{"Content-Type": requestBody.type}
+					,headers || {}
+					),
+				method: "PATCH",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "TaxonomyCategory"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+					/**
+					 * Updates only the fields received in the request body. Other fields are left untouched. - Default method for JSON body
+							 * @param taxonomyCategoryId
+						 * @param taxonomyCategory
+					 */
+					public async patchTaxonomyCategory(
+									taxonomyCategoryId: string,
+							taxonomyCategory?: TaxonomyCategory,
+						headers?: {[name: string]: string}
+					): Promise<{
+							body: TaxonomyCategory;
+						response: Response;
+					}> {
+						return this.patchTaxonomyCategoryWithContentType(
+										taxonomyCategoryId,
+							{
+								parameters: {
+										taxonomyCategory: taxonomyCategory
+								},
+								type: "application/json"
+							},
+							headers
+						);
+					}
+		/**
+		 * Inserts a new Category in a Scope.
+				 * @param assetLibraryId
+		 		* @param requestBody Request body that can be one of multiple content types
+		 * @param headers Optional custom request headers
+		 */
+		public async postAssetLibraryTaxonomyCategoryWithContentType(
+						assetLibraryId: number,
+					requestBody:
+							{
+								parameters: {
+										taxonomyCategory?: TaxonomyCategory
+								},
+								type: "application/json"
+							}
+								|
+							{
+								parameters: {
+										taxonomyCategory?: TaxonomyCategory
+								},
+								type: "application/xml"
+							}
+								,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: TaxonomyCategory;
+			response: Response;
+		}> {
+				let body;
+						if (requestBody.type === "application/json") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyCategory, "TaxonomyCategory"));
+						}
+						if (requestBody.type === "application/xml") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyCategory, "TaxonomyCategory"));
+						}
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-categories"
+						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
+				;
+
+			const queryParameters: any = {};
+
+						if (assetLibraryId === null || assetLibraryId === undefined) {
+							throw new Error("Required parameter assetLibraryId was null or undefined when calling postAssetLibraryTaxonomyCategory.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+					body: body,
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+								,{"Content-Type": requestBody.type}
+					,headers || {}
+					),
+				method: "POST",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "TaxonomyCategory"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+					/**
+					 * Inserts a new Category in a Scope. - Default method for JSON body
+							 * @param assetLibraryId
+						 * @param taxonomyCategory
+					 */
+					public async postAssetLibraryTaxonomyCategory(
+									assetLibraryId: number,
+							taxonomyCategory?: TaxonomyCategory,
+						headers?: {[name: string]: string}
+					): Promise<{
+							body: TaxonomyCategory;
+						response: Response;
+					}> {
+						return this.postAssetLibraryTaxonomyCategoryWithContentType(
+										assetLibraryId,
+							{
+								parameters: {
+										taxonomyCategory: taxonomyCategory
+								},
+								type: "application/json"
+							},
+							headers
+						);
+					}
+		/**
+		 * Inserts a new Category in a Scope.
+				 * @param siteId
+		 		* @param requestBody Request body that can be one of multiple content types
+		 * @param headers Optional custom request headers
+		 */
+		public async postSiteTaxonomyCategoryWithContentType(
+						siteId: number,
+					requestBody:
+							{
+								parameters: {
+										taxonomyCategory?: TaxonomyCategory
+								},
+								type: "application/json"
+							}
+								|
+							{
+								parameters: {
+										taxonomyCategory?: TaxonomyCategory
+								},
+								type: "application/xml"
+							}
+								,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: TaxonomyCategory;
+			response: Response;
+		}> {
+				let body;
+						if (requestBody.type === "application/json") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyCategory, "TaxonomyCategory"));
+						}
+						if (requestBody.type === "application/xml") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyCategory, "TaxonomyCategory"));
+						}
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-categories"
+						.replace("{siteId}",encodeURIComponent(siteId))
+				;
+
+			const queryParameters: any = {};
+
+						if (siteId === null || siteId === undefined) {
+							throw new Error("Required parameter siteId was null or undefined when calling postSiteTaxonomyCategory.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+					body: body,
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+								,{"Content-Type": requestBody.type}
+					,headers || {}
+					),
+				method: "POST",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "TaxonomyCategory"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+					/**
+					 * Inserts a new Category in a Scope. - Default method for JSON body
+							 * @param siteId
+						 * @param taxonomyCategory
+					 */
+					public async postSiteTaxonomyCategory(
+									siteId: number,
+							taxonomyCategory?: TaxonomyCategory,
+						headers?: {[name: string]: string}
+					): Promise<{
+							body: TaxonomyCategory;
+						response: Response;
+					}> {
+						return this.postSiteTaxonomyCategoryWithContentType(
+										siteId,
+							{
+								parameters: {
+										taxonomyCategory: taxonomyCategory
+								},
+								type: "application/json"
+							},
+							headers
+						);
+					}
+		/**
+		 * Inserts a new child taxonomy category.
+				 * @param parentTaxonomyCategoryId
+		 		* @param requestBody Request body that can be one of multiple content types
+		 * @param headers Optional custom request headers
+		 */
+		public async postTaxonomyCategoryTaxonomyCategoryWithContentType(
+						parentTaxonomyCategoryId: string,
+					requestBody:
+							{
+								parameters: {
+										taxonomyCategory?: TaxonomyCategory
+								},
+								type: "application/json"
+							}
+								|
+							{
+								parameters: {
+										taxonomyCategory?: TaxonomyCategory
+								},
+								type: "application/xml"
+							}
+								,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: TaxonomyCategory;
+			response: Response;
+		}> {
+				let body;
+						if (requestBody.type === "application/json") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyCategory, "TaxonomyCategory"));
+						}
+						if (requestBody.type === "application/xml") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyCategory, "TaxonomyCategory"));
+						}
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/taxonomy-categories/{parentTaxonomyCategoryId}/taxonomy-categories"
+						.replace("{parentTaxonomyCategoryId}",encodeURIComponent(parentTaxonomyCategoryId))
+				;
+
+			const queryParameters: any = {};
+
+						if (parentTaxonomyCategoryId === null || parentTaxonomyCategoryId === undefined) {
+							throw new Error("Required parameter parentTaxonomyCategoryId was null or undefined when calling postTaxonomyCategoryTaxonomyCategory.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+					body: body,
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+								,{"Content-Type": requestBody.type}
+					,headers || {}
+					),
+				method: "POST",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "TaxonomyCategory"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+					/**
+					 * Inserts a new child taxonomy category. - Default method for JSON body
+							 * @param parentTaxonomyCategoryId
+						 * @param taxonomyCategory
+					 */
+					public async postTaxonomyCategoryTaxonomyCategory(
+									parentTaxonomyCategoryId: string,
+							taxonomyCategory?: TaxonomyCategory,
+						headers?: {[name: string]: string}
+					): Promise<{
+							body: TaxonomyCategory;
+						response: Response;
+					}> {
+						return this.postTaxonomyCategoryTaxonomyCategoryWithContentType(
+										parentTaxonomyCategoryId,
+							{
+								parameters: {
+										taxonomyCategory: taxonomyCategory
+								},
+								type: "application/json"
+							},
+							headers
+						);
+					}
+		/**
+		 * Inserts a new taxonomy category in a taxonomy vocabulary.
+				 * @param taxonomyVocabularyId
+		 		* @param requestBody Request body that can be one of multiple content types
+		 * @param headers Optional custom request headers
+		 */
+		public async postTaxonomyVocabularyTaxonomyCategoryWithContentType(
+						taxonomyVocabularyId: number,
+					requestBody:
+							{
+								parameters: {
+										taxonomyCategory?: TaxonomyCategory
+								},
+								type: "application/json"
+							}
+								|
+							{
+								parameters: {
+										taxonomyCategory?: TaxonomyCategory
+								},
+								type: "application/xml"
+							}
+								,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: TaxonomyCategory;
+			response: Response;
+		}> {
+				let body;
+						if (requestBody.type === "application/json") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyCategory, "TaxonomyCategory"));
+						}
+						if (requestBody.type === "application/xml") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyCategory, "TaxonomyCategory"));
+						}
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories"
+						.replace("{taxonomyVocabularyId}",encodeURIComponent(taxonomyVocabularyId))
+				;
+
+			const queryParameters: any = {};
+
+						if (taxonomyVocabularyId === null || taxonomyVocabularyId === undefined) {
+							throw new Error("Required parameter taxonomyVocabularyId was null or undefined when calling postTaxonomyVocabularyTaxonomyCategory.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+					body: body,
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+								,{"Content-Type": requestBody.type}
+					,headers || {}
+					),
+				method: "POST",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "TaxonomyCategory"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+					/**
+					 * Inserts a new taxonomy category in a taxonomy vocabulary. - Default method for JSON body
+							 * @param taxonomyVocabularyId
+						 * @param taxonomyCategory
+					 */
+					public async postTaxonomyVocabularyTaxonomyCategory(
+									taxonomyVocabularyId: number,
+							taxonomyCategory?: TaxonomyCategory,
+						headers?: {[name: string]: string}
+					): Promise<{
+							body: TaxonomyCategory;
+						response: Response;
+					}> {
+						return this.postTaxonomyVocabularyTaxonomyCategoryWithContentType(
+										taxonomyVocabularyId,
+							{
+								parameters: {
+										taxonomyCategory: taxonomyCategory
+								},
+								type: "application/json"
+							},
+							headers
+						);
+					}
+		/**
+		 * Updates the asset library's taxonomy category with the given external reference code, or creates it if it not exists.
+				 * @param assetLibraryId
+				 * @param externalReferenceCode
+		 		* @param requestBody Request body that can be one of multiple content types
+		 * @param headers Optional custom request headers
+		 */
+		public async putAssetLibraryTaxonomyCategoryByExternalReferenceCodeWithContentType(
+						assetLibraryId: number,
+						externalReferenceCode: string,
+					requestBody:
+							{
+								parameters: {
+										taxonomyCategory?: TaxonomyCategory
+								},
+								type: "application/json"
+							}
+								|
+							{
+								parameters: {
+										taxonomyCategory?: TaxonomyCategory
+								},
+								type: "application/xml"
+							}
+								,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: TaxonomyCategory;
+			response: Response;
+		}> {
+				let body;
+						if (requestBody.type === "application/json") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyCategory, "TaxonomyCategory"));
+						}
+						if (requestBody.type === "application/xml") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyCategory, "TaxonomyCategory"));
+						}
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-categories/by-external-reference-code/{externalReferenceCode}"
+						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
+										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
+				;
+
+			const queryParameters: any = {};
+
+						if (assetLibraryId === null || assetLibraryId === undefined) {
+							throw new Error("Required parameter assetLibraryId was null or undefined when calling putAssetLibraryTaxonomyCategoryByExternalReferenceCode.");
+						}
+
+						if (externalReferenceCode === null || externalReferenceCode === undefined) {
+							throw new Error("Required parameter externalReferenceCode was null or undefined when calling putAssetLibraryTaxonomyCategoryByExternalReferenceCode.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+					body: body,
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+								,{"Content-Type": requestBody.type}
+					,headers || {}
+					),
+				method: "PUT",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "TaxonomyCategory"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+					/**
+					 * Updates the asset library's taxonomy category with the given external reference code, or creates it if it not exists. - Default method for JSON body
+							 * @param assetLibraryId
+							 * @param externalReferenceCode
+						 * @param taxonomyCategory
+					 */
+					public async putAssetLibraryTaxonomyCategoryByExternalReferenceCode(
+									assetLibraryId: number,
+									externalReferenceCode: string,
+							taxonomyCategory?: TaxonomyCategory,
+						headers?: {[name: string]: string}
+					): Promise<{
+							body: TaxonomyCategory;
+						response: Response;
+					}> {
+						return this.putAssetLibraryTaxonomyCategoryByExternalReferenceCodeWithContentType(
+										assetLibraryId,
+										externalReferenceCode,
+							{
+								parameters: {
+										taxonomyCategory: taxonomyCategory
+								},
+								type: "application/json"
+							},
+							headers
+						);
+					}
+		/**
+		 * Updates the site's taxonomy category with the given external reference code, or creates it if it not exists.
+				 * @param siteId
+				 * @param externalReferenceCode
+		 		* @param requestBody Request body that can be one of multiple content types
+		 * @param headers Optional custom request headers
+		 */
+		public async putSiteTaxonomyCategoryByExternalReferenceCodeWithContentType(
+						siteId: number,
+						externalReferenceCode: string,
+					requestBody:
+							{
+								parameters: {
+										taxonomyCategory?: TaxonomyCategory
+								},
+								type: "application/json"
+							}
+								|
+							{
+								parameters: {
+										taxonomyCategory?: TaxonomyCategory
+								},
+								type: "application/xml"
+							}
+								,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: TaxonomyCategory;
+			response: Response;
+		}> {
+				let body;
+						if (requestBody.type === "application/json") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyCategory, "TaxonomyCategory"));
+						}
+						if (requestBody.type === "application/xml") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyCategory, "TaxonomyCategory"));
+						}
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-categories/by-external-reference-code/{externalReferenceCode}"
+						.replace("{siteId}",encodeURIComponent(siteId))
+										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
+				;
+
+			const queryParameters: any = {};
+
+						if (siteId === null || siteId === undefined) {
+							throw new Error("Required parameter siteId was null or undefined when calling putSiteTaxonomyCategoryByExternalReferenceCode.");
+						}
+
+						if (externalReferenceCode === null || externalReferenceCode === undefined) {
+							throw new Error("Required parameter externalReferenceCode was null or undefined when calling putSiteTaxonomyCategoryByExternalReferenceCode.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+					body: body,
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+								,{"Content-Type": requestBody.type}
+					,headers || {}
+					),
+				method: "PUT",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "TaxonomyCategory"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+					/**
+					 * Updates the site's taxonomy category with the given external reference code, or creates it if it not exists. - Default method for JSON body
+							 * @param siteId
+							 * @param externalReferenceCode
+						 * @param taxonomyCategory
+					 */
+					public async putSiteTaxonomyCategoryByExternalReferenceCode(
+									siteId: number,
+									externalReferenceCode: string,
+							taxonomyCategory?: TaxonomyCategory,
+						headers?: {[name: string]: string}
+					): Promise<{
+							body: TaxonomyCategory;
+						response: Response;
+					}> {
+						return this.putSiteTaxonomyCategoryByExternalReferenceCodeWithContentType(
+										siteId,
+										externalReferenceCode,
+							{
+								parameters: {
+										taxonomyCategory: taxonomyCategory
+								},
+								type: "application/json"
+							},
+							headers
+						);
+					}
+		/**
+		 * Replaces the taxonomy category with the information sent in the request body. Any missing fields are deleted unless they are required.
+				 * @param taxonomyCategoryId
+		 		* @param requestBody Request body that can be one of multiple content types
+		 * @param headers Optional custom request headers
+		 */
+		public async putTaxonomyCategoryWithContentType(
+						taxonomyCategoryId: string,
+					requestBody:
+							{
+								parameters: {
+										taxonomyCategory?: TaxonomyCategory
+								},
+								type: "application/json"
+							}
+								|
+							{
+								parameters: {
+										taxonomyCategory?: TaxonomyCategory
+								},
+								type: "application/xml"
+							}
+								,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: TaxonomyCategory;
+			response: Response;
+		}> {
+				let body;
+						if (requestBody.type === "application/json") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyCategory, "TaxonomyCategory"));
+						}
+						if (requestBody.type === "application/xml") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyCategory, "TaxonomyCategory"));
+						}
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/taxonomy-categories/{taxonomyCategoryId}"
+						.replace("{taxonomyCategoryId}",encodeURIComponent(taxonomyCategoryId))
+				;
+
+			const queryParameters: any = {};
+
+						if (taxonomyCategoryId === null || taxonomyCategoryId === undefined) {
+							throw new Error("Required parameter taxonomyCategoryId was null or undefined when calling putTaxonomyCategory.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+					body: body,
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+								,{"Content-Type": requestBody.type}
+					,headers || {}
+					),
+				method: "PUT",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "TaxonomyCategory"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+					/**
+					 * Replaces the taxonomy category with the information sent in the request body. Any missing fields are deleted unless they are required. - Default method for JSON body
+							 * @param taxonomyCategoryId
+						 * @param taxonomyCategory
+					 */
+					public async putTaxonomyCategory(
+									taxonomyCategoryId: string,
+							taxonomyCategory?: TaxonomyCategory,
+						headers?: {[name: string]: string}
+					): Promise<{
+							body: TaxonomyCategory;
+						response: Response;
+					}> {
+						return this.putTaxonomyCategoryWithContentType(
+										taxonomyCategoryId,
+							{
+								parameters: {
+										taxonomyCategory: taxonomyCategory
+								},
+								type: "application/json"
+							},
+							headers
+						);
+					}
+		/**
+		 * 
+				 * @param taxonomyCategoryId
+		 * @param headers Optional custom request headers
+		 */
+		public async putTaxonomyCategoryPermissionsPage(
+						taxonomyCategoryId: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/taxonomy-categories/{taxonomyCategoryId}/permissions"
+						.replace("{taxonomyCategoryId}",encodeURIComponent(taxonomyCategoryId))
+				;
+
+			const queryParameters: any = {};
+
+						if (taxonomyCategoryId === null || taxonomyCategoryId === undefined) {
+							throw new Error("Required parameter taxonomyCategoryId was null or undefined when calling putTaxonomyCategoryPermissionsPage.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "PUT",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Updates the site's taxonomy category with the given external reference code, or creates it if it not exists.
+				 * @param taxonomyVocabularyId
+				 * @param externalReferenceCode
+		 		* @param requestBody Request body that can be one of multiple content types
+		 * @param headers Optional custom request headers
+		 */
+		public async putTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCodeWithContentType(
+						taxonomyVocabularyId: number,
+						externalReferenceCode: string,
+					requestBody:
+							{
+								parameters: {
+										taxonomyCategory?: TaxonomyCategory
+								},
+								type: "application/json"
+							}
+								|
+							{
+								parameters: {
+										taxonomyCategory?: TaxonomyCategory
+								},
+								type: "application/xml"
+							}
+								,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: TaxonomyCategory;
+			response: Response;
+		}> {
+				let body;
+						if (requestBody.type === "application/json") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyCategory, "TaxonomyCategory"));
+						}
+						if (requestBody.type === "application/xml") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyCategory, "TaxonomyCategory"));
+						}
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories/by-external-reference-code/{externalReferenceCode}"
+						.replace("{taxonomyVocabularyId}",encodeURIComponent(taxonomyVocabularyId))
+										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
+				;
+
+			const queryParameters: any = {};
+
+						if (taxonomyVocabularyId === null || taxonomyVocabularyId === undefined) {
+							throw new Error("Required parameter taxonomyVocabularyId was null or undefined when calling putTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode.");
+						}
+
+						if (externalReferenceCode === null || externalReferenceCode === undefined) {
+							throw new Error("Required parameter externalReferenceCode was null or undefined when calling putTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+					body: body,
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+								,{"Content-Type": requestBody.type}
+					,headers || {}
+					),
+				method: "PUT",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "TaxonomyCategory"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+					/**
+					 * Updates the site's taxonomy category with the given external reference code, or creates it if it not exists. - Default method for JSON body
+							 * @param taxonomyVocabularyId
+							 * @param externalReferenceCode
+						 * @param taxonomyCategory
+					 */
+					public async putTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode(
+									taxonomyVocabularyId: number,
+									externalReferenceCode: string,
+							taxonomyCategory?: TaxonomyCategory,
+						headers?: {[name: string]: string}
+					): Promise<{
+							body: TaxonomyCategory;
+						response: Response;
+					}> {
+						return this.putTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCodeWithContentType(
+										taxonomyVocabularyId,
+										externalReferenceCode,
+							{
+								parameters: {
+										taxonomyCategory: taxonomyCategory
+								},
+								type: "application/json"
+							},
+							headers
+						);
+					}
+}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/apis/TaxonomyVocabularyAPI.ts
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/apis/TaxonomyVocabularyAPI.ts
@@ -1,0 +1,1618 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ObjectSerializer} from '../utils/SerDes';
+
+		import {PageTaxonomyVocabulary} from '../models/PageTaxonomyVocabulary';
+		import {TaxonomyVocabulary} from '../models/TaxonomyVocabulary';
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+
+export class TaxonomyVocabularyAPI {
+	protected _basePath: string;
+	protected _defaultHeaders: any = {};
+
+	constructor(basePath?: string) {
+		if (basePath) {
+			this._basePath = basePath;
+		}
+	}
+
+	set defaultHeaders(defaultHeaders: any) {
+		this._defaultHeaders = defaultHeaders;
+	}
+
+		/**
+		 * Deletes the asset library's taxonomy vocabulary by external reference code.
+				 * @param assetLibraryId
+				 * @param externalReferenceCode
+		 * @param headers Optional custom request headers
+		 */
+		public async deleteAssetLibraryTaxonomyVocabularyByExternalReferenceCode(
+						assetLibraryId: number,
+						externalReferenceCode: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-vocabularies/by-external-reference-code/{externalReferenceCode}"
+						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
+										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
+				;
+
+			const queryParameters: any = {};
+
+						if (assetLibraryId === null || assetLibraryId === undefined) {
+							throw new Error("Required parameter assetLibraryId was null or undefined when calling deleteAssetLibraryTaxonomyVocabularyByExternalReferenceCode.");
+						}
+
+						if (externalReferenceCode === null || externalReferenceCode === undefined) {
+							throw new Error("Required parameter externalReferenceCode was null or undefined when calling deleteAssetLibraryTaxonomyVocabularyByExternalReferenceCode.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "DELETE",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Deletes the site's taxonomy vocabulary by external reference code.
+				 * @param siteId
+				 * @param externalReferenceCode
+		 * @param headers Optional custom request headers
+		 */
+		public async deleteSiteTaxonomyVocabularyByExternalReferenceCode(
+						siteId: number,
+						externalReferenceCode: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies/by-external-reference-code/{externalReferenceCode}"
+						.replace("{siteId}",encodeURIComponent(siteId))
+										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
+				;
+
+			const queryParameters: any = {};
+
+						if (siteId === null || siteId === undefined) {
+							throw new Error("Required parameter siteId was null or undefined when calling deleteSiteTaxonomyVocabularyByExternalReferenceCode.");
+						}
+
+						if (externalReferenceCode === null || externalReferenceCode === undefined) {
+							throw new Error("Required parameter externalReferenceCode was null or undefined when calling deleteSiteTaxonomyVocabularyByExternalReferenceCode.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "DELETE",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Deletes the taxonomy vocabulary and returns a 204 if the operation succeeds.
+				 * @param taxonomyVocabularyId
+		 * @param headers Optional custom request headers
+		 */
+		public async deleteTaxonomyVocabulary(
+						taxonomyVocabularyId: number,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}"
+						.replace("{taxonomyVocabularyId}",encodeURIComponent(taxonomyVocabularyId))
+				;
+
+			const queryParameters: any = {};
+
+						if (taxonomyVocabularyId === null || taxonomyVocabularyId === undefined) {
+							throw new Error("Required parameter taxonomyVocabularyId was null or undefined when calling deleteTaxonomyVocabulary.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "DELETE",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * 
+				 * @param assetLibraryId
+				 * @param aggregationTerms
+				 * @param fields
+				 * @param filter
+				 * @param page
+				 * @param pageSize
+				 * @param restrictFields
+				 * @param search
+				 * @param sort
+		 * @param headers Optional custom request headers
+		 */
+		public async getAssetLibraryTaxonomyVocabulariesPage(
+						assetLibraryId: number,
+						aggregationTerms?: Array<string>,
+						fields?: string,
+						filter?: string,
+						page?: number,
+						pageSize?: number,
+						restrictFields?: string,
+						search?: string,
+						sort?: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: PageTaxonomyVocabulary;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-vocabularies"
+						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
+																																				;
+
+			const queryParameters: any = {};
+
+						if (assetLibraryId === null || assetLibraryId === undefined) {
+							throw new Error("Required parameter assetLibraryId was null or undefined when calling getAssetLibraryTaxonomyVocabulariesPage.");
+						}
+
+						if (aggregationTerms !== undefined) {
+							queryParameters["aggregationTerms"] = ObjectSerializer.serialize(aggregationTerms, "Array<string>");
+						}
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (filter !== undefined) {
+							queryParameters["filter"] = ObjectSerializer.serialize(filter, "string");
+						}
+
+						if (page !== undefined) {
+							queryParameters["page"] = ObjectSerializer.serialize(page, "number");
+						}
+
+						if (pageSize !== undefined) {
+							queryParameters["pageSize"] = ObjectSerializer.serialize(pageSize, "number");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+						if (search !== undefined) {
+							queryParameters["search"] = ObjectSerializer.serialize(search, "string");
+						}
+
+						if (sort !== undefined) {
+							queryParameters["sort"] = ObjectSerializer.serialize(sort, "string");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "PageTaxonomyVocabulary"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Retrieves the asset library's taxonomy vocabulary by external reference code.
+				 * @param assetLibraryId
+				 * @param externalReferenceCode
+				 * @param fields
+				 * @param restrictFields
+		 * @param headers Optional custom request headers
+		 */
+		public async getAssetLibraryTaxonomyVocabularyByExternalReferenceCode(
+						assetLibraryId: number,
+						externalReferenceCode: string,
+						fields?: string,
+						restrictFields?: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: TaxonomyVocabulary;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-vocabularies/by-external-reference-code/{externalReferenceCode}"
+						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
+										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
+												;
+
+			const queryParameters: any = {};
+
+						if (assetLibraryId === null || assetLibraryId === undefined) {
+							throw new Error("Required parameter assetLibraryId was null or undefined when calling getAssetLibraryTaxonomyVocabularyByExternalReferenceCode.");
+						}
+
+						if (externalReferenceCode === null || externalReferenceCode === undefined) {
+							throw new Error("Required parameter externalReferenceCode was null or undefined when calling getAssetLibraryTaxonomyVocabularyByExternalReferenceCode.");
+						}
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "TaxonomyVocabulary"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * 
+				 * @param assetLibraryId
+				 * @param fields
+				 * @param restrictFields
+				 * @param roleNames
+		 * @param headers Optional custom request headers
+		 */
+		public async getAssetLibraryTaxonomyVocabularyPermissionsPage(
+						assetLibraryId: number,
+						fields?: string,
+						restrictFields?: string,
+						roleNames?: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-vocabularies/permissions"
+						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
+																;
+
+			const queryParameters: any = {};
+
+						if (assetLibraryId === null || assetLibraryId === undefined) {
+							throw new Error("Required parameter assetLibraryId was null or undefined when calling getAssetLibraryTaxonomyVocabularyPermissionsPage.");
+						}
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+						if (roleNames !== undefined) {
+							queryParameters["roleNames"] = ObjectSerializer.serialize(roleNames, "string");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Retrieves a Site's taxonomy vocabularies. Results can be paginated, filtered, searched, and sorted.
+				 * @param siteId
+				 * @param aggregationTerms
+				 * @param fields
+				 * @param filter
+				 * @param page
+				 * @param pageSize
+				 * @param restrictFields
+				 * @param search
+				 * @param sort
+		 * @param headers Optional custom request headers
+		 */
+		public async getSiteTaxonomyVocabulariesPage(
+						siteId: number,
+						aggregationTerms?: Array<string>,
+						fields?: string,
+						filter?: string,
+						page?: number,
+						pageSize?: number,
+						restrictFields?: string,
+						search?: string,
+						sort?: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: PageTaxonomyVocabulary;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies"
+						.replace("{siteId}",encodeURIComponent(siteId))
+																																				;
+
+			const queryParameters: any = {};
+
+						if (siteId === null || siteId === undefined) {
+							throw new Error("Required parameter siteId was null or undefined when calling getSiteTaxonomyVocabulariesPage.");
+						}
+
+						if (aggregationTerms !== undefined) {
+							queryParameters["aggregationTerms"] = ObjectSerializer.serialize(aggregationTerms, "Array<string>");
+						}
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (filter !== undefined) {
+							queryParameters["filter"] = ObjectSerializer.serialize(filter, "string");
+						}
+
+						if (page !== undefined) {
+							queryParameters["page"] = ObjectSerializer.serialize(page, "number");
+						}
+
+						if (pageSize !== undefined) {
+							queryParameters["pageSize"] = ObjectSerializer.serialize(pageSize, "number");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+						if (search !== undefined) {
+							queryParameters["search"] = ObjectSerializer.serialize(search, "string");
+						}
+
+						if (sort !== undefined) {
+							queryParameters["sort"] = ObjectSerializer.serialize(sort, "string");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "PageTaxonomyVocabulary"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Retrieves the site's taxonomy vocabulary by external reference code.
+				 * @param siteId
+				 * @param externalReferenceCode
+				 * @param fields
+				 * @param restrictFields
+		 * @param headers Optional custom request headers
+		 */
+		public async getSiteTaxonomyVocabularyByExternalReferenceCode(
+						siteId: number,
+						externalReferenceCode: string,
+						fields?: string,
+						restrictFields?: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: TaxonomyVocabulary;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies/by-external-reference-code/{externalReferenceCode}"
+						.replace("{siteId}",encodeURIComponent(siteId))
+										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
+												;
+
+			const queryParameters: any = {};
+
+						if (siteId === null || siteId === undefined) {
+							throw new Error("Required parameter siteId was null or undefined when calling getSiteTaxonomyVocabularyByExternalReferenceCode.");
+						}
+
+						if (externalReferenceCode === null || externalReferenceCode === undefined) {
+							throw new Error("Required parameter externalReferenceCode was null or undefined when calling getSiteTaxonomyVocabularyByExternalReferenceCode.");
+						}
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "TaxonomyVocabulary"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * 
+				 * @param siteId
+				 * @param fields
+				 * @param restrictFields
+				 * @param roleNames
+		 * @param headers Optional custom request headers
+		 */
+		public async getSiteTaxonomyVocabularyPermissionsPage(
+						siteId: number,
+						fields?: string,
+						restrictFields?: string,
+						roleNames?: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies/permissions"
+						.replace("{siteId}",encodeURIComponent(siteId))
+																;
+
+			const queryParameters: any = {};
+
+						if (siteId === null || siteId === undefined) {
+							throw new Error("Required parameter siteId was null or undefined when calling getSiteTaxonomyVocabularyPermissionsPage.");
+						}
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+						if (roleNames !== undefined) {
+							queryParameters["roleNames"] = ObjectSerializer.serialize(roleNames, "string");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Retrieves a taxonomy vocabulary.
+				 * @param taxonomyVocabularyId
+				 * @param fields
+				 * @param restrictFields
+		 * @param headers Optional custom request headers
+		 */
+		public async getTaxonomyVocabulary(
+						taxonomyVocabularyId: number,
+						fields?: string,
+						restrictFields?: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: TaxonomyVocabulary;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}"
+						.replace("{taxonomyVocabularyId}",encodeURIComponent(taxonomyVocabularyId))
+												;
+
+			const queryParameters: any = {};
+
+						if (taxonomyVocabularyId === null || taxonomyVocabularyId === undefined) {
+							throw new Error("Required parameter taxonomyVocabularyId was null or undefined when calling getTaxonomyVocabulary.");
+						}
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "TaxonomyVocabulary"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * 
+				 * @param taxonomyVocabularyId
+				 * @param fields
+				 * @param restrictFields
+				 * @param roleNames
+		 * @param headers Optional custom request headers
+		 */
+		public async getTaxonomyVocabularyPermissionsPage(
+						taxonomyVocabularyId: number,
+						fields?: string,
+						restrictFields?: string,
+						roleNames?: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/permissions"
+						.replace("{taxonomyVocabularyId}",encodeURIComponent(taxonomyVocabularyId))
+																;
+
+			const queryParameters: any = {};
+
+						if (taxonomyVocabularyId === null || taxonomyVocabularyId === undefined) {
+							throw new Error("Required parameter taxonomyVocabularyId was null or undefined when calling getTaxonomyVocabularyPermissionsPage.");
+						}
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+						if (roleNames !== undefined) {
+							queryParameters["roleNames"] = ObjectSerializer.serialize(roleNames, "string");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Updates only the fields received in the request body. Any other fields are left untouched.
+				 * @param taxonomyVocabularyId
+		 		* @param requestBody Request body that can be one of multiple content types
+		 * @param headers Optional custom request headers
+		 */
+		public async patchTaxonomyVocabularyWithContentType(
+						taxonomyVocabularyId: number,
+					requestBody:
+							{
+								parameters: {
+										taxonomyVocabulary?: TaxonomyVocabulary
+								},
+								type: "application/json"
+							}
+								|
+							{
+								parameters: {
+										taxonomyVocabulary?: TaxonomyVocabulary
+								},
+								type: "application/xml"
+							}
+								,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: TaxonomyVocabulary;
+			response: Response;
+		}> {
+				let body;
+						if (requestBody.type === "application/json") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyVocabulary, "TaxonomyVocabulary"));
+						}
+						if (requestBody.type === "application/xml") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyVocabulary, "TaxonomyVocabulary"));
+						}
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}"
+						.replace("{taxonomyVocabularyId}",encodeURIComponent(taxonomyVocabularyId))
+				;
+
+			const queryParameters: any = {};
+
+						if (taxonomyVocabularyId === null || taxonomyVocabularyId === undefined) {
+							throw new Error("Required parameter taxonomyVocabularyId was null or undefined when calling patchTaxonomyVocabulary.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+					body: body,
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+								,{"Content-Type": requestBody.type}
+					,headers || {}
+					),
+				method: "PATCH",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "TaxonomyVocabulary"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+					/**
+					 * Updates only the fields received in the request body. Any other fields are left untouched. - Default method for JSON body
+							 * @param taxonomyVocabularyId
+						 * @param taxonomyVocabulary
+					 */
+					public async patchTaxonomyVocabulary(
+									taxonomyVocabularyId: number,
+							taxonomyVocabulary?: TaxonomyVocabulary,
+						headers?: {[name: string]: string}
+					): Promise<{
+							body: TaxonomyVocabulary;
+						response: Response;
+					}> {
+						return this.patchTaxonomyVocabularyWithContentType(
+										taxonomyVocabularyId,
+							{
+								parameters: {
+										taxonomyVocabulary: taxonomyVocabulary
+								},
+								type: "application/json"
+							},
+							headers
+						);
+					}
+		/**
+		 * 
+				 * @param assetLibraryId
+		 		* @param requestBody Request body that can be one of multiple content types
+		 * @param headers Optional custom request headers
+		 */
+		public async postAssetLibraryTaxonomyVocabularyWithContentType(
+						assetLibraryId: number,
+					requestBody:
+							{
+								parameters: {
+										taxonomyVocabulary?: TaxonomyVocabulary
+								},
+								type: "application/json"
+							}
+								|
+							{
+								parameters: {
+										taxonomyVocabulary?: TaxonomyVocabulary
+								},
+								type: "application/xml"
+							}
+								,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: TaxonomyVocabulary;
+			response: Response;
+		}> {
+				let body;
+						if (requestBody.type === "application/json") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyVocabulary, "TaxonomyVocabulary"));
+						}
+						if (requestBody.type === "application/xml") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyVocabulary, "TaxonomyVocabulary"));
+						}
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-vocabularies"
+						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
+				;
+
+			const queryParameters: any = {};
+
+						if (assetLibraryId === null || assetLibraryId === undefined) {
+							throw new Error("Required parameter assetLibraryId was null or undefined when calling postAssetLibraryTaxonomyVocabulary.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+					body: body,
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+								,{"Content-Type": requestBody.type}
+					,headers || {}
+					),
+				method: "POST",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "TaxonomyVocabulary"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+					/**
+					 *  - Default method for JSON body
+							 * @param assetLibraryId
+						 * @param taxonomyVocabulary
+					 */
+					public async postAssetLibraryTaxonomyVocabulary(
+									assetLibraryId: number,
+							taxonomyVocabulary?: TaxonomyVocabulary,
+						headers?: {[name: string]: string}
+					): Promise<{
+							body: TaxonomyVocabulary;
+						response: Response;
+					}> {
+						return this.postAssetLibraryTaxonomyVocabularyWithContentType(
+										assetLibraryId,
+							{
+								parameters: {
+										taxonomyVocabulary: taxonomyVocabulary
+								},
+								type: "application/json"
+							},
+							headers
+						);
+					}
+		/**
+		 * Inserts a new taxonomy vocabulary in a Site.
+				 * @param siteId
+		 		* @param requestBody Request body that can be one of multiple content types
+		 * @param headers Optional custom request headers
+		 */
+		public async postSiteTaxonomyVocabularyWithContentType(
+						siteId: number,
+					requestBody:
+							{
+								parameters: {
+										taxonomyVocabulary?: TaxonomyVocabulary
+								},
+								type: "application/json"
+							}
+								|
+							{
+								parameters: {
+										taxonomyVocabulary?: TaxonomyVocabulary
+								},
+								type: "application/xml"
+							}
+								,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: TaxonomyVocabulary;
+			response: Response;
+		}> {
+				let body;
+						if (requestBody.type === "application/json") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyVocabulary, "TaxonomyVocabulary"));
+						}
+						if (requestBody.type === "application/xml") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyVocabulary, "TaxonomyVocabulary"));
+						}
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies"
+						.replace("{siteId}",encodeURIComponent(siteId))
+				;
+
+			const queryParameters: any = {};
+
+						if (siteId === null || siteId === undefined) {
+							throw new Error("Required parameter siteId was null or undefined when calling postSiteTaxonomyVocabulary.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+					body: body,
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+								,{"Content-Type": requestBody.type}
+					,headers || {}
+					),
+				method: "POST",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "TaxonomyVocabulary"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+					/**
+					 * Inserts a new taxonomy vocabulary in a Site. - Default method for JSON body
+							 * @param siteId
+						 * @param taxonomyVocabulary
+					 */
+					public async postSiteTaxonomyVocabulary(
+									siteId: number,
+							taxonomyVocabulary?: TaxonomyVocabulary,
+						headers?: {[name: string]: string}
+					): Promise<{
+							body: TaxonomyVocabulary;
+						response: Response;
+					}> {
+						return this.postSiteTaxonomyVocabularyWithContentType(
+										siteId,
+							{
+								parameters: {
+										taxonomyVocabulary: taxonomyVocabulary
+								},
+								type: "application/json"
+							},
+							headers
+						);
+					}
+		/**
+		 * Updates the asset library's taxonomy vocabulary with the given external reference code, or creates it if it not exists.
+				 * @param assetLibraryId
+				 * @param externalReferenceCode
+		 		* @param requestBody Request body that can be one of multiple content types
+		 * @param headers Optional custom request headers
+		 */
+		public async putAssetLibraryTaxonomyVocabularyByExternalReferenceCodeWithContentType(
+						assetLibraryId: number,
+						externalReferenceCode: string,
+					requestBody:
+							{
+								parameters: {
+										taxonomyVocabulary?: TaxonomyVocabulary
+								},
+								type: "application/json"
+							}
+								|
+							{
+								parameters: {
+										taxonomyVocabulary?: TaxonomyVocabulary
+								},
+								type: "application/xml"
+							}
+								,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: TaxonomyVocabulary;
+			response: Response;
+		}> {
+				let body;
+						if (requestBody.type === "application/json") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyVocabulary, "TaxonomyVocabulary"));
+						}
+						if (requestBody.type === "application/xml") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyVocabulary, "TaxonomyVocabulary"));
+						}
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-vocabularies/by-external-reference-code/{externalReferenceCode}"
+						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
+										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
+				;
+
+			const queryParameters: any = {};
+
+						if (assetLibraryId === null || assetLibraryId === undefined) {
+							throw new Error("Required parameter assetLibraryId was null or undefined when calling putAssetLibraryTaxonomyVocabularyByExternalReferenceCode.");
+						}
+
+						if (externalReferenceCode === null || externalReferenceCode === undefined) {
+							throw new Error("Required parameter externalReferenceCode was null or undefined when calling putAssetLibraryTaxonomyVocabularyByExternalReferenceCode.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+					body: body,
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+								,{"Content-Type": requestBody.type}
+					,headers || {}
+					),
+				method: "PUT",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "TaxonomyVocabulary"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+					/**
+					 * Updates the asset library's taxonomy vocabulary with the given external reference code, or creates it if it not exists. - Default method for JSON body
+							 * @param assetLibraryId
+							 * @param externalReferenceCode
+						 * @param taxonomyVocabulary
+					 */
+					public async putAssetLibraryTaxonomyVocabularyByExternalReferenceCode(
+									assetLibraryId: number,
+									externalReferenceCode: string,
+							taxonomyVocabulary?: TaxonomyVocabulary,
+						headers?: {[name: string]: string}
+					): Promise<{
+							body: TaxonomyVocabulary;
+						response: Response;
+					}> {
+						return this.putAssetLibraryTaxonomyVocabularyByExternalReferenceCodeWithContentType(
+										assetLibraryId,
+										externalReferenceCode,
+							{
+								parameters: {
+										taxonomyVocabulary: taxonomyVocabulary
+								},
+								type: "application/json"
+							},
+							headers
+						);
+					}
+		/**
+		 * 
+				 * @param assetLibraryId
+		 * @param headers Optional custom request headers
+		 */
+		public async putAssetLibraryTaxonomyVocabularyPermissionsPage(
+						assetLibraryId: number,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-vocabularies/permissions"
+						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
+				;
+
+			const queryParameters: any = {};
+
+						if (assetLibraryId === null || assetLibraryId === undefined) {
+							throw new Error("Required parameter assetLibraryId was null or undefined when calling putAssetLibraryTaxonomyVocabularyPermissionsPage.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "PUT",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Updates the site's taxonomy vocabulary with the given external reference code, or creates it if it not exists.
+				 * @param siteId
+				 * @param externalReferenceCode
+		 		* @param requestBody Request body that can be one of multiple content types
+		 * @param headers Optional custom request headers
+		 */
+		public async putSiteTaxonomyVocabularyByExternalReferenceCodeWithContentType(
+						siteId: number,
+						externalReferenceCode: string,
+					requestBody:
+							{
+								parameters: {
+										taxonomyVocabulary?: TaxonomyVocabulary
+								},
+								type: "application/json"
+							}
+								|
+							{
+								parameters: {
+										taxonomyVocabulary?: TaxonomyVocabulary
+								},
+								type: "application/xml"
+							}
+								,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: TaxonomyVocabulary;
+			response: Response;
+		}> {
+				let body;
+						if (requestBody.type === "application/json") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyVocabulary, "TaxonomyVocabulary"));
+						}
+						if (requestBody.type === "application/xml") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyVocabulary, "TaxonomyVocabulary"));
+						}
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies/by-external-reference-code/{externalReferenceCode}"
+						.replace("{siteId}",encodeURIComponent(siteId))
+										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
+				;
+
+			const queryParameters: any = {};
+
+						if (siteId === null || siteId === undefined) {
+							throw new Error("Required parameter siteId was null or undefined when calling putSiteTaxonomyVocabularyByExternalReferenceCode.");
+						}
+
+						if (externalReferenceCode === null || externalReferenceCode === undefined) {
+							throw new Error("Required parameter externalReferenceCode was null or undefined when calling putSiteTaxonomyVocabularyByExternalReferenceCode.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+					body: body,
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+								,{"Content-Type": requestBody.type}
+					,headers || {}
+					),
+				method: "PUT",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "TaxonomyVocabulary"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+					/**
+					 * Updates the site's taxonomy vocabulary with the given external reference code, or creates it if it not exists. - Default method for JSON body
+							 * @param siteId
+							 * @param externalReferenceCode
+						 * @param taxonomyVocabulary
+					 */
+					public async putSiteTaxonomyVocabularyByExternalReferenceCode(
+									siteId: number,
+									externalReferenceCode: string,
+							taxonomyVocabulary?: TaxonomyVocabulary,
+						headers?: {[name: string]: string}
+					): Promise<{
+							body: TaxonomyVocabulary;
+						response: Response;
+					}> {
+						return this.putSiteTaxonomyVocabularyByExternalReferenceCodeWithContentType(
+										siteId,
+										externalReferenceCode,
+							{
+								parameters: {
+										taxonomyVocabulary: taxonomyVocabulary
+								},
+								type: "application/json"
+							},
+							headers
+						);
+					}
+		/**
+		 * 
+				 * @param siteId
+		 * @param headers Optional custom request headers
+		 */
+		public async putSiteTaxonomyVocabularyPermissionsPage(
+						siteId: number,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies/permissions"
+						.replace("{siteId}",encodeURIComponent(siteId))
+				;
+
+			const queryParameters: any = {};
+
+						if (siteId === null || siteId === undefined) {
+							throw new Error("Required parameter siteId was null or undefined when calling putSiteTaxonomyVocabularyPermissionsPage.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "PUT",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * Replaces the taxonomy vocabulary with the information sent in the request body. Any missing fields are deleted unless they are required.
+				 * @param taxonomyVocabularyId
+		 		* @param requestBody Request body that can be one of multiple content types
+		 * @param headers Optional custom request headers
+		 */
+		public async putTaxonomyVocabularyWithContentType(
+						taxonomyVocabularyId: number,
+					requestBody:
+							{
+								parameters: {
+										taxonomyVocabulary?: TaxonomyVocabulary
+								},
+								type: "application/json"
+							}
+								|
+							{
+								parameters: {
+										taxonomyVocabulary?: TaxonomyVocabulary
+								},
+								type: "application/xml"
+							}
+								,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body: TaxonomyVocabulary;
+			response: Response;
+		}> {
+				let body;
+						if (requestBody.type === "application/json") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyVocabulary, "TaxonomyVocabulary"));
+						}
+						if (requestBody.type === "application/xml") {
+								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.taxonomyVocabulary, "TaxonomyVocabulary"));
+						}
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}"
+						.replace("{taxonomyVocabularyId}",encodeURIComponent(taxonomyVocabularyId))
+				;
+
+			const queryParameters: any = {};
+
+						if (taxonomyVocabularyId === null || taxonomyVocabularyId === undefined) {
+							throw new Error("Required parameter taxonomyVocabularyId was null or undefined when calling putTaxonomyVocabulary.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+					body: body,
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+								,{"Content-Type": requestBody.type}
+					,headers || {}
+					),
+				method: "PUT",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: ObjectSerializer.deserialize(await response.json(), "TaxonomyVocabulary"), response};
+					}
+					else {
+						return {body: await response.text() as any, response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+					/**
+					 * Replaces the taxonomy vocabulary with the information sent in the request body. Any missing fields are deleted unless they are required. - Default method for JSON body
+							 * @param taxonomyVocabularyId
+						 * @param taxonomyVocabulary
+					 */
+					public async putTaxonomyVocabulary(
+									taxonomyVocabularyId: number,
+							taxonomyVocabulary?: TaxonomyVocabulary,
+						headers?: {[name: string]: string}
+					): Promise<{
+							body: TaxonomyVocabulary;
+						response: Response;
+					}> {
+						return this.putTaxonomyVocabularyWithContentType(
+										taxonomyVocabularyId,
+							{
+								parameters: {
+										taxonomyVocabulary: taxonomyVocabulary
+								},
+								type: "application/json"
+							},
+							headers
+						);
+					}
+		/**
+		 * 
+				 * @param taxonomyVocabularyId
+		 * @param headers Optional custom request headers
+		 */
+		public async putTaxonomyVocabularyPermissionsPage(
+						taxonomyVocabularyId: number,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/permissions"
+						.replace("{taxonomyVocabularyId}",encodeURIComponent(taxonomyVocabularyId))
+				;
+
+			const queryParameters: any = {};
+
+						if (taxonomyVocabularyId === null || taxonomyVocabularyId === undefined) {
+							throw new Error("Required parameter taxonomyVocabularyId was null or undefined when calling putTaxonomyVocabularyPermissionsPage.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "PUT",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/index.ts
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/index.ts
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+
+	export {KeywordAPI} from './apis/KeywordAPI';
+	export {TaxonomyCategoryAPI} from './apis/TaxonomyCategoryAPI';
+	export {TaxonomyVocabularyAPI} from './apis/TaxonomyVocabularyAPI';
+
+	export {AssetLibrary} from './models/AssetLibrary';
+	export {AssetType} from './models/AssetType';
+	export {Creator} from './models/Creator';
+	export {Facet} from './models/Facet';
+	export {FacetValue} from './models/FacetValue';
+	export {Keyword} from './models/Keyword';
+	export {PageKeyword} from './models/PageKeyword';
+	export {PagePermission} from './models/PagePermission';
+	export {PageTaxonomyCategory} from './models/PageTaxonomyCategory';
+	export {PageTaxonomyVocabulary} from './models/PageTaxonomyVocabulary';
+	export {Permission} from './models/Permission';
+	export {TaxonomyCategory} from './models/TaxonomyCategory';
+	export {TaxonomyCategoryProperty} from './models/TaxonomyCategoryProperty';
+	export {TaxonomyVocabulary} from './models/TaxonomyVocabulary';

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/AssetLibrary.ts
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/AssetLibrary.ts
@@ -1,0 +1,44 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+
+	export class AssetLibrary {
+			"id"?: number;
+			"name"?: string;
+			"name_i18n"?: {[key: string]: string;};
+
+		static "discriminator": string | undefined = undefined;
+
+	static "attributeTypeMap": Array<{
+		baseName: string;
+		name: string;
+		type: string;
+	}> = [
+		{
+			baseName: "id",
+			name: "id",
+			type: "number",
+		},
+		{
+			baseName: "name",
+			name: "name",
+			type: "string",
+		},
+		{
+			baseName: "name_i18n",
+			name: "name_i18n",
+			type: "{[key: string]: string;}",
+		},
+		];
+
+		static getAttributeTypeMap() {
+				return AssetLibrary.attributeTypeMap;
+		}
+	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/AssetType.ts
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/AssetType.ts
@@ -1,0 +1,53 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+
+	/**
+	* Represents the asset type associated with a `TaxonomyCategory`.
+	*/
+	export class AssetType {
+			"required"?: boolean;
+			"subtype"?: string;
+			"type"?: string;
+			"typeId"?: number;
+
+		static "discriminator": string | undefined = undefined;
+
+	static "attributeTypeMap": Array<{
+		baseName: string;
+		name: string;
+		type: string;
+	}> = [
+		{
+			baseName: "required",
+			name: "required",
+			type: "boolean",
+		},
+		{
+			baseName: "subtype",
+			name: "subtype",
+			type: "string",
+		},
+		{
+			baseName: "type",
+			name: "type",
+			type: "string",
+		},
+		{
+			baseName: "typeId",
+			name: "typeId",
+			type: "number",
+		},
+		];
+
+		static getAttributeTypeMap() {
+				return AssetType.attributeTypeMap;
+		}
+	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/Creator.ts
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/Creator.ts
@@ -1,0 +1,83 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+
+	/**
+	* Represents the user who created the content. Properties follow the [creator](https://schema.org/creator) specification.
+	*/
+	export class Creator {
+			"additionalName"?: string;
+			"contentType"?: string;
+			"externalReferenceCode"?: string;
+			"familyName"?: string;
+			"givenName"?: string;
+			"id"?: number;
+			"image"?: string;
+			"name"?: string;
+			"profileURL"?: string;
+
+		static "discriminator": string | undefined = undefined;
+
+	static "attributeTypeMap": Array<{
+		baseName: string;
+		name: string;
+		type: string;
+	}> = [
+		{
+			baseName: "additionalName",
+			name: "additionalName",
+			type: "string",
+		},
+		{
+			baseName: "contentType",
+			name: "contentType",
+			type: "string",
+		},
+		{
+			baseName: "externalReferenceCode",
+			name: "externalReferenceCode",
+			type: "string",
+		},
+		{
+			baseName: "familyName",
+			name: "familyName",
+			type: "string",
+		},
+		{
+			baseName: "givenName",
+			name: "givenName",
+			type: "string",
+		},
+		{
+			baseName: "id",
+			name: "id",
+			type: "number",
+		},
+		{
+			baseName: "image",
+			name: "image",
+			type: "string",
+		},
+		{
+			baseName: "name",
+			name: "name",
+			type: "string",
+		},
+		{
+			baseName: "profileURL",
+			name: "profileURL",
+			type: "string",
+		},
+		];
+
+		static getAttributeTypeMap() {
+				return Creator.attributeTypeMap;
+		}
+	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/Facet.ts
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/Facet.ts
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+			import {FacetValue} from './FacetValue';
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+
+	export class Facet {
+			"facetCriteria"?: string;
+			"facetValues"?: Array<FacetValue>;
+
+		static "discriminator": string | undefined = undefined;
+
+	static "attributeTypeMap": Array<{
+		baseName: string;
+		name: string;
+		type: string;
+	}> = [
+		{
+			baseName: "facetCriteria",
+			name: "facetCriteria",
+			type: "string",
+		},
+		{
+			baseName: "facetValues",
+			name: "facetValues",
+			type: "Array<FacetValue>",
+		},
+		];
+
+		static getAttributeTypeMap() {
+				return Facet.attributeTypeMap;
+		}
+	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/FacetValue.ts
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/FacetValue.ts
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+
+	export class FacetValue {
+			"numberOfOccurrences"?: number;
+			"term"?: string;
+
+		static "discriminator": string | undefined = undefined;
+
+	static "attributeTypeMap": Array<{
+		baseName: string;
+		name: string;
+		type: string;
+	}> = [
+		{
+			baseName: "numberOfOccurrences",
+			name: "numberOfOccurrences",
+			type: "number",
+		},
+		{
+			baseName: "term",
+			name: "term",
+			type: "string",
+		},
+		];
+
+		static getAttributeTypeMap() {
+				return FacetValue.attributeTypeMap;
+		}
+	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/Keyword.ts
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/Keyword.ts
@@ -1,0 +1,109 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+			import {AssetLibrary} from './AssetLibrary';
+			import {Creator} from './Creator';
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+
+	/**
+	* Represents a keyword that describes content. Properties follow the [keywords](https://schema.org/keywords) specification.
+	*/
+	export class Keyword {
+			"actions"?: {[key: string]: {[key: string]: string;};};
+			"assetLibraries"?: Array<AssetLibrary>;
+			"assetLibraryKey"?: string;
+			"creator"?: Creator;
+			"dateCreated"?: Date;
+			"dateModified"?: Date;
+			"externalReferenceCode"?: string;
+			"id"?: number;
+			"keywordUsageCount"?: number;
+			"name"?: string;
+			"siteExternalReferenceCode"?: string;
+			"siteId"?: number;
+			"subscribed"?: boolean;
+
+		static "discriminator": string | undefined = undefined;
+
+	static "attributeTypeMap": Array<{
+		baseName: string;
+		name: string;
+		type: string;
+	}> = [
+		{
+			baseName: "actions",
+			name: "actions",
+			type: "{[key: string]: {[key: string]: string;};}",
+		},
+		{
+			baseName: "assetLibraries",
+			name: "assetLibraries",
+			type: "Array<AssetLibrary>",
+		},
+		{
+			baseName: "assetLibraryKey",
+			name: "assetLibraryKey",
+			type: "string",
+		},
+		{
+			baseName: "creator",
+			name: "creator",
+			type: "Creator",
+		},
+		{
+			baseName: "dateCreated",
+			name: "dateCreated",
+			type: "Date",
+		},
+		{
+			baseName: "dateModified",
+			name: "dateModified",
+			type: "Date",
+		},
+		{
+			baseName: "externalReferenceCode",
+			name: "externalReferenceCode",
+			type: "string",
+		},
+		{
+			baseName: "id",
+			name: "id",
+			type: "number",
+		},
+		{
+			baseName: "keywordUsageCount",
+			name: "keywordUsageCount",
+			type: "number",
+		},
+		{
+			baseName: "name",
+			name: "name",
+			type: "string",
+		},
+		{
+			baseName: "siteExternalReferenceCode",
+			name: "siteExternalReferenceCode",
+			type: "string",
+		},
+		{
+			baseName: "siteId",
+			name: "siteId",
+			type: "number",
+		},
+		{
+			baseName: "subscribed",
+			name: "subscribed",
+			type: "boolean",
+		},
+		];
+
+		static getAttributeTypeMap() {
+				return Keyword.attributeTypeMap;
+		}
+	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/PageKeyword.ts
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/PageKeyword.ts
@@ -1,0 +1,70 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+			import {Facet} from './Facet';
+			import {Keyword} from './Keyword';
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+
+	export class PageKeyword {
+			"actions"?: {[key: string]: {[key: string]: string;};};
+			"facets"?: Array<Facet>;
+			"items"?: Array<Keyword>;
+			"lastPage"?: number;
+			"page"?: number;
+			"pageSize"?: number;
+			"totalCount"?: number;
+
+		static "discriminator": string | undefined = undefined;
+
+	static "attributeTypeMap": Array<{
+		baseName: string;
+		name: string;
+		type: string;
+	}> = [
+		{
+			baseName: "actions",
+			name: "actions",
+			type: "{[key: string]: {[key: string]: string;};}",
+		},
+		{
+			baseName: "facets",
+			name: "facets",
+			type: "Array<Facet>",
+		},
+		{
+			baseName: "items",
+			name: "items",
+			type: "Array<Keyword>",
+		},
+		{
+			baseName: "lastPage",
+			name: "lastPage",
+			type: "number",
+		},
+		{
+			baseName: "page",
+			name: "page",
+			type: "number",
+		},
+		{
+			baseName: "pageSize",
+			name: "pageSize",
+			type: "number",
+		},
+		{
+			baseName: "totalCount",
+			name: "totalCount",
+			type: "number",
+		},
+		];
+
+		static getAttributeTypeMap() {
+				return PageKeyword.attributeTypeMap;
+		}
+	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/PagePermission.ts
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/PagePermission.ts
@@ -1,0 +1,70 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+			import {Facet} from './Facet';
+			import {Permission} from './Permission';
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+
+	export class PagePermission {
+			"actions"?: {[key: string]: {[key: string]: string;};};
+			"facets"?: Array<Facet>;
+			"items"?: Array<Permission>;
+			"lastPage"?: number;
+			"page"?: number;
+			"pageSize"?: number;
+			"totalCount"?: number;
+
+		static "discriminator": string | undefined = undefined;
+
+	static "attributeTypeMap": Array<{
+		baseName: string;
+		name: string;
+		type: string;
+	}> = [
+		{
+			baseName: "actions",
+			name: "actions",
+			type: "{[key: string]: {[key: string]: string;};}",
+		},
+		{
+			baseName: "facets",
+			name: "facets",
+			type: "Array<Facet>",
+		},
+		{
+			baseName: "items",
+			name: "items",
+			type: "Array<Permission>",
+		},
+		{
+			baseName: "lastPage",
+			name: "lastPage",
+			type: "number",
+		},
+		{
+			baseName: "page",
+			name: "page",
+			type: "number",
+		},
+		{
+			baseName: "pageSize",
+			name: "pageSize",
+			type: "number",
+		},
+		{
+			baseName: "totalCount",
+			name: "totalCount",
+			type: "number",
+		},
+		];
+
+		static getAttributeTypeMap() {
+				return PagePermission.attributeTypeMap;
+		}
+	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/PageTaxonomyCategory.ts
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/PageTaxonomyCategory.ts
@@ -1,0 +1,70 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+			import {Facet} from './Facet';
+			import {TaxonomyCategory} from './TaxonomyCategory';
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+
+	export class PageTaxonomyCategory {
+			"actions"?: {[key: string]: {[key: string]: string;};};
+			"facets"?: Array<Facet>;
+			"items"?: Array<TaxonomyCategory>;
+			"lastPage"?: number;
+			"page"?: number;
+			"pageSize"?: number;
+			"totalCount"?: number;
+
+		static "discriminator": string | undefined = undefined;
+
+	static "attributeTypeMap": Array<{
+		baseName: string;
+		name: string;
+		type: string;
+	}> = [
+		{
+			baseName: "actions",
+			name: "actions",
+			type: "{[key: string]: {[key: string]: string;};}",
+		},
+		{
+			baseName: "facets",
+			name: "facets",
+			type: "Array<Facet>",
+		},
+		{
+			baseName: "items",
+			name: "items",
+			type: "Array<TaxonomyCategory>",
+		},
+		{
+			baseName: "lastPage",
+			name: "lastPage",
+			type: "number",
+		},
+		{
+			baseName: "page",
+			name: "page",
+			type: "number",
+		},
+		{
+			baseName: "pageSize",
+			name: "pageSize",
+			type: "number",
+		},
+		{
+			baseName: "totalCount",
+			name: "totalCount",
+			type: "number",
+		},
+		];
+
+		static getAttributeTypeMap() {
+				return PageTaxonomyCategory.attributeTypeMap;
+		}
+	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/PageTaxonomyVocabulary.ts
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/PageTaxonomyVocabulary.ts
@@ -1,0 +1,70 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+			import {Facet} from './Facet';
+			import {TaxonomyVocabulary} from './TaxonomyVocabulary';
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+
+	export class PageTaxonomyVocabulary {
+			"actions"?: {[key: string]: {[key: string]: string;};};
+			"facets"?: Array<Facet>;
+			"items"?: Array<TaxonomyVocabulary>;
+			"lastPage"?: number;
+			"page"?: number;
+			"pageSize"?: number;
+			"totalCount"?: number;
+
+		static "discriminator": string | undefined = undefined;
+
+	static "attributeTypeMap": Array<{
+		baseName: string;
+		name: string;
+		type: string;
+	}> = [
+		{
+			baseName: "actions",
+			name: "actions",
+			type: "{[key: string]: {[key: string]: string;};}",
+		},
+		{
+			baseName: "facets",
+			name: "facets",
+			type: "Array<Facet>",
+		},
+		{
+			baseName: "items",
+			name: "items",
+			type: "Array<TaxonomyVocabulary>",
+		},
+		{
+			baseName: "lastPage",
+			name: "lastPage",
+			type: "number",
+		},
+		{
+			baseName: "page",
+			name: "page",
+			type: "number",
+		},
+		{
+			baseName: "pageSize",
+			name: "pageSize",
+			type: "number",
+		},
+		{
+			baseName: "totalCount",
+			name: "totalCount",
+			type: "number",
+		},
+		];
+
+		static getAttributeTypeMap() {
+				return PageTaxonomyVocabulary.attributeTypeMap;
+		}
+	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/Permission.ts
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/Permission.ts
@@ -1,0 +1,44 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+
+	export class Permission {
+			"actionIds"?: Array<string>;
+			"roleName"?: string;
+			"xml"?: object;
+
+		static "discriminator": string | undefined = undefined;
+
+	static "attributeTypeMap": Array<{
+		baseName: string;
+		name: string;
+		type: string;
+	}> = [
+		{
+			baseName: "actionIds",
+			name: "actionIds",
+			type: "Array<string>",
+		},
+		{
+			baseName: "roleName",
+			name: "roleName",
+			type: "string",
+		},
+		{
+			baseName: "xml",
+			name: "xml",
+			type: "object",
+		},
+		];
+
+		static getAttributeTypeMap() {
+				return Permission.attributeTypeMap;
+		}
+	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/TaxonomyCategory.ts
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/TaxonomyCategory.ts
@@ -1,0 +1,164 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+			import {Creator} from './Creator';
+			import {Permission} from './Permission';
+			import {TaxonomyCategoryProperty} from './TaxonomyCategoryProperty';
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+
+	/**
+	* Represents a category, which is a hierarchical classification that can be associated with particular asset types. Properties follow the [category](https://schema.org/category) specification.
+	*/
+	export class TaxonomyCategory {
+			"actions"?: {[key: string]: {[key: string]: string;};};
+			"assetLibraryKey"?: string;
+			"availableLanguages"?: Array<string>;
+			"creator"?: Creator;
+			"dateCreated"?: Date;
+			"dateModified"?: Date;
+			"description"?: string;
+			"description_i18n"?: {[key: string]: string;};
+			"externalReferenceCode"?: string;
+			"id"?: string;
+			"name"?: string;
+			"name_i18n"?: {[key: string]: string;};
+			"numberOfTaxonomyCategories"?: number;
+			"parentTaxonomyCategory"?: object;
+			"parentTaxonomyVocabulary"?: object;
+			"permissions"?: Array<Permission>;
+			"siteExternalReferenceCode"?: string;
+			"siteId"?: number;
+			"taxonomyCategoryProperties"?: Array<TaxonomyCategoryProperty>;
+			"taxonomyCategoryUsageCount"?: number;
+			"taxonomyVocabularyId"?: number;
+			"viewableBy"?: 'Anyone' | 'Members' | 'Owner';
+
+		static "discriminator": string | undefined = undefined;
+
+	static "attributeTypeMap": Array<{
+		baseName: string;
+		name: string;
+		type: string;
+	}> = [
+		{
+			baseName: "actions",
+			name: "actions",
+			type: "{[key: string]: {[key: string]: string;};}",
+		},
+		{
+			baseName: "assetLibraryKey",
+			name: "assetLibraryKey",
+			type: "string",
+		},
+		{
+			baseName: "availableLanguages",
+			name: "availableLanguages",
+			type: "Array<string>",
+		},
+		{
+			baseName: "creator",
+			name: "creator",
+			type: "Creator",
+		},
+		{
+			baseName: "dateCreated",
+			name: "dateCreated",
+			type: "Date",
+		},
+		{
+			baseName: "dateModified",
+			name: "dateModified",
+			type: "Date",
+		},
+		{
+			baseName: "description",
+			name: "description",
+			type: "string",
+		},
+		{
+			baseName: "description_i18n",
+			name: "description_i18n",
+			type: "{[key: string]: string;}",
+		},
+		{
+			baseName: "externalReferenceCode",
+			name: "externalReferenceCode",
+			type: "string",
+		},
+		{
+			baseName: "id",
+			name: "id",
+			type: "string",
+		},
+		{
+			baseName: "name",
+			name: "name",
+			type: "string",
+		},
+		{
+			baseName: "name_i18n",
+			name: "name_i18n",
+			type: "{[key: string]: string;}",
+		},
+		{
+			baseName: "numberOfTaxonomyCategories",
+			name: "numberOfTaxonomyCategories",
+			type: "number",
+		},
+		{
+			baseName: "parentTaxonomyCategory",
+			name: "parentTaxonomyCategory",
+			type: "object",
+		},
+		{
+			baseName: "parentTaxonomyVocabulary",
+			name: "parentTaxonomyVocabulary",
+			type: "object",
+		},
+		{
+			baseName: "permissions",
+			name: "permissions",
+			type: "Array<Permission>",
+		},
+		{
+			baseName: "siteExternalReferenceCode",
+			name: "siteExternalReferenceCode",
+			type: "string",
+		},
+		{
+			baseName: "siteId",
+			name: "siteId",
+			type: "number",
+		},
+		{
+			baseName: "taxonomyCategoryProperties",
+			name: "taxonomyCategoryProperties",
+			type: "Array<TaxonomyCategoryProperty>",
+		},
+		{
+			baseName: "taxonomyCategoryUsageCount",
+			name: "taxonomyCategoryUsageCount",
+			type: "number",
+		},
+		{
+			baseName: "taxonomyVocabularyId",
+			name: "taxonomyVocabularyId",
+			type: "number",
+		},
+		{
+			baseName: "viewableBy",
+			name: "viewableBy",
+			type: "'Anyone' | 'Members' | 'Owner'",
+		},
+		];
+
+		static getAttributeTypeMap() {
+				return TaxonomyCategory.attributeTypeMap;
+		}
+	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/TaxonomyCategoryProperty.ts
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/TaxonomyCategoryProperty.ts
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+
+	/**
+	* Key value pair to associate detailed information with a category.
+	*/
+	export class TaxonomyCategoryProperty {
+			"externalReferenceCode"?: string;
+			"key"?: string;
+			"value"?: string;
+
+		static "discriminator": string | undefined = undefined;
+
+	static "attributeTypeMap": Array<{
+		baseName: string;
+		name: string;
+		type: string;
+	}> = [
+		{
+			baseName: "externalReferenceCode",
+			name: "externalReferenceCode",
+			type: "string",
+		},
+		{
+			baseName: "key",
+			name: "key",
+			type: "string",
+		},
+		{
+			baseName: "value",
+			name: "value",
+			type: "string",
+		},
+		];
+
+		static getAttributeTypeMap() {
+				return TaxonomyCategoryProperty.attributeTypeMap;
+		}
+	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/TaxonomyVocabulary.ts
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/TaxonomyVocabulary.ts
@@ -1,0 +1,159 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+			import {AssetLibrary} from './AssetLibrary';
+			import {AssetType} from './AssetType';
+			import {Creator} from './Creator';
+			import {Permission} from './Permission';
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+
+	/**
+	* Represents a vocabulary, which is a grouping of categories for a specific purpose (e.g., classification, sorting, etc.).
+	*/
+	export class TaxonomyVocabulary {
+			"actions"?: {[key: string]: {[key: string]: string;};};
+			"assetLibraries"?: Array<AssetLibrary>;
+			"assetLibraryKey"?: string;
+			"assetTypes"?: Array<AssetType>;
+			"availableLanguages"?: Array<string>;
+			"creator"?: Creator;
+			"dateCreated"?: Date;
+			"dateModified"?: Date;
+			"description"?: string;
+			"description_i18n"?: {[key: string]: string;};
+			"externalReferenceCode"?: string;
+			"id"?: number;
+			"multiValued"?: boolean;
+			"name"?: string;
+			"name_i18n"?: {[key: string]: string;};
+			"numberOfTaxonomyCategories"?: number;
+			"permissions"?: Array<Permission>;
+			"siteExternalReferenceCode"?: string;
+			"siteId"?: number;
+			"viewableBy"?: 'Anyone' | 'Members' | 'Owner';
+			"visibilityType"?: 'PUBLIC' | 'INTERNAL';
+
+		static "discriminator": string | undefined = undefined;
+
+	static "attributeTypeMap": Array<{
+		baseName: string;
+		name: string;
+		type: string;
+	}> = [
+		{
+			baseName: "actions",
+			name: "actions",
+			type: "{[key: string]: {[key: string]: string;};}",
+		},
+		{
+			baseName: "assetLibraries",
+			name: "assetLibraries",
+			type: "Array<AssetLibrary>",
+		},
+		{
+			baseName: "assetLibraryKey",
+			name: "assetLibraryKey",
+			type: "string",
+		},
+		{
+			baseName: "assetTypes",
+			name: "assetTypes",
+			type: "Array<AssetType>",
+		},
+		{
+			baseName: "availableLanguages",
+			name: "availableLanguages",
+			type: "Array<string>",
+		},
+		{
+			baseName: "creator",
+			name: "creator",
+			type: "Creator",
+		},
+		{
+			baseName: "dateCreated",
+			name: "dateCreated",
+			type: "Date",
+		},
+		{
+			baseName: "dateModified",
+			name: "dateModified",
+			type: "Date",
+		},
+		{
+			baseName: "description",
+			name: "description",
+			type: "string",
+		},
+		{
+			baseName: "description_i18n",
+			name: "description_i18n",
+			type: "{[key: string]: string;}",
+		},
+		{
+			baseName: "externalReferenceCode",
+			name: "externalReferenceCode",
+			type: "string",
+		},
+		{
+			baseName: "id",
+			name: "id",
+			type: "number",
+		},
+		{
+			baseName: "multiValued",
+			name: "multiValued",
+			type: "boolean",
+		},
+		{
+			baseName: "name",
+			name: "name",
+			type: "string",
+		},
+		{
+			baseName: "name_i18n",
+			name: "name_i18n",
+			type: "{[key: string]: string;}",
+		},
+		{
+			baseName: "numberOfTaxonomyCategories",
+			name: "numberOfTaxonomyCategories",
+			type: "number",
+		},
+		{
+			baseName: "permissions",
+			name: "permissions",
+			type: "Array<Permission>",
+		},
+		{
+			baseName: "siteExternalReferenceCode",
+			name: "siteExternalReferenceCode",
+			type: "string",
+		},
+		{
+			baseName: "siteId",
+			name: "siteId",
+			type: "number",
+		},
+		{
+			baseName: "viewableBy",
+			name: "viewableBy",
+			type: "'Anyone' | 'Members' | 'Owner'",
+		},
+		{
+			baseName: "visibilityType",
+			name: "visibilityType",
+			type: "'PUBLIC' | 'INTERNAL'",
+		},
+		];
+
+		static getAttributeTypeMap() {
+				return TaxonomyVocabulary.attributeTypeMap;
+		}
+	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/utils/SerDes.ts
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/utils/SerDes.ts
@@ -1,0 +1,246 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+	import {AssetLibrary} from '../models/AssetLibrary';
+	import {AssetType} from '../models/AssetType';
+	import {Creator} from '../models/Creator';
+	import {Facet} from '../models/Facet';
+	import {FacetValue} from '../models/FacetValue';
+	import {Keyword} from '../models/Keyword';
+	import {PageKeyword} from '../models/PageKeyword';
+	import {PagePermission} from '../models/PagePermission';
+	import {PageTaxonomyCategory} from '../models/PageTaxonomyCategory';
+	import {PageTaxonomyVocabulary} from '../models/PageTaxonomyVocabulary';
+	import {Permission} from '../models/Permission';
+	import {TaxonomyCategory} from '../models/TaxonomyCategory';
+	import {TaxonomyCategoryProperty} from '../models/TaxonomyCategoryProperty';
+	import {TaxonomyVocabulary} from '../models/TaxonomyVocabulary';
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+
+function endsWith(str: string, match: string): boolean {
+	return (
+		str.length >= match.length &&
+		str.substring(str.length - match.length) === match
+	);
+}
+
+function startsWith(str: string, match: string): boolean {
+	return str.substring(0, match.length) === match;
+}
+
+const arrayPrefix = "Array<";
+const arraySuffix = ">";
+const mapPrefix = "{ [key: string]: ";
+const mapSuffix = "; }";
+const nullableSuffix = " | null";
+const optionalSuffix = " | undefined";
+const primitives = new Set([
+	"string",
+	"boolean",
+	"double",
+	"integer",
+	"long",
+	"float",
+	"number",
+	"any",
+]);
+const typeMap: {[index: string]: any} = {
+	AssetLibrary,
+	AssetType,
+	Creator,
+	Facet,
+	FacetValue,
+	Keyword,
+	PageKeyword,
+	PagePermission,
+	PageTaxonomyCategory,
+	PageTaxonomyVocabulary,
+	Permission,
+	TaxonomyCategory,
+	TaxonomyCategoryProperty,
+	TaxonomyVocabulary,
+};
+
+export class ObjectSerializer {
+	public static deserialize(data: any, type: string): any {
+		type = ObjectSerializer.findCorrectType(data, type);
+		if (data === undefined) {
+			return data;
+		}
+		else if (primitives.has(type.toLowerCase())) {
+			return data;
+		}
+		else if (endsWith(type, nullableSuffix)) {
+			const subType: string = type.slice(0, -nullableSuffix.length);
+
+			return ObjectSerializer.deserialize(data, subType);
+		}
+		else if (endsWith(type, optionalSuffix)) {
+			const subType: string = type.slice(0, -optionalSuffix.length);
+
+			return ObjectSerializer.deserialize(data, subType);
+		}
+		else if (startsWith(type, arrayPrefix)) {
+			const subType: string = type.slice(
+				arrayPrefix.length,
+				-arraySuffix.length
+			);
+			const transformedData: any[] = [];
+			for (let index = 0; index < data.length; index++) {
+				const datum = data[index];
+				transformedData.push(
+					ObjectSerializer.deserialize(datum, subType)
+				);
+			}
+
+			return transformedData;
+		}
+		else if (startsWith(type, mapPrefix)) {
+			const subType: string = type.slice(
+				mapPrefix.length,
+				-mapSuffix.length
+			);
+			const transformedData: {[key: string]: any} = {};
+			for (const key in data) {
+				transformedData[key] = ObjectSerializer.deserialize(
+					data[key],
+					subType
+				);
+			}
+
+			return transformedData;
+		}
+		else if (type === "Date") {
+			return new Date(data);
+		}
+		else {
+			if (!typeMap[type]) {
+				return data;
+			}
+			const instance = new typeMap[type]();
+			const attributeTypes = typeMap[type].getAttributeTypeMap();
+			for (let index = 0; index < attributeTypes.length; index++) {
+				const attributeType = attributeTypes[index];
+				instance[attributeType.name] = ObjectSerializer.deserialize(
+					data[attributeType.baseName],
+					attributeType.type
+				);
+			}
+
+			return instance;
+		}
+	}
+
+	public static findCorrectType(data: any, expectedType: string) {
+		if (data === undefined) {
+			return expectedType;
+		}
+		else if (primitives.has(expectedType.toLowerCase())) {
+			return expectedType;
+		}
+		else if (expectedType === "Date") {
+			return expectedType;
+		}
+		else {
+			if (!typeMap[expectedType]) {
+				return expectedType;
+			}
+
+			const discriminatorProperty = typeMap[expectedType].discriminator;
+			if (discriminatorProperty === null) {
+				return expectedType;
+			}
+			else {
+				if (data[discriminatorProperty]) {
+					const discriminatorType = data[discriminatorProperty];
+					if (typeMap[discriminatorType]) {
+						return discriminatorType;
+					}
+					else {
+						return expectedType;
+					}
+				}
+				else {
+					return expectedType;
+				}
+			}
+		}
+	}
+
+	public static serialize(data: any, type: string): any {
+		if (data === undefined) {
+			return data;
+		}
+		else if (primitives.has(type.toLowerCase())) {
+			return data;
+		}
+		else if (endsWith(type, nullableSuffix)) {
+			const subType: string = type.slice(0, -nullableSuffix.length);
+
+			return ObjectSerializer.serialize(data, subType);
+		}
+		else if (endsWith(type, optionalSuffix)) {
+			const subType: string = type.slice(0, -optionalSuffix.length);
+
+			return ObjectSerializer.serialize(data, subType);
+		}
+		else if (startsWith(type, arrayPrefix)) {
+			const subType: string = type.slice(
+				arrayPrefix.length,
+				-arraySuffix.length
+			);
+			const transformedData: any[] = [];
+			for (let index = 0; index < data.length; index++) {
+				const datum = data[index];
+				transformedData.push(
+					ObjectSerializer.serialize(datum, subType)
+				);
+			}
+
+			return transformedData;
+		}
+		else if (startsWith(type, mapPrefix)) {
+			const subType: string = type.slice(
+				mapPrefix.length,
+				-mapSuffix.length
+			);
+			const transformedData: {[key: string]: any} = {};
+			for (const key in data) {
+				transformedData[key] = ObjectSerializer.serialize(
+					data[key],
+					subType
+				);
+			}
+
+			return transformedData;
+		}
+		else if (type === "Date") {
+			return data.toISOString();
+		}
+		else {
+			if (!typeMap[type]) {
+				return data;
+			}
+
+			type = this.findCorrectType(data, type);
+
+			const attributeTypes = typeMap[type].getAttributeTypeMap();
+			const instance: {[index: string]: any} = {};
+			for (let index = 0; index < attributeTypes.length; index++) {
+				const attributeType = attributeTypes[index];
+				instance[attributeType.baseName] = ObjectSerializer.serialize(
+					data[attributeType.name],
+					attributeType.type
+				);
+			}
+
+			return instance;
+		}
+	}
+}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-config.yaml
@@ -9,6 +9,7 @@ clientDir: ../headless-admin-taxonomy-client/src/main/java
 compatibilityVersion: 14
 forcePredictableOperationId: true
 generateActionProviders: true
+generateClientJS: true
 generatePermissions: true
 javaEEPackage: jakarta
 testDir: ../headless-admin-taxonomy-test/src/testIntegration/java

--- a/modules/node-scripts.config.js
+++ b/modules/node-scripts.config.js
@@ -10,7 +10,7 @@
  */
 
 module.exports = {
-	hash: '47265456422574305e7760d8a995b9655b49c60af6f90ff55dfbaacd9936220e',
+	hash: 'dce66b80048d584301f6d169fd8ede1a64a1ae737f264566b5231bc1cadd2263',
 	imports: {
 		'@liferay/accessibility-menu-web': [],
 		'@liferay/accessibility-settings-state-web': [],
@@ -204,6 +204,7 @@ module.exports = {
 		'@liferay/frontend-js-walkthrough-web': [],
 		'@liferay/frontend-taglib': [],
 		'@liferay/frontend-theme-dialect-style-guide-sample-web': [],
+		'@liferay/headless-admin-taxonomy-client-js': [],
 		'@liferay/headless-builder-web': [],
 		'@liferay/image-uploader-web': [],
 		'@liferay/journal-content-web': [],

--- a/modules/test/playwright/helpers/HeadlessSiteApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessSiteApiHelper.ts
@@ -12,6 +12,7 @@ type TSite = {
 	active?: boolean;
 	externalReferenceCode?: string;
 	id?: number;
+	key?: string;
 	membershipType?: string;
 	name: string;
 	parentSiteKey?: string;

--- a/modules/test/playwright/helpers/HeadlessSiteApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessSiteApiHelper.ts
@@ -57,6 +57,12 @@ export class HeadlessSiteApiHelper {
 		);
 	}
 
+	async getSite(siteId: string): Promise<Site> {
+		return this.apiHelpers.get(
+			`${this.apiHelpers.baseUrl}${this.basePath}/sites/${siteId}`
+		);
+	}
+
 	async getSiteByERC(externalReferenceCode: string): Promise<Site> {
 		return this.apiHelpers.get(
 			`${this.apiHelpers.baseUrl}${this.basePath}/sites/by-external-reference-code/${externalReferenceCode}`

--- a/modules/test/playwright/package-lock.json
+++ b/modules/test/playwright/package-lock.json
@@ -16,6 +16,7 @@
 			},
 			"devDependencies": {
 				"@axe-core/playwright": "^4.9.1",
+				"@liferay/headless-admin-taxonomy-client-js": "../../apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js",
 				"@liferay/layout-js-components-web": "../../apps/layout/layout-js-components-web/",
 				"@liferay/object-admin-rest-client-js": "../../apps/object/object-admin-rest-client-js",
 				"@liferay/portal-tools-rest-builder-test-client-js": "../../util/portal-tools-rest-builder-test-client-js",
@@ -29,9 +30,18 @@
 				"zip-a-folder": "^3.1.6"
 			}
 		},
+		"../../apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js": {
+			"name": "@liferay/headless-admin-taxonomy-client-js",
+			"version": "1.0.0",
+			"dev": true,
+			"devDependencies": {
+				"@types/node": "^12",
+				"typescript": "^4.0 || ^5.0"
+			}
+		},
 		"../../apps/layout/layout-js-components-web": {
 			"name": "@liferay/layout-js-components-web",
-			"version": "1.0.50",
+			"version": "1.0.51",
 			"dev": true,
 			"dependencies": {
 				"@clayui/alert": "*",
@@ -152,6 +162,10 @@
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
 			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
 			"dev": true
+		},
+		"node_modules/@liferay/headless-admin-taxonomy-client-js": {
+			"resolved": "../../apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js",
+			"link": true
 		},
 		"node_modules/@liferay/layout-js-components-web": {
 			"resolved": "../../apps/layout/layout-js-components-web",
@@ -1573,6 +1587,13 @@
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
 			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
 			"dev": true
+		},
+		"@liferay/headless-admin-taxonomy-client-js": {
+			"version": "file:../../apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js",
+			"requires": {
+				"@types/node": "^12",
+				"typescript": "^4.0 || ^5.0"
+			}
 		},
 		"@liferay/layout-js-components-web": {
 			"version": "file:../../apps/layout/layout-js-components-web",

--- a/modules/test/playwright/package.json
+++ b/modules/test/playwright/package.json
@@ -9,6 +9,7 @@
 	"description": "",
 	"devDependencies": {
 		"@axe-core/playwright": "^4.9.1",
+		"@liferay/headless-admin-taxonomy-client-js": "../../apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js",
 		"@liferay/layout-js-components-web": "../../apps/layout/layout-js-components-web/",
 		"@liferay/object-admin-rest-client-js": "../../apps/object/object-admin-rest-client-js",
 		"@liferay/portal-tools-rest-builder-test-client-js": "../../util/portal-tools-rest-builder-test-client-js",

--- a/modules/test/playwright/tests/export-import-web/main/stagingUseCase.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/stagingUseCase.spec.ts
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {
+	TaxonomyCategoryAPI,
+	TaxonomyVocabularyAPI,
+} from '@liferay/headless-admin-taxonomy-client-js';
 import {expect, mergeTests} from '@playwright/test';
 import {createReadStream, readdirSync} from 'fs';
 import path from 'path';
@@ -30,6 +34,7 @@ import {exportImportConfig} from './export_import.config';
 import {exportPageTest} from './fixtures/exportPageTest';
 import {stagingConfigurationPageTest} from './fixtures/stagingConfigurationPageTest';
 import {stagingPageTest} from './fixtures/stagingPageTest';
+import {StageableEntities} from './utils/stagingConstants';
 import {unzipAndCheckFolder} from './utils/stagingUtil';
 
 const test = mergeTests(
@@ -104,6 +109,109 @@ testWithBatchStagingFF(
 				objectDefinition.pluralLabel.en_US
 			)
 		).toHaveCount(0);
+	}
+);
+
+testWithBatchStagingFF(
+	'Taxonomy Categories can be staged through batch',
+	{tag: ['@LPD-76007']},
+	async ({apiHelpers, stagingPage}) => {
+		const site = await apiHelpers.headlessSite.createSite({
+			name: getRandomString(),
+		});
+
+		apiHelpers.data.push({
+			id: site.id,
+			type: 'site',
+		});
+
+		const taxonomyVocabularyAPIClient = await apiHelpers.buildRestClient(
+			TaxonomyVocabularyAPI
+		);
+
+		const {body: taxonomyVocabulary} =
+			await taxonomyVocabularyAPIClient.postSiteTaxonomyVocabulary(
+				Number(site.id),
+				{
+					externalReferenceCode: getRandomString(),
+					name: getRandomString(),
+				}
+			);
+
+		const taxonomyCategoryAPIClient =
+			await apiHelpers.buildRestClient(TaxonomyCategoryAPI);
+
+		const {body: taxonomyCategory1} =
+			await taxonomyCategoryAPIClient.postSiteTaxonomyCategory(
+				Number(site.id),
+				{
+					externalReferenceCode: getRandomString(),
+					name: getRandomString(),
+					taxonomyVocabularyId: taxonomyVocabulary.id,
+				}
+			);
+
+		const {body: taxonomyCategory2} =
+			await taxonomyCategoryAPIClient.postSiteTaxonomyCategory(
+				Number(site.id),
+				{
+					externalReferenceCode: getRandomString(),
+					name: getRandomString(),
+					taxonomyVocabularyId: taxonomyVocabulary.id,
+				}
+			);
+
+		await stagingPage.goto(site.name);
+		await stagingPage.enableLocalStaging([StageableEntities.CATEGORIES]);
+
+		const stagingSite = await apiHelpers.headlessSite.getSite(
+			`${site.key}-staging`
+		);
+
+		expect(
+			(
+				await taxonomyCategoryAPIClient.getSiteTaxonomyCategoryByExternalReferenceCode(
+					Number(stagingSite.id),
+					taxonomyCategory1.externalReferenceCode
+				)
+			).body
+		).toMatchObject({
+			externalReferenceCode: taxonomyCategory1.externalReferenceCode,
+			name: taxonomyCategory1.name,
+			parentTaxonomyVocabulary: {
+				externalReferenceCode: taxonomyVocabulary.externalReferenceCode,
+			},
+			siteId: stagingSite.id,
+		});
+
+		expect(
+			(
+				await taxonomyCategoryAPIClient.getSiteTaxonomyCategoryByExternalReferenceCode(
+					Number(stagingSite.id),
+					taxonomyCategory2.externalReferenceCode
+				)
+			).body
+		).toMatchObject({
+			externalReferenceCode: taxonomyCategory2.externalReferenceCode,
+			name: taxonomyCategory2.name,
+			parentTaxonomyVocabulary: {
+				externalReferenceCode: taxonomyVocabulary.externalReferenceCode,
+			},
+			siteId: stagingSite.id,
+		});
+
+		expect(
+			(
+				await taxonomyVocabularyAPIClient.getSiteTaxonomyVocabularyByExternalReferenceCode(
+					Number(stagingSite.id),
+					taxonomyVocabulary.externalReferenceCode
+				)
+			).body
+		).toMatchObject({
+			externalReferenceCode: taxonomyVocabulary.externalReferenceCode,
+			name: taxonomyVocabulary.name,
+			siteId: stagingSite.id,
+		});
 	}
 );
 

--- a/modules/test/playwright/tests/export-import-web/main/utils/stagingConstants.ts
+++ b/modules/test/playwright/tests/export-import-web/main/utils/stagingConstants.ts
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export enum StageableEntities {
+	SELECT_ALL = 'Select All',
+	BLOGS = 'Blogs',
+	BOOKMARKS = 'Bookmarks',
+	CALENDAR = 'Calendar',
+	CATEGORIES = 'Categories',
+	DOCUMENTS_AND_MEDIA = 'Documents and Media',
+	DYNAMIC_DATA_LISTS = 'Dynamic Data Lists',
+	DYNAMIC_DATA_MAPPING_DATA_PROVIDER_WEB = 'Dynamic Data Mapping Data Provider Web',
+	FORMS = 'Forms',
+	KNOWLEDGE_BASE = 'Knowledge Base',
+	MESSAGE_BOARDS = 'Message Boards',
+	PAGES = 'Pages',
+	REPORTS_ADMIN = 'Reports Admin',
+	SEGMENTS = 'Segments',
+	TAGS = 'Tags',
+	TEMPLATES = 'Templates',
+	WEB_CONTENT = 'Web Content',
+}


### PR DESCRIPTION
**What's changed?:**
- REST APIs used by the new promote content logic check if the `PERMISSIONS` actionID is available. A special staging permission checker didn't take this sort of permission into account so it has been updated to allow it.

**What's new?:**
- A new functional test has been incorporated to make sure that staging works with Categories since it's one of the new supported entities

More details in the following **Jira Ticket**: [LPD-76007](https://liferay.atlassian.net/browse/LPD-76007)