### PR TITLE
LPD-75534 Page experience priority in case that it is not specified

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageExperienceResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageExperienceResourceImpl.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.LayoutLocalService;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
@@ -183,16 +182,11 @@ public class PageExperienceResourceImpl extends BasePageExperienceResourceImpl {
 				LayoutServiceContextHelperUtil.getServiceContextAutoCloseable(
 					layout, contextUser)) {
 
-			int priority = segmentsExperience.getPriority();
-
-			if (pageExperience.getPriority() != null) {
-				priority = pageExperience.getPriority();
-			}
-
 			return _toPageExperience(
 				SegmentsExperienceUtil.updateSegmentsExperience(
 					_fragmentEntryProcessorRegistry, _infoItemServiceRegistry,
-					layout, pageExperience, priority, segmentsExperience,
+					layout, pageExperience, pageExperience.getPriority(),
+					segmentsExperience,
 					ServiceContextUtil.createServiceContext(
 						groupId, contextHttpServletRequest,
 						contextUser.getUserId())));
@@ -230,8 +224,7 @@ public class PageExperienceResourceImpl extends BasePageExperienceResourceImpl {
 			return _toPageExperience(
 				SegmentsExperienceUtil.addSegmentsExperience(
 					_fragmentEntryProcessorRegistry, _infoItemServiceRegistry,
-					layout, pageExperience,
-					GetterUtil.getInteger(pageExperience.getPriority()),
+					layout, pageExperience, pageExperience.getPriority(),
 					ServiceContextUtil.createServiceContext(
 						groupId, contextHttpServletRequest,
 						contextUser.getUserId(), pageExperience.getUuid())));

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
@@ -1231,7 +1231,9 @@ public class LayoutUtil {
 
 				SegmentsExperienceServiceUtil.updateSegmentsExperiencePriority(
 					actualSegmentsExperience.getSegmentsExperienceId(),
-					GetterUtil.getInteger(pageExperience.getPriority()));
+					PageExperienceUtil.getPriority(
+						pageExperience.getKey(), layout,
+						pageExperience.getPriority()));
 			}
 		}
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageExperienceUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageExperienceUtil.java
@@ -6,10 +6,12 @@
 package com.liferay.headless.admin.site.internal.resource.v1_0.util;
 
 import com.liferay.headless.admin.site.dto.v1_0.PageExperience;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.segments.constants.SegmentsExperienceConstants;
 import com.liferay.segments.model.SegmentsExperience;
+import com.liferay.segments.service.SegmentsExperienceLocalServiceUtil;
 
 import java.util.HashSet;
 import java.util.Objects;
@@ -37,6 +39,23 @@ public class PageExperienceUtil {
 		}
 
 		throw new UnsupportedOperationException();
+	}
+
+	public static int getPriority(String key, Layout layout, Integer priority) {
+		if (Objects.equals(key, SegmentsExperienceConstants.KEY_DEFAULT)) {
+			return 0;
+		}
+
+		if (priority != null) {
+			return priority;
+		}
+
+		int segmentsExperienceLowestPriority =
+			SegmentsExperienceLocalServiceUtil.
+				getSegmentsExperienceLowestPriority(
+					layout.getGroupId(), layout.getPlid());
+
+		return segmentsExperienceLowestPriority - 1;
 	}
 
 	public static void validatePageExperiences(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/SegmentsExperienceUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/SegmentsExperienceUtil.java
@@ -37,7 +37,7 @@ public class SegmentsExperienceUtil {
 	public static SegmentsExperience addSegmentsExperience(
 			FragmentEntryProcessorRegistry fragmentEntryProcessorRegistry,
 			InfoItemServiceRegistry infoItemServiceRegistry, Layout layout,
-			PageExperience pageExperience, int priority,
+			PageExperience pageExperience, Integer priority,
 			ServiceContext serviceContext)
 		throws Exception {
 
@@ -49,7 +49,9 @@ public class SegmentsExperienceUtil {
 					pageExperience.getSegmentItemExternalReference()),
 				pageExperience.getKey(), layout.getPlid(),
 				LocalizedMapUtil.getLocalizedMap(pageExperience.getName_i18n()),
-				priority, true,
+				PageExperienceUtil.getPriority(
+					pageExperience.getKey(), layout, priority),
+				true,
 				UnicodePropertiesBuilder.create(
 					true
 				).build(),
@@ -71,7 +73,7 @@ public class SegmentsExperienceUtil {
 	public static SegmentsExperience updateSegmentsExperience(
 			FragmentEntryProcessorRegistry fragmentEntryProcessorRegistry,
 			InfoItemServiceRegistry infoItemServiceRegistry, Layout layout,
-			PageExperience pageExperience, int priority,
+			PageExperience pageExperience, Integer priority,
 			SegmentsExperience segmentsExperience,
 			ServiceContext serviceContext)
 		throws Exception {
@@ -83,10 +85,14 @@ public class SegmentsExperienceUtil {
 				serviceContext),
 			layout, segmentsExperience.getSegmentsExperienceId());
 
-		if (priority != segmentsExperience.getPriority()) {
+		int finalPriority = PageExperienceUtil.getPriority(
+			pageExperience.getKey(), layout, priority);
+
+		if (finalPriority != segmentsExperience.getPriority()) {
 			segmentsExperience =
 				SegmentsExperienceServiceUtil.updateSegmentsExperiencePriority(
-					segmentsExperience.getSegmentsExperienceId(), priority);
+					segmentsExperience.getSegmentsExperienceId(),
+					finalPriority);
 		}
 
 		return SegmentsExperienceServiceUtil.updateSegmentsExperience(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -135,6 +135,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -2717,10 +2718,46 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 		_testPutSiteSitePageWithPageExperiences(
 			pageExperiences, putSitePage, sitePageResource);
+
+		PageExperience[] putPageExperiences = ArrayUtil.append(
+			PageExperiencesTestUtil.getPageExperiences(
+				testCompany.getGroupId(), testGroup.getGroupId(),
+				contentPageSpecification.getExternalReferenceCode()),
+			defaultPageExperience);
+
+		Arrays.sort(putPageExperiences, comparator);
+
+		putPageExperiences = TransformUtil.transform(
+			putPageExperiences,
+			pageExperience -> {
+				pageExperience.setPriority(() -> null);
+
+				return pageExperience;
+			},
+			PageExperience.class);
+
+		PageExperience[] expectedPageExperiences = Arrays.copyOf(
+			putPageExperiences, putPageExperiences.length);
+
+		AtomicInteger priority = new AtomicInteger();
+
+		expectedPageExperiences = TransformUtil.transform(
+			expectedPageExperiences,
+			pageExperience -> {
+				pageExperience.setPriority(priority::getAndDecrement);
+
+				return pageExperience;
+			},
+			PageExperience.class);
+
+		_testPutSiteSitePageWithPageExperiences(
+			expectedPageExperiences, putPageExperiences, putSitePage,
+			sitePageResource);
 	}
 
 	private SitePage _testPutSiteSitePageWithPageExperiences(
-			PageExperience[] pageExperiences, SitePage sitePage,
+			PageExperience[] expectedPageExperiences,
+			PageExperience[] putPageExperiences, SitePage sitePage,
 			SitePageResource sitePageResource)
 		throws Exception {
 
@@ -2730,7 +2767,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		ContentPageSpecification contentPageSpecification =
 			(ContentPageSpecification)pageSpecifications[0];
 
-		contentPageSpecification.setPageExperiences(pageExperiences);
+		contentPageSpecification.setPageExperiences(putPageExperiences);
 
 		SitePage putSitePage = sitePageResource.putSiteSitePage(
 			testGroup.getExternalReferenceCode(),
@@ -2742,9 +2779,19 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			(ContentPageSpecification)pageSpecifications[0];
 
 		Assert.assertArrayEquals(
-			pageExperiences, contentPageSpecification.getPageExperiences());
+			expectedPageExperiences,
+			contentPageSpecification.getPageExperiences());
 
 		return putSitePage;
+	}
+
+	private SitePage _testPutSiteSitePageWithPageExperiences(
+			PageExperience[] pageExperiences, SitePage sitePage,
+			SitePageResource sitePageResource)
+		throws Exception {
+
+		return _testPutSiteSitePageWithPageExperiences(
+			pageExperiences, pageExperiences, sitePage, sitePageResource);
 	}
 
 	private void _testPutSiteSitePageWithPageSpecifications() throws Exception {

--- a/modules/apps/segments/segments-api/bnd.bnd
+++ b/modules/apps/segments/segments-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Segments API
 Bundle-SymbolicName: com.liferay.segments.api
-Bundle-Version: 29.3.2
+Bundle-Version: 29.4.0
 Export-Package:\
 	com.liferay.segments,\
 	com.liferay.segments.configuration,\

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceLocalService.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceLocalService.java
@@ -351,6 +351,9 @@ public interface SegmentsExperienceLocalService
 			String uuid, long groupId)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getSegmentsExperienceLowestPriority(long groupId, long plid);
+
 	/**
 	 * Returns a range of all the segments experiences.
 	 *

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceLocalServiceUtil.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceLocalServiceUtil.java
@@ -439,6 +439,12 @@ public class SegmentsExperienceLocalServiceUtil {
 			uuid, groupId);
 	}
 
+	public static int getSegmentsExperienceLowestPriority(
+		long groupId, long plid) {
+
+		return getService().getSegmentsExperienceLowestPriority(groupId, plid);
+	}
+
 	/**
 	 * Returns a range of all the segments experiences.
 	 *

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceLocalServiceWrapper.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceLocalServiceWrapper.java
@@ -498,6 +498,12 @@ public class SegmentsExperienceLocalServiceWrapper
 			getSegmentsExperienceByUuidAndGroupId(uuid, groupId);
 	}
 
+	@Override
+	public int getSegmentsExperienceLowestPriority(long groupId, long plid) {
+		return _segmentsExperienceLocalService.
+			getSegmentsExperienceLowestPriority(groupId, plid);
+	}
+
 	/**
 	 * Returns a range of all the segments experiences.
 	 *

--- a/modules/apps/segments/segments-api/src/main/resources/com/liferay/segments/service/packageinfo
+++ b/modules/apps/segments/segments-api/src/main/resources/com/liferay/segments/service/packageinfo
@@ -1,1 +1,1 @@
-version 15.2.0
+version 15.3.0

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceLocalServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceLocalServiceImpl.java
@@ -84,12 +84,13 @@ public class SegmentsExperienceLocalServiceImpl
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		int lowestPriority = _getLowestPriority(groupId, plid);
+		int segmentsExperienceLowestPriority =
+			getSegmentsExperienceLowestPriority(groupId, plid);
 
 		return addSegmentsExperience(
 			externalReferenceCode, userId, groupId, segmentsEntryId, plid,
-			nameMap, lowestPriority - 1, active, typeSettingsUnicodeProperties,
-			serviceContext);
+			nameMap, segmentsExperienceLowestPriority - 1, active,
+			typeSettingsUnicodeProperties, serviceContext);
 	}
 
 	@Override
@@ -372,6 +373,18 @@ public class SegmentsExperienceLocalServiceImpl
 	}
 
 	@Override
+	public int getSegmentsExperienceLowestPriority(long groupId, long plid) {
+		SegmentsExperience segmentsExperience =
+			segmentsExperiencePersistence.fetchByG_P_Last(groupId, plid, null);
+
+		if (segmentsExperience == null) {
+			return 0;
+		}
+
+		return segmentsExperience.getPriority();
+	}
+
+	@Override
 	public List<SegmentsExperience> getSegmentsExperiences(
 		long groupId, long plid) {
 
@@ -633,17 +646,6 @@ public class SegmentsExperienceLocalServiceImpl
 	private int _getHighestPriority(long groupId, long plid) {
 		SegmentsExperience segmentsExperience =
 			segmentsExperiencePersistence.fetchByG_P_First(groupId, plid, null);
-
-		if (segmentsExperience == null) {
-			return 0;
-		}
-
-		return segmentsExperience.getPriority();
-	}
-
-	private int _getLowestPriority(long groupId, long plid) {
-		SegmentsExperience segmentsExperience =
-			segmentsExperiencePersistence.fetchByG_P_Last(groupId, plid, null);
 
 		if (segmentsExperience == null) {
 			return 0;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-75534

# What is this solving?

Take into account to set  a priority below the lowest one in case if it is not specified. 

# How is it fixed?

Take it into account in the PageExperiengeUtil and LayoutUtil to manage it.

# How to verify?

Run included integration tests
