### PR TITLE
LPD-75077 Followup

### DIFF
--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseState.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseState.java
@@ -92,8 +92,7 @@ public class PreupgradeVerifyDatabaseState extends PreupgradeVerifyProcess {
 						"Unable to get table names for company " + companyId,
 						portalException);
 				}
-			},
-			PortalInstancePool.getCompanyIds());
+			});
 
 		if (tableNames.isEmpty()) {
 			return;


### PR DESCRIPTION
Don't set the companyIds as parameter, let forEachCompany set the correct companies to loop and avoid the new validation added by LPD-51236