### PR TITLE
LPD-69685 Move unit test to the correct package

### DIFF
--- a/portal-kernel/test/unit/com/liferay/portal/kernel/dao/db/DBTypeToSQLMapTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/dao/db/DBTypeToSQLMapTest.java
@@ -17,11 +17,6 @@ import org.junit.Test;
  */
 public class DBTypeToSQLMapTest {
 
-	@ClassRule
-	@Rule
-	public static final LiferayUnitTestRule liferayUnitTestRule =
-		LiferayUnitTestRule.INSTANCE;
-
 	@Test
 	public void testGetReturnsActual() {
 		DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(_SQL_DEFAULT);

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/dao/db/DBTypeToSQLMapTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/dao/db/DBTypeToSQLMapTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 /**
  * @author Mariano Álvaro Sáiz
  */
-public class DBTypeSQLMapTest {
+public class DBTypeToSQLMapTest {
 
 	@ClassRule
 	@Rule


### PR DESCRIPTION
`DBTypeSQLMapTest` is located in portal-impl/test/unit/com/liferay/portal/kernel/dao/db/ but it is testing `DBTypeToSQLMap` from portal-kernel/src/com/liferay/portal/kernel/dao/db/

We have to move it to **portal-kernel/test/unit/com/liferay/portal/kernel/dao/db/** to match the `DBTypeToSQLMap` location.

We have also to rename it from `DBTypeSQLMapTest` to `DBTypeToSQLMapTest`, to match the class it is testing.