### PR TITLE
LPD-71347 LPD-77488

### DIFF
--- a/modules/apps/export-import/export-import-test-util/src/main/java/com/liferay/exportimport/test/rule/LazyReferencingTestRule.java
+++ b/modules/apps/export-import/export-import-test-util/src/main/java/com/liferay/exportimport/test/rule/LazyReferencingTestRule.java
@@ -5,12 +5,9 @@
 
 package com.liferay.exportimport.test.rule;
 
-import com.liferay.petra.lang.CentralizedThreadLocal;
-import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
-import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.exportimport.test.util.LazyReferencingTestUtil;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.test.rule.AbstractTestRule;
-
-import java.util.function.Supplier;
 
 import org.junit.runner.Description;
 
@@ -51,12 +48,8 @@ public class LazyReferencingTestRule extends AbstractTestRule<Void, Void> {
 	}
 
 	private void _restoreLazyReferencingThreadLocal() {
-		if (_originalCentralizedThreadLocal != null) {
-			_originalCentralizedThreadLocal.set(_originalValue);
-
-			ReflectionTestUtil.setFieldValue(
-				_originalCentralizedThreadLocal, "_supplier",
-				_originalSupplier);
+		if (_safeCloseable != null) {
+			_safeCloseable.close();
 		}
 	}
 
@@ -65,21 +58,12 @@ public class LazyReferencingTestRule extends AbstractTestRule<Void, Void> {
 			LazyReferencing.class);
 
 		if (lazyReferencing != null) {
-			_originalCentralizedThreadLocal = ReflectionTestUtil.getFieldValue(
-				LazyReferencingThreadLocal.class, "_enabled");
-
-			_originalValue = _originalCentralizedThreadLocal.get();
-
-			_originalCentralizedThreadLocal.set(lazyReferencing.enabled());
-
-			_originalSupplier = ReflectionTestUtil.getAndSetFieldValue(
-				_originalCentralizedThreadLocal, "_supplier",
-				lazyReferencing::enabled);
+			_safeCloseable =
+				LazyReferencingTestUtil.setLazyReferencingWithSafeCloseable(
+					lazyReferencing.enabled());
 		}
 	}
 
-	private CentralizedThreadLocal<Boolean> _originalCentralizedThreadLocal;
-	private Supplier<Boolean> _originalSupplier;
-	private Boolean _originalValue;
+	private SafeCloseable _safeCloseable;
 
 }

--- a/modules/apps/export-import/export-import-test-util/src/main/java/com/liferay/exportimport/test/util/LazyReferencingTestUtil.java
+++ b/modules/apps/export-import/export-import-test-util/src/main/java/com/liferay/exportimport/test/util/LazyReferencingTestUtil.java
@@ -19,11 +19,11 @@ import java.util.function.Supplier;
 public class LazyReferencingTestUtil {
 
 	public static void executeWithLazyReferencingSafeCloseable(
-			boolean lazyReferencing, UnsafeRunnable<Exception> unsafeRunnable)
+			UnsafeRunnable<Exception> unsafeRunnable)
 		throws Exception {
 
 		try (SafeCloseable safeCloseable = setLazyReferencingWithSafeCloseable(
-				lazyReferencing)) {
+				true)) {
 
 			unsafeRunnable.run();
 		}

--- a/modules/apps/export-import/export-import-test-util/src/main/java/com/liferay/exportimport/test/util/LazyReferencingTestUtil.java
+++ b/modules/apps/export-import/export-import-test-util/src/main/java/com/liferay/exportimport/test/util/LazyReferencingTestUtil.java
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.exportimport.test.util;
+
+import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.petra.lang.CentralizedThreadLocal;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+
+import java.util.function.Supplier;
+
+/**
+ * @author Carlos Correa
+ */
+public class LazyReferencingTestUtil {
+
+	public static void executeWithLazyReferencingSafeCloseable(
+			boolean lazyReferencing, UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		try (SafeCloseable safeCloseable = setLazyReferencingWithSafeCloseable(
+				lazyReferencing)) {
+
+			unsafeRunnable.run();
+		}
+	}
+
+	public static SafeCloseable setLazyReferencingWithSafeCloseable(
+		boolean lazyReferencing) {
+
+		CentralizedThreadLocal<Boolean> originalCentralizedThreadLocal =
+			ReflectionTestUtil.getFieldValue(
+				LazyReferencingThreadLocal.class, "_enabled");
+
+		Boolean originalValue = originalCentralizedThreadLocal.get();
+
+		originalCentralizedThreadLocal.set(lazyReferencing);
+
+		Supplier<Boolean> originalSupplier =
+			ReflectionTestUtil.getAndSetFieldValue(
+				originalCentralizedThreadLocal, "_supplier",
+				() -> lazyReferencing);
+
+		return () -> {
+			originalCentralizedThreadLocal.set(originalValue);
+
+			ReflectionTestUtil.setFieldValue(
+				originalCentralizedThreadLocal, "_supplier", originalSupplier);
+		};
+	}
+
+}

--- a/modules/apps/export-import/export-import-test-util/src/test/java/com/liferay/exportimport/test/util/LazyReferencingTestUtilTest.java
+++ b/modules/apps/export-import/export-import-test-util/src/test/java/com/liferay/exportimport/test/util/LazyReferencingTestUtilTest.java
@@ -1,0 +1,85 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.exportimport.test.util;
+
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Carlos Correa
+ */
+public class LazyReferencingTestUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testExecuteWithLazyReferencingSafeCloseable() throws Exception {
+		Assert.assertFalse(LazyReferencingThreadLocal.isEnabled());
+		Assert.assertFalse(_run(LazyReferencingThreadLocal::isEnabled));
+
+		LazyReferencingTestUtil.executeWithLazyReferencingSafeCloseable(
+			() -> {
+				Assert.assertTrue(LazyReferencingThreadLocal.isEnabled());
+				Assert.assertTrue(_run(LazyReferencingThreadLocal::isEnabled));
+			});
+
+		Assert.assertFalse(LazyReferencingThreadLocal.isEnabled());
+		Assert.assertFalse(_run(LazyReferencingThreadLocal::isEnabled));
+	}
+
+	@Test
+	public void testSetLazyReferencingWithSafeCloseable() throws Exception {
+		Assert.assertFalse(LazyReferencingThreadLocal.isEnabled());
+		Assert.assertFalse(_run(LazyReferencingThreadLocal::isEnabled));
+
+		try (SafeCloseable safeCloseable =
+				LazyReferencingTestUtil.setLazyReferencingWithSafeCloseable(
+					false)) {
+
+			Assert.assertFalse(LazyReferencingThreadLocal.isEnabled());
+			Assert.assertFalse(_run(LazyReferencingThreadLocal::isEnabled));
+		}
+
+		Assert.assertFalse(LazyReferencingThreadLocal.isEnabled());
+		Assert.assertFalse(_run(LazyReferencingThreadLocal::isEnabled));
+
+		try (SafeCloseable safeCloseable =
+				LazyReferencingTestUtil.setLazyReferencingWithSafeCloseable(
+					true)) {
+
+			Assert.assertTrue(LazyReferencingThreadLocal.isEnabled());
+			Assert.assertTrue(_run(LazyReferencingThreadLocal::isEnabled));
+		}
+
+		Assert.assertFalse(LazyReferencingThreadLocal.isEnabled());
+		Assert.assertFalse(_run(LazyReferencingThreadLocal::isEnabled));
+	}
+
+	private Boolean _run(Supplier<Boolean> supplier) throws Exception {
+		AtomicReference<Boolean> atomicReference = new AtomicReference<>();
+
+		Thread thread = new Thread(() -> atomicReference.set(supplier.get()));
+
+		thread.start();
+
+		thread.join();
+
+		return atomicReference.get();
+	}
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/ServiceContextUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/ServiceContextUtil.java
@@ -190,14 +190,9 @@ public class ServiceContextUtil {
 				}
 
 				AssetCategory assetCategory =
-					AssetCategoryServiceUtil.
-						fetchCategoryByExternalReferenceCode(
-							itemExternalReference.getExternalReferenceCode(),
-							scopeGroupId);
-
-				if (assetCategory == null) {
-					throw new UnsupportedOperationException();
-				}
+					AssetCategoryServiceUtil.getOrAddEmptyCategory(
+						itemExternalReference.getExternalReferenceCode(),
+						scopeGroupId);
 
 				return assetCategory.getCategoryId();
 			});

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -11,6 +11,8 @@ import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.test.util.DLTestUtil;
+import com.liferay.exportimport.test.rule.LazyReferencing;
+import com.liferay.exportimport.test.rule.LazyReferencingTestRule;
 import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.contributor.FragmentCollectionContributorRegistry;
 import com.liferay.fragment.entry.processor.constants.FragmentEntryProcessorConstants;
@@ -159,7 +161,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
-			new LiferayIntegrationTestRule(),
+			LazyReferencingTestRule.INSTANCE, new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Ignore
@@ -399,7 +401,6 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		_testPutSiteSitePageWithExportedSitePage();
 		_testPutSiteSitePageWithExportedSitePageWithLayoutIdFriendlyURL();
 		_testPutSiteSitePageWithFormFragmentPageElements();
-		_testPutSiteSitePageWithMissingTaxonomyCategories();
 		_testPutSiteSitePageWithPageElements();
 		_testPutSiteSitePageWithPageExperiences();
 		_testPutSiteSitePageWithPageSpecifications();
@@ -420,6 +421,70 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 				getMasterLayoutPageTemplateEntryLayout(serviceContext),
 			LayoutUtilityPageEntryTestUtil.getLayoutUtilityPageEntryLayout(
 				serviceContext));
+	}
+
+	@LazyReferencing
+	@Test
+	@TestInfo("LPD-77124")
+	public void testPutSiteSitePageWithMissingTaxonomyCategories()
+		throws Exception {
+
+		ItemExternalReference[] taxonomyCategoryItemExternalReferences = {
+			new ItemExternalReference() {
+				{
+					setClassName(AssetCategory.class::getName);
+					setExternalReferenceCode(RandomTestUtil::randomString);
+
+					Group group = _groupLocalService.getGroup(
+						testCompany.getGroupId());
+
+					setScope(
+						() -> new Scope() {
+							{
+								setExternalReferenceCode(
+									group::getExternalReferenceCode);
+								setType(() -> Type.SITE);
+							}
+						});
+				}
+			},
+			new ItemExternalReference() {
+				{
+					setClassName(AssetCategory.class::getName);
+					setExternalReferenceCode(RandomTestUtil::randomString);
+				}
+			}
+		};
+
+		SitePage randomSitePage = _getRandomSitePage(
+			RandomTestUtil.randomString(), null,
+			ServiceContextTestUtil.getServiceContext(
+				testGroup, TestPropsValues.getUserId()),
+			taxonomyCategoryItemExternalReferences, SitePage.Type.WIDGET_PAGE,
+			RandomTestUtil.randomString());
+
+		SitePage putSitePage = sitePageResource.putSiteSitePage(
+			testGroup.getExternalReferenceCode(),
+			randomSitePage.getExternalReferenceCode(), randomSitePage);
+
+		Assert.assertTrue(
+			Objects.deepEquals(
+				randomSitePage.getTaxonomyCategoryItemExternalReferences(),
+				putSitePage.getTaxonomyCategoryItemExternalReferences()));
+
+		Assert.assertNotNull(
+			_assetCategoryLocalService.
+				fetchAssetCategoryByExternalReferenceCode(
+					taxonomyCategoryItemExternalReferences[0].
+						getExternalReferenceCode(),
+					testCompany.getGroupId()));
+
+		Assert.assertNotNull(
+			_assetCategoryLocalService.
+				fetchAssetCategoryByExternalReferenceCode(
+					taxonomyCategoryItemExternalReferences[1].
+						getExternalReferenceCode(),
+					testGroup.getGroupId()));
 	}
 
 	@Override
@@ -2702,67 +2767,6 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			fragmentEntryLinks, infoForm, expectedInfoForm,
 			_layoutLocalService.getLayoutByExternalReferenceCode(
 				layout.getExternalReferenceCode(), testGroup.getGroupId()));
-	}
-
-	private void _testPutSiteSitePageWithMissingTaxonomyCategories()
-		throws Exception {
-
-		ItemExternalReference[] taxonomyCategoryItemExternalReferences = {
-			new ItemExternalReference() {
-				{
-					setClassName(AssetCategory.class::getName);
-					setExternalReferenceCode(RandomTestUtil::randomString);
-
-					Group group = _groupLocalService.getGroup(
-						testCompany.getGroupId());
-
-					setScope(
-						() -> new Scope() {
-							{
-								setExternalReferenceCode(
-									group::getExternalReferenceCode);
-								setType(() -> Type.SITE);
-							}
-						});
-				}
-			},
-			new ItemExternalReference() {
-				{
-					setClassName(AssetCategory.class::getName);
-					setExternalReferenceCode(RandomTestUtil::randomString);
-				}
-			}
-		};
-
-		SitePage randomSitePage = _getRandomSitePage(
-			RandomTestUtil.randomString(), null,
-			ServiceContextTestUtil.getServiceContext(
-				testGroup, TestPropsValues.getUserId()),
-			taxonomyCategoryItemExternalReferences, SitePage.Type.WIDGET_PAGE,
-			RandomTestUtil.randomString());
-
-		SitePage putSitePage = sitePageResource.putSiteSitePage(
-			testGroup.getExternalReferenceCode(),
-			randomSitePage.getExternalReferenceCode(), randomSitePage);
-
-		Assert.assertTrue(
-			Objects.deepEquals(
-				randomSitePage.getTaxonomyCategoryItemExternalReferences(),
-				putSitePage.getTaxonomyCategoryItemExternalReferences()));
-
-		Assert.assertNotNull(
-			_assetCategoryLocalService.
-				fetchAssetCategoryByExternalReferenceCode(
-					taxonomyCategoryItemExternalReferences[0].
-						getExternalReferenceCode(),
-					testCompany.getGroupId()));
-
-		Assert.assertNotNull(
-			_assetCategoryLocalService.
-				fetchAssetCategoryByExternalReferenceCode(
-					taxonomyCategoryItemExternalReferences[1].
-						getExternalReferenceCode(),
-					testGroup.getGroupId()));
 	}
 
 	private void _testPutSiteSitePageWithPageElements() throws Exception {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -11,8 +11,8 @@ import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.test.util.DLTestUtil;
-import com.liferay.exportimport.test.rule.LazyReferencing;
 import com.liferay.exportimport.test.rule.LazyReferencingTestRule;
+import com.liferay.exportimport.test.util.LazyReferencingTestUtil;
 import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.contributor.FragmentCollectionContributorRegistry;
 import com.liferay.fragment.entry.processor.constants.FragmentEntryProcessorConstants;
@@ -401,6 +401,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		_testPutSiteSitePageWithExportedSitePage();
 		_testPutSiteSitePageWithExportedSitePageWithLayoutIdFriendlyURL();
 		_testPutSiteSitePageWithFormFragmentPageElements();
+		LazyReferencingTestUtil.executeWithLazyReferencingSafeCloseable(
+			this::_testPutSiteSitePageWithMissingTaxonomyCategories);
 		_assertProblemException(
 			"NOT_FOUND", null,
 			this::_testPutSiteSitePageWithMissingTaxonomyCategories);
@@ -424,15 +426,6 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 				getMasterLayoutPageTemplateEntryLayout(serviceContext),
 			LayoutUtilityPageEntryTestUtil.getLayoutUtilityPageEntryLayout(
 				serviceContext));
-	}
-
-	@LazyReferencing
-	@Test
-	@TestInfo("LPD-77124")
-	public void testPutSiteSitePageWithMissingTaxonomyCategories()
-		throws Exception {
-
-		_testPutSiteSitePageWithMissingTaxonomyCategories();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -388,7 +388,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 	@Override
 	@Test
-	@TestInfo({"LPD-74331", "LPD-75450"})
+	@TestInfo({"LPD-74331", "LPD-75450", "LPD-77124"})
 	public void testPutSiteSitePage() throws Exception {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
@@ -401,6 +401,9 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		_testPutSiteSitePageWithExportedSitePage();
 		_testPutSiteSitePageWithExportedSitePageWithLayoutIdFriendlyURL();
 		_testPutSiteSitePageWithFormFragmentPageElements();
+		_assertProblemException(
+			"NOT_FOUND", null,
+			this::_testPutSiteSitePageWithMissingTaxonomyCategories);
 		_testPutSiteSitePageWithPageElements();
 		_testPutSiteSitePageWithPageExperiences();
 		_testPutSiteSitePageWithPageSpecifications();
@@ -429,62 +432,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 	public void testPutSiteSitePageWithMissingTaxonomyCategories()
 		throws Exception {
 
-		ItemExternalReference[] taxonomyCategoryItemExternalReferences = {
-			new ItemExternalReference() {
-				{
-					setClassName(AssetCategory.class::getName);
-					setExternalReferenceCode(RandomTestUtil::randomString);
-
-					Group group = _groupLocalService.getGroup(
-						testCompany.getGroupId());
-
-					setScope(
-						() -> new Scope() {
-							{
-								setExternalReferenceCode(
-									group::getExternalReferenceCode);
-								setType(() -> Type.SITE);
-							}
-						});
-				}
-			},
-			new ItemExternalReference() {
-				{
-					setClassName(AssetCategory.class::getName);
-					setExternalReferenceCode(RandomTestUtil::randomString);
-				}
-			}
-		};
-
-		SitePage randomSitePage = _getRandomSitePage(
-			RandomTestUtil.randomString(), null,
-			ServiceContextTestUtil.getServiceContext(
-				testGroup, TestPropsValues.getUserId()),
-			taxonomyCategoryItemExternalReferences, SitePage.Type.WIDGET_PAGE,
-			RandomTestUtil.randomString());
-
-		SitePage putSitePage = sitePageResource.putSiteSitePage(
-			testGroup.getExternalReferenceCode(),
-			randomSitePage.getExternalReferenceCode(), randomSitePage);
-
-		Assert.assertTrue(
-			Objects.deepEquals(
-				randomSitePage.getTaxonomyCategoryItemExternalReferences(),
-				putSitePage.getTaxonomyCategoryItemExternalReferences()));
-
-		Assert.assertNotNull(
-			_assetCategoryLocalService.
-				fetchAssetCategoryByExternalReferenceCode(
-					taxonomyCategoryItemExternalReferences[0].
-						getExternalReferenceCode(),
-					testCompany.getGroupId()));
-
-		Assert.assertNotNull(
-			_assetCategoryLocalService.
-				fetchAssetCategoryByExternalReferenceCode(
-					taxonomyCategoryItemExternalReferences[1].
-						getExternalReferenceCode(),
-					testGroup.getGroupId()));
+		_testPutSiteSitePageWithMissingTaxonomyCategories();
 	}
 
 	@Override
@@ -903,7 +851,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 	}
 
 	private void _assertProblemException(
-			String expectedTitle, UnsafeRunnable<Exception> unsafeRunnable)
+			String expectedStatus, String expectedTitle,
+			UnsafeRunnable<Exception> unsafeRunnable)
 		throws Exception {
 
 		try {
@@ -913,9 +862,16 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		catch (Problem.ProblemException problemException) {
 			Problem problem = problemException.getProblem();
 
-			Assert.assertEquals("BAD_REQUEST", problem.getStatus());
+			Assert.assertEquals(expectedStatus, problem.getStatus());
 			Assert.assertEquals(expectedTitle, problem.getTitle());
 		}
+	}
+
+	private void _assertProblemException(
+			String expectedTitle, UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		_assertProblemException("BAD_REQUEST", expectedTitle, unsafeRunnable);
 	}
 
 	private void _assertPutSiteSitePageProblemException(
@@ -2767,6 +2723,67 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			fragmentEntryLinks, infoForm, expectedInfoForm,
 			_layoutLocalService.getLayoutByExternalReferenceCode(
 				layout.getExternalReferenceCode(), testGroup.getGroupId()));
+	}
+
+	private void _testPutSiteSitePageWithMissingTaxonomyCategories()
+		throws Exception {
+
+		ItemExternalReference[] taxonomyCategoryItemExternalReferences = {
+			new ItemExternalReference() {
+				{
+					setClassName(AssetCategory.class::getName);
+					setExternalReferenceCode(RandomTestUtil::randomString);
+
+					Group group = _groupLocalService.getGroup(
+						testCompany.getGroupId());
+
+					setScope(
+						() -> new Scope() {
+							{
+								setExternalReferenceCode(
+									group::getExternalReferenceCode);
+								setType(() -> Type.SITE);
+							}
+						});
+				}
+			},
+			new ItemExternalReference() {
+				{
+					setClassName(AssetCategory.class::getName);
+					setExternalReferenceCode(RandomTestUtil::randomString);
+				}
+			}
+		};
+
+		SitePage randomSitePage = _getRandomSitePage(
+			RandomTestUtil.randomString(), null,
+			ServiceContextTestUtil.getServiceContext(
+				testGroup, TestPropsValues.getUserId()),
+			taxonomyCategoryItemExternalReferences, SitePage.Type.WIDGET_PAGE,
+			RandomTestUtil.randomString());
+
+		SitePage putSitePage = sitePageResource.putSiteSitePage(
+			testGroup.getExternalReferenceCode(),
+			randomSitePage.getExternalReferenceCode(), randomSitePage);
+
+		Assert.assertTrue(
+			Objects.deepEquals(
+				randomSitePage.getTaxonomyCategoryItemExternalReferences(),
+				putSitePage.getTaxonomyCategoryItemExternalReferences()));
+
+		Assert.assertNotNull(
+			_assetCategoryLocalService.
+				fetchAssetCategoryByExternalReferenceCode(
+					taxonomyCategoryItemExternalReferences[0].
+						getExternalReferenceCode(),
+					testCompany.getGroupId()));
+
+		Assert.assertNotNull(
+			_assetCategoryLocalService.
+				fetchAssetCategoryByExternalReferenceCode(
+					taxonomyCategoryItemExternalReferences[1].
+						getExternalReferenceCode(),
+					testGroup.getGroupId()));
 	}
 
 	private void _testPutSiteSitePageWithPageElements() throws Exception {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -6,6 +6,8 @@
 package com.liferay.headless.admin.site.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.test.util.DLTestUtil;
@@ -397,6 +399,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		_testPutSiteSitePageWithExportedSitePage();
 		_testPutSiteSitePageWithExportedSitePageWithLayoutIdFriendlyURL();
 		_testPutSiteSitePageWithFormFragmentPageElements();
+		_testPutSiteSitePageWithMissingTaxonomyCategories();
 		_testPutSiteSitePageWithPageElements();
 		_testPutSiteSitePageWithPageExperiences();
 		_testPutSiteSitePageWithPageSpecifications();
@@ -1293,7 +1296,9 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 	private SitePage _getRandomSitePage(
 			String externalReferenceCode,
 			String parentSitePageExternalReferenceCode,
-			ServiceContext serviceContext, SitePage.Type type, String uuid)
+			ServiceContext serviceContext,
+			ItemExternalReference[] taxonomyCategoryItemExternalReferences,
+			SitePage.Type type, String uuid)
 		throws Exception {
 
 		SitePage sitePage = new SitePage();
@@ -1324,12 +1329,25 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		sitePage.setParentSitePageExternalReferenceCode(
 			parentSitePageExternalReferenceCode);
 		sitePage.setTaxonomyCategoryItemExternalReferences(
-			AssetTestUtil.randomTaxonomyCategoryItemExternalReferences(
-				testCompany.getGroupId(), serviceContext));
+			taxonomyCategoryItemExternalReferences);
 		sitePage.setType(type);
 		sitePage.setUuid(uuid);
 
 		return sitePage;
+	}
+
+	private SitePage _getRandomSitePage(
+			String externalReferenceCode,
+			String parentSitePageExternalReferenceCode,
+			ServiceContext serviceContext, SitePage.Type type, String uuid)
+		throws Exception {
+
+		return _getRandomSitePage(
+			externalReferenceCode, parentSitePageExternalReferenceCode,
+			serviceContext,
+			AssetTestUtil.randomTaxonomyCategoryItemExternalReferences(
+				testCompany.getGroupId(), serviceContext),
+			type, uuid);
 	}
 
 	private SitePage _getRandomSitePageWithWidgetPageTemplate(
@@ -2686,6 +2704,67 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 				layout.getExternalReferenceCode(), testGroup.getGroupId()));
 	}
 
+	private void _testPutSiteSitePageWithMissingTaxonomyCategories()
+		throws Exception {
+
+		ItemExternalReference[] taxonomyCategoryItemExternalReferences = {
+			new ItemExternalReference() {
+				{
+					setClassName(AssetCategory.class::getName);
+					setExternalReferenceCode(RandomTestUtil::randomString);
+
+					Group group = _groupLocalService.getGroup(
+						testCompany.getGroupId());
+
+					setScope(
+						() -> new Scope() {
+							{
+								setExternalReferenceCode(
+									group::getExternalReferenceCode);
+								setType(() -> Type.SITE);
+							}
+						});
+				}
+			},
+			new ItemExternalReference() {
+				{
+					setClassName(AssetCategory.class::getName);
+					setExternalReferenceCode(RandomTestUtil::randomString);
+				}
+			}
+		};
+
+		SitePage randomSitePage = _getRandomSitePage(
+			RandomTestUtil.randomString(), null,
+			ServiceContextTestUtil.getServiceContext(
+				testGroup, TestPropsValues.getUserId()),
+			taxonomyCategoryItemExternalReferences, SitePage.Type.WIDGET_PAGE,
+			RandomTestUtil.randomString());
+
+		SitePage putSitePage = sitePageResource.putSiteSitePage(
+			testGroup.getExternalReferenceCode(),
+			randomSitePage.getExternalReferenceCode(), randomSitePage);
+
+		Assert.assertTrue(
+			Objects.deepEquals(
+				randomSitePage.getTaxonomyCategoryItemExternalReferences(),
+				putSitePage.getTaxonomyCategoryItemExternalReferences()));
+
+		Assert.assertNotNull(
+			_assetCategoryLocalService.
+				fetchAssetCategoryByExternalReferenceCode(
+					taxonomyCategoryItemExternalReferences[0].
+						getExternalReferenceCode(),
+					testCompany.getGroupId()));
+
+		Assert.assertNotNull(
+			_assetCategoryLocalService.
+				fetchAssetCategoryByExternalReferenceCode(
+					taxonomyCategoryItemExternalReferences[1].
+						getExternalReferenceCode(),
+					testGroup.getGroupId()));
+	}
+
 	private void _testPutSiteSitePageWithPageElements() throws Exception {
 		PageElement[] pageElements = PageElementsTestUtil.getPageElements(
 			testGroup.getGroupId());
@@ -3218,6 +3297,9 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 	private static final List<SitePage.Type> _types = Arrays.asList(
 		SitePage.Type.CONTENT_PAGE, SitePage.Type.WIDGET_PAGE);
+
+	@Inject
+	private AssetCategoryLocalService _assetCategoryLocalService;
 
 	@Inject
 	private DefaultInputFragmentEntryConfigurationProvider


### PR DESCRIPTION
Hi @brianchandotcom ,

I am sending again a PR to fix this : https://github.com/brianchandotcom/liferay-portal/pull/169729#issuecomment-3805580978

Regards!

https://liferay.atlassian.net/browse/LPD-71347

# What is this solving?

Fix bug. After this we were throwing an error when an asset cagory did not exist, now, we are getting it if LazyReferecing is not enabled or creating it with empty values if not.

# How is it fixed?

Use getOrAddEmptyCategory when we are creating categories associated to the site page. I have had to introduce SitePageResourceTest to the source-formatter-suppressions.xml since I have had to use the injected SitePageResource in order to enable LazyReference for the test. Please let me know if you need more information about this.

# How to verify?

Run included integration tests