### PR TITLE
LPD-76246 provide delete, patch and copy methods for task definition

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/KaleoWorkflowModelConverterImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/KaleoWorkflowModelConverterImpl.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.DefaultWorkflowDefinition;
@@ -138,6 +139,10 @@ public class KaleoWorkflowModelConverterImpl
 			kaleoDefinition.getModifiedDate());
 		defaultWorkflowDefinition.setName(kaleoDefinition.getName());
 		defaultWorkflowDefinition.setScope(kaleoDefinition.getScope());
+		defaultWorkflowDefinition.setSystem(
+			ArrayUtil.contains(
+				WorkflowDefinitionConstants.SYSTEM_WORKFLOW_DEFINITION_NAMES,
+				kaleoDefinition.getName()));
 		defaultWorkflowDefinition.setTitle(kaleoDefinition.getTitle());
 		defaultWorkflowDefinition.setUserId(kaleoDefinition.getUserId());
 		defaultWorkflowDefinition.setVersion(kaleoDefinition.getVersion());
@@ -179,6 +184,11 @@ public class KaleoWorkflowModelConverterImpl
 
 			defaultWorkflowDefinition.setActive(kaleoDefinition.isActive());
 			defaultWorkflowDefinition.setScope(kaleoDefinition.getScope());
+			defaultWorkflowDefinition.setSystem(
+				ArrayUtil.contains(
+					WorkflowDefinitionConstants.
+						SYSTEM_WORKFLOW_DEFINITION_NAMES,
+					kaleoDefinition.getName()));
 			defaultWorkflowDefinition.setWorkflowDefinitionId(
 				kaleoDefinition.getKaleoDefinitionId());
 		}

--- a/modules/apps/portal-workflow/portal-workflow-web/src/test/java/com/liferay/portal/workflow/web/internal/util/filter/WorkflowDefinitionImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/test/java/com/liferay/portal/workflow/web/internal/util/filter/WorkflowDefinitionImpl.java
@@ -5,9 +5,11 @@
 
 package com.liferay.portal.workflow.web.internal.util.filter;
 
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.workflow.WorkflowDefinition;
 import com.liferay.portal.kernel.workflow.WorkflowNode;
 import com.liferay.portal.kernel.workflow.WorkflowTransition;
+import com.liferay.portal.workflow.constants.WorkflowDefinitionConstants;
 
 import java.io.InputStream;
 
@@ -112,6 +114,13 @@ public class WorkflowDefinitionImpl implements WorkflowDefinition {
 	@Override
 	public boolean isActive() {
 		return _active;
+	}
+
+	@Override
+	public boolean isSystem() {
+		return ArrayUtil.contains(
+			WorkflowDefinitionConstants.SYSTEM_WORKFLOW_DEFINITION_NAMES,
+			getName());
 	}
 
 	private final boolean _active;

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/AgentsFactory.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/AgentsFactory.java
@@ -34,8 +34,8 @@ public class AgentsFactory {
 		try {
 			Page<TaskDefinition> page =
 				_taskDefinitionManager.getTaskDefinitions(
-					_agentContext.getCompanyId(), null, null, null,
-					Pagination.of(1, 20), null);
+					_agentContext.getCompanyId(), null, null,
+					Pagination.of(1, 20), null, null);
 
 			return TransformUtil.transformToArray(
 				page.getItems(),

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/AgentsFactory.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/AgentsFactory.java
@@ -1,0 +1,63 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.internal.agent;
+
+import com.liferay.ai.hub.agent.AgentContext;
+import com.liferay.ai.hub.rest.dto.v1_0.TaskDefinition;
+import com.liferay.ai.hub.rest.manager.v1_0.TaskDefinitionManager;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.workflow.WorkflowInstanceManager;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+
+/**
+ * @author Feliphe Marinho
+ * @author João Victor Alves
+ */
+public class AgentsFactory {
+
+	public AgentsFactory(
+		AgentContext agentContext, TaskDefinitionManager taskDefinitionManager,
+		WorkflowInstanceManager workflowInstanceManager) {
+
+		_agentContext = agentContext;
+		_taskDefinitionManager = taskDefinitionManager;
+		_workflowInstanceManager = workflowInstanceManager;
+	}
+
+	public Object[] create() {
+		try {
+			Page<TaskDefinition> page =
+				_taskDefinitionManager.getTaskDefinitions(
+					_agentContext.getCompanyId(), null, null, null,
+					Pagination.of(1, 20), null);
+
+			return TransformUtil.transformToArray(
+				page.getItems(),
+				taskDefinition -> new AgentSpecsProviderImpl(
+					_agentContext, taskDefinition.getDescription(),
+					taskDefinition.getName(), taskDefinition.getVersion(),
+					_workflowInstanceManager),
+				Object.class);
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
+
+		return new AgentSpecsProviderImpl[0];
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(AgentsFactory.class);
+
+	private final AgentContext _agentContext;
+	private final TaskDefinitionManager _taskDefinitionManager;
+	private final WorkflowInstanceManager _workflowInstanceManager;
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/AgentsFactoryImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/AgentsFactoryImpl.java
@@ -41,10 +41,9 @@ public class AgentsFactoryImpl implements AgentsFactory {
 
 			Page<TaskDefinition> page =
 				_taskDefinitionManager.getTaskDefinitions(
-					agentContext.getCompanyId(),
-					agentContext.getDTOConverterContext(), null,
+					agentContext.getCompanyId(), null,
 					_toFilter(serviceContext.getLocale()), Pagination.of(1, 20),
-					null);
+					null, null);
 
 			return TransformUtil.transformToArray(
 				page.getItems(),

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/SupervisorAgentImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/SupervisorAgentImpl.java
@@ -9,18 +9,21 @@ import com.liferay.ai.hub.agent.AgentContext;
 import com.liferay.ai.hub.agent.AgentsFactory;
 import com.liferay.ai.hub.agent.SupervisorAgent;
 import com.liferay.ai.hub.rest.resource.v1_0.util.SseUtil;
+import com.liferay.petra.concurrent.NoticeableExecutorService;
 import com.liferay.petra.executor.PortalExecutorManager;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.auth.CompanyInheritableThreadLocalCallable;
 import com.liferay.portal.kernel.util.MapUtil;
 
 import dev.langchain4j.agentic.AgenticServices;
 import dev.langchain4j.agentic.supervisor.SupervisorResponseStrategy;
 import dev.langchain4j.model.vertexai.gemini.VertexAiGeminiChatModel;
 
-import java.util.concurrent.ExecutorService;
-
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -32,34 +35,45 @@ public class SupervisorAgentImpl implements SupervisorAgent {
 
 	@Override
 	public void invoke(AgentContext agentContext) {
-		ExecutorService executorService =
-			_portalExecutorManager.getPortalExecutor(
-				SupervisorAgentImpl.class.getName());
-
 		Object[] agents = _agentsFactory.create(agentContext);
 
-		executorService.submit(
-			() -> {
-				try (VertexAiGeminiChatModel vertexAiGeminiChatModel =
-						VertexAiGeminiChatModel.builder(
-						).location(
-							"us-central1"
-						).modelName(
-							"gemini-2.5-flash-lite"
-						).project(
-							"ai-hub-liferay"
-						).build()) {
+		_noticeableExecutorService.submit(
+			new CompanyInheritableThreadLocalCallable<>(
+				() -> {
+					try (VertexAiGeminiChatModel vertexAiGeminiChatModel =
+							VertexAiGeminiChatModel.builder(
+							).location(
+								"us-central1"
+							).modelName(
+								"gemini-2.5-flash-lite"
+							).project(
+								"ai-hub-liferay"
+							).build()) {
 
-					_invoke(agentContext, agents, vertexAiGeminiChatModel);
-				}
-				catch (Exception exception) {
-					_log.error(exception);
+						_invoke(agentContext, agents, vertexAiGeminiChatModel);
+					}
+					catch (Exception exception) {
+						_log.error(exception);
 
-					SseUtil.send(
-						"I cannot fulfill this request.", "Chat Message Sent",
-						agentContext.getSseEventSinkKey());
-				}
-			});
+						SseUtil.send(
+							"I cannot fulfill this request.",
+							"Chat Message Sent",
+							agentContext.getSseEventSinkKey());
+					}
+
+					return null;
+				}));
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_noticeableExecutorService = _portalExecutorManager.getPortalExecutor(
+			SupervisorAgentImpl.class.getName());
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_noticeableExecutorService.shutdown();
 	}
 
 	private void _invoke(
@@ -86,6 +100,8 @@ public class SupervisorAgentImpl implements SupervisorAgent {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		SupervisorAgentImpl.class);
+
+	private NoticeableExecutorService _noticeableExecutorService;
 
 	@Reference
 	private AgentsFactory _agentsFactory;

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/SupervisorAgentImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/SupervisorAgentImpl.java
@@ -101,10 +101,10 @@ public class SupervisorAgentImpl implements SupervisorAgent {
 	private static final Log _log = LogFactoryUtil.getLog(
 		SupervisorAgentImpl.class);
 
-	private NoticeableExecutorService _noticeableExecutorService;
-
 	@Reference
 	private AgentsFactory _agentsFactory;
+
+	private NoticeableExecutorService _noticeableExecutorService;
 
 	@Reference
 	private PortalExecutorManager _portalExecutorManager;

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/mcp/tool/provider/MCPToolProviderUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/mcp/tool/provider/MCPToolProviderUtil.java
@@ -14,6 +14,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserServiceUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -132,14 +133,20 @@ public class MCPToolProviderUtil {
 		ObjectEntryManager objectEntryManager, long userId) {
 
 		try {
+			String groupKey = GroupConstants.GUEST;
+
 			Group group = GroupLocalServiceUtil.fetchGroup(groupId);
+
+			if (group != null) {
+				groupKey = group.getGroupKey();
+			}
 
 			Page<ObjectEntry> page = objectEntryManager.getObjectEntries(
 				companyId,
 				ObjectDefinitionLocalServiceUtil.
 					fetchObjectDefinitionByExternalReferenceCode(
 						"L_MCP_SERVER", companyId),
-				group.getGroupKey(), null,
+				groupKey, null,
 				new DefaultDTOConverterContext(
 					false, Map.of(), dtoConverterRegistry, null, locale, null,
 					UserServiceUtil.getUserById(userId)),
@@ -167,7 +174,7 @@ public class MCPToolProviderUtil {
 			Base64.Encoder encoder = Base64.getEncoder();
 
 			String credentials =
-				jsonObject.getString("userName") +
+				jsonObject.getString("userName") + ":" +
 					jsonObject.getString("password");
 
 			return "Basic " +

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/LLMNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/LLMNodeExecutor.java
@@ -15,7 +15,6 @@ import com.liferay.ai.hub.rest.resource.v1_0.util.SseUtil;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.petra.lang.SafeCloseable;
-import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
@@ -77,7 +76,6 @@ public class LLMNodeExecutor extends BaseNodeExecutor {
 		throws PortalException {
 
 		long companyId = CompanyThreadLocal.getCompanyId();
-		long ctCollectionId = CTCollectionThreadLocal.getCTCollectionId();
 		KaleoInstanceToken kaleoInstanceToken =
 			executionContext.getKaleoInstanceToken();
 
@@ -123,9 +121,8 @@ public class LLMNodeExecutor extends BaseNodeExecutor {
 				GetterUtil.getString(workflowContext.get("memoryId"))
 			).onCompleteResponse(
 				response -> _completeResponse(
-					response, companyId, ctCollectionId, executionContext,
-					currentKaleoNode, kaleoNodeSettingValues,
-					vertexAiGeminiStreamingChatModel)
+					response, companyId, executionContext, currentKaleoNode,
+					kaleoNodeSettingValues, vertexAiGeminiStreamingChatModel)
 			).onError(
 				throwable -> vertexAiGeminiStreamingChatModel.close()
 			).systemMessageProvider(
@@ -174,14 +171,13 @@ public class LLMNodeExecutor extends BaseNodeExecutor {
 	}
 
 	private void _completeResponse(
-		ChatResponse chatResponse, long companyId, long ctCollectionId,
+		ChatResponse chatResponse, long companyId,
 		ExecutionContext executionContext, KaleoNode kaleoNode,
 		Map<String, String> kaleoNodeSettingValues,
 		VertexAiGeminiStreamingChatModel vertexAiGeminiStreamingChatModel) {
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-					companyId, ctCollectionId)) {
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId)) {
 
 			Map<String, Serializable> workflowContext =
 				executionContext.getWorkflowContext();

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/dto/v1_0/TaskDefinition.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/dto/v1_0/TaskDefinition.java
@@ -18,6 +18,8 @@ import com.liferay.portal.vulcan.util.ObjectMapperUtil;
 
 import jakarta.annotation.Generated;
 
+import jakarta.validation.Valid;
+
 import jakarta.xml.bind.annotation.XmlRootElement;
 
 import java.io.Serializable;
@@ -45,6 +47,49 @@ public class TaskDefinition implements Serializable {
 	public static TaskDefinition unsafeToDTO(String json) {
 		return ObjectMapperUtil.unsafeReadValue(TaskDefinition.class, json);
 	}
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public Map<String, Map<String, String>> getActions() {
+		if (_actionsSupplier != null) {
+			actions = _actionsSupplier.get();
+
+			_actionsSupplier = null;
+		}
+
+		return actions;
+	}
+
+	public void setActions(Map<String, Map<String, String>> actions) {
+		this.actions = actions;
+
+		_actionsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setActions(
+		UnsafeSupplier<Map<String, Map<String, String>>, Exception>
+			actionsUnsafeSupplier) {
+
+		_actionsSupplier = () -> {
+			try {
+				return actionsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Map<String, Map<String, String>> actions;
+
+	@JsonIgnore
+	private Supplier<Map<String, Map<String, String>>> _actionsSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
 	public Boolean getActive() {
@@ -129,6 +174,86 @@ public class TaskDefinition implements Serializable {
 	private Supplier<String> _descriptionSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
+	public String getExternalReferenceCode() {
+		if (_externalReferenceCodeSupplier != null) {
+			externalReferenceCode = _externalReferenceCodeSupplier.get();
+
+			_externalReferenceCodeSupplier = null;
+		}
+
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+
+		_externalReferenceCodeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		_externalReferenceCodeSupplier = () -> {
+			try {
+				return externalReferenceCodeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String externalReferenceCode;
+
+	@JsonIgnore
+	private Supplier<String> _externalReferenceCodeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getId() {
+		if (_idSupplier != null) {
+			id = _idSupplier.get();
+
+			_idSupplier = null;
+		}
+
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+
+		_idSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		_idSupplier = () -> {
+			try {
+				return idUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long id;
+
+	@JsonIgnore
+	private Supplier<Long> _idSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
 	public String getName() {
 		if (_nameSupplier != null) {
 			name = _nameSupplier.get();
@@ -168,6 +293,47 @@ public class TaskDefinition implements Serializable {
 	private Supplier<String> _nameSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
+	public String getTitle() {
+		if (_titleSupplier != null) {
+			title = _titleSupplier.get();
+
+			_titleSupplier = null;
+		}
+
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+
+		_titleSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setTitle(
+		UnsafeSupplier<String, Exception> titleUnsafeSupplier) {
+
+		_titleSupplier = () -> {
+			try {
+				return titleUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String title;
+
+	@JsonIgnore
+	private Supplier<String> _titleSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
 	public Integer getVersion() {
 		if (_versionSupplier != null) {
 			version = _versionSupplier.get();
@@ -202,7 +368,7 @@ public class TaskDefinition implements Serializable {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Integer version;
 
 	@JsonIgnore
@@ -235,6 +401,18 @@ public class TaskDefinition implements Serializable {
 
 		sb.append("{");
 
+		Map<String, Map<String, String>> actions = getActions();
+
+		if (actions != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actions\": ");
+
+			sb.append(_toJSON(actions));
+		}
+
 		Boolean active = getActive();
 
 		if (active != null) {
@@ -263,6 +441,34 @@ public class TaskDefinition implements Serializable {
 			sb.append("\"");
 		}
 
+		String externalReferenceCode = getExternalReferenceCode();
+
+		if (externalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(externalReferenceCode));
+
+			sb.append("\"");
+		}
+
+		Long id = getId();
+
+		if (id != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(id);
+		}
+
 		String name = getName();
 
 		if (name != null) {
@@ -275,6 +481,22 @@ public class TaskDefinition implements Serializable {
 			sb.append("\"");
 
 			sb.append(_escape(name));
+
+			sb.append("\"");
+		}
+
+		String title = getTitle();
+
+		if (title != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(title));
 
 			sb.append("\"");
 		}

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/manager/v1_0/TaskDefinitionManager.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/manager/v1_0/TaskDefinitionManager.java
@@ -19,21 +19,21 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 public interface TaskDefinitionManager {
 
 	public void deleteTaskDefinition(
-			long taskDefinitionId, DTOConverterContext dtoConverterContext)
+			DTOConverterContext dtoConverterContext, long taskDefinitionId)
 		throws Exception;
 
 	public Page<TaskDefinition> getTaskDefinitions(
 			long companyId, DTOConverterContext dtoConverterContext,
-			String search, Filter filter, Pagination pagination, Sort[] sorts)
+			Filter filter, Pagination pagination, String search, Sort[] sorts)
 		throws Exception;
 
 	public TaskDefinition patchTaskDefinitionUpdateActive(
-			long taskDefinitionId, boolean active,
-			DTOConverterContext dtoConverterContext)
+			boolean active, DTOConverterContext dtoConverterContext,
+			long taskDefinitionId)
 		throws Exception;
 
 	public TaskDefinition postTaskDefinitionCopy(
-			long taskDefinitionId, DTOConverterContext dtoConverterContext)
+			DTOConverterContext dtoConverterContext, long taskDefinitionId)
 		throws Exception;
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/manager/v1_0/TaskDefinitionManager.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/manager/v1_0/TaskDefinitionManager.java
@@ -18,9 +18,22 @@ import com.liferay.portal.vulcan.pagination.Pagination;
  */
 public interface TaskDefinitionManager {
 
+	public void deleteTaskDefinition(
+			long taskDefinitionId, DTOConverterContext dtoConverterContext)
+		throws Exception;
+
 	public Page<TaskDefinition> getTaskDefinitions(
 			long companyId, DTOConverterContext dtoConverterContext,
 			String search, Filter filter, Pagination pagination, Sort[] sorts)
+		throws Exception;
+
+	public TaskDefinition patchTaskDefinitionUpdateActive(
+			long taskDefinitionId, boolean active,
+			DTOConverterContext dtoConverterContext)
+		throws Exception;
+
+	public TaskDefinition postTaskDefinitionCopy(
+			long taskDefinitionId, DTOConverterContext dtoConverterContext)
 		throws Exception;
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/resource/v1_0/TaskDefinitionResource.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/resource/v1_0/TaskDefinitionResource.java
@@ -46,11 +46,23 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface TaskDefinitionResource {
 
+	public void deleteTaskDefinition(Long taskDefinitionId) throws Exception;
+
+	public Response deleteTaskDefinitionBatch(String callbackURL, Object object)
+		throws Exception;
+
 	public Page<TaskDefinition> getTaskDefinitionsPage(
 			String search,
 			com.liferay.portal.kernel.search.filter.Filter filter,
 			Pagination pagination,
 			com.liferay.portal.kernel.search.Sort[] sorts)
+		throws Exception;
+
+	public TaskDefinition patchTaskDefinitionUpdateActive(
+			Long taskDefinitionId, Boolean active)
+		throws Exception;
+
+	public TaskDefinition postTaskDefinitionCopy(Long taskDefinitionId)
 		throws Exception;
 
 	public Response postTaskDefinitionsPageExportBatch(

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/resources/com/liferay/ai/hub/rest/resource/v1_0/packageinfo
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/resources/com/liferay/ai/hub/rest/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-client/src/main/java/com/liferay/ai/hub/rest/client/dto/v1_0/TaskDefinition.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-client/src/main/java/com/liferay/ai/hub/rest/client/dto/v1_0/TaskDefinition.java
@@ -12,6 +12,7 @@ import jakarta.annotation.Generated;
 
 import java.io.Serializable;
 
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -24,6 +25,28 @@ public class TaskDefinition implements Cloneable, Serializable {
 	public static TaskDefinition toDTO(String json) {
 		return TaskDefinitionSerDes.toDTO(json);
 	}
+
+	public Map<String, Map<String, String>> getActions() {
+		return actions;
+	}
+
+	public void setActions(Map<String, Map<String, String>> actions) {
+		this.actions = actions;
+	}
+
+	public void setActions(
+		UnsafeSupplier<Map<String, Map<String, String>>, Exception>
+			actionsUnsafeSupplier) {
+
+		try {
+			actions = actionsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Map<String, Map<String, String>> actions;
 
 	public Boolean getActive() {
 		return active;
@@ -67,6 +90,46 @@ public class TaskDefinition implements Cloneable, Serializable {
 
 	protected String description;
 
+	public String getExternalReferenceCode() {
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		try {
+			externalReferenceCode = externalReferenceCodeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String externalReferenceCode;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long id;
+
 	public String getName() {
 		return name;
 	}
@@ -85,6 +148,27 @@ public class TaskDefinition implements Cloneable, Serializable {
 	}
 
 	protected String name;
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public void setTitle(
+		UnsafeSupplier<String, Exception> titleUnsafeSupplier) {
+
+		try {
+			title = titleUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String title;
 
 	public Integer getVersion() {
 		return version;

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-client/src/main/java/com/liferay/ai/hub/rest/client/resource/v1_0/TaskDefinitionResource.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-client/src/main/java/com/liferay/ai/hub/rest/client/resource/v1_0/TaskDefinitionResource.java
@@ -34,6 +34,19 @@ public interface TaskDefinitionResource {
 		return new Builder();
 	}
 
+	public void deleteTaskDefinition(Long taskDefinitionId) throws Exception;
+
+	public HttpInvoker.HttpResponse deleteTaskDefinitionHttpResponse(
+			Long taskDefinitionId)
+		throws Exception;
+
+	public void deleteTaskDefinitionBatch(String callbackURL, Object object)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse deleteTaskDefinitionBatchHttpResponse(
+			String callbackURL, Object object)
+		throws Exception;
+
 	public Page<TaskDefinition> getTaskDefinitionsPage(
 			String search, String filterString, Pagination pagination,
 			String sortString)
@@ -42,6 +55,21 @@ public interface TaskDefinitionResource {
 	public HttpInvoker.HttpResponse getTaskDefinitionsPageHttpResponse(
 			String search, String filterString, Pagination pagination,
 			String sortString)
+		throws Exception;
+
+	public TaskDefinition patchTaskDefinitionUpdateActive(
+			Long taskDefinitionId, Boolean active)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse patchTaskDefinitionUpdateActiveHttpResponse(
+			Long taskDefinitionId, Boolean active)
+		throws Exception;
+
+	public TaskDefinition postTaskDefinitionCopy(Long taskDefinitionId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postTaskDefinitionCopyHttpResponse(
+			Long taskDefinitionId)
 		throws Exception;
 
 	public void postTaskDefinitionsPageExportBatch(
@@ -164,6 +192,210 @@ public interface TaskDefinitionResource {
 	public static class TaskDefinitionResourceImpl
 		implements TaskDefinitionResource {
 
+		public void deleteTaskDefinition(Long taskDefinitionId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				deleteTaskDefinitionHttpResponse(taskDefinitionId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return;
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse deleteTaskDefinitionHttpResponse(
+				Long taskDefinitionId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/ai-hub/v1.0/task-definitions/{taskDefinitionId}");
+
+			httpInvoker.path("taskDefinitionId", taskDefinitionId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void deleteTaskDefinitionBatch(String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				deleteTaskDefinitionBatchHttpResponse(callbackURL, object);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse deleteTaskDefinitionBatchHttpResponse(
+				String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(object.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/ai-hub/v1.0/task-definitions/batch");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
 		public Page<TaskDefinition> getTaskDefinitionsPage(
 				String search, String filterString, Pagination pagination,
 				String sortString)
@@ -281,6 +513,227 @@ public interface TaskDefinitionResource {
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
 						"/o/ai-hub/v1.0/task-definitions");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public TaskDefinition patchTaskDefinitionUpdateActive(
+				Long taskDefinitionId, Boolean active)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				patchTaskDefinitionUpdateActiveHttpResponse(
+					taskDefinitionId, active);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return TaskDefinitionSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				patchTaskDefinitionUpdateActiveHttpResponse(
+					Long taskDefinitionId, Boolean active)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body("[]", "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.PATCH);
+
+			if (active != null) {
+				httpInvoker.parameter("active", String.valueOf(active));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/ai-hub/v1.0/task-definitions/{taskDefinitionId}/update-active");
+
+			httpInvoker.path("taskDefinitionId", taskDefinitionId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public TaskDefinition postTaskDefinitionCopy(Long taskDefinitionId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postTaskDefinitionCopyHttpResponse(taskDefinitionId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return TaskDefinitionSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse postTaskDefinitionCopyHttpResponse(
+				Long taskDefinitionId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body("[]", "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/ai-hub/v1.0/task-definitions/{taskDefinitionId}/copy");
+
+			httpInvoker.path("taskDefinitionId", taskDefinitionId);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-client/src/main/java/com/liferay/ai/hub/rest/client/serdes/v1_0/TaskDefinitionSerDes.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-client/src/main/java/com/liferay/ai/hub/rest/client/serdes/v1_0/TaskDefinitionSerDes.java
@@ -46,6 +46,16 @@ public class TaskDefinitionSerDes {
 
 		sb.append("{");
 
+		if (taskDefinition.getActions() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actions\": ");
+
+			sb.append(_toJSON(taskDefinition.getActions()));
+		}
+
 		if (taskDefinition.getActive() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -70,6 +80,30 @@ public class TaskDefinitionSerDes {
 			sb.append("\"");
 		}
 
+		if (taskDefinition.getExternalReferenceCode() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(taskDefinition.getExternalReferenceCode()));
+
+			sb.append("\"");
+		}
+
+		if (taskDefinition.getId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(taskDefinition.getId());
+		}
+
 		if (taskDefinition.getName() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -80,6 +114,20 @@ public class TaskDefinitionSerDes {
 			sb.append("\"");
 
 			sb.append(_escape(taskDefinition.getName()));
+
+			sb.append("\"");
+		}
+
+		if (taskDefinition.getTitle() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(taskDefinition.getTitle()));
 
 			sb.append("\"");
 		}
@@ -113,6 +161,13 @@ public class TaskDefinitionSerDes {
 
 		Map<String, String> map = new TreeMap<>();
 
+		if (taskDefinition.getActions() == null) {
+			map.put("actions", null);
+		}
+		else {
+			map.put("actions", String.valueOf(taskDefinition.getActions()));
+		}
+
 		if (taskDefinition.getActive() == null) {
 			map.put("active", null);
 		}
@@ -128,11 +183,34 @@ public class TaskDefinitionSerDes {
 				"description", String.valueOf(taskDefinition.getDescription()));
 		}
 
+		if (taskDefinition.getExternalReferenceCode() == null) {
+			map.put("externalReferenceCode", null);
+		}
+		else {
+			map.put(
+				"externalReferenceCode",
+				String.valueOf(taskDefinition.getExternalReferenceCode()));
+		}
+
+		if (taskDefinition.getId() == null) {
+			map.put("id", null);
+		}
+		else {
+			map.put("id", String.valueOf(taskDefinition.getId()));
+		}
+
 		if (taskDefinition.getName() == null) {
 			map.put("name", null);
 		}
 		else {
 			map.put("name", String.valueOf(taskDefinition.getName()));
+		}
+
+		if (taskDefinition.getTitle() == null) {
+			map.put("title", null);
+		}
+		else {
+			map.put("title", String.valueOf(taskDefinition.getTitle()));
 		}
 
 		if (taskDefinition.getVersion() == null) {
@@ -160,13 +238,27 @@ public class TaskDefinitionSerDes {
 
 		@Override
 		protected boolean parseMaps(String jsonParserFieldName) {
-			if (Objects.equals(jsonParserFieldName, "active")) {
+			if (Objects.equals(jsonParserFieldName, "actions")) {
+				return true;
+			}
+			else if (Objects.equals(jsonParserFieldName, "active")) {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "description")) {
 				return false;
 			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "name")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "version")) {
@@ -181,7 +273,13 @@ public class TaskDefinitionSerDes {
 			TaskDefinition taskDefinition, String jsonParserFieldName,
 			Object jsonParserFieldValue) {
 
-			if (Objects.equals(jsonParserFieldName, "active")) {
+			if (Objects.equals(jsonParserFieldName, "actions")) {
+				if (jsonParserFieldValue != null) {
+					taskDefinition.setActions(
+						(Map<String, Map<String, String>>)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "active")) {
 				if (jsonParserFieldValue != null) {
 					taskDefinition.setActive((Boolean)jsonParserFieldValue);
 				}
@@ -191,9 +289,28 @@ public class TaskDefinitionSerDes {
 					taskDefinition.setDescription((String)jsonParserFieldValue);
 				}
 			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				if (jsonParserFieldValue != null) {
+					taskDefinition.setExternalReferenceCode(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				if (jsonParserFieldValue != null) {
+					taskDefinition.setId(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
 			else if (Objects.equals(jsonParserFieldName, "name")) {
 				if (jsonParserFieldValue != null) {
 					taskDefinition.setName((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				if (jsonParserFieldValue != null) {
+					taskDefinition.setTitle((String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "version")) {

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/rest-openapi.yaml
@@ -41,13 +41,30 @@ components:
             type: object
         TaskDefinition:
             properties:
+                actions:
+                    additionalProperties:
+                        additionalProperties:
+                            type: string
+                        type: object
+                    readOnly: true
+                    type: object
                 active:
                     type: boolean
                 description:
                     type: string
+                externalReferenceCode:
+                    readOnly: true
+                    type: string
+                id:
+                    format: int64
+                    readOnly: true
+                    type: integer
                 name:
                     type: string
+                title:
+                    type: string
                 version:
+                    readOnly: true
                     type: integer
             type: object
         Token:
@@ -65,7 +82,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.ai.hub.rest.client', and version '1.0.4'."
+        'com.liferay.ai.hub.rest.client', and version '1.0.5'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html
@@ -150,6 +167,67 @@ paths:
                                 items:
                                     $ref: "#/components/schemas/TaskDefinition"
                                 type: array
+            tags: ["TaskDefinition"]
+    "/task-definitions/{taskDefinitionId}":
+        delete:
+            operationId: deleteTaskDefinition
+            parameters:
+                -   in: path
+                    name: taskDefinitionId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["TaskDefinition"]
+    "/task-definitions/{taskDefinitionId}/copy":
+        post:
+            operationId: postTaskDefinitionCopy
+            parameters:
+                -   in: path
+                    name: taskDefinitionId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/TaskDefinition"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/TaskDefinition"
+            tags: ["TaskDefinition"]
+    "/task-definitions/{taskDefinitionId}/update-active":
+        patch:
+            operationId: patchTaskDefinitionUpdateActive
+            parameters:
+                -   in: path
+                    name: taskDefinitionId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: active
+                    required: true
+                    schema:
+                        type: boolean
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/TaskDefinition"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/TaskDefinition"
             tags: ["TaskDefinition"]
     "/tasks":
         post:

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/TaskDefinitionManagerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/TaskDefinitionManagerImpl.java
@@ -6,21 +6,32 @@
 package com.liferay.ai.hub.rest.internal.manager.v1_0;
 
 import com.liferay.ai.hub.rest.dto.v1_0.TaskDefinition;
+import com.liferay.ai.hub.rest.internal.resource.v1_0.TaskDefinitionResourceImpl;
 import com.liferay.ai.hub.rest.manager.v1_0.TaskDefinitionManager;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowDefinition;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.SearchUtil;
 import com.liferay.portal.workflow.constants.WorkflowDefinitionConstants;
+import com.liferay.portal.workflow.kaleo.model.KaleoDefinition;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinitionVersion;
 import com.liferay.portal.workflow.manager.WorkflowDefinitionManager;
+
+import java.util.Locale;
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -33,13 +44,44 @@ import org.osgi.service.component.annotations.Reference;
 public class TaskDefinitionManagerImpl implements TaskDefinitionManager {
 
 	@Override
+	public void deleteTaskDefinition(
+			long taskDefinitionId, DTOConverterContext dtoConverterContext)
+		throws Exception {
+
+		WorkflowDefinition workflowDefinition =
+			_workflowDefinitionManager.getWorkflowDefinition(taskDefinitionId);
+
+		_workflowDefinitionManager.updateActive(
+			workflowDefinition.getCompanyId(), dtoConverterContext.getUserId(),
+			workflowDefinition.getName(), workflowDefinition.getVersion(),
+			false);
+
+		_workflowDefinitionManager.undeployWorkflowDefinition(
+			workflowDefinition.getCompanyId(), dtoConverterContext.getUserId(),
+			workflowDefinition.getName(), workflowDefinition.getVersion());
+	}
+
+	@Override
 	public Page<TaskDefinition> getTaskDefinitions(
 			long companyId, DTOConverterContext dtoConverterContext,
 			String search, Filter filter, Pagination pagination, Sort[] sorts)
 		throws Exception {
 
+		Map<String, Map<String, String>> actions = null;
+
+		if (dtoConverterContext != null) {
+			actions = HashMapBuilder.<String, Map<String, String>>put(
+				"get",
+				ActionUtil.addAction(
+					ActionKeys.VIEW, TaskDefinitionResourceImpl.class, null,
+					"getTaskDefinitionsPage",
+					_kaleoDefinitionModelResourcePermission, (Long)null,
+					dtoConverterContext.getUriInfo())
+			).build();
+		}
+
 		return SearchUtil.search(
-			dtoConverterContext.getActions(),
+			actions,
 			booleanQuery -> {
 				BooleanFilter booleanFilter =
 					booleanQuery.getPreBooleanFilter();
@@ -55,22 +97,137 @@ public class TaskDefinitionManagerImpl implements TaskDefinitionManager {
 			document -> _toTaskDefinition(
 				_workflowDefinitionManager.getWorkflowDefinition(
 					companyId, document.get(Field.NAME),
-					GetterUtil.getInteger(document.get(Field.VERSION)))));
+					GetterUtil.getInteger(document.get(Field.VERSION))),
+				dtoConverterContext));
+	}
+
+	@Override
+	public TaskDefinition patchTaskDefinitionUpdateActive(
+			long taskDefinitionId, boolean active,
+			DTOConverterContext dtoConverterContext)
+		throws Exception {
+
+		WorkflowDefinition workflowDefinition =
+			_workflowDefinitionManager.getWorkflowDefinition(taskDefinitionId);
+
+		workflowDefinition = _workflowDefinitionManager.updateActive(
+			workflowDefinition.getCompanyId(), dtoConverterContext.getUserId(),
+			workflowDefinition.getName(), workflowDefinition.getVersion(),
+			active);
+
+		return _toTaskDefinition(workflowDefinition, dtoConverterContext);
+	}
+
+	@Override
+	public TaskDefinition postTaskDefinitionCopy(
+			long taskDefinitionId, DTOConverterContext dtoConverterContext)
+		throws Exception {
+
+		WorkflowDefinition workflowDefinition =
+			_workflowDefinitionManager.getWorkflowDefinition(taskDefinitionId);
+
+		String content = workflowDefinition.getContent();
+
+		Locale locale = dtoConverterContext.getLocale();
+
+		workflowDefinition =
+			_workflowDefinitionManager.deployWorkflowDefinition(
+				null, workflowDefinition.getCompanyId(),
+				workflowDefinition.getUserId(),
+				LanguageUtil.format(
+					locale, "copy-of-x",
+					workflowDefinition.getTitle(locale.getDisplayLanguage())),
+				StringUtil.randomString(), WorkflowDefinitionConstants.SCOPE_AI,
+				content.getBytes());
+
+		return _toTaskDefinition(workflowDefinition, dtoConverterContext);
 	}
 
 	private TaskDefinition _toTaskDefinition(
-			WorkflowDefinition workflowDefinition)
+			WorkflowDefinition workflowDefinition,
+			DTOConverterContext dtoConverterContext)
 		throws PortalException {
 
 		return new TaskDefinition() {
 			{
+				if (dtoConverterContext != null) {
+					setActions(
+						() -> HashMapBuilder.put(
+							"copy",
+							ActionUtil.addAction(
+								ActionKeys.ADD_DEFINITION,
+								TaskDefinitionResourceImpl.class,
+								workflowDefinition.getWorkflowDefinitionId(),
+								"postTaskDefinitionCopy",
+								_kaleoDefinitionModelResourcePermission,
+								(Long)null, dtoConverterContext.getUriInfo())
+						).put(
+							"delete",
+							() -> {
+								if (workflowDefinition.isSystem()) {
+									return null;
+								}
+
+								return ActionUtil.addAction(
+									ActionKeys.DELETE,
+									TaskDefinitionResourceImpl.class,
+									workflowDefinition.
+										getWorkflowDefinitionId(),
+									"deleteTaskDefinition",
+									_kaleoDefinitionModelResourcePermission,
+									(Long)null,
+									dtoConverterContext.getUriInfo());
+							}
+						).put(
+							workflowDefinition.isActive() ? "disable" :
+								"enable",
+							() -> {
+								if (workflowDefinition.isSystem()) {
+									return null;
+								}
+
+								return ActionUtil.addAction(
+									workflowDefinition.isActive() ?
+										ActionKeys.DEACTIVATE :
+											ActionKeys.ACTIVATE,
+									TaskDefinitionResourceImpl.class,
+									workflowDefinition.
+										getWorkflowDefinitionId(),
+									"patchTaskDefinitionUpdateActive",
+									_kaleoDefinitionModelResourcePermission,
+									(Long)null,
+									dtoConverterContext.getUriInfo());
+							}
+						).build());
+				}
+
 				setActive(workflowDefinition::isActive);
 				setDescription(workflowDefinition::getDescription);
+				setExternalReferenceCode(
+					workflowDefinition::getExternalReferenceCode);
+				setId(workflowDefinition::getWorkflowDefinitionId);
 				setName(workflowDefinition::getName);
+				setTitle(
+					() -> {
+						if (dtoConverterContext == null) {
+							return workflowDefinition.getTitle();
+						}
+
+						Locale locale = dtoConverterContext.getLocale();
+
+						return workflowDefinition.getTitle(
+							locale.getDisplayLanguage());
+					});
 				setVersion(workflowDefinition::getVersion);
 			}
 		};
 	}
+
+	@Reference(
+		target = "(model.class.name=com.liferay.portal.workflow.kaleo.model.KaleoDefinition)"
+	)
+	private ModelResourcePermission<KaleoDefinition>
+		_kaleoDefinitionModelResourcePermission;
 
 	@Reference
 	private WorkflowDefinitionManager _workflowDefinitionManager;

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/TaskDefinitionManagerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/TaskDefinitionManagerImpl.java
@@ -32,6 +32,7 @@ import com.liferay.portal.workflow.manager.WorkflowDefinitionManager;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -143,6 +144,23 @@ public class TaskDefinitionManagerImpl implements TaskDefinitionManager {
 		return _toTaskDefinition(dtoConverterContext, workflowDefinition);
 	}
 
+	private Map<String, String> _addAction(
+		DTOConverterContext dtoConverterContext, String methodName,
+		WorkflowDefinition workflowDefinition) {
+
+		if (!Objects.equals(methodName, "postTaskDefinitionCopy") &&
+			workflowDefinition.isSystem()) {
+
+			return null;
+		}
+
+		return ActionUtil.addAction(
+			ActionKeys.ADD_DEFINITION, TaskDefinitionResourceImpl.class,
+			workflowDefinition.getWorkflowDefinitionId(), methodName,
+			_kaleoDefinitionModelResourcePermission, (Long)null,
+			dtoConverterContext.getUriInfo());
+	}
+
 	private TaskDefinition _toTaskDefinition(
 			DTOConverterContext dtoConverterContext,
 			WorkflowDefinition workflowDefinition)
@@ -153,51 +171,39 @@ public class TaskDefinitionManagerImpl implements TaskDefinitionManager {
 				if (dtoConverterContext != null) {
 					setActions(
 						() -> HashMapBuilder.put(
+							"activate",
+							() -> {
+								if (workflowDefinition.isActive()) {
+									return null;
+								}
+
+								return _addAction(
+									dtoConverterContext,
+									"patchTaskDefinitionUpdateActive",
+									workflowDefinition);
+							}
+						).put(
 							"copy",
-							ActionUtil.addAction(
-								ActionKeys.ADD_DEFINITION,
-								TaskDefinitionResourceImpl.class,
-								workflowDefinition.getWorkflowDefinitionId(),
-								"postTaskDefinitionCopy",
-								_kaleoDefinitionModelResourcePermission,
-								(Long)null, dtoConverterContext.getUriInfo())
+							_addAction(
+								dtoConverterContext, "postTaskDefinitionCopy",
+								workflowDefinition)
+						).put(
+							"deactivate",
+							() -> {
+								if (!workflowDefinition.isActive()) {
+									return null;
+								}
+
+								return _addAction(
+									dtoConverterContext,
+									"patchTaskDefinitionUpdateActive",
+									workflowDefinition);
+							}
 						).put(
 							"delete",
-							() -> {
-								if (workflowDefinition.isSystem()) {
-									return null;
-								}
-
-								return ActionUtil.addAction(
-									ActionKeys.DELETE,
-									TaskDefinitionResourceImpl.class,
-									workflowDefinition.
-										getWorkflowDefinitionId(),
-									"deleteTaskDefinition",
-									_kaleoDefinitionModelResourcePermission,
-									(Long)null,
-									dtoConverterContext.getUriInfo());
-							}
-						).put(
-							workflowDefinition.isActive() ? "disable" :
-								"enable",
-							() -> {
-								if (workflowDefinition.isSystem()) {
-									return null;
-								}
-
-								return ActionUtil.addAction(
-									workflowDefinition.isActive() ?
-										ActionKeys.DEACTIVATE :
-											ActionKeys.ACTIVATE,
-									TaskDefinitionResourceImpl.class,
-									workflowDefinition.
-										getWorkflowDefinitionId(),
-									"patchTaskDefinitionUpdateActive",
-									_kaleoDefinitionModelResourcePermission,
-									(Long)null,
-									dtoConverterContext.getUriInfo());
-							}
+							() -> _addAction(
+								dtoConverterContext, "deleteTaskDefinition",
+								workflowDefinition)
 						).build());
 				}
 

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/TaskDefinitionManagerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/TaskDefinitionManagerImpl.java
@@ -45,7 +45,7 @@ public class TaskDefinitionManagerImpl implements TaskDefinitionManager {
 
 	@Override
 	public void deleteTaskDefinition(
-			long taskDefinitionId, DTOConverterContext dtoConverterContext)
+			DTOConverterContext dtoConverterContext, long taskDefinitionId)
 		throws Exception {
 
 		WorkflowDefinition workflowDefinition =
@@ -64,7 +64,7 @@ public class TaskDefinitionManagerImpl implements TaskDefinitionManager {
 	@Override
 	public Page<TaskDefinition> getTaskDefinitions(
 			long companyId, DTOConverterContext dtoConverterContext,
-			String search, Filter filter, Pagination pagination, Sort[] sorts)
+			Filter filter, Pagination pagination, String search, Sort[] sorts)
 		throws Exception {
 
 		Map<String, Map<String, String>> actions = null;
@@ -95,16 +95,16 @@ public class TaskDefinitionManagerImpl implements TaskDefinitionManager {
 				Field.NAME, Field.VERSION),
 			searchContext -> searchContext.setCompanyId(companyId), sorts,
 			document -> _toTaskDefinition(
+				dtoConverterContext,
 				_workflowDefinitionManager.getWorkflowDefinition(
 					companyId, document.get(Field.NAME),
-					GetterUtil.getInteger(document.get(Field.VERSION))),
-				dtoConverterContext));
+					GetterUtil.getInteger(document.get(Field.VERSION)))));
 	}
 
 	@Override
 	public TaskDefinition patchTaskDefinitionUpdateActive(
-			long taskDefinitionId, boolean active,
-			DTOConverterContext dtoConverterContext)
+			boolean active, DTOConverterContext dtoConverterContext,
+			long taskDefinitionId)
 		throws Exception {
 
 		WorkflowDefinition workflowDefinition =
@@ -115,12 +115,12 @@ public class TaskDefinitionManagerImpl implements TaskDefinitionManager {
 			workflowDefinition.getName(), workflowDefinition.getVersion(),
 			active);
 
-		return _toTaskDefinition(workflowDefinition, dtoConverterContext);
+		return _toTaskDefinition(dtoConverterContext, workflowDefinition);
 	}
 
 	@Override
 	public TaskDefinition postTaskDefinitionCopy(
-			long taskDefinitionId, DTOConverterContext dtoConverterContext)
+			DTOConverterContext dtoConverterContext, long taskDefinitionId)
 		throws Exception {
 
 		WorkflowDefinition workflowDefinition =
@@ -140,12 +140,12 @@ public class TaskDefinitionManagerImpl implements TaskDefinitionManager {
 				StringUtil.randomString(), WorkflowDefinitionConstants.SCOPE_AI,
 				content.getBytes());
 
-		return _toTaskDefinition(workflowDefinition, dtoConverterContext);
+		return _toTaskDefinition(dtoConverterContext, workflowDefinition);
 	}
 
 	private TaskDefinition _toTaskDefinition(
-			WorkflowDefinition workflowDefinition,
-			DTOConverterContext dtoConverterContext)
+			DTOConverterContext dtoConverterContext,
+			WorkflowDefinition workflowDefinition)
 		throws PortalException {
 
 		return new TaskDefinition() {

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/BaseTaskDefinitionResourceImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/BaseTaskDefinitionResourceImpl.java
@@ -69,6 +69,82 @@ public abstract class BaseTaskDefinitionResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -X 'DELETE' 'http://localhost:8080/o/ai-hub/v1.0/task-definitions/{taskDefinitionId}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "taskDefinitionId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "TaskDefinition")
+		}
+	)
+	@jakarta.ws.rs.DELETE
+	@jakarta.ws.rs.Path("/task-definitions/{taskDefinitionId}")
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public void deleteTaskDefinition(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("taskDefinitionId")
+			Long taskDefinitionId)
+		throws Exception {
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'DELETE' 'http://localhost:8080/o/ai-hub/v1.0/task-definitions/batch'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "callbackURL"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "TaskDefinition")
+		}
+	)
+	@jakarta.ws.rs.Consumes("application/json")
+	@jakarta.ws.rs.DELETE
+	@jakarta.ws.rs.Path("/task-definitions/batch")
+	@jakarta.ws.rs.Produces("application/json")
+	@Override
+	public Response deleteTaskDefinitionBatch(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("callbackURL")
+			String callbackURL,
+			Object object)
+		throws Exception {
+
+		vulcanBatchEngineImportTaskResource.setContextAcceptLanguage(
+			contextAcceptLanguage);
+		vulcanBatchEngineImportTaskResource.setContextCompany(contextCompany);
+		vulcanBatchEngineImportTaskResource.setContextHttpServletRequest(
+			contextHttpServletRequest);
+		vulcanBatchEngineImportTaskResource.setContextUriInfo(contextUriInfo);
+		vulcanBatchEngineImportTaskResource.setContextUser(contextUser);
+
+		Response.ResponseBuilder responseBuilder = Response.accepted();
+
+		return responseBuilder.entity(
+			vulcanBatchEngineImportTaskResource.deleteImportTask(
+				TaskDefinition.class.getName(), callbackURL, object)
+		).build();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -X 'GET' 'http://localhost:8080/o/ai-hub/v1.0/task-definitions'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
@@ -116,6 +192,78 @@ public abstract class BaseTaskDefinitionResourceImpl
 		throws Exception {
 
 		return Page.of(Collections.emptyList());
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'PATCH' 'http://localhost:8080/o/ai-hub/v1.0/task-definitions/{taskDefinitionId}/update-active'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "taskDefinitionId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "active"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "TaskDefinition")
+		}
+	)
+	@jakarta.ws.rs.PATCH
+	@jakarta.ws.rs.Path("/task-definitions/{taskDefinitionId}/update-active")
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public TaskDefinition patchTaskDefinitionUpdateActive(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("taskDefinitionId")
+			Long taskDefinitionId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.QueryParam("active")
+			Boolean active)
+		throws Exception {
+
+		return new TaskDefinition();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/ai-hub/v1.0/task-definitions/{taskDefinitionId}/copy'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "taskDefinitionId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "TaskDefinition")
+		}
+	)
+	@jakarta.ws.rs.Path("/task-definitions/{taskDefinitionId}/copy")
+	@jakarta.ws.rs.POST
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public TaskDefinition postTaskDefinitionCopy(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("taskDefinitionId")
+			Long taskDefinitionId)
+		throws Exception {
+
+		return new TaskDefinition();
 	}
 
 	/**
@@ -217,8 +365,26 @@ public abstract class BaseTaskDefinitionResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
+		UnsafeFunction<TaskDefinition, TaskDefinition, Exception>
+			taskDefinitionUnsafeFunction = taskDefinition -> {
+				deleteTaskDefinition(taskDefinition.getId());
+
+				return taskDefinition;
+			};
+
+		if (contextBatchUnsafeBiConsumer != null) {
+			contextBatchUnsafeBiConsumer.accept(
+				taskDefinitions, taskDefinitionUnsafeFunction);
+		}
+		else if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				taskDefinitions, taskDefinitionUnsafeFunction::apply);
+		}
+		else {
+			for (TaskDefinition taskDefinition : taskDefinitions) {
+				taskDefinitionUnsafeFunction.apply(taskDefinition);
+			}
+		}
 	}
 
 	public Set<String> getAvailableCreateStrategies() {

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.ai.hub.rest.client', and version '1.0.4'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.ai.hub.rest.client', and version '1.0.5'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/TaskDefinitionResourceImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/TaskDefinitionResourceImpl.java
@@ -11,15 +11,11 @@ import com.liferay.ai.hub.rest.resource.v1_0.TaskDefinitionResource;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
-import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
-import com.liferay.portal.workflow.kaleo.model.KaleoDefinition;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
@@ -35,6 +31,13 @@ import org.osgi.service.component.annotations.ServiceScope;
 	scope = ServiceScope.PROTOTYPE, service = TaskDefinitionResource.class
 )
 public class TaskDefinitionResourceImpl extends BaseTaskDefinitionResourceImpl {
+
+	@Override
+	public void deleteTaskDefinition(Long taskDefinitionId) throws Exception {
+		_taskDefinitionManager.deleteTaskDefinition(
+			taskDefinitionId,
+			_createDefaultDTOConverterContext(taskDefinitionId));
+	}
 
 	@Override
 	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
@@ -54,18 +57,37 @@ public class TaskDefinitionResourceImpl extends BaseTaskDefinitionResourceImpl {
 
 		return _taskDefinitionManager.getTaskDefinitions(
 			contextCompany.getCompanyId(),
-			new DefaultDTOConverterContext(
-				contextAcceptLanguage.isAcceptAllLanguages(),
-				HashMapBuilder.put(
-					"get",
-					addAction(
-						ActionKeys.VIEW, null, "getTaskDefinitionsPage",
-						_kaleoDefinitionModelResourcePermission)
-				).build(),
-				_dtoConverterRegistry, contextHttpServletRequest, null,
-				contextAcceptLanguage.getPreferredLocale(), contextUriInfo,
-				contextUser),
-			search, filter, pagination, sorts);
+			_createDefaultDTOConverterContext(null), search, filter, pagination,
+			sorts);
+	}
+
+	@Override
+	public TaskDefinition patchTaskDefinitionUpdateActive(
+			Long taskDefinitionId, Boolean active)
+		throws Exception {
+
+		return _taskDefinitionManager.patchTaskDefinitionUpdateActive(
+			taskDefinitionId, active,
+			_createDefaultDTOConverterContext(taskDefinitionId));
+	}
+
+	@Override
+	public TaskDefinition postTaskDefinitionCopy(Long taskDefinitionId)
+		throws Exception {
+
+		return _taskDefinitionManager.postTaskDefinitionCopy(
+			taskDefinitionId,
+			_createDefaultDTOConverterContext(taskDefinitionId));
+	}
+
+	private DefaultDTOConverterContext _createDefaultDTOConverterContext(
+		Long taskDefinitionId) {
+
+		return new DefaultDTOConverterContext(
+			contextAcceptLanguage.isAcceptAllLanguages(), null,
+			_dtoConverterRegistry, contextHttpServletRequest, taskDefinitionId,
+			contextAcceptLanguage.getPreferredLocale(), contextUriInfo,
+			contextUser);
 	}
 
 	@Reference

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/TaskDefinitionResourceImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/TaskDefinitionResourceImpl.java
@@ -12,6 +12,7 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.pagination.Page;
@@ -41,8 +42,7 @@ public class TaskDefinitionResourceImpl extends BaseTaskDefinitionResourceImpl {
 		}
 
 		_taskDefinitionManager.deleteTaskDefinition(
-			_createDefaultDTOConverterContext(taskDefinitionId),
-			taskDefinitionId);
+			_createDTOConverterContext(taskDefinitionId), taskDefinitionId);
 	}
 
 	@Override
@@ -62,9 +62,8 @@ public class TaskDefinitionResourceImpl extends BaseTaskDefinitionResourceImpl {
 		}
 
 		return _taskDefinitionManager.getTaskDefinitions(
-			contextCompany.getCompanyId(),
-			_createDefaultDTOConverterContext(null), filter, pagination, search,
-			sorts);
+			contextCompany.getCompanyId(), _createDTOConverterContext(null),
+			filter, pagination, search, sorts);
 	}
 
 	@Override
@@ -79,7 +78,7 @@ public class TaskDefinitionResourceImpl extends BaseTaskDefinitionResourceImpl {
 		}
 
 		return _taskDefinitionManager.patchTaskDefinitionUpdateActive(
-			active, _createDefaultDTOConverterContext(taskDefinitionId),
+			active, _createDTOConverterContext(taskDefinitionId),
 			taskDefinitionId);
 	}
 
@@ -94,11 +93,10 @@ public class TaskDefinitionResourceImpl extends BaseTaskDefinitionResourceImpl {
 		}
 
 		return _taskDefinitionManager.postTaskDefinitionCopy(
-			_createDefaultDTOConverterContext(taskDefinitionId),
-			taskDefinitionId);
+			_createDTOConverterContext(taskDefinitionId), taskDefinitionId);
 	}
 
-	private DefaultDTOConverterContext _createDefaultDTOConverterContext(
+	private DTOConverterContext _createDTOConverterContext(
 		Long taskDefinitionId) {
 
 		return new DefaultDTOConverterContext(

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/TaskDefinitionResourceImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/TaskDefinitionResourceImpl.java
@@ -34,9 +34,15 @@ public class TaskDefinitionResourceImpl extends BaseTaskDefinitionResourceImpl {
 
 	@Override
 	public void deleteTaskDefinition(Long taskDefinitionId) throws Exception {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-62272")) {
+
+			throw new UnsupportedOperationException();
+		}
+
 		_taskDefinitionManager.deleteTaskDefinition(
-			taskDefinitionId,
-			_createDefaultDTOConverterContext(taskDefinitionId));
+			_createDefaultDTOConverterContext(taskDefinitionId),
+			taskDefinitionId);
 	}
 
 	@Override
@@ -57,7 +63,7 @@ public class TaskDefinitionResourceImpl extends BaseTaskDefinitionResourceImpl {
 
 		return _taskDefinitionManager.getTaskDefinitions(
 			contextCompany.getCompanyId(),
-			_createDefaultDTOConverterContext(null), search, filter, pagination,
+			_createDefaultDTOConverterContext(null), filter, pagination, search,
 			sorts);
 	}
 
@@ -66,18 +72,30 @@ public class TaskDefinitionResourceImpl extends BaseTaskDefinitionResourceImpl {
 			Long taskDefinitionId, Boolean active)
 		throws Exception {
 
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-62272")) {
+
+			throw new UnsupportedOperationException();
+		}
+
 		return _taskDefinitionManager.patchTaskDefinitionUpdateActive(
-			taskDefinitionId, active,
-			_createDefaultDTOConverterContext(taskDefinitionId));
+			active, _createDefaultDTOConverterContext(taskDefinitionId),
+			taskDefinitionId);
 	}
 
 	@Override
 	public TaskDefinition postTaskDefinitionCopy(Long taskDefinitionId)
 		throws Exception {
 
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-62272")) {
+
+			throw new UnsupportedOperationException();
+		}
+
 		return _taskDefinitionManager.postTaskDefinitionCopy(
-			taskDefinitionId,
-			_createDefaultDTOConverterContext(taskDefinitionId));
+			_createDefaultDTOConverterContext(taskDefinitionId),
+			taskDefinitionId);
 	}
 
 	private DefaultDTOConverterContext _createDefaultDTOConverterContext(

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/TaskDefinitionResourceImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/TaskDefinitionResourceImpl.java
@@ -112,12 +112,6 @@ public class TaskDefinitionResourceImpl extends BaseTaskDefinitionResourceImpl {
 	@Reference(target = "(entity.model.name=TaskDefinition)")
 	private EntityModel _entityModel;
 
-	@Reference(
-		target = "(model.class.name=com.liferay.portal.workflow.kaleo.model.KaleoDefinition)"
-	)
-	private ModelResourcePermission<KaleoDefinition>
-		_kaleoDefinitionModelResourcePermission;
-
 	@Reference
 	private TaskDefinitionManager _taskDefinitionManager;
 

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/build.gradle
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/build.gradle
@@ -16,6 +16,8 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationImplementation project(":apps:portal-workflow:portal-workflow-api")
+	testIntegrationImplementation project(":apps:portal-workflow:portal-workflow-kaleo-api")
+	testIntegrationImplementation project(":apps:portal-workflow:portal-workflow-kaleo-definition-api")
 	testIntegrationImplementation project(":apps:site:site-api")
 	testIntegrationImplementation project(":dxp:apps:ai-hub:ai-hub-api")
 	testIntegrationImplementation project(":dxp:apps:ai-hub:ai-hub-rest-api")

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/BaseTaskDefinitionResourceTestCase.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/BaseTaskDefinitionResourceTestCase.java
@@ -19,6 +19,9 @@ import com.liferay.ai.hub.rest.client.pagination.Page;
 import com.liferay.ai.hub.rest.client.pagination.Pagination;
 import com.liferay.ai.hub.rest.client.resource.v1_0.TaskDefinitionResource;
 import com.liferay.ai.hub.rest.client.serdes.v1_0.TaskDefinitionSerDes;
+import com.liferay.headless.batch.engine.client.dto.v1_0.ImportTask;
+import com.liferay.headless.batch.engine.client.http.HttpInvoker.HttpResponse;
+import com.liferay.headless.batch.engine.client.resource.v1_0.ImportTaskResource;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -112,6 +115,16 @@ public abstract class BaseTaskDefinitionResourceTestCase {
 		).locale(
 			LocaleUtil.getDefault()
 		).build();
+
+		importTaskResource = ImportTaskResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(), 8080, "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
 	}
 
 	@After
@@ -171,7 +184,9 @@ public abstract class BaseTaskDefinitionResourceTestCase {
 		TaskDefinition taskDefinition = randomTaskDefinition();
 
 		taskDefinition.setDescription(regex);
+		taskDefinition.setExternalReferenceCode(regex);
 		taskDefinition.setName(regex);
+		taskDefinition.setTitle(regex);
 
 		String json = TaskDefinitionSerDes.toJSON(taskDefinition);
 
@@ -180,7 +195,64 @@ public abstract class BaseTaskDefinitionResourceTestCase {
 		taskDefinition = TaskDefinitionSerDes.toDTO(json);
 
 		Assert.assertEquals(regex, taskDefinition.getDescription());
+		Assert.assertEquals(regex, taskDefinition.getExternalReferenceCode());
 		Assert.assertEquals(regex, taskDefinition.getName());
+		Assert.assertEquals(regex, taskDefinition.getTitle());
+	}
+
+	@Test
+	public void testDeleteTaskDefinition() throws Exception {
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		TaskDefinition taskDefinition =
+			testDeleteTaskDefinition_addTaskDefinition();
+
+		assertHttpResponseStatusCode(
+			204,
+			taskDefinitionResource.deleteTaskDefinitionHttpResponse(
+				taskDefinition.getId()));
+	}
+
+	protected TaskDefinition testDeleteTaskDefinition_addTaskDefinition()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testDeleteTaskDefinitionBatch() throws Exception {
+		TaskDefinition taskDefinition1 =
+			testDeleteTaskDefinitionBatch_addTaskDefinition();
+
+		testDeleteTaskDefinitionBatch_deleteTaskDefinition(
+			202, null, taskDefinition1.getId());
+	}
+
+	protected TaskDefinition testDeleteTaskDefinitionBatch_addTaskDefinition()
+		throws Exception {
+
+		return testDeleteTaskDefinition_addTaskDefinition();
+	}
+
+	protected void testDeleteTaskDefinitionBatch_deleteTaskDefinition(
+			int expectedStatusCode, String externalReferenceCode, Long id)
+		throws Exception {
+
+		HttpInvoker.HttpResponse httpResponse =
+			taskDefinitionResource.deleteTaskDefinitionBatchHttpResponse(
+				null,
+				JSONUtil.putAll(
+					JSONUtil.put(
+						"externalReferenceCode", () -> externalReferenceCode
+					).put(
+						"id", () -> id
+					)));
+
+		Assert.assertEquals(expectedStatusCode, httpResponse.getStatusCode());
+
+		waitForFinish(
+			"COMPLETED",
+			JSONFactoryUtil.createJSONObject(httpResponse.getContent()));
 	}
 
 	@Test
@@ -207,6 +279,10 @@ public abstract class BaseTaskDefinitionResourceTestCase {
 		assertContains(taskDefinition1, (List<TaskDefinition>)page.getItems());
 		assertContains(taskDefinition2, (List<TaskDefinition>)page.getItems());
 		assertValid(page, testGetTaskDefinitionsPage_getExpectedActions());
+
+		taskDefinitionResource.deleteTaskDefinition(taskDefinition1.getId());
+
+		taskDefinitionResource.deleteTaskDefinition(taskDefinition2.getId());
 	}
 
 	protected Map<String, Map<String, String>>
@@ -556,8 +632,77 @@ public abstract class BaseTaskDefinitionResourceTestCase {
 	}
 
 	@Test
+	public void testPatchTaskDefinitionUpdateActive() throws Exception {
+		Assert.assertTrue(false);
+	}
+
+	@Test
+	public void testPostTaskDefinitionCopy() throws Exception {
+		TaskDefinition randomTaskDefinition = randomTaskDefinition();
+
+		TaskDefinition postTaskDefinition =
+			testPostTaskDefinitionCopy_addTaskDefinition(randomTaskDefinition);
+
+		assertEquals(randomTaskDefinition, postTaskDefinition);
+		assertValid(postTaskDefinition);
+	}
+
+	protected TaskDefinition testPostTaskDefinitionCopy_addTaskDefinition(
+			TaskDefinition taskDefinition)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
 	public void testBatchEngineDeleteImportTask() throws Exception {
-		Assert.assertTrue(true);
+		TaskDefinition taskDefinition1 =
+			testBatchEngineDeleteImportTask_addTaskDefinition();
+
+		testBatchEngineDeleteImportTask_deleteTaskDefinition(
+			200, null, taskDefinition1.getId());
+	}
+
+	protected TaskDefinition testBatchEngineDeleteImportTask_addTaskDefinition()
+		throws Exception {
+
+		return testDeleteTaskDefinition_addTaskDefinition();
+	}
+
+	protected void testBatchEngineDeleteImportTask_deleteTaskDefinition(
+			int expectedStatusCode, String externalReferenceCode, Long id,
+			String... parameters)
+		throws Exception {
+
+		ImportTaskResource importTaskResource = ImportTaskResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(), 8080, "http"
+		).parameters(
+			parameters
+		).build();
+
+		HttpResponse httpResponse =
+			importTaskResource.deleteImportTaskHttpResponse(
+				"com.liferay.ai.hub.rest.dto.v1_0.TaskDefinition", null, null,
+				null, null,
+				JSONUtil.putAll(
+					JSONUtil.put(
+						"externalReferenceCode", () -> externalReferenceCode
+					).put(
+						"id", () -> id
+					)));
+
+		Assert.assertEquals(expectedStatusCode, httpResponse.getStatusCode());
+
+		if (expectedStatusCode == 200) {
+			waitForFinish(
+				"COMPLETED",
+				JSONFactoryUtil.createJSONObject(httpResponse.getContent()));
+		}
 	}
 
 	@Rule
@@ -636,8 +781,20 @@ public abstract class BaseTaskDefinitionResourceTestCase {
 	protected void assertValid(TaskDefinition taskDefinition) throws Exception {
 		boolean valid = true;
 
+		if (taskDefinition.getId() == null) {
+			valid = false;
+		}
+
 		for (String additionalAssertFieldName :
 				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("actions", additionalAssertFieldName)) {
+				if (taskDefinition.getActions() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
 
 			if (Objects.equals("active", additionalAssertFieldName)) {
 				if (taskDefinition.getActive() == null) {
@@ -655,8 +812,26 @@ public abstract class BaseTaskDefinitionResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals(
+					"externalReferenceCode", additionalAssertFieldName)) {
+
+				if (taskDefinition.getExternalReferenceCode() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("name", additionalAssertFieldName)) {
 				if (taskDefinition.getName() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("title", additionalAssertFieldName)) {
+				if (taskDefinition.getTitle() == null) {
 					valid = false;
 				}
 
@@ -729,6 +904,10 @@ public abstract class BaseTaskDefinitionResourceTestCase {
 	protected List<GraphQLField> getGraphQLFields() throws Exception {
 		List<GraphQLField> graphQLFields = new ArrayList<>();
 
+		graphQLFields.add(new GraphQLField("externalReferenceCode"));
+
+		graphQLFields.add(new GraphQLField("id"));
+
 		for (java.lang.reflect.Field field :
 				getDeclaredFields(
 					com.liferay.ai.hub.rest.dto.v1_0.TaskDefinition.class)) {
@@ -789,6 +968,17 @@ public abstract class BaseTaskDefinitionResourceTestCase {
 		for (String additionalAssertFieldName :
 				getAdditionalAssertFieldNames()) {
 
+			if (Objects.equals("actions", additionalAssertFieldName)) {
+				if (!equals(
+						(Map)taskDefinition1.getActions(),
+						(Map)taskDefinition2.getActions())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("active", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
 						taskDefinition1.getActive(),
@@ -811,9 +1001,43 @@ public abstract class BaseTaskDefinitionResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals(
+					"externalReferenceCode", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						taskDefinition1.getExternalReferenceCode(),
+						taskDefinition2.getExternalReferenceCode())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("id", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						taskDefinition1.getId(), taskDefinition2.getId())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("name", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
 						taskDefinition1.getName(), taskDefinition2.getName())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("title", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						taskDefinition1.getTitle(),
+						taskDefinition2.getTitle())) {
 
 					return false;
 				}
@@ -940,6 +1164,11 @@ public abstract class BaseTaskDefinitionResourceTestCase {
 		sb.append(operator);
 		sb.append(" ");
 
+		if (entityFieldName.equals("actions")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
 		if (entityFieldName.equals("active")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -991,8 +1220,105 @@ public abstract class BaseTaskDefinitionResourceTestCase {
 			return sb.toString();
 		}
 
+		if (entityFieldName.equals("externalReferenceCode")) {
+			Object object = taskDefinition.getExternalReferenceCode();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("id")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
 		if (entityFieldName.equals("name")) {
 			Object object = taskDefinition.getName();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("title")) {
+			Object object = taskDefinition.getTitle();
 
 			String value = String.valueOf(object);
 
@@ -1091,7 +1417,11 @@ public abstract class BaseTaskDefinitionResourceTestCase {
 				active = RandomTestUtil.randomBoolean();
 				description = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
+				externalReferenceCode = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				id = RandomTestUtil.randomLong();
 				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
+				title = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				version = RandomTestUtil.randomInt();
 			}
 		};
@@ -1107,7 +1437,30 @@ public abstract class BaseTaskDefinitionResourceTestCase {
 		return randomTaskDefinition();
 	}
 
+	protected final JSONObject waitForFinish(
+			String expectedExecuteStatus, JSONObject jsonObject)
+		throws Exception {
+
+		while (true) {
+			ImportTask importTask = importTaskResource.getImportTask(
+				jsonObject.getLong("id"));
+
+			ImportTask.ExecuteStatus executeStatus =
+				importTask.getExecuteStatus();
+
+			if (StringUtil.equals(executeStatus.getValue(), "COMPLETED") ||
+				StringUtil.equals(executeStatus.getValue(), "FAILED")) {
+
+				Assert.assertEquals(
+					expectedExecuteStatus, executeStatus.getValue());
+
+				return jsonObject;
+			}
+		}
+	}
+
 	protected TaskDefinitionResource taskDefinitionResource;
+	protected ImportTaskResource importTaskResource;
 	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
 	protected com.liferay.portal.kernel.model.Company testCompany;
 	protected com.liferay.portal.kernel.model.Group testGroup;

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/TaskDefinitionResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/TaskDefinitionResourceTest.java
@@ -147,7 +147,6 @@ public class TaskDefinitionResourceTest
 		Assert.assertEquals(
 			workflowDefinition1.getDescription(),
 			workflowDefinition2.getDescription());
-
 		Assert.assertEquals(
 			workflowDefinition1.getContentAsXML(),
 			workflowDefinition2.getContentAsXML());
@@ -155,10 +154,8 @@ public class TaskDefinitionResourceTest
 		Assert.assertNotEquals(
 			workflowDefinition1.getWorkflowDefinitionId(),
 			workflowDefinition2.getWorkflowDefinitionId());
-
 		Assert.assertNotEquals(
 			workflowDefinition1.getName(), workflowDefinition2.getName());
-
 		Assert.assertNotEquals(
 			workflowDefinition1.getExternalReferenceCode(),
 			workflowDefinition2.getExternalReferenceCode());
@@ -167,6 +164,19 @@ public class TaskDefinitionResourceTest
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
 		return new String[] {"active", "name", "version"};
+	}
+
+	@Override
+	protected TaskDefinition testDeleteTaskDefinition_addTaskDefinition()
+		throws Exception {
+
+		WorkflowDefinition workflowDefinition = _deployWorkflowDefinition();
+
+		return new TaskDefinition() {
+			{
+				setId(workflowDefinition::getWorkflowDefinitionId);
+			}
+		};
 	}
 
 	@Override

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/TaskDefinitionResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/TaskDefinitionResourceTest.java
@@ -14,17 +14,24 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.AssertUtils;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.workflow.NoSuchWorkflowDefinitionException;
+import com.liferay.portal.kernel.workflow.WorkflowDefinition;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.workflow.constants.WorkflowDefinitionConstants;
+import com.liferay.portal.workflow.kaleo.exception.NoSuchDefinitionException;
+import com.liferay.portal.workflow.manager.WorkflowDefinitionManager;
 import com.liferay.site.initializer.SiteInitializer;
 import com.liferay.site.initializer.SiteInitializerRegistry;
 
 import java.util.List;
 
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -71,6 +78,24 @@ public class TaskDefinitionResourceTest
 	}
 
 	@Test
+	public void testDeleteTaskDefinition() throws Exception {
+		WorkflowDefinition workflowDefinition = _deployWorkflowDefinition();
+
+		long workflowDefinitionId =
+			workflowDefinition.getWorkflowDefinitionId();
+
+		taskDefinitionResource.deleteTaskDefinition(workflowDefinitionId);
+
+		AssertUtils.assertFailure(
+			NoSuchWorkflowDefinitionException.class,
+			NoSuchDefinitionException.class.getName() +
+				": No KaleoDefinition exists with the primary key " +
+					workflowDefinitionId,
+			() -> _workflowDefinitionManager.getWorkflowDefinition(
+				workflowDefinitionId));
+	}
+
+	@Test
 	public void testGetTaskDefinitionsPage() throws Exception {
 		_testGetTaskDefinitionsPage();
 		_testGetTaskDefinitionsPageWithFilter();
@@ -88,6 +113,57 @@ public class TaskDefinitionResourceTest
 	public void testGetTaskDefinitionsPageWithSortInteger() throws Exception {
 	}
 
+	@Test
+	public void testPatchTaskDefinitionUpdateActive() throws Exception {
+		WorkflowDefinition workflowDefinition = _deployWorkflowDefinition();
+
+		TaskDefinition taskDefinition =
+			taskDefinitionResource.patchTaskDefinitionUpdateActive(
+				workflowDefinition.getWorkflowDefinitionId(), false);
+
+		Assert.assertFalse(taskDefinition.getActive());
+
+		taskDefinition = taskDefinitionResource.patchTaskDefinitionUpdateActive(
+			workflowDefinition.getWorkflowDefinitionId(), true);
+
+		Assert.assertTrue(taskDefinition.getActive());
+	}
+
+	@Test
+	public void testPostTaskDefinitionCopy() throws Exception {
+		WorkflowDefinition workflowDefinition1 =
+			_workflowDefinitionManager.getLatestWorkflowDefinition(
+				TestPropsValues.getCompanyId(),
+				WorkflowDefinitionConstants.NAME_CHANGE_TONE);
+
+		TaskDefinition taskDefinition =
+			taskDefinitionResource.postTaskDefinitionCopy(
+				workflowDefinition1.getWorkflowDefinitionId());
+
+		WorkflowDefinition workflowDefinition2 =
+			_workflowDefinitionManager.getWorkflowDefinition(
+				taskDefinition.getId());
+
+		Assert.assertEquals(
+			workflowDefinition1.getDescription(),
+			workflowDefinition2.getDescription());
+
+		Assert.assertEquals(
+			workflowDefinition1.getContentAsXML(),
+			workflowDefinition2.getContentAsXML());
+
+		Assert.assertNotEquals(
+			workflowDefinition1.getWorkflowDefinitionId(),
+			workflowDefinition2.getWorkflowDefinitionId());
+
+		Assert.assertNotEquals(
+			workflowDefinition1.getName(), workflowDefinition2.getName());
+
+		Assert.assertNotEquals(
+			workflowDefinition1.getExternalReferenceCode(),
+			workflowDefinition2.getExternalReferenceCode());
+	}
+
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
 		return new String[] {"active", "name", "version"};
@@ -98,6 +174,19 @@ public class TaskDefinitionResourceTest
 		TaskDefinition taskDefinition) {
 
 		return taskDefinition;
+	}
+
+	private WorkflowDefinition _deployWorkflowDefinition() throws Exception {
+		WorkflowDefinition workflowDefinition =
+			_workflowDefinitionManager.getLatestWorkflowDefinition(
+				TestPropsValues.getCompanyId(), "Single Approver");
+
+		String content = workflowDefinition.getContent();
+
+		return _workflowDefinitionManager.deployWorkflowDefinition(
+			null, workflowDefinition.getCompanyId(),
+			workflowDefinition.getUserId(), workflowDefinition.getTitle(),
+			RandomTestUtil.randomString(), content.getBytes());
 	}
 
 	private void _testGetTaskDefinitionsPage() throws Exception {
@@ -178,5 +267,8 @@ public class TaskDefinitionResourceTest
 				version = 1;
 			}
 		});
+
+	@Inject
+	private WorkflowDefinitionManager _workflowDefinitionManager;
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/TaskDefinitionResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/TaskDefinitionResourceTest.java
@@ -77,6 +77,7 @@ public class TaskDefinitionResourceTest
 		ServiceContextThreadLocal.popServiceContext();
 	}
 
+	@Override
 	@Test
 	public void testDeleteTaskDefinition() throws Exception {
 		WorkflowDefinition workflowDefinition = _deployWorkflowDefinition();
@@ -95,6 +96,7 @@ public class TaskDefinitionResourceTest
 				workflowDefinitionId));
 	}
 
+	@Override
 	@Test
 	public void testGetTaskDefinitionsPage() throws Exception {
 		_testGetTaskDefinitionsPage();
@@ -113,6 +115,7 @@ public class TaskDefinitionResourceTest
 	public void testGetTaskDefinitionsPageWithSortInteger() throws Exception {
 	}
 
+	@Override
 	@Test
 	public void testPatchTaskDefinitionUpdateActive() throws Exception {
 		WorkflowDefinition workflowDefinition = _deployWorkflowDefinition();
@@ -129,6 +132,7 @@ public class TaskDefinitionResourceTest
 		Assert.assertTrue(taskDefinition.getActive());
 	}
 
+	@Override
 	@Test
 	public void testPostTaskDefinitionCopy() throws Exception {
 		WorkflowDefinition workflowDefinition1 =

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/display/context/TaskDefinitionDisplayContext.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/display/context/TaskDefinitionDisplayContext.java
@@ -72,7 +72,24 @@ public class TaskDefinitionDisplayContext {
 				HttpComponentsUtil.addParameter(
 					_getBaseURL(_themeDisplay.getCompany(), namespace),
 					namespace + "name", "{name}"),
-				"view", "view", "view", "get", null, null));
+				"view", "view", LanguageUtil.get(_httpServletRequest, "view"),
+				"get", null, null),
+			new FDSActionDropdownItem(
+				getAPIURL() + "/{id}/copy", "copy", "copy",
+				LanguageUtil.get(_httpServletRequest, "duplicate"), "post",
+				"copy", "async"),
+			new FDSActionDropdownItem(
+				getAPIURL() + "/{id}", "trash", "delete",
+				LanguageUtil.get(_httpServletRequest, "delete"), "delete",
+				"delete", "async"),
+			new FDSActionDropdownItem(
+				getAPIURL() + "/{id}/update-active?active=false", "no-bot",
+				"disable", LanguageUtil.get(_httpServletRequest, "disable"),
+				"patch", "disable", "async"),
+			new FDSActionDropdownItem(
+				getAPIURL() + "/{id}/update-active?active=true", "plug",
+				"enable", LanguageUtil.get(_httpServletRequest, "enable"),
+				"patch", "enable", "async"));
 	}
 
 	private String _getBaseURL(Company company, String namespace)

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/display/context/TaskDefinitionDisplayContext.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/display/context/TaskDefinitionDisplayContext.java
@@ -85,11 +85,11 @@ public class TaskDefinitionDisplayContext {
 			new FDSActionDropdownItem(
 				getAPIURL() + "/{id}/update-active?active=false", "no-bot",
 				"disable", LanguageUtil.get(_httpServletRequest, "disable"),
-				"patch", "disable", "async"),
+				"patch", "deactivate", "async"),
 			new FDSActionDropdownItem(
 				getAPIURL() + "/{id}/update-active?active=true", "plug",
 				"enable", LanguageUtil.get(_httpServletRequest, "enable"),
-				"patch", "enable", "async"));
+				"patch", "activate", "async"));
 	}
 
 	private String _getBaseURL(Company company, String namespace)

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/frontend/data/set/view/list/TaskDefinitionListFDSView.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/java/com/liferay/ai/hub/web/internal/frontend/data/set/view/list/TaskDefinitionListFDSView.java
@@ -27,7 +27,7 @@ public class TaskDefinitionListFDSView extends BaseListFDSView {
 
 	@Override
 	public String getTitle() {
-		return "name";
+		return "title";
 	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/workflow/DefaultWorkflowDefinition.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/workflow/DefaultWorkflowDefinition.java
@@ -126,6 +126,11 @@ public class DefaultWorkflowDefinition
 		return _active;
 	}
 
+	@Override
+	public boolean isSystem() {
+		return _system;
+	}
+
 	public void setActive(boolean active) {
 		_active = active;
 	}
@@ -174,6 +179,10 @@ public class DefaultWorkflowDefinition
 		_scope = scope;
 	}
 
+	public void setSystem(boolean system) {
+		_system = system;
+	}
+
 	public void setTitle(String title) {
 		_title = title;
 	}
@@ -212,6 +221,7 @@ public class DefaultWorkflowDefinition
 	private String _name;
 	private Map<String, Object> _optionalAttributes;
 	private String _scope;
+	private boolean _system;
 	private String _title;
 	private long _userId;
 	private int _version;

--- a/portal-kernel/src/com/liferay/portal/kernel/workflow/WorkflowDefinition.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/workflow/WorkflowDefinition.java
@@ -73,4 +73,6 @@ public interface WorkflowDefinition extends WorkflowModel {
 
 	public boolean isActive();
 
+	public boolean isSystem();
+
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/workflow/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/workflow/packageinfo
@@ -1,1 +1,1 @@
-version 26.0.0
+version 26.1.0


### PR DESCRIPTION
- **LPD-76246 generated: gradlew buildRest**
- **LPD-76246 feat: provide delete, patch and copy methods for task definition api**
- **LPD-76246 feat: add a fallback approach if the group is null**
- **LPD-76246 fix: retrieve the title instead of the name**
- **LPD-76246 test: ensure delete, patch and copy methods are working**
- **LPD-76246 feat: provide copy, delete, disable and enable dropdown actions**
- **LPD-76246 refactor: not needed**
- **LPD-76246 refactor: pass the dto converter context as null since we do not need actions on this part**
- **LPD-76246 fix: set the company thread local when invoking the supervisor in a different thread**
- **LPD-76246 feat: create a method in the workflow definition class to inform if it is system**
- **LPD-76246 generated: gradlew baseline**
- **LPD-76246 style: sort parameters of task definition manager**
- **LPD-76246 refactor: simplify**
- **LPD-76246 test: fix delete batch test**
- **LPD-76246 style: rename**
- **LPD-76246 test: annotate with override the overrided test methods**
- **LPD-76246 refactor: not needed**
