### PR TITLE
LPD-69612 Rebuild buildRest to account for client-js

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/TaxonomyCategory.ts
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client-js/src/models/TaxonomyCategory.ts
@@ -31,6 +31,7 @@
 			"numberOfTaxonomyCategories"?: number;
 			"parentTaxonomyCategory"?: object;
 			"parentTaxonomyVocabulary"?: object;
+			"path"?: string;
 			"permissions"?: Array<Permission>;
 			"siteExternalReferenceCode"?: string;
 			"siteId"?: number;
@@ -120,6 +121,11 @@
 			baseName: "parentTaxonomyVocabulary",
 			name: "parentTaxonomyVocabulary",
 			type: "object",
+		},
+		{
+			baseName: "path",
+			name: "path",
+			type: "string",
 		},
 		{
 			baseName: "permissions",


### PR DESCRIPTION
Reran buildRest to add new property path for [headless-admin-taxonomy-client-js/src/models/TaxonomyCategory.ts](https://github.com/brianchandotcom/liferay-portal/compare/master...dsitu:liferay-portal:LPD-69612?expand=1#diff-da650ee6e1bc01caad6d2ae58921b56c9f17076f527d96e7909a7b335b3aeaba). My original buildRest was built before TaxonomyCategory.ts was upstream.

Ref: https://liferay.slack.com/archives/CLCD3DQLF/p1770072163915269?thread_ts=1770069197.300799&cid=CLCD3DQLF