### PR TITLE
LPD-78132 Improve link to missing page redirection

### DIFF
--- a/modules/apps/layout/layout-type-controller/layout-type-controller-link-to-page/src/main/java/com/liferay/layout/type/controller/link/to/page/internal/layout/type/controller/LinkToPageLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-link-to-page/src/main/java/com/liferay/layout/type/controller/link/to/page/internal/layout/type/controller/LinkToPageLayoutTypeController.java
@@ -10,6 +10,7 @@ import com.liferay.layout.type.controller.BaseLayoutTypeControllerImpl;
 import com.liferay.layout.type.controller.link.to.page.internal.constants.LinkToPageLayoutTypeControllerWebKeys;
 import com.liferay.petra.io.unsync.UnsyncStringWriter;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutTypeController;
@@ -44,7 +45,9 @@ public class LinkToPageLayoutTypeController
 	}
 
 	@Override
-	public UnicodeProperties getTypeSettingsProperties(Layout layout) {
+	public UnicodeProperties getTypeSettingsProperties(Layout layout)
+		throws PortalException {
+
 		UnicodeProperties typeSettingsUnicodeProperties =
 			layout.getTypeSettingsProperties();
 
@@ -70,12 +73,8 @@ public class LinkToPageLayoutTypeController
 		}
 
 		Layout linkToLayout =
-			_layoutLocalService.fetchLayoutByExternalReferenceCode(
+			_layoutLocalService.getLayoutByExternalReferenceCode(
 				linkToLayoutExternalReferenceCode, layout.getGroupId());
-
-		if (linkToLayout == null) {
-			return typeSettingsUnicodeProperties;
-		}
 
 		typeSettingsUnicodeProperties.put(
 			"linkToLayoutId", String.valueOf(linkToLayout.getLayoutId()));

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-test/src/testIntegration/java/com/liferay/layout/type/controller/link/to/page/internal/layout/type/controller/test/LinkToPageLayoutTypeControllerTest.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-test/src/testIntegration/java/com/liferay/layout/type/controller/link/to/page/internal/layout/type/controller/test/LinkToPageLayoutTypeControllerTest.java
@@ -7,12 +7,14 @@ package com.liferay.layout.type.controller.link.to.page.internal.layout.type.con
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutTypeController;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -74,6 +76,15 @@ public class LinkToPageLayoutTypeControllerTest {
 		Assert.assertEquals(
 			String.valueOf(linkToLayout.getLayoutId()),
 			typeSettingsUnicodeProperties.getProperty("linkToLayoutId"));
+
+		typeSettingsUnicodeProperties.clear();
+
+		typeSettingsUnicodeProperties.put(
+			"linkToLayoutExternalReferenceCode", StringUtil.randomString());
+
+		Assert.assertThrows(
+			NoSuchLayoutException.class,
+			() -> _layoutTypeController.getTypeSettingsProperties(layout));
 	}
 
 	private Group _group;

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplGetLayoutActualURLTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplGetLayoutActualURLTest.java
@@ -187,8 +187,8 @@ public class PortalImplGetLayoutActualURLTest
 		return lastLevelLayouts.get(pos);
 	}
 
-	private void _assertGetLayoutActualURL(
-		Layout expectedLayout, Layout layout) {
+	private void _assertGetLayoutActualURL(Layout expectedLayout, Layout layout)
+		throws Exception {
 
 		_multiVMPool.clear();
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -2545,12 +2545,14 @@ public class PortalImpl implements Portal {
 	}
 
 	@Override
-	public String getLayoutActualURL(Layout layout) {
+	public String getLayoutActualURL(Layout layout) throws PortalException {
 		return getLayoutActualURL(layout, getPathMain());
 	}
 
 	@Override
-	public String getLayoutActualURL(Layout layout, String mainPath) {
+	public String getLayoutActualURL(Layout layout, String mainPath)
+		throws PortalException {
+
 		Map<String, String> variables = _getVariables(
 			LayoutLocalServiceUtil.getBrowsableLayout(layout), mainPath);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/model/LayoutTypeController.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/LayoutTypeController.java
@@ -31,7 +31,9 @@ public interface LayoutTypeController extends Serializable {
 
 	public String getType();
 
-	public default UnicodeProperties getTypeSettingsProperties(Layout layout) {
+	public default UnicodeProperties getTypeSettingsProperties(Layout layout)
+		throws PortalException {
+
 		return layout.getTypeSettingsProperties();
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
@@ -618,9 +618,10 @@ public interface Portal {
 
 	public String getJsSafePortletId(String portletId);
 
-	public String getLayoutActualURL(Layout layout);
+	public String getLayoutActualURL(Layout layout) throws PortalException;
 
-	public String getLayoutActualURL(Layout layout, String mainPath);
+	public String getLayoutActualURL(Layout layout, String mainPath)
+		throws PortalException;
 
 	public String getLayoutActualURL(
 			long groupId, boolean privateLayout, String mainPath,

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
@@ -868,11 +868,15 @@ public class PortalUtil {
 		return _portal.getJsSafePortletId(portletId);
 	}
 
-	public static String getLayoutActualURL(Layout layout) {
+	public static String getLayoutActualURL(Layout layout)
+		throws PortalException {
+
 		return _portal.getLayoutActualURL(layout);
 	}
 
-	public static String getLayoutActualURL(Layout layout, String mainPath) {
+	public static String getLayoutActualURL(Layout layout, String mainPath)
+		throws PortalException {
+
 		return _portal.getLayoutActualURL(layout, mainPath);
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-78132

Improve link to missing page redirection in case we import a link to page poiting to a missing page, in that case, we are using the getLayoutByExternalReferenceCode instead if fetchLayoutByExternalReferenceCode since we want to keep the behavior of the current functionallity when if the linked page does not exist we are throwing an exception and showing 404 layout utility page.

@ruben-pulido, finally I added the PortalException instead of Exception since we are throwing PortalException for all method from Portal class that we are getting a layout. Please, let me know if you need more information about this.