### PR TITLE
LPD-62940 Download link doesn't work in data tab of CTEntry entities

### DIFF
--- a/modules/apps/change-tracking/change-tracking-spi/src/main/java/com/liferay/change/tracking/spi/display/BaseCTDisplayRenderer.java
+++ b/modules/apps/change-tracking/change-tracking-spi/src/main/java/com/liferay/change/tracking/spi/display/BaseCTDisplayRenderer.java
@@ -262,6 +262,7 @@ public abstract class BaseCTDisplayRenderer<T extends BaseModel<T>>
 		LinkTag linkTag = new LinkTag();
 
 		linkTag.setDisplayType("primary");
+		linkTag.setDynamicAttribute(StringPool.BLANK, "data-senna-off", "true");
 		linkTag.setHref(displayContext.getDownloadURL(version, size, fileName));
 		linkTag.setIcon("download");
 		linkTag.setLabel("download");

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/change/tracking/spi/display/DLFileVersionCTDisplayRenderer.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/change/tracking/spi/display/DLFileVersionCTDisplayRenderer.java
@@ -267,7 +267,7 @@ public class DLFileVersionCTDisplayRenderer
 
 		return store.getFileAsStream(
 			dlFileVersion.getCompanyId(), dlFileEntry.getDataRepositoryId(),
-			dlFileEntry.getName(), parts[0]);
+			dlFileEntry.getName(), dlFileVersion.getStoreFileName());
 	}
 
 	@Override

--- a/modules/test/playwright/pages/change-tracking-web/ChangeTrackingPage.ts
+++ b/modules/test/playwright/pages/change-tracking-web/ChangeTrackingPage.ts
@@ -437,7 +437,10 @@ export class ChangeTrackingPage {
 	}
 
 	async reviewChange(title: string) {
-		await this.page.getByRole('link', {name: title}).first().click();
+		const changeTitle = this.page.getByRole('link', {name: title}).first();
+
+		await changeTitle.waitFor();
+		await changeTitle.click();
 
 		await this.page.locator('h2').filter({hasText: title}).waitFor();
 	}

--- a/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/main/reviewChanges.spec.ts
@@ -13,6 +13,7 @@ import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
 import {changeTrackingPagesTest} from '../../../fixtures/changeTrackingPagesTest';
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {documentLibraryPagesTest} from '../../../fixtures/documentLibraryPages.fixtures';
 import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
 import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
 import {pagesAdminPagesTest} from '../../../fixtures/pagesAdminPagesTest';
@@ -31,6 +32,7 @@ export const test = mergeTests(
 	apiHelpersTest,
 	changeTrackingPagesTest,
 	dataApiHelpersTest,
+	documentLibraryPagesTest,
 	featureFlagsTest({
 		'LPD-34594': {enabled: true},
 		'LPS-164563': {enabled: true},
@@ -861,4 +863,46 @@ test('LPD-76512 User custom view is enabled for review changes', async ({
 	await expect(viewsSelectorButton).toBeVisible();
 
 	await expect(viewsSelectorButton).toHaveText('Default View');
+});
+
+test('LPD-62940 Assert download button is visible and functional in the data tab', async ({
+	changeTrackingPage,
+	ctCollection,
+	documentLibraryEditFilePage,
+	documentLibraryPage,
+	page,
+}) => {
+	await changeTrackingPage.workOnPublication(ctCollection);
+
+	await documentLibraryPage.goto();
+
+	await page.getByTitle('Provided by Liferay').click();
+
+	await documentLibraryPage.goToFileEntryAction('Edit', 'astronaut.png');
+
+	await page
+		.locator(
+			'#_com_liferay_document_library_web_portlet_DLAdminPortlet_title'
+		)
+		.fill('astronaut2');
+
+	await documentLibraryEditFilePage.publishButton.click();
+
+	await changeTrackingPage.goToReviewChanges(ctCollection.body.name);
+	await changeTrackingPage.reviewChange('astronaut2');
+	await changeTrackingPage.selectTab('Data');
+
+	const downloadPromise = page.waitForEvent('download');
+
+	const downloadButton = page
+		.locator('.btn-primary', {
+			hasText: 'Download',
+		})
+		.first();
+
+	await downloadButton.scrollIntoViewIfNeeded();
+	await downloadButton.click();
+
+	const download = await downloadPromise;
+	expect(download.suggestedFilename()).toEqual('astronaut.png');
 });


### PR DESCRIPTION
Rebase of #169968 

Forwarded from: https://github.com/liferay-site-management/liferay-portal/pull/2919 (Took 2 ci:forward attempts in 3 hours 17 minutes)
[Console](https://test-1-36.liferay.com/job/forward-pullrequest/1386//consoleFull)

@liferay-site-management

Original pull request comment:
https://liferay.atlassian.net/browse/LPD-62940