### PR TITLE
Lpd 78300

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor4/ClassicEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor4/ClassicEditor.js
@@ -59,33 +59,61 @@ const ClassicEditor = forwardRef(
 						};
 					}}
 					onInstanceReady={({editor}) => {
-						editor.setData(contents, {
-							callback: () => {
-								editor.resetUndo();
+						const loadData = () => {
+							editor.setData(contents, {
+								callback: () => {
+									editor.resetUndo();
 
-								onReady({editor});
-							},
-							noSnapshot: true,
-						});
+									onReady({editor});
+								},
+								noSnapshot: true,
+							});
+						};
+
+						const isBBCodePluginEnabled =
+							editor.config.extraPlugins?.indexOf('bbcode') !==
+							-1;
+
+						if (isBBCodePluginEnabled) {
+							const hasProcessor =
+								editor.dataProcessor &&
+								editor.dataProcessor.constructor.name ===
+									'BBCodeDataProcessor';
+
+							if (hasProcessor) {
+								loadData();
+							}
+							else {
+								editor.once(
+									'customDataProcessorLoaded',
+									loadData
+								);
+							}
+						}
+						else {
+							loadData();
+						}
 
 						const iframe = document.querySelector(
 							'iframe.cke_wysiwyg_frame'
 						);
 
-						iframe.onload = function () {
-							const iframeDocument = iframe.contentDocument;
-							const iframeBody =
-								iframeDocument.querySelector(
-									'body.cke_editable'
-								);
+						if (iframe) {
+							iframe.onload = function () {
+								const iframeDocument = iframe.contentDocument;
+								const iframeBody =
+									iframeDocument.querySelector(
+										'body.cke_editable'
+									);
 
-							if (iframeBody) {
-								iframeBody.setAttribute(
-									'aria-required',
-									ariaRequired
-								);
-							}
-						};
+								if (iframeBody) {
+									iframeBody.setAttribute(
+										'aria-required',
+										ariaRequired
+									);
+								}
+							};
+						}
 					}}
 					ref={ref}
 					{...otherProps}

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor4/bbcode.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor4/bbcode.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {isolatedSiteTest} from '../../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../../fixtures/loginTest';
+import {messageBoardsPagesTest} from '../../../../../fixtures/messageBoardsTest';
+
+export const test = mergeTests(
+	isolatedSiteTest,
+	loginTest(),
+	messageBoardsPagesTest
+);
+
+test(
+	'Check bbcode data is formatted',
+	{tag: '@LPD-78300'},
+	async ({messageBoardsEditThreadPage, page, site}) => {
+		await page.route('**/bbcode_parser.js*', async (route) => {
+			await new Promise((resolve) => setTimeout(resolve, 1000));
+
+			await route.continue();
+		});
+
+		await messageBoardsEditThreadPage.goto(site.friendlyUrlPath);
+
+		const subjectText = page.getByLabel('Subject Required');
+
+		await expect(subjectText).toBeVisible();
+
+		await subjectText.fill('test');
+
+		const sourceButton = page.getByLabel('Source');
+
+		await expect(sourceButton).toBeVisible();
+
+		await sourceButton.click();
+
+		await page
+			.getByLabel(
+				'Editor, _com_liferay_message_boards_web_portlet_MBAdminPortlet_bodyEditor',
+				{exact: true}
+			)
+			.fill('- [b]BBcode strong / bold[/b]');
+
+		await page.getByRole('button', {name: 'Publish'}).click();
+
+		await expect(
+			page.getByText('Success:Your request completed successfully.')
+		).toBeVisible();
+
+		const actionButton = page.getByRole('button', {name: 'Actions'});
+
+		await expect(actionButton).toBeVisible();
+
+		await actionButton.click();
+
+		const editButton = page.getByRole('menuitem', {name: 'Edit'});
+
+		await expect(editButton).toBeVisible();
+
+		await editButton.click();
+
+		expect(page.getByText('- BBcode strong / bold')).toBeVisible({
+			timeout: 5000,
+		});
+	}
+);


### PR DESCRIPTION
FWD: https://github.com/liferay-frontend/liferay-portal/pull/5296

https://liferay.atlassian.net/browse/LPP-62756
https://liferay.atlassian.net/browse/LPD-78300

There is a race condition between bbcode and ckeditor when there is a slow connection. The ckeditor is displaying the data before the bbcode can process the data.

The solution I did was wait for customDataProcessorLoaded to be called and then load the data.
If the customDataProcessorLoaded is taking too long, it will display the data it currently has after 5 seconds so that the user can see some information. It will eventually be replaced when the customDataProcessorLoaded is triggered.

Please let me know if there are any questions or comments about this.
Thank you!