### PR TITLE
LPD-78508 UpgradeCatchAllCheckTest prints the wrong test case names

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -4962,6 +4962,14 @@
 	},
 	{
 		"classNames": [
+			"JournalUtil"
+		],
+		"from": "addRecentArticle(ActionRequest paramName, JournalArticle paramName)",
+		"issueKey": "LPD-58341",
+		"to": ""
+	},
+	{
+		"classNames": [
 			"ProxyModeThreadLocal"
 		],
 		"from": "setForceSync(boolean paramName)",
@@ -4992,14 +5000,6 @@
 		"from": "addDiscussionMessage(long param, String param, long param, String param, long param, long param, long param, String param, String param, ServiceContext param)",
 		"issueKey": "LPD-58406",
 		"to": "addDiscussionMessage(null, param#0#, param#1#, param#2#, param#3#, param#4#, param#5#, param#6#, param#7#, param#8#, param#9#)"
-	},
-	{
-		"classNames": [
-			"JournalUtil"
-		],
-		"from": "addRecentArticle(ActionRequest paramName, JournalArticle paramName)",
-		"issueKey": "LPD-58341",
-		"to": ""
 	},
 	{
 		"classNames": [
@@ -5042,18 +5042,6 @@
 		"from": "getUniqueFileName(long paramName, long paramName, String paramName)",
 		"issueKey": "LPD-58469",
 		"to": "getUniqueFileName(param#0#, param#1#, param#2#, false)"
-	},
-	{
-		"ClassNames": [
-			"UserLocalService",
-			"UserLocalServiceUtil"
-		],
-		"from": "addUser(long paramName, long paramName, boolean paramName, String paramName, String paramName, boolean paramName, String paramName, String paramName, Locale paramName, String paramName, String paramName, String paramName, long paramName, long paramName, boolean paramName, int paramName, int paramName, int paramName, String paramName, long[] paramName, long[] paramName, long[] paramName, long[] paramName, boolean paramName, ServiceContext paramName)",
-		"issueKey": "LPD-58511",
-		"newImports": [
-			"com.liferay.portal.kernel.model.UserConstants"
-		],
-		"to": "addUser(param#0#, param#1#, param#2#, param#3#, param#4#, param#5#, param#6#, param#7#, param#8#, param#9#, param#10#, param#11#, param#12#, param#13#, param#14#, param#15#, param#16#, param#17#, param#18#, UserConstants.TYPE_REGULAR, param#19#, param#20#, param#21#, param#22#, param#23#, param#24#)"
 	},
 	{
 		"classNames": [
@@ -5162,6 +5150,18 @@
 		"from": "updateFileEntryAndCheckIn(long paramName, String paramName, String paramName, String paramName, String paramName, String paramName, DLVersionNumberIncrease paramName, InputStream paramName, long paramName, ServiceContext paramName)",
 		"issueKey": "LPD-58470",
 		"to": "updateFileEntryAndCheckIn(param#0#, param#1#, param#2#, param#3#, null, param#4#, param#5#, param#6#, param#7#, param#8#, null, null, null, param#9#)"
+	},
+	{
+		"ClassNames": [
+			"UserLocalService",
+			"UserLocalServiceUtil"
+		],
+		"from": "addUser(long paramName, long paramName, boolean paramName, String paramName, String paramName, boolean paramName, String paramName, String paramName, Locale paramName, String paramName, String paramName, String paramName, long paramName, long paramName, boolean paramName, int paramName, int paramName, int paramName, String paramName, long[] paramName, long[] paramName, long[] paramName, long[] paramName, boolean paramName, ServiceContext paramName)",
+		"issueKey": "LPD-58511",
+		"newImports": [
+			"com.liferay.portal.kernel.model.UserConstants"
+		],
+		"to": "addUser(param#0#, param#1#, param#2#, param#3#, param#4#, param#5#, param#6#, param#7#, param#8#, param#9#, param#10#, param#11#, param#12#, param#13#, param#14#, param#15#, param#16#, param#17#, param#18#, UserConstants.TYPE_REGULAR, param#19#, param#20#, param#21#, param#22#, param#23#, param#24#)"
 	},
 	{
 		"classNames": [

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/UpgradeCatchAllCheckTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/UpgradeCatchAllCheckTest.java
@@ -42,7 +42,7 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class UpgradeCatchAllCheckTest extends BaseSourceProcessorTestCase {
 
-	@Parameterized.Parameters(name = "Testcase-{index}: Testing {0}.{1}")
+	@Parameterized.Parameters(name = "Testcase-{index}: Testing {1}.{2}")
 	public static Iterable<Object[]> data() throws Exception {
 		List<Object[]> objectsArray = new ArrayList<>();
 


### PR DESCRIPTION
This is an update for [LPD-78508](https://liferay.atlassian.net/browse/LPD-78508).
