### PR TITLE
LPD-77067 add a test for nested creator.name filter in FDS

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/CreatorSelectionFDSFilter.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/CreatorSelectionFDSFilter.java
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.data.set.sample.web.internal.filter;
+
+import com.liferay.frontend.data.set.filter.BaseSelectionFDSFilter;
+import com.liferay.frontend.data.set.filter.FDSFilter;
+import com.liferay.frontend.data.set.sample.web.internal.constants.FDSSampleFDSNames;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Liferay
+ */
+@Component(
+	property = "frontend.data.set.name=" + FDSSampleFDSNames.ADVANCED,
+	service = FDSFilter.class
+)
+public class CreatorSelectionFDSFilter extends BaseSelectionFDSFilter {
+
+	@Override
+	public String getAPIURL() {
+		return "o/c/fdssamples";
+	}
+
+	@Override
+	public String getId() {
+		return "creator.name";
+	}
+
+	@Override
+	public String getItemKey() {
+		return "creator.id";
+	}
+
+	@Override
+	public String getItemLabel() {
+		return "creator.name";
+	}
+
+	@Override
+	public String getLabel() {
+		return "creator";
+	}
+
+	@Override
+	public boolean isAutocompleteEnabled() {
+		return true;
+	}
+
+	@Override
+	public boolean isMultiple() {
+		return true;
+	}
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/CreatorSelectionFDSFilter.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/CreatorSelectionFDSFilter.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -12,7 +12,7 @@ import com.liferay.frontend.data.set.sample.web.internal.constants.FDSSampleFDSN
 import org.osgi.service.component.annotations.Component;
 
 /**
- * @author Liferay
+ * @author Kresimir Coko
  */
 @Component(
 	property = "frontend.data.set.name=" + FDSSampleFDSNames.ADVANCED,

--- a/modules/test/playwright/tests/frontend-data-set-web/main/pages/FDSSamplePage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/pages/FDSSamplePage.ts
@@ -30,10 +30,14 @@ export class FDSSamplePage {
 		itemActionButtons: Locator;
 		items: Locator;
 	};
+	readonly creatorFilterSearchInput: Locator;
 	readonly emptyStateContainer: Locator;
 	readonly fdsWrapper: Locator;
 	readonly fileDropModal: Locator;
 	readonly filterDropdownMenu: Locator;
+	readonly filterMenu: Locator;
+	readonly filterMenuSearchInput: Locator;
+	readonly filterShowResultsOrAddButton: Locator;
 	readonly infoPanel: Locator;
 	readonly itemActionButton: Locator;
 	readonly itemActionsButtons: Locator;
@@ -111,12 +115,23 @@ export class FDSSamplePage {
 			itemActionButtons: cardItems.getByLabel('More actions'),
 			items: cardItems,
 		};
+		this.creatorFilterSearchInput = page
+			.locator('.data-set-filter')
+			.getByRole('textbox', {name: 'Search'})
+			.first();
 		this.emptyStateContainer = page.locator('.fds .c-empty-state');
 		this.fdsWrapper = page.locator('div.data-set-wrapper').first();
 		this.fileDropModal = page.getByRole('dialog', {
 			name: 'Custom dummy file uploader',
 		});
 		this.filterDropdownMenu = page.locator('.data-set-filter');
+		this.filterMenu = page.locator('.dropdown-menu');
+		this.filterMenuSearchInput = this.filterMenu
+			.getByLabel('Search')
+			.first();
+		this.filterShowResultsOrAddButton = this.filterMenu
+			.getByRole('button', {name: 'Show Results'})
+			.or(this.filterMenu.getByRole('button', {name: 'Add Filter'}));
 		this.infoPanel = page.locator('.fds-info-panel');
 
 		this.itemActionsButtons = page.locator(

--- a/modules/test/playwright/tests/frontend-data-set-web/main/pages/FDSSamplePage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/pages/FDSSamplePage.ts
@@ -117,8 +117,7 @@ export class FDSSamplePage {
 		};
 		this.creatorFilterSearchInput = page
 			.locator('.data-set-filter')
-			.getByRole('textbox', {name: 'Search'})
-			.first();
+			.getByRole('textbox', {name: 'Search'});
 		this.emptyStateContainer = page.locator('.fds .c-empty-state');
 		this.fdsWrapper = page.locator('div.data-set-wrapper').first();
 		this.fileDropModal = page.getByRole('dialog', {

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/filters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/filters.spec.ts
@@ -9,9 +9,9 @@ import {apiHelpersTest} from '../../../../../fixtures/apiHelpersTest';
 import {featureFlagsTest} from '../../../../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../../../fixtures/loginTest';
+import {clickAndExpectToBeVisible} from '../../../../../utils/clickAndExpectToBeVisible';
 import {waitForFDS} from '../../../../../utils/waitFor';
 import {fdsSamplePageTest} from '../../fixtures/fdsSamplePageTest';
-import {clickAndExpectToBeVisible} from '../../../../../utils/clickAndExpectToBeVisible';
 
 const test = mergeTests(
 	apiHelpersTest,

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/filters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/filters.spec.ts
@@ -227,6 +227,35 @@ test(
 				await expect(
 					page.getByRole('menuitem', {name: 'Status'})
 				).toBeVisible();
+				await expect(
+					page.getByRole('menuitem', {name: 'Creator'})
+				).toBeVisible();
+			});
+
+			await test.step('Enter a search term "creator"', async () => {
+				await page
+					.locator('.dropdown-menu')
+					.getByLabel('Search')
+					.first()
+					.fill('creator');
+			});
+
+			await test.step('Check only the "creator" filter appears', async () => {
+				await expect(
+					page.getByRole('menuitem', {name: 'Color'})
+				).not.toBeVisible();
+				await expect(
+					page.getByRole('menuitem', {name: 'Date Range'})
+				).not.toBeVisible();
+				await expect(
+					page.getByRole('menuitem', {name: 'Size'})
+				).not.toBeVisible();
+				await expect(
+					page.getByRole('menuitem', {name: 'Status'})
+				).not.toBeVisible();
+				await expect(
+					page.getByRole('menuitem', {name: 'Creator'})
+				).toBeVisible();
 			});
 		});
 
@@ -475,6 +504,173 @@ test(
 				await expect(
 					fdsSamplePage.activeFiltersToolbar.container
 				).not.toBeVisible();
+			});
+		});
+
+		await test.step('Check creator filter functionality', async () => {
+			await test.step('Refresh the page', async () => {
+				await fdsSamplePage.selectTab('Advanced');
+
+				await waitForFDS({page});
+			});
+
+			await test.step('Select creator filter from dropdown', async () => {
+				await fdsSamplePage.managementToolbar.filterButton.click();
+
+				await page
+					.locator('.dropdown-menu')
+					.getByRole('menuitem', {name: 'Creator'})
+					.click();
+			});
+
+			await test.step('Verify autocomplete input appears', async () => {
+				await expect(
+					page.locator('.data-set-filter').getByRole('textbox', { name: 'Search' }).first()
+				).toBeVisible();
+			});
+
+			await test.step('Search for and select a creator', async () => {
+				const searchInput = page
+					.locator('.data-set-filter')
+					.getByRole('textbox', { name: 'Search' })
+					.first();
+
+				await searchInput.fill('test');
+
+				await page.waitForTimeout(500);
+
+				const firstCreatorCheckbox = page
+					.locator('.dropdown-menu')
+					.getByRole('checkbox')
+					.first();
+
+				if (await firstCreatorCheckbox.isVisible({timeout: 2000}).catch(() => false)) {
+					const creatorLabel = await firstCreatorCheckbox
+						.locator('..')
+						.textContent()
+						.catch(() => '');
+
+					await firstCreatorCheckbox.check();
+
+					await page
+						.locator('.dropdown-menu')
+						.getByRole('button', {name: 'Show Results'})
+						.or(
+							page
+								.locator('.dropdown-menu')
+								.getByRole('button', {name: 'Add Filter'})
+						)
+						.click();
+
+					await page
+						.getByText('This is a description for sample')
+						.first()
+						.waitFor();
+
+
+					if (creatorLabel) {
+						await expect(
+							page.getByRole('button', {
+								name: new RegExp(`Creator:.*${creatorLabel.trim()}`),
+							})
+						).toBeVisible();
+					}
+				}
+			});
+
+			await test.step('Verify creator names appear in table cells', async () => {
+				const authorCells = page
+					.locator('table tbody tr td')
+					.filter({hasText: /./})
+					.first();
+
+				await expect(authorCells).toBeVisible();
+			});
+		});
+
+		await test.step('Check creator filter summary box operations', async () => {
+			await test.step('Refresh the page', async () => {
+				await fdsSamplePage.selectTab('Advanced');
+
+				await waitForFDS({page});
+			});
+
+			await test.step('Apply creator filter', async () => {
+				await fdsSamplePage.managementToolbar.filterButton.click();
+
+				await page
+					.locator('.dropdown-menu')
+					.getByRole('menuitem', {name: 'Creator'})
+					.click();
+
+				const searchInput = page
+					.locator('.dropdown-menu')
+					.getByRole('textbox', { name: 'Search' })
+					.first();
+
+				await searchInput.fill('test');
+
+				await page.waitForTimeout(500);
+
+				const creatorCheckboxes = page
+					.locator('.dropdown-menu')
+					.getByRole('checkbox');
+
+				const checkboxCount = await creatorCheckboxes.count();
+
+				if (checkboxCount > 0) {
+					await creatorCheckboxes.first().check();
+
+					if (checkboxCount > 1) {
+						await creatorCheckboxes.nth(1).check();
+					}
+
+					await page
+						.locator('.dropdown-menu')
+						.getByRole('button', {name: 'Show Results'})
+						.or(
+							page
+								.locator('.dropdown-menu')
+								.getByRole('button', {name: 'Add Filter'})
+						)
+						.click();
+
+					await page
+						.getByText('This is a description for sample')
+						.first()
+						.waitFor();
+				}
+			});
+
+			await test.step('Open creator filter summary box and verify it shows creator names', async () => {
+				const creatorFilterButton = page
+					.getByRole('button')
+					.filter({hasText: /^Creator:/});
+
+				if (await creatorFilterButton.isVisible({timeout: 2000}).catch(() => false)) {
+					await creatorFilterButton.click();
+
+					await expect(
+						page.getByRole('checkbox').first()
+					).toBeVisible();
+				}
+			});
+
+			await test.step('Test removing creator filter using remove button', async () => {
+				const removeButton = page.getByRole('button', {name: 'Remove Filter'});
+
+				if (await removeButton.isVisible({timeout: 2000}).catch(() => false)) {
+					await removeButton.click();
+
+					await page
+						.getByText('This is a description for sample')
+						.first()
+						.waitFor();
+
+					await expect(
+						page.getByRole('button').filter({hasText: /^Creator:/})
+					).not.toBeVisible();
+				}
 			});
 		});
 	}

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/filters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/filters.spec.ts
@@ -11,6 +11,7 @@ import {isolatedSiteTest} from '../../../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../../../fixtures/loginTest';
 import {waitForFDS} from '../../../../../utils/waitFor';
 import {fdsSamplePageTest} from '../../fixtures/fdsSamplePageTest';
+import {clickAndExpectToBeVisible} from '../../../../../utils/clickAndExpectToBeVisible';
 
 const test = mergeTests(
 	apiHelpersTest,
@@ -46,6 +47,10 @@ test(
 			.or(page.getByRole('cell', {name: '🍏'}));
 		const redCells = page.getByRole('cell', {name: 'Red'});
 		const yellowCells = page.getByRole('cell', {name: 'Yellow'});
+
+		const creatorFilterSummaryButton = page
+			.getByRole('button')
+			.filter({hasText: /^Creator:/});
 
 		const filtersFragment = {
 			activeToggle: page.getByTestId('activeFiltersFDSSampleToggle'),
@@ -113,9 +118,7 @@ test(
 
 		await test.step('Check searching the available filters in filter dropdown', async () => {
 			await test.step('Open filter dropdown', async () => {
-				await fdsSamplePage.managementToolbar.container
-					.getByRole('button', {name: 'Filter'})
-					.click();
+				await fdsSamplePage.managementToolbar.filterButton.click();
 			});
 
 			await test.step('Check grouped FDS filters visibility', async () => {
@@ -178,11 +181,7 @@ test(
 			});
 
 			await test.step('Enter a search term "status"', async () => {
-				await page
-					.locator('.dropdown-menu')
-					.getByLabel('Search')
-					.first()
-					.fill('status');
+				await fdsSamplePage.filterMenuSearchInput.fill('status');
 			});
 
 			await test.step('Check only the "status" filter appears', async () => {
@@ -233,11 +232,7 @@ test(
 			});
 
 			await test.step('Enter a search term "creator"', async () => {
-				await page
-					.locator('.dropdown-menu')
-					.getByLabel('Search')
-					.first()
-					.fill('creator');
+				await fdsSamplePage.filterMenuSearchInput.fill('creator');
 			});
 
 			await test.step('Check only the "creator" filter appears', async () => {
@@ -271,25 +266,15 @@ test(
 					.getByRole('button', {name: 'Filter'})
 					.click();
 
-				await page
-					.locator('.dropdown-menu')
+				await fdsSamplePage.filterMenu
 					.getByRole('menuitem', {name: 'Color'})
 					.click();
 
-				await page
-					.locator('.dropdown-menu')
+				await fdsSamplePage.filterMenu
 					.getByRole('checkbox', {name: 'Red'})
 					.check();
 
-				await page
-					.locator('.dropdown-menu')
-					.getByRole('button', {name: 'Show Results'})
-					.or(
-						page
-							.locator('.dropdown-menu')
-							.getByRole('button', {name: 'Add Filter'})
-					)
-					.click();
+				await fdsSamplePage.filterShowResultsOrAddButton.click();
 
 				await page
 					.getByText('This is a description for sample 10.')
@@ -314,7 +299,9 @@ test(
 			await test.step('Exclude "Blue", "Green" and "Yellow" colors', async () => {
 				await fdsSamplePage.managementToolbar.filterButton.click();
 
-				await page.getByRole('menuitem', {name: 'Color'}).click();
+				await fdsSamplePage.filterMenu
+					.getByRole('menuitem', {name: 'Color'})
+					.click();
 
 				await fdsSamplePage.filterDropdownMenu
 					.getByLabel('Exclude')
@@ -457,7 +444,9 @@ test(
 
 				await activeFiltersButton.click();
 
-				await page.getByRole('menuitem', {name: 'Color'}).click();
+				await fdsSamplePage.filterMenu
+					.getByRole('menuitem', {name: 'Color'})
+					.click();
 
 				await expect(
 					page.getByRole('checkbox', {name: 'Green'})
@@ -514,77 +503,49 @@ test(
 				await waitForFDS({page});
 			});
 
-			await test.step('Select creator filter from dropdown', async () => {
+			await test.step('Select creator filter from dropdown and verify autocomplete input appears', async () => {
 				await fdsSamplePage.managementToolbar.filterButton.click();
 
-				await page
-					.locator('.dropdown-menu')
-					.getByRole('menuitem', {name: 'Creator'})
-					.click();
-			});
-
-			await test.step('Verify autocomplete input appears', async () => {
-				await expect(
-					page.locator('.data-set-filter').getByRole('textbox', { name: 'Search' }).first()
-				).toBeVisible();
+				await clickAndExpectToBeVisible({
+					target: fdsSamplePage.creatorFilterSearchInput,
+					trigger: fdsSamplePage.filterMenu.getByRole('menuitem', {
+						name: 'Creator',
+					}),
+				});
 			});
 
 			await test.step('Search for and select a creator', async () => {
-				const searchInput = page
-					.locator('.data-set-filter')
-					.getByRole('textbox', { name: 'Search' })
-					.first();
+				await fdsSamplePage.creatorFilterSearchInput.fill('test');
 
-				await searchInput.fill('test');
-
-				await page.waitForTimeout(500);
-
-				const firstCreatorCheckbox = page
-					.locator('.dropdown-menu')
+				const firstCreatorCheckbox = fdsSamplePage.filterMenu
 					.getByRole('checkbox')
 					.first();
 
-				if (await firstCreatorCheckbox.isVisible({timeout: 2000}).catch(() => false)) {
-					const creatorLabel = await firstCreatorCheckbox
-						.locator('..')
-						.textContent()
-						.catch(() => '');
+				await expect(firstCreatorCheckbox).toBeVisible();
 
-					await firstCreatorCheckbox.check();
+				const creatorLabel = await firstCreatorCheckbox
+					.locator('..')
+					.textContent();
 
-					await page
-						.locator('.dropdown-menu')
-						.getByRole('button', {name: 'Show Results'})
-						.or(
-							page
-								.locator('.dropdown-menu')
-								.getByRole('button', {name: 'Add Filter'})
-						)
-						.click();
+				await firstCreatorCheckbox.check();
 
-					await page
-						.getByText('This is a description for sample')
-						.first()
-						.waitFor();
+				await fdsSamplePage.filterShowResultsOrAddButton.click();
 
+				await expect(
+					page.getByText('This is a description for sample').first()
+				).toBeVisible();
 
-					if (creatorLabel) {
-						await expect(
-							page.getByRole('button', {
-								name: new RegExp(`Creator:.*${creatorLabel.trim()}`),
-							})
-						).toBeVisible();
-					}
-				}
+				await expect(
+					page.getByRole('button', {
+						name: new RegExp(
+							`Creator:.*${creatorLabel?.trim() ?? ''}`
+						),
+					})
+				).toBeVisible();
 			});
 
 			await test.step('Verify creator names appear in table cells', async () => {
-				const authorCells = page
-					.locator('table tbody tr td')
-					.filter({hasText: /./})
-					.first();
-
-				await expect(authorCells).toBeVisible();
+				await expect(page.getByRole('cell').first()).toBeVisible();
 			});
 		});
 
@@ -598,79 +559,49 @@ test(
 			await test.step('Apply creator filter', async () => {
 				await fdsSamplePage.managementToolbar.filterButton.click();
 
-				await page
-					.locator('.dropdown-menu')
+				await fdsSamplePage.filterMenu
 					.getByRole('menuitem', {name: 'Creator'})
 					.click();
 
-				const searchInput = page
-					.locator('.dropdown-menu')
-					.getByRole('textbox', { name: 'Search' })
+				await fdsSamplePage.creatorFilterSearchInput.fill('test');
+
+				const firstCreatorCheckbox = fdsSamplePage.filterMenu
+					.getByRole('checkbox')
 					.first();
 
-				await searchInput.fill('test');
+				await expect(firstCreatorCheckbox).toBeVisible();
 
-				await page.waitForTimeout(500);
+				await firstCreatorCheckbox.check();
 
-				const creatorCheckboxes = page
-					.locator('.dropdown-menu')
-					.getByRole('checkbox');
+				await fdsSamplePage.filterShowResultsOrAddButton.click();
 
-				const checkboxCount = await creatorCheckboxes.count();
-
-				if (checkboxCount > 0) {
-					await creatorCheckboxes.first().check();
-
-					if (checkboxCount > 1) {
-						await creatorCheckboxes.nth(1).check();
-					}
-
-					await page
-						.locator('.dropdown-menu')
-						.getByRole('button', {name: 'Show Results'})
-						.or(
-							page
-								.locator('.dropdown-menu')
-								.getByRole('button', {name: 'Add Filter'})
-						)
-						.click();
-
-					await page
-						.getByText('This is a description for sample')
-						.first()
-						.waitFor();
-				}
+				await expect(
+					page.getByText('This is a description for sample').first()
+				).toBeVisible();
 			});
 
 			await test.step('Open creator filter summary box and verify it shows creator names', async () => {
-				const creatorFilterButton = page
-					.getByRole('button')
-					.filter({hasText: /^Creator:/});
+				await expect(creatorFilterSummaryButton).toBeVisible();
 
-				if (await creatorFilterButton.isVisible({timeout: 2000}).catch(() => false)) {
-					await creatorFilterButton.click();
+				await creatorFilterSummaryButton.click();
 
-					await expect(
-						page.getByRole('checkbox').first()
-					).toBeVisible();
-				}
+				await expect(page.getByRole('checkbox').first()).toBeVisible();
 			});
 
-			await test.step('Test removing creator filter using remove button', async () => {
-				const removeButton = page.getByRole('button', {name: 'Remove Filter'});
+			await test.step('Remove creator filter using the remove button', async () => {
+				const removeButton = page
+					.getByRole('group')
+					.getByLabel('Remove Filter');
 
-				if (await removeButton.isVisible({timeout: 2000}).catch(() => false)) {
-					await removeButton.click();
+				await expect(removeButton).toBeVisible({timeout: 10000});
 
-					await page
-						.getByText('This is a description for sample')
-						.first()
-						.waitFor();
+				await removeButton.click();
 
-					await expect(
-						page.getByRole('button').filter({hasText: /^Creator:/})
-					).not.toBeVisible();
-				}
+				await expect(
+					page.getByText('This is a description for sample').first()
+				).toBeVisible();
+
+				await expect(creatorFilterSummaryButton).not.toBeVisible();
 			});
 		});
 	}


### PR DESCRIPTION
Manual forward from https://github.com/liferay-frontend/liferay-portal/pull/5286

Original pull request comment:
New functionality introduced in [LPD-75673](https://liferay.atlassian.net/browse/LPD-75673) | https://github.com/liferay-bpm/liferay-portal/pull/5599 added support for filtering nested properties in the FDS filter - this PR introduces a test for it and the required infrastructure.

Previously forwarded with some rebase problems in https://github.com/brianchandotcom/liferay-portal/pull/170070