### PR TITLE
LPD-73533 [CMP] Use loadData instead of Liferay.Fire

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.ts
@@ -4,6 +4,7 @@
  */
 
 export {default as FrontendDataSet} from './FrontendDataSet';
+export {default as FrontendDataSetContext} from './FrontendDataSetContext';
 export {default as DateRenderer} from './cell_renderers/DateRenderer';
 export {default as DateTimeRenderer} from './cell_renderers/DateTimeRenderer';
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/types.ts
@@ -272,7 +272,6 @@ export interface IView {
 	contentRenderer?: string;
 	contentRendererClientExtension?: boolean;
 	contentRendererModuleURL?: string;
-	dataSetId?: string;
 	default?: boolean;
 	label?: string;
 	name?: string;

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/CreateTaskModal.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/CreateTaskModal.tsx
@@ -6,7 +6,6 @@
 import ClayButton from '@clayui/button';
 import ClayForm from '@clayui/form';
 import ClayModal from '@clayui/modal';
-import {FDS_EVENT} from '@liferay/frontend-data-set-web';
 import {AssigneeValue} from '@liferay/object-dynamic-data-mapping-form-field-type';
 import {DatePicker} from '@liferay/object-js-components-web';
 import {
@@ -30,13 +29,13 @@ import './../AssigneeTrigger.scss';
 
 type CreateTaskModalProps = {
 	closeModal: () => void;
-	dataSetId: string;
+	loadData: Function;
 	state: string;
 };
 
 export default function CreateTaskModal({
 	closeModal,
-	dataSetId,
+	loadData,
 	state,
 }: CreateTaskModalProps) {
 	const [states, setStates] = useState([]);
@@ -74,7 +73,7 @@ export default function CreateTaskModal({
 			if (!error) {
 				closeModal();
 
-				Liferay.fire(FDS_EVENT.UPDATE_DISPLAY, {id: dataSetId});
+				loadData();
 
 				displayCreateSuccessToast(values.title);
 			}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/EditAssigneeModalContent.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/EditAssigneeModalContent.tsx
@@ -17,7 +17,7 @@ import './../AssigneeTrigger.scss';
 
 type Props = {
 	closeModal: () => void;
-	loadData: () => void;
+	loadData: Function;
 	taskId: string;
 	taskTitle: string;
 	value: AssigneeValue | {} | null;

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/TasksFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/TasksFDSPropsTransformer.tsx
@@ -117,7 +117,6 @@ export default function TasksFDSPropsTransformer({
 
 	const kanbanView: IView = {
 		component: (props: any) => KanbanView({...props}),
-		dataSetId: id,
 		default: false,
 		label: Liferay.Language.get('kanban'),
 		name: 'kanban',

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/KanbanView.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/KanbanView.tsx
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import React, {useCallback, useEffect, useState} from 'react';
+import {FrontendDataSetContext} from '@liferay/frontend-data-set-web';
+import React, {useCallback, useContext, useEffect, useState} from 'react';
 
 import {
 	KANBAN_COLUMN_ORDER,
@@ -17,7 +18,6 @@ import Board from './components/Board';
 import {KanbanViewContext} from './context';
 
 interface KanbanViewProps {
-	dataSetId: string;
 	items: ITask[];
 	itemsActions: IItemsActions[];
 }
@@ -49,6 +49,7 @@ function mapByStateCode(items: ITask[]): {[key: string]: IColumn} {
 }
 
 function KanbanView(props: KanbanViewProps) {
+	const {loadData} = useContext(FrontendDataSetContext);
 	const [boardData] = useState(mapByStateCode(props.items));
 
 	const changeTaskStatus = useCallback(() => {}, []);
@@ -66,8 +67,8 @@ function KanbanView(props: KanbanViewProps) {
 			value={{
 				boardData,
 				changeTaskStatus,
-				dataSetId: props.dataSetId,
 				itemsActions: props.itemsActions,
+				loadData,
 			}}
 		>
 			<Board />

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/components/Column.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/components/Column.tsx
@@ -24,7 +24,7 @@ interface IColumnProps {
 export default function Column({
 	column: {icon, key, name, tasks},
 }: IColumnProps) {
-	const {dataSetId} = useContext(KanbanViewContext);
+	const {loadData} = useContext(KanbanViewContext);
 
 	return (
 		<Col className="lfr__kaban-view-column">
@@ -58,7 +58,7 @@ export default function Column({
 							}) => (
 								<CreateTaskModal
 									closeModal={closeModal}
-									dataSetId={dataSetId}
+									loadData={loadData}
 									state={key}
 								/>
 							),

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/components/Task.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/components/Task.tsx
@@ -8,7 +8,6 @@ import Card from '@clayui/card/src/Card';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import Label from '@clayui/label';
-import {FDS_EVENT} from '@liferay/frontend-data-set-web';
 import {AssigneeAvatar} from '@liferay/object-dynamic-data-mapping-form-field-type';
 import {displayErrorToast} from '@liferay/site-cms-site-initializer';
 import {navigate} from 'frontend-js-web';
@@ -33,7 +32,7 @@ import {KanbanViewContext} from '../context';
 import './Task.scss';
 
 export default function Task(props: ITask) {
-	const {dataSetId, itemsActions} = useContext(KanbanViewContext);
+	const {itemsActions, loadData} = useContext(KanbanViewContext);
 
 	return (
 		<Card>
@@ -111,10 +110,7 @@ export default function Task(props: ITask) {
 										});
 
 										if (!error) {
-											Liferay.fire(
-												FDS_EVENT.UPDATE_DISPLAY,
-												{id: dataSetId}
-											);
+											loadData();
 
 											displayAssignSuccessToast(
 												props.embedded.title,
@@ -140,12 +136,7 @@ export default function Task(props: ITask) {
 											}) => (
 												<EditAssigneeModalContent
 													closeModal={closeModal}
-													loadData={() =>
-														Liferay.fire(
-															FDS_EVENT.UPDATE_DISPLAY,
-															{id: dataSetId}
-														)
-													}
+													loadData={loadData}
 													taskId={String(
 														props.embedded.id
 													)}
@@ -193,10 +184,7 @@ export default function Task(props: ITask) {
 															);
 
 														if (!error) {
-															Liferay.fire(
-																FDS_EVENT.UPDATE_DISPLAY,
-																{id: dataSetId}
-															);
+															loadData();
 
 															displayDeleteSuccessToast(
 																props.embedded

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/context.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/context.ts
@@ -10,8 +10,8 @@ import {IColumn, IItemsActions, IKanbanState} from '../../../../utils/types';
 interface IKanbanContext {
 	boardData: {[k: string]: IColumn};
 	changeTaskStatus: React.Dispatch<React.SetStateAction<IKanbanState>>;
-	dataSetId: string;
 	itemsActions: IItemsActions[];
+	loadData: Function;
 }
 
 export const KanbanViewContext = React.createContext({} as IKanbanContext);

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/Column.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/Column.spec.tsx
@@ -36,8 +36,8 @@ describe('Kanban Column', () => {
 				value={{
 					boardData: {},
 					changeTaskStatus: () => {},
-					dataSetId: 'dataSetId',
 					itemsActions: [],
+					loadData: () => {},
 				}}
 			>
 				<Column column={column} />
@@ -65,8 +65,8 @@ describe('Kanban Column', () => {
 				value={{
 					boardData: {},
 					changeTaskStatus: () => {},
-					dataSetId: 'dataSetId',
 					itemsActions: [],
+					loadData: () => {},
 				}}
 			>
 				<Column column={column} />

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/KanbanView.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/KanbanView.spec.tsx
@@ -34,7 +34,7 @@ describe('KanbanView mapping and lifecycle', () => {
 		] as any;
 
 		const {unmount} = render(
-			<KanbanView dataSetId="datasetId" items={items} itemsActions={[]} />
+			<KanbanView items={items} itemsActions={[]} />
 		);
 
 		expect((global as any).Liferay.fire).toHaveBeenCalledWith(

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/Task.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/Task.spec.tsx
@@ -12,15 +12,14 @@ import Task from '../../js/components/props_transformer/views/kanban_view/compon
 import {KanbanViewContext} from '../../js/components/props_transformer/views/kanban_view/context';
 import {mockNavigate} from '../../tests/js/__mocks__/frontend-js-web';
 
-const mockGetUserAccount = jest.fn();
-const mockPatchTaskById = jest.fn();
 const mockDisplayAssignSuccessToast = jest.fn();
 const mockDisplayErrorToast = jest.fn();
+const mockGetUserAccount = jest.fn();
 const mockLoadData = jest.fn();
+const mockPatchTaskById = jest.fn();
 
-jest.mock('../../js/utils/api', () => ({
-	getUserAccount: (...args: any[]) => mockGetUserAccount(...args),
-	patchTaskById: (...args: any[]) => mockPatchTaskById(...args),
+jest.mock('@liferay/site-cms-site-initializer', () => ({
+	displayErrorToast: (...args: any[]) => mockDisplayErrorToast(...args),
 }));
 
 jest.mock('frontend-js-components-web', () => ({
@@ -28,13 +27,14 @@ jest.mock('frontend-js-components-web', () => ({
 	openToast: jest.fn(),
 }));
 
+jest.mock('../../js/utils/api', () => ({
+	getUserAccount: (...args: any[]) => mockGetUserAccount(...args),
+	patchTaskById: (...args: any[]) => mockPatchTaskById(...args),
+}));
+
 jest.mock('../../js/utils/toastUtil', () => ({
 	displayAssignSuccessToast: (...args: any[]) =>
 		mockDisplayAssignSuccessToast(...args),
-}));
-
-jest.mock('@liferay/site-cms-site-initializer', () => ({
-	displayErrorToast: (...args: any[]) => mockDisplayErrorToast(...args),
 }));
 
 describe('Kanban Task actions', () => {

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/Task.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/Task.spec.tsx
@@ -16,6 +16,7 @@ const mockGetUserAccount = jest.fn();
 const mockPatchTaskById = jest.fn();
 const mockDisplayAssignSuccessToast = jest.fn();
 const mockDisplayErrorToast = jest.fn();
+const mockLoadData = jest.fn();
 
 jest.mock('../../js/utils/api', () => ({
 	getUserAccount: (...args: any[]) => mockGetUserAccount(...args),
@@ -53,8 +54,8 @@ describe('Kanban Task actions', () => {
 				value={{
 					boardData: {},
 					changeTaskStatus: () => {},
-					dataSetId: 'dataSetId',
 					itemsActions,
+					loadData: mockLoadData,
 				}}
 			>
 				<Task {...baseProps} />
@@ -77,7 +78,7 @@ describe('Kanban Task actions', () => {
 		await waitFor(() => expect(mockPatchTaskById).toHaveBeenCalled());
 
 		await waitFor(() => {
-			expect((global as any).Liferay.fire).toHaveBeenCalled();
+			expect(mockLoadData).toHaveBeenCalled();
 			expect(mockDisplayAssignSuccessToast).toHaveBeenCalledWith(
 				'Task title',
 				'Current User'


### PR DESCRIPTION
Jira [ticket](https://liferay.atlassian.net/browse/LPD-73627)

The goal of this pull request is to enable the use of `loadData` within the Kanban view.