### PR TITLE
LPD-79329 Fix upgrade failure "Status: Unsatisfied components prevent…

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
@@ -5,9 +5,7 @@
 
 package com.liferay.oauth2.provider.service.impl;
 
-import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
-import com.liferay.document.library.kernel.store.Store;
 import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.oauth2.provider.constants.OAuth2ProviderConstants;
 import com.liferay.oauth2.provider.exception.DuplicateOAuth2ApplicationClientIdException;
@@ -49,7 +47,6 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
-import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -955,11 +952,6 @@ public class OAuth2ApplicationLocalServiceImpl
 	@Reference
 	private GroupLocalService _groupLocalService;
 
-	@Reference(
-		target = "(indexer.class.name=com.liferay.document.library.kernel.model.DLFileEntry)"
-	)
-	private Indexer<DLFileEntry> _indexer;
-
 	@Reference
 	private OAuth2ApplicationScopeAliasesLocalService
 		_oAuth2ApplicationScopeAliasesLocalService;
@@ -972,9 +964,6 @@ public class OAuth2ApplicationLocalServiceImpl
 
 	@Reference
 	private ResourceLocalService _resourceLocalService;
-
-	@Reference(target = "(default=true)")
-	private Store _store;
 
 	@Reference
 	private UserLocalService _userLocalService;


### PR DESCRIPTION
… upgrade processes to be registered" caused by 0387415f19858db416644afc6cd6f847d751bbbe.

OAuth2ProviderShortcutUpgradeStepRegistrator is collected for upgrade run, it depends on OAuth2ApplicationLocalServiceImpl which further depends on DLFileEntry Indexer. Indexer is not available for upgrade client run, causing the upgrade failure.

The 2 unused reference in OAuth2ApplicationLocalServiceImpl "private Indexer<DLFileEntry> _indexer;" and "private Store _store;" was added to support startup time PortletFileRepository file adding from updateIcon().

The only OAuth2ApplicationLocalServiceImpl.updateIcon() invoker at startup time was AnalyticsCloudInitialRequestPortalInstanceLifecycleListener which was refactored to InitialRequestPortalInstanceLifecycleListener in c2f6862a to postpone its execution to first request serving time.

The 2 unused fields are simply not needed anymore.