### PR TITLE
LPD-77977 Follow-up: Set environment var to psql when executing it in local without docker

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -6247,6 +6247,7 @@ ${custom.upgrade.properties}</echo>
 									<equals arg1="${database.type}" arg2="postgresql" />
 									<then>
 										<get-database-property property.name="database.host" />
+										<get-database-property property.name="database.password" />
 										<get-database-property property.name="database.username" />
 
 										<condition property="database.host" value="localhost">
@@ -6263,6 +6264,7 @@ ${custom.upgrade.properties}</echo>
 												<arg value="${database.host}" />
 												<arg value="-U" />
 												<arg value="${database.username}" />
+												<env key="PGPASSWORD" value="${database.password}" />
 											</exec>
 										</retry>
 									</then>
@@ -15794,6 +15796,7 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 							</antcall>
 
 							<get-database-property property.name="database.host" />
+							<get-database-property property.name="database.password" />
 							<get-database-property property.name="database.schema" />
 							<get-database-property property.name="database.username" />
 
@@ -15808,6 +15811,7 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 								<arg value="--file=${liferay.home}/${database.type}.sql" />
 								<arg value="--host=${database.host}" />
 								<arg value="--username=${database.username}" />
+								<env key="PGPASSWORD" value="${database.password}" />
 							</exec>
 						</then>
 					</elseif>


### PR DESCRIPTION
I am setting the environment var to psql when executing it in local without docker for creating or importing the database in the same way it is done with docker, see:
 - https://github.com/jorgediaz-lr/liferay-portal/blob/55b53518e13c565fe4073f428633bda05af62d69/build-test.xml#L6076-L6082
 - https://github.com/jorgediaz-lr/liferay-portal/blob/55b53518e13c565fe4073f428633bda05af62d69/build-test.xml#L15575-L15580 

