### PR TITLE
LPD-79495 When sidecar shutdown fails, we need to open the _shutdownC…

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sidecar/ElasticsearchServerUtil.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sidecar/ElasticsearchServerUtil.java
@@ -86,6 +86,8 @@ public class ElasticsearchServerUtil {
 				_logger.warn("Unable to invoke stop method", exception);
 			}
 
+			_shutdownCountDownLatch.countDown();
+
 			System.exit(ExitCodes.CODE_ERROR);
 		}
 

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/sidecar/ElasticsearchServerUtil.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/sidecar/ElasticsearchServerUtil.java
@@ -86,6 +86,8 @@ public class ElasticsearchServerUtil {
 				_logger.warn("Unable to invoke stop method", exception);
 			}
 
+			_shutdownCountDownLatch.countDown();
+
 			System.exit(ExitCodes.CODE_ERROR);
 		}
 


### PR DESCRIPTION
…ountDownLatch before System.exit(). Otherwise when Heartbeat thread kills abandoned sidecar jvm, it will cause shutdownhook deadlock.

"HeartbeatThread" #54 [3897440] daemon prio=5 os_prio=0 cpu=14.78ms elapsed=43726.71s tid=0x0000798548778740 nid=3897440 in Object.wait()  [0x00007984fcdfe000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait0(java.base@21.0.8/Native Method)
	- waiting on <0x00000000c3168df8> (a java.lang.Thread) at java.lang.Object.wait(java.base@21.0.8/Object.java:366) at java.lang.Thread.join(java.base@21.0.8/Thread.java:2078)
	- locked <0x00000000c3168df8> (a java.lang.Thread) at java.lang.Thread.join(java.base@21.0.8/Thread.java:2154) at java.lang.ApplicationShutdownHooks.runHooks(java.base@21.0.8/ApplicationShutdownHooks.java:114) at java.lang.ApplicationShutdownHooks$1.run(java.base@21.0.8/ApplicationShutdownHooks.java:47) at java.lang.Shutdown.runHooks(java.base@21.0.8/Shutdown.java:130) at java.lang.Shutdown.exit(java.base@21.0.8/Shutdown.java:167)
	- locked <0x00000000ffe826b8> (a java.lang.Class for java.lang.Shutdown) at java.lang.Runtime.exit(java.base@21.0.8/Runtime.java:188) at java.lang.System.exit(java.base@21.0.8/System.java:1920) at com.liferay.portal.search.elasticsearch7.internal.sidecar.ElasticsearchServerUtil.shutdown(ElasticsearchServerUtil.java:89) at com.liferay.portal.search.elasticsearch7.internal.sidecar.SidecarMainProcessCallable.lambda$call$0(SidecarMainProcessCallable.java:26) at com.liferay.portal.search.elasticsearch7.internal.sidecar.SidecarMainProcessCallable$$Lambda/0x0000798478008218.shutdown(Unknown Source) at com.liferay.petra.process.local.LocalProcessLauncher$HeartbeatThread.run(LocalProcessLauncher.java:290)

   Locked ownable synchronizers:
	- None

"Elasticsearch Server Shutdown Hook" #79 [3910360] daemon prio=5 os_prio=0 cpu=0.08ms elapsed=43576.69s tid=0x0000798410007cd0 nid=3910360 waiting on condition  [0x00007984729fe000]
   java.lang.Thread.State: WAITING (parking)
	at jdk.internal.misc.Unsafe.park(java.base@21.0.8/Native Method)
	- parking to wait for  <0x00000000c0002440> (a java.util.concurrent.CountDownLatch$Sync) at java.util.concurrent.locks.LockSupport.park(java.base@21.0.8/LockSupport.java:221) at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@21.0.8/AbstractQueuedSynchronizer.java:754) at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(java.base@21.0.8/AbstractQueuedSynchronizer.java:1099) at java.util.concurrent.CountDownLatch.await(java.base@21.0.8/CountDownLatch.java:230) at com.liferay.portal.search.elasticsearch7.internal.sidecar.ElasticsearchServerUtil.lambda$_addShutdownHook$0(ElasticsearchServerUtil.java:140) at com.liferay.portal.search.elasticsearch7.internal.sidecar.ElasticsearchServerUtil$$Lambda/0x0000798478a3d000.run(Unknown Source) at java.lang.Thread.runWith(java.base@21.0.8/Thread.java:1596) at java.lang.Thread.run(java.base@21.0.8/Thread.java:1583)

   Locked ownable synchronizers:
	- None