### PR TITLE
LPD-76453 Allow members to access to content and files only from the spaces where they are members

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseDisplayContextTestCase.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseDisplayContextTestCase.java
@@ -19,6 +19,7 @@ import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -154,11 +155,25 @@ public abstract class BaseDisplayContextTestCase {
 	protected MockHttpServletRequest getMockHttpServletRequest()
 		throws Exception {
 
-		return getMockHttpServletRequest(null);
+		return getMockHttpServletRequest(TestPropsValues.getUser(), null);
 	}
 
 	protected MockHttpServletRequest getMockHttpServletRequest(
 			ObjectEntryFolder objectEntryFolder)
+		throws Exception {
+
+		return getMockHttpServletRequest(
+			TestPropsValues.getUser(), objectEntryFolder);
+	}
+
+	protected MockHttpServletRequest getMockHttpServletRequest(User user)
+		throws Exception {
+
+		return getMockHttpServletRequest(user, null);
+	}
+
+	protected MockHttpServletRequest getMockHttpServletRequest(
+			User user, ObjectEntryFolder objectEntryFolder)
 		throws Exception {
 
 		MockHttpServletRequest mockHttpServletRequest =
@@ -170,13 +185,21 @@ public abstract class BaseDisplayContextTestCase {
 		}
 
 		mockHttpServletRequest.setAttribute(
-			WebKeys.THEME_DISPLAY, getThemeDisplay(mockHttpServletRequest));
+			WebKeys.THEME_DISPLAY,
+			getThemeDisplay(user, mockHttpServletRequest));
 
 		return mockHttpServletRequest;
 	}
 
 	protected ThemeDisplay getThemeDisplay(
 			HttpServletRequest httpServletRequest)
+		throws Exception {
+
+		return getThemeDisplay(TestPropsValues.getUser(), httpServletRequest);
+	}
+
+	protected ThemeDisplay getThemeDisplay(
+			User user, HttpServletRequest httpServletRequest)
 		throws Exception {
 
 		ThemeDisplay themeDisplay = new ThemeDisplay();
@@ -195,12 +218,12 @@ public abstract class BaseDisplayContextTestCase {
 		themeDisplay.setPermissionChecker(
 			PermissionThreadLocal.getPermissionChecker());
 		themeDisplay.setPortalURL("http://localhost:8080");
-		themeDisplay.setRealUser(TestPropsValues.getUser());
+		themeDisplay.setRealUser(user);
 		themeDisplay.setRequest(httpServletRequest);
 		themeDisplay.setScopeGroupId(group.getGroupId());
 		themeDisplay.setSiteGroupId(group.getGroupId());
 		themeDisplay.setURLCurrent("http://localhost:8080/currentURL");
-		themeDisplay.setUser(TestPropsValues.getUser());
+		themeDisplay.setUser(user);
 
 		return themeDisplay;
 	}

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
@@ -211,7 +211,7 @@ public abstract class BaseSectionDisplayContextTestCase
 							StringPool.BLANK, Collections.emptyMap(),
 							themeDisplay,
 							RequestBackedPortletURLFactoryUtil.create(
-								getMockHttpServletRequest()));
+								mockHttpServletRequest));
 
 					Map<String, Object> data =
 						contentItemCommentEditorConfiguration.getData();

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
@@ -40,18 +40,21 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -302,6 +305,42 @@ public abstract class BaseSectionDisplayContextTestCase
 	}
 
 	@Test
+	public void testGetCMSSectionFilterString() throws Exception {
+		DepotEntry depotEntry1 = addDepotEntry(
+			TestPropsValues.getUserId(), StringUtil.randomString());
+
+		User user = UserTestUtil.addUser(
+			companyLocalService.getCompany(TestPropsValues.getCompanyId()),
+			RoleConstants.CMS_ADMINISTRATOR);
+
+		DepotEntry depotEntry2 = addDepotEntry(
+			user.getUserId(), StringUtil.randomString());
+
+		try {
+			Object displayContext = getSectionDisplayContext(
+				getMockHttpServletRequest(TestPropsValues.getUser()));
+
+			String filterString = getCMSSectionFilterString(displayContext);
+
+			Assert.assertTrue(
+				filterString.contains(
+					"groupIds/any(g:g in (" + depotEntry1.getGroupId() + "))"));
+
+			displayContext = getSectionDisplayContext(
+				getMockHttpServletRequest(user));
+
+			filterString = getCMSSectionFilterString(displayContext);
+
+			Assert.assertFalse(filterString.contains("groupIds/any"));
+		}
+		finally {
+			_depotEntryLocalService.deleteDepotEntry(depotEntry1);
+			_depotEntryLocalService.deleteDepotEntry(depotEntry2);
+			_userLocalService.deleteUser(user);
+		}
+	}
+
+	@Test
 	@TestInfo("LPD-50664")
 	public void testGetCreationMenu() throws Exception {
 		Map<String, String> expectedCreationMenuItems =
@@ -435,6 +474,21 @@ public abstract class BaseSectionDisplayContextTestCase
 			WorkflowConstants.STATUS_APPROVED);
 	}
 
+	protected DepotEntry addDepotEntry(long userId, String name)
+		throws Exception {
+
+		return _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), name
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext(
+				group.getGroupId(), userId));
+	}
+
 	protected DepotEntry addDepotEntry(String name, int type) throws Exception {
 		return _depotEntryLocalService.addDepotEntry(
 			HashMapBuilder.put(
@@ -444,6 +498,12 @@ public abstract class BaseSectionDisplayContextTestCase
 				LocaleUtil.getDefault(), StringUtil.randomString()
 			).build(),
 			type, ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+	}
+
+	protected String getCMSSectionFilterString(Object displayContext) {
+		return ReflectionTestUtil.invoke(
+			displayContext, "getCMSSectionFilterString", new Class<?>[0],
+			new Object[0]);
 	}
 
 	protected CreationMenu getCreationMenu() throws Exception {
@@ -962,5 +1022,8 @@ public abstract class BaseSectionDisplayContextTestCase
 	@Inject
 	private TranslationInfoItemFieldValuesExporterRegistry
 		_translationInfoItemFieldValuesExporterRegistry;
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
@@ -11,6 +11,7 @@ import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -46,6 +47,13 @@ public class ViewAllSectionDisplayContextTest
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Override
+	protected String getCMSSectionFilterString(Object displayContext) {
+		return ReflectionTestUtil.invoke(
+			displayContext, "getAdditionalAPIURLParameters", new Class<?>[0],
+			new Object[0]);
+	}
 
 	@Override
 	protected Map<String, String> getExpectedCreationMenuItems()

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewRecycleBinSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewRecycleBinSectionDisplayContextTest.java
@@ -47,7 +47,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 /**
@@ -90,12 +89,13 @@ public class ViewRecycleBinSectionDisplayContextTest
 			_getBreadcrumbProps(displayContext));
 	}
 
+	@Override
 	@Test
 	public void testGetCMSSectionFilterString() throws Exception {
 		Object displayContext = getSectionDisplayContext(
 			getMockHttpServletRequest());
 
-		String filterString = _getCMSSectionFilterString(displayContext);
+		String filterString = getCMSSectionFilterString(displayContext);
 
 		Assert.assertTrue(
 			filterString.contains("status eq " + WorkflowConstants.STATUS_ANY));
@@ -112,7 +112,7 @@ public class ViewRecycleBinSectionDisplayContextTest
 				GetterUtil.getBoolean(
 					depotGroup.getTypeSettingsProperty("trashEnabled")));
 
-			filterString = _getCMSSectionFilterString(displayContext);
+			filterString = getCMSSectionFilterString(displayContext);
 
 			Assert.assertTrue(
 				filterString.contains(
@@ -163,12 +163,6 @@ public class ViewRecycleBinSectionDisplayContextTest
 		return Collections.emptyMap();
 	}
 
-	protected MockHttpServletRequest getMockHttpServletRequest()
-		throws Exception {
-
-		return getMockHttpServletRequest(null);
-	}
-
 	@Override
 	protected String getObjectFolderExternalReferenceCode() {
 		if (RandomTestUtil.randomBoolean()) {
@@ -208,12 +202,6 @@ public class ViewRecycleBinSectionDisplayContextTest
 	private HashMap<String, Object> _getBreadcrumbProps(Object displayContext) {
 		return ReflectionTestUtil.invoke(
 			displayContext, "getBreadcrumbProps", new Class<?>[0]);
-	}
-
-	private String _getCMSSectionFilterString(Object displayContext) {
-		return ReflectionTestUtil.invoke(
-			displayContext, "getCMSSectionFilterString", new Class<?>[0],
-			new Object[0]);
 	}
 
 	private void _setTrashEnabledGroupProperty(Group group, String value)

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewRecycleBinSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewRecycleBinSectionDisplayContextTest.java
@@ -6,7 +6,6 @@
 package com.liferay.site.cms.site.initializer.internal.display.context.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.fragment.renderer.FragmentRenderer;
@@ -15,15 +14,22 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -93,36 +99,53 @@ public class ViewRecycleBinSectionDisplayContextTest
 	@Test
 	public void testGetCMSSectionFilterString() throws Exception {
 		Object displayContext = getSectionDisplayContext(
-			getMockHttpServletRequest());
+			getMockHttpServletRequest(TestPropsValues.getUser()));
 
 		String filterString = getCMSSectionFilterString(displayContext);
 
 		Assert.assertTrue(
 			filterString.contains("status eq " + WorkflowConstants.STATUS_ANY));
 
-		DepotEntry depotEntry = addDepotEntry(
-			RandomTestUtil.randomString(), DepotConstants.TYPE_SPACE);
+		DepotEntry depotEntry1 = _addDepotEntry(
+			TestPropsValues.getUserId(), false);
+		DepotEntry depotEntry2 = _addDepotEntry(
+			TestPropsValues.getUserId(), true);
+
+		User user = UserTestUtil.addUser(
+			companyLocalService.getCompany(TestPropsValues.getCompanyId()),
+			RoleConstants.CMS_ADMINISTRATOR);
+
+		DepotEntry depotEntry3 = _addDepotEntry(user.getUserId(), true);
 
 		try {
-			Group depotGroup = depotEntry.getGroup();
-
-			_setTrashEnabledGroupProperty(depotGroup, Boolean.TRUE.toString());
-
-			Assert.assertTrue(
-				GetterUtil.getBoolean(
-					depotGroup.getTypeSettingsProperty("trashEnabled")));
+			_assertTrashEnabled(depotEntry1, false);
+			_assertTrashEnabled(depotEntry2, true);
+			_assertTrashEnabled(depotEntry3, true);
 
 			filterString = getCMSSectionFilterString(displayContext);
 
 			Assert.assertTrue(
 				filterString.contains(
-					StringBundler.concat(
-						"status eq ", WorkflowConstants.STATUS_IN_TRASH,
-						" and groupIds/any(g:g in (", depotGroup.getGroupId(),
-						"))")));
+					_getExpectedFilterString(depotEntry2.getGroupId())));
+
+			displayContext = getSectionDisplayContext(
+				getMockHttpServletRequest(user));
+
+			filterString = getCMSSectionFilterString(displayContext);
+
+			Assert.assertTrue(
+				filterString.contains(
+					_getExpectedFilterString(
+						depotEntry2.getGroupId(), depotEntry3.getGroupId())) ||
+				filterString.contains(
+					_getExpectedFilterString(
+						depotEntry3.getGroupId(), depotEntry2.getGroupId())));
 		}
 		finally {
-			_depotEntryLocalService.deleteDepotEntry(depotEntry);
+			_depotEntryLocalService.deleteDepotEntry(depotEntry1);
+			_depotEntryLocalService.deleteDepotEntry(depotEntry2);
+			_depotEntryLocalService.deleteDepotEntry(depotEntry3);
+			_userLocalService.deleteUser(user);
 		}
 	}
 
@@ -199,9 +222,41 @@ public class ViewRecycleBinSectionDisplayContextTest
 		return viewRecycleBinSectionDisplayContext;
 	}
 
+	private DepotEntry _addDepotEntry(long userId, boolean trashEnabled)
+		throws Exception {
+
+		DepotEntry depotEntry = addDepotEntry(
+			userId, RandomTestUtil.randomString());
+
+		_setTrashEnabledGroupProperty(
+			depotEntry.getGroup(), String.valueOf(trashEnabled));
+
+		return depotEntry;
+	}
+
+	private void _assertTrashEnabled(
+			DepotEntry depotEntry, boolean expectedTrashEnabled)
+		throws Exception {
+
+		Group depotGroup = depotEntry.getGroup();
+
+		Assert.assertEquals(
+			expectedTrashEnabled,
+			GetterUtil.getBoolean(
+				depotGroup.getTypeSettingsProperty("trashEnabled")));
+	}
+
 	private HashMap<String, Object> _getBreadcrumbProps(Object displayContext) {
 		return ReflectionTestUtil.invoke(
 			displayContext, "getBreadcrumbProps", new Class<?>[0]);
+	}
+
+	private String _getExpectedFilterString(long... groupIds) {
+		String groupIdsString = StringUtil.merge(groupIds, StringPool.COMMA);
+
+		return StringBundler.concat(
+			"status eq ", WorkflowConstants.STATUS_IN_TRASH,
+			" and groupIds/any(g:g in (", groupIdsString, "))");
 	}
 
 	private void _setTrashEnabledGroupProperty(Group group, String value)
@@ -230,5 +285,8 @@ public class ViewRecycleBinSectionDisplayContextTest
 
 	@Inject
 	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewSharedWithMeSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewSharedWithMeSectionDisplayContextTest.java
@@ -157,6 +157,11 @@ public class ViewSharedWithMeSectionDisplayContextTest
 	}
 
 	@Override
+	@Test
+	public void testGetCMSSectionFilterString() throws Exception {
+	}
+
+	@Override
 	protected CreationMenu getCreationMenu(ObjectEntryFolder objectEntryFolder)
 		throws Exception {
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -353,6 +353,11 @@ public abstract class BaseSectionDisplayContext {
 			));
 	}
 
+	protected String appendGroupIds(String filterString) {
+		return _sectionDisplayContextHelper.appendGroupIds(
+			filterString, httpServletRequest);
+	}
+
 	protected String appendStatus(String filterString) {
 		return _sectionDisplayContextHelper.appendStatus(filterString);
 	}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
@@ -34,11 +34,13 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -81,6 +83,39 @@ public class SectionDisplayContextHelper {
 		_objectEntryFolderModelResourcePermission =
 			objectEntryFolderModelResourcePermission;
 		_portal = portal;
+	}
+
+	public String appendGroupIds(
+		String filterString, HttpServletRequest httpServletRequest) {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		try {
+			boolean cmsAdministrator = RoleLocalServiceUtil.hasUserRole(
+				themeDisplay.getUserId(), themeDisplay.getCompanyId(),
+				RoleConstants.CMS_ADMINISTRATOR, true);
+
+			if (cmsAdministrator) {
+				return filterString;
+			}
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+
+		String depotEntryGroupIdsString = StringUtil.merge(
+			_depotEntryLocalService.getDepotEntryGroupIds(
+				themeDisplay.getCompanyId(), themeDisplay.getUserId(),
+				DepotConstants.TYPE_SPACE),
+			StringPool.COMMA);
+
+		return StringBundler.concat(
+			filterString, " and groupIds/any(g:g in (",
+			depotEntryGroupIdsString, "))");
 	}
 
 	public String appendStatus(String filterString) {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewContentsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewContentsSectionDisplayContext.java
@@ -82,7 +82,8 @@ public class ViewContentsSectionDisplayContext
 
 	@Override
 	protected String getCMSSectionFilterString() {
-		return appendStatus("cmsRoot eq true and cmsSection eq 'contents'");
+		return appendGroupIds(
+			appendStatus("cmsRoot eq true and cmsSection eq 'contents'"));
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFilesSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFilesSectionDisplayContext.java
@@ -92,7 +92,8 @@ public class ViewFilesSectionDisplayContext
 
 	@Override
 	protected String getCMSSectionFilterString() {
-		return appendStatus("cmsRoot eq true and cmsSection eq 'files'");
+		return appendGroupIds(
+			appendStatus("cmsRoot eq true and cmsSection eq 'files'"));
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeRecentAssetsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeRecentAssetsSectionDisplayContext.java
@@ -95,9 +95,10 @@ public class ViewHomeRecentAssetsSectionDisplayContext
 
 	@Override
 	protected String getCMSSectionFilterString() {
-		return appendStatus(
-			"cmsKind eq 'object' and (cmsSection eq 'contents' or cmsSection " +
-				"eq 'files')");
+		return appendGroupIds(
+			appendStatus(
+				"cmsKind eq 'object' and (cmsSection eq 'contents' or " +
+					"cmsSection eq 'files')"));
 	}
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewRecycleBinSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewRecycleBinSectionDisplayContext.java
@@ -17,6 +17,7 @@ import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.language.Language;
@@ -24,10 +25,11 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -189,22 +191,22 @@ public class ViewRecycleBinSectionDisplayContext
 			"cmsRoot eq true and (cmsSection eq 'contents' or cmsSection eq " +
 				"'files') and status eq ";
 
-		Long[] groupIds;
+		List<Long> groupIds;
 
 		try {
 			groupIds = _getDepotGroupIds(_themeDisplay.getCompanyId());
 		}
-		catch (Exception exception) {
+		catch (PortalException portalException) {
 			if (_log.isDebugEnabled()) {
 				_log.debug(
 					"Unable to get depot group IDs for group " + _groupId,
-					exception);
+					portalException);
 			}
 
 			return filterString + WorkflowConstants.STATUS_ANY;
 		}
 
-		if (ArrayUtil.isEmpty(groupIds)) {
+		if (groupIds.isEmpty()) {
 			return filterString + WorkflowConstants.STATUS_ANY;
 		}
 
@@ -214,21 +216,39 @@ public class ViewRecycleBinSectionDisplayContext
 			"))");
 	}
 
-	private Long[] _getDepotGroupIds(long companyId) throws Exception {
-		return TransformUtil.transformToArray(
-			depotEntryLocalService.getDepotEntries(
-				companyId, DepotConstants.TYPE_SPACE),
-			depotEntry -> {
-				Group group = groupLocalService.fetchGroup(
-					depotEntry.getGroupId());
+	private List<Long> _getDepotGroupIds(long companyId)
+		throws PortalException {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		boolean cmsAdministrator = RoleLocalServiceUtil.hasUserRole(
+			themeDisplay.getUserId(), themeDisplay.getCompanyId(),
+			RoleConstants.CMS_ADMINISTRATOR, true);
+
+		List<Long> depotEntryGroupIds;
+
+		if (cmsAdministrator) {
+			depotEntryGroupIds = depotEntryLocalService.getDepotEntryGroupIds(
+				companyId, DepotConstants.TYPE_SPACE);
+		}
+		else {
+			depotEntryGroupIds = depotEntryLocalService.getDepotEntryGroupIds(
+				companyId, themeDisplay.getUserId(), DepotConstants.TYPE_SPACE);
+		}
+
+		return TransformUtil.transform(
+			depotEntryGroupIds,
+			depotEntryGroupId -> {
+				Group group = groupLocalService.fetchGroup(depotEntryGroupId);
 
 				if ((group == null) || !_trashHelper.isTrashEnabled(group)) {
 					return null;
 				}
 
 				return group.getGroupId();
-			},
-			Long.class);
+			});
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/ViewAllSectionSystemFDSEntry.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/ViewAllSectionSystemFDSEntry.java
@@ -37,9 +37,11 @@ public class ViewAllSectionSystemFDSEntry implements SystemFDSEntry {
 	public String getAdditionalAPIURLParameters(
 		HttpServletRequest httpServletRequest) {
 
-		String filterString = _sectionDisplayContextHelper.appendStatus(
-			"cmsKind eq 'object' and (cmsSection eq 'contents' or cmsSection " +
-				"eq 'files')");
+		String filterString = _sectionDisplayContextHelper.appendGroupIds(
+			_sectionDisplayContextHelper.appendStatus(
+				"cmsKind eq 'object' and (cmsSection eq 'contents' or " +
+					"cmsSection eq 'files')"),
+			httpServletRequest);
 
 		if (httpServletRequest.getParameter("q") != null) {
 			return HttpComponentsUtil.addParameters(

--- a/portal-test/bnd.bnd
+++ b/portal-test/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 32.2.2
+Bundle-Version: 32.3.0
 Export-Package:\
 	com.liferay.portal.kernel.dao.db.test,\
 	com.liferay.portal.kernel.test,\

--- a/portal-test/src/com/liferay/portal/kernel/test/util/UserTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/UserTestUtil.java
@@ -201,6 +201,19 @@ public class UserTestUtil {
 			ServiceContextTestUtil.getServiceContext());
 	}
 
+	public static User addUser(Company company, String roleName)
+		throws Exception {
+
+		User user = addUser(company);
+
+		Role role = RoleLocalServiceUtil.getRole(
+			company.getCompanyId(), roleName);
+
+		UserLocalServiceUtil.addRoleUser(role.getRoleId(), user);
+
+		return user;
+	}
+
 	public static User addUser(long... groupIds) throws Exception {
 		return addUser(
 			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),

--- a/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 10.3.0
+version 10.4.0


### PR DESCRIPTION
Redirected from: https://github.com/liferay-content-management/liferay-portal/pull/7764

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-76453

Users can only see assets from the spaces they are members of.


# How am I fixing it?

Appending to the filtering string the IDs of the allowed Spaces.

AFAIK affected views are:

* Recent assets in Home
* All
* Contents
* Files
* Recycle Bin

# How can you verify that it works?

Run integration tests:

`cd modules/apps/site/site-cms-site-initializer-test`

* `gw tI --tests "ViewAllSectionDisplayContextTest.testGetCMSSectionFilterString"`
* `gw tI --tests "ViewContentsSectionDisplayContextTest.testGetCMSSectionFilterString"`
* `gw tI --tests "ViewFilesSectionDisplayContextTest.testGetCMSSectionFilterString"`
* `gw tI --tests "ViewRecycleBinSectionDisplayContextTest.testGetCMSSectionFilterString"`


