### PR TITLE
LPD-79172 A CMS Administrator cannot see the assets

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
@@ -6,7 +6,10 @@
 package com.liferay.object.service.impl;
 
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.constants.DepotRolesConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.exportimport.kernel.empty.model.EmptyModelManager;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
@@ -36,6 +39,7 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.search.Indexer;
@@ -72,6 +76,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -669,7 +674,11 @@ public class ObjectEntryFolderLocalServiceImpl
 				ModelPermissions modelPermissions =
 					serviceContext.getModelPermissions();
 
-				if (modelPermissions == null) {
+				if ((modelPermissions == null) ||
+					!Objects.equals(
+						modelPermissions.getResourceName(),
+						ObjectEntryFolder.class.getName())) {
+
 					modelPermissions = ModelPermissionsFactory.create(
 						ObjectEntryFolder.class.getName());
 
@@ -682,6 +691,18 @@ public class ObjectEntryFolderLocalServiceImpl
 				modelPermissions.addRolePermissions(
 					DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER,
 					ActionKeys.ADD_ENTRY, ActionKeys.VIEW);
+
+				if (group.isDepot()) {
+					DepotEntry depotEntry =
+						_depotEntryLocalService.getGroupDepotEntry(
+							group.getGroupId());
+
+					if (depotEntry.getType() == DepotConstants.TYPE_SPACE) {
+						modelPermissions.addRolePermissions(
+							RoleConstants.CMS_ADMINISTRATOR,
+							ActionKeys.ADD_ENTRY, ActionKeys.VIEW);
+					}
+				}
 			}
 
 			_resourceLocalService.addModelResources(
@@ -1063,6 +1084,9 @@ public class ObjectEntryFolderLocalServiceImpl
 
 	@Reference
 	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Reference
 	private EmptyModelManager _emptyModelManager;

--- a/modules/apps/object/object-test/build.gradle
+++ b/modules/apps/object/object-test/build.gradle
@@ -79,6 +79,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:sharing:sharing-api")
 	testIntegrationImplementation project(":apps:sharing:sharing-test-util")
 	testIntegrationImplementation project(":apps:site:site-api")
+	testIntegrationImplementation project(":apps:site:site-cms-site-initializer-api")
 	testIntegrationImplementation project(":apps:site:site-cms-site-initializer-test-util")
 	testIntegrationImplementation project(":apps:staging:staging-api")
 	testIntegrationImplementation project(":apps:static:osgi:osgi-util")

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryFolderLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryFolderLocalServiceTest.java
@@ -6,7 +6,10 @@
 package com.liferay.object.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.constants.DepotRolesConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.report.constants.ExportImportReportEntryConstants;
 import com.liferay.exportimport.report.model.ExportImportReportEntry;
@@ -61,6 +64,7 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+import com.liferay.site.cms.site.initializer.util.RoleUtil;
 import com.liferay.trash.model.TrashEntry;
 import com.liferay.trash.service.TrashEntryLocalService;
 
@@ -205,6 +209,33 @@ public class ObjectEntryFolderLocalServiceTest {
 		role = _roleLocalService.fetchRole(
 			TestPropsValues.getCompanyId(),
 			DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
+
+		Assert.assertTrue(
+			_resourcePermissionLocalService.hasResourcePermission(
+				TestPropsValues.getCompanyId(),
+				ObjectEntryFolder.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(objectEntryFolder.getObjectEntryFolderId()),
+				role.getRoleId(), ActionKeys.ADD_ENTRY));
+
+		role = RoleUtil.getOrAddCMSAdministratorRole(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId());
+
+		Assert.assertFalse(
+			_resourcePermissionLocalService.hasResourcePermission(
+				TestPropsValues.getCompanyId(),
+				ObjectEntryFolder.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(objectEntryFolder.getObjectEntryFolderId()),
+				role.getRoleId(), ActionKeys.ADD_ENTRY));
+
+		DepotEntry depotEntry = _getDepotEntry();
+
+		objectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					"L_CONTENTS", depotEntry.getGroupId(),
+					depotEntry.getCompanyId());
 
 		Assert.assertTrue(
 			_resourcePermissionLocalService.hasResourcePermission(
@@ -776,6 +807,20 @@ public class ObjectEntryFolderLocalServiceTest {
 		Assert.assertEquals(expectedStatus, objectEntry.getStatus());
 	}
 
+	private DepotEntry _getDepotEntry() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		serviceContext.setAddGroupPermissions(false);
+		serviceContext.setAddGuestPermissions(false);
+
+		return _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			null, DepotConstants.TYPE_SPACE, serviceContext);
+	}
+
 	private void _testCopyObjectEntryFolder(long groupId) throws Exception {
 		ObjectEntryFolder objectEntryFolder1 =
 			ObjectEntryFolderTestUtil.addObjectEntryFolder(groupId);
@@ -1057,6 +1102,9 @@ public class ObjectEntryFolderLocalServiceTest {
 			_objectEntryLocalService.getObjectEntryFolderObjectEntriesCount(
 				groupId, objectEntryFolder1.getObjectEntryFolderId()));
 	}
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Inject
 	private ExportImportReportEntryLocalService


### PR DESCRIPTION
Redirected from: https://github.com/liferay-content-management/liferay-portal/pull/7771

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-79172

A CMS Administrator can create assets but he/she cannot see them

# How am I fixing it?

The problem was that the assets where being created but inside no object entry folder, because the CMS Admin doesn't have the permission to create assets into the root object entry folder L_CONTENTS or L_FILES.

This was a lack of permission for the root folders only, because new subfolders allow the CMS Admin to create assets.

The solution was to add the permission during the creation of a object entry folder, as it is already being done with permissions for ASSET_LIBRARY_ADMINISTRATOR and ASSET_LIBRARY_CONTENT_REVIEWER.

Another place where we can add the missing permission could be `ObjectEntryFolderUtil.addObjectEntryFolders` which is where the root folders are being created.

# How can you verify that it works?

`cd modules/apps/object/object-test`

`gw tI --tests "ObjectEntryFolderLocalServiceTest.testAddObjectEntryFolder"`