### PR TITLE
LPD-79722 Broken mock HttpServletRequest trigger NPE when indexing La…

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutServiceContextHelperImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutServiceContextHelperImpl.java
@@ -322,7 +322,11 @@ public class LayoutServiceContextHelperImpl
 					}
 
 					public String getRequestURI() {
-						return StringPool.BLANK;
+						return StringPool.SLASH;
+					}
+
+					public String getScheme() {
+						return "http";
 					}
 
 					public ServletContext getServletContext() {


### PR DESCRIPTION
…youts. Caused by 4658e9faf41050ebbc2bc49faa32e7a5f2cf7c9b

2026-02-19 03:52:48.217 ERROR [SystemExecutorServiceUtil-28][IncludeTag:119] Current URL null generates exception: java.lang.NullPointerException: Cannot invoke "String.equals(Object)" because "scheme" is null java.lang.NullPointerException: Cannot invoke "String.equals(Object)" because "scheme" is null
	at org.apache.catalina.util.RequestUtil.getRequestURL(RequestUtil.java:48) ~[catalina.jar:10.1.48]
	at org.apache.catalina.core.ApplicationHttpRequest.getRequestURL(ApplicationHttpRequest.java:488) ~[catalina.jar:10.1.48]
	at jakarta.servlet.http.HttpServletRequestWrapper.getRequestURL(HttpServletRequestWrapper.java:205) ~[servlet-api.jar:6.0]
	at com.liferay.portal.kernel.util.HttpComponentsUtil.getCompleteURL(HttpComponentsUtil.java:213) ~[portal-kernel.jar:?]
	at com.liferay.portal.util.PortalImpl.getCurrentURL(PortalImpl.java:2142) ~[portal-impl.jar:?]
	at com.liferay.portal.kernel.util.PortalUtil.getCurrentURL(PortalUtil.java:650) ~[portal-kernel.jar:?]
	at org.apache.jsp.html.taglib.aui.input.page_jsp._jspService(page_jsp.java:606) ~[?:?]
	at org.apache.jasper.runtime.HttpJspBase.service(HttpJspBase.java:62) ~[jasper.jar:10.1.48]
	at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:658) ~[servlet-api.jar:6.0]
	at org.apache.jasper.servlet.JspServletWrapper.service(JspServletWrapper.java:428) ~[jasper.jar:10.1.48]
	at org.apache.jasper.servlet.JspServlet.serviceJspFile(JspServlet.java:350) ~[jasper.jar:10.1.48]
	at org.apache.jasper.servlet.JspServlet.service(JspServlet.java:301) ~[jasper.jar:10.1.48]
	at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:658) ~[servlet-api.jar:6.0]
	at com.liferay.shielded.container.internal.proxy.ServletWrapper.service(ServletWrapper.java:103) ~[com.liferay.shielded.container.impl.jar:?]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[catalina.jar:10.1.48]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:138) ~[catalina.jar:10.1.48]
	at com.liferay.portal.kernel.servlet.filters.invoker.InvokerFilterChain.doFilter(InvokerFilterChain.java:117) ~[portal-kernel.jar:?]
	at com.liferay.portal.kernel.servlet.filters.invoker.InvokerFilter.doFilter(InvokerFilter.java:114) ~[portal-kernel.jar:?]
	at com.liferay.shielded.container.internal.proxy.FilterWrapper.doFilter(FilterWrapper.java:69) ~[com.liferay.shielded.container.impl.jar:?]