### PR TITLE
LPD-79782 Async bulk request executing so that the ES communication c…

### DIFF
--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterImpl.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterImpl.java
@@ -7,6 +7,7 @@ package com.liferay.portal.search.elasticsearch7.internal.search.engine.adapter;
 
 import com.liferay.petra.lang.CentralizedThreadLocal;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.kernel.concurrent.SystemExecutorServiceUtil;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.SearchContext;
@@ -43,6 +44,10 @@ import com.liferay.portal.search.engine.adapter.snapshot.SnapshotResponse;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.elasticsearch.index.query.QueryBuilder;
 
@@ -153,18 +158,36 @@ public class ElasticsearchSearchEngineAdapterImpl
 				return null;
 			}
 
-			try {
-				S documentResponse =
-					(S)_documentRequestExecutor.executeBulkDocumentRequest(
-						bulkDocumentRequest);
+			BulkDocumentRequest transferCopyBulkDocumentRequest =
+				bulkDocumentRequest.transferCopy();
 
-				bulkableDocumentRequests.clear();
+			AtomicReference<Future<?>> futureReference =
+				new AtomicReference<>();
 
-				return documentResponse;
-			}
-			catch (RuntimeException runtimeException) {
-				throw _getRuntimeException(runtimeException);
-			}
+			FutureTask<?> futureTask = new FutureTask<Void>(
+				() -> {
+					try {
+						_documentRequestExecutor.executeBulkDocumentRequest(
+							transferCopyBulkDocumentRequest);
+					}
+					finally {
+						SearchContext.unregisterBatchModeSyncFuture(
+							futureReference.get());
+					}
+
+					return null;
+				});
+
+			futureReference.set(futureTask);
+
+			SearchContext.registerBatchModeSyncFuture(futureTask);
+
+			ExecutorService executorService =
+				SystemExecutorServiceUtil.getExecutorService();
+
+			executorService.execute(futureTask);
+
+			return null;
 		}
 
 		try {

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterImpl.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterImpl.java
@@ -9,6 +9,7 @@ import co.elastic.clients.elasticsearch._types.query_dsl.QueryVariant;
 
 import com.liferay.petra.lang.CentralizedThreadLocal;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.kernel.concurrent.SystemExecutorServiceUtil;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.SearchContext;
@@ -45,6 +46,10 @@ import com.liferay.portal.search.engine.adapter.snapshot.SnapshotResponse;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -153,18 +158,36 @@ public class ElasticsearchSearchEngineAdapterImpl
 				return null;
 			}
 
-			try {
-				S documentResponse =
-					(S)_documentRequestExecutor.executeBulkDocumentRequest(
-						bulkDocumentRequest);
+			BulkDocumentRequest transferCopyBulkDocumentRequest =
+				bulkDocumentRequest.transferCopy();
 
-				bulkableDocumentRequests.clear();
+			AtomicReference<Future<?>> futureReference =
+				new AtomicReference<>();
 
-				return documentResponse;
-			}
-			catch (RuntimeException runtimeException) {
-				throw _getRuntimeException(runtimeException);
-			}
+			FutureTask<?> futureTask = new FutureTask<Void>(
+				() -> {
+					try {
+						_documentRequestExecutor.executeBulkDocumentRequest(
+							transferCopyBulkDocumentRequest);
+					}
+					finally {
+						SearchContext.unregisterBatchModeSyncFuture(
+							futureReference.get());
+					}
+
+					return null;
+				});
+
+			futureReference.set(futureTask);
+
+			SearchContext.registerBatchModeSyncFuture(futureTask);
+
+			ExecutorService executorService =
+				SystemExecutorServiceUtil.getExecutorService();
+
+			executorService.execute(futureTask);
+
+			return null;
 		}
 
 		try {

--- a/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/BulkDocumentRequest.java
+++ b/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/BulkDocumentRequest.java
@@ -42,6 +42,17 @@ public class BulkDocumentRequest
 		_refresh = refresh;
 	}
 
+	public BulkDocumentRequest transferCopy() {
+		BulkDocumentRequest bulkDocumentRequest = new BulkDocumentRequest();
+
+		bulkDocumentRequest._bulkableDocumentRequests.addAll(
+			_bulkableDocumentRequests);
+
+		_bulkableDocumentRequests.clear();
+
+		return bulkDocumentRequest;
+	}
+
 	private final List<BulkableDocumentRequest<?>> _bulkableDocumentRequests =
 		new ArrayList<>();
 	private boolean _refresh;


### PR DESCRIPTION
…an go concurrently with reindexer's ActionableDynamicQuery process. Normally DB and ES are 2 separate servers, doing this can convert the sequential external service IO bottlenecks into parallel bottlenecks. We no longer bonds to the sum of them, but only to the longer of the two.