### PR TITLE
Lpd 79783 4

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -3345,6 +3345,7 @@ tenantId=&quot;${ms.exchange.tenant.id}&quot;</echo>
 	<macrodef name="prepare-portal-elasticsearch-osgi-configuration">
 		<sequential>
 			<echo file="${liferay.home}/osgi/configs/com.liferay.portal.search.elasticsearch8.configuration.ElasticsearchConfiguration.config">additionalConfigurations="http.host:\ _local_,_site_"${line.separator}logExceptionsOnly=B"false"${line.separator}sidecarShutdownTimeout=L"20000"${line.separator}sidecarHttpPort="AUTO"${line.separator}sidecarJVMOptions=["-Xms256m","-Xmx512m"]</echo>
+			<echo file="${liferay.home}/osgi/configs/com.liferay.portal.search.internal.background.task.ReindexPortalBackgroundTaskExecutor.config">parallelIndexing=B"false"</echo>
 		</sequential>
 	</macrodef>
 

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/ReindexPortalBackgroundTaskExecutor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/ReindexPortalBackgroundTaskExecutor.java
@@ -15,12 +15,14 @@ import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.background.task.ReindexBackgroundTaskConstants;
 import com.liferay.portal.kernel.search.background.task.ReindexStatusMessageSenderUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.search.index.ConcurrentReindexManager;
 import com.liferay.portal.search.index.SyncReindexManager;
 import com.liferay.portal.search.internal.SearchEngineInitializer;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
@@ -45,8 +47,13 @@ public class ReindexPortalBackgroundTaskExecutor
 	}
 
 	@Activate
-	protected void activate(BundleContext bundleContext) {
+	protected void activate(
+		BundleContext bundleContext, Map<String, Object> properties) {
+
 		_bundleContext = bundleContext;
+
+		_parallelIndexing = GetterUtil.getBoolean(
+			properties.get("parallelIndexing"), true);
 	}
 
 	@Override
@@ -54,67 +61,72 @@ public class ReindexPortalBackgroundTaskExecutor
 			String className, long[] companyIds, String executionMode)
 		throws Exception {
 
-		ExecutorService executorService =
-			_portalExecutorManager.getPortalExecutor(
-				ReindexPortalBackgroundTaskExecutor.class.getName());
+		if (_parallelIndexing) {
+			ExecutorService executorService =
+				_portalExecutorManager.getPortalExecutor(
+					ReindexPortalBackgroundTaskExecutor.class.getName());
 
-		List<Future<?>> futures = new ArrayList<>();
+			List<Future<?>> futures = new ArrayList<>();
 
-		try (SafeCloseable safeCloseable = SearchContext.openBatchMode()) {
-			for (long companyId : companyIds) {
-				futures.add(
-					executorService.submit(
-						() -> {
-							ReindexStatusMessageSenderUtil.sendStatusMessage(
-								ReindexBackgroundTaskConstants.PORTAL_START,
-								companyId, companyIds);
+			try (SafeCloseable safeCloseable = SearchContext.openBatchMode()) {
+				for (long companyId : companyIds) {
+					futures.add(
+						executorService.submit(
+							() -> {
+								_reindex(companyId, companyIds, executionMode);
 
-							if (_log.isInfoEnabled()) {
-								_log.info(
-									StringBundler.concat(
-										"Start reindexing company ", companyId,
-										" with execution mode ",
-										executionMode));
-							}
+								return null;
+							}));
+				}
 
-							try {
-								SearchEngineInitializer
-									searchEngineInitializer =
-										new SearchEngineInitializer(
-											_bundleContext, companyId,
-											_concurrentReindexManagerSnapshot.
-												get(),
-											executionMode,
-											_portalExecutorManager,
-											_syncReindexManagerSnapshot.get());
-
-								searchEngineInitializer.reindex();
-							}
-							catch (Exception exception) {
-								_log.error(exception);
-							}
-							finally {
-								ReindexStatusMessageSenderUtil.
-									sendStatusMessage(
-										ReindexBackgroundTaskConstants.
-											PORTAL_END,
-										companyId, companyIds);
-
-								if (_log.isInfoEnabled()) {
-									_log.info(
-										StringBundler.concat(
-											"Finished reindexing company ",
-											companyId, " with execution mode ",
-											executionMode));
-								}
-							}
-
-							return null;
-						}));
+				for (Future<?> future : futures) {
+					future.get();
+				}
 			}
+		}
+		else {
+			for (long companyId : companyIds) {
+				_reindex(companyId, companyIds, executionMode);
+			}
+		}
+	}
 
-			for (Future<?> future : futures) {
-				future.get();
+	private void _reindex(
+			long companyId, long[] companyIds, String executionMode)
+		throws Exception {
+
+		ReindexStatusMessageSenderUtil.sendStatusMessage(
+			ReindexBackgroundTaskConstants.PORTAL_START, companyId, companyIds);
+
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				StringBundler.concat(
+					"Start reindexing company ", companyId,
+					" with execution mode ", executionMode));
+		}
+
+		try {
+			SearchEngineInitializer searchEngineInitializer =
+				new SearchEngineInitializer(
+					_bundleContext, companyId,
+					_concurrentReindexManagerSnapshot.get(), executionMode,
+					_portalExecutorManager, _syncReindexManagerSnapshot.get());
+
+			searchEngineInitializer.reindex();
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+		}
+		finally {
+			ReindexStatusMessageSenderUtil.sendStatusMessage(
+				ReindexBackgroundTaskConstants.PORTAL_END, companyId,
+				companyIds);
+
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					StringBundler.concat(
+						"Finished reindexing company ", companyId,
+						" with execution mode ", executionMode));
 			}
 		}
 	}
@@ -132,6 +144,7 @@ public class ReindexPortalBackgroundTaskExecutor
 			null, true);
 
 	private BundleContext _bundleContext;
+	private boolean _parallelIndexing;
 
 	@Reference
 	private PortalExecutorManager _portalExecutorManager;


### PR DESCRIPTION
@vicnate5 @nikki-pru @jeffwu0724 I will need some help from CI team for this commit https://github.com/brianchandotcom/liferay-portal/commit/d5311842ff54f84fe19d1970a044b558c48cafc8

The problem is, the out of box sidecar heap settings is not big enough to support concurrent companies indexing for certain CI tests. I think only the search upgrade tests are affected, due to the data amount is relatively speaking large. Once we concurrently dumping data into ES, it crashes the sidecar.

Since CI has limited memory, I don't want to bump the heap size, but selectively disable the parallel companies indexing for those data heavy test case.

Right now, I am disabling it for all CI tests. I need someone to help to shrink the scope to only those tests.