### PR TITLE
Lpd 77956

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/XMLEmptyLinesCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/XMLEmptyLinesCheck.java
@@ -5,6 +5,7 @@
 
 package com.liferay.source.formatter.check;
 
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.source.formatter.check.util.XMLSourceUtil;
 
@@ -52,7 +53,7 @@ public class XMLEmptyLinesCheck extends BaseEmptyLinesCheck {
 		if (fileName.startsWith(getBaseDirName() + "build") ||
 			fileName.matches(".*/(build|tools/).*")) {
 
-			return content;
+			return _fixEmptyLinesBetweenTagsInBuildFile(content);
 		}
 
 		if (fileName.endsWith("-log4j-ext.xml") ||
@@ -72,6 +73,36 @@ public class XMLEmptyLinesCheck extends BaseEmptyLinesCheck {
 
 			return StringUtil.replaceFirst(
 				content, "\n\n", "\n", matcher.end(1));
+		}
+
+		return content;
+	}
+
+	private String _fixEmptyLinesBetweenTagsInBuildFile(String content) {
+		Matcher matcher =
+			_emptyLineBetweenSiblingTagsInBuildFilePattern.matcher(content);
+
+		while (matcher.find()) {
+			String tabs1 = matcher.group(1);
+			String tabs2 = matcher.group(4);
+
+			if (!tabs1.equals(tabs2)) {
+				continue;
+			}
+
+			String lineBreaks = matcher.group(3);
+			String tagName2 = matcher.group(5);
+
+			if (ArrayUtil.contains(_CONDITIONAL_TAG_NAMES, tagName2)) {
+				if (lineBreaks.equals("\n\n")) {
+					return StringUtil.replaceFirst(
+						content, "\n\n", "\n", matcher.end(1));
+				}
+			}
+			else if (lineBreaks.equals("\n")) {
+				return StringUtil.replaceFirst(
+					content, "\n", "\n\n", matcher.end(1));
+			}
 		}
 
 		return content;
@@ -138,6 +169,13 @@ public class XMLEmptyLinesCheck extends BaseEmptyLinesCheck {
 		return content;
 	}
 
+	private static final String[] _CONDITIONAL_TAG_NAMES = {
+		"else", "elseif", "then"
+	};
+
+	private static final Pattern _emptyLineBetweenSiblingTagsInBuildFilePattern =
+		Pattern.compile(
+			"\n(\t*)</([-\\w:]+)>(\n+)(\t*)<([-\\w:]+)[> \n]");
 	private static final Pattern _emptyLineBetweenTagsPattern = Pattern.compile(
 		"\n(\t*)<[\\w/].*[^-]>(\n\n)(\t*)<(\\w)");
 	private static final Pattern _emptyLineInTagPattern1 = Pattern.compile(

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/XMLSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/XMLSourceProcessorTest.java
@@ -13,6 +13,11 @@ import org.junit.Test;
 public class XMLSourceProcessorTest extends BaseSourceProcessorTestCase {
 
 	@Test
+	public void testIncorrectEmptyLinesInBuildXML() throws Exception {
+		test("build-IncorrectEmptyLines.testxml");
+	}
+
+	@Test
 	public void testIncorrectEmptyLines() throws Exception {
 		test("IncorrectEmptyLines1.testxml");
 		test("IncorrectEmptyLines2.testxml");

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/build-IncorrectEmptyLines.testxml
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/build-IncorrectEmptyLines.testxml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+
+<project basedir="." default="test" name="test">
+	<target name="test">
+		<if>
+			<equals arg1="${test}" arg2="true" />
+			<then>
+				<echo>true</echo>
+			</then>
+
+			<else>
+				<echo>false</echo>
+			</else>
+		</if>
+		<delete dir="${test.dir}" />
+	</target>
+</project>

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/build-IncorrectEmptyLines.testxml
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/build-IncorrectEmptyLines.testxml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+
+<project basedir="." default="test" name="test">
+	<target name="test">
+		<if>
+			<equals arg1="${test}" arg2="true" />
+			<then>
+				<echo>true</echo>
+			</then>
+			<else>
+				<echo>false</echo>
+			</else>
+		</if>
+
+		<delete dir="${test.dir}" />
+	</target>
+</project>


### PR DESCRIPTION
Changes made

  1. XMLEmptyLinesCheck.java — The main fix:
  - Added ArrayUtil import
  - Changed _fixEmptyLinesBetweenTags to call _fixEmptyLinesBetweenTagsInBuildFile(content) instead of returning early for build files
  - Added _fixEmptyLinesBetweenTagsInBuildFile method that uses a regex to match closing/opening tag pairs at the same indent level:
    - Conditional tags (else, elseif, then): removes empty lines between them (like Java's } else {)
    - Other sibling tags: adds an empty line if missing
  - Added _CONDITIONAL_TAG_NAMES constant and _emptyLineBetweenSiblingTagsInBuildFilePattern pattern

  2. Test fixtures (new files):
  - build-IncorrectEmptyLines.testxml — Input with a redundant empty line between </then> and <else>, and a missing empty line between
  </if> and <delete>
  - expected/build-IncorrectEmptyLines.testxml — Expected output with both issues fixed

  3. XMLSourceProcessorTest.java — Added testIncorrectEmptyLinesInBuildXML test method

  Note: The test file was named build-IncorrectEmptyLines.testxml (starting with build) so it matches the build file detection regex
  .*/(build|tools/).* in the check. The plan's suggested name IncorrectEmptyLinesInBuildXML wouldn't have triggered the build file code
  path.