### PR TITLE
LPD-79250 Followup

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DatabaseTableAndColumnCaseDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DatabaseTableAndColumnCaseDataCleanupPreupgradeProcess.java
@@ -162,7 +162,7 @@ public class DatabaseTableAndColumnCaseDataCleanupPreupgradeProcess
 			DataCleanupLoggingUtil.logRename(
 				_log, tableName + StringPool.PERIOD + columnName,
 				tableName + StringPool.PERIOD + expectedColumnName,
-				"it had an incorrect column name casing");
+				" because it was incorrectly cased");
 
 			int index = columnDefinition.indexOf(StringPool.SPACE);
 


### PR DESCRIPTION
Not necessary to specify that the column is incorrect.

Align the error message with the one from the test.