### PR TITLE
LPD-80062 Fail in upgrade poshi tests in case of errors | Fix servicecomponent com.liferay.changeset.service is outdated error

### DIFF
--- a/modules/apps/changeset/changeset-service/src/main/resources/service.properties
+++ b/modules/apps/changeset/changeset-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.changeset.service
-    build.number=1
-    build.date=1525361743173
+    build.number=2
+    build.date=1771891431368

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalContinuousUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalContinuousUpgrade.testcase
@@ -59,7 +59,7 @@ definition {
 	@priority = 4
 	test AutoUpgradeFromLatest7413UpdateWithDBPartitionEnabled {
 		property custom.properties = "virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";
-		property database.types = "mysql";
+		property database.types = "mysql,postgresql";
 		property liferay.online.properties = "true";
 		property timeout.explicit.wait = "120";
 
@@ -125,7 +125,7 @@ definition {
 
 	@priority = 4
 	test AutoUpgradeFromLatest7413UpdateWithDBPartitionEnabledAndHeadlessAPI {
-		property database.types = "mysql";
+		property database.types = "mysql,postgresql";
 		property liferay.online.properties = "true";
 
 		User.firstLoginPG(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalContinuousUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalContinuousUpgrade.testcase
@@ -10,6 +10,7 @@ definition {
 	property portal.smoke.upgrades = "false";
 	property portal.upstream = "true";
 	property skip.start.app.server = "true";
+	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
 	property test.run.type = "single";
 	property testcase.url = "file:///opt/dev/projects/github/liferay-portal/";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalDatabaseValidationUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalDatabaseValidationUpgrade.testcase
@@ -7,6 +7,7 @@ definition {
 	property database.types = "mysql";
 	property portal.release = "true";
 	property portal.upstream = "true";
+	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
 	property test.run.type = "single";
 	property testray.main.component.name = "Database Upgrade Framework";


### PR DESCRIPTION
Manually forwarded from https://github.com/liferay-database-infra/liferay-portal/pull/3317. Tests were executed there

> I am setting `property test.assert.warning.exceptions = "true";` to PortalContinuousUpgrade.testcase and PortalDatabaseValidationUpgrade.testcase upgrade poshi tests so they will fail in case of any error during the upgrade execution
> 
> I am also updating the service.properties of changeset-service to avoid the detected error 
> ```
> 2026-02-23 16:28:30.386 ERROR [main][ServiceComponentPostUpgradeDataCleanupProcess:120] Content of table servicecomponent for bundle com.liferay.changeset.service is outdated
> ```
> after activating `property test.assert.warning.exceptions = "true";`