### PR TITLE
LPD-80210 Fix compile error (portletId renamed to targetPortletId)

### DIFF
--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/exportimport/data/handler/StagedGroupStagedModelDataHandler.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/exportimport/data/handler/StagedGroupStagedModelDataHandler.java
@@ -664,7 +664,8 @@ public class StagedGroupStagedModelDataHandler
 
 				if (importPortletControlsMap.get(
 						PortletDataHandlerKeys.PORTLET_DATA) ||
-					_isHidden(portletDataContext.getCompanyId(), portletId)) {
+					_isHidden(
+						portletDataContext.getCompanyId(), targetPortletId)) {
 
 					_portletImportController.importPortletData(
 						portletDataContext, portletDataElement);


### PR DESCRIPTION
[LPD-80210](https://liferay.atlassian.net/browse/LPD-80210)

Fix compile error: `portletId` was renamed to `targetPortletId` by https://github.com/liferay/liferay-portal/commit/04fd6d977b0f1da5a2ccac4ca2045768f0b7715d