### PR TITLE
LPD-78764 Fix Object Entries Portlet import when the classname of the Object Definition is different

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletImportControllerImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletImportControllerImpl.java
@@ -45,6 +45,8 @@ import com.liferay.exportimport.kernel.staging.Staging;
 import com.liferay.exportimport.lar.DeletionSystemEventImporter;
 import com.liferay.exportimport.lar.PermissionImporter;
 import com.liferay.exportimport.portlet.data.handler.provider.PortletDataHandlerProvider;
+import com.liferay.exportimport.portlet.element.handler.PortletElementHandler;
+import com.liferay.exportimport.portlet.element.handler.PortletElementHandlerFactory;
 import com.liferay.exportimport.portlet.preferences.processor.Capability;
 import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
 import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessorRegistryUtil;
@@ -1148,23 +1150,30 @@ public class PortletImportControllerImpl implements PortletImportController {
 		String expectedRootPortletId = PortletIdCodec.decodePortletName(
 			portletId);
 
-		if (!expectedRootPortletId.equals(rootPortletId)) {
+		PortletElementHandler portletElementHandler =
+			_portletElementHandlerFactory.create(
+				rootElement.element("portlet"));
+
+		String targetPortletId = portletElementHandler.getTargetPortletId(
+			companyId);
+
+		if (!expectedRootPortletId.equals(rootPortletId) &&
+			!expectedRootPortletId.equals(targetPortletId)) {
+
 			throw new PortletIdException(expectedRootPortletId);
 		}
 
-		Element portletElement = rootElement.element("portlet");
-
 		String schemaVersion = GetterUtil.getString(
-			portletElement.attributeValue("schema-version"), "1.0.0");
+			portletElementHandler.getSchemaVersion(), "1.0.0");
 
 		PortletDataHandler portletDataHandler =
-			_portletDataHandlerProvider.provide(companyId, portletId);
+			_portletDataHandlerProvider.provide(companyId, targetPortletId);
 
 		if (!portletDataHandler.validateSchemaVersion(schemaVersion)) {
 			throw new LayoutImportException(
 				LayoutImportException.TYPE_WRONG_PORTLET_SCHEMA_VERSION,
 				new Object[] {
-					schemaVersion, portletId,
+					schemaVersion, targetPortletId,
 					portletDataHandler.getSchemaVersion()
 				});
 		}
@@ -1548,6 +1557,9 @@ public class PortletImportControllerImpl implements PortletImportController {
 	@Reference
 	private PortletDataHandlerStatusMessageSender
 		_portletDataHandlerStatusMessageSender;
+
+	@Reference
+	private PortletElementHandlerFactory _portletElementHandlerFactory;
 
 	@Reference
 	private PortletItemLocalService _portletItemLocalService;

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
@@ -322,8 +322,9 @@ public class BatchEnginePortletDataHandler extends BasePortletDataHandler {
 		_updatePortletDataHandlerControls();
 	}
 
-	public void unregisterExportImportVulcanBatchEngineTaskItemDelegate(
-		String batchEngineClassName, String taskItemDelegateName) {
+	public ExportImportVulcanBatchEngineTaskItemDelegate.ExportImportDescriptor
+		unregisterExportImportVulcanBatchEngineTaskItemDelegate(
+			String batchEngineClassName, String taskItemDelegateName) {
 
 		Iterator<Registration> iterator = _registrations.iterator();
 
@@ -342,9 +343,11 @@ public class BatchEnginePortletDataHandler extends BasePortletDataHandler {
 				_updateDeletionSystemEventStagedModelTypes();
 				_updatePortletDataHandlerControls();
 
-				return;
+				return registration.getExportImportDescriptor();
 			}
 		}
+
+		return null;
 	}
 
 	@Override

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandlerRegistrar.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandlerRegistrar.java
@@ -15,16 +15,10 @@ import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngin
 import com.liferay.osgi.service.tracker.collections.EagerServiceTrackerCustomizer;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
-import com.liferay.petra.concurrent.DCLSingleton;
-import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener;
-import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.staging.StagingGroupHelper;
@@ -32,9 +26,6 @@ import com.liferay.staging.StagingGroupHelper;
 import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
@@ -52,105 +43,33 @@ public class BatchEnginePortletDataHandlerRegistrar {
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
-		_portalInstanceLifecycleListenerServiceRegistration =
-			bundleContext.registerService(
-				PortalInstanceLifecycleListener.class,
-				new BasePortalInstanceLifecycleListener() {
-
-					@Override
-					public void portalInstanceRegistered(Company company) {
-						_registerCompany(
-							bundleContext, company.getCompanyId(), true);
-					}
-
-					@Override
-					public void portalInstanceUnregistered(Company company) {
-						_registerCompany(
-							bundleContext, company.getCompanyId(), false);
-					}
-
-				},
-				null);
+		_serviceTrackerList = ServiceTrackerListFactory.open(
+			bundleContext, null,
+			"(export.import.vulcan.batch.engine.task.item.delegate=true)",
+			new VulcanBatchEngineTaskItemDelegateServiceTrackerCustomizer(
+				bundleContext));
 	}
 
 	@Deactivate
 	protected void deactivate() {
-		_portalInstanceLifecycleListenerServiceRegistration.unregister();
-
-		_serviceTrackerListDCLSingleton.destroy(ServiceTrackerList::close);
+		_serviceTrackerList.close();
 	}
 
-	private void _registerCompany(
-		BundleContext bundleContext, long companyId, boolean enabled) {
-
-		if (enabled) {
-			if (_enabledCompanyIds.contains(companyId)) {
-				return;
-			}
-
-			_enabledCompanyIds.add(companyId);
-		}
-		else {
-			_enabledCompanyIds.remove(companyId);
-		}
-
-		if (_enabledCompanyIds.isEmpty()) {
-			_serviceTrackerListDCLSingleton.destroy(ServiceTrackerList::close);
-
-			return;
-		}
-
-		AtomicBoolean newOpen = new AtomicBoolean();
-
-		_serviceTrackerListDCLSingleton.getSingleton(
-			() -> {
-				newOpen.set(true);
-
-				return ServiceTrackerListFactory.open(
-					bundleContext, null,
-					"(export.import.vulcan.batch.engine.task.item." +
-						"delegate=true)",
-					new VulcanBatchEngineTaskItemDelegateServiceTrackerCustomizer(
-						bundleContext, companyId));
-			});
-
-		if (newOpen.get()) {
-			return;
-		}
-
-		for (ServiceRegistration<PortletDataHandler> serviceRegistration :
-				_serviceRegistrations.values()) {
-
-			Dictionary<String, Object> properties = _toProperties(
-				serviceRegistration.getReference());
-
-			serviceRegistration.setProperties(
-				_setEnabledCompanyIds(properties));
-		}
-	}
-
-	private Dictionary<String, Object> _setEnabledCompanyIds(
-		Dictionary<String, Object> properties) {
+	private Dictionary<String, Object> _setEnabledCompanyId(
+		long companyId, Dictionary<String, Object> properties) {
 
 		return HashMapDictionaryBuilder.<String, Object>putAll(
 			properties
 		).put(
-			"companyId", ArrayUtil.toStringArray(_enabledCompanyIds)
+			"companyId",
+			() -> {
+				if (companyId == 0) {
+					return null;
+				}
+
+				return String.valueOf(companyId);
+			}
 		).build();
-	}
-
-	private Dictionary<String, Object> _toProperties(
-		ServiceReference<?> serviceReference) {
-
-		Dictionary<String, Object> properties = new HashMapDictionary<>();
-
-		for (String key : serviceReference.getPropertyKeys()) {
-			Object value = serviceReference.getProperty(key);
-
-			properties.put(key, value);
-		}
-
-		return properties;
 	}
 
 	@Reference
@@ -172,21 +91,16 @@ public class BatchEnginePortletDataHandlerRegistrar {
 	@Reference
 	private ClassNameLocalService _classNameLocalService;
 
-	private final Set<Long> _enabledCompanyIds = new CopyOnWriteArraySet<>();
-
 	@Reference
 	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;
 
-	private ServiceRegistration<PortalInstanceLifecycleListener>
-		_portalInstanceLifecycleListenerServiceRegistration;
 	private final Map<String, ServiceRegistration<PortletDataHandler>>
-		_serviceRegistrations = new HashMap<>();
-	private final DCLSingleton
-		<ServiceTrackerList<ServiceRegistration<PortletDataHandler>>>
-			_serviceTrackerListDCLSingleton = new DCLSingleton<>();
+		_portletIdServiceRegistrations = new HashMap<>();
+	private ServiceTrackerList<ServiceRegistration<PortletDataHandler>>
+		_serviceTrackerList;
 
 	@Reference
 	private StagingGroupHelper _stagingGroupHelper;
@@ -197,16 +111,18 @@ public class BatchEnginePortletDataHandlerRegistrar {
 			 ServiceRegistration<PortletDataHandler>> {
 
 		public VulcanBatchEngineTaskItemDelegateServiceTrackerCustomizer(
-			BundleContext bundleContext, long companyId) {
+			BundleContext bundleContext) {
 
 			_bundleContext = bundleContext;
-			_companyId = companyId;
 		}
 
 		@Override
 		public ServiceRegistration<PortletDataHandler> addingService(
 			ServiceReference<VulcanBatchEngineTaskItemDelegate>
 				serviceReference) {
+
+			long companyId = GetterUtil.getLong(
+				serviceReference.getProperty("companyId"));
 
 			ExportImportVulcanBatchEngineTaskItemDelegate<?>
 				exportImportVulcanBatchEngineTaskItemDelegate =
@@ -220,15 +136,11 @@ public class BatchEnginePortletDataHandlerRegistrar {
 
 			String portletId = exportImportDescriptor.getPortletId();
 
-			BatchEnginePortletDataHandler
-				previousBatchEnginePortletDataHandler =
-					BatchEnginePortletDataHandlerRegistryUtil.getByPortletId(
-						_companyId, portletId);
-
 			BatchEnginePortletDataHandler batchEnginePortletDataHandler =
-				previousBatchEnginePortletDataHandler;
+				BatchEnginePortletDataHandlerRegistryUtil.getByPortletId(
+					companyId, portletId);
 
-			if (previousBatchEnginePortletDataHandler == null) {
+			if (batchEnginePortletDataHandler == null) {
 				batchEnginePortletDataHandler =
 					new BatchEnginePortletDataHandler(
 						_batchEngineExportTaskExecutor,
@@ -254,27 +166,27 @@ public class BatchEnginePortletDataHandlerRegistrar {
 					(String)serviceReference.getProperty(
 						"batch.engine.task.item.delegate.name"));
 
-			BatchEnginePortletDataHandlerRegistryUtil.put(
-				batchEnginePortletDataHandler, _companyId,
-				exportImportDescriptor.getKey(), portletId);
+			BatchEnginePortletDataHandlerRegistryUtil.
+				registerBatchEnginePortletDataHandler(
+					batchEnginePortletDataHandler, companyId, portletId);
+			BatchEnginePortletDataHandlerRegistryUtil.registerKey(
+				companyId, exportImportDescriptor.getKey(), portletId);
 
-			if (previousBatchEnginePortletDataHandler != null) {
-				return _serviceRegistrations.get(portletId);
-			}
+			BatchEnginePortletDataHandler finalBatchEnginePortletDataHandler =
+				batchEnginePortletDataHandler;
 
-			ServiceRegistration<PortletDataHandler> serviceRegistration =
-				_bundleContext.registerService(
-					PortletDataHandler.class, batchEnginePortletDataHandler,
-					_setEnabledCompanyIds(
+			return _portletIdServiceRegistrations.computeIfAbsent(
+				portletId,
+				key -> _bundleContext.registerService(
+					PortletDataHandler.class,
+					finalBatchEnginePortletDataHandler,
+					_setEnabledCompanyId(
+						companyId,
 						HashMapDictionaryBuilder.<String, Object>put(
 							"jakarta.portlet.name", portletId
 						).put(
 							"service.ranking", Integer.MAX_VALUE
-						).build()));
-
-			_serviceRegistrations.put(portletId, serviceRegistration);
-
-			return serviceRegistration;
+						).build())));
 		}
 
 		@Override
@@ -290,6 +202,9 @@ public class BatchEnginePortletDataHandlerRegistrar {
 				serviceReference,
 			ServiceRegistration<PortletDataHandler> serviceRegistration) {
 
+			long companyId = GetterUtil.getLong(
+				serviceReference.getProperty("companyId"));
+
 			ExportImportVulcanBatchEngineTaskItemDelegate<?>
 				exportImportVulcanBatchEngineTaskItemDelegate =
 					(ExportImportVulcanBatchEngineTaskItemDelegate<?>)
@@ -304,36 +219,41 @@ public class BatchEnginePortletDataHandlerRegistrar {
 
 			BatchEnginePortletDataHandler batchEnginePortletDataHandler =
 				BatchEnginePortletDataHandlerRegistryUtil.getByPortletId(
-					_companyId, portletId);
+					companyId, portletId);
 
 			if (batchEnginePortletDataHandler == null) {
 				return;
 			}
 
-			batchEnginePortletDataHandler.
-				unregisterExportImportVulcanBatchEngineTaskItemDelegate(
-					GetterUtil.getObject(
+			exportImportDescriptor =
+				batchEnginePortletDataHandler.
+					unregisterExportImportVulcanBatchEngineTaskItemDelegate(
+						GetterUtil.getObject(
+							(String)serviceReference.getProperty(
+								"batch.engine.task.item.delegate.class.name"),
+							() -> (String)serviceReference.getProperty(
+								"batch.engine.entity.class.name")),
 						(String)serviceReference.getProperty(
-							"batch.engine.task.item.delegate.class.name"),
-						() -> (String)serviceReference.getProperty(
-							"batch.engine.entity.class.name")),
-					(String)serviceReference.getProperty(
-						"batch.engine.task.item.delegate.name"));
+							"batch.engine.task.item.delegate.name"));
+
+			if (exportImportDescriptor != null) {
+				BatchEnginePortletDataHandlerRegistryUtil.unregisterKey(
+					companyId, exportImportDescriptor.getKey(), portletId);
+			}
 
 			String[] classNames = batchEnginePortletDataHandler.getClassNames();
 
 			if (classNames.length == 0) {
 				serviceRegistration.unregister();
 
-				BatchEnginePortletDataHandlerRegistryUtil.remove(
-					_companyId, exportImportDescriptor.getKey(), portletId);
+				BatchEnginePortletDataHandlerRegistryUtil.unregister(
+					companyId, portletId);
 
-				_serviceRegistrations.remove(portletId);
+				_portletIdServiceRegistrations.remove(portletId);
 			}
 		}
 
 		private final BundleContext _bundleContext;
-		private final long _companyId;
 
 	}
 

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandlerRegistryUtil.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandlerRegistryUtil.java
@@ -6,7 +6,10 @@
 package com.liferay.exportimport.internal.data.handler;
 
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 /**
  * @author Vendel Toreki
@@ -17,127 +20,167 @@ public class BatchEnginePortletDataHandlerRegistryUtil {
 	public static BatchEnginePortletDataHandler getByClassName(
 		long companyId, String className) {
 
-		return getByPortletId(companyId, _getPortletId(companyId, className));
-	}
-
-	public static BatchEnginePortletDataHandler getByPortletId(
-		long companyId, String portletId) {
-
-		Map<String, BatchEnginePortletDataHandler>
-			batchEnginePortletDataHandlers =
-				_batchEnginePortletDataHandlersMap.get(companyId);
-
-		if (batchEnginePortletDataHandlers == null) {
+		if (!_classNamePortletIdsMap.containsKey(className)) {
 			return null;
 		}
 
-		return batchEnginePortletDataHandlers.get(portletId);
+		String portletId = _classNamePortletIdsMap.get(className);
+
+		if (!_isAllowed(companyId, portletId)) {
+			return null;
+		}
+
+		return _portletIdBatchEnginePortletDataHandlersMap.get(portletId);
 	}
 
 	public static String getPortletId(long companyId, String key) {
-		Map<String, String> portletIds = _keyPortletIdsMap.get(companyId);
+		String portletId = null;
 
-		if (portletIds == null) {
+		if (_allCompaniesKeyPortletIdsMap.containsKey(key)) {
+			portletId = _allCompaniesKeyPortletIdsMap.get(key);
+		}
+		else if (_companyIdKeyPortletIdsMap.containsKey(companyId)) {
+			Map<String, String> keyPortletIdsMap =
+				_companyIdKeyPortletIdsMap.get(companyId);
+
+			if (keyPortletIdsMap.containsKey(key)) {
+				portletId = keyPortletIdsMap.get(key);
+			}
+		}
+
+		if (!_isAllowed(companyId, portletId)) {
 			return null;
 		}
 
-		return portletIds.get(key);
+		return portletId;
 	}
 
 	public static boolean hasByClassName(String className, long companyId) {
-		Map<String, String> portletIds = _classNamePortletIdsMap.get(companyId);
-
-		if (portletIds == null) {
+		if (!_classNamePortletIdsMap.containsKey(className)) {
 			return false;
 		}
 
-		return portletIds.containsKey(className);
+		String portletId = _classNamePortletIdsMap.get(className);
+
+		return _isAllowed(companyId, portletId);
 	}
 
-	protected static void put(
-		BatchEnginePortletDataHandler batchEnginePortletDataHandler,
-		long companyId, String key, String portletId) {
+	protected static BatchEnginePortletDataHandler getByPortletId(
+		long companyId, String portletId) {
 
-		Map<String, BatchEnginePortletDataHandler>
-			batchEnginePortletDataHandlers =
-				_batchEnginePortletDataHandlersMap.computeIfAbsent(
-					companyId, k -> new ConcurrentHashMap<>());
-
-		batchEnginePortletDataHandlers.put(
-			portletId, batchEnginePortletDataHandler);
-
-		Map<String, String> keyPortletIds = _keyPortletIdsMap.computeIfAbsent(
-			companyId, k -> new ConcurrentHashMap<>());
-
-		keyPortletIds.put(key, portletId);
-
-		Map<String, String> classNamePortletIds =
-			_classNamePortletIdsMap.computeIfAbsent(
-				companyId, k -> new ConcurrentHashMap<>());
-
-		for (String className : batchEnginePortletDataHandler.getClassNames()) {
-			classNamePortletIds.put(className, portletId);
-		}
-	}
-
-	protected static void remove(long companyId, String key, String portletId) {
-		_batchEnginePortletDataHandlersMap.computeIfPresent(
-			companyId,
-			(key1, batchEnginePortletDataHandlers) -> {
-				BatchEnginePortletDataHandler batchEnginePortletDataHandler =
-					batchEnginePortletDataHandlers.remove(portletId);
-
-				if (batchEnginePortletDataHandler != null) {
-					_removePortletIds(
-						batchEnginePortletDataHandler, companyId, portletId);
-
-					_keyPortletIdsMap.computeIfPresent(
-						companyId,
-						(key2, keyPortletIds) -> {
-							keyPortletIds.remove(key);
-
-							return keyPortletIds.isEmpty() ? null :
-								keyPortletIds;
-						});
-				}
-
-				return batchEnginePortletDataHandlers.isEmpty() ? null :
-					batchEnginePortletDataHandlers;
-			});
-	}
-
-	private static String _getPortletId(long companyId, String className) {
-		Map<String, String> portletIds = _classNamePortletIdsMap.get(companyId);
-
-		if (portletIds == null) {
+		if (!_isAllowed(companyId, portletId)) {
 			return null;
 		}
 
-		return portletIds.get(className);
+		return _portletIdBatchEnginePortletDataHandlersMap.get(portletId);
 	}
 
-	private static void _removePortletIds(
+	protected static void registerBatchEnginePortletDataHandler(
 		BatchEnginePortletDataHandler batchEnginePortletDataHandler,
-		long companyId, String portletId) {
+		Long companyId, String portletId) {
 
-		_classNamePortletIdsMap.computeIfPresent(
-			companyId,
-			(key, portletIds) -> {
-				for (String className :
-						batchEnginePortletDataHandler.getClassNames()) {
+		if (_isAllCompanies(companyId)) {
+			_allCompaniesPortletIds.add(portletId);
+		}
+		else {
+			_portletIdCompanyIdMap.put(portletId, companyId);
+		}
 
-					portletIds.remove(className, portletId);
-				}
+		_portletIdBatchEnginePortletDataHandlersMap.put(
+			portletId, batchEnginePortletDataHandler);
 
-				return portletIds.isEmpty() ? null : portletIds;
-			});
+		for (String className : batchEnginePortletDataHandler.getClassNames()) {
+			_classNamePortletIdsMap.put(className, portletId);
+		}
 	}
 
-	private static final Map<Long, Map<String, BatchEnginePortletDataHandler>>
-		_batchEnginePortletDataHandlersMap = new ConcurrentHashMap<>();
+	protected static void registerKey(
+		Long companyId, String key, String portletId) {
+
+		if (_isAllCompanies(companyId)) {
+			_allCompaniesKeyPortletIdsMap.put(key, portletId);
+		}
+		else {
+			_companyIdKeyPortletIdsMap.computeIfAbsent(
+				companyId, __ -> new ConcurrentHashMap<>()
+			).put(
+				key, portletId
+			);
+		}
+	}
+
+	protected static void unregister(Long companyId, String portletId) {
+		if (_isAllCompanies(companyId)) {
+			_allCompaniesPortletIds.remove(portletId);
+		}
+		else {
+			_portletIdCompanyIdMap.remove(portletId, companyId);
+		}
+
+		_portletIdBatchEnginePortletDataHandlersMap.remove(portletId);
+
+		_removeEntries(_classNamePortletIdsMap, portletId);
+	}
+
+	protected static void unregisterKey(
+		Long companyId, String key, String portletId) {
+
+		if (_isAllCompanies(companyId)) {
+			_allCompaniesKeyPortletIdsMap.remove(key, portletId);
+		}
+
+		if (!_companyIdKeyPortletIdsMap.containsKey(companyId)) {
+			return;
+		}
+
+		Map<String, String> keyPortletIdsMap = _companyIdKeyPortletIdsMap.get(
+			companyId);
+
+		keyPortletIdsMap.remove(key, portletId);
+
+		if (keyPortletIdsMap.isEmpty()) {
+			_companyIdKeyPortletIdsMap.remove(companyId);
+		}
+	}
+
+	private static boolean _isAllCompanies(Long companyId) {
+		if ((companyId == null) || (companyId == 0)) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private static boolean _isAllowed(long companyId, String portletId) {
+		if (portletId == null) {
+			return false;
+		}
+
+		if (_allCompaniesPortletIds.contains(portletId)) {
+			return true;
+		}
+
+		return Objects.equals(companyId, _portletIdCompanyIdMap.get(portletId));
+	}
+
+	private static void _removeEntries(Map<String, String> map, String value) {
+		map.entrySet(
+		).removeIf(
+			entry -> Objects.equals(entry.getValue(), value)
+		);
+	}
+
+	private static final Map<String, String> _allCompaniesKeyPortletIdsMap =
+		new ConcurrentHashMap<>();
+	private static final Set<String> _allCompaniesPortletIds =
+		new CopyOnWriteArraySet<>();
+	private static final Map<String, String> _classNamePortletIdsMap =
+		new ConcurrentHashMap<>();
 	private static final Map<Long, Map<String, String>>
-		_classNamePortletIdsMap = new ConcurrentHashMap<>();
-	private static final Map<Long, Map<String, String>> _keyPortletIdsMap =
+		_companyIdKeyPortletIdsMap = new ConcurrentHashMap<>();
+	private static final Map<String, BatchEnginePortletDataHandler>
+		_portletIdBatchEnginePortletDataHandlersMap = new ConcurrentHashMap<>();
+	private static final Map<String, Long> _portletIdCompanyIdMap =
 		new ConcurrentHashMap<>();
 
 }

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandlerRegistryUtil.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandlerRegistryUtil.java
@@ -77,7 +77,7 @@ public class BatchEnginePortletDataHandlerRegistryUtil {
 
 	protected static void registerBatchEnginePortletDataHandler(
 		BatchEnginePortletDataHandler batchEnginePortletDataHandler,
-		Long companyId, String portletId) {
+		long companyId, String portletId) {
 
 		if (_isAllCompanies(companyId)) {
 			_allCompaniesPortletIds.add(portletId);
@@ -95,7 +95,7 @@ public class BatchEnginePortletDataHandlerRegistryUtil {
 	}
 
 	protected static void registerKey(
-		Long companyId, String key, String portletId) {
+		long companyId, String key, String portletId) {
 
 		if (_isAllCompanies(companyId)) {
 			_allCompaniesKeyPortletIdsMap.put(key, portletId);
@@ -109,7 +109,7 @@ public class BatchEnginePortletDataHandlerRegistryUtil {
 		}
 	}
 
-	protected static void unregister(Long companyId, String portletId) {
+	protected static void unregister(long companyId, String portletId) {
 		if (_isAllCompanies(companyId)) {
 			_allCompaniesPortletIds.remove(portletId);
 		}
@@ -123,7 +123,7 @@ public class BatchEnginePortletDataHandlerRegistryUtil {
 	}
 
 	protected static void unregisterKey(
-		Long companyId, String key, String portletId) {
+		long companyId, String key, String portletId) {
 
 		if (_isAllCompanies(companyId)) {
 			_allCompaniesKeyPortletIdsMap.remove(key, portletId);
@@ -143,8 +143,8 @@ public class BatchEnginePortletDataHandlerRegistryUtil {
 		}
 	}
 
-	private static boolean _isAllCompanies(Long companyId) {
-		if ((companyId == null) || (companyId == 0)) {
+	private static boolean _isAllCompanies(long companyId) {
+		if (companyId == 0) {
 			return true;
 		}
 

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerRegistrarTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerRegistrarTest.java
@@ -80,24 +80,36 @@ public class BatchEnginePortletDataHandlerRegistrarTest {
 	@Test
 	@TestInfo({"LPD-56301", "LPD-65119", "LPD-68124"})
 	public void test() throws Exception {
-		String portletId = RandomTestUtil.randomString();
+		String portletId1 = RandomTestUtil.randomString();
+		String portletId2 = RandomTestUtil.randomString();
 
 		Assert.assertNull(
 			_portletDataHandlerProvider.provide(
-				TestPropsValues.getCompanyId(), portletId));
+				TestPropsValues.getCompanyId(), portletId1));
+		Assert.assertNull(
+			_portletDataHandlerProvider.provide(
+				TestPropsValues.getCompanyId(), portletId2));
 
 		String className1 = RandomTestUtil.randomString();
 		String className2 = RandomTestUtil.randomString();
+		String className3 = RandomTestUtil.randomString();
 
 		try (SafeCloseable safeCloseable1 = _registerServiceWithSafeCloseable(
 				Portlet.class,
 				new GenericPortlet() {
 				},
-				MapUtil.singletonDictionary("jakarta.portlet.name", portletId));
+				MapUtil.singletonDictionary(
+					"jakarta.portlet.name", portletId1));
 			SafeCloseable safeCloseable2 = _registerServiceWithSafeCloseable(
+				Portlet.class,
+				new GenericPortlet() {
+				},
+				MapUtil.singletonDictionary(
+					"jakarta.portlet.name", portletId2));
+			SafeCloseable safeCloseable3 = _registerServiceWithSafeCloseable(
 				VulcanBatchEngineTaskItemDelegate.class,
 				new TestExportImportVulcanBatchEngineTaskItemDelegate(
-					className1, portletId),
+					className1, portletId1),
 				HashMapDictionaryBuilder.put(
 					"batch.engine.task.item.delegate", "true"
 				).put(
@@ -106,10 +118,10 @@ public class BatchEnginePortletDataHandlerRegistrarTest {
 					"export.import.vulcan.batch.engine.task.item.delegate",
 					"true"
 				).build());
-			SafeCloseable safeCloseable3 = _registerServiceWithSafeCloseable(
+			SafeCloseable safeCloseable4 = _registerServiceWithSafeCloseable(
 				VulcanBatchEngineTaskItemDelegate.class,
 				new TestExportImportVulcanBatchEngineTaskItemDelegate(
-					className2, portletId),
+					className2, portletId1),
 				HashMapDictionaryBuilder.put(
 					"batch.engine.task.item.delegate", "true"
 				).put(
@@ -117,10 +129,24 @@ public class BatchEnginePortletDataHandlerRegistrarTest {
 				).put(
 					"export.import.vulcan.batch.engine.task.item.delegate",
 					"true"
+				).build());
+			SafeCloseable safeCloseable5 = _registerServiceWithSafeCloseable(
+				VulcanBatchEngineTaskItemDelegate.class,
+				new TestExportImportVulcanBatchEngineTaskItemDelegate(
+					className3, portletId2),
+				HashMapDictionaryBuilder.put(
+					"batch.engine.task.item.delegate", "true"
+				).put(
+					"batch.engine.task.item.delegate.class.name", className3
+				).put(
+					"companyId", String.valueOf(TestPropsValues.getCompanyId())
+				).put(
+					"export.import.vulcan.batch.engine.task.item.delegate",
+					"true"
 				).build())) {
 
 			_assertPortletDataHandler(
-				TestPropsValues.getCompanyId(), portletId,
+				TestPropsValues.getCompanyId(), portletId1,
 				portletDataHandler ->
 					StringUtil.contains(
 						ClassUtil.getClassName(portletDataHandler),
@@ -131,20 +157,36 @@ public class BatchEnginePortletDataHandlerRegistrarTest {
 					_hasPortletDataHandlerControls(
 						new PortletDataHandlerControl[] {
 							new PortletDataHandlerBoolean(
-								portletId, className1, className1, true, false,
+								portletId1, className1, className1, true, false,
 								null, className1, null),
 							new PortletDataHandlerBoolean(
-								portletId, className2, className2, true, false,
+								portletId1, className2, className2, true, false,
 								null, className2, null)
 						},
 						portletDataHandler.
 							getExportPortletDataHandlerControls()));
 
+			_assertPortletDataHandler(
+				TestPropsValues.getCompanyId(), portletId2,
+				portletDataHandler ->
+					StringUtil.contains(
+						ClassUtil.getClassName(portletDataHandler),
+						"BatchEnginePortletDataHandler", StringPool.PERIOD) &&
+					Arrays.equals(
+						new String[] {className3},
+						portletDataHandler.getClassNames()) &&
+					_hasPortletDataHandlerControls(
+						new PortletDataHandlerControl[0],
+						portletDataHandler.
+							getExportPortletDataHandlerControls()));
+
 			Assert.assertEquals(
-				1, _getRegisteredPortletDataHandlersCount(portletId));
+				1, _getRegisteredPortletDataHandlersCount(portletId1));
+			Assert.assertEquals(
+				1, _getRegisteredPortletDataHandlersCount(portletId2));
 
 			_assertPortletDataHandler(
-				RandomTestUtil.randomLong(), portletId,
+				RandomTestUtil.randomLong(), portletId1,
 				portletDataHandler ->
 					StringUtil.contains(
 						ClassUtil.getClassName(portletDataHandler),
@@ -153,10 +195,16 @@ public class BatchEnginePortletDataHandlerRegistrarTest {
 						new String[] {className1, className2},
 						portletDataHandler.getClassNames()));
 
-			safeCloseable2.close();
+			_assertPortletDataHandler(
+				RandomTestUtil.randomLong(), portletId2,
+				portletDataHandler -> StringUtil.contains(
+					ClassUtil.getClassName(portletDataHandler),
+					"DefaultPortletDataHandler", StringPool.PERIOD));
+
+			safeCloseable3.close();
 
 			_assertPortletDataHandler(
-				TestPropsValues.getCompanyId(), portletId,
+				TestPropsValues.getCompanyId(), portletId1,
 				portletDataHandler ->
 					StringUtil.contains(
 						ClassUtil.getClassName(portletDataHandler),
@@ -169,10 +217,10 @@ public class BatchEnginePortletDataHandlerRegistrarTest {
 						portletDataHandler.
 							getExportPortletDataHandlerControls()));
 
-			safeCloseable3.close();
+			safeCloseable4.close();
 
 			_assertPortletDataHandler(
-				TestPropsValues.getCompanyId(), portletId,
+				TestPropsValues.getCompanyId(), portletId1,
 				portletDataHandler -> StringUtil.contains(
 					ClassUtil.getClassName(portletDataHandler),
 					"DefaultPortletDataHandler", StringPool.PERIOD));

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerRegistrarTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerRegistrarTest.java
@@ -25,7 +25,6 @@ import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ClassUtil;
@@ -144,10 +143,8 @@ public class BatchEnginePortletDataHandlerRegistrarTest {
 			Assert.assertEquals(
 				1, _getRegisteredPortletDataHandlersCount(portletId));
 
-			Company company = CompanyTestUtil.addCompany();
-
 			_assertPortletDataHandler(
-				company.getCompanyId(), portletId,
+				RandomTestUtil.randomLong(), portletId,
 				portletDataHandler ->
 					StringUtil.contains(
 						ClassUtil.getClassName(portletDataHandler),
@@ -155,12 +152,6 @@ public class BatchEnginePortletDataHandlerRegistrarTest {
 					Arrays.equals(
 						new String[] {className1, className2},
 						portletDataHandler.getClassNames()));
-
-			_assertPortletDataHandler(
-				RandomTestUtil.randomLong(), portletId,
-				portletDataHandler -> StringUtil.contains(
-					ClassUtil.getClassName(portletDataHandler),
-					"DefaultPortletDataHandler", StringPool.PERIOD));
 
 			safeCloseable2.close();
 

--- a/modules/test/playwright/tests/export-import-web/main/fixtures/portletExportImportPageTest.ts
+++ b/modules/test/playwright/tests/export-import-web/main/fixtures/portletExportImportPageTest.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {PortletExportImportPage} from '../pages/PortletExportImportPage';
+
+const portletExportImportPageTest = test.extend<{
+	portletExportImportPage: PortletExportImportPage;
+}>({
+	portletExportImportPage: async ({page}, use) => {
+		await use(new PortletExportImportPage(page));
+	},
+});
+
+export {portletExportImportPageTest};

--- a/modules/test/playwright/tests/export-import-web/main/instance.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/instance.import.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+	ObjectDefinition,
 	ObjectDefinitionAPI,
 	ObjectRelationshipAPI,
 } from '@liferay/object-admin-rest-client-js';
@@ -20,18 +21,23 @@ import {objectPagesTest} from '../../../fixtures/objectPagesTest';
 import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
 import {pageTemplatesPagesTest} from '../../../fixtures/pageTemplatesPagesTest';
 import {wikiPagesTest} from '../../../fixtures/wikiPagesTest';
+import {DataApiHelpers} from '../../../helpers/ApiHelpers';
+import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import {getRandomInt} from '../../../utils/getRandomInt';
 import {normalizeRestPath} from '../../../utils/normalizeRestPath';
 import performLogin, {
+	performLoginViaApi,
 	performLogout,
 	performUserSwitch,
 	userData,
 } from '../../../utils/performLogin';
+import {PORTLET_URLS} from '../../../utils/portletUrls';
 import {readFileFromZip} from '../../../utils/zip';
 import {generateObjectEntryValues} from '../../object-web/main/utils/generateObjectEntry';
 import {generateObjectFields} from '../../object-web/main/utils/generateObjectFields';
 import {companyExportImportPageTest} from './fixtures/companyExportImportPagesTest';
 import {exportImportPagesTest} from './fixtures/exportImportPagesTest';
+import {portletExportImportPageTest} from './fixtures/portletExportImportPageTest';
 import {stagingPageTest} from './fixtures/stagingPageTest';
 import {createUserAssignRolesAndLogin} from './utils/createUserAssignRolesAndLogin';
 import {toDateRangeDate, toDateRangeTime} from './utils/dateRangeUtil';
@@ -52,6 +58,7 @@ export const test = mergeTests(
 	objectPagesTest,
 	pageEditorPagesTest,
 	pageTemplatesPagesTest,
+	portletExportImportPageTest,
 	stagingPageTest,
 	wikiPagesTest
 );
@@ -1161,5 +1168,142 @@ test('Can import at instance level when LAR contains custom objects without exis
 	await companyExportImportPage.import({
 		filePath: exportFilePath,
 		taskStatus: 'completedWithErrors',
+	});
+});
+
+test('Can import object with different classname via portlet', async ({
+	apiHelpers,
+	applicationsMenuPage,
+	featureFlags,
+	page,
+	portletExportImportPage,
+	viewObjectDefinitionsPage,
+}) => {
+	test.slow();
+	let objectDefinition: ObjectDefinition;
+	let objectDefinitionFilePath: string;
+	let objectEntryFilePath: string;
+
+	await test.step('Create and download Object Definition LAR', async () => {
+		objectDefinition =
+			await apiHelpers.objectAdmin.postRandomObjectDefinition({
+				panelCategoryKey: 'control_panel.object',
+				status: {code: 0},
+			});
+
+		apiHelpers.data.push({
+			id: objectDefinition.id,
+			type: 'objectDefinition',
+		});
+
+		await viewObjectDefinitionsPage.goto();
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: viewObjectDefinitionsPage.page
+				.locator('.dropdown-menu')
+				.getByRole('menuitem', {name: 'Export / Import'}),
+			trigger: viewObjectDefinitionsPage.page.getByLabel('Options'),
+		});
+
+		objectDefinitionFilePath = await portletExportImportPage.exportLARFile(
+			/Objects-\d+\.portlet\.lar/
+		);
+	});
+
+	await test.step('Create and download Object Entry LAR', async () => {
+		await apiHelpers.objectEntry.postObjectEntry(
+			{externalReferenceCode: '', textField: objectDefinition.name},
+			`${normalizeRestPath(objectDefinition.restContextPath)}`
+		);
+		await applicationsMenuPage.goToObjectDefinition(objectDefinition.name);
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: page
+				.locator('.dropdown-menu')
+				.getByRole('menuitem', {name: 'Export / Import'}),
+			trigger: page.getByLabel('Options'),
+		});
+
+		objectEntryFilePath = await portletExportImportPage.exportLARFile(
+			/ObjectDefinition\d+-\d+\.portlet\.lar/
+		);
+	});
+
+	await test.step('Create and Configure Virtual Instance (Able)', async () => {
+		const virtualInstance =
+			await apiHelpers.headlessPortalInstance.addVirtualInstance({
+				domain: 'liferay.com',
+				portalInstanceId: 'www.able.com',
+				virtualHost: 'www.able.com',
+			});
+
+		apiHelpers.data.push({
+			id: virtualInstance.portalInstanceId,
+			type: 'virtual-instance',
+		});
+
+		await performLoginViaApi({
+			loginUrl: 'http://www.able.com:8080',
+			page,
+			screenName: 'test',
+		});
+
+		const virtualInstanceApiHelpers = new DataApiHelpers(
+			page,
+			'http://www.able.com:8080'
+		);
+
+		for (const featureFlag of featureFlags) {
+			await virtualInstanceApiHelpers.featureFlag.updateFeatureFlag(
+				featureFlag.key,
+				featureFlag.enabled,
+				'http://www.able.com:8080'
+			);
+		}
+	});
+
+	await test.step('Object Definition into Virtual Instance', async () => {
+		await page.goto(
+			`http://www.able.com:8080/group/guest${PORTLET_URLS.objects}`
+		);
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: page
+				.locator('.dropdown-menu')
+				.getByRole('menuitem', {name: 'Export / Import'}),
+			trigger: page.getByLabel('Options'),
+		});
+
+		await portletExportImportPage.importLARFile(objectDefinitionFilePath);
+		await expect(
+			portletExportImportPage.frame
+				.getByRole('cell', {name: 'Successful'})
+				.first()
+		).toBeVisible();
+	});
+
+	await test.step('Import Object Entry into Virtual Instance & Verify', async () => {
+		await page.goto(`http://www.able.com:8080`);
+		await page.getByLabel('Open Applications MenuCtrl+').click();
+		await page.getByRole('tab', {name: 'Control Panel'}).click();
+		await page.getByRole('menuitem', {name: objectDefinition.name}).click();
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: page
+				.locator('.dropdown-menu')
+				.getByRole('menuitem', {name: 'Export / Import'}),
+			trigger: page.getByLabel('Options'),
+		});
+
+		await portletExportImportPage.importLARFile(objectEntryFilePath);
+		await expect(
+			portletExportImportPage.frame
+				.getByRole('cell', {name: 'Successful'})
+				.first()
+		).toBeVisible();
 	});
 });

--- a/modules/test/playwright/tests/export-import-web/main/instance.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/instance.import.spec.ts
@@ -21,7 +21,7 @@ import {objectPagesTest} from '../../../fixtures/objectPagesTest';
 import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
 import {pageTemplatesPagesTest} from '../../../fixtures/pageTemplatesPagesTest';
 import {wikiPagesTest} from '../../../fixtures/wikiPagesTest';
-import {DataApiHelpers} from '../../../helpers/ApiHelpers';
+import {ApiHelpers, DataApiHelpers} from '../../../helpers/ApiHelpers';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import {getRandomInt} from '../../../utils/getRandomInt';
 import {normalizeRestPath} from '../../../utils/normalizeRestPath';
@@ -1231,6 +1231,8 @@ test('Can import object with different classname via portlet', async ({
 		);
 	});
 
+	let virtualInstanceApiHelpers: ApiHelpers;
+
 	await test.step('Create and Configure Virtual Instance (Able)', async () => {
 		const virtualInstance =
 			await apiHelpers.headlessPortalInstance.addVirtualInstance({
@@ -1250,7 +1252,7 @@ test('Can import object with different classname via portlet', async ({
 			screenName: 'test',
 		});
 
-		const virtualInstanceApiHelpers = new DataApiHelpers(
+		virtualInstanceApiHelpers = new DataApiHelpers(
 			page,
 			'http://www.able.com:8080'
 		);
@@ -1299,11 +1301,25 @@ test('Can import object with different classname via portlet', async ({
 			trigger: page.getByLabel('Options'),
 		});
 
+		const {totalCount: beforeImportingTotalCount} =
+			await virtualInstanceApiHelpers.objectEntry.getObjectDefinitionObjectEntries(
+				'c/' + objectDefinition.name.toLowerCase() + 's'
+			);
+
+		expect(beforeImportingTotalCount).toBe(0);
+
 		await portletExportImportPage.importLARFile(objectEntryFilePath);
 		await expect(
 			portletExportImportPage.frame
 				.getByRole('cell', {name: 'Successful'})
 				.first()
 		).toBeVisible();
+
+		const {totalCount: afterImportingTotalCount} =
+			await virtualInstanceApiHelpers.objectEntry.getObjectDefinitionObjectEntries(
+				'c/' + objectDefinition.name.toLowerCase() + 's'
+			);
+
+		expect(afterImportingTotalCount).toBe(1);
 	});
 });

--- a/modules/test/playwright/tests/export-import-web/main/instance.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/instance.import.spec.ts
@@ -1181,8 +1181,8 @@ test('Can import object with different classname via portlet', async ({
 }) => {
 	test.slow();
 	let objectDefinition: ObjectDefinition;
-	let objectDefinitionFilePath: string;
-	let objectEntryFilePath: string;
+	let objectDefinitionsFilePath: string;
+	let objectEntriesFilePath: string;
 
 	await test.step('Create and download Object Definition LAR', async () => {
 		objectDefinition =
@@ -1206,7 +1206,7 @@ test('Can import object with different classname via portlet', async ({
 			trigger: viewObjectDefinitionsPage.page.getByLabel('Options'),
 		});
 
-		objectDefinitionFilePath = await portletExportImportPage.exportLARFile(
+		objectDefinitionsFilePath = await portletExportImportPage.exportLARFile(
 			/Objects-\d+\.portlet\.lar/
 		);
 	});
@@ -1226,7 +1226,7 @@ test('Can import object with different classname via portlet', async ({
 			trigger: page.getByLabel('Options'),
 		});
 
-		objectEntryFilePath = await portletExportImportPage.exportLARFile(
+		objectEntriesFilePath = await portletExportImportPage.exportLARFile(
 			/ObjectDefinition\d+-\d+\.portlet\.lar/
 		);
 	});
@@ -1279,7 +1279,7 @@ test('Can import object with different classname via portlet', async ({
 			trigger: page.getByLabel('Options'),
 		});
 
-		await portletExportImportPage.importLARFile(objectDefinitionFilePath);
+		await portletExportImportPage.importLARFile(objectDefinitionsFilePath);
 		await expect(
 			portletExportImportPage.frame
 				.getByRole('cell', {name: 'Successful'})
@@ -1308,7 +1308,7 @@ test('Can import object with different classname via portlet', async ({
 
 		expect(beforeImportingTotalCount).toBe(0);
 
-		await portletExportImportPage.importLARFile(objectEntryFilePath);
+		await portletExportImportPage.importLARFile(objectEntriesFilePath);
 		await expect(
 			portletExportImportPage.frame
 				.getByRole('cell', {name: 'Successful'})

--- a/modules/test/playwright/tests/export-import-web/main/instance.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/instance.import.spec.ts
@@ -21,7 +21,7 @@ import {objectPagesTest} from '../../../fixtures/objectPagesTest';
 import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
 import {pageTemplatesPagesTest} from '../../../fixtures/pageTemplatesPagesTest';
 import {wikiPagesTest} from '../../../fixtures/wikiPagesTest';
-import {ApiHelpers, DataApiHelpers} from '../../../helpers/ApiHelpers';
+import {DataApiHelpers} from '../../../helpers/ApiHelpers';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import {getRandomInt} from '../../../utils/getRandomInt';
 import {normalizeRestPath} from '../../../utils/normalizeRestPath';
@@ -1231,7 +1231,7 @@ test('Can import object with different classname via portlet', async ({
 		);
 	});
 
-	let virtualInstanceApiHelpers: ApiHelpers;
+	let virtualInstanceApiHelpers: DataApiHelpers;
 
 	await test.step('Create and Configure Virtual Instance (Able)', async () => {
 		const virtualInstance =

--- a/modules/test/playwright/tests/export-import-web/main/pages/PortletExportImportPage.ts
+++ b/modules/test/playwright/tests/export-import-web/main/pages/PortletExportImportPage.ts
@@ -19,20 +19,18 @@ export class PortletExportImportPage {
 	async exportLARFile(fileNamePattern: RegExp): Promise<string> {
 		await this.frame.getByRole('button', {name: 'Export'}).click();
 
-		const downloadCell = this.frame
+		const downloadLink = this.frame
 			.getByRole('cell', {name: fileNamePattern})
-			.first();
-		await downloadCell.waitFor();
-
-		const downloadLink = downloadCell.getByRole('link');
-		const rawText = await downloadLink.innerText();
-
-		const fileName = rawText.split('(')[0].trim();
-		const filePath = `${getTempDir()}/${fileName}`;
+			.first()
+			.getByRole('link');
 
 		const downloadPromise = this.page.waitForEvent('download');
+
 		await downloadLink.click();
+
 		const download = await downloadPromise;
+
+		const filePath = `${getTempDir()}/${download.suggestedFilename()}`;
 
 		await download.saveAs(filePath);
 
@@ -41,10 +39,10 @@ export class PortletExportImportPage {
 
 	async importLARFile(filePath: string): Promise<void> {
 		await this.frame.getByRole('link', {name: 'Import'}).click();
+
 		await this.frame.locator('input[type="file"]').setInputFiles(filePath);
 		await this.frame.getByRole('button', {name: 'Continue'}).click();
 
-		await this.frame.getByText(/The import LAR file is deleted/).waitFor();
 		await this.frame.getByRole('button', {name: 'Import'}).click();
 	}
 }

--- a/modules/test/playwright/tests/export-import-web/main/pages/PortletExportImportPage.ts
+++ b/modules/test/playwright/tests/export-import-web/main/pages/PortletExportImportPage.ts
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {FrameLocator, Page} from '@playwright/test';
+
+import {getTempDir} from '../../../../utils/temp';
+
+export class PortletExportImportPage {
+	readonly frame: FrameLocator;
+	readonly page: Page;
+
+	constructor(page: Page) {
+		this.frame = page.frameLocator('iframe[title="Export \\/ Import"]');
+		this.page = page;
+	}
+
+	async exportLARFile(fileNamePattern: RegExp): Promise<string> {
+		await this.frame.getByRole('button', {name: 'Export'}).click();
+
+		const downloadCell = this.frame
+			.getByRole('cell', {name: fileNamePattern})
+			.first();
+		await downloadCell.waitFor();
+
+		const downloadLink = downloadCell.getByRole('link');
+		const rawText = await downloadLink.innerText();
+
+		const fileName = rawText.split('(')[0].trim();
+		const filePath = `${getTempDir()}/${fileName}`;
+
+		const downloadPromise = this.page.waitForEvent('download');
+		await downloadLink.click();
+		const download = await downloadPromise;
+
+		await download.saveAs(filePath);
+
+		return filePath;
+	}
+
+	async importLARFile(filePath: string): Promise<void> {
+		await this.frame.getByRole('link', {name: 'Import'}).click();
+		await this.frame.locator('input[type="file"]').setInputFiles(filePath);
+		await this.frame.getByRole('button', {name: 'Continue'}).click();
+
+		await this.frame.getByText(/The import LAR file is deleted/).waitFor();
+		await this.frame.getByRole('button', {name: 'Import'}).click();
+	}
+}


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-78764

---

Rebased on top of: https://github.com/brianchandotcom/liferay-portal/pull/170729, so it will be sent to Brian when the PR is merged.

The purpose of this PR is:
- To get the target porletID (the portletId of the destination environment) for Object Entries, as the classname and portletId can not be the same between different environments. So, for the export/import performed from the menu inside the Object Entries portlet, we need to update the code to get that target portletId.
- Furthermore, as part of this bug, I am fixing the multitenancy when registering the BatchEnginePortletDataHandler. Before this PR, we were always handling the first companyId given by the PortalInstanceLifecycleListener (_companyId attribute), as we were only opening a singleton Service tracker customizer