### PR TITLE
LPD-80055 After clicking on the viewURL of CMS 2.0 Object Entry Folder in search results, all portlets on the page become "temporarily unavailable"

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/result/display/context/builder/SearchResultContentDisplayContextBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/result/display/context/builder/SearchResultContentDisplayContextBuilder.java
@@ -70,6 +70,9 @@ public class SearchResultContentDisplayContextBuilder {
 			boolean hasEditPermission = assetRenderer.hasEditPermission(
 				_permissionChecker);
 
+			searchResultContentDisplayContext.setHasEditPermission(
+				hasEditPermission);
+
 			if (hasEditPermission) {
 				PortletURL editPortletURL = assetRenderer.getURLEdit(
 					_portal.getLiferayPortletRequest(_renderRequest),
@@ -80,8 +83,6 @@ public class SearchResultContentDisplayContextBuilder {
 						(ThemeDisplay)_renderRequest.getAttribute(
 							WebKeys.THEME_DISPLAY);
 
-					searchResultContentDisplayContext.setHasEditPermission(
-						true);
 					searchResultContentDisplayContext.setIconEditTarget(title);
 					searchResultContentDisplayContext.setIconURLString(
 						PortletURLBuilder.create(
@@ -96,10 +97,6 @@ public class SearchResultContentDisplayContextBuilder {
 								return portletDisplay.getId();
 							}
 						).buildString());
-				}
-				else {
-					searchResultContentDisplayContext.setHasEditPermission(
-						false);
 				}
 			}
 

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/result/display/context/builder/SearchResultContentDisplayContextBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/result/display/context/builder/SearchResultContentDisplayContextBuilder.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.search.web.internal.result.display.context.SearchResultContentDisplayContext;
 
+import jakarta.portlet.PortletURL;
 import jakarta.portlet.RenderRequest;
 import jakarta.portlet.RenderResponse;
 
@@ -69,30 +70,37 @@ public class SearchResultContentDisplayContextBuilder {
 			boolean hasEditPermission = assetRenderer.hasEditPermission(
 				_permissionChecker);
 
-			searchResultContentDisplayContext.setHasEditPermission(
-				hasEditPermission);
-
 			if (hasEditPermission) {
-				ThemeDisplay themeDisplay =
-					(ThemeDisplay)_renderRequest.getAttribute(
-						WebKeys.THEME_DISPLAY);
+				PortletURL editPortletURL = assetRenderer.getURLEdit(
+					_portal.getLiferayPortletRequest(_renderRequest),
+					_portal.getLiferayPortletResponse(_renderResponse));
 
-				searchResultContentDisplayContext.setIconEditTarget(title);
-				searchResultContentDisplayContext.setIconURLString(
-					PortletURLBuilder.create(
-						assetRenderer.getURLEdit(
-							_portal.getLiferayPortletRequest(_renderRequest),
-							_portal.getLiferayPortletResponse(_renderResponse))
-					).setRedirect(
-						themeDisplay.getURLCurrent()
-					).setPortletResource(
-						() -> {
-							PortletDisplay portletDisplay =
-								themeDisplay.getPortletDisplay();
+				if (editPortletURL != null) {
+					ThemeDisplay themeDisplay =
+						(ThemeDisplay)_renderRequest.getAttribute(
+							WebKeys.THEME_DISPLAY);
 
-							return portletDisplay.getId();
-						}
-					).buildString());
+					searchResultContentDisplayContext.setHasEditPermission(
+						true);
+					searchResultContentDisplayContext.setIconEditTarget(title);
+					searchResultContentDisplayContext.setIconURLString(
+						PortletURLBuilder.create(
+							editPortletURL
+						).setRedirect(
+							themeDisplay.getURLCurrent()
+						).setPortletResource(
+							() -> {
+								PortletDisplay portletDisplay =
+									themeDisplay.getPortletDisplay();
+
+								return portletDisplay.getId();
+							}
+						).buildString());
+				}
+				else {
+					searchResultContentDisplayContext.setHasEditPermission(
+						false);
+				}
 			}
 
 			searchResultContentDisplayContext.setShowExtraInfo(

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -49,7 +49,7 @@ SearchResultContentDisplayContext searchResultContentDisplayContext = searchResu
 				<%= HtmlUtil.escape(searchResultContentDisplayContext.getHeaderTitle()) %>
 			</span>
 
-			<c:if test="<%= searchResultContentDisplayContext.hasEditPermission() %>">
+			<c:if test="<%= searchResultContentDisplayContext.hasEditPermission() && (searchResultContentDisplayContext.getIconURLString() != null) %>">
 				<span class="d-inline-flex">
 					<liferay-ui:icon
 						cssClass="visible-interaction"

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/result/display/context/builder/SearchResultContentDisplayContextBuilderTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/result/display/context/builder/SearchResultContentDisplayContextBuilderTest.java
@@ -110,7 +110,7 @@ public class SearchResultContentDisplayContextBuilderTest {
 	}
 
 	@Test
-	public void testEditPermissionFalseFromURLEdit() throws Exception {
+	public void testIconMissingFromNullURLEdit() throws Exception {
 		Mockito.doReturn(
 			null
 		).when(
@@ -122,7 +122,7 @@ public class SearchResultContentDisplayContextBuilderTest {
 		SearchResultContentDisplayContext searchResultContentDisplayContext =
 			_buildDisplayContext();
 
-		Assert.assertFalse(
+		Assert.assertTrue(
 			searchResultContentDisplayContext.hasEditPermission());
 
 		_assertIconMissing(searchResultContentDisplayContext);

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/result/display/context/builder/SearchResultContentDisplayContextBuilderTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/result/display/context/builder/SearchResultContentDisplayContextBuilderTest.java
@@ -110,6 +110,25 @@ public class SearchResultContentDisplayContextBuilderTest {
 	}
 
 	@Test
+	public void testEditPermissionFalseFromURLEdit() throws Exception {
+		Mockito.doReturn(
+			null
+		).when(
+			_assetRenderer
+		).getURLEdit(
+			Mockito.any(), Mockito.any()
+		);
+
+		SearchResultContentDisplayContext searchResultContentDisplayContext =
+			_buildDisplayContext();
+
+		Assert.assertFalse(
+			searchResultContentDisplayContext.hasEditPermission());
+
+		_assertIconMissing(searchResultContentDisplayContext);
+	}
+
+	@Test
 	public void testVisible() throws Exception {
 		SearchResultContentDisplayContext searchResultContentDisplayContext =
 			_buildDisplayContext();

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/result/display/context/builder/SearchResultContentDisplayContextBuilderTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/result/display/context/builder/SearchResultContentDisplayContextBuilderTest.java
@@ -110,7 +110,7 @@ public class SearchResultContentDisplayContextBuilderTest {
 	}
 
 	@Test
-	public void testIconMissingFromNullURLEdit() throws Exception {
+	public void testNullURL() throws Exception {
 		Mockito.doReturn(
 			null
 		).when(


### PR DESCRIPTION
Resent from https://github.com/brianchandotcom/liferay-portal/pull/170994 
Updated the test method name ~ Let me know if there's anything else, thank you!

> https://liferay.atlassian.net/browse/LPD-80055 - After clicking on the viewURL of CMS 2.0 Object Entry Folder in search results, all portlets on the page become "temporarily unavailable"
> 
> A null pointer exception occurs after having a null value in `assetRenderer.getURLEdit(...)` for object entry folders, so these changes offer a check in place to prevent these "temporarily unavailable" portlet errors.
> 
> Before:
> <img width="1281" height="805" alt="Screenshot 2026-02-25 at 2 32 05 PM" src="https://github.com/user-attachments/assets/d3b204fa-9667-47c4-921a-5a7d2b967a91" />
> 
> After:
> <img width="1281" height="625" alt="Screenshot 2026-02-25 at 2 47 22 PM" src="https://github.com/user-attachments/assets/c1e42f3d-16a1-4c7a-a49f-331da978638a" />
> 
> Building a proper edit URL and view page can be done on the `ObjectEntryFolderAssetRenderer` side, for the future.