### PR TITLE
LPD-78054 ensure workflow definitions scoped by account are available to be modified if the user has access to a non ai hub account

### DIFF
--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/WorkflowDefinitionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/WorkflowDefinitionResourceImpl.java
@@ -193,11 +193,11 @@ public class WorkflowDefinitionResourceImpl
 			transform(
 				_workflowDefinitionManager.getLatestWorkflowDefinitions(
 					active, contextCompany.getCompanyId(),
+					contextUser.getUserId(),
 					GetterUtil.getString(
 						scope, WorkflowDefinitionConstants.SCOPE_ALL),
 					pagination.getStartPosition(), pagination.getEndPosition(),
-					_toOrderByComparator((Sort)ArrayUtil.getValue(sorts, 0)),
-					contextUser.getUserId()),
+					_toOrderByComparator((Sort)ArrayUtil.getValue(sorts, 0))),
 				this::_toWorkflowDefinition),
 			pagination,
 			_workflowDefinitionManager.getLatestWorkflowDefinitionsCount(

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/WorkflowDefinitionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/WorkflowDefinitionResourceImpl.java
@@ -196,7 +196,8 @@ public class WorkflowDefinitionResourceImpl
 					GetterUtil.getString(
 						scope, WorkflowDefinitionConstants.SCOPE_ALL),
 					pagination.getStartPosition(), pagination.getEndPosition(),
-					_toOrderByComparator((Sort)ArrayUtil.getValue(sorts, 0))),
+					_toOrderByComparator((Sort)ArrayUtil.getValue(sorts, 0)),
+					contextUser.getUserId()),
 				this::_toWorkflowDefinition),
 			pagination,
 			_workflowDefinitionManager.getLatestWorkflowDefinitionsCount(

--- a/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/manager/WorkflowDefinitionManager.java
+++ b/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/manager/WorkflowDefinitionManager.java
@@ -65,22 +65,12 @@ public interface WorkflowDefinitionManager {
 	}
 
 	public default List<WorkflowDefinition> getLatestWorkflowDefinitions(
-			Boolean active, long companyId, String scope, int start, int end,
-			OrderByComparator<WorkflowDefinition> orderByComparator,
-			long userId)
+			Boolean active, long companyId, long userId, String scope,
+			int start, int end,
+			OrderByComparator<WorkflowDefinition> orderByComparator)
 		throws WorkflowException {
 
 		throw new UnsupportedOperationException();
-	}
-
-	public default List<WorkflowDefinition> getLatestWorkflowDefinitions(
-			long companyId, String scope, int start, int end,
-			OrderByComparator<WorkflowDefinition> orderByComparator,
-			long userId)
-		throws WorkflowException {
-
-		return getLatestWorkflowDefinitions(
-			null, companyId, scope, start, end, orderByComparator, userId);
 	}
 
 	public default int getLatestWorkflowDefinitionsCount(

--- a/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/manager/WorkflowDefinitionManager.java
+++ b/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/manager/WorkflowDefinitionManager.java
@@ -66,7 +66,8 @@ public interface WorkflowDefinitionManager {
 
 	public default List<WorkflowDefinition> getLatestWorkflowDefinitions(
 			Boolean active, long companyId, String scope, int start, int end,
-			OrderByComparator<WorkflowDefinition> orderByComparator)
+			OrderByComparator<WorkflowDefinition> orderByComparator,
+			long userId)
 		throws WorkflowException {
 
 		throw new UnsupportedOperationException();
@@ -74,11 +75,12 @@ public interface WorkflowDefinitionManager {
 
 	public default List<WorkflowDefinition> getLatestWorkflowDefinitions(
 			long companyId, String scope, int start, int end,
-			OrderByComparator<WorkflowDefinition> orderByComparator)
+			OrderByComparator<WorkflowDefinition> orderByComparator,
+			long userId)
 		throws WorkflowException {
 
 		return getLatestWorkflowDefinitions(
-			null, companyId, scope, start, end, orderByComparator);
+			null, companyId, scope, start, end, orderByComparator, userId);
 	}
 
 	public default int getLatestWorkflowDefinitionsCount(

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/bnd.bnd
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Workflow Kaleo API
 Bundle-SymbolicName: com.liferay.portal.workflow.kaleo.api
-Bundle-Version: 19.6.1
+Bundle-Version: 20.0.0
 Export-Package:\
 	com.liferay.portal.workflow.kaleo,\
 	com.liferay.portal.workflow.kaleo.constants,\

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoDefinitionPersistence.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoDefinitionPersistence.java
@@ -718,161 +718,6 @@ public interface KaleoDefinitionPersistence
 	public int countByC_N(long companyId, String name);
 
 	/**
-	 * Returns all the kaleo definitions where companyId = &#63; and scope = &#63;.
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @return the matching kaleo definitions
-	 */
-	public java.util.List<KaleoDefinition> findByC_S(
-		long companyId, String scope);
-
-	/**
-	 * Returns a range of all the kaleo definitions where companyId = &#63; and scope = &#63;.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
-	 * </p>
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @param start the lower bound of the range of kaleo definitions
-	 * @param end the upper bound of the range of kaleo definitions (not inclusive)
-	 * @return the range of matching kaleo definitions
-	 */
-	public java.util.List<KaleoDefinition> findByC_S(
-		long companyId, String scope, int start, int end);
-
-	/**
-	 * Returns an ordered range of all the kaleo definitions where companyId = &#63; and scope = &#63;.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
-	 * </p>
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @param start the lower bound of the range of kaleo definitions
-	 * @param end the upper bound of the range of kaleo definitions (not inclusive)
-	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
-	 * @return the ordered range of matching kaleo definitions
-	 */
-	public java.util.List<KaleoDefinition> findByC_S(
-		long companyId, String scope, int start, int end,
-		com.liferay.portal.kernel.util.OrderByComparator<KaleoDefinition>
-			orderByComparator);
-
-	/**
-	 * Returns an ordered range of all the kaleo definitions where companyId = &#63; and scope = &#63;.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
-	 * </p>
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @param start the lower bound of the range of kaleo definitions
-	 * @param end the upper bound of the range of kaleo definitions (not inclusive)
-	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
-	 * @param useFinderCache whether to use the finder cache
-	 * @return the ordered range of matching kaleo definitions
-	 */
-	public java.util.List<KaleoDefinition> findByC_S(
-		long companyId, String scope, int start, int end,
-		com.liferay.portal.kernel.util.OrderByComparator<KaleoDefinition>
-			orderByComparator,
-		boolean useFinderCache);
-
-	/**
-	 * Returns the first kaleo definition in the ordered set where companyId = &#63; and scope = &#63;.
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the first matching kaleo definition
-	 * @throws NoSuchDefinitionException if a matching kaleo definition could not be found
-	 */
-	public KaleoDefinition findByC_S_First(
-			long companyId, String scope,
-			com.liferay.portal.kernel.util.OrderByComparator<KaleoDefinition>
-				orderByComparator)
-		throws NoSuchDefinitionException;
-
-	/**
-	 * Returns the first kaleo definition in the ordered set where companyId = &#63; and scope = &#63;.
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the first matching kaleo definition, or <code>null</code> if a matching kaleo definition could not be found
-	 */
-	public KaleoDefinition fetchByC_S_First(
-		long companyId, String scope,
-		com.liferay.portal.kernel.util.OrderByComparator<KaleoDefinition>
-			orderByComparator);
-
-	/**
-	 * Returns the last kaleo definition in the ordered set where companyId = &#63; and scope = &#63;.
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the last matching kaleo definition
-	 * @throws NoSuchDefinitionException if a matching kaleo definition could not be found
-	 */
-	public KaleoDefinition findByC_S_Last(
-			long companyId, String scope,
-			com.liferay.portal.kernel.util.OrderByComparator<KaleoDefinition>
-				orderByComparator)
-		throws NoSuchDefinitionException;
-
-	/**
-	 * Returns the last kaleo definition in the ordered set where companyId = &#63; and scope = &#63;.
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the last matching kaleo definition, or <code>null</code> if a matching kaleo definition could not be found
-	 */
-	public KaleoDefinition fetchByC_S_Last(
-		long companyId, String scope,
-		com.liferay.portal.kernel.util.OrderByComparator<KaleoDefinition>
-			orderByComparator);
-
-	/**
-	 * Returns the kaleo definitions before and after the current kaleo definition in the ordered set where companyId = &#63; and scope = &#63;.
-	 *
-	 * @param kaleoDefinitionId the primary key of the current kaleo definition
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the previous, current, and next kaleo definition
-	 * @throws NoSuchDefinitionException if a kaleo definition with the primary key could not be found
-	 */
-	public KaleoDefinition[] findByC_S_PrevAndNext(
-			long kaleoDefinitionId, long companyId, String scope,
-			com.liferay.portal.kernel.util.OrderByComparator<KaleoDefinition>
-				orderByComparator)
-		throws NoSuchDefinitionException;
-
-	/**
-	 * Removes all the kaleo definitions where companyId = &#63; and scope = &#63; from the database.
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 */
-	public void removeByC_S(long companyId, String scope);
-
-	/**
-	 * Returns the number of kaleo definitions where companyId = &#63; and scope = &#63;.
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @return the number of matching kaleo definitions
-	 */
-	public int countByC_S(long companyId, String scope);
-
-	/**
 	 * Returns all the kaleo definitions where companyId = &#63; and active = &#63;.
 	 *
 	 * @param companyId the company ID
@@ -1028,6 +873,172 @@ public interface KaleoDefinitionPersistence
 	public int countByC_A(long companyId, boolean active);
 
 	/**
+	 * Returns all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @return the matching kaleo definitions
+	 */
+	public java.util.List<KaleoDefinition> findByG_C_S(
+		long groupId, long companyId, String scope);
+
+	/**
+	 * Returns a range of all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @param start the lower bound of the range of kaleo definitions
+	 * @param end the upper bound of the range of kaleo definitions (not inclusive)
+	 * @return the range of matching kaleo definitions
+	 */
+	public java.util.List<KaleoDefinition> findByG_C_S(
+		long groupId, long companyId, String scope, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @param start the lower bound of the range of kaleo definitions
+	 * @param end the upper bound of the range of kaleo definitions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching kaleo definitions
+	 */
+	public java.util.List<KaleoDefinition> findByG_C_S(
+		long groupId, long companyId, String scope, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<KaleoDefinition>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @param start the lower bound of the range of kaleo definitions
+	 * @param end the upper bound of the range of kaleo definitions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching kaleo definitions
+	 */
+	public java.util.List<KaleoDefinition> findByG_C_S(
+		long groupId, long companyId, String scope, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<KaleoDefinition>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching kaleo definition
+	 * @throws NoSuchDefinitionException if a matching kaleo definition could not be found
+	 */
+	public KaleoDefinition findByG_C_S_First(
+			long groupId, long companyId, String scope,
+			com.liferay.portal.kernel.util.OrderByComparator<KaleoDefinition>
+				orderByComparator)
+		throws NoSuchDefinitionException;
+
+	/**
+	 * Returns the first kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching kaleo definition, or <code>null</code> if a matching kaleo definition could not be found
+	 */
+	public KaleoDefinition fetchByG_C_S_First(
+		long groupId, long companyId, String scope,
+		com.liferay.portal.kernel.util.OrderByComparator<KaleoDefinition>
+			orderByComparator);
+
+	/**
+	 * Returns the last kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching kaleo definition
+	 * @throws NoSuchDefinitionException if a matching kaleo definition could not be found
+	 */
+	public KaleoDefinition findByG_C_S_Last(
+			long groupId, long companyId, String scope,
+			com.liferay.portal.kernel.util.OrderByComparator<KaleoDefinition>
+				orderByComparator)
+		throws NoSuchDefinitionException;
+
+	/**
+	 * Returns the last kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching kaleo definition, or <code>null</code> if a matching kaleo definition could not be found
+	 */
+	public KaleoDefinition fetchByG_C_S_Last(
+		long groupId, long companyId, String scope,
+		com.liferay.portal.kernel.util.OrderByComparator<KaleoDefinition>
+			orderByComparator);
+
+	/**
+	 * Returns the kaleo definitions before and after the current kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * @param kaleoDefinitionId the primary key of the current kaleo definition
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next kaleo definition
+	 * @throws NoSuchDefinitionException if a kaleo definition with the primary key could not be found
+	 */
+	public KaleoDefinition[] findByG_C_S_PrevAndNext(
+			long kaleoDefinitionId, long groupId, long companyId, String scope,
+			com.liferay.portal.kernel.util.OrderByComparator<KaleoDefinition>
+				orderByComparator)
+		throws NoSuchDefinitionException;
+
+	/**
+	 * Removes all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 */
+	public void removeByG_C_S(long groupId, long companyId, String scope);
+
+	/**
+	 * Returns the number of kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @return the number of matching kaleo definitions
+	 */
+	public int countByG_C_S(long groupId, long companyId, String scope);
+
+	/**
 	 * Returns the kaleo definition where companyId = &#63; and name = &#63; and version = &#63; or throws a <code>NoSuchDefinitionException</code> if it could not be found.
 	 *
 	 * @param companyId the company ID
@@ -1143,23 +1154,25 @@ public interface KaleoDefinitionPersistence
 	public int countByC_N_A(long companyId, String name, boolean active);
 
 	/**
-	 * Returns all the kaleo definitions where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
 	 * @return the matching kaleo definitions
 	 */
-	public java.util.List<KaleoDefinition> findByC_S_A(
-		long companyId, String scope, boolean active);
+	public java.util.List<KaleoDefinition> findByG_C_S_A(
+		long groupId, long companyId, String scope, boolean active);
 
 	/**
-	 * Returns a range of all the kaleo definitions where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns a range of all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
 	 * </p>
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
@@ -1167,16 +1180,18 @@ public interface KaleoDefinitionPersistence
 	 * @param end the upper bound of the range of kaleo definitions (not inclusive)
 	 * @return the range of matching kaleo definitions
 	 */
-	public java.util.List<KaleoDefinition> findByC_S_A(
-		long companyId, String scope, boolean active, int start, int end);
+	public java.util.List<KaleoDefinition> findByG_C_S_A(
+		long groupId, long companyId, String scope, boolean active, int start,
+		int end);
 
 	/**
-	 * Returns an ordered range of all the kaleo definitions where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns an ordered range of all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
 	 * </p>
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
@@ -1185,18 +1200,20 @@ public interface KaleoDefinitionPersistence
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching kaleo definitions
 	 */
-	public java.util.List<KaleoDefinition> findByC_S_A(
-		long companyId, String scope, boolean active, int start, int end,
+	public java.util.List<KaleoDefinition> findByG_C_S_A(
+		long groupId, long companyId, String scope, boolean active, int start,
+		int end,
 		com.liferay.portal.kernel.util.OrderByComparator<KaleoDefinition>
 			orderByComparator);
 
 	/**
-	 * Returns an ordered range of all the kaleo definitions where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns an ordered range of all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
 	 * </p>
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
@@ -1206,15 +1223,17 @@ public interface KaleoDefinitionPersistence
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the ordered range of matching kaleo definitions
 	 */
-	public java.util.List<KaleoDefinition> findByC_S_A(
-		long companyId, String scope, boolean active, int start, int end,
+	public java.util.List<KaleoDefinition> findByG_C_S_A(
+		long groupId, long companyId, String scope, boolean active, int start,
+		int end,
 		com.liferay.portal.kernel.util.OrderByComparator<KaleoDefinition>
 			orderByComparator,
 		boolean useFinderCache);
 
 	/**
-	 * Returns the first kaleo definition in the ordered set where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns the first kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
@@ -1222,29 +1241,31 @@ public interface KaleoDefinitionPersistence
 	 * @return the first matching kaleo definition
 	 * @throws NoSuchDefinitionException if a matching kaleo definition could not be found
 	 */
-	public KaleoDefinition findByC_S_A_First(
-			long companyId, String scope, boolean active,
+	public KaleoDefinition findByG_C_S_A_First(
+			long groupId, long companyId, String scope, boolean active,
 			com.liferay.portal.kernel.util.OrderByComparator<KaleoDefinition>
 				orderByComparator)
 		throws NoSuchDefinitionException;
 
 	/**
-	 * Returns the first kaleo definition in the ordered set where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns the first kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching kaleo definition, or <code>null</code> if a matching kaleo definition could not be found
 	 */
-	public KaleoDefinition fetchByC_S_A_First(
-		long companyId, String scope, boolean active,
+	public KaleoDefinition fetchByG_C_S_A_First(
+		long groupId, long companyId, String scope, boolean active,
 		com.liferay.portal.kernel.util.OrderByComparator<KaleoDefinition>
 			orderByComparator);
 
 	/**
-	 * Returns the last kaleo definition in the ordered set where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns the last kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
@@ -1252,30 +1273,32 @@ public interface KaleoDefinitionPersistence
 	 * @return the last matching kaleo definition
 	 * @throws NoSuchDefinitionException if a matching kaleo definition could not be found
 	 */
-	public KaleoDefinition findByC_S_A_Last(
-			long companyId, String scope, boolean active,
+	public KaleoDefinition findByG_C_S_A_Last(
+			long groupId, long companyId, String scope, boolean active,
 			com.liferay.portal.kernel.util.OrderByComparator<KaleoDefinition>
 				orderByComparator)
 		throws NoSuchDefinitionException;
 
 	/**
-	 * Returns the last kaleo definition in the ordered set where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns the last kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching kaleo definition, or <code>null</code> if a matching kaleo definition could not be found
 	 */
-	public KaleoDefinition fetchByC_S_A_Last(
-		long companyId, String scope, boolean active,
+	public KaleoDefinition fetchByG_C_S_A_Last(
+		long groupId, long companyId, String scope, boolean active,
 		com.liferay.portal.kernel.util.OrderByComparator<KaleoDefinition>
 			orderByComparator);
 
 	/**
-	 * Returns the kaleo definitions before and after the current kaleo definition in the ordered set where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns the kaleo definitions before and after the current kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
 	 * @param kaleoDefinitionId the primary key of the current kaleo definition
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
@@ -1283,31 +1306,35 @@ public interface KaleoDefinitionPersistence
 	 * @return the previous, current, and next kaleo definition
 	 * @throws NoSuchDefinitionException if a kaleo definition with the primary key could not be found
 	 */
-	public KaleoDefinition[] findByC_S_A_PrevAndNext(
-			long kaleoDefinitionId, long companyId, String scope,
+	public KaleoDefinition[] findByG_C_S_A_PrevAndNext(
+			long kaleoDefinitionId, long groupId, long companyId, String scope,
 			boolean active,
 			com.liferay.portal.kernel.util.OrderByComparator<KaleoDefinition>
 				orderByComparator)
 		throws NoSuchDefinitionException;
 
 	/**
-	 * Removes all the kaleo definitions where companyId = &#63; and scope = &#63; and active = &#63; from the database.
+	 * Removes all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63; from the database.
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
 	 */
-	public void removeByC_S_A(long companyId, String scope, boolean active);
+	public void removeByG_C_S_A(
+		long groupId, long companyId, String scope, boolean active);
 
 	/**
-	 * Returns the number of kaleo definitions where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns the number of kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
 	 * @return the number of matching kaleo definitions
 	 */
-	public int countByC_S_A(long companyId, String scope, boolean active);
+	public int countByG_C_S_A(
+		long groupId, long companyId, String scope, boolean active);
 
 	/**
 	 * Returns the kaleo definition where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchDefinitionException</code> if it could not be found.

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoDefinitionUtil.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoDefinitionUtil.java
@@ -941,195 +941,6 @@ public class KaleoDefinitionUtil {
 	}
 
 	/**
-	 * Returns all the kaleo definitions where companyId = &#63; and scope = &#63;.
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @return the matching kaleo definitions
-	 */
-	public static List<KaleoDefinition> findByC_S(
-		long companyId, String scope) {
-
-		return getPersistence().findByC_S(companyId, scope);
-	}
-
-	/**
-	 * Returns a range of all the kaleo definitions where companyId = &#63; and scope = &#63;.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
-	 * </p>
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @param start the lower bound of the range of kaleo definitions
-	 * @param end the upper bound of the range of kaleo definitions (not inclusive)
-	 * @return the range of matching kaleo definitions
-	 */
-	public static List<KaleoDefinition> findByC_S(
-		long companyId, String scope, int start, int end) {
-
-		return getPersistence().findByC_S(companyId, scope, start, end);
-	}
-
-	/**
-	 * Returns an ordered range of all the kaleo definitions where companyId = &#63; and scope = &#63;.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
-	 * </p>
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @param start the lower bound of the range of kaleo definitions
-	 * @param end the upper bound of the range of kaleo definitions (not inclusive)
-	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
-	 * @return the ordered range of matching kaleo definitions
-	 */
-	public static List<KaleoDefinition> findByC_S(
-		long companyId, String scope, int start, int end,
-		OrderByComparator<KaleoDefinition> orderByComparator) {
-
-		return getPersistence().findByC_S(
-			companyId, scope, start, end, orderByComparator);
-	}
-
-	/**
-	 * Returns an ordered range of all the kaleo definitions where companyId = &#63; and scope = &#63;.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
-	 * </p>
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @param start the lower bound of the range of kaleo definitions
-	 * @param end the upper bound of the range of kaleo definitions (not inclusive)
-	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
-	 * @param useFinderCache whether to use the finder cache
-	 * @return the ordered range of matching kaleo definitions
-	 */
-	public static List<KaleoDefinition> findByC_S(
-		long companyId, String scope, int start, int end,
-		OrderByComparator<KaleoDefinition> orderByComparator,
-		boolean useFinderCache) {
-
-		return getPersistence().findByC_S(
-			companyId, scope, start, end, orderByComparator, useFinderCache);
-	}
-
-	/**
-	 * Returns the first kaleo definition in the ordered set where companyId = &#63; and scope = &#63;.
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the first matching kaleo definition
-	 * @throws NoSuchDefinitionException if a matching kaleo definition could not be found
-	 */
-	public static KaleoDefinition findByC_S_First(
-			long companyId, String scope,
-			OrderByComparator<KaleoDefinition> orderByComparator)
-		throws com.liferay.portal.workflow.kaleo.exception.
-			NoSuchDefinitionException {
-
-		return getPersistence().findByC_S_First(
-			companyId, scope, orderByComparator);
-	}
-
-	/**
-	 * Returns the first kaleo definition in the ordered set where companyId = &#63; and scope = &#63;.
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the first matching kaleo definition, or <code>null</code> if a matching kaleo definition could not be found
-	 */
-	public static KaleoDefinition fetchByC_S_First(
-		long companyId, String scope,
-		OrderByComparator<KaleoDefinition> orderByComparator) {
-
-		return getPersistence().fetchByC_S_First(
-			companyId, scope, orderByComparator);
-	}
-
-	/**
-	 * Returns the last kaleo definition in the ordered set where companyId = &#63; and scope = &#63;.
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the last matching kaleo definition
-	 * @throws NoSuchDefinitionException if a matching kaleo definition could not be found
-	 */
-	public static KaleoDefinition findByC_S_Last(
-			long companyId, String scope,
-			OrderByComparator<KaleoDefinition> orderByComparator)
-		throws com.liferay.portal.workflow.kaleo.exception.
-			NoSuchDefinitionException {
-
-		return getPersistence().findByC_S_Last(
-			companyId, scope, orderByComparator);
-	}
-
-	/**
-	 * Returns the last kaleo definition in the ordered set where companyId = &#63; and scope = &#63;.
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the last matching kaleo definition, or <code>null</code> if a matching kaleo definition could not be found
-	 */
-	public static KaleoDefinition fetchByC_S_Last(
-		long companyId, String scope,
-		OrderByComparator<KaleoDefinition> orderByComparator) {
-
-		return getPersistence().fetchByC_S_Last(
-			companyId, scope, orderByComparator);
-	}
-
-	/**
-	 * Returns the kaleo definitions before and after the current kaleo definition in the ordered set where companyId = &#63; and scope = &#63;.
-	 *
-	 * @param kaleoDefinitionId the primary key of the current kaleo definition
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the previous, current, and next kaleo definition
-	 * @throws NoSuchDefinitionException if a kaleo definition with the primary key could not be found
-	 */
-	public static KaleoDefinition[] findByC_S_PrevAndNext(
-			long kaleoDefinitionId, long companyId, String scope,
-			OrderByComparator<KaleoDefinition> orderByComparator)
-		throws com.liferay.portal.workflow.kaleo.exception.
-			NoSuchDefinitionException {
-
-		return getPersistence().findByC_S_PrevAndNext(
-			kaleoDefinitionId, companyId, scope, orderByComparator);
-	}
-
-	/**
-	 * Removes all the kaleo definitions where companyId = &#63; and scope = &#63; from the database.
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 */
-	public static void removeByC_S(long companyId, String scope) {
-		getPersistence().removeByC_S(companyId, scope);
-	}
-
-	/**
-	 * Returns the number of kaleo definitions where companyId = &#63; and scope = &#63;.
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @return the number of matching kaleo definitions
-	 */
-	public static int countByC_S(long companyId, String scope) {
-		return getPersistence().countByC_S(companyId, scope);
-	}
-
-	/**
 	 * Returns all the kaleo definitions where companyId = &#63; and active = &#63;.
 	 *
 	 * @param companyId the company ID
@@ -1319,6 +1130,210 @@ public class KaleoDefinitionUtil {
 	}
 
 	/**
+	 * Returns all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @return the matching kaleo definitions
+	 */
+	public static List<KaleoDefinition> findByG_C_S(
+		long groupId, long companyId, String scope) {
+
+		return getPersistence().findByG_C_S(groupId, companyId, scope);
+	}
+
+	/**
+	 * Returns a range of all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @param start the lower bound of the range of kaleo definitions
+	 * @param end the upper bound of the range of kaleo definitions (not inclusive)
+	 * @return the range of matching kaleo definitions
+	 */
+	public static List<KaleoDefinition> findByG_C_S(
+		long groupId, long companyId, String scope, int start, int end) {
+
+		return getPersistence().findByG_C_S(
+			groupId, companyId, scope, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @param start the lower bound of the range of kaleo definitions
+	 * @param end the upper bound of the range of kaleo definitions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching kaleo definitions
+	 */
+	public static List<KaleoDefinition> findByG_C_S(
+		long groupId, long companyId, String scope, int start, int end,
+		OrderByComparator<KaleoDefinition> orderByComparator) {
+
+		return getPersistence().findByG_C_S(
+			groupId, companyId, scope, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @param start the lower bound of the range of kaleo definitions
+	 * @param end the upper bound of the range of kaleo definitions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching kaleo definitions
+	 */
+	public static List<KaleoDefinition> findByG_C_S(
+		long groupId, long companyId, String scope, int start, int end,
+		OrderByComparator<KaleoDefinition> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByG_C_S(
+			groupId, companyId, scope, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching kaleo definition
+	 * @throws NoSuchDefinitionException if a matching kaleo definition could not be found
+	 */
+	public static KaleoDefinition findByG_C_S_First(
+			long groupId, long companyId, String scope,
+			OrderByComparator<KaleoDefinition> orderByComparator)
+		throws com.liferay.portal.workflow.kaleo.exception.
+			NoSuchDefinitionException {
+
+		return getPersistence().findByG_C_S_First(
+			groupId, companyId, scope, orderByComparator);
+	}
+
+	/**
+	 * Returns the first kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching kaleo definition, or <code>null</code> if a matching kaleo definition could not be found
+	 */
+	public static KaleoDefinition fetchByG_C_S_First(
+		long groupId, long companyId, String scope,
+		OrderByComparator<KaleoDefinition> orderByComparator) {
+
+		return getPersistence().fetchByG_C_S_First(
+			groupId, companyId, scope, orderByComparator);
+	}
+
+	/**
+	 * Returns the last kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching kaleo definition
+	 * @throws NoSuchDefinitionException if a matching kaleo definition could not be found
+	 */
+	public static KaleoDefinition findByG_C_S_Last(
+			long groupId, long companyId, String scope,
+			OrderByComparator<KaleoDefinition> orderByComparator)
+		throws com.liferay.portal.workflow.kaleo.exception.
+			NoSuchDefinitionException {
+
+		return getPersistence().findByG_C_S_Last(
+			groupId, companyId, scope, orderByComparator);
+	}
+
+	/**
+	 * Returns the last kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching kaleo definition, or <code>null</code> if a matching kaleo definition could not be found
+	 */
+	public static KaleoDefinition fetchByG_C_S_Last(
+		long groupId, long companyId, String scope,
+		OrderByComparator<KaleoDefinition> orderByComparator) {
+
+		return getPersistence().fetchByG_C_S_Last(
+			groupId, companyId, scope, orderByComparator);
+	}
+
+	/**
+	 * Returns the kaleo definitions before and after the current kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * @param kaleoDefinitionId the primary key of the current kaleo definition
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next kaleo definition
+	 * @throws NoSuchDefinitionException if a kaleo definition with the primary key could not be found
+	 */
+	public static KaleoDefinition[] findByG_C_S_PrevAndNext(
+			long kaleoDefinitionId, long groupId, long companyId, String scope,
+			OrderByComparator<KaleoDefinition> orderByComparator)
+		throws com.liferay.portal.workflow.kaleo.exception.
+			NoSuchDefinitionException {
+
+		return getPersistence().findByG_C_S_PrevAndNext(
+			kaleoDefinitionId, groupId, companyId, scope, orderByComparator);
+	}
+
+	/**
+	 * Removes all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 */
+	public static void removeByG_C_S(
+		long groupId, long companyId, String scope) {
+
+		getPersistence().removeByG_C_S(groupId, companyId, scope);
+	}
+
+	/**
+	 * Returns the number of kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @return the number of matching kaleo definitions
+	 */
+	public static int countByG_C_S(long groupId, long companyId, String scope) {
+		return getPersistence().countByG_C_S(groupId, companyId, scope);
+	}
+
+	/**
 	 * Returns the kaleo definition where companyId = &#63; and name = &#63; and version = &#63; or throws a <code>NoSuchDefinitionException</code> if it could not be found.
 	 *
 	 * @param companyId the company ID
@@ -1471,26 +1486,29 @@ public class KaleoDefinitionUtil {
 	}
 
 	/**
-	 * Returns all the kaleo definitions where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
 	 * @return the matching kaleo definitions
 	 */
-	public static List<KaleoDefinition> findByC_S_A(
-		long companyId, String scope, boolean active) {
+	public static List<KaleoDefinition> findByG_C_S_A(
+		long groupId, long companyId, String scope, boolean active) {
 
-		return getPersistence().findByC_S_A(companyId, scope, active);
+		return getPersistence().findByG_C_S_A(
+			groupId, companyId, scope, active);
 	}
 
 	/**
-	 * Returns a range of all the kaleo definitions where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns a range of all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
 	 * </p>
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
@@ -1498,20 +1516,22 @@ public class KaleoDefinitionUtil {
 	 * @param end the upper bound of the range of kaleo definitions (not inclusive)
 	 * @return the range of matching kaleo definitions
 	 */
-	public static List<KaleoDefinition> findByC_S_A(
-		long companyId, String scope, boolean active, int start, int end) {
+	public static List<KaleoDefinition> findByG_C_S_A(
+		long groupId, long companyId, String scope, boolean active, int start,
+		int end) {
 
-		return getPersistence().findByC_S_A(
-			companyId, scope, active, start, end);
+		return getPersistence().findByG_C_S_A(
+			groupId, companyId, scope, active, start, end);
 	}
 
 	/**
-	 * Returns an ordered range of all the kaleo definitions where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns an ordered range of all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
 	 * </p>
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
@@ -1520,21 +1540,22 @@ public class KaleoDefinitionUtil {
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching kaleo definitions
 	 */
-	public static List<KaleoDefinition> findByC_S_A(
-		long companyId, String scope, boolean active, int start, int end,
-		OrderByComparator<KaleoDefinition> orderByComparator) {
+	public static List<KaleoDefinition> findByG_C_S_A(
+		long groupId, long companyId, String scope, boolean active, int start,
+		int end, OrderByComparator<KaleoDefinition> orderByComparator) {
 
-		return getPersistence().findByC_S_A(
-			companyId, scope, active, start, end, orderByComparator);
+		return getPersistence().findByG_C_S_A(
+			groupId, companyId, scope, active, start, end, orderByComparator);
 	}
 
 	/**
-	 * Returns an ordered range of all the kaleo definitions where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns an ordered range of all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
 	 * </p>
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
@@ -1544,19 +1565,20 @@ public class KaleoDefinitionUtil {
 	 * @param useFinderCache whether to use the finder cache
 	 * @return the ordered range of matching kaleo definitions
 	 */
-	public static List<KaleoDefinition> findByC_S_A(
-		long companyId, String scope, boolean active, int start, int end,
-		OrderByComparator<KaleoDefinition> orderByComparator,
+	public static List<KaleoDefinition> findByG_C_S_A(
+		long groupId, long companyId, String scope, boolean active, int start,
+		int end, OrderByComparator<KaleoDefinition> orderByComparator,
 		boolean useFinderCache) {
 
-		return getPersistence().findByC_S_A(
-			companyId, scope, active, start, end, orderByComparator,
+		return getPersistence().findByG_C_S_A(
+			groupId, companyId, scope, active, start, end, orderByComparator,
 			useFinderCache);
 	}
 
 	/**
-	 * Returns the first kaleo definition in the ordered set where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns the first kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
@@ -1564,36 +1586,38 @@ public class KaleoDefinitionUtil {
 	 * @return the first matching kaleo definition
 	 * @throws NoSuchDefinitionException if a matching kaleo definition could not be found
 	 */
-	public static KaleoDefinition findByC_S_A_First(
-			long companyId, String scope, boolean active,
+	public static KaleoDefinition findByG_C_S_A_First(
+			long groupId, long companyId, String scope, boolean active,
 			OrderByComparator<KaleoDefinition> orderByComparator)
 		throws com.liferay.portal.workflow.kaleo.exception.
 			NoSuchDefinitionException {
 
-		return getPersistence().findByC_S_A_First(
-			companyId, scope, active, orderByComparator);
+		return getPersistence().findByG_C_S_A_First(
+			groupId, companyId, scope, active, orderByComparator);
 	}
 
 	/**
-	 * Returns the first kaleo definition in the ordered set where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns the first kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the first matching kaleo definition, or <code>null</code> if a matching kaleo definition could not be found
 	 */
-	public static KaleoDefinition fetchByC_S_A_First(
-		long companyId, String scope, boolean active,
+	public static KaleoDefinition fetchByG_C_S_A_First(
+		long groupId, long companyId, String scope, boolean active,
 		OrderByComparator<KaleoDefinition> orderByComparator) {
 
-		return getPersistence().fetchByC_S_A_First(
-			companyId, scope, active, orderByComparator);
+		return getPersistence().fetchByG_C_S_A_First(
+			groupId, companyId, scope, active, orderByComparator);
 	}
 
 	/**
-	 * Returns the last kaleo definition in the ordered set where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns the last kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
@@ -1601,37 +1625,39 @@ public class KaleoDefinitionUtil {
 	 * @return the last matching kaleo definition
 	 * @throws NoSuchDefinitionException if a matching kaleo definition could not be found
 	 */
-	public static KaleoDefinition findByC_S_A_Last(
-			long companyId, String scope, boolean active,
+	public static KaleoDefinition findByG_C_S_A_Last(
+			long groupId, long companyId, String scope, boolean active,
 			OrderByComparator<KaleoDefinition> orderByComparator)
 		throws com.liferay.portal.workflow.kaleo.exception.
 			NoSuchDefinitionException {
 
-		return getPersistence().findByC_S_A_Last(
-			companyId, scope, active, orderByComparator);
+		return getPersistence().findByG_C_S_A_Last(
+			groupId, companyId, scope, active, orderByComparator);
 	}
 
 	/**
-	 * Returns the last kaleo definition in the ordered set where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns the last kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
 	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
 	 * @return the last matching kaleo definition, or <code>null</code> if a matching kaleo definition could not be found
 	 */
-	public static KaleoDefinition fetchByC_S_A_Last(
-		long companyId, String scope, boolean active,
+	public static KaleoDefinition fetchByG_C_S_A_Last(
+		long groupId, long companyId, String scope, boolean active,
 		OrderByComparator<KaleoDefinition> orderByComparator) {
 
-		return getPersistence().fetchByC_S_A_Last(
-			companyId, scope, active, orderByComparator);
+		return getPersistence().fetchByG_C_S_A_Last(
+			groupId, companyId, scope, active, orderByComparator);
 	}
 
 	/**
-	 * Returns the kaleo definitions before and after the current kaleo definition in the ordered set where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns the kaleo definitions before and after the current kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
 	 * @param kaleoDefinitionId the primary key of the current kaleo definition
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
@@ -1639,42 +1665,46 @@ public class KaleoDefinitionUtil {
 	 * @return the previous, current, and next kaleo definition
 	 * @throws NoSuchDefinitionException if a kaleo definition with the primary key could not be found
 	 */
-	public static KaleoDefinition[] findByC_S_A_PrevAndNext(
-			long kaleoDefinitionId, long companyId, String scope,
+	public static KaleoDefinition[] findByG_C_S_A_PrevAndNext(
+			long kaleoDefinitionId, long groupId, long companyId, String scope,
 			boolean active,
 			OrderByComparator<KaleoDefinition> orderByComparator)
 		throws com.liferay.portal.workflow.kaleo.exception.
 			NoSuchDefinitionException {
 
-		return getPersistence().findByC_S_A_PrevAndNext(
-			kaleoDefinitionId, companyId, scope, active, orderByComparator);
+		return getPersistence().findByG_C_S_A_PrevAndNext(
+			kaleoDefinitionId, groupId, companyId, scope, active,
+			orderByComparator);
 	}
 
 	/**
-	 * Removes all the kaleo definitions where companyId = &#63; and scope = &#63; and active = &#63; from the database.
+	 * Removes all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63; from the database.
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
 	 */
-	public static void removeByC_S_A(
-		long companyId, String scope, boolean active) {
+	public static void removeByG_C_S_A(
+		long groupId, long companyId, String scope, boolean active) {
 
-		getPersistence().removeByC_S_A(companyId, scope, active);
+		getPersistence().removeByG_C_S_A(groupId, companyId, scope, active);
 	}
 
 	/**
-	 * Returns the number of kaleo definitions where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns the number of kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
 	 * @return the number of matching kaleo definitions
 	 */
-	public static int countByC_S_A(
-		long companyId, String scope, boolean active) {
+	public static int countByG_C_S_A(
+		long groupId, long companyId, String scope, boolean active) {
 
-		return getPersistence().countByC_S_A(companyId, scope, active);
+		return getPersistence().countByG_C_S_A(
+			groupId, companyId, scope, active);
 	}
 
 	/**

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/resources/com/liferay/portal/workflow/kaleo/service/persistence/packageinfo
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/resources/com/liferay/portal/workflow/kaleo/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 5.9.0
+version 6.0.0

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowDefinitionManagerImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowDefinitionManagerImpl.java
@@ -168,9 +168,9 @@ public class WorkflowDefinitionManagerImpl
 
 	@Override
 	public List<WorkflowDefinition> getLatestWorkflowDefinitions(
-			Boolean active, long companyId, String scope, int start, int end,
-			OrderByComparator<WorkflowDefinition> orderByComparator,
-			long userId)
+			Boolean active, long companyId, long userId, String scope,
+			int start, int end,
+			OrderByComparator<WorkflowDefinition> orderByComparator)
 		throws WorkflowException {
 
 		return _getLatestWorkflowDefinitions(

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowDefinitionManagerImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowDefinitionManagerImpl.java
@@ -169,11 +169,13 @@ public class WorkflowDefinitionManagerImpl
 	@Override
 	public List<WorkflowDefinition> getLatestWorkflowDefinitions(
 			Boolean active, long companyId, String scope, int start, int end,
-			OrderByComparator<WorkflowDefinition> orderByComparator)
+			OrderByComparator<WorkflowDefinition> orderByComparator,
+			long userId)
 		throws WorkflowException {
 
 		return _getLatestWorkflowDefinitions(
-			companyId, active, scope, start, end, orderByComparator, false);
+			companyId, active, scope, start, end, orderByComparator, false,
+			userId);
 	}
 
 	@Override
@@ -296,7 +298,7 @@ public class WorkflowDefinitionManagerImpl
 		throws WorkflowException {
 
 		return _getLatestWorkflowDefinitions(
-			companyId, null, scope, start, end, orderByComparator, true);
+			companyId, null, scope, start, end, orderByComparator, true, 0L);
 	}
 
 	@Override
@@ -520,13 +522,14 @@ public class WorkflowDefinitionManagerImpl
 	private List<WorkflowDefinition> _getLatestWorkflowDefinitions(
 			long companyId, Boolean active, String scope, int start, int end,
 			OrderByComparator<WorkflowDefinition> orderByComparator,
-			boolean liberal)
+			boolean liberal, long userId)
 		throws WorkflowException {
 
 		try {
 			ServiceContext serviceContext = new ServiceContext();
 
 			serviceContext.setCompanyId(companyId);
+			serviceContext.setUserId(userId);
 
 			List<KaleoDefinition> kaleoDefinitions = null;
 
@@ -548,14 +551,12 @@ public class WorkflowDefinitionManagerImpl
 				kaleoDefinitions = _get(
 					liberal,
 					() -> _kaleoDefinitionLocalService.getScopeKaleoDefinitions(
-						WorkflowDefinitionConstants.SCOPE_ALL, active, start,
-						end,
+						scope, active, start, end,
 						KaleoDefinitionOrderByComparator.getOrderByComparator(
 							orderByComparator, _kaleoWorkflowModelConverter),
 						serviceContext),
 					() -> _kaleoDefinitionService.getScopeKaleoDefinitions(
-						WorkflowDefinitionConstants.SCOPE_ALL, active, start,
-						end,
+						scope, active, start, end,
 						KaleoDefinitionOrderByComparator.getOrderByComparator(
 							orderByComparator, _kaleoWorkflowModelConverter),
 						serviceContext));

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/security/permission/resource/KaleoDefinitionModelResourcePermission.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/security/permission/resource/KaleoDefinitionModelResourcePermission.java
@@ -5,13 +5,17 @@
 
 package com.liferay.portal.workflow.kaleo.runtime.integration.internal.security.permission.resource;
 
+import com.liferay.account.model.AccountEntry;
+import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.workflow.configuration.WorkflowDefinitionConfiguration;
@@ -19,6 +23,7 @@ import com.liferay.portal.workflow.kaleo.model.KaleoDefinition;
 import com.liferay.portal.workflow.kaleo.service.KaleoDefinitionLocalService;
 
 import java.util.Map;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -74,6 +79,33 @@ public class KaleoDefinitionModelResourcePermission
 			return true;
 		}
 
+		if (kaleoDefinition == null) {
+			return false;
+		}
+
+		long groupId = kaleoDefinition.getGroupId();
+
+		if (groupId == 0) {
+			return false;
+		}
+
+		Group group = _groupLocalService.fetchGroup(groupId);
+
+		AccountEntry accountEntry =
+			_accountEntryLocalService.fetchUserAccountEntry(
+				permissionChecker.getUserId(), group.getClassPK());
+
+		if (accountEntry == null) {
+			return false;
+		}
+
+		if (Objects.equals(ActionKeys.VIEW, actionId) ||
+			!Objects.equals(
+				accountEntry.getExternalReferenceCode(), "L_AI_HUB")) {
+
+			return true;
+		}
+
 		return false;
 	}
 
@@ -110,7 +142,13 @@ public class KaleoDefinitionModelResourcePermission
 			workflowDefinitionConfiguration.companyAdministratorCanPublish();
 	}
 
+	@Reference
+	private AccountEntryLocalService _accountEntryLocalService;
+
 	private volatile boolean _companyAdministratorCanPublish;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private KaleoDefinitionLocalService _kaleoDefinitionLocalService;

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/security/permission/resource/WorkflowPortletResourcePermission.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/security/permission/resource/WorkflowPortletResourcePermission.java
@@ -8,6 +8,9 @@ package com.liferay.portal.workflow.kaleo.runtime.integration.internal.security.
 import com.liferay.account.model.AccountEntry;
 import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
@@ -17,6 +20,7 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.workflow.configuration.WorkflowDefinitionConfiguration;
 
 import java.util.Map;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -64,28 +68,14 @@ public class WorkflowPortletResourcePermission
 	public boolean contains(
 		PermissionChecker permissionChecker, long groupId, String actionId) {
 
-		if (permissionChecker.isOmniadmin() ||
-			(_companyAdministratorCanPublish &&
-			 permissionChecker.isCompanyAdmin())) {
-
-			return true;
+		try {
+			return _contains(permissionChecker, groupId);
 		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
 
-		if (groupId == 0) {
 			return false;
 		}
-
-		Group group = _groupLocalService.fetchGroup(groupId);
-
-		AccountEntry accountEntry =
-			_accountEntryLocalService.fetchUserAccountEntry(
-				permissionChecker.getUserId(), group.getClassPK());
-
-		if (accountEntry != null) {
-			return true;
-		}
-
-		return false;
 	}
 
 	@Override
@@ -103,6 +93,37 @@ public class WorkflowPortletResourcePermission
 		_companyAdministratorCanPublish =
 			workflowDefinitionConfiguration.companyAdministratorCanPublish();
 	}
+
+	private boolean _contains(PermissionChecker permissionChecker, long groupId)
+		throws PortalException {
+
+		if (permissionChecker.isOmniadmin() ||
+			(_companyAdministratorCanPublish &&
+			 permissionChecker.isCompanyAdmin())) {
+
+			return true;
+		}
+
+		if (groupId == 0) {
+			return false;
+		}
+
+		Group group = _groupLocalService.fetchGroup(groupId);
+
+		AccountEntry accountEntry =
+			_accountEntryLocalService.fetchUserAccountEntry(
+				permissionChecker.getUserId(), group.getClassPK());
+
+		if (accountEntry == null) {
+			return false;
+		}
+
+		return !Objects.equals(
+			accountEntry.getExternalReferenceCode(), "L_AI_HUB");
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		WorkflowPortletResourcePermission.class);
 
 	@Reference
 	private AccountEntryLocalService _accountEntryLocalService;

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/service.xml
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/service.xml
@@ -165,13 +165,14 @@
 			<finder-column name="companyId" />
 			<finder-column name="name" />
 		</finder>
-		<finder name="C_S" return-type="Collection">
-			<finder-column name="companyId" />
-			<finder-column name="scope" />
-		</finder>
 		<finder name="C_A" return-type="Collection">
 			<finder-column name="companyId" />
 			<finder-column name="active" />
+		</finder>
+		<finder name="G_C_S" return-type="Collection">
+			<finder-column name="groupId" />
+			<finder-column name="companyId" />
+			<finder-column name="scope" />
 		</finder>
 		<finder name="C_N_V" return-type="KaleoDefinition">
 			<finder-column name="companyId" />
@@ -183,7 +184,8 @@
 			<finder-column name="name" />
 			<finder-column name="active" />
 		</finder>
-		<finder name="C_S_A" return-type="Collection">
+		<finder name="G_C_S_A" return-type="Collection">
+			<finder-column name="groupId" />
 			<finder-column name="companyId" />
 			<finder-column name="scope" />
 			<finder-column name="active" />

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoDefinitionLocalServiceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoDefinitionLocalServiceImpl.java
@@ -5,6 +5,9 @@
 
 package com.liferay.portal.workflow.kaleo.service.impl;
 
+import com.liferay.account.model.AccountEntry;
+import com.liferay.account.model.AccountEntryUserRel;
+import com.liferay.account.service.AccountEntryUserRelLocalService;
 import com.liferay.exportimport.kernel.staging.Staging;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
@@ -17,6 +20,7 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowException;
+import com.liferay.portal.workflow.constants.WorkflowDefinitionConstants;
 import com.liferay.portal.workflow.kaleo.definition.util.WorkflowDefinitionContentUtil;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinition;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinitionVersion;
@@ -31,6 +35,7 @@ import com.liferay.portal.workflow.kaleo.service.persistence.KaleoDefinitionVers
 
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -322,9 +327,9 @@ public class KaleoDefinitionLocalServiceImpl
 		OrderByComparator<KaleoDefinition> orderByComparator,
 		ServiceContext serviceContext) {
 
-		return kaleoDefinitionPersistence.findByC_S_A(
-			serviceContext.getCompanyId(), scope, active, start, end,
-			orderByComparator);
+		return kaleoDefinitionPersistence.findByG_C_S_A(
+			_getGroupId(scope, serviceContext), serviceContext.getCompanyId(),
+			scope, active, start, end, orderByComparator);
 	}
 
 	@Override
@@ -333,25 +338,27 @@ public class KaleoDefinitionLocalServiceImpl
 		OrderByComparator<KaleoDefinition> orderByComparator,
 		ServiceContext serviceContext) {
 
-		return kaleoDefinitionPersistence.findByC_S(
-			serviceContext.getCompanyId(), scope, start, end,
-			orderByComparator);
+		return kaleoDefinitionPersistence.findByG_C_S(
+			_getGroupId(scope, serviceContext), serviceContext.getCompanyId(),
+			scope, start, end, orderByComparator);
 	}
 
 	@Override
 	public int getScopeKaleoDefinitionsCount(
 		String scope, boolean active, ServiceContext serviceContext) {
 
-		return kaleoDefinitionPersistence.countByC_S_A(
-			serviceContext.getCompanyId(), scope, active);
+		return kaleoDefinitionPersistence.countByG_C_S_A(
+			_getGroupId(scope, serviceContext), serviceContext.getCompanyId(),
+			scope, active);
 	}
 
 	@Override
 	public int getScopeKaleoDefinitionsCount(
 		String scope, ServiceContext serviceContext) {
 
-		return kaleoDefinitionPersistence.countByC_S(
-			serviceContext.getCompanyId(), scope);
+		return kaleoDefinitionPersistence.countByG_C_S(
+			_getGroupId(scope, serviceContext), serviceContext.getCompanyId(),
+			scope);
 	}
 
 	@Override
@@ -400,9 +407,47 @@ public class KaleoDefinitionLocalServiceImpl
 		return kaleoDefinition;
 	}
 
+	private long _getGroupId(String scope, ServiceContext serviceContext) {
+		if (!Objects.equals(WorkflowDefinitionConstants.SCOPE_AI, scope)) {
+			return 0L;
+		}
+
+		List<AccountEntryUserRel> accountEntryUserRels =
+			_accountEntryUserRelLocalService.
+				getAccountEntryUserRelsByAccountUserId(
+					serviceContext.getUserId());
+
+		if (accountEntryUserRels.size() != 2) {
+			return 0L;
+		}
+
+		try {
+			for (AccountEntryUserRel accountEntryUserRel :
+					accountEntryUserRels) {
+
+				AccountEntry accountEntry =
+					accountEntryUserRel.getAccountEntry();
+
+				if (!Objects.equals(
+						accountEntry.getExternalReferenceCode(), "L_AI_HUB")) {
+
+					return accountEntry.getAccountEntryGroupId();
+				}
+			}
+		}
+		catch (PortalException portalException) {
+			throw new RuntimeException(portalException);
+		}
+
+		return 0L;
+	}
+
 	private String _getVersion(int version) {
 		return version + StringPool.PERIOD + 0;
 	}
+
+	@Reference
+	private AccountEntryUserRelLocalService _accountEntryUserRelLocalService;
 
 	@Reference
 	private KaleoConditionLocalService _kaleoConditionLocalService;

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoDefinitionServiceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoDefinitionServiceImpl.java
@@ -56,11 +56,13 @@ public class KaleoDefinitionServiceImpl extends KaleoDefinitionServiceBaseImpl {
 	public KaleoDefinition getKaleoDefinition(long kaleoDefinitionId)
 		throws PortalException {
 
-		_kaleoDefinitionModelResourcePermission.check(
-			getPermissionChecker(), null, ActionKeys.VIEW);
+		KaleoDefinition kaleoDefinition =
+			_kaleoDefinitionLocalService.getKaleoDefinition(kaleoDefinitionId);
 
-		return _kaleoDefinitionLocalService.getKaleoDefinition(
-			kaleoDefinitionId);
+		_kaleoDefinitionModelResourcePermission.check(
+			getPermissionChecker(), kaleoDefinition, ActionKeys.VIEW);
+
+		return kaleoDefinition;
 	}
 
 	@Override
@@ -68,12 +70,15 @@ public class KaleoDefinitionServiceImpl extends KaleoDefinitionServiceBaseImpl {
 			String externalReferenceCode, long companyId)
 		throws PortalException {
 
-		_kaleoDefinitionModelResourcePermission.check(
-			getPermissionChecker(), null, ActionKeys.VIEW);
+		KaleoDefinition kaleoDefinition =
+			_kaleoDefinitionLocalService.
+				getKaleoDefinitionByExternalReferenceCode(
+					externalReferenceCode, companyId);
 
-		return _kaleoDefinitionLocalService.
-			getKaleoDefinitionByExternalReferenceCode(
-				externalReferenceCode, companyId);
+		_kaleoDefinitionModelResourcePermission.check(
+			getPermissionChecker(), kaleoDefinition, ActionKeys.VIEW);
+
+		return kaleoDefinition;
 	}
 
 	@Override
@@ -81,11 +86,14 @@ public class KaleoDefinitionServiceImpl extends KaleoDefinitionServiceBaseImpl {
 			String name, ServiceContext serviceContext)
 		throws PortalException {
 
-		_kaleoDefinitionModelResourcePermission.check(
-			getPermissionChecker(), null, ActionKeys.VIEW);
+		KaleoDefinition kaleoDefinition =
+			_kaleoDefinitionLocalService.getKaleoDefinition(
+				name, serviceContext);
 
-		return _kaleoDefinitionLocalService.getKaleoDefinition(
-			name, serviceContext);
+		_kaleoDefinitionModelResourcePermission.check(
+			getPermissionChecker(), kaleoDefinition, ActionKeys.VIEW);
+
+		return kaleoDefinition;
 	}
 
 	@Override

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/impl/KaleoDefinitionPersistenceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/impl/KaleoDefinitionPersistenceImpl.java
@@ -2684,598 +2684,6 @@ public class KaleoDefinitionPersistenceImpl
 	private static final String _FINDER_COLUMN_C_N_NAME_3 =
 		"(kaleoDefinition.name IS NULL OR kaleoDefinition.name = '')";
 
-	private FinderPath _finderPathWithPaginationFindByC_S;
-	private FinderPath _finderPathWithoutPaginationFindByC_S;
-	private FinderPath _finderPathCountByC_S;
-
-	/**
-	 * Returns all the kaleo definitions where companyId = &#63; and scope = &#63;.
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @return the matching kaleo definitions
-	 */
-	@Override
-	public List<KaleoDefinition> findByC_S(long companyId, String scope) {
-		return findByC_S(
-			companyId, scope, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
-	}
-
-	/**
-	 * Returns a range of all the kaleo definitions where companyId = &#63; and scope = &#63;.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
-	 * </p>
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @param start the lower bound of the range of kaleo definitions
-	 * @param end the upper bound of the range of kaleo definitions (not inclusive)
-	 * @return the range of matching kaleo definitions
-	 */
-	@Override
-	public List<KaleoDefinition> findByC_S(
-		long companyId, String scope, int start, int end) {
-
-		return findByC_S(companyId, scope, start, end, null);
-	}
-
-	/**
-	 * Returns an ordered range of all the kaleo definitions where companyId = &#63; and scope = &#63;.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
-	 * </p>
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @param start the lower bound of the range of kaleo definitions
-	 * @param end the upper bound of the range of kaleo definitions (not inclusive)
-	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
-	 * @return the ordered range of matching kaleo definitions
-	 */
-	@Override
-	public List<KaleoDefinition> findByC_S(
-		long companyId, String scope, int start, int end,
-		OrderByComparator<KaleoDefinition> orderByComparator) {
-
-		return findByC_S(companyId, scope, start, end, orderByComparator, true);
-	}
-
-	/**
-	 * Returns an ordered range of all the kaleo definitions where companyId = &#63; and scope = &#63;.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
-	 * </p>
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @param start the lower bound of the range of kaleo definitions
-	 * @param end the upper bound of the range of kaleo definitions (not inclusive)
-	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
-	 * @param useFinderCache whether to use the finder cache
-	 * @return the ordered range of matching kaleo definitions
-	 */
-	@Override
-	public List<KaleoDefinition> findByC_S(
-		long companyId, String scope, int start, int end,
-		OrderByComparator<KaleoDefinition> orderByComparator,
-		boolean useFinderCache) {
-
-		try (SafeCloseable safeCloseable =
-				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
-					KaleoDefinition.class)) {
-
-			scope = Objects.toString(scope, "");
-
-			FinderPath finderPath = null;
-			Object[] finderArgs = null;
-
-			if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
-				(orderByComparator == null)) {
-
-				if (useFinderCache) {
-					finderPath = _finderPathWithoutPaginationFindByC_S;
-					finderArgs = new Object[] {companyId, scope};
-				}
-			}
-			else if (useFinderCache) {
-				finderPath = _finderPathWithPaginationFindByC_S;
-				finderArgs = new Object[] {
-					companyId, scope, start, end, orderByComparator
-				};
-			}
-
-			List<KaleoDefinition> list = null;
-
-			if (useFinderCache) {
-				list = (List<KaleoDefinition>)finderCache.getResult(
-					finderPath, finderArgs, this);
-
-				if ((list != null) && !list.isEmpty()) {
-					for (KaleoDefinition kaleoDefinition : list) {
-						if ((companyId != kaleoDefinition.getCompanyId()) ||
-							!scope.equals(kaleoDefinition.getScope())) {
-
-							list = null;
-
-							break;
-						}
-					}
-				}
-			}
-
-			if (list == null) {
-				StringBundler sb = null;
-
-				if (orderByComparator != null) {
-					sb = new StringBundler(
-						4 + (orderByComparator.getOrderByFields().length * 2));
-				}
-				else {
-					sb = new StringBundler(4);
-				}
-
-				sb.append(_SQL_SELECT_KALEODEFINITION_WHERE);
-
-				sb.append(_FINDER_COLUMN_C_S_COMPANYID_2);
-
-				boolean bindScope = false;
-
-				if (scope.isEmpty()) {
-					sb.append(_FINDER_COLUMN_C_S_SCOPE_3);
-				}
-				else {
-					bindScope = true;
-
-					sb.append(_FINDER_COLUMN_C_S_SCOPE_2);
-				}
-
-				if (orderByComparator != null) {
-					appendOrderByComparator(
-						sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
-				}
-				else {
-					sb.append(KaleoDefinitionModelImpl.ORDER_BY_JPQL);
-				}
-
-				String sql = sb.toString();
-
-				Session session = null;
-
-				try {
-					session = openSession();
-
-					Query query = session.createQuery(sql);
-
-					QueryPos queryPos = QueryPos.getInstance(query);
-
-					queryPos.add(companyId);
-
-					if (bindScope) {
-						queryPos.add(scope);
-					}
-
-					list = (List<KaleoDefinition>)QueryUtil.list(
-						query, getDialect(), start, end);
-
-					cacheResult(list);
-
-					if (useFinderCache) {
-						finderCache.putResult(finderPath, finderArgs, list);
-					}
-				}
-				catch (Exception exception) {
-					throw processException(exception);
-				}
-				finally {
-					closeSession(session);
-				}
-			}
-
-			return list;
-		}
-	}
-
-	/**
-	 * Returns the first kaleo definition in the ordered set where companyId = &#63; and scope = &#63;.
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the first matching kaleo definition
-	 * @throws NoSuchDefinitionException if a matching kaleo definition could not be found
-	 */
-	@Override
-	public KaleoDefinition findByC_S_First(
-			long companyId, String scope,
-			OrderByComparator<KaleoDefinition> orderByComparator)
-		throws NoSuchDefinitionException {
-
-		KaleoDefinition kaleoDefinition = fetchByC_S_First(
-			companyId, scope, orderByComparator);
-
-		if (kaleoDefinition != null) {
-			return kaleoDefinition;
-		}
-
-		StringBundler sb = new StringBundler(6);
-
-		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
-
-		sb.append("companyId=");
-		sb.append(companyId);
-
-		sb.append(", scope=");
-		sb.append(scope);
-
-		sb.append("}");
-
-		throw new NoSuchDefinitionException(sb.toString());
-	}
-
-	/**
-	 * Returns the first kaleo definition in the ordered set where companyId = &#63; and scope = &#63;.
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the first matching kaleo definition, or <code>null</code> if a matching kaleo definition could not be found
-	 */
-	@Override
-	public KaleoDefinition fetchByC_S_First(
-		long companyId, String scope,
-		OrderByComparator<KaleoDefinition> orderByComparator) {
-
-		List<KaleoDefinition> list = findByC_S(
-			companyId, scope, 0, 1, orderByComparator);
-
-		if (!list.isEmpty()) {
-			return list.get(0);
-		}
-
-		return null;
-	}
-
-	/**
-	 * Returns the last kaleo definition in the ordered set where companyId = &#63; and scope = &#63;.
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the last matching kaleo definition
-	 * @throws NoSuchDefinitionException if a matching kaleo definition could not be found
-	 */
-	@Override
-	public KaleoDefinition findByC_S_Last(
-			long companyId, String scope,
-			OrderByComparator<KaleoDefinition> orderByComparator)
-		throws NoSuchDefinitionException {
-
-		KaleoDefinition kaleoDefinition = fetchByC_S_Last(
-			companyId, scope, orderByComparator);
-
-		if (kaleoDefinition != null) {
-			return kaleoDefinition;
-		}
-
-		StringBundler sb = new StringBundler(6);
-
-		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
-
-		sb.append("companyId=");
-		sb.append(companyId);
-
-		sb.append(", scope=");
-		sb.append(scope);
-
-		sb.append("}");
-
-		throw new NoSuchDefinitionException(sb.toString());
-	}
-
-	/**
-	 * Returns the last kaleo definition in the ordered set where companyId = &#63; and scope = &#63;.
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the last matching kaleo definition, or <code>null</code> if a matching kaleo definition could not be found
-	 */
-	@Override
-	public KaleoDefinition fetchByC_S_Last(
-		long companyId, String scope,
-		OrderByComparator<KaleoDefinition> orderByComparator) {
-
-		int count = countByC_S(companyId, scope);
-
-		if (count == 0) {
-			return null;
-		}
-
-		List<KaleoDefinition> list = findByC_S(
-			companyId, scope, count - 1, count, orderByComparator);
-
-		if (!list.isEmpty()) {
-			return list.get(0);
-		}
-
-		return null;
-	}
-
-	/**
-	 * Returns the kaleo definitions before and after the current kaleo definition in the ordered set where companyId = &#63; and scope = &#63;.
-	 *
-	 * @param kaleoDefinitionId the primary key of the current kaleo definition
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the previous, current, and next kaleo definition
-	 * @throws NoSuchDefinitionException if a kaleo definition with the primary key could not be found
-	 */
-	@Override
-	public KaleoDefinition[] findByC_S_PrevAndNext(
-			long kaleoDefinitionId, long companyId, String scope,
-			OrderByComparator<KaleoDefinition> orderByComparator)
-		throws NoSuchDefinitionException {
-
-		scope = Objects.toString(scope, "");
-
-		KaleoDefinition kaleoDefinition = findByPrimaryKey(kaleoDefinitionId);
-
-		Session session = null;
-
-		try {
-			session = openSession();
-
-			KaleoDefinition[] array = new KaleoDefinitionImpl[3];
-
-			array[0] = getByC_S_PrevAndNext(
-				session, kaleoDefinition, companyId, scope, orderByComparator,
-				true);
-
-			array[1] = kaleoDefinition;
-
-			array[2] = getByC_S_PrevAndNext(
-				session, kaleoDefinition, companyId, scope, orderByComparator,
-				false);
-
-			return array;
-		}
-		catch (Exception exception) {
-			throw processException(exception);
-		}
-		finally {
-			closeSession(session);
-		}
-	}
-
-	protected KaleoDefinition getByC_S_PrevAndNext(
-		Session session, KaleoDefinition kaleoDefinition, long companyId,
-		String scope, OrderByComparator<KaleoDefinition> orderByComparator,
-		boolean previous) {
-
-		StringBundler sb = null;
-
-		if (orderByComparator != null) {
-			sb = new StringBundler(
-				5 + (orderByComparator.getOrderByConditionFields().length * 3) +
-					(orderByComparator.getOrderByFields().length * 3));
-		}
-		else {
-			sb = new StringBundler(4);
-		}
-
-		sb.append(_SQL_SELECT_KALEODEFINITION_WHERE);
-
-		sb.append(_FINDER_COLUMN_C_S_COMPANYID_2);
-
-		boolean bindScope = false;
-
-		if (scope.isEmpty()) {
-			sb.append(_FINDER_COLUMN_C_S_SCOPE_3);
-		}
-		else {
-			bindScope = true;
-
-			sb.append(_FINDER_COLUMN_C_S_SCOPE_2);
-		}
-
-		if (orderByComparator != null) {
-			String[] orderByConditionFields =
-				orderByComparator.getOrderByConditionFields();
-
-			if (orderByConditionFields.length > 0) {
-				sb.append(WHERE_AND);
-			}
-
-			for (int i = 0; i < orderByConditionFields.length; i++) {
-				sb.append(_ORDER_BY_ENTITY_ALIAS);
-				sb.append(orderByConditionFields[i]);
-
-				if ((i + 1) < orderByConditionFields.length) {
-					if (orderByComparator.isAscending() ^ previous) {
-						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
-					}
-					else {
-						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
-					}
-				}
-				else {
-					if (orderByComparator.isAscending() ^ previous) {
-						sb.append(WHERE_GREATER_THAN);
-					}
-					else {
-						sb.append(WHERE_LESSER_THAN);
-					}
-				}
-			}
-
-			sb.append(ORDER_BY_CLAUSE);
-
-			String[] orderByFields = orderByComparator.getOrderByFields();
-
-			for (int i = 0; i < orderByFields.length; i++) {
-				sb.append(_ORDER_BY_ENTITY_ALIAS);
-				sb.append(orderByFields[i]);
-
-				if ((i + 1) < orderByFields.length) {
-					if (orderByComparator.isAscending() ^ previous) {
-						sb.append(ORDER_BY_ASC_HAS_NEXT);
-					}
-					else {
-						sb.append(ORDER_BY_DESC_HAS_NEXT);
-					}
-				}
-				else {
-					if (orderByComparator.isAscending() ^ previous) {
-						sb.append(ORDER_BY_ASC);
-					}
-					else {
-						sb.append(ORDER_BY_DESC);
-					}
-				}
-			}
-		}
-		else {
-			sb.append(KaleoDefinitionModelImpl.ORDER_BY_JPQL);
-		}
-
-		String sql = sb.toString();
-
-		Query query = session.createQuery(sql);
-
-		query.setFirstResult(0);
-		query.setMaxResults(2);
-
-		QueryPos queryPos = QueryPos.getInstance(query);
-
-		queryPos.add(companyId);
-
-		if (bindScope) {
-			queryPos.add(scope);
-		}
-
-		if (orderByComparator != null) {
-			for (Object orderByConditionValue :
-					orderByComparator.getOrderByConditionValues(
-						kaleoDefinition)) {
-
-				queryPos.add(orderByConditionValue);
-			}
-		}
-
-		List<KaleoDefinition> list = query.list();
-
-		if (list.size() == 2) {
-			return list.get(1);
-		}
-		else {
-			return null;
-		}
-	}
-
-	/**
-	 * Removes all the kaleo definitions where companyId = &#63; and scope = &#63; from the database.
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 */
-	@Override
-	public void removeByC_S(long companyId, String scope) {
-		for (KaleoDefinition kaleoDefinition :
-				findByC_S(
-					companyId, scope, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-					null)) {
-
-			remove(kaleoDefinition);
-		}
-	}
-
-	/**
-	 * Returns the number of kaleo definitions where companyId = &#63; and scope = &#63;.
-	 *
-	 * @param companyId the company ID
-	 * @param scope the scope
-	 * @return the number of matching kaleo definitions
-	 */
-	@Override
-	public int countByC_S(long companyId, String scope) {
-		try (SafeCloseable safeCloseable =
-				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
-					KaleoDefinition.class)) {
-
-			scope = Objects.toString(scope, "");
-
-			FinderPath finderPath = _finderPathCountByC_S;
-
-			Object[] finderArgs = new Object[] {companyId, scope};
-
-			Long count = (Long)finderCache.getResult(
-				finderPath, finderArgs, this);
-
-			if (count == null) {
-				StringBundler sb = new StringBundler(3);
-
-				sb.append(_SQL_COUNT_KALEODEFINITION_WHERE);
-
-				sb.append(_FINDER_COLUMN_C_S_COMPANYID_2);
-
-				boolean bindScope = false;
-
-				if (scope.isEmpty()) {
-					sb.append(_FINDER_COLUMN_C_S_SCOPE_3);
-				}
-				else {
-					bindScope = true;
-
-					sb.append(_FINDER_COLUMN_C_S_SCOPE_2);
-				}
-
-				String sql = sb.toString();
-
-				Session session = null;
-
-				try {
-					session = openSession();
-
-					Query query = session.createQuery(sql);
-
-					QueryPos queryPos = QueryPos.getInstance(query);
-
-					queryPos.add(companyId);
-
-					if (bindScope) {
-						queryPos.add(scope);
-					}
-
-					count = (Long)query.uniqueResult();
-
-					finderCache.putResult(finderPath, finderArgs, count);
-				}
-				catch (Exception exception) {
-					throw processException(exception);
-				}
-				finally {
-					closeSession(session);
-				}
-			}
-
-			return count.intValue();
-		}
-	}
-
-	private static final String _FINDER_COLUMN_C_S_COMPANYID_2 =
-		"kaleoDefinition.companyId = ? AND ";
-
-	private static final String _FINDER_COLUMN_C_S_SCOPE_2 =
-		"kaleoDefinition.scope = ?";
-
-	private static final String _FINDER_COLUMN_C_S_SCOPE_3 =
-		"(kaleoDefinition.scope IS NULL OR kaleoDefinition.scope = '')";
-
 	private FinderPath _finderPathWithPaginationFindByC_A;
 	private FinderPath _finderPathWithoutPaginationFindByC_A;
 	private FinderPath _finderPathCountByC_A;
@@ -3827,6 +3235,636 @@ public class KaleoDefinitionPersistenceImpl
 	private static final String _FINDER_COLUMN_C_A_ACTIVE_2 =
 		"kaleoDefinition.active = ?";
 
+	private FinderPath _finderPathWithPaginationFindByG_C_S;
+	private FinderPath _finderPathWithoutPaginationFindByG_C_S;
+	private FinderPath _finderPathCountByG_C_S;
+
+	/**
+	 * Returns all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @return the matching kaleo definitions
+	 */
+	@Override
+	public List<KaleoDefinition> findByG_C_S(
+		long groupId, long companyId, String scope) {
+
+		return findByG_C_S(
+			groupId, companyId, scope, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+			null);
+	}
+
+	/**
+	 * Returns a range of all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @param start the lower bound of the range of kaleo definitions
+	 * @param end the upper bound of the range of kaleo definitions (not inclusive)
+	 * @return the range of matching kaleo definitions
+	 */
+	@Override
+	public List<KaleoDefinition> findByG_C_S(
+		long groupId, long companyId, String scope, int start, int end) {
+
+		return findByG_C_S(groupId, companyId, scope, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @param start the lower bound of the range of kaleo definitions
+	 * @param end the upper bound of the range of kaleo definitions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching kaleo definitions
+	 */
+	@Override
+	public List<KaleoDefinition> findByG_C_S(
+		long groupId, long companyId, String scope, int start, int end,
+		OrderByComparator<KaleoDefinition> orderByComparator) {
+
+		return findByG_C_S(
+			groupId, companyId, scope, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @param start the lower bound of the range of kaleo definitions
+	 * @param end the upper bound of the range of kaleo definitions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching kaleo definitions
+	 */
+	@Override
+	public List<KaleoDefinition> findByG_C_S(
+		long groupId, long companyId, String scope, int start, int end,
+		OrderByComparator<KaleoDefinition> orderByComparator,
+		boolean useFinderCache) {
+
+		try (SafeCloseable safeCloseable =
+				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
+					KaleoDefinition.class)) {
+
+			scope = Objects.toString(scope, "");
+
+			FinderPath finderPath = null;
+			Object[] finderArgs = null;
+
+			if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+				(orderByComparator == null)) {
+
+				if (useFinderCache) {
+					finderPath = _finderPathWithoutPaginationFindByG_C_S;
+					finderArgs = new Object[] {groupId, companyId, scope};
+				}
+			}
+			else if (useFinderCache) {
+				finderPath = _finderPathWithPaginationFindByG_C_S;
+				finderArgs = new Object[] {
+					groupId, companyId, scope, start, end, orderByComparator
+				};
+			}
+
+			List<KaleoDefinition> list = null;
+
+			if (useFinderCache) {
+				list = (List<KaleoDefinition>)finderCache.getResult(
+					finderPath, finderArgs, this);
+
+				if ((list != null) && !list.isEmpty()) {
+					for (KaleoDefinition kaleoDefinition : list) {
+						if ((groupId != kaleoDefinition.getGroupId()) ||
+							(companyId != kaleoDefinition.getCompanyId()) ||
+							!scope.equals(kaleoDefinition.getScope())) {
+
+							list = null;
+
+							break;
+						}
+					}
+				}
+			}
+
+			if (list == null) {
+				StringBundler sb = null;
+
+				if (orderByComparator != null) {
+					sb = new StringBundler(
+						5 + (orderByComparator.getOrderByFields().length * 2));
+				}
+				else {
+					sb = new StringBundler(5);
+				}
+
+				sb.append(_SQL_SELECT_KALEODEFINITION_WHERE);
+
+				sb.append(_FINDER_COLUMN_G_C_S_GROUPID_2);
+
+				sb.append(_FINDER_COLUMN_G_C_S_COMPANYID_2);
+
+				boolean bindScope = false;
+
+				if (scope.isEmpty()) {
+					sb.append(_FINDER_COLUMN_G_C_S_SCOPE_3);
+				}
+				else {
+					bindScope = true;
+
+					sb.append(_FINDER_COLUMN_G_C_S_SCOPE_2);
+				}
+
+				if (orderByComparator != null) {
+					appendOrderByComparator(
+						sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+				}
+				else {
+					sb.append(KaleoDefinitionModelImpl.ORDER_BY_JPQL);
+				}
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(groupId);
+
+					queryPos.add(companyId);
+
+					if (bindScope) {
+						queryPos.add(scope);
+					}
+
+					list = (List<KaleoDefinition>)QueryUtil.list(
+						query, getDialect(), start, end);
+
+					cacheResult(list);
+
+					if (useFinderCache) {
+						finderCache.putResult(finderPath, finderArgs, list);
+					}
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return list;
+		}
+	}
+
+	/**
+	 * Returns the first kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching kaleo definition
+	 * @throws NoSuchDefinitionException if a matching kaleo definition could not be found
+	 */
+	@Override
+	public KaleoDefinition findByG_C_S_First(
+			long groupId, long companyId, String scope,
+			OrderByComparator<KaleoDefinition> orderByComparator)
+		throws NoSuchDefinitionException {
+
+		KaleoDefinition kaleoDefinition = fetchByG_C_S_First(
+			groupId, companyId, scope, orderByComparator);
+
+		if (kaleoDefinition != null) {
+			return kaleoDefinition;
+		}
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", companyId=");
+		sb.append(companyId);
+
+		sb.append(", scope=");
+		sb.append(scope);
+
+		sb.append("}");
+
+		throw new NoSuchDefinitionException(sb.toString());
+	}
+
+	/**
+	 * Returns the first kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching kaleo definition, or <code>null</code> if a matching kaleo definition could not be found
+	 */
+	@Override
+	public KaleoDefinition fetchByG_C_S_First(
+		long groupId, long companyId, String scope,
+		OrderByComparator<KaleoDefinition> orderByComparator) {
+
+		List<KaleoDefinition> list = findByG_C_S(
+			groupId, companyId, scope, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching kaleo definition
+	 * @throws NoSuchDefinitionException if a matching kaleo definition could not be found
+	 */
+	@Override
+	public KaleoDefinition findByG_C_S_Last(
+			long groupId, long companyId, String scope,
+			OrderByComparator<KaleoDefinition> orderByComparator)
+		throws NoSuchDefinitionException {
+
+		KaleoDefinition kaleoDefinition = fetchByG_C_S_Last(
+			groupId, companyId, scope, orderByComparator);
+
+		if (kaleoDefinition != null) {
+			return kaleoDefinition;
+		}
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", companyId=");
+		sb.append(companyId);
+
+		sb.append(", scope=");
+		sb.append(scope);
+
+		sb.append("}");
+
+		throw new NoSuchDefinitionException(sb.toString());
+	}
+
+	/**
+	 * Returns the last kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching kaleo definition, or <code>null</code> if a matching kaleo definition could not be found
+	 */
+	@Override
+	public KaleoDefinition fetchByG_C_S_Last(
+		long groupId, long companyId, String scope,
+		OrderByComparator<KaleoDefinition> orderByComparator) {
+
+		int count = countByG_C_S(groupId, companyId, scope);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<KaleoDefinition> list = findByG_C_S(
+			groupId, companyId, scope, count - 1, count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the kaleo definitions before and after the current kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * @param kaleoDefinitionId the primary key of the current kaleo definition
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next kaleo definition
+	 * @throws NoSuchDefinitionException if a kaleo definition with the primary key could not be found
+	 */
+	@Override
+	public KaleoDefinition[] findByG_C_S_PrevAndNext(
+			long kaleoDefinitionId, long groupId, long companyId, String scope,
+			OrderByComparator<KaleoDefinition> orderByComparator)
+		throws NoSuchDefinitionException {
+
+		scope = Objects.toString(scope, "");
+
+		KaleoDefinition kaleoDefinition = findByPrimaryKey(kaleoDefinitionId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			KaleoDefinition[] array = new KaleoDefinitionImpl[3];
+
+			array[0] = getByG_C_S_PrevAndNext(
+				session, kaleoDefinition, groupId, companyId, scope,
+				orderByComparator, true);
+
+			array[1] = kaleoDefinition;
+
+			array[2] = getByG_C_S_PrevAndNext(
+				session, kaleoDefinition, groupId, companyId, scope,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected KaleoDefinition getByG_C_S_PrevAndNext(
+		Session session, KaleoDefinition kaleoDefinition, long groupId,
+		long companyId, String scope,
+		OrderByComparator<KaleoDefinition> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				6 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(5);
+		}
+
+		sb.append(_SQL_SELECT_KALEODEFINITION_WHERE);
+
+		sb.append(_FINDER_COLUMN_G_C_S_GROUPID_2);
+
+		sb.append(_FINDER_COLUMN_G_C_S_COMPANYID_2);
+
+		boolean bindScope = false;
+
+		if (scope.isEmpty()) {
+			sb.append(_FINDER_COLUMN_G_C_S_SCOPE_3);
+		}
+		else {
+			bindScope = true;
+
+			sb.append(_FINDER_COLUMN_G_C_S_SCOPE_2);
+		}
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(KaleoDefinitionModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(groupId);
+
+		queryPos.add(companyId);
+
+		if (bindScope) {
+			queryPos.add(scope);
+		}
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						kaleoDefinition)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<KaleoDefinition> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 */
+	@Override
+	public void removeByG_C_S(long groupId, long companyId, String scope) {
+		for (KaleoDefinition kaleoDefinition :
+				findByG_C_S(
+					groupId, companyId, scope, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null)) {
+
+			remove(kaleoDefinition);
+		}
+	}
+
+	/**
+	 * Returns the number of kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param companyId the company ID
+	 * @param scope the scope
+	 * @return the number of matching kaleo definitions
+	 */
+	@Override
+	public int countByG_C_S(long groupId, long companyId, String scope) {
+		try (SafeCloseable safeCloseable =
+				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
+					KaleoDefinition.class)) {
+
+			scope = Objects.toString(scope, "");
+
+			FinderPath finderPath = _finderPathCountByG_C_S;
+
+			Object[] finderArgs = new Object[] {groupId, companyId, scope};
+
+			Long count = (Long)finderCache.getResult(
+				finderPath, finderArgs, this);
+
+			if (count == null) {
+				StringBundler sb = new StringBundler(4);
+
+				sb.append(_SQL_COUNT_KALEODEFINITION_WHERE);
+
+				sb.append(_FINDER_COLUMN_G_C_S_GROUPID_2);
+
+				sb.append(_FINDER_COLUMN_G_C_S_COMPANYID_2);
+
+				boolean bindScope = false;
+
+				if (scope.isEmpty()) {
+					sb.append(_FINDER_COLUMN_G_C_S_SCOPE_3);
+				}
+				else {
+					bindScope = true;
+
+					sb.append(_FINDER_COLUMN_G_C_S_SCOPE_2);
+				}
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(groupId);
+
+					queryPos.add(companyId);
+
+					if (bindScope) {
+						queryPos.add(scope);
+					}
+
+					count = (Long)query.uniqueResult();
+
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return count.intValue();
+		}
+	}
+
+	private static final String _FINDER_COLUMN_G_C_S_GROUPID_2 =
+		"kaleoDefinition.groupId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_C_S_COMPANYID_2 =
+		"kaleoDefinition.companyId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_C_S_SCOPE_2 =
+		"kaleoDefinition.scope = ?";
+
+	private static final String _FINDER_COLUMN_G_C_S_SCOPE_3 =
+		"(kaleoDefinition.scope IS NULL OR kaleoDefinition.scope = '')";
+
 	private FinderPath _finderPathFetchByC_N_V;
 
 	/**
@@ -4308,34 +4346,36 @@ public class KaleoDefinitionPersistenceImpl
 	private static final String _FINDER_COLUMN_C_N_A_ACTIVE_2 =
 		"kaleoDefinition.active = ?";
 
-	private FinderPath _finderPathWithPaginationFindByC_S_A;
-	private FinderPath _finderPathWithoutPaginationFindByC_S_A;
-	private FinderPath _finderPathCountByC_S_A;
+	private FinderPath _finderPathWithPaginationFindByG_C_S_A;
+	private FinderPath _finderPathWithoutPaginationFindByG_C_S_A;
+	private FinderPath _finderPathCountByG_C_S_A;
 
 	/**
-	 * Returns all the kaleo definitions where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
 	 * @return the matching kaleo definitions
 	 */
 	@Override
-	public List<KaleoDefinition> findByC_S_A(
-		long companyId, String scope, boolean active) {
+	public List<KaleoDefinition> findByG_C_S_A(
+		long groupId, long companyId, String scope, boolean active) {
 
-		return findByC_S_A(
-			companyId, scope, active, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-			null);
+		return findByG_C_S_A(
+			groupId, companyId, scope, active, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
 	}
 
 	/**
-	 * Returns a range of all the kaleo definitions where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns a range of all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
 	 * </p>
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
@@ -4344,19 +4384,22 @@ public class KaleoDefinitionPersistenceImpl
 	 * @return the range of matching kaleo definitions
 	 */
 	@Override
-	public List<KaleoDefinition> findByC_S_A(
-		long companyId, String scope, boolean active, int start, int end) {
+	public List<KaleoDefinition> findByG_C_S_A(
+		long groupId, long companyId, String scope, boolean active, int start,
+		int end) {
 
-		return findByC_S_A(companyId, scope, active, start, end, null);
+		return findByG_C_S_A(
+			groupId, companyId, scope, active, start, end, null);
 	}
 
 	/**
-	 * Returns an ordered range of all the kaleo definitions where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns an ordered range of all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
 	 * </p>
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
@@ -4366,21 +4409,23 @@ public class KaleoDefinitionPersistenceImpl
 	 * @return the ordered range of matching kaleo definitions
 	 */
 	@Override
-	public List<KaleoDefinition> findByC_S_A(
-		long companyId, String scope, boolean active, int start, int end,
-		OrderByComparator<KaleoDefinition> orderByComparator) {
+	public List<KaleoDefinition> findByG_C_S_A(
+		long groupId, long companyId, String scope, boolean active, int start,
+		int end, OrderByComparator<KaleoDefinition> orderByComparator) {
 
-		return findByC_S_A(
-			companyId, scope, active, start, end, orderByComparator, true);
+		return findByG_C_S_A(
+			groupId, companyId, scope, active, start, end, orderByComparator,
+			true);
 	}
 
 	/**
-	 * Returns an ordered range of all the kaleo definitions where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns an ordered range of all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KaleoDefinitionModelImpl</code>.
 	 * </p>
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
@@ -4391,9 +4436,9 @@ public class KaleoDefinitionPersistenceImpl
 	 * @return the ordered range of matching kaleo definitions
 	 */
 	@Override
-	public List<KaleoDefinition> findByC_S_A(
-		long companyId, String scope, boolean active, int start, int end,
-		OrderByComparator<KaleoDefinition> orderByComparator,
+	public List<KaleoDefinition> findByG_C_S_A(
+		long groupId, long companyId, String scope, boolean active, int start,
+		int end, OrderByComparator<KaleoDefinition> orderByComparator,
 		boolean useFinderCache) {
 
 		try (SafeCloseable safeCloseable =
@@ -4409,14 +4454,17 @@ public class KaleoDefinitionPersistenceImpl
 				(orderByComparator == null)) {
 
 				if (useFinderCache) {
-					finderPath = _finderPathWithoutPaginationFindByC_S_A;
-					finderArgs = new Object[] {companyId, scope, active};
+					finderPath = _finderPathWithoutPaginationFindByG_C_S_A;
+					finderArgs = new Object[] {
+						groupId, companyId, scope, active
+					};
 				}
 			}
 			else if (useFinderCache) {
-				finderPath = _finderPathWithPaginationFindByC_S_A;
+				finderPath = _finderPathWithPaginationFindByG_C_S_A;
 				finderArgs = new Object[] {
-					companyId, scope, active, start, end, orderByComparator
+					groupId, companyId, scope, active, start, end,
+					orderByComparator
 				};
 			}
 
@@ -4428,7 +4476,8 @@ public class KaleoDefinitionPersistenceImpl
 
 				if ((list != null) && !list.isEmpty()) {
 					for (KaleoDefinition kaleoDefinition : list) {
-						if ((companyId != kaleoDefinition.getCompanyId()) ||
+						if ((groupId != kaleoDefinition.getGroupId()) ||
+							(companyId != kaleoDefinition.getCompanyId()) ||
 							!scope.equals(kaleoDefinition.getScope()) ||
 							(active != kaleoDefinition.isActive())) {
 
@@ -4445,28 +4494,30 @@ public class KaleoDefinitionPersistenceImpl
 
 				if (orderByComparator != null) {
 					sb = new StringBundler(
-						5 + (orderByComparator.getOrderByFields().length * 2));
+						6 + (orderByComparator.getOrderByFields().length * 2));
 				}
 				else {
-					sb = new StringBundler(5);
+					sb = new StringBundler(6);
 				}
 
 				sb.append(_SQL_SELECT_KALEODEFINITION_WHERE);
 
-				sb.append(_FINDER_COLUMN_C_S_A_COMPANYID_2);
+				sb.append(_FINDER_COLUMN_G_C_S_A_GROUPID_2);
+
+				sb.append(_FINDER_COLUMN_G_C_S_A_COMPANYID_2);
 
 				boolean bindScope = false;
 
 				if (scope.isEmpty()) {
-					sb.append(_FINDER_COLUMN_C_S_A_SCOPE_3);
+					sb.append(_FINDER_COLUMN_G_C_S_A_SCOPE_3);
 				}
 				else {
 					bindScope = true;
 
-					sb.append(_FINDER_COLUMN_C_S_A_SCOPE_2);
+					sb.append(_FINDER_COLUMN_G_C_S_A_SCOPE_2);
 				}
 
-				sb.append(_FINDER_COLUMN_C_S_A_ACTIVE_2);
+				sb.append(_FINDER_COLUMN_G_C_S_A_ACTIVE_2);
 
 				if (orderByComparator != null) {
 					appendOrderByComparator(
@@ -4486,6 +4537,8 @@ public class KaleoDefinitionPersistenceImpl
 					Query query = session.createQuery(sql);
 
 					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(groupId);
 
 					queryPos.add(companyId);
 
@@ -4517,8 +4570,9 @@ public class KaleoDefinitionPersistenceImpl
 	}
 
 	/**
-	 * Returns the first kaleo definition in the ordered set where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns the first kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
@@ -4527,23 +4581,26 @@ public class KaleoDefinitionPersistenceImpl
 	 * @throws NoSuchDefinitionException if a matching kaleo definition could not be found
 	 */
 	@Override
-	public KaleoDefinition findByC_S_A_First(
-			long companyId, String scope, boolean active,
+	public KaleoDefinition findByG_C_S_A_First(
+			long groupId, long companyId, String scope, boolean active,
 			OrderByComparator<KaleoDefinition> orderByComparator)
 		throws NoSuchDefinitionException {
 
-		KaleoDefinition kaleoDefinition = fetchByC_S_A_First(
-			companyId, scope, active, orderByComparator);
+		KaleoDefinition kaleoDefinition = fetchByG_C_S_A_First(
+			groupId, companyId, scope, active, orderByComparator);
 
 		if (kaleoDefinition != null) {
 			return kaleoDefinition;
 		}
 
-		StringBundler sb = new StringBundler(8);
+		StringBundler sb = new StringBundler(10);
 
 		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-		sb.append("companyId=");
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", companyId=");
 		sb.append(companyId);
 
 		sb.append(", scope=");
@@ -4558,8 +4615,9 @@ public class KaleoDefinitionPersistenceImpl
 	}
 
 	/**
-	 * Returns the first kaleo definition in the ordered set where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns the first kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
@@ -4567,12 +4625,12 @@ public class KaleoDefinitionPersistenceImpl
 	 * @return the first matching kaleo definition, or <code>null</code> if a matching kaleo definition could not be found
 	 */
 	@Override
-	public KaleoDefinition fetchByC_S_A_First(
-		long companyId, String scope, boolean active,
+	public KaleoDefinition fetchByG_C_S_A_First(
+		long groupId, long companyId, String scope, boolean active,
 		OrderByComparator<KaleoDefinition> orderByComparator) {
 
-		List<KaleoDefinition> list = findByC_S_A(
-			companyId, scope, active, 0, 1, orderByComparator);
+		List<KaleoDefinition> list = findByG_C_S_A(
+			groupId, companyId, scope, active, 0, 1, orderByComparator);
 
 		if (!list.isEmpty()) {
 			return list.get(0);
@@ -4582,8 +4640,9 @@ public class KaleoDefinitionPersistenceImpl
 	}
 
 	/**
-	 * Returns the last kaleo definition in the ordered set where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns the last kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
@@ -4592,23 +4651,26 @@ public class KaleoDefinitionPersistenceImpl
 	 * @throws NoSuchDefinitionException if a matching kaleo definition could not be found
 	 */
 	@Override
-	public KaleoDefinition findByC_S_A_Last(
-			long companyId, String scope, boolean active,
+	public KaleoDefinition findByG_C_S_A_Last(
+			long groupId, long companyId, String scope, boolean active,
 			OrderByComparator<KaleoDefinition> orderByComparator)
 		throws NoSuchDefinitionException {
 
-		KaleoDefinition kaleoDefinition = fetchByC_S_A_Last(
-			companyId, scope, active, orderByComparator);
+		KaleoDefinition kaleoDefinition = fetchByG_C_S_A_Last(
+			groupId, companyId, scope, active, orderByComparator);
 
 		if (kaleoDefinition != null) {
 			return kaleoDefinition;
 		}
 
-		StringBundler sb = new StringBundler(8);
+		StringBundler sb = new StringBundler(10);
 
 		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
 
-		sb.append("companyId=");
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", companyId=");
 		sb.append(companyId);
 
 		sb.append(", scope=");
@@ -4623,8 +4685,9 @@ public class KaleoDefinitionPersistenceImpl
 	}
 
 	/**
-	 * Returns the last kaleo definition in the ordered set where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns the last kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
@@ -4632,18 +4695,19 @@ public class KaleoDefinitionPersistenceImpl
 	 * @return the last matching kaleo definition, or <code>null</code> if a matching kaleo definition could not be found
 	 */
 	@Override
-	public KaleoDefinition fetchByC_S_A_Last(
-		long companyId, String scope, boolean active,
+	public KaleoDefinition fetchByG_C_S_A_Last(
+		long groupId, long companyId, String scope, boolean active,
 		OrderByComparator<KaleoDefinition> orderByComparator) {
 
-		int count = countByC_S_A(companyId, scope, active);
+		int count = countByG_C_S_A(groupId, companyId, scope, active);
 
 		if (count == 0) {
 			return null;
 		}
 
-		List<KaleoDefinition> list = findByC_S_A(
-			companyId, scope, active, count - 1, count, orderByComparator);
+		List<KaleoDefinition> list = findByG_C_S_A(
+			groupId, companyId, scope, active, count - 1, count,
+			orderByComparator);
 
 		if (!list.isEmpty()) {
 			return list.get(0);
@@ -4653,9 +4717,10 @@ public class KaleoDefinitionPersistenceImpl
 	}
 
 	/**
-	 * Returns the kaleo definitions before and after the current kaleo definition in the ordered set where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns the kaleo definitions before and after the current kaleo definition in the ordered set where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
 	 * @param kaleoDefinitionId the primary key of the current kaleo definition
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
@@ -4664,8 +4729,8 @@ public class KaleoDefinitionPersistenceImpl
 	 * @throws NoSuchDefinitionException if a kaleo definition with the primary key could not be found
 	 */
 	@Override
-	public KaleoDefinition[] findByC_S_A_PrevAndNext(
-			long kaleoDefinitionId, long companyId, String scope,
+	public KaleoDefinition[] findByG_C_S_A_PrevAndNext(
+			long kaleoDefinitionId, long groupId, long companyId, String scope,
 			boolean active,
 			OrderByComparator<KaleoDefinition> orderByComparator)
 		throws NoSuchDefinitionException {
@@ -4681,14 +4746,14 @@ public class KaleoDefinitionPersistenceImpl
 
 			KaleoDefinition[] array = new KaleoDefinitionImpl[3];
 
-			array[0] = getByC_S_A_PrevAndNext(
-				session, kaleoDefinition, companyId, scope, active,
+			array[0] = getByG_C_S_A_PrevAndNext(
+				session, kaleoDefinition, groupId, companyId, scope, active,
 				orderByComparator, true);
 
 			array[1] = kaleoDefinition;
 
-			array[2] = getByC_S_A_PrevAndNext(
-				session, kaleoDefinition, companyId, scope, active,
+			array[2] = getByG_C_S_A_PrevAndNext(
+				session, kaleoDefinition, groupId, companyId, scope, active,
 				orderByComparator, false);
 
 			return array;
@@ -4701,9 +4766,9 @@ public class KaleoDefinitionPersistenceImpl
 		}
 	}
 
-	protected KaleoDefinition getByC_S_A_PrevAndNext(
-		Session session, KaleoDefinition kaleoDefinition, long companyId,
-		String scope, boolean active,
+	protected KaleoDefinition getByG_C_S_A_PrevAndNext(
+		Session session, KaleoDefinition kaleoDefinition, long groupId,
+		long companyId, String scope, boolean active,
 		OrderByComparator<KaleoDefinition> orderByComparator,
 		boolean previous) {
 
@@ -4711,29 +4776,31 @@ public class KaleoDefinitionPersistenceImpl
 
 		if (orderByComparator != null) {
 			sb = new StringBundler(
-				6 + (orderByComparator.getOrderByConditionFields().length * 3) +
+				7 + (orderByComparator.getOrderByConditionFields().length * 3) +
 					(orderByComparator.getOrderByFields().length * 3));
 		}
 		else {
-			sb = new StringBundler(5);
+			sb = new StringBundler(6);
 		}
 
 		sb.append(_SQL_SELECT_KALEODEFINITION_WHERE);
 
-		sb.append(_FINDER_COLUMN_C_S_A_COMPANYID_2);
+		sb.append(_FINDER_COLUMN_G_C_S_A_GROUPID_2);
+
+		sb.append(_FINDER_COLUMN_G_C_S_A_COMPANYID_2);
 
 		boolean bindScope = false;
 
 		if (scope.isEmpty()) {
-			sb.append(_FINDER_COLUMN_C_S_A_SCOPE_3);
+			sb.append(_FINDER_COLUMN_G_C_S_A_SCOPE_3);
 		}
 		else {
 			bindScope = true;
 
-			sb.append(_FINDER_COLUMN_C_S_A_SCOPE_2);
+			sb.append(_FINDER_COLUMN_G_C_S_A_SCOPE_2);
 		}
 
-		sb.append(_FINDER_COLUMN_C_S_A_ACTIVE_2);
+		sb.append(_FINDER_COLUMN_G_C_S_A_ACTIVE_2);
 
 		if (orderByComparator != null) {
 			String[] orderByConditionFields =
@@ -4804,6 +4871,8 @@ public class KaleoDefinitionPersistenceImpl
 
 		QueryPos queryPos = QueryPos.getInstance(query);
 
+		queryPos.add(groupId);
+
 		queryPos.add(companyId);
 
 		if (bindScope) {
@@ -4832,17 +4901,20 @@ public class KaleoDefinitionPersistenceImpl
 	}
 
 	/**
-	 * Removes all the kaleo definitions where companyId = &#63; and scope = &#63; and active = &#63; from the database.
+	 * Removes all the kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63; from the database.
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
 	 */
 	@Override
-	public void removeByC_S_A(long companyId, String scope, boolean active) {
+	public void removeByG_C_S_A(
+		long groupId, long companyId, String scope, boolean active) {
+
 		for (KaleoDefinition kaleoDefinition :
-				findByC_S_A(
-					companyId, scope, active, QueryUtil.ALL_POS,
+				findByG_C_S_A(
+					groupId, companyId, scope, active, QueryUtil.ALL_POS,
 					QueryUtil.ALL_POS, null)) {
 
 			remove(kaleoDefinition);
@@ -4850,47 +4922,54 @@ public class KaleoDefinitionPersistenceImpl
 	}
 
 	/**
-	 * Returns the number of kaleo definitions where companyId = &#63; and scope = &#63; and active = &#63;.
+	 * Returns the number of kaleo definitions where groupId = &#63; and companyId = &#63; and scope = &#63; and active = &#63;.
 	 *
+	 * @param groupId the group ID
 	 * @param companyId the company ID
 	 * @param scope the scope
 	 * @param active the active
 	 * @return the number of matching kaleo definitions
 	 */
 	@Override
-	public int countByC_S_A(long companyId, String scope, boolean active) {
+	public int countByG_C_S_A(
+		long groupId, long companyId, String scope, boolean active) {
+
 		try (SafeCloseable safeCloseable =
 				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
 					KaleoDefinition.class)) {
 
 			scope = Objects.toString(scope, "");
 
-			FinderPath finderPath = _finderPathCountByC_S_A;
+			FinderPath finderPath = _finderPathCountByG_C_S_A;
 
-			Object[] finderArgs = new Object[] {companyId, scope, active};
+			Object[] finderArgs = new Object[] {
+				groupId, companyId, scope, active
+			};
 
 			Long count = (Long)finderCache.getResult(
 				finderPath, finderArgs, this);
 
 			if (count == null) {
-				StringBundler sb = new StringBundler(4);
+				StringBundler sb = new StringBundler(5);
 
 				sb.append(_SQL_COUNT_KALEODEFINITION_WHERE);
 
-				sb.append(_FINDER_COLUMN_C_S_A_COMPANYID_2);
+				sb.append(_FINDER_COLUMN_G_C_S_A_GROUPID_2);
+
+				sb.append(_FINDER_COLUMN_G_C_S_A_COMPANYID_2);
 
 				boolean bindScope = false;
 
 				if (scope.isEmpty()) {
-					sb.append(_FINDER_COLUMN_C_S_A_SCOPE_3);
+					sb.append(_FINDER_COLUMN_G_C_S_A_SCOPE_3);
 				}
 				else {
 					bindScope = true;
 
-					sb.append(_FINDER_COLUMN_C_S_A_SCOPE_2);
+					sb.append(_FINDER_COLUMN_G_C_S_A_SCOPE_2);
 				}
 
-				sb.append(_FINDER_COLUMN_C_S_A_ACTIVE_2);
+				sb.append(_FINDER_COLUMN_G_C_S_A_ACTIVE_2);
 
 				String sql = sb.toString();
 
@@ -4902,6 +4981,8 @@ public class KaleoDefinitionPersistenceImpl
 					Query query = session.createQuery(sql);
 
 					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(groupId);
 
 					queryPos.add(companyId);
 
@@ -4927,16 +5008,19 @@ public class KaleoDefinitionPersistenceImpl
 		}
 	}
 
-	private static final String _FINDER_COLUMN_C_S_A_COMPANYID_2 =
+	private static final String _FINDER_COLUMN_G_C_S_A_GROUPID_2 =
+		"kaleoDefinition.groupId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_C_S_A_COMPANYID_2 =
 		"kaleoDefinition.companyId = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_S_A_SCOPE_2 =
+	private static final String _FINDER_COLUMN_G_C_S_A_SCOPE_2 =
 		"kaleoDefinition.scope = ? AND ";
 
-	private static final String _FINDER_COLUMN_C_S_A_SCOPE_3 =
+	private static final String _FINDER_COLUMN_G_C_S_A_SCOPE_3 =
 		"(kaleoDefinition.scope IS NULL OR kaleoDefinition.scope = '') AND ";
 
-	private static final String _FINDER_COLUMN_C_S_A_ACTIVE_2 =
+	private static final String _FINDER_COLUMN_G_C_S_A_ACTIVE_2 =
 		"kaleoDefinition.active = ?";
 
 	private FinderPath _finderPathFetchByERC_C;
@@ -6247,25 +6331,6 @@ public class KaleoDefinitionPersistenceImpl
 			new String[] {Long.class.getName(), String.class.getName()},
 			new String[] {"companyId", "name"}, true);
 
-		_finderPathWithPaginationFindByC_S = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_S",
-			new String[] {
-				Long.class.getName(), String.class.getName(),
-				Integer.class.getName(), Integer.class.getName(),
-				OrderByComparator.class.getName()
-			},
-			new String[] {"companyId", "scope"}, true);
-
-		_finderPathWithoutPaginationFindByC_S = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_S",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "scope"}, true);
-
-		_finderPathCountByC_S = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_S",
-			new String[] {Long.class.getName(), String.class.getName()},
-			new String[] {"companyId", "scope"}, false);
-
 		_finderPathWithPaginationFindByC_A = new FinderPath(
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_A",
 			new String[] {
@@ -6285,6 +6350,31 @@ public class KaleoDefinitionPersistenceImpl
 			new String[] {Long.class.getName(), Boolean.class.getName()},
 			new String[] {"companyId", "active_"}, false);
 
+		_finderPathWithPaginationFindByG_C_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_C_S",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "companyId", "scope"}, true);
+
+		_finderPathWithoutPaginationFindByG_C_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_C_S",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"groupId", "companyId", "scope"}, true);
+
+		_finderPathCountByG_C_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C_S",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"groupId", "companyId", "scope"}, false);
+
 		_finderPathFetchByC_N_V = new FinderPath(
 			FINDER_CLASS_NAME_ENTITY, "fetchByC_N_V",
 			new String[] {
@@ -6301,30 +6391,31 @@ public class KaleoDefinitionPersistenceImpl
 			},
 			new String[] {"companyId", "name", "active_"}, true);
 
-		_finderPathWithPaginationFindByC_S_A = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_S_A",
+		_finderPathWithPaginationFindByG_C_S_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_C_S_A",
 			new String[] {
-				Long.class.getName(), String.class.getName(),
-				Boolean.class.getName(), Integer.class.getName(),
-				Integer.class.getName(), OrderByComparator.class.getName()
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
 			},
-			new String[] {"companyId", "scope", "active_"}, true);
+			new String[] {"groupId", "companyId", "scope", "active_"}, true);
 
-		_finderPathWithoutPaginationFindByC_S_A = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_S_A",
+		_finderPathWithoutPaginationFindByG_C_S_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_C_S_A",
 			new String[] {
-				Long.class.getName(), String.class.getName(),
-				Boolean.class.getName()
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName(), Boolean.class.getName()
 			},
-			new String[] {"companyId", "scope", "active_"}, true);
+			new String[] {"groupId", "companyId", "scope", "active_"}, true);
 
-		_finderPathCountByC_S_A = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_S_A",
+		_finderPathCountByG_C_S_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C_S_A",
 			new String[] {
-				Long.class.getName(), String.class.getName(),
-				Boolean.class.getName()
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName(), Boolean.class.getName()
 			},
-			new String[] {"companyId", "scope", "active_"}, false);
+			new String[] {"groupId", "companyId", "scope", "active_"}, false);
 
 		_finderPathFetchByERC_C = new FinderPath(
 			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/resources/META-INF/sql/indexes.sql
@@ -8,12 +8,12 @@ create index IX_353B7FB5 on KaleoCondition (kaleoDefinitionVersionId);
 create index IX_86CBD4C on KaleoCondition (kaleoNodeId);
 
 create index IX_EEFC11D0 on KaleoDefinition (active_);
+create index IX_A99EF6D4 on KaleoDefinition (companyId, active_, groupId, scope[$COLUMN_LENGTH:75$]);
 create index IX_37ED1EF9 on KaleoDefinition (companyId, active_, name[$COLUMN_LENGTH:200$]);
-create index IX_D1C1A80A on KaleoDefinition (companyId, active_, scope[$COLUMN_LENGTH:75$]);
 create unique index IX_9F17D510 on KaleoDefinition (companyId, ctCollectionId, externalReferenceCode[$COLUMN_LENGTH:75$]);
+create index IX_72193B49 on KaleoDefinition (companyId, groupId, scope[$COLUMN_LENGTH:75$]);
 create index IX_EC14F81A on KaleoDefinition (companyId, name[$COLUMN_LENGTH:200$], version);
-create index IX_6E339BF5 on KaleoDefinition (companyId, scope[$COLUMN_LENGTH:75$]);
-create unique index IX_1EE07E31 on KaleoDefinition (uuid_[$COLUMN_LENGTH:75$], ctCollectionId, groupId);
+create unique index IX_9A534D2D on KaleoDefinition (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId);
 
 create unique index IX_3ADEC2A on KaleoDefinitionVersion (companyId, name[$COLUMN_LENGTH:200$], version[$COLUMN_LENGTH:75$], ctCollectionId);
 

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/resources/service.properties
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.portal.workflow.kaleo.service
-    build.number=13
-    build.date=1762872856317
+    build.number=14
+    build.date=1772481363684

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoDefinitionPersistenceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoDefinitionPersistenceTest.java
@@ -286,20 +286,21 @@ public class KaleoDefinitionPersistenceTest {
 	}
 
 	@Test
-	public void testCountByC_S() throws Exception {
-		_persistence.countByC_S(RandomTestUtil.nextLong(), "");
-
-		_persistence.countByC_S(0L, "null");
-
-		_persistence.countByC_S(0L, (String)null);
-	}
-
-	@Test
 	public void testCountByC_A() throws Exception {
 		_persistence.countByC_A(
 			RandomTestUtil.nextLong(), RandomTestUtil.randomBoolean());
 
 		_persistence.countByC_A(0L, RandomTestUtil.randomBoolean());
+	}
+
+	@Test
+	public void testCountByG_C_S() throws Exception {
+		_persistence.countByG_C_S(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(), "");
+
+		_persistence.countByG_C_S(0L, 0L, "null");
+
+		_persistence.countByG_C_S(0L, 0L, (String)null);
 	}
 
 	@Test
@@ -324,14 +325,16 @@ public class KaleoDefinitionPersistenceTest {
 	}
 
 	@Test
-	public void testCountByC_S_A() throws Exception {
-		_persistence.countByC_S_A(
-			RandomTestUtil.nextLong(), "", RandomTestUtil.randomBoolean());
+	public void testCountByG_C_S_A() throws Exception {
+		_persistence.countByG_C_S_A(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(), "",
+			RandomTestUtil.randomBoolean());
 
-		_persistence.countByC_S_A(0L, "null", RandomTestUtil.randomBoolean());
+		_persistence.countByG_C_S_A(
+			0L, 0L, "null", RandomTestUtil.randomBoolean());
 
-		_persistence.countByC_S_A(
-			0L, (String)null, RandomTestUtil.randomBoolean());
+		_persistence.countByG_C_S_A(
+			0L, 0L, (String)null, RandomTestUtil.randomBoolean());
 	}
 
 	@Test

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoDefinitionServiceImplTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoDefinitionServiceImplTest.java
@@ -5,6 +5,10 @@
 
 package com.liferay.portal.workflow.kaleo.service.test;
 
+import com.liferay.account.constants.AccountConstants;
+import com.liferay.account.model.AccountEntry;
+import com.liferay.account.service.AccountEntryLocalService;
+import com.liferay.account.service.AccountEntryUserRelLocalService;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -17,6 +21,7 @@ import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerBumper;
@@ -109,59 +114,19 @@ public class KaleoDefinitionServiceImplTest {
 
 	@Test
 	public void testAddKaleoDefinition() throws Exception {
-
-		// Administrator with "company.administrator.can.publish" disabled
-
-		_setUpPermissionThreadLocal(_companyAdminUser);
-
-		AssertUtils.assertFailure(
-			PrincipalException.MustHavePermission.class,
-			StringBundler.concat(
-				"User ", _companyAdminUser.getUserId(), " must have ",
-				"ADD_DEFINITION, ", WorkflowConstants.RESOURCE_NAME,
-				" permission for null "),
-			this::_addKaleoDefinition);
-
-		// Administrator with "company.administrator.can.publish" enabled
-
-		ConfigurationTestUtil.saveConfiguration(
-			_configuration,
-			HashMapDictionaryBuilder.<String, Object>put(
-				"company.administrator.can.publish", true
-			).build());
-
-		Assert.assertNotNull(_addKaleoDefinition());
+		_testAddKaleoDefinition();
+		_testAddKaleoDefinitionWithGroupId();
 	}
 
 	@Test
 	public void testGetKaleoDefinition() throws Exception {
-		KaleoDefinition kaleoDefinition = _addKaleoDefinition();
-
-		User user = _addUser();
-
-		_setUpPermissionThreadLocal(user);
-
-		AssertUtils.assertFailure(
-			PrincipalException.MustBeCompanyAdmin.class,
-			StringBundler.concat(
-				"User ", user.getUserId(), " must be the company ",
-				"administrator to perform the action"),
-			() -> _kaleoDefinitionService.getKaleoDefinition(
-				kaleoDefinition.getKaleoDefinitionId()));
-
-		_setUpPermissionThreadLocal(_companyAdminUser);
-
-		Assert.assertEquals(
-			kaleoDefinition,
-			_kaleoDefinitionService.getKaleoDefinition(
-				kaleoDefinition.getKaleoDefinitionId()));
+		_testGetKaleoDefinition();
+		_testGetKaleoDefinitionWithGroupId();
 	}
 
 	@Test
 	public void testGetScopeKaleoDefinitions() throws Exception {
 		User user = _addUser();
-
-		_setUpPermissionThreadLocal(user);
 
 		AssertUtils.assertFailure(
 			PrincipalException.MustBeCompanyAdmin.class,
@@ -200,6 +165,185 @@ public class KaleoDefinitionServiceImplTest {
 
 	@Test
 	public void testUpdateKaleoDefinition() throws Exception {
+		_testUpdateKaleoDefinition();
+		_testUpdateKaleoDefinitionWithGroupId();
+	}
+
+	private AccountEntry _addAccountEntry() throws Exception {
+		return _accountEntryLocalService.addAccountEntry(
+			StringPool.BLANK, TestPropsValues.getUserId(), 0L,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			null, null, RandomTestUtil.randomString(),
+			AccountConstants.ACCOUNT_ENTRY_TYPE_BUSINESS,
+			WorkflowConstants.STATUS_APPROVED,
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private KaleoDefinition _addKaleoDefinition() throws Exception {
+		return _kaleoDefinitionService.addKaleoDefinition(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			_read(), "company", 1, _serviceContext);
+	}
+
+	private KaleoDefinition _addKaleoDefinition(ServiceContext serviceContext)
+		throws Exception {
+
+		return _kaleoDefinitionService.addKaleoDefinition(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			_read(), "ai", 1, serviceContext);
+	}
+
+	private User _addUser() throws Exception {
+		return _addUser(_company.getCompanyId());
+	}
+
+	private User _addUser(long companyId) throws Exception {
+		User user = UserTestUtil.addUser(
+			companyId, TestPropsValues.getUserId(),
+			RandomTestUtil.randomString(
+				NumericStringRandomizerBumper.INSTANCE,
+				UniqueStringRandomizerBumper.INSTANCE),
+			LocaleUtil.getDefault(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), new long[0], _serviceContext);
+
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(user));
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		return user;
+	}
+
+	private String _read() throws Exception {
+		ClassLoader classLoader =
+			BaseKaleoLocalServiceTestCase.class.getClassLoader();
+
+		try (InputStream inputStream = classLoader.getResourceAsStream(
+				"com/liferay/portal/workflow/kaleo/dependencies" +
+					"/legal-marketing-workflow-definition.xml")) {
+
+			return StringUtil.read(inputStream);
+		}
+	}
+
+	private void _setUpPermissionThreadLocal(User user) {
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(user));
+	}
+
+	private void _testAddKaleoDefinition() throws Exception {
+
+		// Administrator with "company.administrator.can.publish" disabled
+
+		_setUpPermissionThreadLocal(_companyAdminUser);
+
+		AssertUtils.assertFailure(
+			PrincipalException.MustHavePermission.class,
+			StringBundler.concat(
+				"User ", _companyAdminUser.getUserId(), " must have ",
+				"ADD_DEFINITION, ", WorkflowConstants.RESOURCE_NAME,
+				" permission for null "),
+			this::_addKaleoDefinition);
+
+		// Administrator with "company.administrator.can.publish" enabled
+
+		ConfigurationTestUtil.saveConfiguration(
+			_configuration,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"company.administrator.can.publish", true
+			).build());
+
+		Assert.assertNotNull(_addKaleoDefinition());
+	}
+
+	private void _testAddKaleoDefinitionWithGroupId() throws Exception {
+		AccountEntry accountEntry = _addAccountEntry();
+
+		User user = _addUser(TestPropsValues.getCompanyId());
+
+		AssertUtils.assertFailure(
+			PrincipalException.MustHavePermission.class,
+			StringBundler.concat(
+				"User ", user.getUserId(), " must have ADD_DEFINITION, ",
+				WorkflowConstants.RESOURCE_NAME, " permission for null "),
+			() -> _addKaleoDefinition(
+				ServiceContextTestUtil.getServiceContext(
+					accountEntry.getAccountEntryGroupId(), user.getUserId())));
+
+		_accountEntryUserRelLocalService.addAccountEntryUserRel(
+			accountEntry.getAccountEntryId(), user.getUserId());
+
+		KaleoDefinition kaleoDefinition = _addKaleoDefinition(
+			ServiceContextTestUtil.getServiceContext(
+				accountEntry.getAccountEntryGroupId(), user.getUserId()));
+
+		Assert.assertEquals(
+			accountEntry.getAccountEntryGroupId(),
+			kaleoDefinition.getGroupId());
+	}
+
+	private void _testGetKaleoDefinition() throws Exception {
+		KaleoDefinition kaleoDefinition = _addKaleoDefinition();
+
+		User user = _addUser();
+
+		AssertUtils.assertFailure(
+			PrincipalException.MustBeCompanyAdmin.class,
+			StringBundler.concat(
+				"User ", user.getUserId(), " must be the company ",
+				"administrator to perform the action"),
+			() -> _kaleoDefinitionService.getKaleoDefinition(
+				kaleoDefinition.getKaleoDefinitionId()));
+
+		_setUpPermissionThreadLocal(_companyAdminUser);
+
+		Assert.assertEquals(
+			kaleoDefinition,
+			_kaleoDefinitionService.getKaleoDefinition(
+				kaleoDefinition.getKaleoDefinitionId()));
+	}
+
+	private void _testGetKaleoDefinitionWithGroupId() throws Exception {
+		AccountEntry accountEntry = _addAccountEntry();
+
+		ConfigurationTestUtil.saveConfiguration(
+			_configuration,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"company.administrator.can.publish", true
+			).build());
+
+		KaleoDefinition kaleoDefinition = _addKaleoDefinition(
+			ServiceContextTestUtil.getServiceContext(
+				accountEntry.getAccountEntryGroupId(),
+				TestPropsValues.getUserId()));
+
+		Assert.assertEquals(
+			accountEntry.getAccountEntryGroupId(),
+			kaleoDefinition.getGroupId());
+
+		User user = _addUser(TestPropsValues.getCompanyId());
+
+		AssertUtils.assertFailure(
+			PrincipalException.MustBeCompanyAdmin.class,
+			StringBundler.concat(
+				"User ", user.getUserId(), " must be the company ",
+				"administrator to perform the action"),
+			() -> _kaleoDefinitionService.getKaleoDefinition(
+				kaleoDefinition.getKaleoDefinitionId()));
+
+		_accountEntryUserRelLocalService.addAccountEntryUserRel(
+			accountEntry.getAccountEntryId(), user.getUserId());
+
+		Assert.assertNotNull(
+			_kaleoDefinitionService.getKaleoDefinition(
+				kaleoDefinition.getKaleoDefinitionId()));
+	}
+
+	private void _testUpdateKaleoDefinition() throws Exception {
 
 		// Administrator with "company.administrator.can.publish" disabled
 
@@ -235,40 +379,44 @@ public class KaleoDefinitionServiceImplTest {
 				kaleoDefinition.getContent(), _serviceContext));
 	}
 
-	private KaleoDefinition _addKaleoDefinition() throws Exception {
-		return _kaleoDefinitionService.addKaleoDefinition(
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			_read(), "company", 1, _serviceContext);
-	}
+	private void _testUpdateKaleoDefinitionWithGroupId() throws Exception {
+		AccountEntry accountEntry = _addAccountEntry();
 
-	private User _addUser() throws Exception {
-		return UserTestUtil.addUser(
-			_company.getCompanyId(), TestPropsValues.getUserId(),
-			RandomTestUtil.randomString(
-				NumericStringRandomizerBumper.INSTANCE,
-				UniqueStringRandomizerBumper.INSTANCE),
-			LocaleUtil.getDefault(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), new long[0], _serviceContext);
-	}
+		KaleoDefinition kaleoDefinition = _addKaleoDefinition(
+			ServiceContextTestUtil.getServiceContext(
+				accountEntry.getAccountEntryGroupId(),
+				TestPropsValues.getUserId()));
 
-	private String _read() throws Exception {
-		ClassLoader classLoader =
-			BaseKaleoLocalServiceTestCase.class.getClassLoader();
+		Assert.assertEquals(
+			accountEntry.getAccountEntryGroupId(),
+			kaleoDefinition.getGroupId());
 
-		try (InputStream inputStream = classLoader.getResourceAsStream(
-				"com/liferay/portal/workflow/kaleo/dependencies" +
-					"/legal-marketing-workflow-definition.xml")) {
+		User user = _addUser(TestPropsValues.getCompanyId());
 
-			return StringUtil.read(inputStream);
-		}
-	}
+		AssertUtils.assertFailure(
+			PrincipalException.MustHavePermission.class,
+			StringBundler.concat(
+				"User ", user.getUserId(), " must have ADD_DEFINITION, ",
+				WorkflowConstants.RESOURCE_NAME, " permission for null "),
+			() -> _kaleoDefinitionService.updateKaleoDefinition(
+				kaleoDefinition.getExternalReferenceCode(),
+				kaleoDefinition.getKaleoDefinitionId(),
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				kaleoDefinition.getContent(),
+				ServiceContextTestUtil.getServiceContext(
+					accountEntry.getAccountEntryGroupId(), user.getUserId())));
 
-	private void _setUpPermissionThreadLocal(User user) {
-		PrincipalThreadLocal.setName(user.getUserId());
+		_accountEntryUserRelLocalService.addAccountEntryUserRel(
+			accountEntry.getAccountEntryId(), user.getUserId());
 
-		PermissionThreadLocal.setPermissionChecker(
-			PermissionCheckerFactoryUtil.create(user));
+		Assert.assertNotNull(
+			_kaleoDefinitionService.updateKaleoDefinition(
+				kaleoDefinition.getExternalReferenceCode(),
+				kaleoDefinition.getKaleoDefinitionId(),
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				kaleoDefinition.getContent(),
+				ServiceContextTestUtil.getServiceContext(
+					accountEntry.getAccountEntryGroupId(), user.getUserId())));
 	}
 
 	private static Company _company;
@@ -277,6 +425,15 @@ public class KaleoDefinitionServiceImplTest {
 
 	@Inject
 	private static ConfigurationAdmin _configurationAdmin;
+
+	@Inject
+	private AccountEntryLocalService _accountEntryLocalService;
+
+	@Inject
+	private AccountEntryUserRelLocalService _accountEntryUserRelLocalService;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
 
 	@Inject
 	private KaleoDefinitionLocalService _kaleoDefinitionLocalService;

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/test/java/com/liferay/portal/workflow/kaleo/designer/web/internal/portlet/display/context/KaleoDesignerDisplayContextTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/test/java/com/liferay/portal/workflow/kaleo/designer/web/internal/portlet/display/context/KaleoDesignerDisplayContextTest.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoader;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -230,7 +231,8 @@ public class KaleoDesignerDisplayContextTest {
 		);
 
 		_kaleoDesignerDisplayContext = new KaleoDesignerDisplayContext(
-			Mockito.mock(ActionExecutorManager.class), renderRequest,
+			Mockito.mock(ActionExecutorManager.class),
+			Mockito.mock(GroupLocalService.class), renderRequest,
 			Mockito.mock(KaleoDefinitionVersionLocalService.class),
 			_portletResourcePermission,
 			Mockito.mock(ResourceBundleLoader.class),


### PR DESCRIPTION
Fixes: https://github.com/liferay-ai-hub/liferay-portal/issues/102

- **LPD-78054 feat: ensure workflow definitions scoped by account are available to be modified if the user has access to that account**
- **LPD-78054 test: ensure workflow definition is scoped by account**
- **LPD-78054 feat: if the scope is ai apply the non system account group of the user into account in the query**
- **LPD-78054 generated: baseline**
- **LPD-78054 generated: gw buildService**