### PR TITLE
LPD-79171 A user assigned to the Space (only space member) should not see button create an asset (4th try)

### DIFF
--- a/modules/apps/depot/depot-api/bnd.bnd
+++ b/modules/apps/depot/depot-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Depot API
 Bundle-SymbolicName: com.liferay.depot.api
-Bundle-Version: 9.3.1
+Bundle-Version: 9.4.0
 Export-Package:\
 	com.liferay.depot.application,\
 	com.liferay.depot.configuration,\

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryService.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryService.java
@@ -68,6 +68,10 @@ public interface DepotEntryService extends BaseService {
 	public DepotEntry getDepotEntry(long depotEntryId) throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<Long> getDepotEntryGroupIds(
+		long companyId, long userId, int type);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<DepotEntry> getGroupConnectedDepotEntries(
 			long groupId, boolean ddmStructuresAvailable, int start, int end)
 		throws PortalException;

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryServiceUtil.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryServiceUtil.java
@@ -67,6 +67,12 @@ public class DepotEntryServiceUtil {
 		return getService().getDepotEntry(depotEntryId);
 	}
 
+	public static List<Long> getDepotEntryGroupIds(
+		long companyId, long userId, int type) {
+
+		return getService().getDepotEntryGroupIds(companyId, userId, type);
+	}
+
 	public static List<DepotEntry> getGroupConnectedDepotEntries(
 			long groupId, boolean ddmStructuresAvailable, int start, int end)
 		throws PortalException {

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryServiceWrapper.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryServiceWrapper.java
@@ -68,6 +68,14 @@ public class DepotEntryServiceWrapper
 	}
 
 	@Override
+	public java.util.List<Long> getDepotEntryGroupIds(
+		long companyId, long userId, int type) {
+
+		return _depotEntryService.getDepotEntryGroupIds(
+			companyId, userId, type);
+	}
+
+	@Override
 	public java.util.List<DepotEntry> getGroupConnectedDepotEntries(
 			long groupId, boolean ddmStructuresAvailable, int start, int end)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/service/packageinfo
+++ b/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/service/packageinfo
@@ -1,1 +1,1 @@
-version 3.3.0
+version 3.4.0

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/http/DepotEntryServiceHttp.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/http/DepotEntryServiceHttp.java
@@ -247,6 +247,38 @@ public class DepotEntryServiceHttp {
 		}
 	}
 
+	public static java.util.List<Long> getDepotEntryGroupIds(
+		HttpPrincipal httpPrincipal, long companyId, long userId, int type) {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				DepotEntryServiceUtil.class, "getDepotEntryGroupIds",
+				_getDepotEntryGroupIdsParameterTypes5);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, companyId, userId, type);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (java.util.List<Long>)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static java.util.List<com.liferay.depot.model.DepotEntry>
 			getGroupConnectedDepotEntries(
 				HttpPrincipal httpPrincipal, long groupId,
@@ -256,7 +288,7 @@ public class DepotEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DepotEntryServiceUtil.class, "getGroupConnectedDepotEntries",
-				_getGroupConnectedDepotEntriesParameterTypes5);
+				_getGroupConnectedDepotEntriesParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, ddmStructuresAvailable, start, end);
@@ -299,7 +331,7 @@ public class DepotEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DepotEntryServiceUtil.class, "getGroupConnectedDepotEntries",
-				_getGroupConnectedDepotEntriesParameterTypes6);
+				_getGroupConnectedDepotEntriesParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, type, start, end);
@@ -341,7 +373,7 @@ public class DepotEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DepotEntryServiceUtil.class,
 				"getGroupConnectedDepotEntriesCount",
-				_getGroupConnectedDepotEntriesCountParameterTypes7);
+				_getGroupConnectedDepotEntriesCountParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, type);
@@ -381,7 +413,7 @@ public class DepotEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DepotEntryServiceUtil.class, "getGroupDepotEntry",
-				_getGroupDepotEntryParameterTypes8);
+				_getGroupDepotEntryParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -426,7 +458,7 @@ public class DepotEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DepotEntryServiceUtil.class, "updateDepotEntry",
-				_updateDepotEntryParameterTypes9);
+				_updateDepotEntryParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, depotEntryId, nameMap, descriptionMap,
@@ -479,21 +511,23 @@ public class DepotEntryServiceHttp {
 		};
 	private static final Class<?>[] _getDepotEntryParameterTypes4 =
 		new Class[] {long.class};
+	private static final Class<?>[] _getDepotEntryGroupIdsParameterTypes5 =
+		new Class[] {long.class, long.class, int.class};
 	private static final Class<?>[]
-		_getGroupConnectedDepotEntriesParameterTypes5 = new Class[] {
+		_getGroupConnectedDepotEntriesParameterTypes6 = new Class[] {
 			long.class, boolean.class, int.class, int.class
 		};
 	private static final Class<?>[]
-		_getGroupConnectedDepotEntriesParameterTypes6 = new Class[] {
+		_getGroupConnectedDepotEntriesParameterTypes7 = new Class[] {
 			long.class, int.class, int.class, int.class
 		};
 	private static final Class<?>[]
-		_getGroupConnectedDepotEntriesCountParameterTypes7 = new Class[] {
+		_getGroupConnectedDepotEntriesCountParameterTypes8 = new Class[] {
 			long.class, int.class
 		};
-	private static final Class<?>[] _getGroupDepotEntryParameterTypes8 =
+	private static final Class<?>[] _getGroupDepotEntryParameterTypes9 =
 		new Class[] {long.class};
-	private static final Class<?>[] _updateDepotEntryParameterTypes9 =
+	private static final Class<?>[] _updateDepotEntryParameterTypes10 =
 		new Class[] {
 			long.class, java.util.Map.class, java.util.Map.class,
 			java.util.Map.class,

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryServiceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryServiceImpl.java
@@ -137,19 +137,19 @@ public class DepotEntryServiceImpl extends DepotEntryServiceBaseImpl {
 			}
 
 			if (userId != getUserId()) {
-				return null;
+				return Collections.emptyList();
 			}
+
+			return depotEntryLocalService.getDepotEntryGroupIds(
+				companyId, userId, type);
 		}
 		catch (PortalException portalException) {
 			if (_log.isDebugEnabled()) {
 				_log.debug(portalException);
 			}
-
-			return null;
 		}
 
-		return depotEntryLocalService.getDepotEntryGroupIds(
-			companyId, userId, type);
+		return Collections.emptyList();
 	}
 
 	@Override

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryServiceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryServiceImpl.java
@@ -12,11 +12,15 @@ import com.liferay.depot.service.base.DepotEntryServiceBaseImpl;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
@@ -116,6 +120,39 @@ public class DepotEntryServiceImpl extends DepotEntryServiceBaseImpl {
 	}
 
 	@Override
+	public List<Long> getDepotEntryGroupIds(
+		long companyId, long userId, int type) {
+
+		try {
+			PermissionChecker permissionChecker = getPermissionChecker();
+
+			if (permissionChecker.isCompanyAdmin() ||
+				((type == DepotConstants.TYPE_SPACE) &&
+				 _roleLocalService.hasUserRole(
+					 getUserId(), companyId, RoleConstants.CMS_ADMINISTRATOR,
+					 true))) {
+
+				return depotEntryLocalService.getDepotEntryGroupIds(
+					companyId, type);
+			}
+
+			if (userId != getUserId()) {
+				return null;
+			}
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+
+			return null;
+		}
+
+		return depotEntryLocalService.getDepotEntryGroupIds(
+			companyId, userId, type);
+	}
+
+	@Override
 	public List<DepotEntry> getGroupConnectedDepotEntries(
 			long groupId, boolean ddmStructuresAvailable, int start, int end)
 		throws PortalException {
@@ -204,6 +241,9 @@ public class DepotEntryServiceImpl extends DepotEntryServiceBaseImpl {
 			typeSettingsUnicodeProperties, serviceContext);
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		DepotEntryServiceImpl.class);
+
 	@Reference(
 		policy = ReferencePolicy.DYNAMIC,
 		policyOption = ReferencePolicyOption.GREEDY,
@@ -218,5 +258,8 @@ public class DepotEntryServiceImpl extends DepotEntryServiceBaseImpl {
 		target = "(resource.name=" + DepotConstants.RESOURCE_NAME + ")"
 	)
 	private volatile PortletResourcePermission _portletResourcePermission;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
 
 }

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
@@ -83,6 +83,7 @@ import com.liferay.translation.exporter.TranslationInfoItemFieldValuesExporterRe
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -384,6 +385,26 @@ public abstract class BaseSectionDisplayContextTestCase
 		DepotEntry depotEntry1 = addDepotEntry(
 			StringUtil.randomString(), TestPropsValues.getUserId());
 
+		User user1 = UserTestUtil.addUser();
+
+		User user2 = UserTestUtil.addUser();
+
+		groupLocalService.addUserGroup(
+			user2.getUserId(), depotEntry1.getGroup());
+
+		User user3 = UserTestUtil.addUser();
+
+		groupLocalService.addUserGroup(
+			user3.getUserId(), depotEntry1.getGroup());
+
+		Role role = _getRoleWithPermissions(ActionKeys.ADD_ENTRY, depotEntry1);
+
+		_userGroupRoleLocalService.addUserGroupRoles(
+			user3.getUserId(), depotEntry1.getGroupId(),
+			new long[] {role.getRoleId()});
+
+		// Create menu in root folder
+
 		_assertCreationMenu(
 			getCreationMenu(adminUser), expectedCreationMenuItems);
 
@@ -393,108 +414,23 @@ public abstract class BaseSectionDisplayContextTestCase
 		_assertCreationMenu(
 			getCreationMenu(adminUser), expectedCreationMenuItems);
 
-		User user = UserTestUtil.addUser();
+		setUser(user1);
 
-		setUser(user);
+		_assertCreationMenu(getCreationMenu(user1), Collections.emptyMap());
 
-		_assertCreationMenu(getCreationMenu(user), Collections.emptyMap());
+		setUser(user2);
 
-		groupLocalService.addUserGroup(
-			user.getUserId(), depotEntry1.getGroup());
+		_assertCreationMenu(getCreationMenu(user2), Collections.emptyMap());
 
-		_assertCreationMenu(getCreationMenu(user), Collections.emptyMap());
+		setUser(user3);
 
-		Role role = _getRoleWithPermissions(ActionKeys.ADD_ENTRY, depotEntry1);
+		_assertCreationMenu(getCreationMenu(user3), expectedCreationMenuItems);
 
-		_userGroupRoleLocalService.addUserGroupRoles(
-			user.getUserId(), depotEntry1.getGroupId(),
-			new long[] {role.getRoleId()});
-
-		_assertCreationMenu(getCreationMenu(user), expectedCreationMenuItems);
-
-		_depotEntryLocalService.deleteDepotEntry(depotEntry1);
-		_depotEntryLocalService.deleteDepotEntry(depotEntry2);
-
-		_userLocalService.deleteUser(user);
-	}
-
-	@Test
-	public void testGetCreationMenuInSubfolder() throws Exception {
-		if (getRootObjectEntryFolderExternalReferenceCode() == null) {
-			return;
-		}
-
-		Map<String, String> expectedCreationMenuItems =
-			getExpectedCreationMenuItems();
-
-		if (expectedCreationMenuItems.isEmpty()) {
-			return;
-		}
-
-		expectedCreationMenuItems = _getLocalizedKeysMap(
-			expectedCreationMenuItems);
-
-		DepotEntry depotEntry = addDepotEntry(
-			StringUtil.randomString(), TestPropsValues.getUserId());
-
-		ObjectEntryFolder objectEntryFolder = _addObjectFolderEntry(
-			depotEntry.getGroup());
+		// Create menu with custom object definitions
 
 		setUser(adminUser);
 
-		_assertCreationMenu(
-			getCreationMenu(objectEntryFolder, adminUser),
-			expectedCreationMenuItems);
-
-		User user = UserTestUtil.addUser();
-
-		setUser(user);
-
-		_assertCreationMenu(
-			getCreationMenu(objectEntryFolder, user), Collections.emptyMap());
-
-		groupLocalService.addUserGroup(user.getUserId(), depotEntry.getGroup());
-
-		_assertCreationMenu(
-			getCreationMenu(objectEntryFolder, user), Collections.emptyMap());
-
-		Role role = _getRoleWithPermissions(ActionKeys.ADD_ENTRY, depotEntry);
-
-		_userGroupRoleLocalService.addUserGroupRoles(
-			user.getUserId(), depotEntry.getGroupId(),
-			new long[] {role.getRoleId()});
-
-		_assertCreationMenu(
-			getCreationMenu(objectEntryFolder, user),
-			expectedCreationMenuItems);
-
-		_depotEntryLocalService.deleteDepotEntry(depotEntry);
-
-		_userLocalService.deleteUser(user);
-	}
-
-	@Test
-	@TestInfo("LPD-50664")
-	public void testGetCreationMenuWithCustomObjectDefinitions()
-		throws Exception {
-
-		Map<String, String> expectedCreationMenuItems =
-			getExpectedCreationMenuItems();
-
-		if (expectedCreationMenuItems.isEmpty()) {
-			return;
-		}
-
-		expectedCreationMenuItems = _getLocalizedKeysMap(
-			expectedCreationMenuItems);
-
-		DepotEntry depotEntry = addDepotEntry(
-			StringUtil.randomString(), TestPropsValues.getUserId());
-
-		setUser(adminUser);
-
-		_assertCreationMenu(
-			getCreationMenu(adminUser), expectedCreationMenuItems);
+		List<ObjectDefinition> objectDefinitions = new ArrayList<>();
 
 		TreeMap<String, String> expectedCustomCreationMenuItems = new TreeMap<>(
 			String.CASE_INSENSITIVE_ORDER);
@@ -519,9 +455,9 @@ public abstract class BaseSectionDisplayContextTestCase
 					objectDefinition,
 					_getRootObjectEntryFolderExternalReferenceCode(
 						objectFolderExternalReferenceCode)));
-		}
 
-		expectedCreationMenuItems.putAll(expectedCustomCreationMenuItems);
+			objectDefinitions.add(objectDefinition);
+		}
 
 		addCustomObjectDefinition(
 			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
@@ -550,9 +486,55 @@ public abstract class BaseSectionDisplayContextTestCase
 			WorkflowConstants.STATUS_APPROVED);
 
 		_assertCreationMenu(
-			getCreationMenu(adminUser), expectedCreationMenuItems);
+			getCreationMenu(adminUser),
+			HashMapBuilder.putAll(
+				expectedCreationMenuItems
+			).putAll(
+				expectedCustomCreationMenuItems
+			).build());
 
-		_depotEntryLocalService.deleteDepotEntry(depotEntry);
+		for (ObjectDefinition objectDefinition : objectDefinitions) {
+			objectDefinitionLocalService.deleteObjectDefinition(
+				objectDefinition);
+		}
+
+		// Create menu within an object entry folder
+
+		if (getRootObjectEntryFolderExternalReferenceCode() != null) {
+			setUser(adminUser);
+
+			ObjectEntryFolder objectEntryFolder = _addObjectFolderEntry(
+				depotEntry1.getGroup());
+
+			_assertCreationMenu(
+				getCreationMenu(objectEntryFolder, adminUser),
+				expectedCreationMenuItems);
+
+			setUser(user1);
+
+			_assertCreationMenu(
+				getCreationMenu(objectEntryFolder, user1),
+				Collections.emptyMap());
+
+			setUser(user2);
+
+			_assertCreationMenu(
+				getCreationMenu(objectEntryFolder, user2),
+				Collections.emptyMap());
+
+			setUser(user3);
+
+			_assertCreationMenu(
+				getCreationMenu(objectEntryFolder, user3),
+				expectedCreationMenuItems);
+		}
+
+		_depotEntryLocalService.deleteDepotEntry(depotEntry1);
+		_depotEntryLocalService.deleteDepotEntry(depotEntry2);
+
+		_userLocalService.deleteUser(user1);
+		_userLocalService.deleteUser(user2);
+		_userLocalService.deleteUser(user3);
 	}
 
 	@Test
@@ -815,8 +797,9 @@ public abstract class BaseSectionDisplayContextTestCase
 	}
 
 	private void _assertCreationMenuContainsDropdownItem(
-		CreationMenu creationMenu, JSONArray expectedAssetLibrariesJSONArray,
-		String expectedLabel) {
+			CreationMenu creationMenu,
+			JSONArray expectedAssetLibrariesJSONArray, String expectedLabel)
+		throws Exception {
 
 		List<DropdownItem> dropdownItems = (List<DropdownItem>)creationMenu.get(
 			"primaryItems");

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
@@ -378,9 +378,8 @@ public abstract class BaseSectionDisplayContextTestCase
 		expectedCreationMenuItems = _getLocalizedKeysMap(
 			expectedCreationMenuItems);
 
-		setUser(adminUser);
-
-		_assertCreationMenu(getCreationMenu(adminUser), Collections.emptyMap());
+		_assertCreationMenu(
+			getCreationMenu(TestPropsValues.getUser()), Collections.emptyMap());
 
 		DepotEntry depotEntry1 = addDepotEntry(
 			StringUtil.randomString(), TestPropsValues.getUserId());
@@ -402,29 +401,6 @@ public abstract class BaseSectionDisplayContextTestCase
 		_userGroupRoleLocalService.addUserGroupRoles(
 			user3.getUserId(), depotEntry1.getGroupId(),
 			new long[] {role.getRoleId()});
-
-		// Create menu in root folder
-
-		_assertCreationMenu(
-			getCreationMenu(adminUser), expectedCreationMenuItems);
-
-		DepotEntry depotEntry2 = addDepotEntry(
-			StringUtil.randomString(), TestPropsValues.getUserId());
-
-		_assertCreationMenu(
-			getCreationMenu(adminUser), expectedCreationMenuItems);
-
-		setUser(user1);
-
-		_assertCreationMenu(getCreationMenu(user1), Collections.emptyMap());
-
-		setUser(user2);
-
-		_assertCreationMenu(getCreationMenu(user2), Collections.emptyMap());
-
-		setUser(user3);
-
-		_assertCreationMenu(getCreationMenu(user3), expectedCreationMenuItems);
 
 		// Create menu with custom object definitions
 
@@ -528,6 +504,31 @@ public abstract class BaseSectionDisplayContextTestCase
 				getCreationMenu(objectEntryFolder, user3),
 				expectedCreationMenuItems);
 		}
+
+		// Create menu in root folder
+
+		setUser(adminUser);
+
+		_assertCreationMenu(
+			getCreationMenu(adminUser), expectedCreationMenuItems);
+
+		DepotEntry depotEntry2 = addDepotEntry(
+			StringUtil.randomString(), TestPropsValues.getUserId());
+
+		_assertCreationMenu(
+			getCreationMenu(adminUser), expectedCreationMenuItems);
+
+		setUser(user1);
+
+		_assertCreationMenu(getCreationMenu(user1), Collections.emptyMap());
+
+		setUser(user2);
+
+		_assertCreationMenu(getCreationMenu(user2), Collections.emptyMap());
+
+		setUser(user3);
+
+		_assertCreationMenu(getCreationMenu(user3), expectedCreationMenuItems);
 
 		_depotEntryLocalService.deleteDepotEntry(depotEntry1);
 		_depotEntryLocalService.deleteDepotEntry(depotEntry2);

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
@@ -40,24 +40,35 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
+import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.permission.ModelPermissions;
+import com.liferay.portal.kernel.service.permission.ModelPermissionsFactory;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PropsKeys;
@@ -84,6 +95,7 @@ import java.util.TreeMap;
 
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -265,15 +277,30 @@ public abstract class BaseSectionDisplayContextTestCase
 		).build();
 	}
 
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		adminUser = TestPropsValues.getUser();
+	}
+
 	@After
 	public void tearDown() throws Exception {
 		_mockHttpServletRequest = null;
 		_objectEntryFolder = null;
+
+		setUser(adminUser);
 	}
 
 	@Test
 	public void testGetAdditionalProps() throws Exception {
+		DepotEntry depotEntry = addDepotEntry(
+			StringUtil.randomString(), TestPropsValues.getUserId());
+
 		_assertEquals(getBaseAdditionalProps(), getAdditionalProps());
+
+		_depotEntryLocalService.deleteDepotEntry(depotEntry);
 	}
 
 	@Test
@@ -339,7 +366,6 @@ public abstract class BaseSectionDisplayContextTestCase
 	}
 
 	@Test
-	@TestInfo("LPD-50664")
 	public void testGetCreationMenu() throws Exception {
 		Map<String, String> expectedCreationMenuItems =
 			getExpectedCreationMenuItems();
@@ -348,7 +374,127 @@ public abstract class BaseSectionDisplayContextTestCase
 			return;
 		}
 
-		_testGetCreationMenu(getCreationMenu(), expectedCreationMenuItems);
+		expectedCreationMenuItems = _getLocalizedKeysMap(
+			expectedCreationMenuItems);
+
+		setUser(adminUser);
+
+		_assertCreationMenu(getCreationMenu(adminUser), Collections.emptyMap());
+
+		DepotEntry depotEntry1 = addDepotEntry(
+			StringUtil.randomString(), TestPropsValues.getUserId());
+
+		_assertCreationMenu(
+			getCreationMenu(adminUser), expectedCreationMenuItems);
+
+		DepotEntry depotEntry2 = addDepotEntry(
+			StringUtil.randomString(), TestPropsValues.getUserId());
+
+		_assertCreationMenu(
+			getCreationMenu(adminUser), expectedCreationMenuItems);
+
+		User user = UserTestUtil.addUser();
+
+		setUser(user);
+
+		_assertCreationMenu(getCreationMenu(user), Collections.emptyMap());
+
+		groupLocalService.addUserGroup(
+			user.getUserId(), depotEntry1.getGroup());
+
+		_assertCreationMenu(getCreationMenu(user), Collections.emptyMap());
+
+		Role role = _getRoleWithPermissions(ActionKeys.ADD_ENTRY, depotEntry1);
+
+		_userGroupRoleLocalService.addUserGroupRoles(
+			user.getUserId(), depotEntry1.getGroupId(),
+			new long[] {role.getRoleId()});
+
+		_assertCreationMenu(getCreationMenu(user), expectedCreationMenuItems);
+
+		_depotEntryLocalService.deleteDepotEntry(depotEntry1);
+		_depotEntryLocalService.deleteDepotEntry(depotEntry2);
+
+		_userLocalService.deleteUser(user);
+	}
+
+	@Test
+	public void testGetCreationMenuInSubfolder() throws Exception {
+		if (getRootObjectEntryFolderExternalReferenceCode() == null) {
+			return;
+		}
+
+		Map<String, String> expectedCreationMenuItems =
+			getExpectedCreationMenuItems();
+
+		if (expectedCreationMenuItems.isEmpty()) {
+			return;
+		}
+
+		expectedCreationMenuItems = _getLocalizedKeysMap(
+			expectedCreationMenuItems);
+
+		DepotEntry depotEntry = addDepotEntry(
+			StringUtil.randomString(), TestPropsValues.getUserId());
+
+		ObjectEntryFolder objectEntryFolder = _addObjectFolderEntry(
+			depotEntry.getGroup());
+
+		setUser(adminUser);
+
+		_assertCreationMenu(
+			getCreationMenu(objectEntryFolder, adminUser),
+			expectedCreationMenuItems);
+
+		User user = UserTestUtil.addUser();
+
+		setUser(user);
+
+		_assertCreationMenu(
+			getCreationMenu(objectEntryFolder, user), Collections.emptyMap());
+
+		groupLocalService.addUserGroup(user.getUserId(), depotEntry.getGroup());
+
+		_assertCreationMenu(
+			getCreationMenu(objectEntryFolder, user), Collections.emptyMap());
+
+		Role role = _getRoleWithPermissions(ActionKeys.ADD_ENTRY, depotEntry);
+
+		_userGroupRoleLocalService.addUserGroupRoles(
+			user.getUserId(), depotEntry.getGroupId(),
+			new long[] {role.getRoleId()});
+
+		_assertCreationMenu(
+			getCreationMenu(objectEntryFolder, user),
+			expectedCreationMenuItems);
+
+		_depotEntryLocalService.deleteDepotEntry(depotEntry);
+
+		_userLocalService.deleteUser(user);
+	}
+
+	@Test
+	@TestInfo("LPD-50664")
+	public void testGetCreationMenuWithCustomObjectDefinitions()
+		throws Exception {
+
+		Map<String, String> expectedCreationMenuItems =
+			getExpectedCreationMenuItems();
+
+		if (expectedCreationMenuItems.isEmpty()) {
+			return;
+		}
+
+		expectedCreationMenuItems = _getLocalizedKeysMap(
+			expectedCreationMenuItems);
+
+		DepotEntry depotEntry = addDepotEntry(
+			StringUtil.randomString(), TestPropsValues.getUserId());
+
+		setUser(adminUser);
+
+		_assertCreationMenu(
+			getCreationMenu(adminUser), expectedCreationMenuItems);
 
 		TreeMap<String, String> expectedCustomCreationMenuItems = new TreeMap<>(
 			String.CASE_INSENSITIVE_ORDER);
@@ -403,7 +549,10 @@ public abstract class BaseSectionDisplayContextTestCase
 			ObjectDefinitionConstants.SCOPE_SITE,
 			WorkflowConstants.STATUS_APPROVED);
 
-		_testGetCreationMenu(getCreationMenu(), expectedCreationMenuItems);
+		_assertCreationMenu(
+			getCreationMenu(adminUser), expectedCreationMenuItems);
+
+		_depotEntryLocalService.deleteDepotEntry(depotEntry);
 	}
 
 	@Test
@@ -504,17 +653,24 @@ public abstract class BaseSectionDisplayContextTestCase
 			new Object[0]);
 	}
 
-	protected CreationMenu getCreationMenu() throws Exception {
-		return getCreationMenu(null);
+	protected CreationMenu getCreationMenu(ObjectEntryFolder objectEntryFolder)
+		throws Exception {
+
+		return getCreationMenu(objectEntryFolder, TestPropsValues.getUser());
 	}
 
-	protected CreationMenu getCreationMenu(ObjectEntryFolder objectEntryFolder)
+	protected CreationMenu getCreationMenu(
+			ObjectEntryFolder objectEntryFolder, User user)
 		throws Exception {
 
 		return ReflectionTestUtil.invoke(
 			getSectionDisplayContext(
-				getMockHttpServletRequest(objectEntryFolder)),
+				getMockHttpServletRequest(objectEntryFolder, user)),
 			"getCreationMenu", new Class<?>[0]);
+	}
+
+	protected CreationMenu getCreationMenu(User user) throws Exception {
+		return getCreationMenu(null, user);
 	}
 
 	protected abstract Map<String, String> getExpectedCreationMenuItems()
@@ -599,6 +755,15 @@ public abstract class BaseSectionDisplayContextTestCase
 			HttpServletRequest httpServletRequest)
 		throws Exception;
 
+	protected void setUser(User user) {
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(user));
+
+		PrincipalThreadLocal.setName(user.getUserId());
+	}
+
+	protected User adminUser;
+
 	@Inject
 	protected GroupLocalService groupLocalService;
 
@@ -620,6 +785,33 @@ public abstract class BaseSectionDisplayContextTestCase
 			rootObjectEntryFolder.getObjectEntryFolderId(),
 			RandomTestUtil.randomString(), null, StringUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+	}
+
+	private void _assertCreationMenu(
+		CreationMenu creationMenu,
+		Map<String, String> expectedCreationMenuItems) {
+
+		List<DropdownItem> dropdownItems = (List<DropdownItem>)creationMenu.get(
+			"primaryItems");
+
+		Assert.assertEquals(
+			dropdownItems.toString(), expectedCreationMenuItems.size(),
+			dropdownItems.size());
+
+		for (DropdownItem dropdownItem : dropdownItems) {
+			String key = (String)dropdownItem.get("label");
+
+			Assert.assertTrue(expectedCreationMenuItems.containsKey(key));
+
+			String value = expectedCreationMenuItems.get(key);
+
+			if (Validator.isNull(value)) {
+				Assert.assertNull(_getRedirect(dropdownItem));
+			}
+			else {
+				Assert.assertEquals(value, _getRedirect(dropdownItem));
+			}
+		}
 	}
 
 	private void _assertCreationMenuContainsDropdownItem(
@@ -807,13 +999,16 @@ public abstract class BaseSectionDisplayContextTestCase
 
 	private JSONArray _getDepotEntriesJSONArray() throws PortalException {
 		return _getDepotEntriesJSONArray(
-			TransformUtil.transform(
-				_depotEntryLocalService.getDepotEntries(
-					group.getCompanyId(), DepotConstants.TYPE_SPACE),
-				DepotEntry::getGroupId));
+			_depotEntryLocalService.getDepotEntryGroupIds(
+				group.getCompanyId(), TestPropsValues.getUserId(),
+				DepotConstants.TYPE_SPACE));
 	}
 
 	private JSONArray _getDepotEntriesJSONArray(List<Long> groupIds) {
+		if (ListUtil.isEmpty(groupIds)) {
+			return null;
+		}
+
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
 		for (Long groupId : groupIds) {
@@ -901,6 +1096,18 @@ public abstract class BaseSectionDisplayContextTestCase
 		return jsonArray;
 	}
 
+	private Map<String, String> _getLocalizedKeysMap(Map<String, String> map) {
+		Map<String, String> localizedKeysMap = new HashMap<>();
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			localizedKeysMap.put(
+				language.get(LocaleUtil.getDefault(), entry.getKey()),
+				entry.getValue());
+		}
+
+		return localizedKeysMap;
+	}
+
 	private String _getRedirect(DropdownItem dropdownItem) {
 		Map<String, Object> map = (HashMap<String, Object>)dropdownItem.get(
 			"data");
@@ -910,6 +1117,37 @@ public abstract class BaseSectionDisplayContextTestCase
 		}
 
 		return (String)map.get("redirect");
+	}
+
+	private Role _getRoleWithPermissions(String actionId, DepotEntry depotEntry)
+		throws Exception {
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		ModelPermissions modelPermissions = ModelPermissionsFactory.create(
+			HashMapBuilder.put(
+				role.getName(), new String[] {actionId}
+			).build(),
+			ObjectEntryFolder.class.getName());
+
+		for (String objectEntryFolderExternalReferenceCode :
+				_getRootObjectEntryFolderExternalReferenceCodes(
+					getRootObjectEntryFolderExternalReferenceCode())) {
+
+			ObjectEntryFolder objectEntryFolder =
+				_objectEntryFolderLocalService.
+					getObjectEntryFolderByExternalReferenceCode(
+						objectEntryFolderExternalReferenceCode,
+						depotEntry.getGroupId(), depotEntry.getCompanyId());
+
+			ResourcePermissionLocalServiceUtil.addModelResourcePermissions(
+				depotEntry.getCompanyId(), depotEntry.getGroupId(),
+				TestPropsValues.getUserId(), ObjectEntryFolder.class.getName(),
+				String.valueOf(objectEntryFolder.getObjectEntryFolderId()),
+				modelPermissions);
+		}
+
+		return role;
 	}
 
 	private String _getRootObjectEntryFolderExternalReferenceCode(
@@ -926,38 +1164,17 @@ public abstract class BaseSectionDisplayContextTestCase
 		return ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES;
 	}
 
-	private void _testGetCreationMenu(
-		CreationMenu creationMenu,
-		Map<String, String> expectedCreationMenuItems) {
+	private String[] _getRootObjectEntryFolderExternalReferenceCodes(
+		String rootObjectEntryFolderExternalReferenceCode) {
 
-		List<DropdownItem> dropdownItems = (List<DropdownItem>)creationMenu.get(
-			"primaryItems");
-
-		Assert.assertEquals(
-			dropdownItems.toString(), expectedCreationMenuItems.size(),
-			dropdownItems.size());
-
-		int index = 0;
-
-		for (Map.Entry<String, String> entry :
-				expectedCreationMenuItems.entrySet()) {
-
-			DropdownItem dropdownItem = dropdownItems.get(index);
-
-			Assert.assertEquals(
-				language.get(LocaleUtil.getDefault(), entry.getKey()),
-				dropdownItem.get("label"));
-
-			if (Validator.isNull(entry.getValue())) {
-				Assert.assertNull(_getRedirect(dropdownItem));
-			}
-			else {
-				Assert.assertEquals(
-					entry.getValue(), _getRedirect(dropdownItem));
-			}
-
-			index++;
+		if (rootObjectEntryFolderExternalReferenceCode == null) {
+			return new String[] {
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS,
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES
+			};
 		}
+
+		return new String[] {rootObjectEntryFolderExternalReferenceCode};
 	}
 
 	private void _testGetDepotEntriesJSONArray(
@@ -1016,6 +1233,9 @@ public abstract class BaseSectionDisplayContextTestCase
 	@Inject
 	private TranslationInfoItemFieldValuesExporterRegistry
 		_translationInfoItemFieldValuesExporterRegistry;
+
+	@Inject
+	private UserGroupRoleLocalService _userGroupRoleLocalService;
 
 	@Inject
 	private UserLocalService _userLocalService;

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewFilesSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewFilesSectionDisplayContextTest.java
@@ -7,36 +7,14 @@ package com.liferay.site.cms.site.initializer.internal.display.context.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.fragment.renderer.FragmentRenderer;
-import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
-import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
-import com.liferay.object.model.ObjectEntryFolder;
-import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.model.ResourceConstants;
-import com.liferay.portal.kernel.model.Role;
-import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.model.role.RoleConstants;
-import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
-import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
-import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
-import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
-import com.liferay.portal.kernel.service.RoleLocalService;
-import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
-import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
-import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -45,13 +23,11 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -81,57 +57,6 @@ public class ViewFilesSectionDisplayContextTest
 		).put(
 			"galleryViewEnabled", true
 		).build();
-	}
-
-	@Test
-	public void testGetCreationMenuWithAddEntryPermission() throws Exception {
-		PermissionChecker originalPermissionChecker =
-			PermissionThreadLocal.getPermissionChecker();
-
-		try {
-			ObjectEntryFolder objectEntryFolder =
-				_objectEntryFolderLocalService.addObjectEntryFolder(
-					null, group.getGroupId(), TestPropsValues.getUserId(),
-					ObjectEntryFolderConstants.
-						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-					RandomTestUtil.randomString(),
-					HashMapBuilder.put(
-						LocaleUtil.getDefault(), StringUtil.randomString()
-					).build(),
-					StringUtil.randomString(),
-					ServiceContextTestUtil.getServiceContext());
-
-			_setUser(UserTestUtil.addUser());
-
-			CreationMenu creationMenu = getCreationMenu(objectEntryFolder);
-
-			List<DropdownItem> primaryItems =
-				(List<DropdownItem>)creationMenu.get("primaryItems");
-
-			Assert.assertEquals(
-				primaryItems.toString(), 0, primaryItems.size());
-
-			Role role = _roleLocalService.getRole(
-				TestPropsValues.getCompanyId(), RoleConstants.USER);
-
-			_resourcePermissionLocalService.setResourcePermissions(
-				TestPropsValues.getCompanyId(),
-				ObjectEntryFolder.class.getName(),
-				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(objectEntryFolder.getObjectEntryFolderId()),
-				role.getRoleId(), new String[] {ActionKeys.ADD_ENTRY});
-
-			creationMenu = getCreationMenu(objectEntryFolder);
-
-			primaryItems = (List<DropdownItem>)creationMenu.get("primaryItems");
-
-			Assert.assertEquals(
-				primaryItems.toString(), 4, primaryItems.size());
-		}
-		finally {
-			PermissionThreadLocal.setPermissionChecker(
-				originalPermissionChecker);
-		}
 	}
 
 	@Override
@@ -176,28 +101,9 @@ public class ViewFilesSectionDisplayContextTest
 		return filesSectionDisplayContext;
 	}
 
-	private void _setUser(User user) {
-		PermissionThreadLocal.setPermissionChecker(
-			PermissionCheckerFactoryUtil.create(user));
-
-		PrincipalThreadLocal.setName(user.getUserId());
-	}
-
 	@Inject(
 		filter = "component.name=com.liferay.site.cms.site.initializer.internal.fragment.renderer.ViewFilesJSPSectionFragmentRenderer"
 	)
 	private FragmentRenderer _fragmentRenderer;
-
-	@Inject
-	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
-
-	@Inject
-	private ResourcePermissionLocalService _resourcePermissionLocalService;
-
-	@Inject
-	private RoleLocalService _roleLocalService;
-
-	@Inject
-	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewRecycleBinSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewRecycleBinSectionDisplayContextTest.java
@@ -116,24 +116,18 @@ public class ViewRecycleBinSectionDisplayContextTest
 
 		_assertTrashEnabled(depotEntry2, true);
 
-		User user = UserTestUtil.addUser(
+		User user1 = UserTestUtil.addUser(
 			companyLocalService.getCompany(TestPropsValues.getCompanyId()),
 			RoleConstants.CMS_ADMINISTRATOR);
 
-		DepotEntry depotEntry3 = _addDepotEntry(true, user.getUserId());
+		DepotEntry depotEntry3 = _addDepotEntry(true, user1.getUserId());
 
 		_assertTrashEnabled(depotEntry3, true);
 
-		filterString = getCMSSectionFilterString(displayContext);
+		setUser(adminUser);
 
-		Assert.assertTrue(
-			filterString.contains(
-				_getExpectedFilterString(depotEntry2.getGroupId())));
-
-		displayContext = getSectionDisplayContext(
-			getMockHttpServletRequest(user));
-
-		filterString = getCMSSectionFilterString(displayContext);
+		filterString = getCMSSectionFilterString(
+			getSectionDisplayContext(getMockHttpServletRequest(adminUser)));
 
 		Assert.assertTrue(
 			filterString.contains(
@@ -143,11 +137,43 @@ public class ViewRecycleBinSectionDisplayContextTest
 				_getExpectedFilterString(
 					depotEntry3.getGroupId(), depotEntry2.getGroupId())));
 
+		setUser(user1);
+
+		filterString = getCMSSectionFilterString(
+			getSectionDisplayContext(getMockHttpServletRequest(user1)));
+
+		Assert.assertTrue(
+			filterString.contains(
+				_getExpectedFilterString(
+					depotEntry2.getGroupId(), depotEntry3.getGroupId())) ||
+			filterString.contains(
+				_getExpectedFilterString(
+					depotEntry3.getGroupId(), depotEntry2.getGroupId())));
+
+		User user2 = UserTestUtil.addUser();
+
+		groupLocalService.addUserGroup(
+			user2.getUserId(), depotEntry1.getGroup());
+
+		groupLocalService.addUserGroup(
+			user2.getUserId(), depotEntry2.getGroup());
+
+		setUser(user2);
+
+		filterString = getCMSSectionFilterString(
+			getSectionDisplayContext(getMockHttpServletRequest(user2)));
+
+		Assert.assertTrue(
+			filterString,
+			filterString.contains(
+				_getExpectedFilterString(depotEntry2.getGroupId())));
+
 		_depotEntryLocalService.deleteDepotEntry(depotEntry1);
 		_depotEntryLocalService.deleteDepotEntry(depotEntry2);
 		_depotEntryLocalService.deleteDepotEntry(depotEntry3);
 
-		_userLocalService.deleteUser(user);
+		_userLocalService.deleteUser(user1);
+		_userLocalService.deleteUser(user2);
 	}
 
 	@Test

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewRelatedAssetsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewRelatedAssetsSectionDisplayContextTest.java
@@ -6,6 +6,7 @@
 package com.liferay.site.cms.site.initializer.internal.display.context.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
@@ -25,7 +26,9 @@ import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
@@ -130,6 +133,17 @@ public class ViewRelatedAssetsSectionDisplayContextTest
 
 	@Test
 	public void testGetCreationMenu() throws Exception {
+		_depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext(
+				group.getGroupId(), TestPropsValues.getUserId()));
+
 		CreationMenu creationMenu = ReflectionTestUtil.invoke(
 			_getViewRelatedAssetsSectionDisplayContext(
 				getMockHttpServletRequest()),

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
@@ -8,6 +8,7 @@ package com.liferay.site.cms.site.initializer.internal.display.context;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.depot.service.DepotEntryServiceUtil;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItemBuilder;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItemList;
@@ -15,11 +16,11 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.info.constants.InfoDisplayWebKeys;
 import com.liferay.object.constants.ObjectDefinitionSettingConstants;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectDefinitionSetting;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalServiceUtil;
-import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
@@ -58,8 +59,10 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -171,30 +174,61 @@ public class SectionDisplayContextHelper {
 		List<DropdownItem> dropdownItems, HttpServletRequest httpServletRequest,
 		String rootObjectEntryFolderExternalReferenceCode) {
 
-		return new CreationMenu() {
-			{
-				if (_hasAddEntryPermission(
-						httpServletRequest,
-						rootObjectEntryFolderExternalReferenceCode)) {
+		CreationMenu creationMenu = new CreationMenu();
 
-					for (DropdownItem dropdownItem : dropdownItems) {
-						JSONArray depotEntriesJSONArray =
-							_getDepotEntriesJSONArray(
-								dropdownItem, httpServletRequest,
-								rootObjectEntryFolderExternalReferenceCode);
+		if (ListUtil.isEmpty(dropdownItems)) {
+			return creationMenu;
+		}
 
-						if (depotEntriesJSONArray == null) {
-							continue;
-						}
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
 
-						dropdownItem.putData(
-							"assetLibraries", depotEntriesJSONArray);
+		List<Long> depotEntryGroupIds = null;
 
-						addPrimaryDropdownItem(dropdownItem);
-					}
-				}
+		ObjectEntryFolder objectEntryFolder = _getObjectEntryFolder(
+			themeDisplay.getCompanyId(),
+			httpServletRequest.getAttribute(InfoDisplayWebKeys.INFO_ITEM),
+			rootObjectEntryFolderExternalReferenceCode);
+
+		if (objectEntryFolder != null) {
+			depotEntryGroupIds = Collections.singletonList(
+				objectEntryFolder.getGroupId());
+		}
+		else {
+			depotEntryGroupIds = DepotEntryServiceUtil.getDepotEntryGroupIds(
+				themeDisplay.getCompanyId(), themeDisplay.getUserId(),
+				DepotConstants.TYPE_SPACE);
+		}
+
+		if (ListUtil.isEmpty(depotEntryGroupIds)) {
+			return creationMenu;
+		}
+
+		depotEntryGroupIds = _filter(
+			depotEntryGroupIds, ActionKeys.ADD_ENTRY,
+			_getRootObjectEntryFolderExternalReferenceCodes(
+				rootObjectEntryFolderExternalReferenceCode),
+			themeDisplay);
+
+		if (ListUtil.isEmpty(depotEntryGroupIds)) {
+			return creationMenu;
+		}
+
+		for (DropdownItem dropdownItem : dropdownItems) {
+			JSONArray depotEntriesJSONArray = _getDepotEntriesJSONArray(
+				depotEntryGroupIds, dropdownItem, themeDisplay.getLocale());
+
+			if (depotEntriesJSONArray == null) {
+				continue;
 			}
-		};
+
+			dropdownItem.putData("assetLibraries", depotEntriesJSONArray);
+
+			creationMenu.addPrimaryDropdownItem(dropdownItem);
+		}
+
+		return creationMenu;
 	}
 
 	public JSONArray getDepotEntriesJSONArray(
@@ -212,15 +246,15 @@ public class SectionDisplayContextHelper {
 
 		if (objectEntryFolder != null) {
 			return _getDepotEntriesJSONArray(
-				List.of(objectEntryFolder.getGroupId()), httpServletRequest);
+				List.of(objectEntryFolder.getGroupId()),
+				themeDisplay.getLocale());
 		}
 
 		return _getDepotEntriesJSONArray(
-			TransformUtil.transform(
-				_depotEntryLocalService.getDepotEntries(
-					themeDisplay.getCompanyId(), DepotConstants.TYPE_SPACE),
-				DepotEntry::getGroupId),
-			httpServletRequest);
+			DepotEntryServiceUtil.getDepotEntryGroupIds(
+				themeDisplay.getCompanyId(), themeDisplay.getUserId(),
+				DepotConstants.TYPE_SPACE),
+			themeDisplay.getLocale());
 	}
 
 	public List<FDSActionDropdownItem> getFDSActionDropdownItems(
@@ -343,6 +377,68 @@ public class SectionDisplayContextHelper {
 				null));
 	}
 
+	private List<Long> _filter(
+		List<Long> depotEntryGroupIds, String actionId,
+		String[] objectEntryFolderExternalReferenceCodes,
+		ThemeDisplay themeDisplay) {
+
+		return ListUtil.filter(
+			depotEntryGroupIds,
+			depotEntryGroupId -> {
+				for (String objectEntryFolderExternalReferenceCode :
+						objectEntryFolderExternalReferenceCodes) {
+
+					ObjectEntryFolder objectEntryFolder =
+						ObjectEntryFolderLocalServiceUtil.
+							fetchObjectEntryFolderByExternalReferenceCode(
+								objectEntryFolderExternalReferenceCode,
+								depotEntryGroupId, themeDisplay.getCompanyId());
+
+					try {
+						if ((objectEntryFolder != null) &&
+							_objectEntryFolderModelResourcePermission.contains(
+								themeDisplay.getPermissionChecker(),
+								objectEntryFolder.getObjectEntryFolderId(),
+								actionId)) {
+
+							return true;
+						}
+					}
+					catch (PortalException portalException) {
+						if (_log.isDebugEnabled()) {
+							_log.debug(portalException);
+						}
+					}
+				}
+
+				return false;
+			});
+	}
+
+	private List<Long> _getAcceptedDepotEntryGroupIds(
+		List<Long> depotEntryGroupIds, long objectDefinitionId) {
+
+		if (_isAcceptAllGroups(objectDefinitionId)) {
+			return depotEntryGroupIds;
+		}
+
+		List<Long> acceptedGroupIds = _getAcceptedGroupIds(objectDefinitionId);
+
+		if (acceptedGroupIds.isEmpty()) {
+			return null;
+		}
+
+		List<Long> validGroupIds = new ArrayList<>();
+
+		for (long groupId : depotEntryGroupIds) {
+			if (acceptedGroupIds.contains(groupId)) {
+				validGroupIds.add(groupId);
+			}
+		}
+
+		return validGroupIds;
+	}
+
 	private List<Long> _getAcceptedGroupIds(long objectDefinitionId) {
 		List<Long> acceptedGroupIds = new ArrayList<>();
 
@@ -367,8 +463,8 @@ public class SectionDisplayContextHelper {
 	}
 
 	private JSONArray _getDepotEntriesJSONArray(
-		DropdownItem dropdownItem, HttpServletRequest httpServletRequest,
-		String rootObjectEntryFolderExternalReferenceCode) {
+		List<Long> depotEntryGroupIds, DropdownItem dropdownItem,
+		Locale locale) {
 
 		Map<String, Object> dropdownItemData =
 			(HashMap<String, Object>)dropdownItem.get("data");
@@ -378,57 +474,25 @@ public class SectionDisplayContextHelper {
 
 		if (objectDefinitionId != 0) {
 			return _getDepotEntriesJSONArray(
-				httpServletRequest, objectDefinitionId,
-				rootObjectEntryFolderExternalReferenceCode);
+				_getAcceptedDepotEntryGroupIds(
+					depotEntryGroupIds, objectDefinitionId),
+				locale);
 		}
 
-		return getDepotEntriesJSONArray(
-			httpServletRequest, rootObjectEntryFolderExternalReferenceCode);
+		return _getDepotEntriesJSONArray(depotEntryGroupIds, locale);
 	}
 
 	private JSONArray _getDepotEntriesJSONArray(
-		HttpServletRequest httpServletRequest, long objectDefinitionId,
-		String rootObjectEntryFolderExternalReferenceCode) {
+		List<Long> groupIds, Locale locale) {
 
-		if (_isAcceptAllGroups(objectDefinitionId)) {
-			return getDepotEntriesJSONArray(
-				httpServletRequest, rootObjectEntryFolderExternalReferenceCode);
-		}
-
-		List<Long> acceptedGroupIds = _getAcceptedGroupIds(objectDefinitionId);
-
-		if (acceptedGroupIds.isEmpty()) {
+		if (ListUtil.isEmpty(groupIds)) {
 			return null;
 		}
-
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
-		ObjectEntryFolder objectEntryFolder = _getObjectEntryFolder(
-			themeDisplay.getCompanyId(),
-			httpServletRequest.getAttribute(InfoDisplayWebKeys.INFO_ITEM),
-			rootObjectEntryFolderExternalReferenceCode);
-
-		if (objectEntryFolder != null) {
-			if (!acceptedGroupIds.contains(objectEntryFolder.getGroupId())) {
-				return null;
-			}
-
-			return _getDepotEntriesJSONArray(
-				List.of(objectEntryFolder.getGroupId()), httpServletRequest);
-		}
-
-		return _getDepotEntriesJSONArray(acceptedGroupIds, httpServletRequest);
-	}
-
-	private JSONArray _getDepotEntriesJSONArray(
-		List<Long> groupIds, HttpServletRequest httpServletRequest) {
 
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
 		for (Long groupId : groupIds) {
-			JSONObject jsonObject = _getJSONObject(groupId, httpServletRequest);
+			JSONObject jsonObject = _getJSONObject(groupId, locale);
 
 			if (jsonObject != null) {
 				jsonArray.put(jsonObject);
@@ -438,25 +502,19 @@ public class SectionDisplayContextHelper {
 		return jsonArray;
 	}
 
-	private JSONObject _getJSONObject(
-		long groupId, HttpServletRequest httpServletRequest) {
-
+	private JSONObject _getJSONObject(long groupId, Locale locale) {
 		Group group = _groupLocalService.fetchGroup(groupId);
 
 		if (group == null) {
 			return null;
 		}
 
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
 		return JSONUtil.put(
 			"externalReferenceCode", group.getExternalReferenceCode()
 		).put(
 			"groupId", group.getGroupId()
 		).put(
-			"name", group.getName(themeDisplay.getLocale())
+			"name", group.getName(locale)
 		);
 	}
 
@@ -576,36 +634,17 @@ public class SectionDisplayContextHelper {
 		);
 	}
 
-	private boolean _hasAddEntryPermission(
-		HttpServletRequest httpServletRequest,
+	private String[] _getRootObjectEntryFolderExternalReferenceCodes(
 		String rootObjectEntryFolderExternalReferenceCode) {
 
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
-		ObjectEntryFolder objectEntryFolder = _getObjectEntryFolder(
-			themeDisplay.getCompanyId(),
-			httpServletRequest.getAttribute(InfoDisplayWebKeys.INFO_ITEM),
-			rootObjectEntryFolderExternalReferenceCode);
-
-		if (objectEntryFolder == null) {
-			return true;
+		if (rootObjectEntryFolderExternalReferenceCode == null) {
+			return new String[] {
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS,
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES
+			};
 		}
 
-		try {
-			return _objectEntryFolderModelResourcePermission.contains(
-				themeDisplay.getPermissionChecker(),
-				objectEntryFolder.getObjectEntryFolderId(),
-				ActionKeys.ADD_ENTRY);
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-		}
-
-		return false;
+		return new String[] {rootObjectEntryFolderExternalReferenceCode};
 	}
 
 	private boolean _isAcceptAllGroups(long objectDefinitionId) {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
@@ -47,6 +47,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -201,10 +202,6 @@ public class SectionDisplayContextHelper {
 				DepotConstants.TYPE_SPACE);
 		}
 
-		if (ListUtil.isEmpty(depotEntryGroupIds)) {
-			return creationMenu;
-		}
-
 		depotEntryGroupIds = _filter(
 			depotEntryGroupIds, ActionKeys.ADD_ENTRY,
 			_getRootObjectEntryFolderExternalReferenceCodes(
@@ -219,7 +216,7 @@ public class SectionDisplayContextHelper {
 			JSONArray depotEntriesJSONArray = _getDepotEntriesJSONArray(
 				depotEntryGroupIds, dropdownItem, themeDisplay.getLocale());
 
-			if (depotEntriesJSONArray == null) {
+			if (depotEntriesJSONArray.length() == 0) {
 				continue;
 			}
 
@@ -425,18 +422,11 @@ public class SectionDisplayContextHelper {
 		List<Long> acceptedGroupIds = _getAcceptedGroupIds(objectDefinitionId);
 
 		if (acceptedGroupIds.isEmpty()) {
-			return null;
+			return Collections.emptyList();
 		}
 
-		List<Long> validGroupIds = new ArrayList<>();
-
-		for (long groupId : depotEntryGroupIds) {
-			if (acceptedGroupIds.contains(groupId)) {
-				validGroupIds.add(groupId);
-			}
-		}
-
-		return validGroupIds;
+		return new ArrayList<>(
+			SetUtil.intersect(acceptedGroupIds, depotEntryGroupIds));
 	}
 
 	private List<Long> _getAcceptedGroupIds(long objectDefinitionId) {
@@ -484,10 +474,6 @@ public class SectionDisplayContextHelper {
 
 	private JSONArray _getDepotEntriesJSONArray(
 		List<Long> groupIds, Locale locale) {
-
-		if (ListUtil.isEmpty(groupIds)) {
-			return null;
-		}
 
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewRecycleBinSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewRecycleBinSectionDisplayContext.java
@@ -7,28 +7,23 @@ package com.liferay.site.cms.site.initializer.internal.display.context;
 
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.depot.service.DepotEntryServiceUtil;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.headless.asset.library.resource.v1_0.AssetLibraryResource;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
-import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringUtil;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -191,23 +186,21 @@ public class ViewRecycleBinSectionDisplayContext
 			"cmsRoot eq true and (cmsSection eq 'contents' or cmsSection eq " +
 				"'files')";
 
-		List<Long> groupIds = null;
+		List<Long> groupIds = ListUtil.filter(
+			DepotEntryServiceUtil.getDepotEntryGroupIds(
+				themeDisplay.getCompanyId(), themeDisplay.getUserId(),
+				DepotConstants.TYPE_SPACE),
+			groupId -> {
+				Group group = groupLocalService.fetchGroup(groupId);
 
-		try {
-			groupIds = _getDepotGroupIds(_themeDisplay.getCompanyId());
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(
-					"Unable to get depot group IDs for group " + _groupId,
-					portalException);
-			}
+				if ((group != null) && _trashHelper.isTrashEnabled(group)) {
+					return true;
+				}
 
-			return filterString + " and status eq " +
-				WorkflowConstants.STATUS_ANY;
-		}
+				return false;
+			});
 
-		if (groupIds.isEmpty()) {
+		if (ListUtil.isEmpty(groupIds)) {
 			return filterString + " and status eq " +
 				WorkflowConstants.STATUS_ANY;
 		}
@@ -217,43 +210,6 @@ public class ViewRecycleBinSectionDisplayContext
 			StringUtil.merge(groupIds, ","), ")) and status eq ",
 			WorkflowConstants.STATUS_IN_TRASH);
 	}
-
-	private List<Long> _getDepotGroupIds(long companyId)
-		throws PortalException {
-
-		List<Long> depotEntryGroupIds = null;
-
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
-		if (RoleLocalServiceUtil.hasUserRole(
-				themeDisplay.getUserId(), themeDisplay.getCompanyId(),
-				RoleConstants.CMS_ADMINISTRATOR, true)) {
-
-			depotEntryGroupIds = depotEntryLocalService.getDepotEntryGroupIds(
-				companyId, DepotConstants.TYPE_SPACE);
-		}
-		else {
-			depotEntryGroupIds = depotEntryLocalService.getDepotEntryGroupIds(
-				companyId, themeDisplay.getUserId(), DepotConstants.TYPE_SPACE);
-		}
-
-		return TransformUtil.transform(
-			depotEntryGroupIds,
-			depotEntryGroupId -> {
-				Group group = groupLocalService.fetchGroup(depotEntryGroupId);
-
-				if ((group == null) || !_trashHelper.isTrashEnabled(group)) {
-					return null;
-				}
-
-				return group.getGroupId();
-			});
-	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		ViewRecycleBinSectionDisplayContext.class);
 
 	private final AssetLibraryResource.Factory _assetLibraryResourceFactory;
 	private final long _groupId;


### PR DESCRIPTION
Sorted comments in test as [Brian suggested](https://github.com/brianchandotcom/liferay-portal/pull/171162#issuecomment-4004392459):

1. // Create menu with custom object definitions
2. // Create menu within an object entry folder
3. // Create menu in root folder

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-79171

The new button should appear only when a user has ADD ENTRY permission or is and CMS Administrator.

# How am I fixing it?

Taking into account permissions and allowed Spaces in `CreationMenu`.

# How can you verify that it works?

Run integration tests for all classes extending `BaseSectionDisplayContextTestCase`

* ViewAllSectionDisplayContextTest
* ViewFilesSectionDisplayContextTest
* ViewContentsSectionDisplayContextTest
* ViewRecycleBinSectionDisplayContextTest
* ViewRelatedAssetsSectionDisplayContextTest
* ViewSharedWithMeSectionDisplayContextTest