### PR TITLE
LPD-78604 In the context of CMS, if the site group and the object entry group are different, return groupFriendlyURL/urlTitle instead

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -232,7 +232,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 		InfoItemFriendlyURLProvider infoItemFriendlyURLProvider =
 			new ObjectEntryInfoItemFriendlyURLProvider(
-				_friendlyURLEntryLocalService, objectDefinition, _portal);
+				_friendlyURLEntryLocalService, _groupLocalService,
+				objectDefinition, _portal);
 
 		PortletResourcePermission portletResourcePermission =
 			_getPortletResourcePermission(objectDefinition.getResourceName());

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFriendlyURLProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFriendlyURLProvider.java
@@ -6,15 +6,24 @@
 package com.liferay.object.web.internal.info.item.provider;
 
 import com.liferay.friendly.url.info.item.provider.InfoItemFriendlyURLProvider;
+import com.liferay.friendly.url.model.FriendlyURLEntry;
 import com.liferay.friendly.url.model.FriendlyURLEntryLocalization;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
 import com.liferay.friendly.url.util.comparator.FriendlyURLEntryLocalizationComparator;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
@@ -30,9 +39,11 @@ public class ObjectEntryInfoItemFriendlyURLProvider
 
 	public ObjectEntryInfoItemFriendlyURLProvider(
 		FriendlyURLEntryLocalService friendlyURLEntryLocalService,
-		ObjectDefinition objectDefinition, Portal portal) {
+		GroupLocalService groupLocalService, ObjectDefinition objectDefinition,
+		Portal portal) {
 
 		_friendlyURLEntryLocalService = friendlyURLEntryLocalService;
+		_groupLocalService = groupLocalService;
 		_objectDefinition = objectDefinition;
 		_portal = portal;
 	}
@@ -40,7 +51,24 @@ public class ObjectEntryInfoItemFriendlyURLProvider
 	@Override
 	public String getFriendlyURL(ObjectEntry objectEntry, String languageId) {
 		if (_objectDefinition.isCMS()) {
-			return String.valueOf(objectEntry.getObjectEntryId());
+			FriendlyURLEntry mainFriendlyURLEntry =
+				_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+					_portal.getClassNameId(objectEntry.getModelClassName()),
+					objectEntry.getObjectEntryId());
+
+			if (mainFriendlyURLEntry == null) {
+				return String.valueOf(objectEntry.getObjectEntryId());
+			}
+
+			long groupId = _getGroupId();
+
+			if ((groupId != GroupConstants.DEFAULT_LIVE_GROUP_ID) &&
+				(groupId != mainFriendlyURLEntry.getGroupId())) {
+
+				return _getGroupFriendlyURL(
+					objectEntry.getObjectEntryId(), mainFriendlyURLEntry,
+					languageId);
+			}
 		}
 
 		String urlTitle = objectEntry.getURLTitle(
@@ -79,10 +107,51 @@ public class ObjectEntryInfoItemFriendlyURLProvider
 		}
 	}
 
+	private String _getGroupFriendlyURL(
+		long objectEntryId, FriendlyURLEntry friendlyURLEntry,
+		String languageId) {
+
+		Group group = _groupLocalService.fetchGroup(
+			friendlyURLEntry.getGroupId());
+
+		if (group == null) {
+			return String.valueOf(objectEntryId);
+		}
+
+		String groupFriendlyURL = group.getFriendlyURL();
+
+		return groupFriendlyURL.replaceFirst(StringPool.SLASH, "") +
+			StringPool.SLASH + friendlyURLEntry.getUrlTitle(languageId);
+	}
+
+	private long _getGroupId() {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext == null) {
+			return GroupThreadLocal.getGroupId();
+		}
+
+		if (serviceContext.getThemeDisplay() == null) {
+			return serviceContext.getScopeGroupId();
+		}
+
+		ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
+
+		if (themeDisplay.getSiteGroupId() !=
+				GroupConstants.DEFAULT_LIVE_GROUP_ID) {
+
+			return themeDisplay.getSiteGroupId();
+		}
+
+		return themeDisplay.getScopeGroupId();
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		ObjectEntryInfoItemFriendlyURLProvider.class);
 
 	private final FriendlyURLEntryLocalService _friendlyURLEntryLocalService;
+	private final GroupLocalService _groupLocalService;
 	private final ObjectDefinition _objectDefinition;
 	private final Portal _portal;
 

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/layout/display/page/ObjectEntryLayoutDisplayPageProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/layout/display/page/ObjectEntryLayoutDisplayPageProvider.java
@@ -28,6 +28,7 @@ import com.liferay.object.service.ObjectEntryVersionLocalServiceUtil;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.web.internal.util.ObjectEntryUtil;
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -35,6 +36,7 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -92,6 +94,21 @@ public class ObjectEntryLayoutDisplayPageProvider
 	@Override
 	public LayoutDisplayPageObjectProvider<ObjectEntry>
 		getLayoutDisplayPageObjectProvider(long groupId, String urlTitle) {
+
+		if (urlTitle.contains(StringPool.SLASH)) {
+			String[] urlNames = urlTitle.split(StringPool.SLASH);
+
+			if (urlNames.length > 1) {
+				Group group = _groupLocalService.fetchFriendlyURLGroup(
+					CompanyThreadLocal.getCompanyId(),
+					StringPool.SLASH + urlNames[0]);
+
+				if (group != null) {
+					return getLayoutDisplayPageObjectProvider(
+						group.getGroupId(), urlNames[1]);
+				}
+			}
+		}
 
 		ObjectEntry objectEntry = _objectEntryLocalService.fetchObjectEntry(
 			groupId, _objectDefinition, urlTitle);

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/info/item/provider/test/ObjectEntryInfoItemFriendlyURLProviderTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/info/item/provider/test/ObjectEntryInfoItemFriendlyURLProviderTest.java
@@ -25,9 +25,11 @@ import com.liferay.object.model.ObjectFolder;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFolderLocalService;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -137,11 +139,27 @@ public class ObjectEntryInfoItemFriendlyURLProviderTest {
 				InfoItemFriendlyURLProvider.class,
 				_objectDefinition.getClassName());
 
-		Assert.assertEquals(
-			String.valueOf(objectEntry.getObjectEntryId()),
-			infoItemFriendlyURLProvider.getFriendlyURL(
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext(
+				TestPropsValues.getGroupId(), TestPropsValues.getUserId()));
+
+		try {
+			String friendlyURL = infoItemFriendlyURLProvider.getFriendlyURL(
 				objectEntry,
-				LanguageUtil.getLanguageId(LocaleUtil.getDefault())));
+				LanguageUtil.getLanguageId(LocaleUtil.getDefault()));
+
+			Group depotEntryGroup = _depotEntry.getGroup();
+
+			Assert.assertEquals(
+				StringBundler.concat(
+					depotEntryGroup.getFriendlyURL(), StringPool.SLASH,
+					objectEntry.getURLTitle(
+						_objectDefinition.getDefaultLocale())),
+				StringPool.SLASH + friendlyURL);
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
 	}
 
 	@DeleteAfterTestRun


### PR DESCRIPTION
CI [errors](https://github.com/liferay-bpm/liferay-portal/pull/5751#issuecomment-4005921906) are not related.