### PR TITLE
LPD-80354 SQLIntegrityConstraintViolationException: Duplicate entry when upgrading p2s7 MySQL database to current master (2nd try)

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/ClassNameUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/ClassNameUpgradeProcessTest.java
@@ -221,6 +221,88 @@ public class ClassNameUpgradeProcessTest {
 				oldStructureId, oldStructureVersionId));
 	}
 
+	@Test
+	public void testUpdateDDMStructureRelatedTables3() throws Exception {
+		long newClassNameId = _getClassNameId(_NEW_CLASS_NAME);
+
+		long newStructureId = _addDDMStructure(newClassNameId);
+
+		_addDLFileEntryMetadata(newStructureId);
+		_addDLFileEntryMetadata(newStructureId);
+
+		long fileVersionId = RandomTestUtil.randomLong();
+
+		_addDLFileEntryMetadata(fileVersionId, newStructureId);
+
+		long newStructureVersionId = _addDDMStructureRelatedTables(
+			newStructureId);
+
+		long oldClassNameId = _addClassName(_OLD_CLASS_NAME);
+
+		long oldStructureId = _addDDMStructure(oldClassNameId);
+
+		_addDLFileEntryMetadata(oldStructureId);
+		_addDLFileEntryMetadata(fileVersionId, oldStructureId);
+
+		long oldStructureVersionId = _addDDMStructureRelatedTables(
+			oldStructureId);
+
+		runUpgrade();
+
+		Assert.assertEquals(
+			newClassNameId, _getDDMStructureClassNameId(newStructureId));
+		Assert.assertEquals(0, _getDDMStructureClassNameId(oldStructureId));
+		Assert.assertEquals(
+			13,
+			_getDDMStructureRelatedTablesCount(
+				newStructureId, newStructureVersionId));
+		Assert.assertEquals(
+			0,
+			_getDDMStructureRelatedTablesCount(
+				oldStructureId, oldStructureVersionId));
+	}
+
+	@Test
+	public void testUpdateDDMStructureRelatedTables4() throws Exception {
+		long newClassNameId = _getClassNameId(_NEW_CLASS_NAME);
+
+		long newStructureId = _addDDMStructure(newClassNameId);
+
+		_addDLFileEntryMetadata(newStructureId);
+
+		long fileVersionId = RandomTestUtil.randomLong();
+
+		_addDLFileEntryMetadata(fileVersionId, newStructureId);
+
+		long newStructureVersionId = _addDDMStructureRelatedTables(
+			newStructureId);
+
+		long oldClassNameId = _addClassName(_OLD_CLASS_NAME);
+
+		long oldStructureId = _addDDMStructure(oldClassNameId);
+
+		_addDLFileEntryMetadata(oldStructureId);
+		_addDLFileEntryMetadata(oldStructureId);
+		_addDLFileEntryMetadata(fileVersionId, oldStructureId);
+
+		long oldStructureVersionId = _addDDMStructureRelatedTables(
+			oldStructureId);
+
+		runUpgrade();
+
+		Assert.assertEquals(0, _getDDMStructureClassNameId(newStructureId));
+		Assert.assertEquals(
+			newClassNameId, _getDDMStructureClassNameId(oldStructureId));
+		Assert.assertEquals(
+			0,
+			_getDDMStructureRelatedTablesCount(
+				newStructureId, newStructureVersionId));
+		Assert.assertEquals(
+			13,
+			_getDDMStructureRelatedTablesCount(
+				oldStructureId, oldStructureVersionId));
+	}
+
 	protected void runUpgrade() throws Exception {
 		UpgradeProcess upgradeProcess = new ClassNameUpgradeProcess();
 
@@ -384,6 +466,13 @@ public class ClassNameUpgradeProcessTest {
 	}
 
 	private long _addDLFileEntryMetadata(long structureId) throws Exception {
+		return _addDLFileEntryMetadata(
+			RandomTestUtil.randomLong(), structureId);
+	}
+
+	private long _addDLFileEntryMetadata(long fileVersionId, long structureId)
+		throws Exception {
+
 		long fileEntryMetadataId = RandomTestUtil.nextLong();
 
 		try (PreparedStatement preparedStatement = _connection.prepareStatement(
@@ -398,7 +487,7 @@ public class ClassNameUpgradeProcessTest {
 			preparedStatement.setLong(3, fileEntryMetadataId);
 			preparedStatement.setLong(4, _companyId);
 			preparedStatement.setLong(5, structureId);
-			preparedStatement.setLong(6, RandomTestUtil.randomLong());
+			preparedStatement.setLong(6, fileVersionId);
 			preparedStatement.setString(7, RandomTestUtil.randomString());
 
 			preparedStatement.executeUpdate();

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/ClassNameUpgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/ClassNameUpgradeProcess.java
@@ -134,6 +134,25 @@ public class ClassNameUpgradeProcess extends UpgradeProcess {
 		}
 	}
 
+	private void _deleteDLFileEntryMetadata(
+			long newStructureId, long oldStructureId)
+		throws Exception {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"delete from DLFileEntryMetadata d1 where DDMStructureId ",
+					"= ? and exists (select 1 from DLFileEntryMetadata d2 ",
+					"where d1.ctCollectionId = d2.ctCollectionId and ",
+					"d2.DDMStructureId = ? and d1.fileVersionId = ",
+					"d2.fileVersionId)"))) {
+
+			preparedStatement.setLong(1, oldStructureId);
+			preparedStatement.setLong(2, newStructureId);
+
+			preparedStatement.execute();
+		}
+	}
+
 	private long _getClassNameId(String value) throws Exception {
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				"select classNameId from ClassName_ where value = ?")) {
@@ -256,6 +275,8 @@ public class ClassNameUpgradeProcess extends UpgradeProcess {
 	private void _updateDDMStructureRelatedTables(
 			long newStructureId, long oldStructureId)
 		throws Exception {
+
+		_deleteDLFileEntryMetadata(newStructureId, oldStructureId);
 
 		_update(
 			"DDMStorageLink", "structureId", newStructureId, oldStructureId);

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/ClassNameUpgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/ClassNameUpgradeProcess.java
@@ -7,6 +7,7 @@ package com.liferay.portal.upgrade.v7_4_x;
 
 import com.liferay.document.library.kernel.processor.RawMetadataProcessor;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 
@@ -138,18 +139,33 @@ public class ClassNameUpgradeProcess extends UpgradeProcess {
 			long newStructureId, long oldStructureId)
 		throws Exception {
 
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
+		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
 				StringBundler.concat(
-					"delete from DLFileEntryMetadata d1 where DDMStructureId ",
-					"= ? and exists (select 1 from DLFileEntryMetadata d2 ",
-					"where d1.ctCollectionId = d2.ctCollectionId and ",
-					"d2.DDMStructureId = ? and d1.fileVersionId = ",
-					"d2.fileVersionId)"))) {
+					"select d1.fileEntryMetadataId from DLFileEntryMetadata ",
+					"d1 where d1.DDMStructureId = ? and exists (select 1 from ",
+					"DLFileEntryMetadata d2 where d1.ctCollectionId = ",
+					"d2.ctCollectionId and d2.DDMStructureId = ? and ",
+					"d1.fileVersionId = d2.fileVersionId)"))) {
 
-			preparedStatement.setLong(1, oldStructureId);
-			preparedStatement.setLong(2, newStructureId);
+			preparedStatement1.setLong(1, oldStructureId);
+			preparedStatement1.setLong(2, newStructureId);
 
-			preparedStatement.execute();
+			try (PreparedStatement preparedStatement2 =
+					AutoBatchPreparedStatementUtil.autoBatch(
+						connection,
+						"delete from DLFileEntryMetadata where " +
+							"fileEntryMetadataId = ?");
+				ResultSet resultSet = preparedStatement1.executeQuery()) {
+
+				while (resultSet.next()) {
+					preparedStatement2.setLong(
+						1, resultSet.getLong("fileEntryMetadataId"));
+
+					preparedStatement2.addBatch();
+				}
+
+				preparedStatement2.executeBatch();
+			}
 		}
 	}
 


### PR DESCRIPTION
Sending from https://github.com/liferay-content-management/liferay-portal/pull/7839 solving rebase errors

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-80354

There is a case where the upgrade process raises a Constraint Violation exception.
This case happens when we have in table `DLFileEntryMetadata` data computed for the same `fileVersionId` for the two different class names, the old one (to remove) and the new one.

I don't know how this can happen because I tried to replicate this scenario via our UI but I couldn't. The scenario I've seen is having the metadata of some files computed with one class name and other files computed with the other class name.

I had to manually change the database to replicate the error scenario. Who knows how the specific customer could have this data. Hopefully there are no more corner cases. 

Although a test has been created to reproduce the same scenario, I couldn't test it with the specific customer database yet, so I set the ON HOLD status until then.

# How am I fixing it?

Deleting duplicated records in table `DLFileEntryMetadata`.

# How can you verify that it works?

`cd modules/apps/portal/portal-upgrade-test`
`gw tI --tests "ClassNameUpgradeProcessTest"`