### PR TITLE
LPD-82358 Solve flakiness when asserting facets in DefaultObjectEntryManagerImpl.testGetObjectEntriesWithAggregationFacets

### DIFF
--- a/modules/apps/object/object-rest-test-util/src/main/java/com/liferay/object/rest/test/util/BaseObjectEntryManagerImplTestCase.java
+++ b/modules/apps/object/object-rest-test-util/src/main/java/com/liferay/object/rest/test/util/BaseObjectEntryManagerImplTestCase.java
@@ -144,14 +144,15 @@ public abstract class BaseObjectEntryManagerImplTestCase {
 			List<Facet.FacetValue> actualFacetFacetValues = new ArrayList<>(
 				actualFacet.getFacetValues());
 
-			actualFacetFacetValues.sort(
-				Comparator.comparing(Facet.FacetValue::getTerm));
+			Comparator<Facet.FacetValue> comparator = Comparator.comparing(
+				Facet.FacetValue::getTerm);
+
+			actualFacetFacetValues.sort(comparator);
 
 			List<Facet.FacetValue> expectedFacetFacetValues = new ArrayList<>(
 				expectedFacet.getFacetValues());
 
-			expectedFacetFacetValues.sort(
-				Comparator.comparing(Facet.FacetValue::getTerm));
+			expectedFacetFacetValues.sort(comparator);
 
 			Assert.assertEquals(
 				actualFacetFacetValues.toString(),

--- a/modules/apps/object/object-rest-test-util/src/main/java/com/liferay/object/rest/test/util/BaseObjectEntryManagerImplTestCase.java
+++ b/modules/apps/object/object-rest-test-util/src/main/java/com/liferay/object/rest/test/util/BaseObjectEntryManagerImplTestCase.java
@@ -31,7 +31,9 @@ import java.text.DateFormat;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -139,11 +141,17 @@ public abstract class BaseObjectEntryManagerImplTestCase {
 				expectedFacet.getFacetCriteria(),
 				actualFacet.getFacetCriteria());
 
-			List<Facet.FacetValue> actualFacetFacetValues =
-				actualFacet.getFacetValues();
+			List<Facet.FacetValue> actualFacetFacetValues = new ArrayList<>(
+				actualFacet.getFacetValues());
 
-			List<Facet.FacetValue> expectedFacetFacetValues =
-				expectedFacet.getFacetValues();
+			actualFacetFacetValues.sort(
+				Comparator.comparing(Facet.FacetValue::getTerm));
+
+			List<Facet.FacetValue> expectedFacetFacetValues = new ArrayList<>(
+				expectedFacet.getFacetValues());
+
+			expectedFacetFacetValues.sort(
+				Comparator.comparing(Facet.FacetValue::getTerm));
 
 			Assert.assertEquals(
 				actualFacetFacetValues.toString(),

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -6167,11 +6167,11 @@ public class DefaultObjectEntryManagerImplTest
 			_objectDefinition1);
 
 		assertFacets(
+			page.getFacets(),
 			List.of(
 				new Facet(
 					"textObjectFieldName",
-					List.of(new Facet.FacetValue(2, textObjectFieldValue)))),
-			page.getFacets());
+					List.of(new Facet.FacetValue(2, textObjectFieldValue)))));
 
 		PermissionThreadLocal.setPermissionChecker(
 			PermissionCheckerFactoryUtil.create(adminUser));
@@ -6203,6 +6203,7 @@ public class DefaultObjectEntryManagerImplTest
 			_objectDefinition2);
 
 		assertFacets(
+			page.getFacets(),
 			List.of(
 				new Facet(
 					_objectRelationshipFieldName,
@@ -6210,8 +6211,7 @@ public class DefaultObjectEntryManagerImplTest
 						new Facet.FacetValue(
 							1, String.valueOf(parentObjectEntry1.getId())),
 						new Facet.FacetValue(
-							2, String.valueOf(parentObjectEntry2.getId()))))),
-			page.getFacets());
+							2, String.valueOf(parentObjectEntry2.getId()))))));
 
 		_defaultObjectEntryManager.updateObjectEntry(
 			_simpleDTOConverterContext, _objectDefinition2,
@@ -6230,6 +6230,7 @@ public class DefaultObjectEntryManagerImplTest
 			_objectDefinition2);
 
 		assertFacets(
+			page.getFacets(),
 			List.of(
 				new Facet(
 					_objectRelationshipFieldName,
@@ -6237,8 +6238,7 @@ public class DefaultObjectEntryManagerImplTest
 						new Facet.FacetValue(
 							2, String.valueOf(parentObjectEntry1.getId())),
 						new Facet.FacetValue(
-							1, String.valueOf(parentObjectEntry2.getId()))))),
-			page.getFacets());
+							1, String.valueOf(parentObjectEntry2.getId()))))));
 
 		_defaultObjectEntryManager.deleteObjectEntry(
 			_objectDefinition2, childObjectEntry.getId());
@@ -6249,6 +6249,7 @@ public class DefaultObjectEntryManagerImplTest
 			_objectDefinition2);
 
 		assertFacets(
+			page.getFacets(),
 			List.of(
 				new Facet(
 					_objectRelationshipFieldName,
@@ -6256,8 +6257,7 @@ public class DefaultObjectEntryManagerImplTest
 						new Facet.FacetValue(
 							1, String.valueOf(parentObjectEntry1.getId())),
 						new Facet.FacetValue(
-							1, String.valueOf(parentObjectEntry2.getId()))))),
-			page.getFacets());
+							1, String.valueOf(parentObjectEntry2.getId()))))));
 	}
 
 	@Test


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-82358

Forwarding manually from: https://github.com/liferay-headless/liferay-portal/pull/3553