### PR TITLE
LPD-80584 Fix regression caused by LPD-71276 b174ee6a . FragmentEntry…

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/FragmentEntryLinkUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/FragmentEntryLinkUtil.java
@@ -61,6 +61,9 @@ public class FragmentEntryLinkUtil {
 
 			String editableValues = fragmentEntryLink.getEditableValues();
 
+			long mvccVersion = fragmentEntryLink.getMvccVersion();
+
+			fragmentEntryLink.setMvccVersion(-1);
 			fragmentEntryLink.setEditableValues(null);
 
 			try {
@@ -82,6 +85,7 @@ public class FragmentEntryLinkUtil {
 				return fragmentEntryLink.getHtml();
 			}
 			finally {
+				fragmentEntryLink.setMvccVersion(mvccVersion);
 				fragmentEntryLink.setEditableValues(editableValues);
 			}
 		}


### PR DESCRIPTION
…Link is a managed object from session, it also has @CacheField attached to entity cache. Unless you are really altering its state for updating, you are not supposed to mess with its tracked internal state. Doing this will lead to corrupt cache. This really is a very bad design, to temporarily swap the EditableValues just for renderring. Without massive refactor, we can force it to set a -1 mvcc version to bypass all its cache state tracking. This is just a workaround to remove release blocker. The original author needs to come back to redesign for this function.

@lfbesada @georgel-pop-lr @achaparro @vicnate5 