### PR TITLE
LPD-79613: Fix for HeadlessBatchEngineExportOrganization#CanExportAllOrganizations

### DIFF
--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testFunctional/tests/HeadlessBatchEngineExportOrganization.testcase
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testFunctional/tests/HeadlessBatchEngineExportOrganization.testcase
@@ -72,7 +72,14 @@ definition {
 		}
 
 		task ("Then the downloaded file includes the testOrganization and its sub_testOrganization") {
+			var downloadDir = PropsUtil.get("output.dir.name");
 			var fileName = selenium.getAttribute("//a[contains(.,'Download file')]@download");
+
+			var crdownloadFileExists = FileUtil.exists("${downloadDir}/${fileName}.crdownload");
+
+			if (${crdownloadFileExists} == "true") {
+				FileUtil.move("${downloadDir}/${fileName}.crdownload", "${downloadDir}/${fileName}");
+			}
 
 			AntCommands.runCommand("build-test.xml", "unzip-temp-file -DfileName=${fileName}");
 


### PR DESCRIPTION
- https://liferay.atlassian.net/browse/LPD-79613

SF and the fix tested [here](https://github.com/liferay-headless/liferay-portal/pull/3561). Sending directly as running other suites is not necessary.