### PR TITLE
LPD-82487  Allow to rename marketplace fragments, don't allow to export empty fragment set

### DIFF
--- a/modules/apps/fragment/fragment-api/bnd.bnd
+++ b/modules/apps/fragment/fragment-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Fragment API
 Bundle-SymbolicName: com.liferay.fragment.api
-Bundle-Version: 59.0.1
+Bundle-Version: 59.1.0
 Export-Package:\
 	com.liferay.fragment.cache,\
 	com.liferay.fragment.configuration,\

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/model/FragmentCollection.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/model/FragmentCollection.java
@@ -69,6 +69,8 @@ public interface FragmentCollection
 				getResourcesMap()
 			throws com.liferay.portal.kernel.exception.PortalException;
 
+	public boolean hasExportableItems();
+
 	public boolean hasResources()
 		throws com.liferay.portal.kernel.exception.PortalException;
 

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/model/FragmentCollectionWrapper.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/model/FragmentCollectionWrapper.java
@@ -381,6 +381,11 @@ public class FragmentCollectionWrapper
 	}
 
 	@Override
+	public boolean hasExportableItems() {
+		return model.hasExportableItems();
+	}
+
+	@Override
 	public boolean hasResources()
 		throws com.liferay.portal.kernel.exception.PortalException {
 

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCompositionLocalService.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCompositionLocalService.java
@@ -380,6 +380,9 @@ public interface FragmentCompositionLocalService
 	public String getUniqueFragmentCompositionName(
 		long groupId, long fragmentCollectionId, String name);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public boolean hasExportableItems(long fragmentCollectionId);
+
 	public FragmentComposition moveFragmentComposition(
 			long fragmentCompositionId, long fragmentCollectionId)
 		throws PortalException;

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCompositionLocalServiceUtil.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCompositionLocalServiceUtil.java
@@ -460,6 +460,10 @@ public class FragmentCompositionLocalServiceUtil {
 			groupId, fragmentCollectionId, name);
 	}
 
+	public static boolean hasExportableItems(long fragmentCollectionId) {
+		return getService().hasExportableItems(fragmentCollectionId);
+	}
+
 	public static FragmentComposition moveFragmentComposition(
 			long fragmentCompositionId, long fragmentCollectionId)
 		throws PortalException {

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCompositionLocalServiceWrapper.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCompositionLocalServiceWrapper.java
@@ -527,6 +527,12 @@ public class FragmentCompositionLocalServiceWrapper
 	}
 
 	@Override
+	public boolean hasExportableItems(long fragmentCollectionId) {
+		return _fragmentCompositionLocalService.hasExportableItems(
+			fragmentCollectionId);
+	}
+
+	@Override
 	public FragmentComposition moveFragmentComposition(
 			long fragmentCompositionId, long fragmentCollectionId)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalService.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalService.java
@@ -432,6 +432,9 @@ public interface FragmentEntryLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<FragmentEntryVersion> getVersions(FragmentEntry fragmentEntry);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public boolean hasExportableItems(long fragmentCollectionId);
+
 	public FragmentEntry moveFragmentEntry(
 			long fragmentEntryId, long fragmentCollectionId)
 		throws PortalException;

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalServiceUtil.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalServiceUtil.java
@@ -533,6 +533,10 @@ public class FragmentEntryLocalServiceUtil {
 		return getService().getVersions(fragmentEntry);
 	}
 
+	public static boolean hasExportableItems(long fragmentCollectionId) {
+		return getService().hasExportableItems(fragmentCollectionId);
+	}
+
 	public static FragmentEntry moveFragmentEntry(
 			long fragmentEntryId, long fragmentCollectionId)
 		throws PortalException {

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalServiceWrapper.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalServiceWrapper.java
@@ -621,6 +621,12 @@ public class FragmentEntryLocalServiceWrapper
 	}
 
 	@Override
+	public boolean hasExportableItems(long fragmentCollectionId) {
+		return _fragmentEntryLocalService.hasExportableItems(
+			fragmentCollectionId);
+	}
+
+	@Override
 	public FragmentEntry moveFragmentEntry(
 			long fragmentEntryId, long fragmentCollectionId)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/model/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/model/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.1.0

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/service/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/service/packageinfo
@@ -1,1 +1,1 @@
-version 16.0.0
+version 16.1.0

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionImpl.java
@@ -131,6 +131,19 @@ public class FragmentCollectionImpl extends FragmentCollectionBaseImpl {
 	}
 
 	@Override
+	public boolean hasExportableItems() {
+		if (FragmentCompositionLocalServiceUtil.hasExportableItems(
+				getFragmentCollectionId()) ||
+			FragmentEntryLocalServiceUtil.hasExportableItems(
+				getFragmentCollectionId())) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
 	public boolean hasResources() throws PortalException {
 		Repository repository = _getRepository(true);
 

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCompositionLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCompositionLocalServiceImpl.java
@@ -9,7 +9,9 @@ import com.liferay.fragment.exception.DuplicateFragmentCompositionKeyException;
 import com.liferay.fragment.exception.FragmentCompositionDescriptionException;
 import com.liferay.fragment.exception.FragmentCompositionNameException;
 import com.liferay.fragment.model.FragmentComposition;
+import com.liferay.fragment.model.FragmentCompositionTable;
 import com.liferay.fragment.service.base.FragmentCompositionLocalServiceBaseImpl;
+import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
@@ -278,6 +280,27 @@ public class FragmentCompositionLocalServiceImpl
 				return newName;
 			}
 		}
+	}
+
+	@Override
+	public boolean hasExportableItems(long fragmentCollectionId) {
+		int count = dslQueryCount(
+			DSLQueryFactoryUtil.count(
+			).from(
+				FragmentCompositionTable.INSTANCE
+			).where(
+				FragmentCompositionTable.INSTANCE.fragmentCollectionId.eq(
+					fragmentCollectionId
+				).and(
+					FragmentCompositionTable.INSTANCE.marketplace.eq(false)
+				)
+			));
+
+		if (count > 0) {
+			return true;
+		}
+
+		return false;
 	}
 
 	@Override

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
@@ -8,6 +8,7 @@ package com.liferay.fragment.service.impl;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.fragment.configuration.FragmentServiceConfiguration;
+import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.constants.FragmentPortletKeys;
 import com.liferay.fragment.exception.DuplicateFragmentEntryKeyException;
 import com.liferay.fragment.exception.FragmentEntryNameException;
@@ -16,11 +17,13 @@ import com.liferay.fragment.exception.RequiredFragmentEntryException;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.fragment.model.FragmentEntryTable;
 import com.liferay.fragment.processor.FragmentEntryProcessorRegistry;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.fragment.service.base.FragmentEntryLocalServiceBaseImpl;
 import com.liferay.fragment.service.persistence.FragmentCollectionPersistence;
 import com.liferay.fragment.validator.FragmentEntryValidator;
+import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
@@ -571,6 +574,32 @@ public class FragmentEntryLocalServiceImpl
 				return newName;
 			}
 		}
+	}
+
+	@Override
+	public boolean hasExportableItems(long fragmentCollectionId) {
+		int count = dslQueryCount(
+			DSLQueryFactoryUtil.count(
+			).from(
+				FragmentEntryTable.INSTANCE
+			).where(
+				FragmentEntryTable.INSTANCE.fragmentCollectionId.eq(
+					fragmentCollectionId
+				).and(
+					FragmentEntryTable.INSTANCE.marketplace.eq(false)
+				).and(
+					FragmentEntryTable.INSTANCE.type.neq(
+						FragmentConstants.TYPE_REACT)
+				).and(
+					FragmentEntryTable.INSTANCE.head.eq(true)
+				)
+			));
+
+		if (count > 0) {
+			return true;
+		}
+
+		return false;
 	}
 
 	@Override

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/model/impl/test/FragmentCollectionImplTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/model/impl/test/FragmentCollectionImplTest.java
@@ -8,12 +8,15 @@ package com.liferay.fragment.model.impl.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLAppService;
+import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.constants.FragmentExportImportConstants;
 import com.liferay.fragment.constants.FragmentPortletKeys;
 import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.model.FragmentComposition;
 import com.liferay.fragment.model.FragmentEntry;
-import com.liferay.fragment.service.FragmentCollectionLocalService;
+import com.liferay.fragment.service.FragmentCompositionLocalService;
 import com.liferay.fragment.service.FragmentEntryLocalService;
+import com.liferay.fragment.test.util.FragmentCompositionTestUtil;
 import com.liferay.fragment.test.util.FragmentEntryTestUtil;
 import com.liferay.fragment.test.util.FragmentTestUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -103,6 +106,53 @@ public class FragmentCollectionImplTest {
 	}
 
 	@Test
+	@TestInfo("LPD-82487")
+	public void testHasExportableItems() throws Exception {
+		Assert.assertFalse(_fragmentCollection.hasExportableItems());
+
+		FragmentComposition marketplaceFragmentComposition =
+			FragmentCompositionTestUtil.addFragmentComposition(
+				_fragmentCollection.getFragmentCollectionId(),
+				RandomTestUtil.randomString());
+
+		marketplaceFragmentComposition.setMarketplace(true);
+
+		_fragmentCompositionLocalService.updateFragmentComposition(
+			marketplaceFragmentComposition);
+
+		Assert.assertFalse(_fragmentCollection.hasExportableItems());
+
+		FragmentEntry reactFragmentEntry =
+			FragmentEntryTestUtil.addFragmentEntryByType(
+				_fragmentCollection.getFragmentCollectionId(),
+				FragmentConstants.TYPE_REACT);
+
+		Assert.assertTrue(reactFragmentEntry.isTypeReact());
+
+		Assert.assertFalse(_fragmentCollection.hasExportableItems());
+
+		FragmentEntry marketplaceFragmentEntry =
+			FragmentEntryTestUtil.addFragmentEntry(
+				_fragmentCollection.getFragmentCollectionId());
+
+		marketplaceFragmentEntry.setMarketplace(true);
+
+		_fragmentEntryLocalService.updateFragmentEntry(
+			marketplaceFragmentEntry);
+
+		Assert.assertFalse(_fragmentCollection.hasExportableItems());
+
+		FragmentComposition exportableFragmentComposition =
+			FragmentCompositionTestUtil.addFragmentComposition(
+				_fragmentCollection.getFragmentCollectionId(),
+				RandomTestUtil.randomString());
+
+		Assert.assertFalse(exportableFragmentComposition.isMarketplace());
+
+		Assert.assertTrue(_fragmentCollection.hasExportableItems());
+	}
+
+	@Test
 	@TestInfo("LPD-33704")
 	public void testPopulateZipWriter() throws Exception {
 		ZipWriter zipWriter = _zipWriterFactory.getZipWriter();
@@ -189,7 +239,7 @@ public class FragmentCollectionImplTest {
 	private FragmentCollection _fragmentCollection;
 
 	@Inject
-	private FragmentCollectionLocalService _fragmentCollectionLocalService;
+	private FragmentCompositionLocalService _fragmentCompositionLocalService;
 
 	@Inject
 	private FragmentEntryLocalService _fragmentEntryLocalService;

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/ExportFragmentCollectionsMVCResourceCommand.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/ExportFragmentCollectionsMVCResourceCommand.java
@@ -69,7 +69,7 @@ public class ExportFragmentCollectionsMVCResourceCommand
 								exportFragmentCollectionId);
 
 						if ((fragmentCollection != null) &&
-							!fragmentCollection.isMarketplace()) {
+							fragmentCollection.hasExportableItems()) {
 
 							return fragmentCollection;
 						}

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProvider.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProvider.java
@@ -107,8 +107,7 @@ public class BasicFragmentEntryActionDropdownItemsProvider {
 					).add(
 						() ->
 							hasManageFragmentEntriesPermission &&
-							!_fragmentEntry.isReadOnly() &&
-							!_fragmentEntry.isMarketplace(),
+							!_fragmentEntry.isReadOnly(),
 						_getRenameFragmentEntryActionUnsafeConsumer()
 					).add(
 						() ->

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/util/FragmentCollectionActionDropdownItemsProvider.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/util/FragmentCollectionActionDropdownItemsProvider.java
@@ -67,7 +67,7 @@ public class FragmentCollectionActionDropdownItemsProvider {
 							FragmentCollection fragmentCollection =
 								_fragmentDisplayContext.getFragmentCollection();
 
-							return !fragmentCollection.isMarketplace();
+							return fragmentCollection.hasExportableItems();
 						},
 						dropdownItem -> {
 							ResourceURL

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/portlet/action/ExportFragmentCollectionsMVCResourceCommandTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/portlet/action/ExportFragmentCollectionsMVCResourceCommandTest.java
@@ -1,0 +1,177 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.web.internal.portlet.action;
+
+import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.service.FragmentCollectionService;
+import com.liferay.portal.kernel.portlet.PortletResponseUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceResponse;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.kernel.zip.ZipWriter;
+import com.liferay.portal.kernel.zip.ZipWriterFactory;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.portlet.ResourceRequest;
+import jakarta.portlet.ResourceResponse;
+
+import java.io.File;
+import java.io.InputStream;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Georgel Pop
+ */
+public class ExportFragmentCollectionsMVCResourceCommandTest {
+
+	@ClassRule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		_timeMockedStatic.when(
+			Time::getTimestamp
+		).thenReturn(
+			String.valueOf(RandomTestUtil.randomLong())
+		);
+
+		Mockito.when(
+			_fragmentCollection.getFragmentCollectionId()
+		).thenReturn(
+			_FRAGMENT_COLLECTION_ID
+		);
+
+		Mockito.when(
+			_fragmentCollectionService.fetchFragmentCollection(
+				_FRAGMENT_COLLECTION_ID)
+		).thenReturn(
+			_fragmentCollection
+		);
+
+		File file = File.createTempFile("fragment-collections", ".zip");
+
+		file.deleteOnExit();
+
+		Mockito.when(
+			_zipWriter.getFile()
+		).thenReturn(
+			file
+		);
+
+		Mockito.when(
+			_zipWriterFactory.getZipWriter()
+		).thenReturn(
+			_zipWriter
+		);
+
+		_portletResponseUtilMockedStatic.when(
+			() -> PortletResponseUtil.sendFile(
+				Mockito.any(ResourceRequest.class),
+				Mockito.any(ResourceResponse.class), Mockito.anyString(),
+				Mockito.any(InputStream.class), Mockito.anyString())
+		).thenAnswer(
+			invocation -> null
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			_exportFragmentCollectionsMVCResourceCommand,
+			"_fragmentCollectionService", _fragmentCollectionService);
+		ReflectionTestUtil.setFieldValue(
+			_exportFragmentCollectionsMVCResourceCommand, "_zipWriterFactory",
+			_zipWriterFactory);
+	}
+
+	@After
+	public void tearDown() {
+		_portletResponseUtilMockedStatic.close();
+		_timeMockedStatic.close();
+	}
+
+	@Test
+	@TestInfo("LPD-82487")
+	public void testServeResourceExportsCollectionWithExportableItems()
+		throws Exception {
+
+		Mockito.when(
+			_fragmentCollection.hasExportableItems()
+		).thenReturn(
+			true
+		);
+
+		_exportFragmentCollectionsMVCResourceCommand.serveResource(
+			_getMockLiferayResourceRequest(),
+			new MockLiferayResourceResponse());
+
+		Mockito.verify(
+			_fragmentCollection
+		).populateZipWriter(
+			_zipWriter
+		);
+	}
+
+	@Test
+	@TestInfo("LPD-82487")
+	public void testServeResourceSkipsCollectionWithoutExportableItems()
+		throws Exception {
+
+		Mockito.when(
+			_fragmentCollection.hasExportableItems()
+		).thenReturn(
+			false
+		);
+
+		_exportFragmentCollectionsMVCResourceCommand.serveResource(
+			_getMockLiferayResourceRequest(),
+			new MockLiferayResourceResponse());
+
+		Mockito.verify(
+			_fragmentCollection, Mockito.never()
+		).populateZipWriter(
+			Mockito.any()
+		);
+	}
+
+	private MockLiferayResourceRequest _getMockLiferayResourceRequest() {
+		MockLiferayResourceRequest mockLiferayResourceRequest =
+			new MockLiferayResourceRequest();
+
+		mockLiferayResourceRequest.setParameter(
+			"fragmentCollectionId", String.valueOf(_FRAGMENT_COLLECTION_ID));
+
+		return mockLiferayResourceRequest;
+	}
+
+	private static final long _FRAGMENT_COLLECTION_ID =
+		RandomTestUtil.randomLong();
+
+	private final ExportFragmentCollectionsMVCResourceCommand
+		_exportFragmentCollectionsMVCResourceCommand =
+			new ExportFragmentCollectionsMVCResourceCommand();
+	private final FragmentCollection _fragmentCollection = Mockito.mock(
+		FragmentCollection.class);
+	private final FragmentCollectionService _fragmentCollectionService =
+		Mockito.mock(FragmentCollectionService.class);
+	private final MockedStatic<PortletResponseUtil>
+		_portletResponseUtilMockedStatic = Mockito.mockStatic(
+			PortletResponseUtil.class);
+	private final MockedStatic<Time> _timeMockedStatic = Mockito.mockStatic(
+		Time.class);
+	private final ZipWriter _zipWriter = Mockito.mock(ZipWriter.class);
+	private final ZipWriterFactory _zipWriterFactory = Mockito.mock(
+		ZipWriterFactory.class);
+
+}

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProviderTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProviderTest.java
@@ -85,6 +85,7 @@ public class BasicFragmentEntryActionDropdownItemsProviderTest
 	}
 
 	@Test
+	@TestInfo("LPD-63087")
 	public void testGetActionDropdownItemstForMarketplaceFragmentEntry()
 		throws Exception {
 
@@ -104,7 +105,7 @@ public class BasicFragmentEntryActionDropdownItemsProviderTest
 		assertDropdownItemsInCorrectOrder(
 			basicFragmentEntryActionDropdownItemsProvider.
 				getActionDropdownItems(),
-			"view-site-usages", "move", "delete");
+			"rename", "view-site-usages", "move", "delete");
 	}
 
 	@Test

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/FragmentCollectionActionDropdownItemsProviderTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/FragmentCollectionActionDropdownItemsProviderTest.java
@@ -7,6 +7,8 @@ package com.liferay.fragment.web.internal.servlet.taglib.util;
 
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.web.internal.display.context.FragmentDisplayContext;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import org.junit.Before;
@@ -36,10 +38,11 @@ public class FragmentCollectionActionDropdownItemsProviderTest
 	}
 
 	@Test
+	@TestInfo("LPD-82487")
 	public void testGetActionDropdowns() {
 		setUpFragmentPermission(true);
 
-		_setUpFragmentCollection(false);
+		_setUpFragmentCollection(false, true);
 
 		FragmentCollectionActionDropdownItemsProvider
 			fragmentCollectionActionDropdownItemsProvider =
@@ -54,10 +57,30 @@ public class FragmentCollectionActionDropdownItemsProviderTest
 	}
 
 	@Test
-	public void testGetActionDropdownsForMarketplaceFragmentCollection() {
+	@TestInfo("LPD-82487")
+	public void testGetActionDropdownsForFragmentCollectionWithExportableComposition() {
 		setUpFragmentPermission(true);
 
-		_setUpFragmentCollection(true);
+		_setUpFragmentCollection(false, true);
+
+		FragmentCollectionActionDropdownItemsProvider
+			fragmentCollectionActionDropdownItemsProvider =
+				new FragmentCollectionActionDropdownItemsProvider(
+					_fragmentDisplayContext, httpServletRequest,
+					renderResponse);
+
+		assertDropdownItemsInCorrectOrder(
+			fragmentCollectionActionDropdownItemsProvider.
+				getActionDropdownItems(),
+			"edit", "export", "import", "delete");
+	}
+
+	@Test
+	@TestInfo("LPD-82487")
+	public void testGetActionDropdownsForFragmentCollectionWithOnlyMarketplaceFragments() {
+		setUpFragmentPermission(true);
+
+		_setUpFragmentCollection(false, false);
 
 		FragmentCollectionActionDropdownItemsProvider
 			fragmentCollectionActionDropdownItemsProvider =
@@ -71,7 +94,72 @@ public class FragmentCollectionActionDropdownItemsProviderTest
 			"edit", "import", "delete");
 	}
 
-	private void _setUpFragmentCollection(boolean marketplace) {
+	@Test
+	@TestInfo("LPD-82487")
+	public void testGetActionDropdownsForMarketplaceFragmentCollection() {
+		setUpFragmentPermission(true);
+
+		_setUpFragmentCollection(true, false);
+
+		FragmentCollectionActionDropdownItemsProvider
+			fragmentCollectionActionDropdownItemsProvider =
+				new FragmentCollectionActionDropdownItemsProvider(
+					_fragmentDisplayContext, httpServletRequest,
+					renderResponse);
+
+		assertDropdownItemsInCorrectOrder(
+			fragmentCollectionActionDropdownItemsProvider.
+				getActionDropdownItems(),
+			"edit", "import", "delete");
+	}
+
+	@Test
+	@TestInfo("LPD-82487")
+	public void testGetActionDropdownsForMarketplaceFragmentCollectionWithExportableFragment() {
+		setUpFragmentPermission(true);
+
+		_setUpFragmentCollection(true, true);
+
+		FragmentCollectionActionDropdownItemsProvider
+			fragmentCollectionActionDropdownItemsProvider =
+				new FragmentCollectionActionDropdownItemsProvider(
+					_fragmentDisplayContext, httpServletRequest,
+					renderResponse);
+
+		assertDropdownItemsInCorrectOrder(
+			fragmentCollectionActionDropdownItemsProvider.
+				getActionDropdownItems(),
+			"edit", "export", "import", "delete");
+	}
+
+	@Test
+	@TestInfo("LPD-82487")
+	public void testGetActionDropdownsWithReactFragment() {
+		setUpFragmentPermission(true);
+
+		_setUpFragmentCollection(false, false);
+
+		FragmentCollectionActionDropdownItemsProvider
+			fragmentCollectionActionDropdownItemsProvider =
+				new FragmentCollectionActionDropdownItemsProvider(
+					_fragmentDisplayContext, httpServletRequest,
+					renderResponse);
+
+		assertDropdownItemsInCorrectOrder(
+			fragmentCollectionActionDropdownItemsProvider.
+				getActionDropdownItems(),
+			"edit", "import", "delete");
+	}
+
+	private void _setUpFragmentCollection(
+		boolean marketplace, boolean hasExportableItems) {
+
+		Mockito.when(
+			_fragmentCollection.getFragmentCollectionId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
 		Mockito.when(
 			_fragmentDisplayContext.getFragmentCollection()
 		).thenReturn(
@@ -82,6 +170,12 @@ public class FragmentCollectionActionDropdownItemsProviderTest
 			_fragmentCollection.isMarketplace()
 		).thenReturn(
 			marketplace
+		);
+
+		Mockito.when(
+			_fragmentCollection.hasExportableItems()
+		).thenReturn(
+			hasExportableItems
 		);
 	}
 

--- a/modules/test/playwright/tests/fragment-web/main/fragmentAdminMarketplace.spec.ts
+++ b/modules/test/playwright/tests/fragment-web/main/fragmentAdminMarketplace.spec.ts
@@ -135,7 +135,7 @@ test(
 test(
 	'Check available actions of marketplace fragment',
 	{
-		tag: '@LPD-43455',
+		tag: ['@LPD-43455', '@LPD-63087'],
 	},
 	async ({apiHelpers, fragmentsPage, page, site}) => {
 
@@ -178,7 +178,7 @@ test(
 
 		// Check available actions
 
-		['View Usages', 'Move', 'Delete'].forEach(async (action) => {
+		['Rename', 'View Usages', 'Move', 'Delete'].forEach(async (action) => {
 			await expect(
 				page.getByRole('menuitem', {name: action})
 			).toBeVisible();
@@ -190,7 +190,6 @@ test(
 			'Mark as Cacheable',
 			'Export',
 			'Make a Copy',
-			'Rename',
 		].forEach(async (action) => {
 			await expect(
 				page.getByRole('menuitem', {name: action})


### PR DESCRIPTION
Manually forwarded, tests run on https://github.com/liferay-page-management/liferay-portal/pull/18245#issuecomment-4069531776