### PR TITLE
LPD-82156 Collection display not showing entries of Repeatible Collection Providers

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/GetAvailableListRenderersMVCResourceCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/GetAvailableListRenderersMVCResourceCommandTest.java
@@ -1,0 +1,109 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.content.page.editor.web.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.info.collection.provider.RepeatableFieldInfoItemCollectionProvider;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceResponse;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import jakarta.portlet.ResourceRequest;
+import jakarta.portlet.ResourceResponse;
+
+import java.io.ByteArrayOutputStream;
+
+import java.util.function.Consumer;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Akhash Ramprakash
+ */
+@RunWith(Arquillian.class)
+public class GetAvailableListRenderersMVCResourceCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	@TestInfo("LPD-82156")
+	public void testDoServeResource() throws Exception {
+		_testDoServeResource(
+			JournalArticle.class.getName(),
+			jsonArray -> Assert.assertFalse(JSONUtil.isEmpty(jsonArray)),
+			JournalArticle.class.getName());
+		_testDoServeResource(
+			JournalArticle.class.getName(),
+			jsonArray -> Assert.assertEquals(0, jsonArray.length()),
+			RepeatableFieldInfoItemCollectionProvider.class.getName());
+	}
+
+	private void _testDoServeResource(
+			String className, Consumer<JSONArray> consumer, String key)
+		throws Exception {
+
+		MockLiferayResourceRequest resourceRequest =
+			new MockLiferayResourceRequest();
+
+		resourceRequest.addParameter("className", className);
+		resourceRequest.addParameter("key", key);
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(TestPropsValues.getCompanyId()));
+
+		resourceRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
+
+		MockLiferayResourceResponse resourceResponse =
+			new MockLiferayResourceResponse();
+
+		ReflectionTestUtil.invoke(
+			_mvcResourceCommand, "doServeResource",
+			new Class<?>[] {ResourceRequest.class, ResourceResponse.class},
+			resourceRequest, resourceResponse);
+
+		ByteArrayOutputStream byteArrayOutputStream =
+			(ByteArrayOutputStream)resourceResponse.getPortletOutputStream();
+
+		JSONArray jsonArray = JSONFactoryUtil.createJSONArray(
+			byteArrayOutputStream.toString());
+
+		consumer.accept(jsonArray);
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject(
+		filter = "mvc.command.name=/layout_content_page_editor/get_available_list_renderers"
+	)
+	private MVCResourceCommand _mvcResourceCommand;
+
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetAvailableListRenderersMVCResourceCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetAvailableListRenderersMVCResourceCommand.java
@@ -5,6 +5,7 @@
 
 package com.liferay.layout.content.page.editor.web.internal.portlet.action;
 
+import com.liferay.info.collection.provider.RepeatableFieldInfoItemCollectionProvider;
 import com.liferay.info.list.renderer.InfoListRenderer;
 import com.liferay.info.list.renderer.InfoListRendererRegistry;
 import com.liferay.info.search.InfoSearchClassMapperRegistry;
@@ -22,7 +23,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import jakarta.portlet.ResourceRequest;
 import jakarta.portlet.ResourceResponse;
 
-import java.util.List;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -47,21 +48,28 @@ public class GetAvailableListRenderersMVCResourceCommand
 
 		JSONArray jsonArray = _jsonFactory.createJSONArray();
 
-		List<InfoListRenderer<?>> infoListRenderers =
-			_infoListRendererRegistry.getInfoListRenderers(
-				_infoSearchClassMapperRegistry.getClassName(
-					ParamUtil.getString(resourceRequest, "className")));
+		if (!Objects.equals(
+				ParamUtil.getString(resourceRequest, "key"),
+				RepeatableFieldInfoItemCollectionProvider.class.getName())) {
 
-		ThemeDisplay themeDisplay = (ThemeDisplay)resourceRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)resourceRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
 
-		for (InfoListRenderer<?> infoListRenderer : infoListRenderers) {
-			jsonArray.put(
-				JSONUtil.put(
-					"label", infoListRenderer.getLabel(themeDisplay.getLocale())
-				).put(
-					"value", infoListRenderer.getKey()
-				));
+			for (InfoListRenderer<?> infoListRenderer :
+					_infoListRendererRegistry.getInfoListRenderers(
+						_infoSearchClassMapperRegistry.getClassName(
+							ParamUtil.getString(
+								resourceRequest, "className")))) {
+
+				jsonArray.put(
+					JSONUtil.put(
+						"label",
+						infoListRenderer.getLabel(themeDisplay.getLocale())
+					).put(
+						"value", infoListRenderer.getKey()
+					));
+			}
 		}
 
 		JSONPortletResponseUtil.writeJSON(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/InfoItemService.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/InfoItemService.ts
@@ -28,10 +28,17 @@ function getAvailableListItemRenderers({
 	});
 }
 
-function getAvailableListRenderers({className}: {className: string}) {
+function getAvailableListRenderers({
+	className,
+	key,
+}: {
+	className: string;
+	key: string;
+}) {
 	return serviceFetch(config.getAvailableListRenderersURL, {
 		body: {
 			className,
+			key,
 		},
 	});
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/collection_general_panel/CollectionGeneralPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/collection_general_panel/CollectionGeneralPanel.js
@@ -317,6 +317,7 @@ export function CollectionGeneralPanel({item}) {
 									VIEWPORT_SIZES.desktop && (
 									<StyleDisplaySelector
 										collectionItemType={collectionItemType}
+										collectionKey={collection.key}
 										handleConfigurationChanged={
 											handleConfigurationChanged
 										}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/collection_general_panel/StyleDisplaySelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/collection_general_panel/StyleDisplaySelector.js
@@ -28,6 +28,7 @@ const DEFAULT_LIST_STYLES = [
 
 export function StyleDisplaySelector({
 	collectionItemType,
+	collectionKey,
 	handleConfigurationChanged,
 	listStyle,
 }) {
@@ -40,22 +41,28 @@ export function StyleDisplaySelector({
 		if (collectionItemType) {
 			InfoItemService.getAvailableListRenderers({
 				className: collectionItemType,
+				key: collectionKey,
 			})
 				.then((response) => {
-					setAvailableListStyles([
-						...DEFAULT_LIST_STYLES,
-						{
-							label: Liferay.Language.get('templates'),
-							options: response,
-							type: 'group',
-						},
-					]);
+					if (response && !!response.length) {
+						setAvailableListStyles([
+							...DEFAULT_LIST_STYLES,
+							{
+								label: Liferay.Language.get('templates'),
+								options: response,
+								type: 'group',
+							},
+						]);
+					}
+					else {
+						setAvailableListStyles(DEFAULT_LIST_STYLES);
+					}
 				})
 				.catch(() => {
 					setAvailableListStyles(DEFAULT_LIST_STYLES);
 				});
 		}
-	}, [collectionItemType]);
+	}, [collectionItemType, collectionKey]);
 
 	return (
 		<ClayForm.Group className="mt-3" small>
@@ -80,6 +87,7 @@ export function StyleDisplaySelector({
 
 StyleDisplaySelector.propTypes = {
 	collectionItemType: PropTypes.string,
+	collectionKey: PropTypes.string,
 	handleConfigurationChanged: PropTypes.func.isRequired,
 	listStyle: PropTypes.string,
 };


### PR DESCRIPTION
Forwarded from: https://github.com/liferay-page-management/liferay-portal/pull/18252

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-82156

Collection display showing default templates for Repeatible Collection Providers

# How am I fixing it?

Check if key is RepeatableFieldInfoItemCollectionProvider then return empty json array

# How can you verify that it works?

Run the included automated tests.