### PR TITLE
LPD-83070 Reorder batch mode close sequence: run callables before fut…

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/search/SearchContext.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/SearchContext.java
@@ -83,9 +83,9 @@ public class SearchContext implements Serializable {
 				Map.Entry<Set<Future<?>>, List<Callable<Void>>> entry =
 					_batchModeSyncFuturesAndCallables.get();
 
-				for (Future<?> future : entry.getKey()) {
+				for (Callable<?> callable : entry.getValue()) {
 					try {
-						future.get();
+						callable.call();
 					}
 					catch (Exception exception2) {
 						if (exception1 != null) {
@@ -96,9 +96,9 @@ public class SearchContext implements Serializable {
 					}
 				}
 
-				for (Callable<?> callable : entry.getValue()) {
+				for (Future<?> future : entry.getKey()) {
 					try {
-						callable.call();
+						future.get();
 					}
 					catch (Exception exception2) {
 						if (exception1 != null) {


### PR DESCRIPTION
…ures

In SearchContext.openBatchMode(), the close lambda previously waited on all registered futures first, then executed callables. This is reversed so callables execute first, then futures are awaited.

This allows callables (e.g. the Elasticsearch final flush) to register new futures during their execution, which are then picked up by the subsequent futures loop.