### PR TITLE
LPD-79450 Fix typo, missing space before 'from'

### DIFF
--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_0/SamlSpSessionUpgradeProcess.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_0/SamlSpSessionUpgradeProcess.java
@@ -124,13 +124,13 @@ public class SamlSpSessionUpgradeProcess extends UpgradeProcess {
 
 	private int _getSamlSpSessionIdOffset() throws SQLException {
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				"select min(samlSpSessionId) - 1 as samlSpSessionIdfrom " +
+				"select min(samlSpSessionId) - 1 as samlSpSessionId from " +
 					"SamlSpSession");
 
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 
 			if (resultSet.next()) {
-				return resultSet.getInt("samlSpSessionIdfrom");
+				return resultSet.getInt("samlSpSessionId");
 			}
 		}
 


### PR DESCRIPTION
There is a missing space before the 'from' keyword causing a malformed SQL.

Caused by f81a6f386bf89350b7f274b001153f13319baa43

@ling-alan-huang
