### PR TITLE
LPD-83268 ConfigurationHandler.read() returns Hashtable, convert it t…

### DIFF
--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/ConfigurationPersistenceManager.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/ConfigurationPersistenceManager.java
@@ -383,9 +383,10 @@ public class ConfigurationPersistenceManager
 						return new HashMapDictionary<>();
 					}
 
-					return ConfigurationHandler.read(
-						new UnsyncByteArrayInputStream(
-							dictionaryString.getBytes(StringPool.UTF8)));
+					return new HashMapDictionary<>(
+						(Map<Object, Object>)ConfigurationHandler.read(
+							new UnsyncByteArrayInputStream(
+								dictionaryString.getBytes(StringPool.UTF8))));
 				}
 			}
 


### PR DESCRIPTION
…o HashMapDictionary before storing into "ConcurrentMap<String, Dictionary<?, ?>> _dictionaries" to prevent runtime Hashtable lock contention like below.

"catalina-exec-15" #812 [1265] daemon prio=5 os_prio=0 cpu=13667.83ms elapsed=231.25s tid=0x000057fada3aa700 nid=1265 waiting for monitor entry  [0x00007dffc58e6000]
   java.lang.Thread.State: BLOCKED (on object monitor)
	at java.util.Hashtable.get(java.base@21.0.1/Hashtable.java:380)
	- waiting to lock <0x00000005815e17e0> (a java.util.Hashtable) at org.apache.felix.cm.impl.persistence.PersistenceManagerProxy.getDictionaries(PersistenceManagerProxy.java:139) at org.apache.felix.cm.impl.ConfigurationManager.listConfigurations(ConfigurationManager.java:535) at org.apache.felix.cm.impl.ConfigurationAdminImpl.listConfigurations(ConfigurationAdminImpl.java:190) at com.liferay.portal.vulcan.internal.configuration.util.ConfigurationUtil.getExcludedOperationIds(ConfigurationUtil.java:41) at com.liferay.portal.vulcan.internal.jaxrs.container.request.filter.ContextContainerRequestFilter._filterExcludedOperationIds(ContextContainerRequestFilter.java:144) at com.liferay.portal.vulcan.internal.jaxrs.container.request.filter.ContextContainerRequestFilter._handleMessage(ContextContainerRequestFilter.java:282) at com.liferay.portal.vulcan.internal.jaxrs.container.request.filter.ContextContainerRequestFilter.handleMessage(ContextContainerRequestFilter.java:124) at com.liferay.portal.vulcan.internal.jaxrs.container.request.filter.ContextContainerRequestFilter.filter(ContextContainerRequestFilter.java:105)