### PR TITLE
LPD-82681 Fix flakiness of the tests that create a txt file using a random content

### DIFF
--- a/modules/apps/document-library/document-library-test-util/bnd.bnd
+++ b/modules/apps/document-library/document-library-test-util/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Document Library Test Utilities
 Bundle-SymbolicName: com.liferay.document.library.test.util
-Bundle-Version: 5.0.2
+Bundle-Version: 5.1.0
 Export-Package:\
 	com.liferay.document.library.test.util,\
 	com.liferay.document.library.test.util.search

--- a/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/DLTestUtil.java
+++ b/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/DLTestUtil.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.ByteArrayInputStream;
 
@@ -94,6 +95,10 @@ public class DLTestUtil {
 		throws PortalException {
 
 		return addDLFolder(groupId, true, serviceContext);
+	}
+
+	public static String randomTextFileContent(int length) {
+		return StringUtil.randomId(length);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(DLTestUtil.class);

--- a/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/DLTestUtil.java
+++ b/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/DLTestUtil.java
@@ -97,8 +97,10 @@ public class DLTestUtil {
 		return addDLFolder(groupId, true, serviceContext);
 	}
 
-	public static String randomTextFileContent(int length) {
-		return StringUtil.randomId(length);
+	public static byte[] randomTextFileContent(int length) {
+		return StringUtil.randomId(
+			length
+		).getBytes();
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(DLTestUtil.class);

--- a/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/DLTestUtil.java
+++ b/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/DLTestUtil.java
@@ -97,11 +97,11 @@ public class DLTestUtil {
 		return addDLFolder(groupId, true, serviceContext);
 	}
 
-	public static byte[] randomTextFileContent() {
-		return randomTextFileContent(8);
+	public static byte[] randomTextFileBytes() {
+		return randomTextFileBytes(8);
 	}
 
-	public static byte[] randomTextFileContent(int length) {
+	public static byte[] randomTextFileBytes(int length) {
 		return StringUtil.randomId(
 			length
 		).getBytes();

--- a/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/DLTestUtil.java
+++ b/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/DLTestUtil.java
@@ -97,6 +97,10 @@ public class DLTestUtil {
 		return addDLFolder(groupId, true, serviceContext);
 	}
 
+	public static byte[] randomTextFileContent() {
+		return randomTextFileContent(8);
+	}
+
 	public static byte[] randomTextFileContent(int length) {
 		return StringUtil.randomId(
 			length

--- a/modules/apps/document-library/document-library-test-util/src/main/resources/com/liferay/document/library/test/util/packageinfo
+++ b/modules/apps/document-library/document-library-test-util/src/main/resources/com/liferay/document/library/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/export-import/export-import-test/build.gradle
+++ b/modules/apps/export-import/export-import-test/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-test-util")
 	testIntegrationImplementation project(":apps:depot:depot-api")
 	testIntegrationImplementation project(":apps:document-library:document-library-api")
+	testIntegrationImplementation project(":apps:document-library:document-library-test-util")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-test-util")
 	testIntegrationImplementation project(":apps:export-import:export-import-api")
 	testIntegrationImplementation project(":apps:export-import:export-import-report-api")

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/background/task/test/LayoutImportBackgroundTaskExecutorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/background/task/test/LayoutImportBackgroundTaskExecutorTest.java
@@ -330,11 +330,13 @@ public class LayoutImportBackgroundTaskExecutorTest {
 			ObjectDefinition objectDefinition, String tempFileName)
 		throws Exception {
 
+		String content = "test\n" + tempFileName;
+
 		return TempFileEntryUtil.addTempFileEntry(
 			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
 			objectDefinition.getPortletId(),
 			TempFileEntryUtil.getTempFileName(tempFileName + ".txt"),
-			FileUtil.createTempFile(tempFileName.getBytes()),
+			FileUtil.createTempFile(content.getBytes()),
 			ContentTypes.TEXT_PLAIN);
 	}
 

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/background/task/test/LayoutImportBackgroundTaskExecutorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/background/task/test/LayoutImportBackgroundTaskExecutorTest.java
@@ -461,14 +461,14 @@ public class LayoutImportBackgroundTaskExecutorTest {
 		"x" + RandomTestUtil.randomString();
 
 	private static final byte[] _OBJECT_FIELD_VALUE_ATTACHMENT_DOCS_AND_MEDIA =
-		DLTestUtil.randomTextFileContent();
+		DLTestUtil.randomTextFileBytes();
 
 	private static final byte[]
 		_OBJECT_FIELD_VALUE_ATTACHMENT_SHOW_FILES_IN_DOCS_AND_MEDIA =
-			DLTestUtil.randomTextFileContent();
+			DLTestUtil.randomTextFileBytes();
 
 	private static final byte[] _OBJECT_FIELD_VALUE_ATTACHMENT_USER_COMPUTER =
-		DLTestUtil.randomTextFileContent();
+		DLTestUtil.randomTextFileBytes();
 
 	@Inject
 	private BackgroundTaskLocalService _backgroundTaskLocalService;

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/background/task/test/LayoutImportBackgroundTaskExecutorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/background/task/test/LayoutImportBackgroundTaskExecutorTest.java
@@ -461,14 +461,14 @@ public class LayoutImportBackgroundTaskExecutorTest {
 		"x" + RandomTestUtil.randomString();
 
 	private static final byte[] _OBJECT_FIELD_VALUE_ATTACHMENT_DOCS_AND_MEDIA =
-		DLTestUtil.randomTextFileContent(8);
+		DLTestUtil.randomTextFileContent();
 
 	private static final byte[]
 		_OBJECT_FIELD_VALUE_ATTACHMENT_SHOW_FILES_IN_DOCS_AND_MEDIA =
-			DLTestUtil.randomTextFileContent(8);
+			DLTestUtil.randomTextFileContent();
 
 	private static final byte[] _OBJECT_FIELD_VALUE_ATTACHMENT_USER_COMPUTER =
-		DLTestUtil.randomTextFileContent(8);
+		DLTestUtil.randomTextFileContent();
 
 	@Inject
 	private BackgroundTaskLocalService _backgroundTaskLocalService;

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/background/task/test/LayoutImportBackgroundTaskExecutorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/background/task/test/LayoutImportBackgroundTaskExecutorTest.java
@@ -301,10 +301,10 @@ public class LayoutImportBackgroundTaskExecutorTest {
 			company.getGroupId());
 
 		FileEntry tempFileEntry1 = _addTempFileEntry(
-			objectDefinition,
-			_OBJECT_FIELD_VALUE_ATTACHMENT_SHOW_FILES_IN_DOCS_AND_MEDIA);
+			_OBJECT_FIELD_VALUE_ATTACHMENT_SHOW_FILES_IN_DOCS_AND_MEDIA,
+			objectDefinition);
 		FileEntry tempFileEntry2 = _addTempFileEntry(
-			objectDefinition, _OBJECT_FIELD_VALUE_ATTACHMENT_USER_COMPUTER);
+			_OBJECT_FIELD_VALUE_ATTACHMENT_USER_COMPUTER, objectDefinition);
 
 		return _objectEntryLocalService.addObjectEntry(
 			groupId, TestPropsValues.getUserId(),
@@ -327,15 +327,14 @@ public class LayoutImportBackgroundTaskExecutorTest {
 	}
 
 	private FileEntry _addTempFileEntry(
-			ObjectDefinition objectDefinition, String tempFileName)
+			String content, ObjectDefinition objectDefinition)
 		throws Exception {
-
-		String content = "test\n" + tempFileName;
 
 		return TempFileEntryUtil.addTempFileEntry(
 			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
 			objectDefinition.getPortletId(),
-			TempFileEntryUtil.getTempFileName(tempFileName + ".txt"),
+			TempFileEntryUtil.getTempFileName(
+				RandomTestUtil.randomString() + ".txt"),
 			FileUtil.createTempFile(content.getBytes()),
 			ContentTypes.TEXT_PLAIN);
 	}
@@ -454,14 +453,14 @@ public class LayoutImportBackgroundTaskExecutorTest {
 		"x" + RandomTestUtil.randomString();
 
 	private static final String _OBJECT_FIELD_VALUE_ATTACHMENT_DOCS_AND_MEDIA =
-		RandomTestUtil.randomString();
+		"test\n" + RandomTestUtil.randomString();
 
 	private static final String
 		_OBJECT_FIELD_VALUE_ATTACHMENT_SHOW_FILES_IN_DOCS_AND_MEDIA =
-			RandomTestUtil.randomString();
+			"test\n" + RandomTestUtil.randomString();
 
 	private static final String _OBJECT_FIELD_VALUE_ATTACHMENT_USER_COMPUTER =
-		RandomTestUtil.randomString();
+		"test\n" + RandomTestUtil.randomString();
 
 	@Inject
 	private BackgroundTaskLocalService _backgroundTaskLocalService;

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/background/task/test/LayoutImportBackgroundTaskExecutorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/background/task/test/LayoutImportBackgroundTaskExecutorTest.java
@@ -46,6 +46,7 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.log.LogCapture;
@@ -461,14 +462,14 @@ public class LayoutImportBackgroundTaskExecutorTest {
 		"x" + RandomTestUtil.randomString();
 
 	private static final String _OBJECT_FIELD_VALUE_ATTACHMENT_DOCS_AND_MEDIA =
-		"test\n" + RandomTestUtil.randomString();
+		StringUtil.randomId(8);
 
 	private static final String
 		_OBJECT_FIELD_VALUE_ATTACHMENT_SHOW_FILES_IN_DOCS_AND_MEDIA =
-			"test\n" + RandomTestUtil.randomString();
+			StringUtil.randomId(8);
 
 	private static final String _OBJECT_FIELD_VALUE_ATTACHMENT_USER_COMPUTER =
-		"test\n" + RandomTestUtil.randomString();
+		StringUtil.randomId(8);
 
 	@Inject
 	private BackgroundTaskLocalService _backgroundTaskLocalService;

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/background/task/test/LayoutImportBackgroundTaskExecutorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/background/task/test/LayoutImportBackgroundTaskExecutorTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.test.util.DLTestUtil;
 import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationSettingsMapFactoryUtil;
 import com.liferay.exportimport.kernel.configuration.constants.ExportImportConfigurationConstants;
 import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
@@ -46,7 +47,6 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.MapUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.log.LogCapture;
@@ -462,14 +462,14 @@ public class LayoutImportBackgroundTaskExecutorTest {
 		"x" + RandomTestUtil.randomString();
 
 	private static final String _OBJECT_FIELD_VALUE_ATTACHMENT_DOCS_AND_MEDIA =
-		StringUtil.randomId(8);
+		DLTestUtil.randomTextFileContent(8);
 
 	private static final String
 		_OBJECT_FIELD_VALUE_ATTACHMENT_SHOW_FILES_IN_DOCS_AND_MEDIA =
-			StringUtil.randomId(8);
+			DLTestUtil.randomTextFileContent(8);
 
 	private static final String _OBJECT_FIELD_VALUE_ATTACHMENT_USER_COMPUTER =
-		StringUtil.randomId(8);
+		DLTestUtil.randomTextFileContent(8);
 
 	@Inject
 	private BackgroundTaskLocalService _backgroundTaskLocalService;

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/background/task/test/LayoutImportBackgroundTaskExecutorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/background/task/test/LayoutImportBackgroundTaskExecutorTest.java
@@ -48,6 +48,8 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.staging.StagingGroupHelper;
@@ -107,38 +109,44 @@ public class LayoutImportBackgroundTaskExecutorTest {
 			GroupConstants.DEFAULT_PARENT_GROUP_ID, objectDefinition,
 			values.get(_OBJECT_FIELD_NAME_TEXT));
 
-		long backgroundTaskId =
-			ExportImportLocalServiceUtil.importLayoutsInBackground(
-				TestPropsValues.getUserId(),
-				ExportImportConfigurationLocalServiceUtil.
-					addExportImportConfiguration(
-						TestPropsValues.getUserId(), group.getGroupId(),
-						RandomTestUtil.randomString(),
-						RandomTestUtil.randomString(), 0,
-						ExportImportConfigurationSettingsMapFactoryUtil.
-							buildImportLayoutSettingsMap(
-								TestPropsValues.getUser(), group.getGroupId(),
-								false, new long[0],
-								_getExportImportParameterMap(
-									false, true,
-									Arrays.asList(objectDefinition))),
-						WorkflowConstants.STATUS_DRAFT,
-						ServiceContextTestUtil.getServiceContext()),
-				larFile);
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.batch.engine.internal." +
+					"BatchEngineImportTaskExecutorImpl",
+				LoggerTestUtil.OFF)) {
 
-		ExportImportTestUtil.retryAssert(
-			1, TimeUnit.SECONDS, 5, TimeUnit.SECONDS,
-			() -> {
-				BackgroundTask backgroundTask =
-					_backgroundTaskLocalService.getBackgroundTask(
-						backgroundTaskId);
+			long backgroundTaskId =
+				ExportImportLocalServiceUtil.importLayoutsInBackground(
+					TestPropsValues.getUserId(),
+					ExportImportConfigurationLocalServiceUtil.
+						addExportImportConfiguration(
+							TestPropsValues.getUserId(), group.getGroupId(),
+							RandomTestUtil.randomString(),
+							RandomTestUtil.randomString(), 0,
+							ExportImportConfigurationSettingsMapFactoryUtil.
+								buildImportLayoutSettingsMap(
+									TestPropsValues.getUser(),
+									group.getGroupId(), false, new long[0],
+									_getExportImportParameterMap(
+										false, true,
+										Arrays.asList(objectDefinition))),
+							WorkflowConstants.STATUS_DRAFT,
+							ServiceContextTestUtil.getServiceContext()),
+					larFile);
 
-				Assert.assertEquals(
-					BackgroundTaskConstants.STATUS_COMPLETED_WITH_ERRORS,
-					backgroundTask.getStatus());
-			});
+			ExportImportTestUtil.retryAssert(
+				1, TimeUnit.SECONDS, 5, TimeUnit.SECONDS,
+				() -> {
+					BackgroundTask backgroundTask =
+						_backgroundTaskLocalService.getBackgroundTask(
+							backgroundTaskId);
 
-		ServiceContextThreadLocal.popServiceContext();
+					Assert.assertEquals(
+						BackgroundTaskConstants.STATUS_COMPLETED_WITH_ERRORS,
+						backgroundTask.getStatus());
+				});
+
+			ServiceContextThreadLocal.popServiceContext();
+		}
 	}
 
 	private DLFileEntry _addDLFileEntry(String content, long groupId)

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/background/task/test/LayoutImportBackgroundTaskExecutorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/background/task/test/LayoutImportBackgroundTaskExecutorTest.java
@@ -150,7 +150,7 @@ public class LayoutImportBackgroundTaskExecutorTest {
 		}
 	}
 
-	private DLFileEntry _addDLFileEntry(String content, long groupId)
+	private DLFileEntry _addDLFileEntry(byte[] content, long groupId)
 		throws Exception {
 
 		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
@@ -159,7 +159,7 @@ public class LayoutImportBackgroundTaskExecutorTest {
 				RandomTestUtil.randomString() + ".txt"),
 			ContentTypes.TEXT_PLAIN, RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
-			new ByteArrayInputStream(content.getBytes()), 0, null, null, null,
+			new ByteArrayInputStream(content), 0, null, null, null,
 			ServiceContextTestUtil.getServiceContext());
 
 		return _dlFileEntryLocalService.getFileEntry(
@@ -336,7 +336,7 @@ public class LayoutImportBackgroundTaskExecutorTest {
 	}
 
 	private FileEntry _addTempFileEntry(
-			String content, ObjectDefinition objectDefinition)
+			byte[] content, ObjectDefinition objectDefinition)
 		throws Exception {
 
 		return TempFileEntryUtil.addTempFileEntry(
@@ -344,8 +344,7 @@ public class LayoutImportBackgroundTaskExecutorTest {
 			objectDefinition.getPortletId(),
 			TempFileEntryUtil.getTempFileName(
 				RandomTestUtil.randomString() + ".txt"),
-			FileUtil.createTempFile(content.getBytes()),
-			ContentTypes.TEXT_PLAIN);
+			FileUtil.createTempFile(content), ContentTypes.TEXT_PLAIN);
 	}
 
 	private void _deleteObjectEntries(ObjectEntry... objectEntries)
@@ -461,14 +460,14 @@ public class LayoutImportBackgroundTaskExecutorTest {
 	private static final String _OBJECT_FIELD_NAME_TEXT =
 		"x" + RandomTestUtil.randomString();
 
-	private static final String _OBJECT_FIELD_VALUE_ATTACHMENT_DOCS_AND_MEDIA =
+	private static final byte[] _OBJECT_FIELD_VALUE_ATTACHMENT_DOCS_AND_MEDIA =
 		DLTestUtil.randomTextFileContent(8);
 
-	private static final String
+	private static final byte[]
 		_OBJECT_FIELD_VALUE_ATTACHMENT_SHOW_FILES_IN_DOCS_AND_MEDIA =
 			DLTestUtil.randomTextFileContent(8);
 
-	private static final String _OBJECT_FIELD_VALUE_ATTACHMENT_USER_COMPUTER =
+	private static final byte[] _OBJECT_FIELD_VALUE_ATTACHMENT_USER_COMPUTER =
 		DLTestUtil.randomTextFileContent(8);
 
 	@Inject

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -2089,7 +2089,7 @@ public class BatchEnginePortletDataHandlerTest {
 			ServiceContextTestUtil.getServiceContext());
 	}
 
-	private DLFileEntry _addDLFileEntry(String content, long groupId)
+	private DLFileEntry _addDLFileEntry(byte[] content, long groupId)
 		throws Exception {
 
 		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
@@ -2098,7 +2098,7 @@ public class BatchEnginePortletDataHandlerTest {
 				RandomTestUtil.randomString() + ".txt"),
 			ContentTypes.TEXT_PLAIN, RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
-			new ByteArrayInputStream(content.getBytes()), 0, null, null, null,
+			new ByteArrayInputStream(content), 0, null, null, null,
 			ServiceContextTestUtil.getServiceContext());
 
 		return _dlFileEntryLocalService.getFileEntry(
@@ -2378,7 +2378,7 @@ public class BatchEnginePortletDataHandlerTest {
 	}
 
 	private FileEntry _addTempFileEntry(
-			String content, ObjectDefinition objectDefinition)
+			byte[] content, ObjectDefinition objectDefinition)
 		throws Exception {
 
 		return TempFileEntryUtil.addTempFileEntry(
@@ -2386,8 +2386,7 @@ public class BatchEnginePortletDataHandlerTest {
 			objectDefinition.getPortletId(),
 			TempFileEntryUtil.getTempFileName(
 				RandomTestUtil.randomString() + ".txt"),
-			FileUtil.createTempFile(content.getBytes()),
-			ContentTypes.TEXT_PLAIN);
+			FileUtil.createTempFile(content), ContentTypes.TEXT_PLAIN);
 	}
 
 	private void _assertComments(
@@ -2575,9 +2574,9 @@ public class BatchEnginePortletDataHandlerTest {
 					importedObjectEntry.getValues(),
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER));
 
-			Assert.assertEquals(
+			Assert.assertArrayEquals(
 				_OBJECT_FIELD_VALUE_ATTACHMENT_USER_COMPUTER,
-				StringUtil.read(dlFileEntry.getContentStream()));
+				StringUtil.read(dlFileEntry.getContentStream()).getBytes());
 		}
 	}
 
@@ -3653,14 +3652,14 @@ public class BatchEnginePortletDataHandlerTest {
 	private static final String _OBJECT_FIELD_NAME_TEXT =
 		"xText" + RandomTestUtil.randomString();
 
-	private static final String _OBJECT_FIELD_VALUE_ATTACHMENT_DOCS_AND_MEDIA =
+	private static final byte[] _OBJECT_FIELD_VALUE_ATTACHMENT_DOCS_AND_MEDIA =
 		DLTestUtil.randomTextFileContent(8);
 
-	private static final String
+	private static final byte[]
 		_OBJECT_FIELD_VALUE_ATTACHMENT_SHOW_FILES_IN_DOCS_AND_MEDIA =
 			DLTestUtil.randomTextFileContent(8);
 
-	private static final String _OBJECT_FIELD_VALUE_ATTACHMENT_USER_COMPUTER =
+	private static final byte[] _OBJECT_FIELD_VALUE_ATTACHMENT_USER_COMPUTER =
 		DLTestUtil.randomTextFileContent(8);
 
 	private static BundleContext _bundleContext;

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -2574,7 +2574,7 @@ public class BatchEnginePortletDataHandlerTest {
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER));
 
 			Assert.assertEquals(
-				_OBJECT_FIELD_VALUE_ATTACHMENT_USER_COMPUTER,
+				"test\n" + _OBJECT_FIELD_VALUE_ATTACHMENT_USER_COMPUTER,
 				StringUtil.read(dlFileEntry.getContentStream()));
 		}
 	}

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -2380,11 +2380,13 @@ public class BatchEnginePortletDataHandlerTest {
 			ObjectDefinition objectDefinition, String tempFileName)
 		throws Exception {
 
+		String content = "test\n" + tempFileName;
+
 		return TempFileEntryUtil.addTempFileEntry(
 			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
 			objectDefinition.getPortletId(),
 			TempFileEntryUtil.getTempFileName(tempFileName + ".txt"),
-			FileUtil.createTempFile(tempFileName.getBytes()),
+			FileUtil.createTempFile(content.getBytes()),
 			ContentTypes.TEXT_PLAIN);
 	}
 

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -3653,14 +3653,14 @@ public class BatchEnginePortletDataHandlerTest {
 		"xText" + RandomTestUtil.randomString();
 
 	private static final String _OBJECT_FIELD_VALUE_ATTACHMENT_DOCS_AND_MEDIA =
-		"test\n" + RandomTestUtil.randomString();
+		StringUtil.randomId(8);
 
 	private static final String
 		_OBJECT_FIELD_VALUE_ATTACHMENT_SHOW_FILES_IN_DOCS_AND_MEDIA =
-			"test\n" + RandomTestUtil.randomString();
+			StringUtil.randomId(8);
 
 	private static final String _OBJECT_FIELD_VALUE_ATTACHMENT_USER_COMPUTER =
-		"test\n" + RandomTestUtil.randomString();
+		StringUtil.randomId(8);
 
 	private static BundleContext _bundleContext;
 	private static final BiFunction

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -3653,14 +3653,14 @@ public class BatchEnginePortletDataHandlerTest {
 		"xText" + RandomTestUtil.randomString();
 
 	private static final byte[] _OBJECT_FIELD_VALUE_ATTACHMENT_DOCS_AND_MEDIA =
-		DLTestUtil.randomTextFileContent(8);
+		DLTestUtil.randomTextFileContent();
 
 	private static final byte[]
 		_OBJECT_FIELD_VALUE_ATTACHMENT_SHOW_FILES_IN_DOCS_AND_MEDIA =
-			DLTestUtil.randomTextFileContent(8);
+			DLTestUtil.randomTextFileContent();
 
 	private static final byte[] _OBJECT_FIELD_VALUE_ATTACHMENT_USER_COMPUTER =
-		DLTestUtil.randomTextFileContent(8);
+		DLTestUtil.randomTextFileContent();
 
 	private static BundleContext _bundleContext;
 	private static final BiFunction

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -2330,10 +2330,10 @@ public class BatchEnginePortletDataHandlerTest {
 			company.getGroupId());
 
 		FileEntry tempFileEntry1 = _addTempFileEntry(
-			objectDefinition,
-			_OBJECT_FIELD_VALUE_ATTACHMENT_SHOW_FILES_IN_DOCS_AND_MEDIA);
+			_OBJECT_FIELD_VALUE_ATTACHMENT_SHOW_FILES_IN_DOCS_AND_MEDIA,
+			objectDefinition);
 		FileEntry tempFileEntry2 = _addTempFileEntry(
-			objectDefinition, _OBJECT_FIELD_VALUE_ATTACHMENT_USER_COMPUTER);
+			_OBJECT_FIELD_VALUE_ATTACHMENT_USER_COMPUTER, objectDefinition);
 
 		return _addObjectEntry(
 			groupId, objectDefinition,
@@ -2377,15 +2377,14 @@ public class BatchEnginePortletDataHandlerTest {
 	}
 
 	private FileEntry _addTempFileEntry(
-			ObjectDefinition objectDefinition, String tempFileName)
+			String content, ObjectDefinition objectDefinition)
 		throws Exception {
-
-		String content = "test\n" + tempFileName;
 
 		return TempFileEntryUtil.addTempFileEntry(
 			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
 			objectDefinition.getPortletId(),
-			TempFileEntryUtil.getTempFileName(tempFileName + ".txt"),
+			TempFileEntryUtil.getTempFileName(
+				RandomTestUtil.randomString() + ".txt"),
 			FileUtil.createTempFile(content.getBytes()),
 			ContentTypes.TEXT_PLAIN);
 	}
@@ -2576,7 +2575,7 @@ public class BatchEnginePortletDataHandlerTest {
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER));
 
 			Assert.assertEquals(
-				"test\n" + _OBJECT_FIELD_VALUE_ATTACHMENT_USER_COMPUTER,
+				_OBJECT_FIELD_VALUE_ATTACHMENT_USER_COMPUTER,
 				StringUtil.read(dlFileEntry.getContentStream()));
 		}
 	}
@@ -3654,14 +3653,14 @@ public class BatchEnginePortletDataHandlerTest {
 		"xText" + RandomTestUtil.randomString();
 
 	private static final String _OBJECT_FIELD_VALUE_ATTACHMENT_DOCS_AND_MEDIA =
-		RandomTestUtil.randomString();
+		"test\n" + RandomTestUtil.randomString();
 
 	private static final String
 		_OBJECT_FIELD_VALUE_ATTACHMENT_SHOW_FILES_IN_DOCS_AND_MEDIA =
-			RandomTestUtil.randomString();
+			"test\n" + RandomTestUtil.randomString();
 
 	private static final String _OBJECT_FIELD_VALUE_ATTACHMENT_USER_COMPUTER =
-		RandomTestUtil.randomString();
+		"test\n" + RandomTestUtil.randomString();
 
 	private static BundleContext _bundleContext;
 	private static final BiFunction

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -3653,14 +3653,14 @@ public class BatchEnginePortletDataHandlerTest {
 		"xText" + RandomTestUtil.randomString();
 
 	private static final byte[] _OBJECT_FIELD_VALUE_ATTACHMENT_DOCS_AND_MEDIA =
-		DLTestUtil.randomTextFileContent();
+		DLTestUtil.randomTextFileBytes();
 
 	private static final byte[]
 		_OBJECT_FIELD_VALUE_ATTACHMENT_SHOW_FILES_IN_DOCS_AND_MEDIA =
-			DLTestUtil.randomTextFileContent();
+			DLTestUtil.randomTextFileBytes();
 
 	private static final byte[] _OBJECT_FIELD_VALUE_ATTACHMENT_USER_COMPUTER =
-		DLTestUtil.randomTextFileContent();
+		DLTestUtil.randomTextFileBytes();
 
 	private static BundleContext _bundleContext;
 	private static final BiFunction

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -16,6 +16,7 @@ import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.test.util.DLTestUtil;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
 import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationSettingsMapFactoryUtil;
@@ -3653,14 +3654,14 @@ public class BatchEnginePortletDataHandlerTest {
 		"xText" + RandomTestUtil.randomString();
 
 	private static final String _OBJECT_FIELD_VALUE_ATTACHMENT_DOCS_AND_MEDIA =
-		StringUtil.randomId(8);
+		DLTestUtil.randomTextFileContent(8);
 
 	private static final String
 		_OBJECT_FIELD_VALUE_ATTACHMENT_SHOW_FILES_IN_DOCS_AND_MEDIA =
-			StringUtil.randomId(8);
+			DLTestUtil.randomTextFileContent(8);
 
 	private static final String _OBJECT_FIELD_VALUE_ATTACHMENT_USER_COMPUTER =
-		StringUtil.randomId(8);
+		DLTestUtil.randomTextFileContent(8);
 
 	private static BundleContext _bundleContext;
 	private static final BiFunction

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -2576,7 +2576,9 @@ public class BatchEnginePortletDataHandlerTest {
 
 			Assert.assertArrayEquals(
 				_OBJECT_FIELD_VALUE_ATTACHMENT_USER_COMPUTER,
-				StringUtil.read(dlFileEntry.getContentStream()).getBytes());
+				StringUtil.read(
+					dlFileEntry.getContentStream()
+				).getBytes());
 		}
 	}
 

--- a/modules/apps/notification/notification-test/build.gradle
+++ b/modules/apps/notification/notification-test/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:commerce:commerce-currency-test-util")
 	testIntegrationImplementation project(":apps:commerce:commerce-product-api")
 	testIntegrationImplementation project(":apps:commerce:commerce-test-util")
+	testIntegrationImplementation project(":apps:document-library:document-library-test-util")
 	testIntegrationImplementation project(":apps:info:info-api")
 	testIntegrationImplementation project(":apps:list-type:list-type-api")
 	testIntegrationImplementation project(":apps:notification:notification-api")

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
@@ -2179,12 +2179,14 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 			String to)
 		throws Exception {
 
+		String content = "test\n" + RandomTestUtil.randomString();
+
 		FileEntry fileEntry = TempFileEntryUtil.addTempFileEntry(
 			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
 			StringUtil.randomString(),
 			TempFileEntryUtil.getTempFileName(
 				StringUtil.randomString() + ".txt"),
-			FileUtil.createTempFile(RandomTestUtil.randomBytes()),
+			FileUtil.createTempFile(content.getBytes()),
 			ContentTypes.TEXT_PLAIN);
 
 		executeNotificationObjectAction(

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
@@ -2185,7 +2185,7 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 			StringUtil.randomString(),
 			TempFileEntryUtil.getTempFileName(
 				StringUtil.randomString() + ".txt"),
-			FileUtil.createTempFile(DLTestUtil.randomTextFileContent(8)),
+			FileUtil.createTempFile(DLTestUtil.randomTextFileContent()),
 			ContentTypes.TEXT_PLAIN);
 
 		executeNotificationObjectAction(

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
@@ -2185,7 +2185,7 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 			StringUtil.randomString(),
 			TempFileEntryUtil.getTempFileName(
 				StringUtil.randomString() + ".txt"),
-			FileUtil.createTempFile(DLTestUtil.randomTextFileContent()),
+			FileUtil.createTempFile(DLTestUtil.randomTextFileBytes()),
 			ContentTypes.TEXT_PLAIN);
 
 		executeNotificationObjectAction(

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
@@ -2179,7 +2179,7 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 			String to)
 		throws Exception {
 
-		String content = "test\n" + RandomTestUtil.randomString();
+		String content = StringUtil.randomId(8);
 
 		FileEntry fileEntry = TempFileEntryUtil.addTempFileEntry(
 			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
@@ -2185,10 +2185,7 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 			StringUtil.randomString(),
 			TempFileEntryUtil.getTempFileName(
 				StringUtil.randomString() + ".txt"),
-			FileUtil.createTempFile(
-				DLTestUtil.randomTextFileContent(
-					8
-				).getBytes()),
+			FileUtil.createTempFile(DLTestUtil.randomTextFileContent(8)),
 			ContentTypes.TEXT_PLAIN);
 
 		executeNotificationObjectAction(

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
@@ -26,6 +26,7 @@ import com.liferay.commerce.service.CommerceSubscriptionEntryLocalService;
 import com.liferay.commerce.test.util.CommerceTestUtil;
 import com.liferay.document.library.kernel.exception.NoSuchFolderException;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.test.util.DLTestUtil;
 import com.liferay.info.item.InfoItemServiceRegistry;
 import com.liferay.list.type.entry.util.ListTypeEntryUtil;
 import com.liferay.list.type.model.ListTypeDefinition;
@@ -2179,14 +2180,15 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 			String to)
 		throws Exception {
 
-		String content = StringUtil.randomId(8);
-
 		FileEntry fileEntry = TempFileEntryUtil.addTempFileEntry(
 			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
 			StringUtil.randomString(),
 			TempFileEntryUtil.getTempFileName(
 				StringUtil.randomString() + ".txt"),
-			FileUtil.createTempFile(content.getBytes()),
+			FileUtil.createTempFile(
+				DLTestUtil.randomTextFileContent(
+					8
+				).getBytes()),
 			ContentTypes.TEXT_PLAIN);
 
 		executeNotificationObjectAction(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -38,6 +38,7 @@ import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryService;
 import com.liferay.document.library.kernel.service.DLFolderService;
+import com.liferay.document.library.test.util.DLTestUtil;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.report.constants.ExportImportReportEntryConstants;
@@ -10549,9 +10550,10 @@ public class DefaultObjectEntryManagerImplTest
 	}
 
 	private File _createTempFile() throws Exception {
-		String content = StringUtil.randomId(8);
-
-		return FileUtil.createTempFile(content.getBytes());
+		return FileUtil.createTempFile(
+			DLTestUtil.randomTextFileContent(
+				8
+			).getBytes());
 	}
 
 	private void _deleteAccountEntryOrganizationRel(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -1563,7 +1563,7 @@ public class DefaultObjectEntryManagerImplTest
 									objectDefinition.getPortletId(),
 									TempFileEntryUtil.getTempFileName(fileName),
 									FileUtil.createTempFile(
-										DLTestUtil.randomTextFileContent()),
+										DLTestUtil.randomTextFileBytes()),
 									ContentTypes.TEXT_PLAIN);
 
 							return fileEntry.getFileEntryId();
@@ -10064,7 +10064,7 @@ public class DefaultObjectEntryManagerImplTest
 			TempFileEntryUtil.addTempFileEntry(
 				TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
 				folderName, TempFileEntryUtil.getTempFileName(title + ".txt"),
-				FileUtil.createTempFile(DLTestUtil.randomTextFileContent()),
+				FileUtil.createTempFile(DLTestUtil.randomTextFileBytes()),
 				ContentTypes.TEXT_PLAIN);
 
 		return fileEntry.getFileEntryId();

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -1563,7 +1563,7 @@ public class DefaultObjectEntryManagerImplTest
 									objectDefinition.getPortletId(),
 									TempFileEntryUtil.getTempFileName(fileName),
 									FileUtil.createTempFile(
-										DLTestUtil.randomTextFileContent(8)),
+										DLTestUtil.randomTextFileContent()),
 									ContentTypes.TEXT_PLAIN);
 
 							return fileEntry.getFileEntryId();
@@ -10064,7 +10064,7 @@ public class DefaultObjectEntryManagerImplTest
 			TempFileEntryUtil.addTempFileEntry(
 				TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
 				folderName, TempFileEntryUtil.getTempFileName(title + ".txt"),
-				FileUtil.createTempFile(DLTestUtil.randomTextFileContent(8)),
+				FileUtil.createTempFile(DLTestUtil.randomTextFileContent()),
 				ContentTypes.TEXT_PLAIN);
 
 		return fileEntry.getFileEntryId();

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -10549,7 +10549,7 @@ public class DefaultObjectEntryManagerImplTest
 	}
 
 	private File _createTempFile() throws Exception {
-		String content = "test\n" + RandomTestUtil.randomString();
+		String content = StringUtil.randomId(8);
 
 		return FileUtil.createTempFile(content.getBytes());
 	}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -229,6 +229,7 @@ import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.subscription.service.SubscriptionLocalService;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.InputStream;
 import java.io.Serializable;
 
@@ -1561,10 +1562,7 @@ public class DefaultObjectEntryManagerImplTest
 									TestPropsValues.getUserId(),
 									objectDefinition.getPortletId(),
 									TempFileEntryUtil.getTempFileName(fileName),
-									FileUtil.createTempFile(
-										RandomTestUtil.randomString(
-										).getBytes()),
-									ContentTypes.TEXT_PLAIN);
+									_createTempFile(), ContentTypes.TEXT_PLAIN);
 
 							return fileEntry.getFileEntryId();
 						}
@@ -10064,8 +10062,7 @@ public class DefaultObjectEntryManagerImplTest
 			TempFileEntryUtil.addTempFileEntry(
 				TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
 				folderName, TempFileEntryUtil.getTempFileName(title + ".txt"),
-				FileUtil.createTempFile(RandomTestUtil.randomBytes()),
-				ContentTypes.TEXT_PLAIN);
+				_createTempFile(), ContentTypes.TEXT_PLAIN);
 
 		return fileEntry.getFileEntryId();
 	}
@@ -10549,6 +10546,12 @@ public class DefaultObjectEntryManagerImplTest
 		objectFieldSetting.setValue(value);
 
 		return objectFieldSetting;
+	}
+
+	private File _createTempFile() throws Exception {
+		String content = "test\n" + RandomTestUtil.randomString();
+
+		return FileUtil.createTempFile(content.getBytes());
 	}
 
 	private void _deleteAccountEntryOrganizationRel(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -230,7 +230,6 @@ import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.subscription.service.SubscriptionLocalService;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.InputStream;
 import java.io.Serializable;
 
@@ -1563,7 +1562,9 @@ public class DefaultObjectEntryManagerImplTest
 									TestPropsValues.getUserId(),
 									objectDefinition.getPortletId(),
 									TempFileEntryUtil.getTempFileName(fileName),
-									_createTempFile(), ContentTypes.TEXT_PLAIN);
+									FileUtil.createTempFile(
+										DLTestUtil.randomTextFileContent(8)),
+									ContentTypes.TEXT_PLAIN);
 
 							return fileEntry.getFileEntryId();
 						}
@@ -10063,7 +10064,8 @@ public class DefaultObjectEntryManagerImplTest
 			TempFileEntryUtil.addTempFileEntry(
 				TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
 				folderName, TempFileEntryUtil.getTempFileName(title + ".txt"),
-				_createTempFile(), ContentTypes.TEXT_PLAIN);
+				FileUtil.createTempFile(DLTestUtil.randomTextFileContent(8)),
+				ContentTypes.TEXT_PLAIN);
 
 		return fileEntry.getFileEntryId();
 	}
@@ -10547,13 +10549,6 @@ public class DefaultObjectEntryManagerImplTest
 		objectFieldSetting.setValue(value);
 
 		return objectFieldSetting;
-	}
-
-	private File _createTempFile() throws Exception {
-		return FileUtil.createTempFile(
-			DLTestUtil.randomTextFileContent(
-				8
-			).getBytes());
 	}
 
 	private void _deleteAccountEntryOrganizationRel(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -7471,7 +7471,7 @@ public class ObjectEntryResourceTest {
 				_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1),
 			scopeJSONObject);
 
-		String content = DLTestUtil.randomTextFileContent(8);
+		byte[] content = DLTestUtil.randomTextFileContent(8);
 
 		fileEntry = _addTempFileEntry(
 			content, _objectDefinition1, RandomTestUtil.randomString());
@@ -7490,7 +7490,7 @@ public class ObjectEntryResourceTest {
 			Http.Method.POST);
 
 		_assertAttachmentJSONObject(
-			null, Base64.encode(content.getBytes()),
+			null, Base64.encode(content),
 			jsonObject.getJSONObject(
 				_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1),
 			scopeJSONObject);
@@ -7519,7 +7519,7 @@ public class ObjectEntryResourceTest {
 			Http.Method.GET);
 
 		_assertAttachmentJSONObject(
-			null, Base64.encode(content.getBytes()),
+			null, Base64.encode(content),
 			jsonObject.getJSONObject(
 				_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1),
 			scopeJSONObject);
@@ -7574,7 +7574,7 @@ public class ObjectEntryResourceTest {
 			Http.Method.GET);
 
 		_assertAttachmentJSONObject(
-			null, Base64.encode(content.getBytes()),
+			null, Base64.encode(content),
 			jsonObject.getJSONObject(
 				_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE),
 			scopeJSONObject);
@@ -12211,7 +12211,7 @@ public class ObjectEntryResourceTest {
 			String.valueOf(_jsonFactory.createJSONObject()),
 			objectDefinition.getRESTContextPath(), Http.Method.POST);
 
-		String fileContent1 = DLTestUtil.randomTextFileContent(8);
+		byte[] fileContent1 = DLTestUtil.randomTextFileContent(8);
 
 		com.liferay.object.rest.dto.v1_0.FileEntry fileEntry1 = _toFileEntry(
 			Base64::encode, fileContent1,
@@ -12224,7 +12224,7 @@ public class ObjectEntryResourceTest {
 
 		fileEntry1.setScope(scope);
 
-		String fileContent2 = DLTestUtil.randomTextFileContent(8);
+		byte[] fileContent2 = DLTestUtil.randomTextFileContent(8);
 
 		com.liferay.object.rest.dto.v1_0.FileEntry fileEntry2 = _toFileEntry(
 			Base64::encode, fileContent2,
@@ -12256,11 +12256,11 @@ public class ObjectEntryResourceTest {
 			jsonObject.getJSONObject("localizedAttachment_i18n");
 
 		_assertAttachmentJSONObject(
-			null, Base64.encode(fileContent1.getBytes()),
+			null, Base64.encode(fileContent1),
 			localizedAttachmentI18nValuesJSONObject.getJSONObject("en_US"),
 			_jsonFactory.createJSONObject(scope.toString()));
 		_assertAttachmentJSONObject(
-			null, Base64.encode(fileContent2.getBytes()),
+			null, Base64.encode(fileContent2),
 			localizedAttachmentI18nValuesJSONObject.getJSONObject("pt_BR"),
 			_jsonFactory.createJSONObject(scope.toString()));
 
@@ -12274,12 +12274,11 @@ public class ObjectEntryResourceTest {
 				ServiceContextTestUtil.getServiceContext());
 
 		DLFileEntry existingDLFileEntry = _addDLFileEntry(
-			StringPool.BLANK, existingFolder.getFolderId());
+			new byte[0], existingFolder.getFolderId());
 
 		com.liferay.object.rest.dto.v1_0.FileEntry fileEntry3 = _toFileEntry(
-			content -> null, StringPool.BLANK,
-			existingDLFileEntry.getFileName(), null, _testGroupId,
-			existingDLFileEntry.getMimeType());
+			content -> null, new byte[0], existingDLFileEntry.getFileName(),
+			null, _testGroupId, existingDLFileEntry.getMimeType());
 
 		fileEntry3.setExternalReferenceCode(
 			existingDLFileEntry.getExternalReferenceCode());
@@ -15513,7 +15512,7 @@ public class ObjectEntryResourceTest {
 		return objectDefinition;
 	}
 
-	private DLFileEntry _addDLFileEntry(String content, long folderId)
+	private DLFileEntry _addDLFileEntry(byte[] content, long folderId)
 		throws Exception {
 
 		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
@@ -15522,7 +15521,7 @@ public class ObjectEntryResourceTest {
 				RandomTestUtil.randomString() + ".txt"),
 			ContentTypes.TEXT_PLAIN, RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
-			new ByteArrayInputStream(content.getBytes()), 0, null, null, null,
+			new ByteArrayInputStream(content), 0, null, null, null,
 			ServiceContextTestUtil.getServiceContext());
 
 		return _dlFileEntryLocalService.getFileEntry(
@@ -15685,15 +15684,14 @@ public class ObjectEntryResourceTest {
 	}
 
 	private FileEntry _addTempFileEntry(
-			String content, ObjectDefinition objectDefinition, String title)
+			byte[] content, ObjectDefinition objectDefinition, String title)
 		throws Exception {
 
 		return TempFileEntryUtil.addTempFileEntry(
 			_testGroupId, TestPropsValues.getUserId(),
 			objectDefinition.getPortletId(),
 			TempFileEntryUtil.getTempFileName(title + ".txt"),
-			FileUtil.createTempFile(content.getBytes()),
-			ContentTypes.TEXT_PLAIN);
+			FileUtil.createTempFile(content), ContentTypes.TEXT_PLAIN);
 	}
 
 	private User _addUser(String userName, String userPassword)
@@ -18232,10 +18230,7 @@ public class ObjectEntryResourceTest {
 			StringUtil.randomString(),
 			TempFileEntryUtil.getTempFileName(
 				StringUtil.randomString() + ".txt"),
-			FileUtil.createTempFile(
-				DLTestUtil.randomTextFileContent(
-					8
-				).getBytes()),
+			FileUtil.createTempFile(DLTestUtil.randomTextFileContent(8)),
 			ContentTypes.TEXT_PLAIN);
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			RandomTestUtil.randomLocaleStringMap(),
@@ -18348,7 +18343,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE,
 			useExternalReferenceCode);
 
-		String fileContent = DLTestUtil.randomTextFileContent(8);
+		byte[] fileContent = DLTestUtil.randomTextFileContent(8);
 
 		com.liferay.portal.kernel.repository.model.Folder existingFolder =
 			_dlAppLocalService.addFolder(
@@ -18713,7 +18708,9 @@ public class ObjectEntryResourceTest {
 				"title", "Unable to decode Base64 file"
 			),
 			_toFileEntry(
-				String::new, "$" + DLTestUtil.randomTextFileContent(7),
+				String::new,
+				ArrayUtil.append(
+					DLTestUtil.randomTextFileContent(7), (byte)'$'),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -19196,10 +19193,7 @@ public class ObjectEntryResourceTest {
 			StringUtil.randomString(),
 			TempFileEntryUtil.getTempFileName(
 				StringUtil.randomString() + ".txt"),
-			FileUtil.createTempFile(
-				DLTestUtil.randomTextFileContent(
-					8
-				).getBytes()),
+			FileUtil.createTempFile(DLTestUtil.randomTextFileContent(8)),
 			ContentTypes.TEXT_PLAIN);
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			RandomTestUtil.randomLocaleStringMap(),
@@ -19305,7 +19299,7 @@ public class ObjectEntryResourceTest {
 			null, objectDefinition,
 			_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE);
 
-		String fileContent = DLTestUtil.randomTextFileContent(8);
+		byte[] fileContent = DLTestUtil.randomTextFileContent(8);
 
 		com.liferay.portal.kernel.repository.model.Folder existingFolder =
 			_dlAppLocalService.addFolder(
@@ -19680,7 +19674,9 @@ public class ObjectEntryResourceTest {
 				"title", "Unable to decode Base64 file"
 			),
 			_toFileEntry(
-				String::new, "$" + DLTestUtil.randomTextFileContent(7),
+				String::new,
+				ArrayUtil.append(
+					DLTestUtil.randomTextFileContent(7), (byte)'$'),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -20461,8 +20457,7 @@ public class ObjectEntryResourceTest {
 				TempFileEntryUtil.getTempFileName("foo.pdf"),
 				FileUtil.createTempFile(
 					DLTestUtil.randomTextFileContent(
-						(_MAX_FILE_SIZE_VALUE * 1024 * 1024) + 1
-					).getBytes()),
+						(_MAX_FILE_SIZE_VALUE * 1024 * 1024) + 1)),
 				ContentTypes.TEXT_PLAIN);
 
 			validationResponse = _validate(
@@ -21255,14 +21250,14 @@ public class ObjectEntryResourceTest {
 	}
 
 	private com.liferay.object.rest.dto.v1_0.FileEntry _toFileEntry(
-		Function<byte[], String> encodeFunction, String fileContent,
+		Function<byte[], String> encodeFunction, byte[] fileContent,
 		String fileName, String folderExternalReferenceCode, Long folderSiteId,
 		String mimeType) {
 
 		com.liferay.object.rest.dto.v1_0.FileEntry fileEntry =
 			new com.liferay.object.rest.dto.v1_0.FileEntry();
 
-		fileEntry.setFileBase64(encodeFunction.apply(fileContent.getBytes()));
+		fileEntry.setFileBase64(encodeFunction.apply(fileContent));
 		fileEntry.setName(fileName);
 		fileEntry.setMimeType(mimeType);
 
@@ -21315,14 +21310,14 @@ public class ObjectEntryResourceTest {
 	}
 
 	private JSONObject _toFileEntryJSONObject(
-			String fileContent, String fileName, Folder folder, String mimeType,
+			byte[] fileContent, String fileName, Folder folder, String mimeType,
 			String objectFieldName)
 		throws Exception {
 
 		com.liferay.object.rest.dto.v1_0.FileEntry fileEntry =
 			new com.liferay.object.rest.dto.v1_0.FileEntry();
 
-		fileEntry.setFileBase64(Base64.encode(fileContent.getBytes()));
+		fileEntry.setFileBase64(Base64.encode(fileContent));
 		fileEntry.setMimeType(mimeType);
 
 		if (StringUtil.equals(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -7243,7 +7243,7 @@ public class ObjectEntryResourceTest {
 					Http.Method.PUT);
 
 				Assert.assertNotEquals(
-					jsonObject.getString("title"), "FORBIDDEN",
+					jsonObject.getString("status"), "FORBIDDEN",
 					jsonObject.getString("status"));
 			}
 		);
@@ -18495,8 +18495,6 @@ public class ObjectEntryResourceTest {
 				_testPatchPutCustomObjectEntryWithAttachmentField(
 					fileEntry -> JSONUtil.put(
 						"status", "FORBIDDEN"
-					).put(
-						"title", "Forbidden"
 					),
 					_toFileEntry(
 						Base64::encode, RandomTestUtil.randomString(),
@@ -19445,8 +19443,6 @@ public class ObjectEntryResourceTest {
 				_testPostCustomObjectEntryWithAttachmentObjectField(
 					fileEntry -> JSONUtil.put(
 						"status", "FORBIDDEN"
-					).put(
-						"title", "Forbidden"
 					),
 					_toFileEntry(
 						Base64::encode, RandomTestUtil.randomString(),

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -7442,7 +7442,7 @@ public class ObjectEntryResourceTest {
 	@Test
 	public void testGetObjectEntryWithAttachmentObjectField() throws Exception {
 		FileEntry fileEntry = _addTempFileEntry(
-			DLTestUtil.randomTextFileContent(), _objectDefinition1,
+			DLTestUtil.randomTextFileBytes(), _objectDefinition1,
 			RandomTestUtil.randomString());
 
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
@@ -7471,7 +7471,7 @@ public class ObjectEntryResourceTest {
 				_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1),
 			scopeJSONObject);
 
-		byte[] content = DLTestUtil.randomTextFileContent();
+		byte[] content = DLTestUtil.randomTextFileBytes();
 
 		fileEntry = _addTempFileEntry(
 			content, _objectDefinition1, RandomTestUtil.randomString());
@@ -7524,7 +7524,7 @@ public class ObjectEntryResourceTest {
 				_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1),
 			scopeJSONObject);
 
-		content = DLTestUtil.randomTextFileContent();
+		content = DLTestUtil.randomTextFileBytes();
 
 		DLFileEntry dlFileEntry = _addDLFileEntry(
 			content, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
@@ -7786,7 +7786,7 @@ public class ObjectEntryResourceTest {
 						"upload",
 						() -> {
 							FileEntry fileEntry = _addTempFileEntry(
-								DLTestUtil.randomTextFileContent(),
+								DLTestUtil.randomTextFileBytes(),
 								objectDefinition, "Old Testament");
 
 							return fileEntry.getFileEntryId();
@@ -7811,7 +7811,7 @@ public class ObjectEntryResourceTest {
 					"upload",
 					() -> {
 						FileEntry fileEntry = _addTempFileEntry(
-							DLTestUtil.randomTextFileContent(),
+							DLTestUtil.randomTextFileBytes(),
 							objectDefinition, "New Testament");
 
 						return fileEntry.getFileEntryId();
@@ -9622,7 +9622,7 @@ public class ObjectEntryResourceTest {
 				JSONFactoryUtil.createJSONObject(
 					String.valueOf(
 						_toFileEntry(
-							Base64::encode, DLTestUtil.randomTextFileContent(),
+							Base64::encode, DLTestUtil.randomTextFileBytes(),
 							RandomTestUtil.randomString() + ".txt", null, null,
 							ContentTypes.TEXT_PLAIN)))
 			).toString(),
@@ -12211,7 +12211,7 @@ public class ObjectEntryResourceTest {
 			String.valueOf(_jsonFactory.createJSONObject()),
 			objectDefinition.getRESTContextPath(), Http.Method.POST);
 
-		byte[] fileContent1 = DLTestUtil.randomTextFileContent();
+		byte[] fileContent1 = DLTestUtil.randomTextFileBytes();
 
 		com.liferay.object.rest.dto.v1_0.FileEntry fileEntry1 = _toFileEntry(
 			Base64::encode, fileContent1,
@@ -12224,7 +12224,7 @@ public class ObjectEntryResourceTest {
 
 		fileEntry1.setScope(scope);
 
-		byte[] fileContent2 = DLTestUtil.randomTextFileContent();
+		byte[] fileContent2 = DLTestUtil.randomTextFileBytes();
 
 		com.liferay.object.rest.dto.v1_0.FileEntry fileEntry2 = _toFileEntry(
 			Base64::encode, fileContent2,
@@ -18230,7 +18230,7 @@ public class ObjectEntryResourceTest {
 			StringUtil.randomString(),
 			TempFileEntryUtil.getTempFileName(
 				StringUtil.randomString() + ".txt"),
-			FileUtil.createTempFile(DLTestUtil.randomTextFileContent()),
+			FileUtil.createTempFile(DLTestUtil.randomTextFileBytes()),
 			ContentTypes.TEXT_PLAIN);
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			RandomTestUtil.randomLocaleStringMap(),
@@ -18246,7 +18246,7 @@ public class ObjectEntryResourceTest {
 					fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_CMS_BASIC_DOCUMENT_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt", null,
 				depotEntry.getGroupId(), customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18264,7 +18264,7 @@ public class ObjectEntryResourceTest {
 					dlFolder1, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder1.getExternalReferenceCode(), dlFolder1.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -18281,7 +18281,7 @@ public class ObjectEntryResourceTest {
 					dlFolder2, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder2.getExternalReferenceCode(), dlFolder2.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -18296,7 +18296,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18309,7 +18309,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt", null,
 				_group.getGroupId(), customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18322,7 +18322,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt", null, _testGroupId,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18335,7 +18335,7 @@ public class ObjectEntryResourceTest {
 		_testPatchPutCustomObjectEntryWithAttachmentField(
 			fileEntry -> JSONUtil.put("status", "NOT_FOUND"),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), _testGroupId,
 				customFileEntry1.getMimeType()),
@@ -18343,7 +18343,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE,
 			useExternalReferenceCode);
 
-		byte[] fileContent = DLTestUtil.randomTextFileContent();
+		byte[] fileContent = DLTestUtil.randomTextFileBytes();
 
 		com.liferay.portal.kernel.repository.model.Folder existingFolder =
 			_dlAppLocalService.addFolder(
@@ -18382,7 +18382,7 @@ public class ObjectEntryResourceTest {
 			useExternalReferenceCode);
 
 		testFileEntry = _toFileEntry(
-			content -> null, DLTestUtil.randomTextFileContent(),
+			content -> null, DLTestUtil.randomTextFileBytes(),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -18452,7 +18452,7 @@ public class ObjectEntryResourceTest {
 					));
 			},
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder1.getExternalReferenceCode(), dlFolder1.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -18492,7 +18492,7 @@ public class ObjectEntryResourceTest {
 				_testPatchPutCustomObjectEntryWithAttachmentField(
 					fileEntry -> JSONUtil.put("status", "FORBIDDEN"),
 					_toFileEntry(
-						Base64::encode, DLTestUtil.randomTextFileContent(),
+						Base64::encode, DLTestUtil.randomTextFileBytes(),
 						RandomTestUtil.randomString() + ".txt",
 						dlFolder.getExternalReferenceCode(),
 						dlFolder.getGroupId(), customFileEntry1.getMimeType()),
@@ -18514,7 +18514,7 @@ public class ObjectEntryResourceTest {
 							dlFolder, fileEntry, objectDefinition,
 							_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 					_toFileEntry(
-						Base64::encode, DLTestUtil.randomTextFileContent(),
+						Base64::encode, DLTestUtil.randomTextFileBytes(),
 						RandomTestUtil.randomString() + ".txt",
 						dlFolder.getExternalReferenceCode(),
 						dlFolder.getGroupId(), customFileEntry1.getMimeType()),
@@ -18648,7 +18648,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_CMS_BASIC_DOCUMENT_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18669,7 +18669,7 @@ public class ObjectEntryResourceTest {
 			),
 			_toFileEntry(
 				Base64::encode,
-				DLTestUtil.randomTextFileContent(
+				DLTestUtil.randomTextFileBytes(
 					(_MAX_FILE_SIZE_VALUE * 1024 * 1024) + 1),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
@@ -18683,7 +18683,7 @@ public class ObjectEntryResourceTest {
 				"title", "File name is null"
 			),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(), null, null,
+				Base64::encode, DLTestUtil.randomTextFileBytes(), null, null,
 				null, customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
 			_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1,
@@ -18695,7 +18695,7 @@ public class ObjectEntryResourceTest {
 				"title", "Invalid file extension for " + fileEntry.getName()
 			),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".err", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18710,7 +18710,7 @@ public class ObjectEntryResourceTest {
 			_toFileEntry(
 				String::new,
 				ArrayUtil.append(
-					DLTestUtil.randomTextFileContent(7), (byte)'$'),
+					DLTestUtil.randomTextFileBytes(7), (byte)'$'),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18725,7 +18725,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18739,7 +18739,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 				customFileEntry1.getMimeType()),
@@ -18754,7 +18754,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18768,7 +18768,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 				customFileEntry1.getMimeType()),
@@ -18780,7 +18780,7 @@ public class ObjectEntryResourceTest {
 		// existing name
 
 		testFileEntry = _toFileEntry(
-			Base64::encode, DLTestUtil.randomTextFileContent(),
+			Base64::encode, DLTestUtil.randomTextFileBytes(),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -18812,7 +18812,7 @@ public class ObjectEntryResourceTest {
 			useExternalReferenceCode);
 
 		testFileEntry = _toFileEntry(
-			Base64::encode, DLTestUtil.randomTextFileContent(),
+			Base64::encode, DLTestUtil.randomTextFileBytes(),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -18859,7 +18859,7 @@ public class ObjectEntryResourceTest {
 						"fileBase64", fileEntry.getFileBase64());
 				}),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, "fileBase64,folder", objectDefinition,
@@ -18878,7 +18878,7 @@ public class ObjectEntryResourceTest {
 						"fileBase64", fileEntry.getFileBase64());
 				}),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, "fileBase64,folder", objectDefinition,
@@ -18902,7 +18902,7 @@ public class ObjectEntryResourceTest {
 			).put(
 				objectFieldName,
 				_toFileEntryJSONObject(
-					DLTestUtil.randomTextFileContent(),
+					DLTestUtil.randomTextFileBytes(),
 					RandomTestUtil.randomString() + ".txt",
 					fileEntry.getFolder(), ContentTypes.TEXT_PLAIN,
 					objectFieldName)
@@ -19193,7 +19193,7 @@ public class ObjectEntryResourceTest {
 			StringUtil.randomString(),
 			TempFileEntryUtil.getTempFileName(
 				StringUtil.randomString() + ".txt"),
-			FileUtil.createTempFile(DLTestUtil.randomTextFileContent()),
+			FileUtil.createTempFile(DLTestUtil.randomTextFileBytes()),
 			ContentTypes.TEXT_PLAIN);
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			RandomTestUtil.randomLocaleStringMap(),
@@ -19209,7 +19209,7 @@ public class ObjectEntryResourceTest {
 					fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_CMS_BASIC_DOCUMENT_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt", null,
 				depotEntry.getGroupId(), customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19226,7 +19226,7 @@ public class ObjectEntryResourceTest {
 					dlFolder1, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder1.getExternalReferenceCode(), dlFolder1.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -19242,7 +19242,7 @@ public class ObjectEntryResourceTest {
 					dlFolder2, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder2.getExternalReferenceCode(), dlFolder2.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -19256,7 +19256,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19268,7 +19268,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt", null,
 				_group.getGroupId(), customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19280,7 +19280,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt", null, _testGroupId,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19292,14 +19292,14 @@ public class ObjectEntryResourceTest {
 		_testPostCustomObjectEntryWithAttachmentObjectField(
 			fileEntry -> JSONUtil.put("status", "NOT_FOUND"),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), _testGroupId,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
 			_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE);
 
-		byte[] fileContent = DLTestUtil.randomTextFileContent();
+		byte[] fileContent = DLTestUtil.randomTextFileBytes();
 
 		com.liferay.portal.kernel.repository.model.Folder existingFolder =
 			_dlAppLocalService.addFolder(
@@ -19337,7 +19337,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE);
 
 		testFileEntry = _toFileEntry(
-			content -> null, DLTestUtil.randomTextFileContent(),
+			content -> null, DLTestUtil.randomTextFileBytes(),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -19406,7 +19406,7 @@ public class ObjectEntryResourceTest {
 					));
 			},
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder1.getExternalReferenceCode(), dlFolder1.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -19440,7 +19440,7 @@ public class ObjectEntryResourceTest {
 				_testPostCustomObjectEntryWithAttachmentObjectField(
 					fileEntry -> JSONUtil.put("status", "FORBIDDEN"),
 					_toFileEntry(
-						Base64::encode, DLTestUtil.randomTextFileContent(),
+						Base64::encode, DLTestUtil.randomTextFileBytes(),
 						RandomTestUtil.randomString() + ".txt",
 						dlFolder.getExternalReferenceCode(),
 						dlFolder.getGroupId(), customFileEntry1.getMimeType()),
@@ -19461,7 +19461,7 @@ public class ObjectEntryResourceTest {
 							dlFolder, fileEntry, objectDefinition,
 							_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 					_toFileEntry(
-						Base64::encode, DLTestUtil.randomTextFileContent(),
+						Base64::encode, DLTestUtil.randomTextFileBytes(),
 						RandomTestUtil.randomString() + ".txt",
 						dlFolder.getExternalReferenceCode(),
 						dlFolder.getGroupId(), customFileEntry1.getMimeType()),
@@ -19618,7 +19618,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_CMS_BASIC_DOCUMENT_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19638,7 +19638,7 @@ public class ObjectEntryResourceTest {
 			),
 			_toFileEntry(
 				Base64::encode,
-				DLTestUtil.randomTextFileContent(
+				DLTestUtil.randomTextFileBytes(
 					(_MAX_FILE_SIZE_VALUE * 1024 * 1024) + 1),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
@@ -19651,7 +19651,7 @@ public class ObjectEntryResourceTest {
 				"title", "File name is null"
 			),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(), null, null,
+				Base64::encode, DLTestUtil.randomTextFileBytes(), null, null,
 				null, customFileEntry1.getMimeType()),
 			null, objectDefinition,
 			_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2);
@@ -19662,7 +19662,7 @@ public class ObjectEntryResourceTest {
 				"title", "Invalid file extension for " + fileEntry.getName()
 			),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".err", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19676,7 +19676,7 @@ public class ObjectEntryResourceTest {
 			_toFileEntry(
 				String::new,
 				ArrayUtil.append(
-					DLTestUtil.randomTextFileContent(7), (byte)'$'),
+					DLTestUtil.randomTextFileBytes(7), (byte)'$'),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19690,7 +19690,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19703,7 +19703,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 				customFileEntry1.getMimeType()),
@@ -19717,7 +19717,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19730,7 +19730,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 				customFileEntry1.getMimeType()),
@@ -19741,7 +19741,7 @@ public class ObjectEntryResourceTest {
 		// existing name
 
 		testFileEntry = _toFileEntry(
-			Base64::encode, DLTestUtil.randomTextFileContent(),
+			Base64::encode, DLTestUtil.randomTextFileBytes(),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -19771,7 +19771,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1);
 
 		testFileEntry = _toFileEntry(
-			Base64::encode, DLTestUtil.randomTextFileContent(),
+			Base64::encode, DLTestUtil.randomTextFileBytes(),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -19803,7 +19803,7 @@ public class ObjectEntryResourceTest {
 		// User computer to documents and media source, file from Base64 with
 		// external reference code
 
-		fileContent = DLTestUtil.randomTextFileContent();
+		fileContent = DLTestUtil.randomTextFileBytes();
 
 		existingDLFileEntry = _addDLFileEntry(
 			fileContent, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
@@ -19835,7 +19835,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2);
 
 		testFileEntry = _toFileEntry(
-			content -> null, DLTestUtil.randomTextFileContent(),
+			content -> null, DLTestUtil.randomTextFileBytes(),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -19887,7 +19887,7 @@ public class ObjectEntryResourceTest {
 						"fileBase64", fileEntry.getFileBase64());
 				}),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			"fileBase64,folder", objectDefinition,
@@ -19905,7 +19905,7 @@ public class ObjectEntryResourceTest {
 						"fileBase64", fileEntry.getFileBase64());
 				}),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(),
+				Base64::encode, DLTestUtil.randomTextFileBytes(),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			"fileBase64,folder", objectDefinition,
@@ -20456,7 +20456,7 @@ public class ObjectEntryResourceTest {
 				objectDefinition.getPortletId(),
 				TempFileEntryUtil.getTempFileName("foo.pdf"),
 				FileUtil.createTempFile(
-					DLTestUtil.randomTextFileContent(
+					DLTestUtil.randomTextFileBytes(
 						(_MAX_FILE_SIZE_VALUE * 1024 * 1024) + 1)),
 				ContentTypes.TEXT_PLAIN);
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -7442,7 +7442,7 @@ public class ObjectEntryResourceTest {
 	@Test
 	public void testGetObjectEntryWithAttachmentObjectField() throws Exception {
 		FileEntry fileEntry = _addTempFileEntry(
-			_getRandomFileContent(8), _objectDefinition1,
+			StringUtil.randomId(8), _objectDefinition1,
 			RandomTestUtil.randomString());
 
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
@@ -7471,7 +7471,7 @@ public class ObjectEntryResourceTest {
 				_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1),
 			scopeJSONObject);
 
-		String content = _getRandomFileContent(8);
+		String content = StringUtil.randomId(8);
 
 		fileEntry = _addTempFileEntry(
 			content, _objectDefinition1, RandomTestUtil.randomString());
@@ -7524,7 +7524,7 @@ public class ObjectEntryResourceTest {
 				_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1),
 			scopeJSONObject);
 
-		content = _getRandomFileContent(8);
+		content = StringUtil.randomId(8);
 
 		DLFileEntry dlFileEntry = _addDLFileEntry(
 			content, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
@@ -7786,7 +7786,7 @@ public class ObjectEntryResourceTest {
 						"upload",
 						() -> {
 							FileEntry fileEntry = _addTempFileEntry(
-								_getRandomFileContent(8), objectDefinition,
+								StringUtil.randomId(8), objectDefinition,
 								"Old Testament");
 
 							return fileEntry.getFileEntryId();
@@ -7811,7 +7811,7 @@ public class ObjectEntryResourceTest {
 					"upload",
 					() -> {
 						FileEntry fileEntry = _addTempFileEntry(
-							_getRandomFileContent(8), objectDefinition,
+							StringUtil.randomId(8), objectDefinition,
 							"New Testament");
 
 						return fileEntry.getFileEntryId();
@@ -9622,7 +9622,7 @@ public class ObjectEntryResourceTest {
 				JSONFactoryUtil.createJSONObject(
 					String.valueOf(
 						_toFileEntry(
-							Base64::encode, _getRandomFileContent(8),
+							Base64::encode, StringUtil.randomId(8),
 							RandomTestUtil.randomString() + ".txt", null, null,
 							ContentTypes.TEXT_PLAIN)))
 			).toString(),
@@ -12211,7 +12211,7 @@ public class ObjectEntryResourceTest {
 			String.valueOf(_jsonFactory.createJSONObject()),
 			objectDefinition.getRESTContextPath(), Http.Method.POST);
 
-		String fileContent1 = _getRandomFileContent(8);
+		String fileContent1 = StringUtil.randomId(8);
 
 		com.liferay.object.rest.dto.v1_0.FileEntry fileEntry1 = _toFileEntry(
 			Base64::encode, fileContent1,
@@ -12224,7 +12224,7 @@ public class ObjectEntryResourceTest {
 
 		fileEntry1.setScope(scope);
 
-		String fileContent2 = _getRandomFileContent(8);
+		String fileContent2 = StringUtil.randomId(8);
 
 		com.liferay.object.rest.dto.v1_0.FileEntry fileEntry2 = _toFileEntry(
 			Base64::encode, fileContent2,
@@ -16704,15 +16704,6 @@ public class ObjectEntryResourceTest {
 		);
 	}
 
-	private String _getRandomFileContent(int size) {
-		String firstLine = "test\n";
-
-		String randomContent = RandomTestUtil.randomString(
-			size - firstLine.length());
-
-		return firstLine + randomContent;
-	}
-
 	private JSONObject _getRelatedJSONObject(
 		JSONObject jsonObject, String nestedFieldName, Type type) {
 
@@ -18242,7 +18233,7 @@ public class ObjectEntryResourceTest {
 			TempFileEntryUtil.getTempFileName(
 				StringUtil.randomString() + ".txt"),
 			FileUtil.createTempFile(
-				_getRandomFileContent(
+				StringUtil.randomId(
 					8
 				).getBytes()),
 			ContentTypes.TEXT_PLAIN);
@@ -18260,7 +18251,7 @@ public class ObjectEntryResourceTest {
 					fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_CMS_BASIC_DOCUMENT_SOURCE)),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt", null,
 				depotEntry.getGroupId(), customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18278,7 +18269,7 @@ public class ObjectEntryResourceTest {
 					dlFolder1, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder1.getExternalReferenceCode(), dlFolder1.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -18295,7 +18286,7 @@ public class ObjectEntryResourceTest {
 					dlFolder2, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder2.getExternalReferenceCode(), dlFolder2.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -18310,7 +18301,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18323,7 +18314,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt", null,
 				_group.getGroupId(), customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18336,7 +18327,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt", null, _testGroupId,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18349,7 +18340,7 @@ public class ObjectEntryResourceTest {
 		_testPatchPutCustomObjectEntryWithAttachmentField(
 			fileEntry -> JSONUtil.put("status", "NOT_FOUND"),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), _testGroupId,
 				customFileEntry1.getMimeType()),
@@ -18357,7 +18348,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE,
 			useExternalReferenceCode);
 
-		String fileContent = _getRandomFileContent(8);
+		String fileContent = StringUtil.randomId(8);
 
 		com.liferay.portal.kernel.repository.model.Folder existingFolder =
 			_dlAppLocalService.addFolder(
@@ -18396,7 +18387,7 @@ public class ObjectEntryResourceTest {
 			useExternalReferenceCode);
 
 		testFileEntry = _toFileEntry(
-			content -> null, _getRandomFileContent(8),
+			content -> null, StringUtil.randomId(8),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -18466,7 +18457,7 @@ public class ObjectEntryResourceTest {
 					));
 			},
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder1.getExternalReferenceCode(), dlFolder1.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -18506,7 +18497,7 @@ public class ObjectEntryResourceTest {
 				_testPatchPutCustomObjectEntryWithAttachmentField(
 					fileEntry -> JSONUtil.put("status", "FORBIDDEN"),
 					_toFileEntry(
-						Base64::encode, _getRandomFileContent(8),
+						Base64::encode, StringUtil.randomId(8),
 						RandomTestUtil.randomString() + ".txt",
 						dlFolder.getExternalReferenceCode(),
 						dlFolder.getGroupId(), customFileEntry1.getMimeType()),
@@ -18528,7 +18519,7 @@ public class ObjectEntryResourceTest {
 							dlFolder, fileEntry, objectDefinition,
 							_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 					_toFileEntry(
-						Base64::encode, _getRandomFileContent(8),
+						Base64::encode, StringUtil.randomId(8),
 						RandomTestUtil.randomString() + ".txt",
 						dlFolder.getExternalReferenceCode(),
 						dlFolder.getGroupId(), customFileEntry1.getMimeType()),
@@ -18662,7 +18653,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_CMS_BASIC_DOCUMENT_SOURCE)),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18683,7 +18674,7 @@ public class ObjectEntryResourceTest {
 			),
 			_toFileEntry(
 				Base64::encode,
-				_getRandomFileContent((_MAX_FILE_SIZE_VALUE * 1024 * 1024) + 1),
+				StringUtil.randomId((_MAX_FILE_SIZE_VALUE * 1024 * 1024) + 1),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18696,7 +18687,7 @@ public class ObjectEntryResourceTest {
 				"title", "File name is null"
 			),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8), null, null, null,
+				Base64::encode, StringUtil.randomId(8), null, null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
 			_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1,
@@ -18708,7 +18699,7 @@ public class ObjectEntryResourceTest {
 				"title", "Invalid file extension for " + fileEntry.getName()
 			),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".err", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18721,7 +18712,7 @@ public class ObjectEntryResourceTest {
 				"title", "Unable to decode Base64 file"
 			),
 			_toFileEntry(
-				String::new, "$" + _getRandomFileContent(7),
+				String::new, "$" + StringUtil.randomId(7),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18736,7 +18727,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1)),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18750,7 +18741,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1)),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 				customFileEntry1.getMimeType()),
@@ -18765,7 +18756,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2)),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18779,7 +18770,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2)),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 				customFileEntry1.getMimeType()),
@@ -18791,7 +18782,7 @@ public class ObjectEntryResourceTest {
 		// existing name
 
 		testFileEntry = _toFileEntry(
-			Base64::encode, _getRandomFileContent(8),
+			Base64::encode, StringUtil.randomId(8),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -18823,7 +18814,7 @@ public class ObjectEntryResourceTest {
 			useExternalReferenceCode);
 
 		testFileEntry = _toFileEntry(
-			Base64::encode, _getRandomFileContent(8),
+			Base64::encode, StringUtil.randomId(8),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -18870,7 +18861,7 @@ public class ObjectEntryResourceTest {
 						"fileBase64", fileEntry.getFileBase64());
 				}),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, "fileBase64,folder", objectDefinition,
@@ -18889,7 +18880,7 @@ public class ObjectEntryResourceTest {
 						"fileBase64", fileEntry.getFileBase64());
 				}),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, "fileBase64,folder", objectDefinition,
@@ -18913,7 +18904,7 @@ public class ObjectEntryResourceTest {
 			).put(
 				objectFieldName,
 				_toFileEntryJSONObject(
-					_getRandomFileContent(8),
+					StringUtil.randomId(8),
 					RandomTestUtil.randomString() + ".txt",
 					fileEntry.getFolder(), ContentTypes.TEXT_PLAIN,
 					objectFieldName)
@@ -19205,7 +19196,7 @@ public class ObjectEntryResourceTest {
 			TempFileEntryUtil.getTempFileName(
 				StringUtil.randomString() + ".txt"),
 			FileUtil.createTempFile(
-				_getRandomFileContent(
+				StringUtil.randomId(
 					8
 				).getBytes()),
 			ContentTypes.TEXT_PLAIN);
@@ -19223,7 +19214,7 @@ public class ObjectEntryResourceTest {
 					fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_CMS_BASIC_DOCUMENT_SOURCE)),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt", null,
 				depotEntry.getGroupId(), customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19240,7 +19231,7 @@ public class ObjectEntryResourceTest {
 					dlFolder1, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder1.getExternalReferenceCode(), dlFolder1.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -19256,7 +19247,7 @@ public class ObjectEntryResourceTest {
 					dlFolder2, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder2.getExternalReferenceCode(), dlFolder2.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -19270,7 +19261,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19282,7 +19273,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt", null,
 				_group.getGroupId(), customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19294,7 +19285,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt", null, _testGroupId,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19306,14 +19297,14 @@ public class ObjectEntryResourceTest {
 		_testPostCustomObjectEntryWithAttachmentObjectField(
 			fileEntry -> JSONUtil.put("status", "NOT_FOUND"),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), _testGroupId,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
 			_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE);
 
-		String fileContent = _getRandomFileContent(8);
+		String fileContent = StringUtil.randomId(8);
 
 		com.liferay.portal.kernel.repository.model.Folder existingFolder =
 			_dlAppLocalService.addFolder(
@@ -19351,7 +19342,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE);
 
 		testFileEntry = _toFileEntry(
-			content -> null, _getRandomFileContent(8),
+			content -> null, StringUtil.randomId(8),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -19420,7 +19411,7 @@ public class ObjectEntryResourceTest {
 					));
 			},
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder1.getExternalReferenceCode(), dlFolder1.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -19454,7 +19445,7 @@ public class ObjectEntryResourceTest {
 				_testPostCustomObjectEntryWithAttachmentObjectField(
 					fileEntry -> JSONUtil.put("status", "FORBIDDEN"),
 					_toFileEntry(
-						Base64::encode, _getRandomFileContent(8),
+						Base64::encode, StringUtil.randomId(8),
 						RandomTestUtil.randomString() + ".txt",
 						dlFolder.getExternalReferenceCode(),
 						dlFolder.getGroupId(), customFileEntry1.getMimeType()),
@@ -19475,7 +19466,7 @@ public class ObjectEntryResourceTest {
 							dlFolder, fileEntry, objectDefinition,
 							_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 					_toFileEntry(
-						Base64::encode, _getRandomFileContent(8),
+						Base64::encode, StringUtil.randomId(8),
 						RandomTestUtil.randomString() + ".txt",
 						dlFolder.getExternalReferenceCode(),
 						dlFolder.getGroupId(), customFileEntry1.getMimeType()),
@@ -19632,7 +19623,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_CMS_BASIC_DOCUMENT_SOURCE)),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19652,7 +19643,7 @@ public class ObjectEntryResourceTest {
 			),
 			_toFileEntry(
 				Base64::encode,
-				_getRandomFileContent((_MAX_FILE_SIZE_VALUE * 1024 * 1024) + 1),
+				StringUtil.randomId((_MAX_FILE_SIZE_VALUE * 1024 * 1024) + 1),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19664,7 +19655,7 @@ public class ObjectEntryResourceTest {
 				"title", "File name is null"
 			),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8), null, null, null,
+				Base64::encode, StringUtil.randomId(8), null, null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
 			_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2);
@@ -19675,7 +19666,7 @@ public class ObjectEntryResourceTest {
 				"title", "Invalid file extension for " + fileEntry.getName()
 			),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".err", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19687,7 +19678,7 @@ public class ObjectEntryResourceTest {
 				"title", "Unable to decode Base64 file"
 			),
 			_toFileEntry(
-				String::new, "$" + _getRandomFileContent(7),
+				String::new, "$" + StringUtil.randomId(7),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19701,7 +19692,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1)),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19714,7 +19705,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1)),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 				customFileEntry1.getMimeType()),
@@ -19728,7 +19719,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2)),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19741,7 +19732,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2)),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 				customFileEntry1.getMimeType()),
@@ -19752,7 +19743,7 @@ public class ObjectEntryResourceTest {
 		// existing name
 
 		testFileEntry = _toFileEntry(
-			Base64::encode, _getRandomFileContent(8),
+			Base64::encode, StringUtil.randomId(8),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -19782,7 +19773,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1);
 
 		testFileEntry = _toFileEntry(
-			Base64::encode, _getRandomFileContent(8),
+			Base64::encode, StringUtil.randomId(8),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -19814,7 +19805,7 @@ public class ObjectEntryResourceTest {
 		// User computer to documents and media source, file from Base64 with
 		// external reference code
 
-		fileContent = _getRandomFileContent(8);
+		fileContent = StringUtil.randomId(8);
 
 		existingDLFileEntry = _addDLFileEntry(
 			fileContent, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
@@ -19846,7 +19837,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2);
 
 		testFileEntry = _toFileEntry(
-			content -> null, _getRandomFileContent(8),
+			content -> null, StringUtil.randomId(8),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -19898,7 +19889,7 @@ public class ObjectEntryResourceTest {
 						"fileBase64", fileEntry.getFileBase64());
 				}),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			"fileBase64,folder", objectDefinition,
@@ -19916,7 +19907,7 @@ public class ObjectEntryResourceTest {
 						"fileBase64", fileEntry.getFileBase64());
 				}),
 			_toFileEntry(
-				Base64::encode, _getRandomFileContent(8),
+				Base64::encode, StringUtil.randomId(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			"fileBase64,folder", objectDefinition,
@@ -20467,7 +20458,7 @@ public class ObjectEntryResourceTest {
 				objectDefinition.getPortletId(),
 				TempFileEntryUtil.getTempFileName("foo.pdf"),
 				FileUtil.createTempFile(
-					_getRandomFileContent(
+					StringUtil.randomId(
 						(_MAX_FILE_SIZE_VALUE * 1024 * 1024) + 1
 					).getBytes()),
 				ContentTypes.TEXT_PLAIN);

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -7441,10 +7441,9 @@ public class ObjectEntryResourceTest {
 
 	@Test
 	public void testGetObjectEntryWithAttachmentObjectField() throws Exception {
-		String content = RandomTestUtil.randomString();
-
 		FileEntry fileEntry = _addTempFileEntry(
-			content, _objectDefinition1, RandomTestUtil.randomString());
+			_getRandomFileContent(8), _objectDefinition1,
+			RandomTestUtil.randomString());
 
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
@@ -7472,7 +7471,7 @@ public class ObjectEntryResourceTest {
 				_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1),
 			scopeJSONObject);
 
-		content = RandomTestUtil.randomString();
+		String content = _getRandomFileContent(8);
 
 		fileEntry = _addTempFileEntry(
 			content, _objectDefinition1, RandomTestUtil.randomString());
@@ -7525,7 +7524,7 @@ public class ObjectEntryResourceTest {
 				_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1),
 			scopeJSONObject);
 
-		content = RandomTestUtil.randomString();
+		content = _getRandomFileContent(8);
 
 		DLFileEntry dlFileEntry = _addDLFileEntry(
 			content, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
@@ -7787,7 +7786,7 @@ public class ObjectEntryResourceTest {
 						"upload",
 						() -> {
 							FileEntry fileEntry = _addTempFileEntry(
-								RandomTestUtil.randomString(), objectDefinition,
+								_getRandomFileContent(8), objectDefinition,
 								"Old Testament");
 
 							return fileEntry.getFileEntryId();
@@ -7812,7 +7811,7 @@ public class ObjectEntryResourceTest {
 					"upload",
 					() -> {
 						FileEntry fileEntry = _addTempFileEntry(
-							RandomTestUtil.randomString(), objectDefinition,
+							_getRandomFileContent(8), objectDefinition,
 							"New Testament");
 
 						return fileEntry.getFileEntryId();
@@ -9623,7 +9622,7 @@ public class ObjectEntryResourceTest {
 				JSONFactoryUtil.createJSONObject(
 					String.valueOf(
 						_toFileEntry(
-							Base64::encode, RandomTestUtil.randomString(),
+							Base64::encode, _getRandomFileContent(8),
 							RandomTestUtil.randomString() + ".txt", null, null,
 							ContentTypes.TEXT_PLAIN)))
 			).toString(),
@@ -12212,7 +12211,7 @@ public class ObjectEntryResourceTest {
 			String.valueOf(_jsonFactory.createJSONObject()),
 			objectDefinition.getRESTContextPath(), Http.Method.POST);
 
-		String fileContent1 = RandomTestUtil.randomString();
+		String fileContent1 = _getRandomFileContent(8);
 
 		com.liferay.object.rest.dto.v1_0.FileEntry fileEntry1 = _toFileEntry(
 			Base64::encode, fileContent1,
@@ -12225,7 +12224,7 @@ public class ObjectEntryResourceTest {
 
 		fileEntry1.setScope(scope);
 
-		String fileContent2 = RandomTestUtil.randomString();
+		String fileContent2 = _getRandomFileContent(8);
 
 		com.liferay.object.rest.dto.v1_0.FileEntry fileEntry2 = _toFileEntry(
 			Base64::encode, fileContent2,
@@ -16705,6 +16704,15 @@ public class ObjectEntryResourceTest {
 		);
 	}
 
+	private String _getRandomFileContent(int size) {
+		String firstLine = "test\n";
+
+		String randomContent = RandomTestUtil.randomString(
+			size - firstLine.length());
+
+		return firstLine + randomContent;
+	}
+
 	private JSONObject _getRelatedJSONObject(
 		JSONObject jsonObject, String nestedFieldName, Type type) {
 
@@ -18233,7 +18241,10 @@ public class ObjectEntryResourceTest {
 			StringUtil.randomString(),
 			TempFileEntryUtil.getTempFileName(
 				StringUtil.randomString() + ".txt"),
-			FileUtil.createTempFile(RandomTestUtil.randomBytes()),
+			FileUtil.createTempFile(
+				_getRandomFileContent(
+					8
+				).getBytes()),
 			ContentTypes.TEXT_PLAIN);
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			RandomTestUtil.randomLocaleStringMap(),
@@ -18249,7 +18260,7 @@ public class ObjectEntryResourceTest {
 					fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_CMS_BASIC_DOCUMENT_SOURCE)),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null,
 				depotEntry.getGroupId(), customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18267,7 +18278,7 @@ public class ObjectEntryResourceTest {
 					dlFolder1, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder1.getExternalReferenceCode(), dlFolder1.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -18284,7 +18295,7 @@ public class ObjectEntryResourceTest {
 					dlFolder2, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder2.getExternalReferenceCode(), dlFolder2.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -18299,7 +18310,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18312,7 +18323,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null,
 				_group.getGroupId(), customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18325,7 +18336,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, _testGroupId,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18338,7 +18349,7 @@ public class ObjectEntryResourceTest {
 		_testPatchPutCustomObjectEntryWithAttachmentField(
 			fileEntry -> JSONUtil.put("status", "NOT_FOUND"),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), _testGroupId,
 				customFileEntry1.getMimeType()),
@@ -18346,7 +18357,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE,
 			useExternalReferenceCode);
 
-		String fileContent = RandomTestUtil.randomString();
+		String fileContent = _getRandomFileContent(8);
 
 		com.liferay.portal.kernel.repository.model.Folder existingFolder =
 			_dlAppLocalService.addFolder(
@@ -18385,7 +18396,7 @@ public class ObjectEntryResourceTest {
 			useExternalReferenceCode);
 
 		testFileEntry = _toFileEntry(
-			content -> null, RandomTestUtil.randomString(),
+			content -> null, _getRandomFileContent(8),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -18455,7 +18466,7 @@ public class ObjectEntryResourceTest {
 					));
 			},
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder1.getExternalReferenceCode(), dlFolder1.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -18493,11 +18504,9 @@ public class ObjectEntryResourceTest {
 					role.getRoleId(), new String[] {ActionKeys.ADD_DOCUMENT});
 
 				_testPatchPutCustomObjectEntryWithAttachmentField(
-					fileEntry -> JSONUtil.put(
-						"status", "FORBIDDEN"
-					),
+					fileEntry -> JSONUtil.put("status", "FORBIDDEN"),
 					_toFileEntry(
-						Base64::encode, RandomTestUtil.randomString(),
+						Base64::encode, _getRandomFileContent(8),
 						RandomTestUtil.randomString() + ".txt",
 						dlFolder.getExternalReferenceCode(),
 						dlFolder.getGroupId(), customFileEntry1.getMimeType()),
@@ -18519,7 +18528,7 @@ public class ObjectEntryResourceTest {
 							dlFolder, fileEntry, objectDefinition,
 							_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 					_toFileEntry(
-						Base64::encode, RandomTestUtil.randomString(),
+						Base64::encode, _getRandomFileContent(8),
 						RandomTestUtil.randomString() + ".txt",
 						dlFolder.getExternalReferenceCode(),
 						dlFolder.getGroupId(), customFileEntry1.getMimeType()),
@@ -18653,7 +18662,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_CMS_BASIC_DOCUMENT_SOURCE)),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18674,8 +18683,7 @@ public class ObjectEntryResourceTest {
 			),
 			_toFileEntry(
 				Base64::encode,
-				RandomTestUtil.randomString(
-					(_MAX_FILE_SIZE_VALUE * 1024 * 1024) + 1),
+				_getRandomFileContent((_MAX_FILE_SIZE_VALUE * 1024 * 1024) + 1),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18688,7 +18696,7 @@ public class ObjectEntryResourceTest {
 				"title", "File name is null"
 			),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(), null, null, null,
+				Base64::encode, _getRandomFileContent(8), null, null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
 			_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1,
@@ -18700,7 +18708,7 @@ public class ObjectEntryResourceTest {
 				"title", "Invalid file extension for " + fileEntry.getName()
 			),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".err", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18713,7 +18721,7 @@ public class ObjectEntryResourceTest {
 				"title", "Unable to decode Base64 file"
 			),
 			_toFileEntry(
-				String::new, "$" + RandomTestUtil.randomString(7),
+				String::new, "$" + _getRandomFileContent(7),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18728,7 +18736,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1)),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18742,7 +18750,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1)),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 				customFileEntry1.getMimeType()),
@@ -18757,7 +18765,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2)),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18771,7 +18779,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2)),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 				customFileEntry1.getMimeType()),
@@ -18783,7 +18791,7 @@ public class ObjectEntryResourceTest {
 		// existing name
 
 		testFileEntry = _toFileEntry(
-			Base64::encode, RandomTestUtil.randomString(),
+			Base64::encode, _getRandomFileContent(8),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -18815,7 +18823,7 @@ public class ObjectEntryResourceTest {
 			useExternalReferenceCode);
 
 		testFileEntry = _toFileEntry(
-			Base64::encode, RandomTestUtil.randomString(),
+			Base64::encode, _getRandomFileContent(8),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -18862,7 +18870,7 @@ public class ObjectEntryResourceTest {
 						"fileBase64", fileEntry.getFileBase64());
 				}),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, "fileBase64,folder", objectDefinition,
@@ -18881,7 +18889,7 @@ public class ObjectEntryResourceTest {
 						"fileBase64", fileEntry.getFileBase64());
 				}),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, "fileBase64,folder", objectDefinition,
@@ -18905,7 +18913,7 @@ public class ObjectEntryResourceTest {
 			).put(
 				objectFieldName,
 				_toFileEntryJSONObject(
-					RandomTestUtil.randomString(),
+					_getRandomFileContent(8),
 					RandomTestUtil.randomString() + ".txt",
 					fileEntry.getFolder(), ContentTypes.TEXT_PLAIN,
 					objectFieldName)
@@ -19196,7 +19204,10 @@ public class ObjectEntryResourceTest {
 			StringUtil.randomString(),
 			TempFileEntryUtil.getTempFileName(
 				StringUtil.randomString() + ".txt"),
-			FileUtil.createTempFile(RandomTestUtil.randomBytes()),
+			FileUtil.createTempFile(
+				_getRandomFileContent(
+					8
+				).getBytes()),
 			ContentTypes.TEXT_PLAIN);
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			RandomTestUtil.randomLocaleStringMap(),
@@ -19212,7 +19223,7 @@ public class ObjectEntryResourceTest {
 					fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_CMS_BASIC_DOCUMENT_SOURCE)),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null,
 				depotEntry.getGroupId(), customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19229,7 +19240,7 @@ public class ObjectEntryResourceTest {
 					dlFolder1, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder1.getExternalReferenceCode(), dlFolder1.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -19245,7 +19256,7 @@ public class ObjectEntryResourceTest {
 					dlFolder2, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder2.getExternalReferenceCode(), dlFolder2.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -19259,7 +19270,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19271,7 +19282,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null,
 				_group.getGroupId(), customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19283,7 +19294,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, _testGroupId,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19295,14 +19306,14 @@ public class ObjectEntryResourceTest {
 		_testPostCustomObjectEntryWithAttachmentObjectField(
 			fileEntry -> JSONUtil.put("status", "NOT_FOUND"),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), _testGroupId,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
 			_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE);
 
-		String fileContent = RandomTestUtil.randomString();
+		String fileContent = _getRandomFileContent(8);
 
 		com.liferay.portal.kernel.repository.model.Folder existingFolder =
 			_dlAppLocalService.addFolder(
@@ -19340,7 +19351,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE);
 
 		testFileEntry = _toFileEntry(
-			content -> null, RandomTestUtil.randomString(),
+			content -> null, _getRandomFileContent(8),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -19409,7 +19420,7 @@ public class ObjectEntryResourceTest {
 					));
 			},
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder1.getExternalReferenceCode(), dlFolder1.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -19441,11 +19452,9 @@ public class ObjectEntryResourceTest {
 					objectDefinition.getResourceName(), role);
 
 				_testPostCustomObjectEntryWithAttachmentObjectField(
-					fileEntry -> JSONUtil.put(
-						"status", "FORBIDDEN"
-					),
+					fileEntry -> JSONUtil.put("status", "FORBIDDEN"),
 					_toFileEntry(
-						Base64::encode, RandomTestUtil.randomString(),
+						Base64::encode, _getRandomFileContent(8),
 						RandomTestUtil.randomString() + ".txt",
 						dlFolder.getExternalReferenceCode(),
 						dlFolder.getGroupId(), customFileEntry1.getMimeType()),
@@ -19466,7 +19475,7 @@ public class ObjectEntryResourceTest {
 							dlFolder, fileEntry, objectDefinition,
 							_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 					_toFileEntry(
-						Base64::encode, RandomTestUtil.randomString(),
+						Base64::encode, _getRandomFileContent(8),
 						RandomTestUtil.randomString() + ".txt",
 						dlFolder.getExternalReferenceCode(),
 						dlFolder.getGroupId(), customFileEntry1.getMimeType()),
@@ -19623,7 +19632,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_CMS_BASIC_DOCUMENT_SOURCE)),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19643,8 +19652,7 @@ public class ObjectEntryResourceTest {
 			),
 			_toFileEntry(
 				Base64::encode,
-				RandomTestUtil.randomString(
-					(_MAX_FILE_SIZE_VALUE * 1024 * 1024) + 1),
+				_getRandomFileContent((_MAX_FILE_SIZE_VALUE * 1024 * 1024) + 1),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19656,7 +19664,7 @@ public class ObjectEntryResourceTest {
 				"title", "File name is null"
 			),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(), null, null, null,
+				Base64::encode, _getRandomFileContent(8), null, null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
 			_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2);
@@ -19667,7 +19675,7 @@ public class ObjectEntryResourceTest {
 				"title", "Invalid file extension for " + fileEntry.getName()
 			),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".err", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19679,7 +19687,7 @@ public class ObjectEntryResourceTest {
 				"title", "Unable to decode Base64 file"
 			),
 			_toFileEntry(
-				String::new, "$" + RandomTestUtil.randomString(7),
+				String::new, "$" + _getRandomFileContent(7),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19693,7 +19701,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1)),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19706,7 +19714,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1)),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 				customFileEntry1.getMimeType()),
@@ -19720,7 +19728,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2)),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19733,7 +19741,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2)),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 				customFileEntry1.getMimeType()),
@@ -19744,7 +19752,7 @@ public class ObjectEntryResourceTest {
 		// existing name
 
 		testFileEntry = _toFileEntry(
-			Base64::encode, RandomTestUtil.randomString(),
+			Base64::encode, _getRandomFileContent(8),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -19774,7 +19782,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1);
 
 		testFileEntry = _toFileEntry(
-			Base64::encode, RandomTestUtil.randomString(),
+			Base64::encode, _getRandomFileContent(8),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -19806,7 +19814,7 @@ public class ObjectEntryResourceTest {
 		// User computer to documents and media source, file from Base64 with
 		// external reference code
 
-		fileContent = RandomTestUtil.randomString();
+		fileContent = _getRandomFileContent(8);
 
 		existingDLFileEntry = _addDLFileEntry(
 			fileContent, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
@@ -19838,7 +19846,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2);
 
 		testFileEntry = _toFileEntry(
-			content -> null, RandomTestUtil.randomString(),
+			content -> null, _getRandomFileContent(8),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -19890,7 +19898,7 @@ public class ObjectEntryResourceTest {
 						"fileBase64", fileEntry.getFileBase64());
 				}),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			"fileBase64,folder", objectDefinition,
@@ -19908,7 +19916,7 @@ public class ObjectEntryResourceTest {
 						"fileBase64", fileEntry.getFileBase64());
 				}),
 			_toFileEntry(
-				Base64::encode, RandomTestUtil.randomString(),
+				Base64::encode, _getRandomFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			"fileBase64,folder", objectDefinition,
@@ -20459,7 +20467,7 @@ public class ObjectEntryResourceTest {
 				objectDefinition.getPortletId(),
 				TempFileEntryUtil.getTempFileName("foo.pdf"),
 				FileUtil.createTempFile(
-					RandomTestUtil.randomString(
+					_getRandomFileContent(
 						(_MAX_FILE_SIZE_VALUE * 1024 * 1024) + 1
 					).getBytes()),
 				ContentTypes.TEXT_PLAIN);

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -7442,7 +7442,7 @@ public class ObjectEntryResourceTest {
 	@Test
 	public void testGetObjectEntryWithAttachmentObjectField() throws Exception {
 		FileEntry fileEntry = _addTempFileEntry(
-			DLTestUtil.randomTextFileContent(8), _objectDefinition1,
+			DLTestUtil.randomTextFileContent(), _objectDefinition1,
 			RandomTestUtil.randomString());
 
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
@@ -7471,7 +7471,7 @@ public class ObjectEntryResourceTest {
 				_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1),
 			scopeJSONObject);
 
-		byte[] content = DLTestUtil.randomTextFileContent(8);
+		byte[] content = DLTestUtil.randomTextFileContent();
 
 		fileEntry = _addTempFileEntry(
 			content, _objectDefinition1, RandomTestUtil.randomString());
@@ -7524,7 +7524,7 @@ public class ObjectEntryResourceTest {
 				_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1),
 			scopeJSONObject);
 
-		content = DLTestUtil.randomTextFileContent(8);
+		content = DLTestUtil.randomTextFileContent();
 
 		DLFileEntry dlFileEntry = _addDLFileEntry(
 			content, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
@@ -7786,7 +7786,7 @@ public class ObjectEntryResourceTest {
 						"upload",
 						() -> {
 							FileEntry fileEntry = _addTempFileEntry(
-								DLTestUtil.randomTextFileContent(8),
+								DLTestUtil.randomTextFileContent(),
 								objectDefinition, "Old Testament");
 
 							return fileEntry.getFileEntryId();
@@ -7811,7 +7811,7 @@ public class ObjectEntryResourceTest {
 					"upload",
 					() -> {
 						FileEntry fileEntry = _addTempFileEntry(
-							DLTestUtil.randomTextFileContent(8),
+							DLTestUtil.randomTextFileContent(),
 							objectDefinition, "New Testament");
 
 						return fileEntry.getFileEntryId();
@@ -9622,7 +9622,7 @@ public class ObjectEntryResourceTest {
 				JSONFactoryUtil.createJSONObject(
 					String.valueOf(
 						_toFileEntry(
-							Base64::encode, DLTestUtil.randomTextFileContent(8),
+							Base64::encode, DLTestUtil.randomTextFileContent(),
 							RandomTestUtil.randomString() + ".txt", null, null,
 							ContentTypes.TEXT_PLAIN)))
 			).toString(),
@@ -12211,7 +12211,7 @@ public class ObjectEntryResourceTest {
 			String.valueOf(_jsonFactory.createJSONObject()),
 			objectDefinition.getRESTContextPath(), Http.Method.POST);
 
-		byte[] fileContent1 = DLTestUtil.randomTextFileContent(8);
+		byte[] fileContent1 = DLTestUtil.randomTextFileContent();
 
 		com.liferay.object.rest.dto.v1_0.FileEntry fileEntry1 = _toFileEntry(
 			Base64::encode, fileContent1,
@@ -12224,7 +12224,7 @@ public class ObjectEntryResourceTest {
 
 		fileEntry1.setScope(scope);
 
-		byte[] fileContent2 = DLTestUtil.randomTextFileContent(8);
+		byte[] fileContent2 = DLTestUtil.randomTextFileContent();
 
 		com.liferay.object.rest.dto.v1_0.FileEntry fileEntry2 = _toFileEntry(
 			Base64::encode, fileContent2,
@@ -18230,7 +18230,7 @@ public class ObjectEntryResourceTest {
 			StringUtil.randomString(),
 			TempFileEntryUtil.getTempFileName(
 				StringUtil.randomString() + ".txt"),
-			FileUtil.createTempFile(DLTestUtil.randomTextFileContent(8)),
+			FileUtil.createTempFile(DLTestUtil.randomTextFileContent()),
 			ContentTypes.TEXT_PLAIN);
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			RandomTestUtil.randomLocaleStringMap(),
@@ -18246,7 +18246,7 @@ public class ObjectEntryResourceTest {
 					fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_CMS_BASIC_DOCUMENT_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt", null,
 				depotEntry.getGroupId(), customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18264,7 +18264,7 @@ public class ObjectEntryResourceTest {
 					dlFolder1, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder1.getExternalReferenceCode(), dlFolder1.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -18281,7 +18281,7 @@ public class ObjectEntryResourceTest {
 					dlFolder2, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder2.getExternalReferenceCode(), dlFolder2.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -18296,7 +18296,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18309,7 +18309,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt", null,
 				_group.getGroupId(), customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18322,7 +18322,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt", null, _testGroupId,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18335,7 +18335,7 @@ public class ObjectEntryResourceTest {
 		_testPatchPutCustomObjectEntryWithAttachmentField(
 			fileEntry -> JSONUtil.put("status", "NOT_FOUND"),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), _testGroupId,
 				customFileEntry1.getMimeType()),
@@ -18343,7 +18343,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE,
 			useExternalReferenceCode);
 
-		byte[] fileContent = DLTestUtil.randomTextFileContent(8);
+		byte[] fileContent = DLTestUtil.randomTextFileContent();
 
 		com.liferay.portal.kernel.repository.model.Folder existingFolder =
 			_dlAppLocalService.addFolder(
@@ -18382,7 +18382,7 @@ public class ObjectEntryResourceTest {
 			useExternalReferenceCode);
 
 		testFileEntry = _toFileEntry(
-			content -> null, DLTestUtil.randomTextFileContent(8),
+			content -> null, DLTestUtil.randomTextFileContent(),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -18452,7 +18452,7 @@ public class ObjectEntryResourceTest {
 					));
 			},
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder1.getExternalReferenceCode(), dlFolder1.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -18492,7 +18492,7 @@ public class ObjectEntryResourceTest {
 				_testPatchPutCustomObjectEntryWithAttachmentField(
 					fileEntry -> JSONUtil.put("status", "FORBIDDEN"),
 					_toFileEntry(
-						Base64::encode, DLTestUtil.randomTextFileContent(8),
+						Base64::encode, DLTestUtil.randomTextFileContent(),
 						RandomTestUtil.randomString() + ".txt",
 						dlFolder.getExternalReferenceCode(),
 						dlFolder.getGroupId(), customFileEntry1.getMimeType()),
@@ -18514,7 +18514,7 @@ public class ObjectEntryResourceTest {
 							dlFolder, fileEntry, objectDefinition,
 							_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 					_toFileEntry(
-						Base64::encode, DLTestUtil.randomTextFileContent(8),
+						Base64::encode, DLTestUtil.randomTextFileContent(),
 						RandomTestUtil.randomString() + ".txt",
 						dlFolder.getExternalReferenceCode(),
 						dlFolder.getGroupId(), customFileEntry1.getMimeType()),
@@ -18648,7 +18648,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_CMS_BASIC_DOCUMENT_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18683,7 +18683,7 @@ public class ObjectEntryResourceTest {
 				"title", "File name is null"
 			),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8), null, null,
+				Base64::encode, DLTestUtil.randomTextFileContent(), null, null,
 				null, customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
 			_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1,
@@ -18695,7 +18695,7 @@ public class ObjectEntryResourceTest {
 				"title", "Invalid file extension for " + fileEntry.getName()
 			),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".err", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18725,7 +18725,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18739,7 +18739,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 				customFileEntry1.getMimeType()),
@@ -18754,7 +18754,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18768,7 +18768,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 				customFileEntry1.getMimeType()),
@@ -18780,7 +18780,7 @@ public class ObjectEntryResourceTest {
 		// existing name
 
 		testFileEntry = _toFileEntry(
-			Base64::encode, DLTestUtil.randomTextFileContent(8),
+			Base64::encode, DLTestUtil.randomTextFileContent(),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -18812,7 +18812,7 @@ public class ObjectEntryResourceTest {
 			useExternalReferenceCode);
 
 		testFileEntry = _toFileEntry(
-			Base64::encode, DLTestUtil.randomTextFileContent(8),
+			Base64::encode, DLTestUtil.randomTextFileContent(),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -18859,7 +18859,7 @@ public class ObjectEntryResourceTest {
 						"fileBase64", fileEntry.getFileBase64());
 				}),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, "fileBase64,folder", objectDefinition,
@@ -18878,7 +18878,7 @@ public class ObjectEntryResourceTest {
 						"fileBase64", fileEntry.getFileBase64());
 				}),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, "fileBase64,folder", objectDefinition,
@@ -18902,7 +18902,7 @@ public class ObjectEntryResourceTest {
 			).put(
 				objectFieldName,
 				_toFileEntryJSONObject(
-					DLTestUtil.randomTextFileContent(8),
+					DLTestUtil.randomTextFileContent(),
 					RandomTestUtil.randomString() + ".txt",
 					fileEntry.getFolder(), ContentTypes.TEXT_PLAIN,
 					objectFieldName)
@@ -19193,7 +19193,7 @@ public class ObjectEntryResourceTest {
 			StringUtil.randomString(),
 			TempFileEntryUtil.getTempFileName(
 				StringUtil.randomString() + ".txt"),
-			FileUtil.createTempFile(DLTestUtil.randomTextFileContent(8)),
+			FileUtil.createTempFile(DLTestUtil.randomTextFileContent()),
 			ContentTypes.TEXT_PLAIN);
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			RandomTestUtil.randomLocaleStringMap(),
@@ -19209,7 +19209,7 @@ public class ObjectEntryResourceTest {
 					fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_CMS_BASIC_DOCUMENT_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt", null,
 				depotEntry.getGroupId(), customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19226,7 +19226,7 @@ public class ObjectEntryResourceTest {
 					dlFolder1, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder1.getExternalReferenceCode(), dlFolder1.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -19242,7 +19242,7 @@ public class ObjectEntryResourceTest {
 					dlFolder2, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder2.getExternalReferenceCode(), dlFolder2.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -19256,7 +19256,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19268,7 +19268,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt", null,
 				_group.getGroupId(), customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19280,7 +19280,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt", null, _testGroupId,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19292,14 +19292,14 @@ public class ObjectEntryResourceTest {
 		_testPostCustomObjectEntryWithAttachmentObjectField(
 			fileEntry -> JSONUtil.put("status", "NOT_FOUND"),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), _testGroupId,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
 			_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE);
 
-		byte[] fileContent = DLTestUtil.randomTextFileContent(8);
+		byte[] fileContent = DLTestUtil.randomTextFileContent();
 
 		com.liferay.portal.kernel.repository.model.Folder existingFolder =
 			_dlAppLocalService.addFolder(
@@ -19337,7 +19337,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE);
 
 		testFileEntry = _toFileEntry(
-			content -> null, DLTestUtil.randomTextFileContent(8),
+			content -> null, DLTestUtil.randomTextFileContent(),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -19406,7 +19406,7 @@ public class ObjectEntryResourceTest {
 					));
 			},
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder1.getExternalReferenceCode(), dlFolder1.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -19440,7 +19440,7 @@ public class ObjectEntryResourceTest {
 				_testPostCustomObjectEntryWithAttachmentObjectField(
 					fileEntry -> JSONUtil.put("status", "FORBIDDEN"),
 					_toFileEntry(
-						Base64::encode, DLTestUtil.randomTextFileContent(8),
+						Base64::encode, DLTestUtil.randomTextFileContent(),
 						RandomTestUtil.randomString() + ".txt",
 						dlFolder.getExternalReferenceCode(),
 						dlFolder.getGroupId(), customFileEntry1.getMimeType()),
@@ -19461,7 +19461,7 @@ public class ObjectEntryResourceTest {
 							dlFolder, fileEntry, objectDefinition,
 							_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 					_toFileEntry(
-						Base64::encode, DLTestUtil.randomTextFileContent(8),
+						Base64::encode, DLTestUtil.randomTextFileContent(),
 						RandomTestUtil.randomString() + ".txt",
 						dlFolder.getExternalReferenceCode(),
 						dlFolder.getGroupId(), customFileEntry1.getMimeType()),
@@ -19618,7 +19618,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_CMS_BASIC_DOCUMENT_SOURCE)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19651,7 +19651,7 @@ public class ObjectEntryResourceTest {
 				"title", "File name is null"
 			),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8), null, null,
+				Base64::encode, DLTestUtil.randomTextFileContent(), null, null,
 				null, customFileEntry1.getMimeType()),
 			null, objectDefinition,
 			_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2);
@@ -19662,7 +19662,7 @@ public class ObjectEntryResourceTest {
 				"title", "Invalid file extension for " + fileEntry.getName()
 			),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".err", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19690,7 +19690,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19703,7 +19703,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 				customFileEntry1.getMimeType()),
@@ -19717,7 +19717,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19730,7 +19730,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2)),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 				customFileEntry1.getMimeType()),
@@ -19741,7 +19741,7 @@ public class ObjectEntryResourceTest {
 		// existing name
 
 		testFileEntry = _toFileEntry(
-			Base64::encode, DLTestUtil.randomTextFileContent(8),
+			Base64::encode, DLTestUtil.randomTextFileContent(),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -19771,7 +19771,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1);
 
 		testFileEntry = _toFileEntry(
-			Base64::encode, DLTestUtil.randomTextFileContent(8),
+			Base64::encode, DLTestUtil.randomTextFileContent(),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -19803,7 +19803,7 @@ public class ObjectEntryResourceTest {
 		// User computer to documents and media source, file from Base64 with
 		// external reference code
 
-		fileContent = DLTestUtil.randomTextFileContent(8);
+		fileContent = DLTestUtil.randomTextFileContent();
 
 		existingDLFileEntry = _addDLFileEntry(
 			fileContent, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
@@ -19835,7 +19835,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2);
 
 		testFileEntry = _toFileEntry(
-			content -> null, DLTestUtil.randomTextFileContent(8),
+			content -> null, DLTestUtil.randomTextFileContent(),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -19887,7 +19887,7 @@ public class ObjectEntryResourceTest {
 						"fileBase64", fileEntry.getFileBase64());
 				}),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			"fileBase64,folder", objectDefinition,
@@ -19905,7 +19905,7 @@ public class ObjectEntryResourceTest {
 						"fileBase64", fileEntry.getFileBase64());
 				}),
 			_toFileEntry(
-				Base64::encode, DLTestUtil.randomTextFileContent(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			"fileBase64,folder", objectDefinition,

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -7811,8 +7811,8 @@ public class ObjectEntryResourceTest {
 					"upload",
 					() -> {
 						FileEntry fileEntry = _addTempFileEntry(
-							DLTestUtil.randomTextFileBytes(),
-							objectDefinition, "New Testament");
+							DLTestUtil.randomTextFileBytes(), objectDefinition,
+							"New Testament");
 
 						return fileEntry.getFileEntryId();
 					}
@@ -18709,8 +18709,7 @@ public class ObjectEntryResourceTest {
 			),
 			_toFileEntry(
 				String::new,
-				ArrayUtil.append(
-					DLTestUtil.randomTextFileBytes(7), (byte)'$'),
+				ArrayUtil.append(DLTestUtil.randomTextFileBytes(7), (byte)'$'),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -19675,8 +19674,7 @@ public class ObjectEntryResourceTest {
 			),
 			_toFileEntry(
 				String::new,
-				ArrayUtil.append(
-					DLTestUtil.randomTextFileBytes(7), (byte)'$'),
+				ArrayUtil.append(DLTestUtil.randomTextFileBytes(7), (byte)'$'),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -7442,7 +7442,7 @@ public class ObjectEntryResourceTest {
 	@Test
 	public void testGetObjectEntryWithAttachmentObjectField() throws Exception {
 		FileEntry fileEntry = _addTempFileEntry(
-			StringUtil.randomId(8), _objectDefinition1,
+			DLTestUtil.randomTextFileContent(8), _objectDefinition1,
 			RandomTestUtil.randomString());
 
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
@@ -7471,7 +7471,7 @@ public class ObjectEntryResourceTest {
 				_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1),
 			scopeJSONObject);
 
-		String content = StringUtil.randomId(8);
+		String content = DLTestUtil.randomTextFileContent(8);
 
 		fileEntry = _addTempFileEntry(
 			content, _objectDefinition1, RandomTestUtil.randomString());
@@ -7524,7 +7524,7 @@ public class ObjectEntryResourceTest {
 				_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1),
 			scopeJSONObject);
 
-		content = StringUtil.randomId(8);
+		content = DLTestUtil.randomTextFileContent(8);
 
 		DLFileEntry dlFileEntry = _addDLFileEntry(
 			content, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
@@ -7786,8 +7786,8 @@ public class ObjectEntryResourceTest {
 						"upload",
 						() -> {
 							FileEntry fileEntry = _addTempFileEntry(
-								StringUtil.randomId(8), objectDefinition,
-								"Old Testament");
+								DLTestUtil.randomTextFileContent(8),
+								objectDefinition, "Old Testament");
 
 							return fileEntry.getFileEntryId();
 						}
@@ -7811,8 +7811,8 @@ public class ObjectEntryResourceTest {
 					"upload",
 					() -> {
 						FileEntry fileEntry = _addTempFileEntry(
-							StringUtil.randomId(8), objectDefinition,
-							"New Testament");
+							DLTestUtil.randomTextFileContent(8),
+							objectDefinition, "New Testament");
 
 						return fileEntry.getFileEntryId();
 					}
@@ -9622,7 +9622,7 @@ public class ObjectEntryResourceTest {
 				JSONFactoryUtil.createJSONObject(
 					String.valueOf(
 						_toFileEntry(
-							Base64::encode, StringUtil.randomId(8),
+							Base64::encode, DLTestUtil.randomTextFileContent(8),
 							RandomTestUtil.randomString() + ".txt", null, null,
 							ContentTypes.TEXT_PLAIN)))
 			).toString(),
@@ -12211,7 +12211,7 @@ public class ObjectEntryResourceTest {
 			String.valueOf(_jsonFactory.createJSONObject()),
 			objectDefinition.getRESTContextPath(), Http.Method.POST);
 
-		String fileContent1 = StringUtil.randomId(8);
+		String fileContent1 = DLTestUtil.randomTextFileContent(8);
 
 		com.liferay.object.rest.dto.v1_0.FileEntry fileEntry1 = _toFileEntry(
 			Base64::encode, fileContent1,
@@ -12224,7 +12224,7 @@ public class ObjectEntryResourceTest {
 
 		fileEntry1.setScope(scope);
 
-		String fileContent2 = StringUtil.randomId(8);
+		String fileContent2 = DLTestUtil.randomTextFileContent(8);
 
 		com.liferay.object.rest.dto.v1_0.FileEntry fileEntry2 = _toFileEntry(
 			Base64::encode, fileContent2,
@@ -18233,7 +18233,7 @@ public class ObjectEntryResourceTest {
 			TempFileEntryUtil.getTempFileName(
 				StringUtil.randomString() + ".txt"),
 			FileUtil.createTempFile(
-				StringUtil.randomId(
+				DLTestUtil.randomTextFileContent(
 					8
 				).getBytes()),
 			ContentTypes.TEXT_PLAIN);
@@ -18251,7 +18251,7 @@ public class ObjectEntryResourceTest {
 					fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_CMS_BASIC_DOCUMENT_SOURCE)),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null,
 				depotEntry.getGroupId(), customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18269,7 +18269,7 @@ public class ObjectEntryResourceTest {
 					dlFolder1, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder1.getExternalReferenceCode(), dlFolder1.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -18286,7 +18286,7 @@ public class ObjectEntryResourceTest {
 					dlFolder2, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder2.getExternalReferenceCode(), dlFolder2.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -18301,7 +18301,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18314,7 +18314,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null,
 				_group.getGroupId(), customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18327,7 +18327,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, _testGroupId,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18340,7 +18340,7 @@ public class ObjectEntryResourceTest {
 		_testPatchPutCustomObjectEntryWithAttachmentField(
 			fileEntry -> JSONUtil.put("status", "NOT_FOUND"),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), _testGroupId,
 				customFileEntry1.getMimeType()),
@@ -18348,7 +18348,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE,
 			useExternalReferenceCode);
 
-		String fileContent = StringUtil.randomId(8);
+		String fileContent = DLTestUtil.randomTextFileContent(8);
 
 		com.liferay.portal.kernel.repository.model.Folder existingFolder =
 			_dlAppLocalService.addFolder(
@@ -18387,7 +18387,7 @@ public class ObjectEntryResourceTest {
 			useExternalReferenceCode);
 
 		testFileEntry = _toFileEntry(
-			content -> null, StringUtil.randomId(8),
+			content -> null, DLTestUtil.randomTextFileContent(8),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -18457,7 +18457,7 @@ public class ObjectEntryResourceTest {
 					));
 			},
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder1.getExternalReferenceCode(), dlFolder1.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -18497,7 +18497,7 @@ public class ObjectEntryResourceTest {
 				_testPatchPutCustomObjectEntryWithAttachmentField(
 					fileEntry -> JSONUtil.put("status", "FORBIDDEN"),
 					_toFileEntry(
-						Base64::encode, StringUtil.randomId(8),
+						Base64::encode, DLTestUtil.randomTextFileContent(8),
 						RandomTestUtil.randomString() + ".txt",
 						dlFolder.getExternalReferenceCode(),
 						dlFolder.getGroupId(), customFileEntry1.getMimeType()),
@@ -18519,7 +18519,7 @@ public class ObjectEntryResourceTest {
 							dlFolder, fileEntry, objectDefinition,
 							_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 					_toFileEntry(
-						Base64::encode, StringUtil.randomId(8),
+						Base64::encode, DLTestUtil.randomTextFileContent(8),
 						RandomTestUtil.randomString() + ".txt",
 						dlFolder.getExternalReferenceCode(),
 						dlFolder.getGroupId(), customFileEntry1.getMimeType()),
@@ -18653,7 +18653,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_CMS_BASIC_DOCUMENT_SOURCE)),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18674,7 +18674,8 @@ public class ObjectEntryResourceTest {
 			),
 			_toFileEntry(
 				Base64::encode,
-				StringUtil.randomId((_MAX_FILE_SIZE_VALUE * 1024 * 1024) + 1),
+				DLTestUtil.randomTextFileContent(
+					(_MAX_FILE_SIZE_VALUE * 1024 * 1024) + 1),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18687,8 +18688,8 @@ public class ObjectEntryResourceTest {
 				"title", "File name is null"
 			),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8), null, null, null,
-				customFileEntry1.getMimeType()),
+				Base64::encode, DLTestUtil.randomTextFileContent(8), null, null,
+				null, customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
 			_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1,
 			useExternalReferenceCode);
@@ -18699,7 +18700,7 @@ public class ObjectEntryResourceTest {
 				"title", "Invalid file extension for " + fileEntry.getName()
 			),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".err", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18712,7 +18713,7 @@ public class ObjectEntryResourceTest {
 				"title", "Unable to decode Base64 file"
 			),
 			_toFileEntry(
-				String::new, "$" + StringUtil.randomId(7),
+				String::new, "$" + DLTestUtil.randomTextFileContent(7),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18727,7 +18728,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1)),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18741,7 +18742,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1)),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 				customFileEntry1.getMimeType()),
@@ -18756,7 +18757,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2)),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, null, objectDefinition,
@@ -18770,7 +18771,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2)),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 				customFileEntry1.getMimeType()),
@@ -18782,7 +18783,7 @@ public class ObjectEntryResourceTest {
 		// existing name
 
 		testFileEntry = _toFileEntry(
-			Base64::encode, StringUtil.randomId(8),
+			Base64::encode, DLTestUtil.randomTextFileContent(8),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -18814,7 +18815,7 @@ public class ObjectEntryResourceTest {
 			useExternalReferenceCode);
 
 		testFileEntry = _toFileEntry(
-			Base64::encode, StringUtil.randomId(8),
+			Base64::encode, DLTestUtil.randomTextFileContent(8),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -18861,7 +18862,7 @@ public class ObjectEntryResourceTest {
 						"fileBase64", fileEntry.getFileBase64());
 				}),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, "fileBase64,folder", objectDefinition,
@@ -18880,7 +18881,7 @@ public class ObjectEntryResourceTest {
 						"fileBase64", fileEntry.getFileBase64());
 				}),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			httpMethod, "fileBase64,folder", objectDefinition,
@@ -18904,7 +18905,7 @@ public class ObjectEntryResourceTest {
 			).put(
 				objectFieldName,
 				_toFileEntryJSONObject(
-					StringUtil.randomId(8),
+					DLTestUtil.randomTextFileContent(8),
 					RandomTestUtil.randomString() + ".txt",
 					fileEntry.getFolder(), ContentTypes.TEXT_PLAIN,
 					objectFieldName)
@@ -19196,7 +19197,7 @@ public class ObjectEntryResourceTest {
 			TempFileEntryUtil.getTempFileName(
 				StringUtil.randomString() + ".txt"),
 			FileUtil.createTempFile(
-				StringUtil.randomId(
+				DLTestUtil.randomTextFileContent(
 					8
 				).getBytes()),
 			ContentTypes.TEXT_PLAIN);
@@ -19214,7 +19215,7 @@ public class ObjectEntryResourceTest {
 					fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_CMS_BASIC_DOCUMENT_SOURCE)),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null,
 				depotEntry.getGroupId(), customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19231,7 +19232,7 @@ public class ObjectEntryResourceTest {
 					dlFolder1, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder1.getExternalReferenceCode(), dlFolder1.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -19247,7 +19248,7 @@ public class ObjectEntryResourceTest {
 					dlFolder2, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder2.getExternalReferenceCode(), dlFolder2.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -19261,7 +19262,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19273,7 +19274,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null,
 				_group.getGroupId(), customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19285,7 +19286,7 @@ public class ObjectEntryResourceTest {
 					null, fileEntry, objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, _testGroupId,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19297,14 +19298,14 @@ public class ObjectEntryResourceTest {
 		_testPostCustomObjectEntryWithAttachmentObjectField(
 			fileEntry -> JSONUtil.put("status", "NOT_FOUND"),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), _testGroupId,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
 			_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE);
 
-		String fileContent = StringUtil.randomId(8);
+		String fileContent = DLTestUtil.randomTextFileContent(8);
 
 		com.liferay.portal.kernel.repository.model.Folder existingFolder =
 			_dlAppLocalService.addFolder(
@@ -19342,7 +19343,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE);
 
 		testFileEntry = _toFileEntry(
-			content -> null, StringUtil.randomId(8),
+			content -> null, DLTestUtil.randomTextFileContent(8),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -19411,7 +19412,7 @@ public class ObjectEntryResourceTest {
 					));
 			},
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt",
 				dlFolder1.getExternalReferenceCode(), dlFolder1.getGroupId(),
 				customFileEntry1.getMimeType()),
@@ -19445,7 +19446,7 @@ public class ObjectEntryResourceTest {
 				_testPostCustomObjectEntryWithAttachmentObjectField(
 					fileEntry -> JSONUtil.put("status", "FORBIDDEN"),
 					_toFileEntry(
-						Base64::encode, StringUtil.randomId(8),
+						Base64::encode, DLTestUtil.randomTextFileContent(8),
 						RandomTestUtil.randomString() + ".txt",
 						dlFolder.getExternalReferenceCode(),
 						dlFolder.getGroupId(), customFileEntry1.getMimeType()),
@@ -19466,7 +19467,7 @@ public class ObjectEntryResourceTest {
 							dlFolder, fileEntry, objectDefinition,
 							_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE)),
 					_toFileEntry(
-						Base64::encode, StringUtil.randomId(8),
+						Base64::encode, DLTestUtil.randomTextFileContent(8),
 						RandomTestUtil.randomString() + ".txt",
 						dlFolder.getExternalReferenceCode(),
 						dlFolder.getGroupId(), customFileEntry1.getMimeType()),
@@ -19623,7 +19624,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_CMS_BASIC_DOCUMENT_SOURCE)),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19643,7 +19644,8 @@ public class ObjectEntryResourceTest {
 			),
 			_toFileEntry(
 				Base64::encode,
-				StringUtil.randomId((_MAX_FILE_SIZE_VALUE * 1024 * 1024) + 1),
+				DLTestUtil.randomTextFileContent(
+					(_MAX_FILE_SIZE_VALUE * 1024 * 1024) + 1),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19655,8 +19657,8 @@ public class ObjectEntryResourceTest {
 				"title", "File name is null"
 			),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8), null, null, null,
-				customFileEntry1.getMimeType()),
+				Base64::encode, DLTestUtil.randomTextFileContent(8), null, null,
+				null, customFileEntry1.getMimeType()),
 			null, objectDefinition,
 			_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2);
 		_testPostCustomObjectEntryWithAttachmentObjectField(
@@ -19666,7 +19668,7 @@ public class ObjectEntryResourceTest {
 				"title", "Invalid file extension for " + fileEntry.getName()
 			),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".err", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19678,7 +19680,7 @@ public class ObjectEntryResourceTest {
 				"title", "Unable to decode Base64 file"
 			),
 			_toFileEntry(
-				String::new, "$" + StringUtil.randomId(7),
+				String::new, "$" + DLTestUtil.randomTextFileContent(7),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19692,7 +19694,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1)),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19705,7 +19707,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1)),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 				customFileEntry1.getMimeType()),
@@ -19719,7 +19721,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2)),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			null, objectDefinition,
@@ -19732,7 +19734,7 @@ public class ObjectEntryResourceTest {
 					objectDefinition,
 					_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2)),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt",
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 				customFileEntry1.getMimeType()),
@@ -19743,7 +19745,7 @@ public class ObjectEntryResourceTest {
 		// existing name
 
 		testFileEntry = _toFileEntry(
-			Base64::encode, StringUtil.randomId(8),
+			Base64::encode, DLTestUtil.randomTextFileContent(8),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -19773,7 +19775,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_1);
 
 		testFileEntry = _toFileEntry(
-			Base64::encode, StringUtil.randomId(8),
+			Base64::encode, DLTestUtil.randomTextFileContent(8),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -19805,7 +19807,7 @@ public class ObjectEntryResourceTest {
 		// User computer to documents and media source, file from Base64 with
 		// external reference code
 
-		fileContent = StringUtil.randomId(8);
+		fileContent = DLTestUtil.randomTextFileContent(8);
 
 		existingDLFileEntry = _addDLFileEntry(
 			fileContent, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
@@ -19837,7 +19839,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_ATTACHMENT_USER_COMPUTER_TO_DOCS_AND_MEDIA_SOURCE_2);
 
 		testFileEntry = _toFileEntry(
-			content -> null, StringUtil.randomId(8),
+			content -> null, DLTestUtil.randomTextFileContent(8),
 			RandomTestUtil.randomString() + ".txt", null, null,
 			customFileEntry1.getMimeType());
 
@@ -19889,7 +19891,7 @@ public class ObjectEntryResourceTest {
 						"fileBase64", fileEntry.getFileBase64());
 				}),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			"fileBase64,folder", objectDefinition,
@@ -19907,7 +19909,7 @@ public class ObjectEntryResourceTest {
 						"fileBase64", fileEntry.getFileBase64());
 				}),
 			_toFileEntry(
-				Base64::encode, StringUtil.randomId(8),
+				Base64::encode, DLTestUtil.randomTextFileContent(8),
 				RandomTestUtil.randomString() + ".txt", null, null,
 				customFileEntry1.getMimeType()),
 			"fileBase64,folder", objectDefinition,
@@ -20458,7 +20460,7 @@ public class ObjectEntryResourceTest {
 				objectDefinition.getPortletId(),
 				TempFileEntryUtil.getTempFileName("foo.pdf"),
 				FileUtil.createTempFile(
-					StringUtil.randomId(
+					DLTestUtil.randomTextFileContent(
 						(_MAX_FILE_SIZE_VALUE * 1024 * 1024) + 1
 					).getBytes()),
 				ContentTypes.TEXT_PLAIN);

--- a/modules/apps/object/object-test/build.gradle
+++ b/modules/apps/object/object-test/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:commerce:commerce-test-util")
 	testIntegrationImplementation project(":apps:depot:depot-api")
 	testIntegrationImplementation project(":apps:document-library:document-library-api")
+	testIntegrationImplementation project(":apps:document-library:document-library-test-util")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-expression")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-form-field-type-api")

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/attachment/test/AttachmentManagerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/attachment/test/AttachmentManagerTest.java
@@ -109,9 +109,8 @@ public class AttachmentManagerTest {
 	@Test
 	public void testGetOrAddFileEntry() throws Exception {
 		FileEntry tempFileEntry = _addTempFileEntry(
-			RandomTestUtil.randomString(), ".txt",
-			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
-			_objectDefinition);
+			_getRandomFileContent(8), ".txt", RandomTestUtil.randomString(),
+			ContentTypes.TEXT_PLAIN, _objectDefinition);
 
 		Folder folder = tempFileEntry.getFolder();
 
@@ -192,9 +191,8 @@ public class AttachmentManagerTest {
 					).build())) {
 
 			tempFileEntry = _addTempFileEntry(
-				RandomTestUtil.randomString(), ".txt",
-				RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
-				_objectDefinition);
+				_getRandomFileContent(8), ".txt", RandomTestUtil.randomString(),
+				ContentTypes.TEXT_PLAIN, _objectDefinition);
 
 			folder = tempFileEntry.getFolder();
 
@@ -221,9 +219,8 @@ public class AttachmentManagerTest {
 						).build())) {
 
 			tempFileEntry = _addTempFileEntry(
-				RandomTestUtil.randomString(), ".txt",
-				RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
-				_objectDefinition);
+				_getRandomFileContent(8), ".txt", RandomTestUtil.randomString(),
+				ContentTypes.TEXT_PLAIN, _objectDefinition);
 
 			folder = tempFileEntry.getFolder();
 
@@ -249,7 +246,7 @@ public class AttachmentManagerTest {
 					).build())) {
 
 			tempFileEntry = _addTempFileEntry(
-				RandomTestUtil.randomString(1000), ".txt",
+				_getRandomFileContent(1000), ".txt",
 				RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
 				_objectDefinition);
 
@@ -316,6 +313,15 @@ public class AttachmentManagerTest {
 			objectDefinition.getPortletId(),
 			TempFileEntryUtil.getTempFileName(fileName + extension),
 			FileUtil.createTempFile(content.getBytes()), mimeType);
+	}
+
+	private String _getRandomFileContent(int size) {
+		String firstLine = "test\n";
+
+		String randomContent = RandomTestUtil.randomString(
+			size - firstLine.length());
+
+		return firstLine + randomContent;
 	}
 
 	@Inject

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/attachment/test/AttachmentManagerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/attachment/test/AttachmentManagerTest.java
@@ -110,7 +110,7 @@ public class AttachmentManagerTest {
 	@Test
 	public void testGetOrAddFileEntry() throws Exception {
 		FileEntry tempFileEntry = _addTempFileEntry(
-			DLTestUtil.randomTextFileContent(8), ".txt",
+			DLTestUtil.randomTextFileContent(), ".txt",
 			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
 			_objectDefinition);
 
@@ -192,7 +192,7 @@ public class AttachmentManagerTest {
 					).build())) {
 
 			tempFileEntry = _addTempFileEntry(
-				DLTestUtil.randomTextFileContent(8), ".txt",
+				DLTestUtil.randomTextFileContent(), ".txt",
 				RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
 				_objectDefinition);
 
@@ -221,7 +221,7 @@ public class AttachmentManagerTest {
 						).build())) {
 
 			tempFileEntry = _addTempFileEntry(
-				DLTestUtil.randomTextFileContent(8), ".txt",
+				DLTestUtil.randomTextFileContent(), ".txt",
 				RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
 				_objectDefinition);
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/attachment/test/AttachmentManagerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/attachment/test/AttachmentManagerTest.java
@@ -12,6 +12,7 @@ import com.liferay.document.library.kernel.exception.FileExtensionException;
 import com.liferay.document.library.kernel.exception.FileMimeTypeException;
 import com.liferay.document.library.kernel.exception.FileSizeException;
 import com.liferay.document.library.kernel.model.DLFolder;
+import com.liferay.document.library.test.util.DLTestUtil;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.field.attachment.AttachmentManager;
@@ -45,7 +46,6 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -110,8 +110,9 @@ public class AttachmentManagerTest {
 	@Test
 	public void testGetOrAddFileEntry() throws Exception {
 		FileEntry tempFileEntry = _addTempFileEntry(
-			StringUtil.randomId(8), ".txt", RandomTestUtil.randomString(),
-			ContentTypes.TEXT_PLAIN, _objectDefinition);
+			DLTestUtil.randomTextFileContent(8), ".txt",
+			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
+			_objectDefinition);
 
 		Folder folder = tempFileEntry.getFolder();
 
@@ -192,8 +193,9 @@ public class AttachmentManagerTest {
 					).build())) {
 
 			tempFileEntry = _addTempFileEntry(
-				StringUtil.randomId(8), ".txt", RandomTestUtil.randomString(),
-				ContentTypes.TEXT_PLAIN, _objectDefinition);
+				DLTestUtil.randomTextFileContent(8), ".txt",
+				RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
+				_objectDefinition);
 
 			folder = tempFileEntry.getFolder();
 
@@ -220,8 +222,9 @@ public class AttachmentManagerTest {
 						).build())) {
 
 			tempFileEntry = _addTempFileEntry(
-				StringUtil.randomId(8), ".txt", RandomTestUtil.randomString(),
-				ContentTypes.TEXT_PLAIN, _objectDefinition);
+				DLTestUtil.randomTextFileContent(8), ".txt",
+				RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
+				_objectDefinition);
 
 			folder = tempFileEntry.getFolder();
 
@@ -247,7 +250,7 @@ public class AttachmentManagerTest {
 					).build())) {
 
 			tempFileEntry = _addTempFileEntry(
-				StringUtil.randomId(1000), ".txt",
+				DLTestUtil.randomTextFileContent(1000), ".txt",
 				RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
 				_objectDefinition);
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/attachment/test/AttachmentManagerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/attachment/test/AttachmentManagerTest.java
@@ -142,7 +142,7 @@ public class AttachmentManagerTest {
 
 		try {
 			tempFileEntry = _addTempFileEntry(
-				RandomTestUtil.randomString(), ".bmp",
+				RandomTestUtil.randomBytes(), ".bmp",
 				RandomTestUtil.randomString(), ContentTypes.IMAGE_BMP,
 				_objectDefinition);
 
@@ -164,9 +164,8 @@ public class AttachmentManagerTest {
 		ObjectDefinition objectDefinition = _addObjectDefinition("*");
 
 		tempFileEntry = _addTempFileEntry(
-			RandomTestUtil.randomString(), ".bmp",
-			RandomTestUtil.randomString(), ContentTypes.IMAGE_BMP,
-			objectDefinition);
+			RandomTestUtil.randomBytes(), ".bmp", RandomTestUtil.randomString(),
+			ContentTypes.IMAGE_BMP, objectDefinition);
 
 		folder = tempFileEntry.getFolder();
 
@@ -308,7 +307,7 @@ public class AttachmentManagerTest {
 	}
 
 	private FileEntry _addTempFileEntry(
-			String content, String extension, String fileName, String mimeType,
+			byte[] content, String extension, String fileName, String mimeType,
 			ObjectDefinition objectDefinition)
 		throws Exception {
 
@@ -316,7 +315,7 @@ public class AttachmentManagerTest {
 			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
 			objectDefinition.getPortletId(),
 			TempFileEntryUtil.getTempFileName(fileName + extension),
-			FileUtil.createTempFile(content.getBytes()), mimeType);
+			FileUtil.createTempFile(content), mimeType);
 	}
 
 	@Inject

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/attachment/test/AttachmentManagerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/attachment/test/AttachmentManagerTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -109,7 +110,7 @@ public class AttachmentManagerTest {
 	@Test
 	public void testGetOrAddFileEntry() throws Exception {
 		FileEntry tempFileEntry = _addTempFileEntry(
-			_getRandomFileContent(8), ".txt", RandomTestUtil.randomString(),
+			StringUtil.randomId(8), ".txt", RandomTestUtil.randomString(),
 			ContentTypes.TEXT_PLAIN, _objectDefinition);
 
 		Folder folder = tempFileEntry.getFolder();
@@ -191,7 +192,7 @@ public class AttachmentManagerTest {
 					).build())) {
 
 			tempFileEntry = _addTempFileEntry(
-				_getRandomFileContent(8), ".txt", RandomTestUtil.randomString(),
+				StringUtil.randomId(8), ".txt", RandomTestUtil.randomString(),
 				ContentTypes.TEXT_PLAIN, _objectDefinition);
 
 			folder = tempFileEntry.getFolder();
@@ -219,7 +220,7 @@ public class AttachmentManagerTest {
 						).build())) {
 
 			tempFileEntry = _addTempFileEntry(
-				_getRandomFileContent(8), ".txt", RandomTestUtil.randomString(),
+				StringUtil.randomId(8), ".txt", RandomTestUtil.randomString(),
 				ContentTypes.TEXT_PLAIN, _objectDefinition);
 
 			folder = tempFileEntry.getFolder();
@@ -246,7 +247,7 @@ public class AttachmentManagerTest {
 					).build())) {
 
 			tempFileEntry = _addTempFileEntry(
-				_getRandomFileContent(1000), ".txt",
+				StringUtil.randomId(1000), ".txt",
 				RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
 				_objectDefinition);
 
@@ -313,15 +314,6 @@ public class AttachmentManagerTest {
 			objectDefinition.getPortletId(),
 			TempFileEntryUtil.getTempFileName(fileName + extension),
 			FileUtil.createTempFile(content.getBytes()), mimeType);
-	}
-
-	private String _getRandomFileContent(int size) {
-		String firstLine = "test\n";
-
-		String randomContent = RandomTestUtil.randomString(
-			size - firstLine.length());
-
-		return firstLine + randomContent;
 	}
 
 	@Inject

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/attachment/test/AttachmentManagerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/attachment/test/AttachmentManagerTest.java
@@ -110,7 +110,7 @@ public class AttachmentManagerTest {
 	@Test
 	public void testGetOrAddFileEntry() throws Exception {
 		FileEntry tempFileEntry = _addTempFileEntry(
-			DLTestUtil.randomTextFileContent(), ".txt",
+			DLTestUtil.randomTextFileBytes(), ".txt",
 			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
 			_objectDefinition);
 
@@ -192,7 +192,7 @@ public class AttachmentManagerTest {
 					).build())) {
 
 			tempFileEntry = _addTempFileEntry(
-				DLTestUtil.randomTextFileContent(), ".txt",
+				DLTestUtil.randomTextFileBytes(), ".txt",
 				RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
 				_objectDefinition);
 
@@ -221,7 +221,7 @@ public class AttachmentManagerTest {
 						).build())) {
 
 			tempFileEntry = _addTempFileEntry(
-				DLTestUtil.randomTextFileContent(), ".txt",
+				DLTestUtil.randomTextFileBytes(), ".txt",
 				RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
 				_objectDefinition);
 
@@ -249,7 +249,7 @@ public class AttachmentManagerTest {
 					).build())) {
 
 			tempFileEntry = _addTempFileEntry(
-				DLTestUtil.randomTextFileContent(1000), ".txt",
+				DLTestUtil.randomTextFileBytes(1000), ".txt",
 				RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
 				_objectDefinition);
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceSearchObjectEntriesTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceSearchObjectEntriesTest.java
@@ -646,10 +646,7 @@ public class ObjectEntryLocalServiceSearchObjectEntriesTest {
 			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
 			_objectDefinition.getPortletId(),
 			TempFileEntryUtil.getTempFileName("document.txt"),
-			FileUtil.createTempFile(
-				DLTestUtil.randomTextFileContent(
-					8
-				).getBytes()),
+			FileUtil.createTempFile(DLTestUtil.randomTextFileContent(8)),
 			ContentTypes.TEXT_PLAIN);
 
 		_addObjectEntry(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceSearchObjectEntriesTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceSearchObjectEntriesTest.java
@@ -646,7 +646,7 @@ public class ObjectEntryLocalServiceSearchObjectEntriesTest {
 			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
 			_objectDefinition.getPortletId(),
 			TempFileEntryUtil.getTempFileName("document.txt"),
-			FileUtil.createTempFile(DLTestUtil.randomTextFileContent()),
+			FileUtil.createTempFile(DLTestUtil.randomTextFileBytes()),
 			ContentTypes.TEXT_PLAIN);
 
 		_addObjectEntry(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceSearchObjectEntriesTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceSearchObjectEntriesTest.java
@@ -641,11 +641,13 @@ public class ObjectEntryLocalServiceSearchObjectEntriesTest {
 
 		_addObjectDefinition(objectField);
 
+		String content = "test\n" + RandomTestUtil.randomString();
+
 		FileEntry fileEntry = TempFileEntryUtil.addTempFileEntry(
 			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
 			_objectDefinition.getPortletId(),
 			TempFileEntryUtil.getTempFileName("document.txt"),
-			FileUtil.createTempFile(RandomTestUtil.randomBytes()),
+			FileUtil.createTempFile(content.getBytes()),
 			ContentTypes.TEXT_PLAIN);
 
 		_addObjectEntry(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceSearchObjectEntriesTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceSearchObjectEntriesTest.java
@@ -7,6 +7,7 @@ package com.liferay.object.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.test.util.DLTestUtil;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectFieldSettingConstants;
@@ -36,7 +37,6 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.Validator;
@@ -642,13 +642,14 @@ public class ObjectEntryLocalServiceSearchObjectEntriesTest {
 
 		_addObjectDefinition(objectField);
 
-		String content = StringUtil.randomId(8);
-
 		FileEntry fileEntry = TempFileEntryUtil.addTempFileEntry(
 			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
 			_objectDefinition.getPortletId(),
 			TempFileEntryUtil.getTempFileName("document.txt"),
-			FileUtil.createTempFile(content.getBytes()),
+			FileUtil.createTempFile(
+				DLTestUtil.randomTextFileContent(
+					8
+				).getBytes()),
 			ContentTypes.TEXT_PLAIN);
 
 		_addObjectEntry(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceSearchObjectEntriesTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceSearchObjectEntriesTest.java
@@ -646,7 +646,7 @@ public class ObjectEntryLocalServiceSearchObjectEntriesTest {
 			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
 			_objectDefinition.getPortletId(),
 			TempFileEntryUtil.getTempFileName("document.txt"),
-			FileUtil.createTempFile(DLTestUtil.randomTextFileContent(8)),
+			FileUtil.createTempFile(DLTestUtil.randomTextFileContent()),
 			ContentTypes.TEXT_PLAIN);
 
 		_addObjectEntry(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceSearchObjectEntriesTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceSearchObjectEntriesTest.java
@@ -36,6 +36,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.Validator;
@@ -641,7 +642,7 @@ public class ObjectEntryLocalServiceSearchObjectEntriesTest {
 
 		_addObjectDefinition(objectField);
 
-		String content = "test\n" + RandomTestUtil.randomString();
+		String content = StringUtil.randomId(8);
 
 		FileEntry fileEntry = TempFileEntryUtil.addTempFileEntry(
 			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -7258,7 +7258,7 @@ public class ObjectEntryLocalServiceTest {
 				RandomTestUtil.randomString() + ".txt"),
 			ContentTypes.TEXT_PLAIN, RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
-			new ByteArrayInputStream(DLTestUtil.randomTextFileContent()), 0,
+			new ByteArrayInputStream(DLTestUtil.randomTextFileBytes()), 0,
 			null, null, null, ServiceContextTestUtil.getServiceContext());
 
 		return _dlFileEntryLocalService.getFileEntry(
@@ -7485,7 +7485,7 @@ public class ObjectEntryLocalServiceTest {
 			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
 			_objectDefinition.getPortletId(),
 			TempFileEntryUtil.getTempFileName(title + ".txt"),
-			FileUtil.createTempFile(DLTestUtil.randomTextFileContent()),
+			FileUtil.createTempFile(DLTestUtil.randomTextFileBytes()),
 			ContentTypes.TEXT_PLAIN);
 	}
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -7258,11 +7258,8 @@ public class ObjectEntryLocalServiceTest {
 				RandomTestUtil.randomString() + ".txt"),
 			ContentTypes.TEXT_PLAIN, RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
-			new ByteArrayInputStream(
-				DLTestUtil.randomTextFileContent(
-					8
-				).getBytes()),
-			0, null, null, null, ServiceContextTestUtil.getServiceContext());
+			new ByteArrayInputStream(DLTestUtil.randomTextFileContent(8)), 0,
+			null, null, null, ServiceContextTestUtil.getServiceContext());
 
 		return _dlFileEntryLocalService.getFileEntry(
 			fileEntry.getFileEntryId());
@@ -7488,10 +7485,7 @@ public class ObjectEntryLocalServiceTest {
 			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
 			_objectDefinition.getPortletId(),
 			TempFileEntryUtil.getTempFileName(title + ".txt"),
-			FileUtil.createTempFile(
-				DLTestUtil.randomTextFileContent(
-					8
-				).getBytes()),
+			FileUtil.createTempFile(DLTestUtil.randomTextFileContent(8)),
 			ContentTypes.TEXT_PLAIN);
 	}
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -7258,7 +7258,7 @@ public class ObjectEntryLocalServiceTest {
 				RandomTestUtil.randomString() + ".txt"),
 			ContentTypes.TEXT_PLAIN, RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
-			new ByteArrayInputStream(DLTestUtil.randomTextFileContent(8)), 0,
+			new ByteArrayInputStream(DLTestUtil.randomTextFileContent()), 0,
 			null, null, null, ServiceContextTestUtil.getServiceContext());
 
 		return _dlFileEntryLocalService.getFileEntry(
@@ -7485,7 +7485,7 @@ public class ObjectEntryLocalServiceTest {
 			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
 			_objectDefinition.getPortletId(),
 			TempFileEntryUtil.getTempFileName(title + ".txt"),
-			FileUtil.createTempFile(DLTestUtil.randomTextFileContent(8)),
+			FileUtil.createTempFile(DLTestUtil.randomTextFileContent()),
 			ContentTypes.TEXT_PLAIN);
 	}
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -7258,8 +7258,8 @@ public class ObjectEntryLocalServiceTest {
 				RandomTestUtil.randomString() + ".txt"),
 			ContentTypes.TEXT_PLAIN, RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
-			new ByteArrayInputStream(DLTestUtil.randomTextFileBytes()), 0,
-			null, null, null, ServiceContextTestUtil.getServiceContext());
+			new ByteArrayInputStream(DLTestUtil.randomTextFileBytes()), 0, null,
+			null, null, ServiceContextTestUtil.getServiceContext());
 
 		return _dlFileEntryLocalService.getFileEntry(
 			fileEntry.getFileEntryId());

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -28,6 +28,7 @@ import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.test.util.DLTestUtil;
 import com.liferay.expando.kernel.model.ExpandoColumn;
 import com.liferay.expando.kernel.model.ExpandoColumnConstants;
 import com.liferay.expando.kernel.model.ExpandoTable;
@@ -7250,8 +7251,6 @@ public class ObjectEntryLocalServiceTest {
 		Company company = _companyLocalService.getCompanyById(
 			TestPropsValues.getCompanyId());
 
-		String content = StringUtil.randomId(8);
-
 		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
 			null, TestPropsValues.getUserId(), company.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
@@ -7259,8 +7258,11 @@ public class ObjectEntryLocalServiceTest {
 				RandomTestUtil.randomString() + ".txt"),
 			ContentTypes.TEXT_PLAIN, RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
-			new ByteArrayInputStream(content.getBytes()), 0, null, null, null,
-			ServiceContextTestUtil.getServiceContext());
+			new ByteArrayInputStream(
+				DLTestUtil.randomTextFileContent(
+					8
+				).getBytes()),
+			0, null, null, null, ServiceContextTestUtil.getServiceContext());
 
 		return _dlFileEntryLocalService.getFileEntry(
 			fileEntry.getFileEntryId());
@@ -7482,13 +7484,14 @@ public class ObjectEntryLocalServiceTest {
 	}
 
 	private FileEntry _addTempFileEntry(String title) throws Exception {
-		String content = StringUtil.randomId(8);
-
 		return TempFileEntryUtil.addTempFileEntry(
 			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
 			_objectDefinition.getPortletId(),
 			TempFileEntryUtil.getTempFileName(title + ".txt"),
-			FileUtil.createTempFile(content.getBytes()),
+			FileUtil.createTempFile(
+				DLTestUtil.randomTextFileContent(
+					8
+				).getBytes()),
 			ContentTypes.TEXT_PLAIN);
 	}
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -7250,7 +7250,7 @@ public class ObjectEntryLocalServiceTest {
 		Company company = _companyLocalService.getCompanyById(
 			TestPropsValues.getCompanyId());
 
-		String content = _getRandomFileContent();
+		String content = StringUtil.randomId(8);
 
 		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
 			null, TestPropsValues.getUserId(), company.getGroupId(),
@@ -7482,7 +7482,7 @@ public class ObjectEntryLocalServiceTest {
 	}
 
 	private FileEntry _addTempFileEntry(String title) throws Exception {
-		String content = _getRandomFileContent();
+		String content = StringUtil.randomId(8);
 
 		return TempFileEntryUtil.addTempFileEntry(
 			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
@@ -7810,10 +7810,6 @@ public class ObjectEntryLocalServiceTest {
 		}
 
 		return ": Invalid transformation format:";
-	}
-
-	private String _getRandomFileContent() {
-		return "test\n" + RandomTestUtil.randomString();
 	}
 
 	private Map<String, Serializable> _getValuesFromCacheField(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -7249,7 +7249,8 @@ public class ObjectEntryLocalServiceTest {
 	private DLFileEntry _addDLFileEntry() throws Exception {
 		Company company = _companyLocalService.getCompanyById(
 			TestPropsValues.getCompanyId());
-		String content = RandomTestUtil.randomString();
+
+		String content = _getRandomFileContent();
 
 		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
 			null, TestPropsValues.getUserId(), company.getGroupId(),
@@ -7481,11 +7482,13 @@ public class ObjectEntryLocalServiceTest {
 	}
 
 	private FileEntry _addTempFileEntry(String title) throws Exception {
+		String content = _getRandomFileContent();
+
 		return TempFileEntryUtil.addTempFileEntry(
 			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
 			_objectDefinition.getPortletId(),
 			TempFileEntryUtil.getTempFileName(title + ".txt"),
-			FileUtil.createTempFile(RandomTestUtil.randomBytes()),
+			FileUtil.createTempFile(content.getBytes()),
 			ContentTypes.TEXT_PLAIN);
 	}
 
@@ -7807,6 +7810,10 @@ public class ObjectEntryLocalServiceTest {
 		}
 
 		return ": Invalid transformation format:";
+	}
+
+	private String _getRandomFileContent() {
+		return "test\n" + RandomTestUtil.randomString();
 	}
 
 	private Map<String, Serializable> _getValuesFromCacheField(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
@@ -1716,7 +1716,7 @@ public class ObjectFieldLocalServiceTest {
 			HashMapBuilder.<String, Serializable>put(
 				"upload",
 				() -> {
-					String content = "test\n" + RandomTestUtil.randomString();
+					String content = StringUtil.randomId(8);
 
 					FileEntry fileEntry = TempFileEntryUtil.addTempFileEntry(
 						TestPropsValues.getGroupId(),

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
@@ -1716,12 +1716,14 @@ public class ObjectFieldLocalServiceTest {
 			HashMapBuilder.<String, Serializable>put(
 				"upload",
 				() -> {
+					String content = "test\n" + RandomTestUtil.randomString();
+
 					FileEntry fileEntry = TempFileEntryUtil.addTempFileEntry(
 						TestPropsValues.getGroupId(),
 						TestPropsValues.getUserId(), StringUtil.randomString(),
 						TempFileEntryUtil.getTempFileName(
 							StringUtil.randomString() + ".txt"),
-						FileUtil.createTempFile(RandomTestUtil.randomBytes()),
+						FileUtil.createTempFile(content.getBytes()),
 						ContentTypes.TEXT_PLAIN);
 
 					return fileEntry.getFileEntryId();

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
@@ -1723,7 +1723,7 @@ public class ObjectFieldLocalServiceTest {
 						TempFileEntryUtil.getTempFileName(
 							StringUtil.randomString() + ".txt"),
 						FileUtil.createTempFile(
-							DLTestUtil.randomTextFileContent()),
+							DLTestUtil.randomTextFileBytes()),
 						ContentTypes.TEXT_PLAIN);
 
 					return fileEntry.getFileEntryId();

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
@@ -1723,7 +1723,7 @@ public class ObjectFieldLocalServiceTest {
 						TempFileEntryUtil.getTempFileName(
 							StringUtil.randomString() + ".txt"),
 						FileUtil.createTempFile(
-							DLTestUtil.randomTextFileContent(8)),
+							DLTestUtil.randomTextFileContent()),
 						ContentTypes.TEXT_PLAIN);
 
 					return fileEntry.getFileEntryId();

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
@@ -11,6 +11,7 @@ import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.test.util.DLTestUtil;
 import com.liferay.list.type.entry.util.ListTypeEntryUtil;
 import com.liferay.list.type.model.ListTypeDefinition;
 import com.liferay.list.type.service.ListTypeDefinitionLocalService;
@@ -1716,14 +1717,15 @@ public class ObjectFieldLocalServiceTest {
 			HashMapBuilder.<String, Serializable>put(
 				"upload",
 				() -> {
-					String content = StringUtil.randomId(8);
-
 					FileEntry fileEntry = TempFileEntryUtil.addTempFileEntry(
 						TestPropsValues.getGroupId(),
 						TestPropsValues.getUserId(), StringUtil.randomString(),
 						TempFileEntryUtil.getTempFileName(
 							StringUtil.randomString() + ".txt"),
-						FileUtil.createTempFile(content.getBytes()),
+						FileUtil.createTempFile(
+							DLTestUtil.randomTextFileContent(
+								8
+							).getBytes()),
 						ContentTypes.TEXT_PLAIN);
 
 					return fileEntry.getFileEntryId();

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
@@ -1723,9 +1723,7 @@ public class ObjectFieldLocalServiceTest {
 						TempFileEntryUtil.getTempFileName(
 							StringUtil.randomString() + ".txt"),
 						FileUtil.createTempFile(
-							DLTestUtil.randomTextFileContent(
-								8
-							).getBytes()),
+							DLTestUtil.randomTextFileContent(8)),
 						ContentTypes.TEXT_PLAIN);
 
 					return fileEntry.getFileEntryId();

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/updater/test/ObjectEntryInfoItemFieldValuesUpdaterTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/updater/test/ObjectEntryInfoItemFieldValuesUpdaterTest.java
@@ -270,7 +270,7 @@ public class ObjectEntryInfoItemFieldValuesUpdaterTest
 	}
 
 	private FileEntry _addTempFileEntry(long groupId) throws Exception {
-		String content = "test\n" + RandomTestUtil.randomString();
+		String content = StringUtil.randomId(8);
 
 		return TempFileEntryUtil.addTempFileEntry(
 			groupId, TestPropsValues.getUserId(), RandomTestUtil.randomString(),

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/updater/test/ObjectEntryInfoItemFieldValuesUpdaterTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/updater/test/ObjectEntryInfoItemFieldValuesUpdaterTest.java
@@ -274,10 +274,7 @@ public class ObjectEntryInfoItemFieldValuesUpdaterTest
 		return TempFileEntryUtil.addTempFileEntry(
 			groupId, TestPropsValues.getUserId(), RandomTestUtil.randomString(),
 			TempFileEntryUtil.getTempFileName("document.txt"),
-			FileUtil.createTempFile(
-				DLTestUtil.randomTextFileContent(
-					8
-				).getBytes()),
+			FileUtil.createTempFile(DLTestUtil.randomTextFileContent(8)),
 			ContentTypes.TEXT_PLAIN);
 	}
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/updater/test/ObjectEntryInfoItemFieldValuesUpdaterTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/updater/test/ObjectEntryInfoItemFieldValuesUpdaterTest.java
@@ -274,7 +274,7 @@ public class ObjectEntryInfoItemFieldValuesUpdaterTest
 		return TempFileEntryUtil.addTempFileEntry(
 			groupId, TestPropsValues.getUserId(), RandomTestUtil.randomString(),
 			TempFileEntryUtil.getTempFileName("document.txt"),
-			FileUtil.createTempFile(DLTestUtil.randomTextFileContent(8)),
+			FileUtil.createTempFile(DLTestUtil.randomTextFileContent()),
 			ContentTypes.TEXT_PLAIN);
 	}
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/updater/test/ObjectEntryInfoItemFieldValuesUpdaterTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/updater/test/ObjectEntryInfoItemFieldValuesUpdaterTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.document.library.test.util.DLTestUtil;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.InfoFieldValue;
 import com.liferay.info.field.type.FileInfoFieldType;
@@ -270,12 +271,13 @@ public class ObjectEntryInfoItemFieldValuesUpdaterTest
 	}
 
 	private FileEntry _addTempFileEntry(long groupId) throws Exception {
-		String content = StringUtil.randomId(8);
-
 		return TempFileEntryUtil.addTempFileEntry(
 			groupId, TestPropsValues.getUserId(), RandomTestUtil.randomString(),
 			TempFileEntryUtil.getTempFileName("document.txt"),
-			FileUtil.createTempFile(content.getBytes()),
+			FileUtil.createTempFile(
+				DLTestUtil.randomTextFileContent(
+					8
+				).getBytes()),
 			ContentTypes.TEXT_PLAIN);
 	}
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/updater/test/ObjectEntryInfoItemFieldValuesUpdaterTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/updater/test/ObjectEntryInfoItemFieldValuesUpdaterTest.java
@@ -270,12 +270,12 @@ public class ObjectEntryInfoItemFieldValuesUpdaterTest
 	}
 
 	private FileEntry _addTempFileEntry(long groupId) throws Exception {
+		String content = "test\n" + RandomTestUtil.randomString();
+
 		return TempFileEntryUtil.addTempFileEntry(
 			groupId, TestPropsValues.getUserId(), RandomTestUtil.randomString(),
 			TempFileEntryUtil.getTempFileName("document.txt"),
-			FileUtil.createTempFile(
-				StringUtil.randomString(
-				).getBytes()),
+			FileUtil.createTempFile(content.getBytes()),
 			ContentTypes.TEXT_PLAIN);
 	}
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/updater/test/ObjectEntryInfoItemFieldValuesUpdaterTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/updater/test/ObjectEntryInfoItemFieldValuesUpdaterTest.java
@@ -274,7 +274,7 @@ public class ObjectEntryInfoItemFieldValuesUpdaterTest
 		return TempFileEntryUtil.addTempFileEntry(
 			groupId, TestPropsValues.getUserId(), RandomTestUtil.randomString(),
 			TempFileEntryUtil.getTempFileName("document.txt"),
-			FileUtil.createTempFile(DLTestUtil.randomTextFileContent()),
+			FileUtil.createTempFile(DLTestUtil.randomTextFileBytes()),
 			ContentTypes.TEXT_PLAIN);
 	}
 


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-82681

See: https://github.com/brianchandotcom/liferay-portal/pull/171863#issuecomment-4092530963

```
>> git grep -C 1 "DLTestUtil.randomTextFileBytes" | grep -v "DLTestUtil.randomTextFileBytes()" | grep randomTextFileBytes -C 1
```
```
modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java-				Base64::encode,
modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java:				DLTestUtil.randomTextFileBytes(
modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java-					(_MAX_FILE_SIZE_VALUE * 1024 * 1024) + 1),
--
modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java-				String::new,
modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java:				ArrayUtil.append(DLTestUtil.randomTextFileBytes(7), (byte)'$'),
modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java-				RandomTestUtil.randomString() + ".txt", null, null,
--
modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java-				Base64::encode,
modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java:				DLTestUtil.randomTextFileBytes(
modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java-					(_MAX_FILE_SIZE_VALUE * 1024 * 1024) + 1),
--
modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java-				String::new,
modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java:				ArrayUtil.append(DLTestUtil.randomTextFileBytes(7), (byte)'$'),
modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java-				RandomTestUtil.randomString() + ".txt", null, null,
--
modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java-				FileUtil.createTempFile(
modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java:					DLTestUtil.randomTextFileBytes(
modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java-						(_MAX_FILE_SIZE_VALUE * 1024 * 1024) + 1)),
--
modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/attachment/test/AttachmentManagerTest.java-			tempFileEntry = _addTempFileEntry(
modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/attachment/test/AttachmentManagerTest.java:				DLTestUtil.randomTextFileBytes(1000), ".txt",
modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/attachment/test/AttachmentManagerTest.java-				RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,

```