### PR TITLE
LPD-81650 Follow-up

### DIFF
--- a/modules/apps/segments/segments-service/src/main/resources/service.properties
+++ b/modules/apps/segments/segments-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.segments.service
-    build.number=8
-    build.date=1773089889872
+    build.number=9
+    build.date=1774009079634


### PR DESCRIPTION
`modules/apps/segments/segments-service/src/main/resources/service.properties` wasn't updated last time the service was regenerated and after the upgrade the ServiceComponent record is detected as outdated because of it.

Updating it, will avoid the ServiceComponent record not being updated