### PR TITLE
LPD-82487 Allow to rename marketplace fragments, don't allow to export empty fragment set follow up

### DIFF
--- a/modules/apps/fragment/fragment-api/bnd.bnd
+++ b/modules/apps/fragment/fragment-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Fragment API
 Bundle-SymbolicName: com.liferay.fragment.api
-Bundle-Version: 60.0.0
+Bundle-Version: 60.1.0
 Export-Package:\
 	com.liferay.fragment.cache,\
 	com.liferay.fragment.configuration,\

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/model/FragmentCollection.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/model/FragmentCollection.java
@@ -72,6 +72,9 @@ public interface FragmentCollection
 	public boolean hasResources()
 		throws com.liferay.portal.kernel.exception.PortalException;
 
+	public boolean isExportable()
+		throws com.liferay.portal.kernel.exception.PortalException;
+
 	public void populateZipWriter(
 			com.liferay.portal.kernel.zip.ZipWriter zipWriter)
 		throws Exception;
@@ -81,4 +84,4 @@ public interface FragmentCollection
 		throws Exception;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-440920962
+// LIFERAY-SERVICE-BUILDER-HASH:-1892763131

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/model/FragmentCollectionWrapper.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/model/FragmentCollectionWrapper.java
@@ -387,6 +387,13 @@ public class FragmentCollectionWrapper
 		return model.hasResources();
 	}
 
+	@Override
+	public boolean isExportable()
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return model.isExportable();
+	}
+
 	/**
 	 * Returns <code>true</code> if this fragment collection is marketplace.
 	 *
@@ -630,4 +637,4 @@ public class FragmentCollectionWrapper
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1775839693
+// LIFERAY-SERVICE-BUILDER-HASH:-1414397000

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCompositionLocalService.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCompositionLocalService.java
@@ -380,6 +380,9 @@ public interface FragmentCompositionLocalService
 	public String getUniqueFragmentCompositionName(
 		long groupId, long fragmentCollectionId, String name);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public boolean hasExportableFragmentCompositions(long fragmentCollectionId);
+
 	public FragmentComposition moveFragmentComposition(
 			long fragmentCompositionId, long fragmentCollectionId)
 		throws PortalException;
@@ -428,4 +431,4 @@ public interface FragmentCompositionLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:472596782
+// LIFERAY-SERVICE-BUILDER-HASH:1261531300

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCompositionLocalServiceUtil.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCompositionLocalServiceUtil.java
@@ -460,6 +460,13 @@ public class FragmentCompositionLocalServiceUtil {
 			groupId, fragmentCollectionId, name);
 	}
 
+	public static boolean hasExportableFragmentCompositions(
+		long fragmentCollectionId) {
+
+		return getService().hasExportableFragmentCompositions(
+			fragmentCollectionId);
+	}
+
 	public static FragmentComposition moveFragmentComposition(
 			long fragmentCompositionId, long fragmentCollectionId)
 		throws PortalException {
@@ -521,4 +528,4 @@ public class FragmentCompositionLocalServiceUtil {
 			FragmentCompositionLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:823944975
+// LIFERAY-SERVICE-BUILDER-HASH:102359497

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCompositionLocalServiceWrapper.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCompositionLocalServiceWrapper.java
@@ -527,6 +527,14 @@ public class FragmentCompositionLocalServiceWrapper
 	}
 
 	@Override
+	public boolean hasExportableFragmentCompositions(
+		long fragmentCollectionId) {
+
+		return _fragmentCompositionLocalService.
+			hasExportableFragmentCompositions(fragmentCollectionId);
+	}
+
+	@Override
 	public FragmentComposition moveFragmentComposition(
 			long fragmentCompositionId, long fragmentCollectionId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -623,4 +631,4 @@ public class FragmentCompositionLocalServiceWrapper
 	private FragmentCompositionLocalService _fragmentCompositionLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:938308998
+// LIFERAY-SERVICE-BUILDER-HASH:-1871585664

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalService.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalService.java
@@ -432,6 +432,9 @@ public interface FragmentEntryLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<FragmentEntryVersion> getVersions(FragmentEntry fragmentEntry);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public boolean hasExportableFragmentEntries(long fragmentCollectionId);
+
 	public FragmentEntry moveFragmentEntry(
 			long fragmentEntryId, long fragmentCollectionId)
 		throws PortalException;
@@ -505,4 +508,4 @@ public interface FragmentEntryLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:775167175
+// LIFERAY-SERVICE-BUILDER-HASH:882194460

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalServiceUtil.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalServiceUtil.java
@@ -533,6 +533,12 @@ public class FragmentEntryLocalServiceUtil {
 		return getService().getVersions(fragmentEntry);
 	}
 
+	public static boolean hasExportableFragmentEntries(
+		long fragmentCollectionId) {
+
+		return getService().hasExportableFragmentEntries(fragmentCollectionId);
+	}
+
 	public static FragmentEntry moveFragmentEntry(
 			long fragmentEntryId, long fragmentCollectionId)
 		throws PortalException {
@@ -632,4 +638,4 @@ public class FragmentEntryLocalServiceUtil {
 			FragmentEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1358558076
+// LIFERAY-SERVICE-BUILDER-HASH:1144222

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalServiceWrapper.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalServiceWrapper.java
@@ -621,6 +621,12 @@ public class FragmentEntryLocalServiceWrapper
 	}
 
 	@Override
+	public boolean hasExportableFragmentEntries(long fragmentCollectionId) {
+		return _fragmentEntryLocalService.hasExportableFragmentEntries(
+			fragmentCollectionId);
+	}
+
+	@Override
 	public FragmentEntry moveFragmentEntry(
 			long fragmentEntryId, long fragmentCollectionId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -760,4 +766,4 @@ public class FragmentEntryLocalServiceWrapper
 	private FragmentEntryLocalService _fragmentEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1282295569
+// LIFERAY-SERVICE-BUILDER-HASH:656993293

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/model/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/model/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.1.0

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/service/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/service/packageinfo
@@ -1,1 +1,1 @@
-version 16.0.0
+version 16.1.0

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionImpl.java
@@ -131,19 +131,6 @@ public class FragmentCollectionImpl extends FragmentCollectionBaseImpl {
 	}
 
 	@Override
-	public boolean hasExportableFragmentCompositionsAndFragmentEntries() {
-		if (FragmentCompositionLocalServiceUtil.
-				hasExportableFragmentCompositions(getFragmentCollectionId()) ||
-			FragmentEntryLocalServiceUtil.hasExportableFragmentEntries(
-				getFragmentCollectionId())) {
-
-			return true;
-		}
-
-		return false;
-	}
-
-	@Override
 	public boolean hasResources() throws PortalException {
 		Repository repository = _getRepository(true);
 
@@ -157,6 +144,20 @@ public class FragmentCollectionImpl extends FragmentCollectionBaseImpl {
 		}
 
 		return true;
+	}
+
+	@Override
+	public boolean isExportable() throws PortalException {
+		if (FragmentCompositionLocalServiceUtil.
+				hasExportableFragmentCompositions(getFragmentCollectionId()) ||
+			FragmentEntryLocalServiceUtil.hasExportableFragmentEntries(
+				getFragmentCollectionId()) ||
+			hasResources()) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	@Override

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionImpl.java
@@ -131,6 +131,19 @@ public class FragmentCollectionImpl extends FragmentCollectionBaseImpl {
 	}
 
 	@Override
+	public boolean hasExportableItems() {
+		if (FragmentCompositionLocalServiceUtil.hasExportableItems(
+				getFragmentCollectionId()) ||
+			FragmentEntryLocalServiceUtil.hasExportableItems(
+				getFragmentCollectionId())) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
 	public boolean hasResources() throws PortalException {
 		Repository repository = _getRepository(true);
 

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionImpl.java
@@ -131,10 +131,10 @@ public class FragmentCollectionImpl extends FragmentCollectionBaseImpl {
 	}
 
 	@Override
-	public boolean hasExportableItems() {
-		if (FragmentCompositionLocalServiceUtil.hasExportableItems(
-				getFragmentCollectionId()) ||
-			FragmentEntryLocalServiceUtil.hasExportableItems(
+	public boolean hasExportableFragmentCompositionsAndFragmentEntries() {
+		if (FragmentCompositionLocalServiceUtil.
+				hasExportableFragmentCompositions(getFragmentCollectionId()) ||
+			FragmentEntryLocalServiceUtil.hasExportableFragmentEntries(
 				getFragmentCollectionId())) {
 
 			return true;

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCompositionLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCompositionLocalServiceImpl.java
@@ -283,7 +283,9 @@ public class FragmentCompositionLocalServiceImpl
 	}
 
 	@Override
-	public boolean hasExportableItems(long fragmentCollectionId) {
+	public boolean hasExportableFragmentCompositions(
+		long fragmentCollectionId) {
+
 		int count = dslQueryCount(
 			DSLQueryFactoryUtil.count(
 			).from(

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCompositionLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCompositionLocalServiceImpl.java
@@ -9,7 +9,9 @@ import com.liferay.fragment.exception.DuplicateFragmentCompositionKeyException;
 import com.liferay.fragment.exception.FragmentCompositionDescriptionException;
 import com.liferay.fragment.exception.FragmentCompositionNameException;
 import com.liferay.fragment.model.FragmentComposition;
+import com.liferay.fragment.model.FragmentCompositionTable;
 import com.liferay.fragment.service.base.FragmentCompositionLocalServiceBaseImpl;
+import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
@@ -278,6 +280,27 @@ public class FragmentCompositionLocalServiceImpl
 				return newName;
 			}
 		}
+	}
+
+	@Override
+	public boolean hasExportableItems(long fragmentCollectionId) {
+		int count = dslQueryCount(
+			DSLQueryFactoryUtil.count(
+			).from(
+				FragmentCompositionTable.INSTANCE
+			).where(
+				FragmentCompositionTable.INSTANCE.fragmentCollectionId.eq(
+					fragmentCollectionId
+				).and(
+					FragmentCompositionTable.INSTANCE.marketplace.eq(false)
+				)
+			));
+
+		if (count > 0) {
+			return true;
+		}
+
+		return false;
 	}
 
 	@Override

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
@@ -577,7 +577,7 @@ public class FragmentEntryLocalServiceImpl
 	}
 
 	@Override
-	public boolean hasExportableItems(long fragmentCollectionId) {
+	public boolean hasExportableFragmentEntries(long fragmentCollectionId) {
 		int count = dslQueryCount(
 			DSLQueryFactoryUtil.count(
 			).from(

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
@@ -8,6 +8,7 @@ package com.liferay.fragment.service.impl;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.fragment.configuration.FragmentServiceConfiguration;
+import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.constants.FragmentPortletKeys;
 import com.liferay.fragment.exception.DuplicateFragmentEntryKeyException;
 import com.liferay.fragment.exception.FragmentEntryNameException;
@@ -16,11 +17,13 @@ import com.liferay.fragment.exception.RequiredFragmentEntryException;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.fragment.model.FragmentEntryTable;
 import com.liferay.fragment.processor.FragmentEntryProcessorRegistry;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.fragment.service.base.FragmentEntryLocalServiceBaseImpl;
 import com.liferay.fragment.service.persistence.FragmentCollectionPersistence;
 import com.liferay.fragment.validator.FragmentEntryValidator;
+import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
@@ -571,6 +574,32 @@ public class FragmentEntryLocalServiceImpl
 				return newName;
 			}
 		}
+	}
+
+	@Override
+	public boolean hasExportableItems(long fragmentCollectionId) {
+		int count = dslQueryCount(
+			DSLQueryFactoryUtil.count(
+			).from(
+				FragmentEntryTable.INSTANCE
+			).where(
+				FragmentEntryTable.INSTANCE.fragmentCollectionId.eq(
+					fragmentCollectionId
+				).and(
+					FragmentEntryTable.INSTANCE.marketplace.eq(false)
+				).and(
+					FragmentEntryTable.INSTANCE.type.neq(
+						FragmentConstants.TYPE_REACT)
+				).and(
+					FragmentEntryTable.INSTANCE.head.eq(true)
+				)
+			));
+
+		if (count > 0) {
+			return true;
+		}
+
+		return false;
 	}
 
 	@Override

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/model/impl/test/FragmentCollectionImplTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/model/impl/test/FragmentCollectionImplTest.java
@@ -8,12 +8,15 @@ package com.liferay.fragment.model.impl.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLAppService;
+import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.constants.FragmentExportImportConstants;
 import com.liferay.fragment.constants.FragmentPortletKeys;
 import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.model.FragmentComposition;
 import com.liferay.fragment.model.FragmentEntry;
-import com.liferay.fragment.service.FragmentCollectionLocalService;
+import com.liferay.fragment.service.FragmentCompositionLocalService;
 import com.liferay.fragment.service.FragmentEntryLocalService;
+import com.liferay.fragment.test.util.FragmentCompositionTestUtil;
 import com.liferay.fragment.test.util.FragmentEntryTestUtil;
 import com.liferay.fragment.test.util.FragmentTestUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -103,6 +106,53 @@ public class FragmentCollectionImplTest {
 	}
 
 	@Test
+	@TestInfo("LPD-82487")
+	public void testHasExportableItems() throws Exception {
+		Assert.assertFalse(_fragmentCollection.hasExportableItems());
+
+		FragmentComposition marketplaceFragmentComposition =
+			FragmentCompositionTestUtil.addFragmentComposition(
+				_fragmentCollection.getFragmentCollectionId(),
+				RandomTestUtil.randomString());
+
+		marketplaceFragmentComposition.setMarketplace(true);
+
+		_fragmentCompositionLocalService.updateFragmentComposition(
+			marketplaceFragmentComposition);
+
+		Assert.assertFalse(_fragmentCollection.hasExportableItems());
+
+		FragmentEntry reactFragmentEntry =
+			FragmentEntryTestUtil.addFragmentEntryByType(
+				_fragmentCollection.getFragmentCollectionId(),
+				FragmentConstants.TYPE_REACT);
+
+		Assert.assertTrue(reactFragmentEntry.isTypeReact());
+
+		Assert.assertFalse(_fragmentCollection.hasExportableItems());
+
+		FragmentEntry marketplaceFragmentEntry =
+			FragmentEntryTestUtil.addFragmentEntry(
+				_fragmentCollection.getFragmentCollectionId());
+
+		marketplaceFragmentEntry.setMarketplace(true);
+
+		_fragmentEntryLocalService.updateFragmentEntry(
+			marketplaceFragmentEntry);
+
+		Assert.assertFalse(_fragmentCollection.hasExportableItems());
+
+		FragmentComposition exportableFragmentComposition =
+			FragmentCompositionTestUtil.addFragmentComposition(
+				_fragmentCollection.getFragmentCollectionId(),
+				RandomTestUtil.randomString());
+
+		Assert.assertFalse(exportableFragmentComposition.isMarketplace());
+
+		Assert.assertTrue(_fragmentCollection.hasExportableItems());
+	}
+
+	@Test
 	@TestInfo("LPD-33704")
 	public void testPopulateZipWriter() throws Exception {
 		ZipWriter zipWriter = _zipWriterFactory.getZipWriter();
@@ -189,7 +239,7 @@ public class FragmentCollectionImplTest {
 	private FragmentCollection _fragmentCollection;
 
 	@Inject
-	private FragmentCollectionLocalService _fragmentCollectionLocalService;
+	private FragmentCompositionLocalService _fragmentCompositionLocalService;
 
 	@Inject
 	private FragmentEntryLocalService _fragmentEntryLocalService;

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/model/impl/test/FragmentCollectionImplTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/model/impl/test/FragmentCollectionImplTest.java
@@ -107,16 +107,17 @@ public class FragmentCollectionImplTest {
 
 	@Test
 	@TestInfo("LPD-82487")
-	public void testHasExportableFragmentCompositionsAndFragmentEntries()
-		throws Exception {
+	public void testIsExportable() throws Exception {
+		Assert.assertTrue(_fragmentCollection.isExportable());
 
-		Assert.assertFalse(
-			_fragmentCollection.
-				hasExportableFragmentCompositionsAndFragmentEntries());
+		FragmentCollection fragmentCollection =
+			FragmentTestUtil.addFragmentCollection(_group.getGroupId());
+
+		Assert.assertFalse(fragmentCollection.isExportable());
 
 		FragmentComposition marketplaceFragmentComposition =
 			FragmentCompositionTestUtil.addFragmentComposition(
-				_fragmentCollection.getFragmentCollectionId(),
+				fragmentCollection.getFragmentCollectionId(),
 				RandomTestUtil.randomString());
 
 		marketplaceFragmentComposition.setMarketplace(true);
@@ -124,44 +125,36 @@ public class FragmentCollectionImplTest {
 		_fragmentCompositionLocalService.updateFragmentComposition(
 			marketplaceFragmentComposition);
 
-		Assert.assertFalse(
-			_fragmentCollection.
-				hasExportableFragmentCompositionsAndFragmentEntries());
+		Assert.assertFalse(fragmentCollection.isExportable());
 
 		FragmentEntry reactFragmentEntry =
 			FragmentEntryTestUtil.addFragmentEntryByType(
-				_fragmentCollection.getFragmentCollectionId(),
+				fragmentCollection.getFragmentCollectionId(),
 				FragmentConstants.TYPE_REACT);
 
 		Assert.assertTrue(reactFragmentEntry.isTypeReact());
 
-		Assert.assertFalse(
-			_fragmentCollection.
-				hasExportableFragmentCompositionsAndFragmentEntries());
+		Assert.assertFalse(fragmentCollection.isExportable());
 
 		FragmentEntry marketplaceFragmentEntry =
 			FragmentEntryTestUtil.addFragmentEntry(
-				_fragmentCollection.getFragmentCollectionId());
+				fragmentCollection.getFragmentCollectionId());
 
 		marketplaceFragmentEntry.setMarketplace(true);
 
 		_fragmentEntryLocalService.updateFragmentEntry(
 			marketplaceFragmentEntry);
 
-		Assert.assertFalse(
-			_fragmentCollection.
-				hasExportableFragmentCompositionsAndFragmentEntries());
+		Assert.assertFalse(fragmentCollection.isExportable());
 
 		FragmentComposition exportableFragmentComposition =
 			FragmentCompositionTestUtil.addFragmentComposition(
-				_fragmentCollection.getFragmentCollectionId(),
+				fragmentCollection.getFragmentCollectionId(),
 				RandomTestUtil.randomString());
 
 		Assert.assertFalse(exportableFragmentComposition.isMarketplace());
 
-		Assert.assertTrue(
-			_fragmentCollection.
-				hasExportableFragmentCompositionsAndFragmentEntries());
+		Assert.assertTrue(fragmentCollection.isExportable());
 	}
 
 	@Test

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/model/impl/test/FragmentCollectionImplTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/model/impl/test/FragmentCollectionImplTest.java
@@ -107,7 +107,9 @@ public class FragmentCollectionImplTest {
 
 	@Test
 	@TestInfo("LPD-82487")
-	public void testHasExportableFragments() throws Exception {
+	public void testHasExportableFragmentCompositionsAndFragmentEntries()
+		throws Exception {
+
 		Assert.assertFalse(
 			_fragmentCollection.
 				hasExportableFragmentCompositionsAndFragmentEntries());

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/model/impl/test/FragmentCollectionImplTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/model/impl/test/FragmentCollectionImplTest.java
@@ -107,8 +107,10 @@ public class FragmentCollectionImplTest {
 
 	@Test
 	@TestInfo("LPD-82487")
-	public void testHasExportableItems() throws Exception {
-		Assert.assertFalse(_fragmentCollection.hasExportableItems());
+	public void testHasExportableFragments() throws Exception {
+		Assert.assertFalse(
+			_fragmentCollection.
+				hasExportableFragmentCompositionsAndFragmentEntries());
 
 		FragmentComposition marketplaceFragmentComposition =
 			FragmentCompositionTestUtil.addFragmentComposition(
@@ -120,7 +122,9 @@ public class FragmentCollectionImplTest {
 		_fragmentCompositionLocalService.updateFragmentComposition(
 			marketplaceFragmentComposition);
 
-		Assert.assertFalse(_fragmentCollection.hasExportableItems());
+		Assert.assertFalse(
+			_fragmentCollection.
+				hasExportableFragmentCompositionsAndFragmentEntries());
 
 		FragmentEntry reactFragmentEntry =
 			FragmentEntryTestUtil.addFragmentEntryByType(
@@ -129,7 +133,9 @@ public class FragmentCollectionImplTest {
 
 		Assert.assertTrue(reactFragmentEntry.isTypeReact());
 
-		Assert.assertFalse(_fragmentCollection.hasExportableItems());
+		Assert.assertFalse(
+			_fragmentCollection.
+				hasExportableFragmentCompositionsAndFragmentEntries());
 
 		FragmentEntry marketplaceFragmentEntry =
 			FragmentEntryTestUtil.addFragmentEntry(
@@ -140,7 +146,9 @@ public class FragmentCollectionImplTest {
 		_fragmentEntryLocalService.updateFragmentEntry(
 			marketplaceFragmentEntry);
 
-		Assert.assertFalse(_fragmentCollection.hasExportableItems());
+		Assert.assertFalse(
+			_fragmentCollection.
+				hasExportableFragmentCompositionsAndFragmentEntries());
 
 		FragmentComposition exportableFragmentComposition =
 			FragmentCompositionTestUtil.addFragmentComposition(
@@ -149,7 +157,9 @@ public class FragmentCollectionImplTest {
 
 		Assert.assertFalse(exportableFragmentComposition.isMarketplace());
 
-		Assert.assertTrue(_fragmentCollection.hasExportableItems());
+		Assert.assertTrue(
+			_fragmentCollection.
+				hasExportableFragmentCompositionsAndFragmentEntries());
 	}
 
 	@Test

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/ExportFragmentCollectionsMVCResourceCommand.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/ExportFragmentCollectionsMVCResourceCommand.java
@@ -69,7 +69,8 @@ public class ExportFragmentCollectionsMVCResourceCommand
 								exportFragmentCollectionId);
 
 						if ((fragmentCollection != null) &&
-							fragmentCollection.hasExportableItems()) {
+							fragmentCollection.
+								hasExportableFragmentCompositionsAndFragmentEntries()) {
 
 							return fragmentCollection;
 						}

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/ExportFragmentCollectionsMVCResourceCommand.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/ExportFragmentCollectionsMVCResourceCommand.java
@@ -69,8 +69,7 @@ public class ExportFragmentCollectionsMVCResourceCommand
 								exportFragmentCollectionId);
 
 						if ((fragmentCollection != null) &&
-							fragmentCollection.
-								hasExportableFragmentCompositionsAndFragmentEntries()) {
+							fragmentCollection.isExportable()) {
 
 							return fragmentCollection;
 						}

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/ExportFragmentCollectionsMVCResourceCommand.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/ExportFragmentCollectionsMVCResourceCommand.java
@@ -69,7 +69,7 @@ public class ExportFragmentCollectionsMVCResourceCommand
 								exportFragmentCollectionId);
 
 						if ((fragmentCollection != null) &&
-							!fragmentCollection.isMarketplace()) {
+							fragmentCollection.hasExportableItems()) {
 
 							return fragmentCollection;
 						}

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProvider.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProvider.java
@@ -107,8 +107,7 @@ public class BasicFragmentEntryActionDropdownItemsProvider {
 					).add(
 						() ->
 							hasManageFragmentEntriesPermission &&
-							!_fragmentEntry.isReadOnly() &&
-							!_fragmentEntry.isMarketplace(),
+							!_fragmentEntry.isReadOnly(),
 						_getRenameFragmentEntryActionUnsafeConsumer()
 					).add(
 						() ->

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/util/FragmentCollectionActionDropdownItemsProvider.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/util/FragmentCollectionActionDropdownItemsProvider.java
@@ -67,7 +67,7 @@ public class FragmentCollectionActionDropdownItemsProvider {
 							FragmentCollection fragmentCollection =
 								_fragmentDisplayContext.getFragmentCollection();
 
-							return !fragmentCollection.isMarketplace();
+							return fragmentCollection.hasExportableItems();
 						},
 						dropdownItem -> {
 							ResourceURL

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/util/FragmentCollectionActionDropdownItemsProvider.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/util/FragmentCollectionActionDropdownItemsProvider.java
@@ -67,8 +67,7 @@ public class FragmentCollectionActionDropdownItemsProvider {
 							FragmentCollection fragmentCollection =
 								_fragmentDisplayContext.getFragmentCollection();
 
-							return fragmentCollection.
-								hasExportableFragmentCompositionsAndFragmentEntries();
+							return fragmentCollection.isExportable();
 						},
 						dropdownItem -> {
 							ResourceURL

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/util/FragmentCollectionActionDropdownItemsProvider.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/util/FragmentCollectionActionDropdownItemsProvider.java
@@ -67,7 +67,8 @@ public class FragmentCollectionActionDropdownItemsProvider {
 							FragmentCollection fragmentCollection =
 								_fragmentDisplayContext.getFragmentCollection();
 
-							return fragmentCollection.hasExportableItems();
+							return fragmentCollection.
+								hasExportableFragmentCompositionsAndFragmentEntries();
 						},
 						dropdownItem -> {
 							ResourceURL

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/portlet/action/ExportFragmentCollectionsMVCResourceCommandTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/portlet/action/ExportFragmentCollectionsMVCResourceCommandTest.java
@@ -107,7 +107,8 @@ public class ExportFragmentCollectionsMVCResourceCommandTest {
 		throws Exception {
 
 		Mockito.when(
-			_fragmentCollection.hasExportableItems()
+			_fragmentCollection.
+				hasExportableFragmentCompositionsAndFragmentEntries()
 		).thenReturn(
 			true
 		);
@@ -129,7 +130,8 @@ public class ExportFragmentCollectionsMVCResourceCommandTest {
 		throws Exception {
 
 		Mockito.when(
-			_fragmentCollection.hasExportableItems()
+			_fragmentCollection.
+				hasExportableFragmentCompositionsAndFragmentEntries()
 		).thenReturn(
 			false
 		);

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/portlet/action/ExportFragmentCollectionsMVCResourceCommandTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/portlet/action/ExportFragmentCollectionsMVCResourceCommandTest.java
@@ -103,12 +103,11 @@ public class ExportFragmentCollectionsMVCResourceCommandTest {
 
 	@Test
 	@TestInfo("LPD-82487")
-	public void testServeResourceExportsCollectionWithExportableItems()
+	public void testServeResourceExportableFragmentCollection()
 		throws Exception {
 
 		Mockito.when(
-			_fragmentCollection.
-				hasExportableFragmentCompositionsAndFragmentEntries()
+			_fragmentCollection.isExportable()
 		).thenReturn(
 			true
 		);
@@ -126,12 +125,11 @@ public class ExportFragmentCollectionsMVCResourceCommandTest {
 
 	@Test
 	@TestInfo("LPD-82487")
-	public void testServeResourceSkipsCollectionWithoutExportableItems()
+	public void testServeResourceNonexportableFragmentCollection()
 		throws Exception {
 
 		Mockito.when(
-			_fragmentCollection.
-				hasExportableFragmentCompositionsAndFragmentEntries()
+			_fragmentCollection.isExportable()
 		).thenReturn(
 			false
 		);

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/portlet/action/ExportFragmentCollectionsMVCResourceCommandTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/portlet/action/ExportFragmentCollectionsMVCResourceCommandTest.java
@@ -1,0 +1,177 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.web.internal.portlet.action;
+
+import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.service.FragmentCollectionService;
+import com.liferay.portal.kernel.portlet.PortletResponseUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceResponse;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.kernel.zip.ZipWriter;
+import com.liferay.portal.kernel.zip.ZipWriterFactory;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.portlet.ResourceRequest;
+import jakarta.portlet.ResourceResponse;
+
+import java.io.File;
+import java.io.InputStream;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Georgel Pop
+ */
+public class ExportFragmentCollectionsMVCResourceCommandTest {
+
+	@ClassRule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		_timeMockedStatic.when(
+			Time::getTimestamp
+		).thenReturn(
+			String.valueOf(RandomTestUtil.randomLong())
+		);
+
+		Mockito.when(
+			_fragmentCollection.getFragmentCollectionId()
+		).thenReturn(
+			_FRAGMENT_COLLECTION_ID
+		);
+
+		Mockito.when(
+			_fragmentCollectionService.fetchFragmentCollection(
+				_FRAGMENT_COLLECTION_ID)
+		).thenReturn(
+			_fragmentCollection
+		);
+
+		File file = File.createTempFile("fragment-collections", ".zip");
+
+		file.deleteOnExit();
+
+		Mockito.when(
+			_zipWriter.getFile()
+		).thenReturn(
+			file
+		);
+
+		Mockito.when(
+			_zipWriterFactory.getZipWriter()
+		).thenReturn(
+			_zipWriter
+		);
+
+		_portletResponseUtilMockedStatic.when(
+			() -> PortletResponseUtil.sendFile(
+				Mockito.any(ResourceRequest.class),
+				Mockito.any(ResourceResponse.class), Mockito.anyString(),
+				Mockito.any(InputStream.class), Mockito.anyString())
+		).thenAnswer(
+			invocation -> null
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			_exportFragmentCollectionsMVCResourceCommand,
+			"_fragmentCollectionService", _fragmentCollectionService);
+		ReflectionTestUtil.setFieldValue(
+			_exportFragmentCollectionsMVCResourceCommand, "_zipWriterFactory",
+			_zipWriterFactory);
+	}
+
+	@After
+	public void tearDown() {
+		_portletResponseUtilMockedStatic.close();
+		_timeMockedStatic.close();
+	}
+
+	@Test
+	@TestInfo("LPD-82487")
+	public void testServeResourceExportsCollectionWithExportableItems()
+		throws Exception {
+
+		Mockito.when(
+			_fragmentCollection.hasExportableItems()
+		).thenReturn(
+			true
+		);
+
+		_exportFragmentCollectionsMVCResourceCommand.serveResource(
+			_getMockLiferayResourceRequest(),
+			new MockLiferayResourceResponse());
+
+		Mockito.verify(
+			_fragmentCollection
+		).populateZipWriter(
+			_zipWriter
+		);
+	}
+
+	@Test
+	@TestInfo("LPD-82487")
+	public void testServeResourceSkipsCollectionWithoutExportableItems()
+		throws Exception {
+
+		Mockito.when(
+			_fragmentCollection.hasExportableItems()
+		).thenReturn(
+			false
+		);
+
+		_exportFragmentCollectionsMVCResourceCommand.serveResource(
+			_getMockLiferayResourceRequest(),
+			new MockLiferayResourceResponse());
+
+		Mockito.verify(
+			_fragmentCollection, Mockito.never()
+		).populateZipWriter(
+			Mockito.any()
+		);
+	}
+
+	private MockLiferayResourceRequest _getMockLiferayResourceRequest() {
+		MockLiferayResourceRequest mockLiferayResourceRequest =
+			new MockLiferayResourceRequest();
+
+		mockLiferayResourceRequest.setParameter(
+			"fragmentCollectionId", String.valueOf(_FRAGMENT_COLLECTION_ID));
+
+		return mockLiferayResourceRequest;
+	}
+
+	private static final long _FRAGMENT_COLLECTION_ID =
+		RandomTestUtil.randomLong();
+
+	private final ExportFragmentCollectionsMVCResourceCommand
+		_exportFragmentCollectionsMVCResourceCommand =
+			new ExportFragmentCollectionsMVCResourceCommand();
+	private final FragmentCollection _fragmentCollection = Mockito.mock(
+		FragmentCollection.class);
+	private final FragmentCollectionService _fragmentCollectionService =
+		Mockito.mock(FragmentCollectionService.class);
+	private final MockedStatic<PortletResponseUtil>
+		_portletResponseUtilMockedStatic = Mockito.mockStatic(
+			PortletResponseUtil.class);
+	private final MockedStatic<Time> _timeMockedStatic = Mockito.mockStatic(
+		Time.class);
+	private final ZipWriter _zipWriter = Mockito.mock(ZipWriter.class);
+	private final ZipWriterFactory _zipWriterFactory = Mockito.mock(
+		ZipWriterFactory.class);
+
+}

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/portlet/action/ExportFragmentCollectionsMVCResourceCommandTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/portlet/action/ExportFragmentCollectionsMVCResourceCommandTest.java
@@ -103,46 +103,35 @@ public class ExportFragmentCollectionsMVCResourceCommandTest {
 
 	@Test
 	@TestInfo("LPD-82487")
-	public void testServeResourceExportableFragmentCollection()
-		throws Exception {
+	public void testServeResource() throws Exception {
+		for (boolean exportable : new boolean[] {false, true}) {
+			Mockito.when(
+				_fragmentCollection.isExportable()
+			).thenReturn(
+				exportable
+			);
 
-		Mockito.when(
-			_fragmentCollection.isExportable()
-		).thenReturn(
-			true
-		);
+			_exportFragmentCollectionsMVCResourceCommand.serveResource(
+				_getMockLiferayResourceRequest(),
+				new MockLiferayResourceResponse());
 
-		_exportFragmentCollectionsMVCResourceCommand.serveResource(
-			_getMockLiferayResourceRequest(),
-			new MockLiferayResourceResponse());
+			if (exportable) {
+				Mockito.verify(
+					_fragmentCollection
+				).populateZipWriter(
+					_zipWriter
+				);
+			}
+			else {
+				Mockito.verify(
+					_fragmentCollection, Mockito.never()
+				).populateZipWriter(
+					Mockito.any()
+				);
+			}
 
-		Mockito.verify(
-			_fragmentCollection
-		).populateZipWriter(
-			_zipWriter
-		);
-	}
-
-	@Test
-	@TestInfo("LPD-82487")
-	public void testServeResourceNonexportableFragmentCollection()
-		throws Exception {
-
-		Mockito.when(
-			_fragmentCollection.isExportable()
-		).thenReturn(
-			false
-		);
-
-		_exportFragmentCollectionsMVCResourceCommand.serveResource(
-			_getMockLiferayResourceRequest(),
-			new MockLiferayResourceResponse());
-
-		Mockito.verify(
-			_fragmentCollection, Mockito.never()
-		).populateZipWriter(
-			Mockito.any()
-		);
+			Mockito.clearInvocations(_fragmentCollection);
+		}
 	}
 
 	private MockLiferayResourceRequest _getMockLiferayResourceRequest() {

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProviderTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProviderTest.java
@@ -85,6 +85,7 @@ public class BasicFragmentEntryActionDropdownItemsProviderTest
 	}
 
 	@Test
+	@TestInfo("LPD-63087")
 	public void testGetActionDropdownItemstForMarketplaceFragmentEntry()
 		throws Exception {
 
@@ -104,7 +105,7 @@ public class BasicFragmentEntryActionDropdownItemsProviderTest
 		assertDropdownItemsInCorrectOrder(
 			basicFragmentEntryActionDropdownItemsProvider.
 				getActionDropdownItems(),
-			"view-site-usages", "move", "delete");
+			"rename", "view-site-usages", "move", "delete");
 	}
 
 	@Test

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/FragmentCollectionActionDropdownItemsProviderTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/FragmentCollectionActionDropdownItemsProviderTest.java
@@ -39,86 +39,33 @@ public class FragmentCollectionActionDropdownItemsProviderTest
 
 	@Test
 	@TestInfo("LPD-82487")
-	public void testGetActionDropdownItemsExportableFragmentCollection()
-		throws Exception {
-
+	public void testGetActionDropdownItems() throws Exception {
 		setUpFragmentPermission(true);
 
-		_setUpFragmentCollection(true, false);
+		for (boolean exportable : new boolean[] {false, true}) {
+			String[] expectedLabels = {"edit", "import", "delete"};
 
-		FragmentCollectionActionDropdownItemsProvider
-			fragmentCollectionActionDropdownItemsProvider =
-				new FragmentCollectionActionDropdownItemsProvider(
-					_fragmentDisplayContext, httpServletRequest,
-					renderResponse);
+			if (exportable) {
+				expectedLabels = new String[] {
+					"edit", "export", "import", "delete"
+				};
+			}
 
-		assertDropdownItemsInCorrectOrder(
-			fragmentCollectionActionDropdownItemsProvider.
-				getActionDropdownItems(),
-			"edit", "export", "import", "delete");
-	}
+			for (boolean marketplace : new boolean[] {false, true}) {
+				_setUpFragmentCollection(exportable, marketplace);
 
-	@Test
-	@TestInfo("LPD-82487")
-	public void testGetActionDropdownItemsNonexportableFragmentCollection()
-		throws Exception {
+				FragmentCollectionActionDropdownItemsProvider
+					fragmentCollectionActionDropdownItemsProvider =
+						new FragmentCollectionActionDropdownItemsProvider(
+							_fragmentDisplayContext, httpServletRequest,
+							renderResponse);
 
-		setUpFragmentPermission(true);
-
-		_setUpFragmentCollection(false, false);
-
-		FragmentCollectionActionDropdownItemsProvider
-			fragmentCollectionActionDropdownItemsProvider =
-				new FragmentCollectionActionDropdownItemsProvider(
-					_fragmentDisplayContext, httpServletRequest,
-					renderResponse);
-
-		assertDropdownItemsInCorrectOrder(
-			fragmentCollectionActionDropdownItemsProvider.
-				getActionDropdownItems(),
-			"edit", "import", "delete");
-	}
-
-	@Test
-	@TestInfo("LPD-82487")
-	public void testGetActionDropdownItemsForMarketplaceFragmentCollection()
-		throws Exception {
-
-		setUpFragmentPermission(true);
-
-		_setUpFragmentCollection(false, true);
-
-		FragmentCollectionActionDropdownItemsProvider
-			fragmentCollectionActionDropdownItemsProvider =
-				new FragmentCollectionActionDropdownItemsProvider(
-					_fragmentDisplayContext, httpServletRequest,
-					renderResponse);
-
-		assertDropdownItemsInCorrectOrder(
-			fragmentCollectionActionDropdownItemsProvider.
-				getActionDropdownItems(),
-			"edit", "import", "delete");
-	}
-
-	@Test
-	@TestInfo("LPD-82487")
-	public void testGetActionDropdownItemsForMarketplaceFragmentCollectionWithExportable()
-		throws Exception {
-
-		setUpFragmentPermission(true);
-
-		_setUpFragmentCollection(true, true);
-
-		FragmentCollectionActionDropdownItemsProvider
-			fragmentCollectionActionDropdownItemsProvider =
-				new FragmentCollectionActionDropdownItemsProvider(
-					_fragmentDisplayContext, httpServletRequest,
-					renderResponse);
-
-		assertDropdownItemsInCorrectOrder(
-			fragmentCollectionActionDropdownItemsProvider.
-				getActionDropdownItems(),
-			"edit", "export", "import", "delete");
+				assertDropdownItemsInCorrectOrder(
+					fragmentCollectionActionDropdownItemsProvider.
+						getActionDropdownItems(),
+					expectedLabels);
+			}
+		}
 	}
 
 	private void _setUpFragmentCollection(

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/FragmentCollectionActionDropdownItemsProviderTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/FragmentCollectionActionDropdownItemsProviderTest.java
@@ -39,10 +39,12 @@ public class FragmentCollectionActionDropdownItemsProviderTest
 
 	@Test
 	@TestInfo("LPD-82487")
-	public void testGetActionDropdowns() {
+	public void testGetActionDropdownItemsExportableFragmentCollection()
+		throws Exception {
+
 		setUpFragmentPermission(true);
 
-		_setUpFragmentCollection(false, true);
+		_setUpFragmentCollection(true, false);
 
 		FragmentCollectionActionDropdownItemsProvider
 			fragmentCollectionActionDropdownItemsProvider =
@@ -58,26 +60,9 @@ public class FragmentCollectionActionDropdownItemsProviderTest
 
 	@Test
 	@TestInfo("LPD-82487")
-	public void testGetActionDropdownsForFragmentCollectionWithExportableComposition() {
-		setUpFragmentPermission(true);
+	public void testGetActionDropdownItemsNonexportableFragmentCollection()
+		throws Exception {
 
-		_setUpFragmentCollection(false, true);
-
-		FragmentCollectionActionDropdownItemsProvider
-			fragmentCollectionActionDropdownItemsProvider =
-				new FragmentCollectionActionDropdownItemsProvider(
-					_fragmentDisplayContext, httpServletRequest,
-					renderResponse);
-
-		assertDropdownItemsInCorrectOrder(
-			fragmentCollectionActionDropdownItemsProvider.
-				getActionDropdownItems(),
-			"edit", "export", "import", "delete");
-	}
-
-	@Test
-	@TestInfo("LPD-82487")
-	public void testGetActionDropdownsForFragmentCollectionWithOnlyMarketplaceFragments() {
 		setUpFragmentPermission(true);
 
 		_setUpFragmentCollection(false, false);
@@ -96,10 +81,12 @@ public class FragmentCollectionActionDropdownItemsProviderTest
 
 	@Test
 	@TestInfo("LPD-82487")
-	public void testGetActionDropdownsForMarketplaceFragmentCollection() {
+	public void testGetActionDropdownItemsForMarketplaceFragmentCollection()
+		throws Exception {
+
 		setUpFragmentPermission(true);
 
-		_setUpFragmentCollection(true, false);
+		_setUpFragmentCollection(false, true);
 
 		FragmentCollectionActionDropdownItemsProvider
 			fragmentCollectionActionDropdownItemsProvider =
@@ -115,7 +102,9 @@ public class FragmentCollectionActionDropdownItemsProviderTest
 
 	@Test
 	@TestInfo("LPD-82487")
-	public void testGetActionDropdownsForMarketplaceFragmentCollectionWithExportableFragment() {
+	public void testGetActionDropdownItemsForMarketplaceFragmentCollectionWithExportable()
+		throws Exception {
+
 		setUpFragmentPermission(true);
 
 		_setUpFragmentCollection(true, true);
@@ -132,27 +121,9 @@ public class FragmentCollectionActionDropdownItemsProviderTest
 			"edit", "export", "import", "delete");
 	}
 
-	@Test
-	@TestInfo("LPD-82487")
-	public void testGetActionDropdownsWithReactFragment() {
-		setUpFragmentPermission(true);
-
-		_setUpFragmentCollection(false, false);
-
-		FragmentCollectionActionDropdownItemsProvider
-			fragmentCollectionActionDropdownItemsProvider =
-				new FragmentCollectionActionDropdownItemsProvider(
-					_fragmentDisplayContext, httpServletRequest,
-					renderResponse);
-
-		assertDropdownItemsInCorrectOrder(
-			fragmentCollectionActionDropdownItemsProvider.
-				getActionDropdownItems(),
-			"edit", "import", "delete");
-	}
-
 	private void _setUpFragmentCollection(
-		boolean marketplace, boolean hasExportableFragments) {
+			boolean exportable, boolean marketplace)
+		throws Exception {
 
 		Mockito.when(
 			_fragmentCollection.getFragmentCollectionId()
@@ -167,16 +138,15 @@ public class FragmentCollectionActionDropdownItemsProviderTest
 		);
 
 		Mockito.when(
-			_fragmentCollection.isMarketplace()
+			_fragmentCollection.isExportable()
 		).thenReturn(
-			marketplace
+			exportable
 		);
 
 		Mockito.when(
-			_fragmentCollection.
-				hasExportableFragmentCompositionsAndFragmentEntries()
+			_fragmentCollection.isMarketplace()
 		).thenReturn(
-			hasExportableFragments
+			marketplace
 		);
 	}
 

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/FragmentCollectionActionDropdownItemsProviderTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/FragmentCollectionActionDropdownItemsProviderTest.java
@@ -7,6 +7,8 @@ package com.liferay.fragment.web.internal.servlet.taglib.util;
 
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.web.internal.display.context.FragmentDisplayContext;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import org.junit.Before;
@@ -36,10 +38,11 @@ public class FragmentCollectionActionDropdownItemsProviderTest
 	}
 
 	@Test
+	@TestInfo("LPD-82487")
 	public void testGetActionDropdowns() {
 		setUpFragmentPermission(true);
 
-		_setUpFragmentCollection(false);
+		_setUpFragmentCollection(false, true);
 
 		FragmentCollectionActionDropdownItemsProvider
 			fragmentCollectionActionDropdownItemsProvider =
@@ -54,10 +57,30 @@ public class FragmentCollectionActionDropdownItemsProviderTest
 	}
 
 	@Test
-	public void testGetActionDropdownsForMarketplaceFragmentCollection() {
+	@TestInfo("LPD-82487")
+	public void testGetActionDropdownsForFragmentCollectionWithExportableComposition() {
 		setUpFragmentPermission(true);
 
-		_setUpFragmentCollection(true);
+		_setUpFragmentCollection(false, true);
+
+		FragmentCollectionActionDropdownItemsProvider
+			fragmentCollectionActionDropdownItemsProvider =
+				new FragmentCollectionActionDropdownItemsProvider(
+					_fragmentDisplayContext, httpServletRequest,
+					renderResponse);
+
+		assertDropdownItemsInCorrectOrder(
+			fragmentCollectionActionDropdownItemsProvider.
+				getActionDropdownItems(),
+			"edit", "export", "import", "delete");
+	}
+
+	@Test
+	@TestInfo("LPD-82487")
+	public void testGetActionDropdownsForFragmentCollectionWithOnlyMarketplaceFragments() {
+		setUpFragmentPermission(true);
+
+		_setUpFragmentCollection(false, false);
 
 		FragmentCollectionActionDropdownItemsProvider
 			fragmentCollectionActionDropdownItemsProvider =
@@ -71,7 +94,72 @@ public class FragmentCollectionActionDropdownItemsProviderTest
 			"edit", "import", "delete");
 	}
 
-	private void _setUpFragmentCollection(boolean marketplace) {
+	@Test
+	@TestInfo("LPD-82487")
+	public void testGetActionDropdownsForMarketplaceFragmentCollection() {
+		setUpFragmentPermission(true);
+
+		_setUpFragmentCollection(true, false);
+
+		FragmentCollectionActionDropdownItemsProvider
+			fragmentCollectionActionDropdownItemsProvider =
+				new FragmentCollectionActionDropdownItemsProvider(
+					_fragmentDisplayContext, httpServletRequest,
+					renderResponse);
+
+		assertDropdownItemsInCorrectOrder(
+			fragmentCollectionActionDropdownItemsProvider.
+				getActionDropdownItems(),
+			"edit", "import", "delete");
+	}
+
+	@Test
+	@TestInfo("LPD-82487")
+	public void testGetActionDropdownsForMarketplaceFragmentCollectionWithExportableFragment() {
+		setUpFragmentPermission(true);
+
+		_setUpFragmentCollection(true, true);
+
+		FragmentCollectionActionDropdownItemsProvider
+			fragmentCollectionActionDropdownItemsProvider =
+				new FragmentCollectionActionDropdownItemsProvider(
+					_fragmentDisplayContext, httpServletRequest,
+					renderResponse);
+
+		assertDropdownItemsInCorrectOrder(
+			fragmentCollectionActionDropdownItemsProvider.
+				getActionDropdownItems(),
+			"edit", "export", "import", "delete");
+	}
+
+	@Test
+	@TestInfo("LPD-82487")
+	public void testGetActionDropdownsWithReactFragment() {
+		setUpFragmentPermission(true);
+
+		_setUpFragmentCollection(false, false);
+
+		FragmentCollectionActionDropdownItemsProvider
+			fragmentCollectionActionDropdownItemsProvider =
+				new FragmentCollectionActionDropdownItemsProvider(
+					_fragmentDisplayContext, httpServletRequest,
+					renderResponse);
+
+		assertDropdownItemsInCorrectOrder(
+			fragmentCollectionActionDropdownItemsProvider.
+				getActionDropdownItems(),
+			"edit", "import", "delete");
+	}
+
+	private void _setUpFragmentCollection(
+		boolean marketplace, boolean hasExportableItems) {
+
+		Mockito.when(
+			_fragmentCollection.getFragmentCollectionId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
 		Mockito.when(
 			_fragmentDisplayContext.getFragmentCollection()
 		).thenReturn(
@@ -82,6 +170,12 @@ public class FragmentCollectionActionDropdownItemsProviderTest
 			_fragmentCollection.isMarketplace()
 		).thenReturn(
 			marketplace
+		);
+
+		Mockito.when(
+			_fragmentCollection.hasExportableItems()
+		).thenReturn(
+			hasExportableItems
 		);
 	}
 

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/FragmentCollectionActionDropdownItemsProviderTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/FragmentCollectionActionDropdownItemsProviderTest.java
@@ -152,7 +152,7 @@ public class FragmentCollectionActionDropdownItemsProviderTest
 	}
 
 	private void _setUpFragmentCollection(
-		boolean marketplace, boolean hasExportableItems) {
+		boolean marketplace, boolean hasExportableFragments) {
 
 		Mockito.when(
 			_fragmentCollection.getFragmentCollectionId()
@@ -173,9 +173,10 @@ public class FragmentCollectionActionDropdownItemsProviderTest
 		);
 
 		Mockito.when(
-			_fragmentCollection.hasExportableItems()
+			_fragmentCollection.
+				hasExportableFragmentCompositionsAndFragmentEntries()
 		).thenReturn(
-			hasExportableItems
+			hasExportableFragments
 		);
 	}
 

--- a/modules/test/playwright/tests/fragment-web/main/fragmentAdminMarketplace.spec.ts
+++ b/modules/test/playwright/tests/fragment-web/main/fragmentAdminMarketplace.spec.ts
@@ -135,7 +135,7 @@ test(
 test(
 	'Check available actions of marketplace fragment',
 	{
-		tag: '@LPD-43455',
+		tag: ['@LPD-43455', '@LPD-63087'],
 	},
 	async ({apiHelpers, fragmentsPage, page, site}) => {
 
@@ -178,7 +178,7 @@ test(
 
 		// Check available actions
 
-		['View Usages', 'Move', 'Delete'].forEach(async (action) => {
+		['Rename', 'View Usages', 'Move', 'Delete'].forEach(async (action) => {
 			await expect(
 				page.getByRole('menuitem', {name: action})
 			).toBeVisible();
@@ -190,7 +190,6 @@ test(
 			'Mark as Cacheable',
 			'Export',
 			'Make a Copy',
-			'Rename',
 		].forEach(async (action) => {
 			await expect(
 				page.getByRole('menuitem', {name: action})


### PR DESCRIPTION
Renaming test methods to match robotic naming conventions. See:
https://github.com/brianchandotcom/liferay-portal/pull/171736#issuecomment-4082575997

Also updated the method name to `isExportable` to take into account whether it has resources.

These changes were already reviewed by @achaparro (thank you!) in:
https://github.com/liferay-page-management/liferay-portal/pull/18265

Please review. Thank you, @brianchandotcom.