### PR TITLE
LPD-80755 Technical Task | Create process to migrate legacy asset publisher configuration to collections

### DIFF
--- a/modules/apps/asset/asset-publisher-api/bnd.bnd
+++ b/modules/apps/asset/asset-publisher-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Asset Publisher API
 Bundle-SymbolicName: com.liferay.asset.publisher.api
-Bundle-Version: 7.0.2
+Bundle-Version: 7.1.0
 Export-Package:\
 	com.liferay.asset.publisher.action,\
 	com.liferay.asset.publisher.constants,\

--- a/modules/apps/asset/asset-publisher-api/src/main/java/com/liferay/asset/publisher/util/AssetPublisherHelper.java
+++ b/modules/apps/asset/asset-publisher-api/src/main/java/com/liferay/asset/publisher/util/AssetPublisherHelper.java
@@ -60,6 +60,15 @@ public interface AssetPublisherHelper {
 	public List<AssetEntry> getAssetEntries(
 			PortletRequest portletRequest,
 			PortletPreferences portletPreferences,
+			PermissionChecker permissionChecker, long companyId,
+			long[] groupIds, boolean checkPermission,
+			boolean deleteMissingAssetEntries, boolean includeNonvisibleAssets,
+			int type)
+		throws Exception;
+
+	public List<AssetEntry> getAssetEntries(
+			PortletRequest portletRequest,
+			PortletPreferences portletPreferences,
 			PermissionChecker permissionChecker, long[] groupIds,
 			boolean deleteMissingAssetEntries, boolean checkPermission)
 		throws Exception;

--- a/modules/apps/asset/asset-publisher-api/src/main/resources/com/liferay/asset/publisher/util/packageinfo
+++ b/modules/apps/asset/asset-publisher-api/src/main/resources/com/liferay/asset/publisher/util/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/asset/asset-publisher-test/build.gradle
+++ b/modules/apps/asset/asset-publisher-test/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-notifications-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
+	testIntegrationImplementation project(":apps:portal:portal-verify-test-util")
 	testIntegrationImplementation project(":apps:portlet-display-template:portlet-display-template-api")
 	testIntegrationImplementation project(":apps:portlet-display-template:portlet-display-template-test-util")
 	testIntegrationImplementation project(":apps:ratings:ratings-test-util")

--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/exportimport/test/AssetPublisherExportImportTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/exportimport/test/AssetPublisherExportImportTest.java
@@ -83,7 +83,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1166,34 +1165,6 @@ public class AssetPublisherExportImportTest extends BaseExportImportTestCase {
 			serviceContext);
 	}
 
-	protected void assertAssetEntries(
-		List<AssetEntry> expectedAssetEntries,
-		List<AssetEntry> actualAssetEntries) {
-
-		Assert.assertEquals(
-			actualAssetEntries.toString(), expectedAssetEntries.size(),
-			actualAssetEntries.size());
-
-		Iterator<AssetEntry> expectedAssetEntriesIterator =
-			expectedAssetEntries.iterator();
-		Iterator<AssetEntry> actualAssetEntriesIterator =
-			actualAssetEntries.iterator();
-
-		while (expectedAssetEntriesIterator.hasNext() &&
-			   actualAssetEntriesIterator.hasNext()) {
-
-			AssetEntry expectedAssetEntry = expectedAssetEntriesIterator.next();
-			AssetEntry actualAssetEntry = actualAssetEntriesIterator.next();
-
-			Assert.assertEquals(
-				expectedAssetEntry.getClassName(),
-				actualAssetEntry.getClassName());
-			Assert.assertEquals(
-				expectedAssetEntry.getClassUuid(),
-				actualAssetEntry.getClassUuid());
-		}
-	}
-
 	protected String[] getAssetEntriesXmls(List<AssetEntry> assetEntries) {
 		String[] assetEntriesXmls = new String[assetEntries.size()];
 
@@ -1289,7 +1260,8 @@ public class AssetPublisherExportImportTest extends BaseExportImportTestCase {
 			actualAssetEntries.addAll(assetEntryResult.getAssetEntries());
 		}
 
-		assertAssetEntries(expectedAssetEntries, actualAssetEntries);
+		AssetPublisherTestUtil.assertAssetEntries(
+			expectedAssetEntries, actualAssetEntries);
 	}
 
 	protected void testExportImportAssetEntries(Group scopeGroup)
@@ -1349,7 +1321,8 @@ public class AssetPublisherExportImportTest extends BaseExportImportTestCase {
 				new MockPortletRequest(), importedPortletPreferences,
 				_permissionChecker, selectedGroupIds, false, false);
 
-		assertAssetEntries(assetEntries, actualAssetEntries);
+		AssetPublisherTestUtil.assertAssetEntries(
+			assetEntries, actualAssetEntries);
 	}
 
 	protected void testSortByAssetVocabulary(boolean globalVocabulary)

--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/exportimport/test/AssetPublisherExportImportTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/exportimport/test/AssetPublisherExportImportTest.java
@@ -1177,7 +1177,7 @@ public class AssetPublisherExportImportTest extends BaseExportImportTestCase {
 		Iterator<AssetEntry> expectedAssetEntriesIterator =
 			expectedAssetEntries.iterator();
 		Iterator<AssetEntry> actualAssetEntriesIterator =
-			expectedAssetEntries.iterator();
+			actualAssetEntries.iterator();
 
 		while (expectedAssetEntriesIterator.hasNext() &&
 			   actualAssetEntriesIterator.hasNext()) {

--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/nofications/test/AssetPublisherUserNotificationTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/nofications/test/AssetPublisherUserNotificationTest.java
@@ -190,17 +190,17 @@ public class AssetPublisherUserNotificationTest {
 	}
 
 	private void _updatePortletPreferences() throws Exception {
-		jakarta.portlet.PortletPreferences portletPreferences =
+		jakarta.portlet.PortletPreferences jxPortletPreferences =
 			LayoutTestUtil.getPortletPreferences(_layout, _portletId);
 
-		portletPreferences.setValue(
+		jxPortletPreferences.setValue(
 			_localization.getLocalizedName(
 				"emailAssetEntryAddedBody",
 				LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault())),
 			_EMAIL_ASSET_ENTRY_ADDED_BODY);
-		portletPreferences.setValue("selectionStyle", "dynamic");
+		jxPortletPreferences.setValue("selectionStyle", "dynamic");
 
-		portletPreferences.store();
+		jxPortletPreferences.store();
 	}
 
 	private static final String _EMAIL_ASSET_ENTRY_ADDED_BODY =

--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/test/util/AssetPublisherTestUtil.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/test/util/AssetPublisherTestUtil.java
@@ -8,6 +8,11 @@ package com.liferay.asset.publisher.test.util;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.petra.string.StringBundler;
 
+import java.util.Iterator;
+import java.util.List;
+
+import org.junit.Assert;
+
 /**
  * Provides a utility method to convert an asset entry to XML format so it can
  * be saved in the Asset Publisher's portlet preferences.
@@ -15,6 +20,34 @@ import com.liferay.petra.string.StringBundler;
  * @author Tamas Molnar
  */
 public class AssetPublisherTestUtil {
+
+	public static void assertAssetEntries(
+		List<AssetEntry> expectedAssetEntries,
+		List<AssetEntry> actualAssetEntries) {
+
+		Assert.assertEquals(
+			actualAssetEntries.toString(), expectedAssetEntries.size(),
+			actualAssetEntries.size());
+
+		Iterator<AssetEntry> expectedAssetEntriesIterator =
+			expectedAssetEntries.iterator();
+		Iterator<AssetEntry> actualAssetEntriesIterator =
+			actualAssetEntries.iterator();
+
+		while (expectedAssetEntriesIterator.hasNext() &&
+			   actualAssetEntriesIterator.hasNext()) {
+
+			AssetEntry expectedAssetEntry = expectedAssetEntriesIterator.next();
+			AssetEntry actualAssetEntry = actualAssetEntriesIterator.next();
+
+			Assert.assertEquals(
+				expectedAssetEntry.getClassName(),
+				actualAssetEntry.getClassName());
+			Assert.assertEquals(
+				expectedAssetEntry.getClassUuid(),
+				actualAssetEntry.getClassUuid());
+		}
+	}
 
 	public static String getAssetEntryXml(AssetEntry assetEntry) {
 		StringBundler sb = new StringBundler(6);

--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/test/util/AssetPublisherTestUtil.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/test/util/AssetPublisherTestUtil.java
@@ -7,8 +7,8 @@ package com.liferay.asset.publisher.test.util;
 
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.SetUtil;
 
-import java.util.Iterator;
 import java.util.List;
 
 import org.junit.Assert;
@@ -29,24 +29,9 @@ public class AssetPublisherTestUtil {
 			actualAssetEntries.toString(), expectedAssetEntries.size(),
 			actualAssetEntries.size());
 
-		Iterator<AssetEntry> expectedAssetEntriesIterator =
-			expectedAssetEntries.iterator();
-		Iterator<AssetEntry> actualAssetEntriesIterator =
-			actualAssetEntries.iterator();
-
-		while (expectedAssetEntriesIterator.hasNext() &&
-			   actualAssetEntriesIterator.hasNext()) {
-
-			AssetEntry expectedAssetEntry = expectedAssetEntriesIterator.next();
-			AssetEntry actualAssetEntry = actualAssetEntriesIterator.next();
-
-			Assert.assertEquals(
-				expectedAssetEntry.getClassName(),
-				actualAssetEntry.getClassName());
-			Assert.assertEquals(
-				expectedAssetEntry.getClassUuid(),
-				actualAssetEntry.getClassUuid());
-		}
+		Assert.assertEquals(
+			SetUtil.fromList(expectedAssetEntries),
+			SetUtil.fromList(actualAssetEntries));
 	}
 
 	public static String getAssetEntryXml(AssetEntry assetEntry) {

--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/web/internal/osgi/commands/test/AssetPublisherOSGiCommandsTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/web/internal/osgi/commands/test/AssetPublisherOSGiCommandsTest.java
@@ -1,0 +1,291 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.publisher.web.internal.osgi.commands.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.asset.kernel.service.persistence.AssetEntryQuery;
+import com.liferay.asset.list.model.AssetListEntry;
+import com.liferay.asset.list.model.AssetListEntrySegmentsEntryRel;
+import com.liferay.asset.list.service.AssetListEntryLocalService;
+import com.liferay.asset.list.service.AssetListEntrySegmentsEntryRelLocalService;
+import com.liferay.asset.publisher.constants.AssetPublisherPortletKeys;
+import com.liferay.asset.publisher.test.util.AssetPublisherTestUtil;
+import com.liferay.asset.publisher.util.AssetEntryResult;
+import com.liferay.asset.publisher.util.AssetPublisherHelper;
+import com.liferay.blogs.model.BlogsEntry;
+import com.liferay.blogs.service.BlogsEntryLocalService;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.segments.constants.SegmentsEntryConstants;
+
+import jakarta.portlet.PortletPreferences;
+
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author ALicia García
+ */
+@RunWith(Arquillian.class)
+public class AssetPublisherOSGiCommandsTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_layout = LayoutTestUtil.addTypePortletLayout(_group.getGroupId());
+
+		_portletId = LayoutTestUtil.addPortletToLayout(
+			_layout, AssetPublisherPortletKeys.ASSET_PUBLISHER);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+	}
+
+	@Test
+	public void testGetAssetEntriesFromDynamicCollection() throws Exception {
+		List<AssetEntry> assetEntries = new ArrayList<>();
+
+		assetEntries.add(_addAssetEntry());
+		assetEntries.add(_addAssetEntry());
+		assetEntries.add(_addAssetEntry());
+
+		PortletPreferences portletPreferences =
+			_setDynamicSelectionStylePreference();
+
+		Assert.assertEquals(
+			"dynamic", portletPreferences.getValue("selectionStyle", null));
+
+		AssetEntryQuery assetEntryQuery =
+			_assetPublisherHelper.getAssetEntryQuery(
+				portletPreferences, _group.getGroupId(), _layout, null, null);
+
+		SearchContainer<AssetEntry> searchContainer = new SearchContainer<>();
+
+		searchContainer.setResultsAndTotal(Collections::emptyList, 10);
+
+		List<AssetEntryResult> actualAssetEntryResults =
+			_assetPublisherHelper.getAssetEntryResults(
+				searchContainer, assetEntryQuery, _layout, portletPreferences,
+				StringPool.BLANK, null, null, TestPropsValues.getCompanyId(),
+				_group.getGroupId(), TestPropsValues.getUserId(),
+				assetEntryQuery.getClassNameIds(), null);
+
+		AssetEntryResult assetEntryResult = actualAssetEntryResults.get(0);
+
+		List<AssetEntry> actualAssetEntries =
+			assetEntryResult.getAssetEntries();
+
+		AssetPublisherTestUtil.assertAssetEntries(
+			assetEntries, assetEntryResult.getAssetEntries());
+
+		_run("migratePortletPreferences");
+
+		portletPreferences =
+			PortletPreferencesFactoryUtil.getExistingPortletSetup(
+				_layout, _portletId);
+
+		Assert.assertEquals(
+			"asset-list", portletPreferences.getValue("selectionStyle", null));
+
+		AssetListEntry assetListEntry =
+			_assetListEntryLocalService.
+				fetchAssetListEntryByExternalReferenceCode(
+					portletPreferences.getValue(
+						"assetListEntryExternalReferenceCode", null),
+					_group.getGroupId());
+
+		Assert.assertNotNull(assetListEntry);
+
+		AssetListEntrySegmentsEntryRel assetListEntrySegmentsEntryRel =
+			_assetListEntrySegmentsEntryRelLocalService.
+				fetchAssetListEntrySegmentsEntryRel(
+					assetListEntry.getAssetListEntryId(),
+					SegmentsEntryConstants.ID_DEFAULT);
+
+		Assert.assertNotNull(assetListEntrySegmentsEntryRel);
+
+		UnicodeProperties unicodeProperties = UnicodePropertiesBuilder.load(
+			assetListEntrySegmentsEntryRel.getTypeSettings()
+		).build();
+
+		Assert.assertEquals(
+			"true", unicodeProperties.getProperty("anyAssetType", null));
+
+		assetEntryQuery = _assetPublisherHelper.getAssetEntryQuery(
+			portletPreferences, _group.getGroupId(), _layout, null, null);
+
+		actualAssetEntryResults = _assetPublisherHelper.getAssetEntryResults(
+			searchContainer, assetEntryQuery, _layout, portletPreferences,
+			StringPool.BLANK, null, null, TestPropsValues.getCompanyId(),
+			_group.getGroupId(), TestPropsValues.getUserId(),
+			assetEntryQuery.getClassNameIds(), null);
+
+		assetEntryResult = actualAssetEntryResults.get(0);
+
+		AssetPublisherTestUtil.assertAssetEntries(
+			actualAssetEntries, assetEntryResult.getAssetEntries());
+	}
+
+	@Test
+	public void testGetAssetEntriesFromManualCollection() throws Exception {
+		AssetEntry assetEntry1 = _addAssetEntry();
+		AssetEntry assetEntry2 = _addAssetEntry();
+		AssetEntry assetEntry3 = _addAssetEntry();
+		AssetEntry assetEntry4 = _addAssetEntry();
+
+		PortletPreferences portletPreferences =
+			_setPortletManualSelectionStylePreference(
+				assetEntry1, assetEntry2, assetEntry3, assetEntry4);
+
+		Assert.assertEquals(
+			"manual", portletPreferences.getValue("selectionStyle", null));
+
+		_run("migratePortletPreferences");
+
+		portletPreferences =
+			PortletPreferencesFactoryUtil.getExistingPortletSetup(
+				_layout, _portletId);
+
+		Assert.assertEquals(
+			"asset-list", portletPreferences.getValue("selectionStyle", null));
+
+		AssetListEntry assetListEntry =
+			_assetListEntryLocalService.
+				fetchAssetListEntryByExternalReferenceCode(
+					portletPreferences.getValue(
+						"assetListEntryExternalReferenceCode", null),
+					_group.getGroupId());
+
+		Assert.assertNotNull(assetListEntry);
+	}
+
+	private AssetEntry _addAssetEntry() throws Exception {
+		BlogsEntry blogsEntry = _blogsEntryLocalService.addEntry(
+			TestPropsValues.getUserId(), RandomTestUtil.randomString(),
+			StringPool.BLANK, StringPool.BLANK, RandomTestUtil.randomString(),
+			1, 1, 1965, 0, 0, true, true, null, StringPool.BLANK, null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		return _assetEntryLocalService.getEntry(
+			_group.getGroupId(), blogsEntry.getUuid());
+	}
+
+	private void _run(String functionName) throws Exception {
+		Class<?> clazz = _assetPublisherOSGiCommands.getClass();
+
+		Method method = clazz.getMethod(functionName);
+
+		method.invoke(_assetPublisherOSGiCommands, null);
+	}
+
+	private PortletPreferences _setDynamicSelectionStylePreference()
+		throws Exception {
+
+		PortletPreferences portletPreferences =
+			LayoutTestUtil.getPortletPreferences(_layout, _portletId);
+
+		portletPreferences.setValue(
+			"scopeIds",
+			AssetPublisherHelper.SCOPE_ID_GROUP_PREFIX + _group.getGroupId());
+		portletPreferences.setValue("selectionStyle", "dynamic");
+
+		portletPreferences.store();
+
+		return portletPreferences;
+	}
+
+	private PortletPreferences _setPortletManualSelectionStylePreference(
+			AssetEntry... assetEntries)
+		throws Exception {
+
+		PortletPreferences portletPreferences =
+			LayoutTestUtil.getPortletPreferences(_layout, _portletId);
+
+		portletPreferences.setValue("selectionStyle", "manual");
+
+		String[] assetEntryXmls = portletPreferences.getValues(
+			"assetEntryXml", new String[0]);
+
+		for (AssetEntry assetEntry : assetEntries) {
+			String assetEntryXml = AssetPublisherTestUtil.getAssetEntryXml(
+				assetEntry);
+
+			if (!ArrayUtil.contains(assetEntryXmls, assetEntryXml)) {
+				assetEntryXmls = ArrayUtil.append(
+					assetEntryXmls, assetEntryXml);
+			}
+		}
+
+		portletPreferences.setValues("assetEntryXml", assetEntryXmls);
+
+		portletPreferences.store();
+
+		return portletPreferences;
+	}
+
+	@Inject(
+		filter = "osgi.command.scope=assetPublisher", type = Inject.NoType.class
+	)
+	private static Object _assetPublisherOSGiCommands;
+
+	@Inject
+	private AssetEntryLocalService _assetEntryLocalService;
+
+	@Inject
+	private AssetListEntryLocalService _assetListEntryLocalService;
+
+	@Inject
+	private AssetListEntrySegmentsEntryRelLocalService
+		_assetListEntrySegmentsEntryRelLocalService;
+
+	@Inject
+	private AssetPublisherHelper _assetPublisherHelper;
+
+	@Inject
+	private BlogsEntryLocalService _blogsEntryLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private Layout _layout;
+	private String _portletId;
+
+}

--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/web/internal/osgi/commands/test/AssetPublisherOSGiCommandsTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/web/internal/osgi/commands/test/AssetPublisherOSGiCommandsTest.java
@@ -132,15 +132,11 @@ public class AssetPublisherOSGiCommandsTest {
 						"assetListEntryExternalReferenceCode", null),
 					_group.getGroupId());
 
-		Assert.assertNotNull(assetListEntry);
-
 		AssetListEntrySegmentsEntryRel assetListEntrySegmentsEntryRel =
 			_assetListEntrySegmentsEntryRelLocalService.
 				fetchAssetListEntrySegmentsEntryRel(
 					assetListEntry.getAssetListEntryId(),
 					SegmentsEntryConstants.ID_DEFAULT);
-
-		Assert.assertNotNull(assetListEntrySegmentsEntryRel);
 
 		UnicodeProperties unicodeProperties = UnicodePropertiesBuilder.load(
 			assetListEntrySegmentsEntryRel.getTypeSettings()

--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/web/internal/osgi/commands/test/AssetPublisherOSGiCommandsTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/web/internal/osgi/commands/test/AssetPublisherOSGiCommandsTest.java
@@ -204,10 +204,10 @@ public class AssetPublisherOSGiCommandsTest {
 			_group.getGroupId(), blogsEntry.getUuid());
 	}
 
-	private void _run(String functionName) throws Exception {
+	private void _run(String name) throws Exception {
 		Class<?> clazz = _assetPublisherOSGiCommands.getClass();
 
-		Method method = clazz.getMethod(functionName);
+		Method method = clazz.getMethod(name);
 
 		method.invoke(_assetPublisherOSGiCommands, null);
 	}

--- a/modules/apps/asset/asset-publisher-web/build.gradle
+++ b/modules/apps/asset/asset-publisher-web/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"
+	compileOnly group: "com.liferay", name: "org.apache.felix.gogo.runtime", version: "1.1.2.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
@@ -9,6 +10,7 @@ dependencies {
 	compileOnly group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
 	compileOnly group: "jakarta.servlet.jsp", name: "jakarta.servlet.jsp-api", version: "3.1.1"
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.cm", version: "1.6.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:asset:asset-api")
@@ -51,6 +53,7 @@ dependencies {
 	compileOnly project(":apps:site:site-item-selector-api")
 	compileOnly project(":apps:social:social-bookmarks-taglib")
 	compileOnly project(":apps:staging:staging-api")
+	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")
 	compileOnly project(":apps:subscription:subscription-api")

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/osgi/commands/AssetPublisherOSGiCommands.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/osgi/commands/AssetPublisherOSGiCommands.java
@@ -71,7 +71,7 @@ public class AssetPublisherOSGiCommands implements OSGiCommands {
 
 	private AssetListEntry _addDynamicAssetListEntry(
 			String instanceId, Layout layout,
-			jakarta.portlet.PortletPreferences portletPreferences,
+			jakarta.portlet.PortletPreferences jxPortletPreferences,
 			long scopeGroupId, ServiceContext serviceContext, long userId)
 		throws Exception {
 
@@ -82,15 +82,15 @@ public class AssetPublisherOSGiCommands implements OSGiCommands {
 			_getTitle(
 				layout.isDraftLayout(), instanceId,
 				name.substring(0, Math.min(name.length(), 60))),
-			_getTypeSettings(layout, portletPreferences), serviceContext);
+			_getTypeSettings(layout, jxPortletPreferences), serviceContext);
 	}
 
 	private AssetListEntry _getAssetListEntry(
 			long companyId, Layout layout, String portletId,
-			jakarta.portlet.PortletPreferences portletPreferences)
+			jakarta.portlet.PortletPreferences jxPortletPreferences)
 		throws Exception {
 
-		String selectionStyle = portletPreferences.getValue(
+		String selectionStyle = jxPortletPreferences.getValue(
 			"selectionStyle", "dynamic");
 
 		long scopeGroupId = _getScopeGroupId(layout);
@@ -109,7 +109,7 @@ public class AssetPublisherOSGiCommands implements OSGiCommands {
 				AssetPublisherSelectionStyleConstants.TYPE_DYNAMIC)) {
 
 			return _addDynamicAssetListEntry(
-				instanceId, layout, portletPreferences, scopeGroupId,
+				instanceId, layout, jxPortletPreferences, scopeGroupId,
 				serviceContext, userId);
 		}
 
@@ -129,9 +129,9 @@ public class AssetPublisherOSGiCommands implements OSGiCommands {
 				name.substring(0, Math.min(name.length(), 60))),
 			ListUtil.toLongArray(
 				_assetPublisherHelper.getAssetEntries(
-					null, portletPreferences, null, companyId,
+					null, jxPortletPreferences, null, companyId,
 					_assetPublisherHelper.getGroupIds(
-						portletPreferences, scopeGroupId, layout),
+						jxPortletPreferences, scopeGroupId, layout),
 					false, true, false,
 					AssetRendererFactory.TYPE_LATEST_APPROVED),
 				AssetEntry::getEntryId),
@@ -159,17 +159,18 @@ public class AssetPublisherOSGiCommands implements OSGiCommands {
 	}
 
 	private String _getTypeSettings(
-		Layout layout, jakarta.portlet.PortletPreferences portletPreferences) {
+		Layout layout,
+		jakarta.portlet.PortletPreferences jxPortletPreferences) {
 
 		UnicodeProperties unicodeProperties = new UnicodeProperties(true);
 
-		Enumeration<String> enumeration = portletPreferences.getNames();
+		Enumeration<String> enumeration = jxPortletPreferences.getNames();
 
 		while (enumeration.hasMoreElements()) {
 			String name = enumeration.nextElement();
 
 			String value = StringUtil.merge(
-				portletPreferences.getValues(name, null));
+				jxPortletPreferences.getValues(name, null));
 
 			if (Validator.isNull(value) || name.contains("email")) {
 				continue;

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/osgi/commands/AssetPublisherOSGiCommands.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/osgi/commands/AssetPublisherOSGiCommands.java
@@ -1,0 +1,322 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.publisher.web.internal.osgi.commands;
+
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.model.AssetRendererFactory;
+import com.liferay.asset.list.model.AssetListEntry;
+import com.liferay.asset.list.service.AssetListEntryLocalService;
+import com.liferay.asset.publisher.constants.AssetPublisherPortletKeys;
+import com.liferay.asset.publisher.util.AssetPublisherHelper;
+import com.liferay.asset.publisher.web.internal.constants.AssetPublisherSelectionStyleConstants;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
+import com.liferay.osgi.util.osgi.commands.OSGiCommands;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
+import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.PortletPreferences;
+import com.liferay.portal.kernel.portlet.PortletIdCodec;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.PortletPreferenceValueLocalService;
+import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.felix.service.command.Descriptor;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Alicia García
+ */
+@Component(
+	property = {
+		"osgi.command.function=migratePortletPreferences",
+		"osgi.command.scope=assetPublisher"
+	},
+	service = OSGiCommands.class
+)
+public class AssetPublisherOSGiCommands implements OSGiCommands {
+
+	@Descriptor("Create a collection from manual and dynamic Asset Publishers")
+	public void migratePortletPreferences() throws PortalException {
+		_companyLocalService.forEachCompanyId(this::_migratePortletPreferences);
+	}
+
+	private AssetListEntry _addDynamicAssetListEntry(
+			String instanceId, Layout layout,
+			jakarta.portlet.PortletPreferences portletPreferences,
+			long scopeGroupId, ServiceContext serviceContext, long userId)
+		throws Exception {
+
+		String name = layout.getName(LocaleUtil.getDefault());
+
+		return _assetListEntryLocalService.addDynamicAssetListEntry(
+			null, userId, scopeGroupId,
+			_getTitle(
+				layout.isDraftLayout(), instanceId,
+				name.substring(0, Math.min(name.length(), 60))),
+			_getTypeSettings(layout, portletPreferences), serviceContext);
+	}
+
+	private AssetListEntry _getAssetListEntry(
+			long companyId, Layout layout, String portletId,
+			jakarta.portlet.PortletPreferences portletPreferences)
+		throws Exception {
+
+		String selectionStyle = portletPreferences.getValue(
+			"selectionStyle", "dynamic");
+
+		long scopeGroupId = _getScopeGroupId(layout);
+		long userId = layout.getUserId();
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setCompanyId(companyId);
+		serviceContext.setScopeGroupId(scopeGroupId);
+		serviceContext.setUserId(userId);
+
+		String instanceId = PortletIdCodec.decodeInstanceId(portletId);
+
+		if (Objects.equals(
+				selectionStyle,
+				AssetPublisherSelectionStyleConstants.TYPE_DYNAMIC)) {
+
+			return _addDynamicAssetListEntry(
+				instanceId, layout, portletPreferences, scopeGroupId,
+				serviceContext, userId);
+		}
+
+		if (!Objects.equals(
+				selectionStyle,
+				AssetPublisherSelectionStyleConstants.TYPE_MANUAL)) {
+
+			return null;
+		}
+
+		String name = layout.getName(LocaleUtil.getDefault());
+
+		return _assetListEntryLocalService.addManualAssetListEntry(
+			null, userId, scopeGroupId,
+			_getTitle(
+				layout.isDraftLayout(), instanceId,
+				name.substring(0, Math.min(name.length(), 60))),
+			ListUtil.toLongArray(
+				_assetPublisherHelper.getAssetEntries(
+					null, portletPreferences, null, companyId,
+					_assetPublisherHelper.getGroupIds(
+						portletPreferences, scopeGroupId, layout),
+					false, true, false,
+					AssetRendererFactory.TYPE_LATEST_APPROVED),
+				AssetEntry::getEntryId),
+			serviceContext);
+	}
+
+	private long _getScopeGroupId(Layout layout) {
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_layoutPageTemplateEntryLocalService.
+				fetchLayoutPageTemplateEntryByPlid(layout.getPlid());
+
+		if ((layoutPageTemplateEntry != null) &&
+			(layoutPageTemplateEntry.getType() ==
+				LayoutPageTemplateEntryTypeConstants.WIDGET_PAGE)) {
+
+			return layoutPageTemplateEntry.getGroupId();
+		}
+
+		return layout.getGroupId();
+	}
+
+	private String _getTitle(boolean draft, String instanceId, String name) {
+		return StringBundler.concat(
+			"AP ", instanceId, draft ? "_0" : "_1", StringPool.SPACE, name);
+	}
+
+	private String _getTypeSettings(
+		Layout layout, jakarta.portlet.PortletPreferences portletPreferences) {
+
+		UnicodeProperties unicodeProperties = new UnicodeProperties(true);
+
+		Enumeration<String> enumeration = portletPreferences.getNames();
+
+		while (enumeration.hasMoreElements()) {
+			String name = enumeration.nextElement();
+
+			String value = StringUtil.merge(
+				portletPreferences.getValues(name, null));
+
+			if (Validator.isNull(value) || name.contains("email")) {
+				continue;
+			}
+
+			if (!name.equals("scopeIds")) {
+				unicodeProperties.put(name, value);
+
+				continue;
+			}
+
+			List<Long> groupIds = TransformUtil.transformToList(
+				value.split(StringPool.COMMA),
+				part -> {
+					if (part.equals("Group_default")) {
+						return layout.getGroupId();
+					}
+
+					if (!part.startsWith("Group_")) {
+						return null;
+					}
+
+					long groupId = GetterUtil.getLong(
+						StringUtil.removeSubstring(part, "Group_"), -1);
+
+					if (groupId != -1) {
+						return groupId;
+					}
+
+					return null;
+				});
+
+			if (groupIds.isEmpty()) {
+				continue;
+			}
+
+			name = "groupIds";
+			value = ListUtil.toString(groupIds, StringPool.BLANK);
+
+			unicodeProperties.put(name, value);
+		}
+
+		if (Validator.isNull(unicodeProperties.getProperty("anyAssetType"))) {
+			unicodeProperties.put("anyAssetType", "true");
+		}
+
+		return unicodeProperties.toString();
+	}
+
+	private void _migratePortletPreferences(Long companyId)
+		throws PortalException {
+
+		ActionableDynamicQuery actionableDynamicQuery =
+			_portletPreferencesLocalService.getActionableDynamicQuery();
+
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property property = PropertyFactoryUtil.forName("portletId");
+
+				dynamicQuery.add(
+					property.like(
+						PortletIdCodec.encode(
+							AssetPublisherPortletKeys.ASSET_PUBLISHER,
+							StringPool.PERCENT)));
+
+				dynamicQuery.add(
+					RestrictionsFactoryUtil.eq("companyId", companyId));
+			});
+		actionableDynamicQuery.setPerformActionMethod(
+			(PortletPreferences portletPreferences) ->
+				_migratePortletPreferences(portletPreferences));
+
+		actionableDynamicQuery.performActions();
+	}
+
+	private void _migratePortletPreferences(
+		PortletPreferences portletPreferences) {
+
+		try {
+			jakarta.portlet.PortletPreferences jxPortletPreferences =
+				_portletPreferenceValueLocalService.getPreferences(
+					portletPreferences);
+
+			Layout layout = _layoutLocalService.fetchLayout(
+				portletPreferences.getPlid());
+
+			if (layout == null) {
+				return;
+			}
+
+			AssetListEntry assetListEntry = _getAssetListEntry(
+				portletPreferences.getCompanyId(), layout,
+				portletPreferences.getPortletId(), jxPortletPreferences);
+
+			if (assetListEntry != null) {
+				jxPortletPreferences.setValue(
+					"assetListEntryExternalReferenceCode",
+					assetListEntry.getExternalReferenceCode());
+
+				if (assetListEntry.getGroupId() != layout.getGroupId()) {
+					Group group = _groupLocalService.getGroup(
+						assetListEntry.getGroupId());
+
+					jxPortletPreferences.setValue(
+						"assetListEntryGroupExternalReferenceCode",
+						group.getExternalReferenceCode());
+				}
+
+				jxPortletPreferences.setValue(
+					"selectionStyle",
+					AssetPublisherSelectionStyleConstants.TYPE_ASSET_LIST);
+
+				jxPortletPreferences.store();
+			}
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AssetPublisherOSGiCommands.class);
+
+	@Reference
+	private AssetListEntryLocalService _assetListEntryLocalService;
+
+	@Reference
+	private AssetPublisherHelper _assetPublisherHelper;
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
+
+	@Reference
+	private LayoutPageTemplateEntryLocalService
+		_layoutPageTemplateEntryLocalService;
+
+	@Reference
+	private PortletPreferencesLocalService _portletPreferencesLocalService;
+
+	@Reference
+	private PortletPreferenceValueLocalService
+		_portletPreferenceValueLocalService;
+
+}

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherHelperImpl.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherHelperImpl.java
@@ -169,37 +169,10 @@ public class AssetPublisherHelperImpl implements AssetPublisherHelper {
 	public List<AssetEntry> getAssetEntries(
 			PortletRequest portletRequest,
 			PortletPreferences portletPreferences,
-			PermissionChecker permissionChecker, long[] groupIds,
-			boolean deleteMissingAssetEntries, boolean checkPermission)
-		throws Exception {
-
-		return getAssetEntries(
-			portletRequest, portletPreferences, permissionChecker, groupIds,
-			deleteMissingAssetEntries, checkPermission, false);
-	}
-
-	@Override
-	public List<AssetEntry> getAssetEntries(
-			PortletRequest portletRequest,
-			PortletPreferences portletPreferences,
-			PermissionChecker permissionChecker, long[] groupIds,
-			boolean deleteMissingAssetEntries, boolean checkPermission,
-			boolean includeNonvisibleAssets)
-		throws Exception {
-
-		return getAssetEntries(
-			portletRequest, portletPreferences, permissionChecker, groupIds,
-			deleteMissingAssetEntries, checkPermission, includeNonvisibleAssets,
-			AssetRendererFactory.TYPE_LATEST_APPROVED);
-	}
-
-	@Override
-	public List<AssetEntry> getAssetEntries(
-			PortletRequest portletRequest,
-			PortletPreferences portletPreferences,
-			PermissionChecker permissionChecker, long[] groupIds,
-			boolean deleteMissingAssetEntries, boolean checkPermission,
-			boolean includeNonvisibleAssets, int type)
+			PermissionChecker permissionChecker, long companyId,
+			long[] groupIds, boolean checkPermission,
+			boolean deleteMissingAssetEntries, boolean includeNonvisibleAssets,
+			int type)
 		throws Exception {
 
 		List<AssetEntry> assetEntries = new ArrayList<>();
@@ -264,9 +237,7 @@ public class AssetPublisherHelperImpl implements AssetPublisherHelper {
 					getAssetRendererFactoryByClassName(
 						assetEntry.getClassName());
 
-			if (!assetRendererFactory.isActive(
-					permissionChecker.getCompanyId())) {
-
+			if (!assetRendererFactory.isActive(companyId)) {
 				if (deleteMissingAssetEntries) {
 					missingAssetEntryUuids.add(assetEntryUuid);
 				}
@@ -303,13 +274,68 @@ public class AssetPublisherHelperImpl implements AssetPublisherHelper {
 				missingAssetEntryUuids, portletPreferences);
 
 			if (!missingAssetEntryUuids.isEmpty()) {
-				SessionMessages.add(
-					portletRequest, "deletedMissingAssetEntries",
-					missingAssetEntryUuids);
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						StringBundler.concat(
+							"The selected asset(s) have been removed from the ",
+							"list because they do not belong in the scope of ",
+							"this widget. : ", missingAssetEntryUuids));
+				}
+
+				if (portletRequest != null) {
+					SessionMessages.add(
+						portletRequest, "deletedMissingAssetEntries",
+						missingAssetEntryUuids);
+				}
 			}
 		}
 
 		return assetEntries;
+	}
+
+	@Override
+	public List<AssetEntry> getAssetEntries(
+			PortletRequest portletRequest,
+			PortletPreferences portletPreferences,
+			PermissionChecker permissionChecker, long[] groupIds,
+			boolean deleteMissingAssetEntries, boolean checkPermission)
+		throws Exception {
+
+		return getAssetEntries(
+			portletRequest, portletPreferences, permissionChecker, groupIds,
+			deleteMissingAssetEntries, checkPermission, false);
+	}
+
+	@Override
+	public List<AssetEntry> getAssetEntries(
+			PortletRequest portletRequest,
+			PortletPreferences portletPreferences,
+			PermissionChecker permissionChecker, long[] groupIds,
+			boolean deleteMissingAssetEntries, boolean checkPermission,
+			boolean includeNonvisibleAssets)
+		throws Exception {
+
+		return getAssetEntries(
+			portletRequest, portletPreferences, permissionChecker, groupIds,
+			deleteMissingAssetEntries, checkPermission, includeNonvisibleAssets,
+			AssetRendererFactory.TYPE_LATEST_APPROVED);
+	}
+
+	@Override
+	public List<AssetEntry> getAssetEntries(
+			PortletRequest portletRequest,
+			PortletPreferences portletPreferences,
+			PermissionChecker permissionChecker, long[] groupIds,
+			boolean deleteMissingAssetEntries, boolean checkPermission,
+			boolean includeNonvisibleAssets, int type)
+		throws Exception {
+
+		long companyId = permissionChecker.getCompanyId();
+
+		return getAssetEntries(
+			portletRequest, portletPreferences, permissionChecker, companyId,
+			groupIds, checkPermission, deleteMissingAssetEntries,
+			includeNonvisibleAssets, type);
 	}
 
 	@Override

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherHelperImpl.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherHelperImpl.java
@@ -275,11 +275,12 @@ public class AssetPublisherHelperImpl implements AssetPublisherHelper {
 
 			if (!missingAssetEntryUuids.isEmpty()) {
 				if (_log.isDebugEnabled()) {
+					String deletedAssetEntries = ListUtil.toString(
+						missingAssetEntryUuids, StringPool.BLANK);
+
 					_log.debug(
-						StringBundler.concat(
-							"The selected asset(s) have been removed from the ",
-							"list because they do not belong in the scope of ",
-							"this widget. : ", missingAssetEntryUuids));
+						"Removing out of scope asset entries: " +
+							deletedAssetEntries);
 				}
 
 				if (portletRequest != null) {

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletImportControllerImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletImportControllerImpl.java
@@ -162,15 +162,16 @@ public class PortletImportControllerImpl implements PortletImportController {
 				portletDataContext.getPlid(),
 				portletDataContext.getPortletId());
 
-		jakarta.portlet.PortletPreferences portletPreferences =
+		jakarta.portlet.PortletPreferences jxPortletPreferences =
 			_portletPreferencesLocalService.fetchPreferences(
 				portletPreferencesIds);
 
-		if (portletPreferences == null) {
-			portletPreferences = new PortletPreferencesImpl();
+		if (jxPortletPreferences == null) {
+			jxPortletPreferences = new PortletPreferencesImpl();
 		}
 
-		String xml = deletePortletData(portletDataContext, portletPreferences);
+		String xml = deletePortletData(
+			portletDataContext, jxPortletPreferences);
 
 		if (xml != null) {
 			_portletPreferencesLocalService.updatePreferences(
@@ -339,7 +340,7 @@ public class PortletImportControllerImpl implements PortletImportController {
 			portlet.getPortletDataHandlerInstance();
 
 		PortletPreferencesIds portletPreferencesIds = null;
-		jakarta.portlet.PortletPreferences portletPreferences = null;
+		jakarta.portlet.PortletPreferences jxPortletPreferences = null;
 
 		if (!portletDataHandler.isBatch() &&
 			(!portlet.isPreferencesUniquePerLayout() ||
@@ -352,17 +353,17 @@ public class PortletImportControllerImpl implements PortletImportController {
 					portletDataContext.getPlid(),
 					portletDataContext.getPortletId());
 
-			portletPreferences =
+			jxPortletPreferences =
 				_portletPreferencesLocalService.fetchPreferences(
 					portletPreferencesIds);
 		}
 
-		if (portletPreferences == null) {
-			portletPreferences = new PortletPreferencesImpl();
+		if (jxPortletPreferences == null) {
+			jxPortletPreferences = new PortletPreferencesImpl();
 		}
 
 		String xml = importPortletData(
-			portletDataContext, portletPreferences, portletDataElement);
+			portletDataContext, jxPortletPreferences, portletDataElement);
 
 		if ((portletPreferencesIds != null) && Validator.isNotNull(xml)) {
 			_portletPreferencesLocalService.updatePreferences(
@@ -1460,35 +1461,35 @@ public class PortletImportControllerImpl implements PortletImportController {
 
 		// Current portlet preferences
 
-		jakarta.portlet.PortletPreferences portletPreferences =
+		jakarta.portlet.PortletPreferences jxPortletPreferences =
 			_portletPreferencesLocalService.getPreferences(
 				portletDataContext.getCompanyId(), ownerId, ownerType, plid,
 				portletId);
 
 		// New portlet preferences
 
-		jakarta.portlet.PortletPreferences jxPortletPreferences =
+		jakarta.portlet.PortletPreferences newJXPortletPreferences =
 			PortletPreferencesFactoryUtil.fromXML(
 				portletDataContext.getCompanyId(), ownerId, ownerType, plid,
 				portletId, xml);
 
 		if (importData || !MergeLayoutPrototypesThreadLocal.isInProgress()) {
-			String currentLastPublishDate = portletPreferences.getValue(
+			String currentLastPublishDate = jxPortletPreferences.getValue(
 				"last-publish-date", null);
-			String newLastPublishDate = jxPortletPreferences.getValue(
+			String newLastPublishDate = newJXPortletPreferences.getValue(
 				"last-publish-date", null);
 
 			if (Validator.isNotNull(currentLastPublishDate)) {
-				jxPortletPreferences.setValue(
+				newJXPortletPreferences.setValue(
 					"last-publish-date", currentLastPublishDate);
 			}
 			else if (Validator.isNotNull(newLastPublishDate)) {
-				jxPortletPreferences.reset("last-publish-date");
+				newJXPortletPreferences.reset("last-publish-date");
 			}
 
 			_portletPreferencesLocalService.updatePreferences(
 				ownerId, ownerType, plid, portletId,
-				PortletPreferencesFactoryUtil.toXML(jxPortletPreferences));
+				PortletPreferencesFactoryUtil.toXML(newJXPortletPreferences));
 
 			return;
 		}
@@ -1498,7 +1499,7 @@ public class PortletImportControllerImpl implements PortletImportController {
 		String[] dataPortletPreferences =
 			portletDataHandler.getDataPortletPreferences();
 
-		Enumeration<String> enumeration = jxPortletPreferences.getNames();
+		Enumeration<String> enumeration = newJXPortletPreferences.getNames();
 
 		while (enumeration.hasMoreElements()) {
 			String name = enumeration.nextElement();
@@ -1509,13 +1510,13 @@ public class PortletImportControllerImpl implements PortletImportController {
 				(Validator.isNull(portletDataContext.getScopeLayoutUuid()) &&
 				 scopeType.equals("company"))) {
 
-				portletPreferences.setValues(
-					name, jxPortletPreferences.getValues(name, null));
+				jxPortletPreferences.setValues(
+					name, newJXPortletPreferences.getValues(name, null));
 			}
 		}
 
 		_portletPreferencesLocalService.updatePreferences(
-			ownerId, ownerType, plid, portletId, portletPreferences);
+			ownerId, ownerType, plid, portletId, jxPortletPreferences);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BasePortletPreferencesUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BasePortletPreferencesUpgradeProcessTest.java
@@ -155,11 +155,11 @@ public class BasePortletPreferencesUpgradeProcessTest
 		long companyId, long ownerId, int ownerType, long plid,
 		String portletId, String xml) {
 
-		jakarta.portlet.PortletPreferences portletPreferences =
+		jakarta.portlet.PortletPreferences jxPortletPreferences =
 			PortletPreferencesFactoryUtil.fromXML(
 				companyId, ownerId, ownerType, plid, portletId, xml);
 
-		return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+		return PortletPreferencesFactoryUtil.toXML(jxPortletPreferences);
 	}
 
 	private void _assertCompanyIds(


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-80509

Implement an upgrade process to convert Asset publisher legacy filters into collections.

# How am I fixing it?

Don't repeat what the code already says, try to give a bird's eye perspective so that the code is easier to understand.

# How can you verify that it works?

Run the included automated tests.

- Go to portal, enable the Instance Deprecated FF : Asset Selection for Asset Publisher (LPD-39304)
- Go to a page - Edit
- Add an asset publisher widget to the page
- Configuration > asset selection > select Manual (deprecated) (or dynamic)
- Select an asset
- Save
- Go to Gogo Shell
- Execute `assetPublisher:migratePortletPreferences`