### PR TITLE
LPD-83349 Non admin users cannot create nor access to content created with a custom structure

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/CMSPermissionsObjectDefinitionLocalServiceWrapperTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/CMSPermissionsObjectDefinitionLocalServiceWrapperTest.java
@@ -13,26 +13,28 @@ import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectFolder;
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFolderLocalService;
-import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Assert;
@@ -114,26 +116,37 @@ public class CMSPermissionsObjectDefinitionLocalServiceWrapperTest {
 				role.getRoleId(), ActionKeys.VIEW));
 	}
 
-	private ObjectDefinition _publishObjectDefinition(long objectFolderId)
+	private ObjectDefinition _publishCustomObjectDefinition(long objectFolderId)
 		throws Exception {
 
 		ObjectDefinition objectDefinition =
-			ObjectDefinitionTestUtil.publishObjectDefinition(
-				"A" + RandomTestUtil.randomString(),
-				ListUtil.fromArray(
+			_objectDefinitionLocalService.addCustomObjectDefinition(
+				null, TestPropsValues.getUserId(), objectFolderId, null, false,
+				true, false, true, false, false, false, false, null,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				"A" + RandomTestUtil.randomString(), null, null,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				true, ObjectDefinitionConstants.SCOPE_DEPOT,
+				ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT,
+				Collections.emptyList(),
+				Collections.singletonList(
 					ObjectFieldUtil.createObjectField(
 						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 						ObjectFieldConstants.DB_TYPE_STRING,
 						RandomTestUtil.randomString(), "text")),
-				objectFolderId, ObjectDefinitionConstants.SCOPE_DEPOT,
-				TestPropsValues.getUserId());
+				Collections.emptyList(), new ServiceContext());
+
+		objectDefinition =
+			_objectDefinitionLocalService.publishCustomObjectDefinition(
+				TestPropsValues.getUserId(),
+				objectDefinition.getObjectDefinitionId());
 
 		_objectDefinitions.add(objectDefinition);
 
 		return objectDefinition;
 	}
 
-	private ObjectDefinition _publishObjectDefinition(
+	private ObjectDefinition _publishCustomObjectDefinition(
 			String objectFolderExternalReferenceCode)
 		throws Exception {
 
@@ -142,13 +155,13 @@ public class CMSPermissionsObjectDefinitionLocalServiceWrapperTest {
 				objectFolderExternalReferenceCode,
 				TestPropsValues.getCompanyId());
 
-		return _publishObjectDefinition(objectFolder.getObjectFolderId());
+		return _publishCustomObjectDefinition(objectFolder.getObjectFolderId());
 	}
 
 	private void _testPublishCustomObjectDefinitionInContentStructuresFolder()
 		throws Exception {
 
-		ObjectDefinition objectDefinition = _publishObjectDefinition(
+		ObjectDefinition objectDefinition = _publishCustomObjectDefinition(
 			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES);
 
 		_assertCMSAdministratorObjectDefinitionPermissions(objectDefinition);
@@ -161,7 +174,7 @@ public class CMSPermissionsObjectDefinitionLocalServiceWrapperTest {
 	private void _testPublishCustomObjectDefinitionInDefaultFolder()
 		throws Exception {
 
-		ObjectDefinition objectDefinition = _publishObjectDefinition(0);
+		ObjectDefinition objectDefinition = _publishCustomObjectDefinition(0);
 
 		long companyId = TestPropsValues.getCompanyId();
 
@@ -191,7 +204,7 @@ public class CMSPermissionsObjectDefinitionLocalServiceWrapperTest {
 	private void _testPublishCustomObjectDefinitionInFileTypesFolder()
 		throws Exception {
 
-		ObjectDefinition objectDefinition = _publishObjectDefinition(
+		ObjectDefinition objectDefinition = _publishCustomObjectDefinition(
 			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES);
 
 		_assertCMSAdministratorObjectDefinitionPermissions(objectDefinition);
@@ -200,6 +213,9 @@ public class CMSPermissionsObjectDefinitionLocalServiceWrapperTest {
 		_assertObjectDefinitionViewPermission(
 			objectDefinition, RoleConstants.USER);
 	}
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	@DeleteAfterTestRun
 	private List<ObjectDefinition> _objectDefinitions = new ArrayList<>();

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/CMSPermissionsObjectDefinitionLocalServiceWrapperTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/CMSPermissionsObjectDefinitionLocalServiceWrapperTest.java
@@ -1,0 +1,216 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectActionKeys;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectFolder;
+import com.liferay.object.service.ObjectFolderLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Adolfo Pérez
+ */
+@FeatureFlag("LPD-17564")
+@RunWith(Arquillian.class)
+public class CMSPermissionsObjectDefinitionLocalServiceWrapperTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		CMSTestUtil.getOrAddGroup(
+			CMSPermissionsObjectDefinitionLocalServiceWrapperTest.class);
+	}
+
+	@Test
+	public void testPublishCustomObjectDefinition() throws Exception {
+		_testPublishCustomObjectDefinitionInContentStructuresFolder();
+		_testPublishCustomObjectDefinitionInDefaultFolder();
+		_testPublishCustomObjectDefinitionInFileTypesFolder();
+	}
+
+	private void _assertCMSAdministratorObjectDefinitionPermissions(
+			ObjectDefinition objectDefinition)
+		throws Exception {
+
+		long companyId = TestPropsValues.getCompanyId();
+
+		Role cmsAdministratorRole = _roleLocalService.getRole(
+			companyId, RoleConstants.CMS_ADMINISTRATOR);
+
+		Assert.assertTrue(
+			_resourcePermissionLocalService.hasResourcePermission(
+				companyId, objectDefinition.getResourceName(),
+				ResourceConstants.SCOPE_COMPANY, String.valueOf(companyId),
+				cmsAdministratorRole.getRoleId(),
+				ObjectActionKeys.ADD_OBJECT_ENTRY));
+
+		for (String actionId :
+				List.of(
+					ActionKeys.DELETE, ActionKeys.PERMISSIONS,
+					ActionKeys.UPDATE, ActionKeys.VIEW)) {
+
+			Assert.assertTrue(
+				_resourcePermissionLocalService.hasResourcePermission(
+					companyId, objectDefinition.getClassName(),
+					ResourceConstants.SCOPE_COMPANY, String.valueOf(companyId),
+					cmsAdministratorRole.getRoleId(), actionId));
+		}
+	}
+
+	private void _assertObjectDefinitionViewPermission(
+			ObjectDefinition objectDefinition, String roleName)
+		throws Exception {
+
+		Role role = _roleLocalService.getRole(
+			TestPropsValues.getCompanyId(), roleName);
+
+		Assert.assertTrue(
+			_resourcePermissionLocalService.hasResourcePermission(
+				TestPropsValues.getCompanyId(),
+				ObjectDefinition.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(objectDefinition.getObjectDefinitionId()),
+				role.getRoleId(), ActionKeys.VIEW));
+	}
+
+	private ObjectDefinition _publishObjectDefinition(long objectFolderId)
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				"A" + RandomTestUtil.randomString(),
+				ListUtil.fromArray(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING,
+						RandomTestUtil.randomString(), "text")),
+				objectFolderId, ObjectDefinitionConstants.SCOPE_DEPOT,
+				TestPropsValues.getUserId());
+
+		_objectDefinitions.add(objectDefinition);
+
+		return objectDefinition;
+	}
+
+	private ObjectDefinition _publishObjectDefinition(
+			String objectFolderExternalReferenceCode)
+		throws Exception {
+
+		ObjectFolder objectFolder =
+			_objectFolderLocalService.getObjectFolderByExternalReferenceCode(
+				objectFolderExternalReferenceCode,
+				TestPropsValues.getCompanyId());
+
+		return _publishObjectDefinition(objectFolder.getObjectFolderId());
+	}
+
+	private void _testPublishCustomObjectDefinitionInContentStructuresFolder()
+		throws Exception {
+
+		ObjectDefinition objectDefinition = _publishObjectDefinition(
+			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES);
+
+		_assertCMSAdministratorObjectDefinitionPermissions(objectDefinition);
+		_assertObjectDefinitionViewPermission(
+			objectDefinition, RoleConstants.GUEST);
+		_assertObjectDefinitionViewPermission(
+			objectDefinition, RoleConstants.USER);
+	}
+
+	private void _testPublishCustomObjectDefinitionInDefaultFolder()
+		throws Exception {
+
+		ObjectDefinition objectDefinition = _publishObjectDefinition(0);
+
+		long companyId = TestPropsValues.getCompanyId();
+
+		Role cmsAdministratorRole = _roleLocalService.fetchRole(
+			companyId, RoleConstants.CMS_ADMINISTRATOR);
+
+		if (cmsAdministratorRole != null) {
+			Assert.assertFalse(
+				_resourcePermissionLocalService.hasResourcePermission(
+					companyId, objectDefinition.getResourceName(),
+					ResourceConstants.SCOPE_COMPANY, String.valueOf(companyId),
+					cmsAdministratorRole.getRoleId(),
+					ObjectActionKeys.ADD_OBJECT_ENTRY));
+		}
+
+		Role guestRole = _roleLocalService.getRole(
+			companyId, RoleConstants.GUEST);
+
+		Assert.assertFalse(
+			_resourcePermissionLocalService.hasResourcePermission(
+				companyId, ObjectDefinition.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(objectDefinition.getObjectDefinitionId()),
+				guestRole.getRoleId(), ActionKeys.VIEW));
+	}
+
+	private void _testPublishCustomObjectDefinitionInFileTypesFolder()
+		throws Exception {
+
+		ObjectDefinition objectDefinition = _publishObjectDefinition(
+			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES);
+
+		_assertCMSAdministratorObjectDefinitionPermissions(objectDefinition);
+		_assertObjectDefinitionViewPermission(
+			objectDefinition, RoleConstants.GUEST);
+		_assertObjectDefinitionViewPermission(
+			objectDefinition, RoleConstants.USER);
+	}
+
+	@DeleteAfterTestRun
+	private List<ObjectDefinition> _objectDefinitions = new ArrayList<>();
+
+	@Inject
+	private ObjectFolderLocalService _objectFolderLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/CMSPermissionsObjectDefinitionLocalServiceWrapperTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/CMSPermissionsObjectDefinitionLocalServiceWrapperTest.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -66,24 +67,27 @@ public class CMSPermissionsObjectDefinitionLocalServiceWrapperTest {
 
 	@Test
 	public void testPublishCustomObjectDefinition() throws Exception {
-		_testPublishCustomObjectDefinitionInContentStructuresFolder();
-		_testPublishCustomObjectDefinitionInDefaultFolder();
-		_testPublishCustomObjectDefinitionInFileTypesFolder();
+		_testPublishCustomObjectDefinition();
+
+		_testPublishCustomObjectDefinition(
+			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES);
+		_testPublishCustomObjectDefinition(
+			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES);
 	}
 
 	private void _assertCMSAdministratorObjectDefinitionPermissions(
 			ObjectDefinition objectDefinition)
 		throws Exception {
 
-		long companyId = TestPropsValues.getCompanyId();
-
 		Role cmsAdministratorRole = _roleLocalService.getRole(
-			companyId, RoleConstants.CMS_ADMINISTRATOR);
+			TestPropsValues.getCompanyId(), RoleConstants.CMS_ADMINISTRATOR);
 
 		Assert.assertTrue(
 			_resourcePermissionLocalService.hasResourcePermission(
-				companyId, objectDefinition.getResourceName(),
-				ResourceConstants.SCOPE_COMPANY, String.valueOf(companyId),
+				TestPropsValues.getCompanyId(),
+				objectDefinition.getResourceName(),
+				ResourceConstants.SCOPE_COMPANY,
+				String.valueOf(TestPropsValues.getCompanyId()),
 				cmsAdministratorRole.getRoleId(),
 				ObjectActionKeys.ADD_OBJECT_ENTRY));
 
@@ -94,8 +98,10 @@ public class CMSPermissionsObjectDefinitionLocalServiceWrapperTest {
 
 			Assert.assertTrue(
 				_resourcePermissionLocalService.hasResourcePermission(
-					companyId, objectDefinition.getClassName(),
-					ResourceConstants.SCOPE_COMPANY, String.valueOf(companyId),
+					TestPropsValues.getCompanyId(),
+					objectDefinition.getClassName(),
+					ResourceConstants.SCOPE_COMPANY,
+					String.valueOf(TestPropsValues.getCompanyId()),
 					cmsAdministratorRole.getRoleId(), actionId));
 		}
 	}
@@ -114,6 +120,21 @@ public class CMSPermissionsObjectDefinitionLocalServiceWrapperTest {
 				ResourceConstants.SCOPE_INDIVIDUAL,
 				String.valueOf(objectDefinition.getObjectDefinitionId()),
 				role.getRoleId(), ActionKeys.VIEW));
+	}
+
+	private long _getObjectFolderId(String objectFolderExternalReferenceCode)
+		throws Exception {
+
+		if (Validator.isNull(objectFolderExternalReferenceCode)) {
+			return 0;
+		}
+
+		ObjectFolder objectFolder =
+			_objectFolderLocalService.getObjectFolderByExternalReferenceCode(
+				objectFolderExternalReferenceCode,
+				TestPropsValues.getCompanyId());
+
+		return objectFolder.getObjectFolderId();
 	}
 
 	private ObjectDefinition _publishCustomObjectDefinition(long objectFolderId)
@@ -146,66 +167,40 @@ public class CMSPermissionsObjectDefinitionLocalServiceWrapperTest {
 		return objectDefinition;
 	}
 
-	private ObjectDefinition _publishCustomObjectDefinition(
-			String objectFolderExternalReferenceCode)
-		throws Exception {
-
-		ObjectFolder objectFolder =
-			_objectFolderLocalService.getObjectFolderByExternalReferenceCode(
-				objectFolderExternalReferenceCode,
-				TestPropsValues.getCompanyId());
-
-		return _publishCustomObjectDefinition(objectFolder.getObjectFolderId());
-	}
-
-	private void _testPublishCustomObjectDefinitionInContentStructuresFolder()
-		throws Exception {
-
+	private void _testPublishCustomObjectDefinition() throws Exception {
 		ObjectDefinition objectDefinition = _publishCustomObjectDefinition(
-			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES);
+			_getObjectFolderId(null));
 
-		_assertCMSAdministratorObjectDefinitionPermissions(objectDefinition);
-		_assertObjectDefinitionViewPermission(
-			objectDefinition, RoleConstants.GUEST);
-		_assertObjectDefinitionViewPermission(
-			objectDefinition, RoleConstants.USER);
-	}
-
-	private void _testPublishCustomObjectDefinitionInDefaultFolder()
-		throws Exception {
-
-		ObjectDefinition objectDefinition = _publishCustomObjectDefinition(0);
-
-		long companyId = TestPropsValues.getCompanyId();
-
-		Role cmsAdministratorRole = _roleLocalService.fetchRole(
-			companyId, RoleConstants.CMS_ADMINISTRATOR);
-
-		if (cmsAdministratorRole != null) {
-			Assert.assertFalse(
-				_resourcePermissionLocalService.hasResourcePermission(
-					companyId, objectDefinition.getResourceName(),
-					ResourceConstants.SCOPE_COMPANY, String.valueOf(companyId),
-					cmsAdministratorRole.getRoleId(),
-					ObjectActionKeys.ADD_OBJECT_ENTRY));
-		}
-
-		Role guestRole = _roleLocalService.getRole(
-			companyId, RoleConstants.GUEST);
+		Role cmsAdministratorRole = _roleLocalService.getRole(
+			TestPropsValues.getCompanyId(), RoleConstants.CMS_ADMINISTRATOR);
 
 		Assert.assertFalse(
 			_resourcePermissionLocalService.hasResourcePermission(
-				companyId, ObjectDefinition.class.getName(),
+				TestPropsValues.getCompanyId(),
+				objectDefinition.getResourceName(),
+				ResourceConstants.SCOPE_COMPANY,
+				String.valueOf(TestPropsValues.getCompanyId()),
+				cmsAdministratorRole.getRoleId(),
+				ObjectActionKeys.ADD_OBJECT_ENTRY));
+
+		Role guestRole = _roleLocalService.getRole(
+			TestPropsValues.getCompanyId(), RoleConstants.GUEST);
+
+		Assert.assertFalse(
+			_resourcePermissionLocalService.hasResourcePermission(
+				TestPropsValues.getCompanyId(),
+				ObjectDefinition.class.getName(),
 				ResourceConstants.SCOPE_INDIVIDUAL,
 				String.valueOf(objectDefinition.getObjectDefinitionId()),
 				guestRole.getRoleId(), ActionKeys.VIEW));
 	}
 
-	private void _testPublishCustomObjectDefinitionInFileTypesFolder()
+	private void _testPublishCustomObjectDefinition(
+			String objectFolderExternalReferenceCode)
 		throws Exception {
 
 		ObjectDefinition objectDefinition = _publishCustomObjectDefinition(
-			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES);
+			_getObjectFolderId(objectFolderExternalReferenceCode));
 
 		_assertCMSAdministratorObjectDefinitionPermissions(objectDefinition);
 		_assertObjectDefinitionViewPermission(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/service/CMSPermissionsObjectDefinitionLocalServiceWrapper.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/service/CMSPermissionsObjectDefinitionLocalServiceWrapper.java
@@ -34,12 +34,39 @@ public class CMSPermissionsObjectDefinitionLocalServiceWrapper
 	extends ObjectDefinitionLocalServiceWrapper {
 
 	@Override
+	public ObjectDefinition publishCustomObjectDefinition(
+			long userId, long objectDefinitionId)
+		throws PortalException {
+
+		return _setResourcePermissions(
+			super.publishCustomObjectDefinition(userId, objectDefinitionId));
+	}
+
+	@Override
 	public ObjectDefinition publishSystemObjectDefinition(
 			long userId, long objectDefinitionId)
 		throws PortalException {
 
-		ObjectDefinition objectDefinition = super.publishSystemObjectDefinition(
-			userId, objectDefinitionId);
+		return _setResourcePermissions(
+			super.publishSystemObjectDefinition(userId, objectDefinitionId));
+	}
+
+	private void _setObjectDefinitionResourcePermissions(
+			ObjectDefinition objectDefinition, String roleName)
+		throws PortalException {
+
+		Role role = _roleLocalService.getRole(
+			objectDefinition.getCompanyId(), roleName);
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			objectDefinition.getCompanyId(), ObjectDefinition.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(objectDefinition.getObjectDefinitionId()),
+			role.getRoleId(), new String[] {ActionKeys.VIEW});
+	}
+
+	private ObjectDefinition _setResourcePermissions(
+		ObjectDefinition objectDefinition) {
 
 		String objectFolderExternalReferenceCode =
 			objectDefinition.getObjectFolderExternalReferenceCode();
@@ -77,28 +104,16 @@ public class CMSPermissionsObjectDefinitionLocalServiceWrapper
 					ActionKeys.UPDATE, ActionKeys.VIEW
 				});
 
-			_setResourcePermissions(objectDefinition, RoleConstants.GUEST);
-			_setResourcePermissions(objectDefinition, RoleConstants.USER);
+			_setObjectDefinitionResourcePermissions(
+				objectDefinition, RoleConstants.GUEST);
+			_setObjectDefinitionResourcePermissions(
+				objectDefinition, RoleConstants.USER);
 		}
 		catch (Exception exception) {
 			_log.error(exception);
 		}
 
 		return objectDefinition;
-	}
-
-	private void _setResourcePermissions(
-			ObjectDefinition objectDefinition, String roleName)
-		throws PortalException {
-
-		Role role = _roleLocalService.getRole(
-			objectDefinition.getCompanyId(), roleName);
-
-		_resourcePermissionLocalService.setResourcePermissions(
-			objectDefinition.getCompanyId(), ObjectDefinition.class.getName(),
-			ResourceConstants.SCOPE_INDIVIDUAL,
-			String.valueOf(objectDefinition.getObjectDefinitionId()),
-			role.getRoleId(), new String[] {ActionKeys.VIEW});
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-83349

Default structures have the VIEW permission for the User role, but newly created ones are created without it. This makes it not possible to nonadmin users to create or edit content using custom structures.

# How am I fixing it?

By adding the VIEW permission for custom structures as well.

# How can you verify that it works?

Run the included integration test.