### PR TITLE
LCD-50423 only create bootstrap release when versions change

### DIFF
--- a/.github/workflows/ci-publish-cloud-scripts.yaml
+++ b/.github/workflows/ci-publish-cloud-scripts.yaml
@@ -63,10 +63,8 @@ on:
             -   master
         paths:
             -   .github/workflows/ci-publish-cloud-scripts.yaml
-            -   cloud/scripts/*
-            -   cloud/terraform/aws/eks/*
-            -   cloud/terraform/aws/gitops/platform/*
-            -   cloud/terraform/aws/gitops/resources/*
-            -   cloud/terraform/aws/grafana/*
+            -   cloud/scripts/bootstrap.sh
+            -   cloud/scripts/versions.tfvars
+            -   cloud/scripts/versions.json
 permissions:
     id-token: write


### PR DESCRIPTION
Resent from here: https://github.com/pt-cloudnative/liferay-portal/pull/31
due to unrelated SF failure

cc @pt-cloudnative