### PR TITLE
LPD-64899: Fix calendar resources getting duplicated on export-import

### DIFF
--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/exportimport/data/handler/CalendarNotificationTemplateStagedModelDataHandler.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/exportimport/data/handler/CalendarNotificationTemplateStagedModelDataHandler.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.xml.Element;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -163,9 +164,10 @@ public class CalendarNotificationTemplateStagedModelDataHandler
 
 		if (portletDataContext.isDataStrategyMirror()) {
 			CalendarNotificationTemplate existingCalendarNotificationTemplate =
-				fetchStagedModelByUuidAndGroupId(
-					calendarNotificationTemplate.getUuid(),
-					portletDataContext.getScopeGroupId());
+				_fetchExistingCalendarNotificationTemplate(
+					body, calendarId, calendarNotificationTemplate,
+					notificationTemplateType, notificationType,
+					portletDataContext);
 
 			if (existingCalendarNotificationTemplate == null) {
 				serviceContext.setUuid(calendarNotificationTemplate.getUuid());
@@ -206,6 +208,39 @@ public class CalendarNotificationTemplateStagedModelDataHandler
 
 		portletDataContext.importClassedModel(
 			calendarNotificationTemplate, importedCalendarNotificationTemplate);
+	}
+
+	private CalendarNotificationTemplate
+		_fetchExistingCalendarNotificationTemplate(
+			String body, long calendarId,
+			CalendarNotificationTemplate calendarNotificationTemplate,
+			NotificationTemplateType notificationTemplateType,
+			NotificationType notificationType,
+			PortletDataContext portletDataContext) {
+
+		CalendarNotificationTemplate existingCalendarNotificationTemplate =
+			fetchStagedModelByUuidAndGroupId(
+				calendarNotificationTemplate.getUuid(),
+				portletDataContext.getScopeGroupId());
+
+		if (existingCalendarNotificationTemplate == null) {
+			existingCalendarNotificationTemplate =
+				_calendarNotificationTemplateLocalService.
+					fetchCalendarNotificationTemplate(
+						calendarId, notificationType, notificationTemplateType);
+		}
+
+		if (existingCalendarNotificationTemplate == null) {
+			return null;
+		}
+
+		if (Objects.equals(
+				body, existingCalendarNotificationTemplate.getBody())) {
+
+			return existingCalendarNotificationTemplate;
+		}
+
+		return null;
 	}
 
 	@Reference

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/exportimport/data/handler/CalendarNotificationTemplateStagedModelDataHandler.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/exportimport/data/handler/CalendarNotificationTemplateStagedModelDataHandler.java
@@ -27,7 +27,6 @@ import com.liferay.portal.kernel.xml.Element;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -165,7 +164,7 @@ public class CalendarNotificationTemplateStagedModelDataHandler
 		if (portletDataContext.isDataStrategyMirror()) {
 			CalendarNotificationTemplate existingCalendarNotificationTemplate =
 				_fetchExistingCalendarNotificationTemplate(
-					body, calendarId, calendarNotificationTemplate,
+					calendarId, calendarNotificationTemplate,
 					notificationTemplateType, notificationType,
 					portletDataContext);
 
@@ -212,7 +211,7 @@ public class CalendarNotificationTemplateStagedModelDataHandler
 
 	private CalendarNotificationTemplate
 		_fetchExistingCalendarNotificationTemplate(
-			String body, long calendarId,
+			long calendarId,
 			CalendarNotificationTemplate calendarNotificationTemplate,
 			NotificationTemplateType notificationTemplateType,
 			NotificationType notificationType,
@@ -230,17 +229,7 @@ public class CalendarNotificationTemplateStagedModelDataHandler
 						calendarId, notificationType, notificationTemplateType);
 		}
 
-		if (existingCalendarNotificationTemplate == null) {
-			return null;
-		}
-
-		if (Objects.equals(
-				body, existingCalendarNotificationTemplate.getBody())) {
-
-			return existingCalendarNotificationTemplate;
-		}
-
-		return null;
+		return existingCalendarNotificationTemplate;
 	}
 
 	@Reference

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/exportimport/data/handler/CalendarStagedModelDataHandler.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/exportimport/data/handler/CalendarStagedModelDataHandler.java
@@ -212,12 +212,17 @@ public class CalendarStagedModelDataHandler
 					calendar.isEnableComments(), calendar.isEnableRatings(),
 					serviceContext);
 
-				importedCalendar.setUuid(calendar.getUuid());
-				importedCalendar.setCreateDate(calendar.getCreateDate());
-				importedCalendar.setModifiedDate(calendar.getModifiedDate());
+				if (!Objects.equals(
+						existingCalendar.getUuid(), calendar.getUuid())) {
 
-				importedCalendar = _calendarLocalService.updateCalendar(
-					importedCalendar);
+					importedCalendar.setUuid(calendar.getUuid());
+					importedCalendar.setCreateDate(calendar.getCreateDate());
+					importedCalendar.setModifiedDate(
+						calendar.getModifiedDate());
+
+					importedCalendar = _calendarLocalService.updateCalendar(
+						importedCalendar);
+				}
 			}
 		}
 		else {
@@ -301,11 +306,11 @@ public class CalendarStagedModelDataHandler
 				companyId, groupId, name);
 		}
 
-		if (existingStagedModel == null) {
-			return false;
+		if (existingStagedModel != null) {
+			return true;
 		}
 
-		return true;
+		return false;
 	}
 
 	@Reference

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/exportimport/data/handler/CalendarStagedModelDataHandler.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/exportimport/data/handler/CalendarStagedModelDataHandler.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.xml.Element;
 
 import java.util.List;
@@ -189,8 +190,8 @@ public class CalendarStagedModelDataHandler
 		Calendar importedCalendar = null;
 
 		if (portletDataContext.isDataStrategyMirror()) {
-			Calendar existingCalendar = fetchStagedModelByUuidAndGroupId(
-				calendar.getUuid(), portletDataContext.getScopeGroupId());
+			Calendar existingCalendar = _fetchExistingCalendar(
+				calendar, portletDataContext);
 
 			if (existingCalendar == null) {
 				serviceContext.setUuid(calendar.getUuid());
@@ -210,6 +211,13 @@ public class CalendarStagedModelDataHandler
 					calendar.getColor(), calendar.isDefaultCalendar(),
 					calendar.isEnableComments(), calendar.isEnableRatings(),
 					serviceContext);
+
+				importedCalendar.setUuid(calendar.getUuid());
+				importedCalendar.setCreateDate(calendar.getCreateDate());
+				importedCalendar.setModifiedDate(calendar.getModifiedDate());
+
+				importedCalendar = _calendarLocalService.updateCalendar(
+					importedCalendar);
 			}
 		}
 		else {
@@ -223,6 +231,32 @@ public class CalendarStagedModelDataHandler
 		}
 
 		portletDataContext.importClassedModel(calendar, importedCalendar);
+	}
+
+	private Calendar _fetchExistingCalendar(
+		Calendar calendar, PortletDataContext portletDataContext) {
+
+		Calendar existingCalendar = fetchStagedModelByUuidAndGroupId(
+			calendar.getUuid(), portletDataContext.getScopeGroupId());
+
+		if (existingCalendar != null) {
+			return existingCalendar;
+		}
+
+		existingCalendar = _fetchExistingCalendar(
+			portletDataContext.getCompanyId(),
+			portletDataContext.getScopeGroupId(),
+			calendar.getName(calendar.getDefaultLanguageId()));
+
+		if ((existingCalendar == null) ||
+			!StringUtil.equals(
+				existingCalendar.getName(calendar.getDefaultLanguageId()),
+				calendar.getName(calendar.getDefaultLanguageId()))) {
+
+			return null;
+		}
+
+		return existingCalendar;
 	}
 
 	private Calendar _fetchExistingCalendar(


### PR DESCRIPTION
(The original PR [here in BPM repo](https://github.com/liferay-bpm/liferay-portal/pull/5858). Sending directly because of ci:forward temporarily not working) 

- https://liferay.atlassian.net/browse/LPD-64899

### The Issue
If there's Calendar portlet on the exported site and the site is exported, the group calendar resource gets duplicated when imported on the target site. This happens, because during the import, when content page containing calendar portlet is imported, it triggers page indexing, which forces the (content) page to render. This in turn triggers the [CalendarResourceUtil](https://github.com/liferay/liferay-portal/blob/6eda0ad97e6c2994e0afe36594f738b9b677e3f6/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/util/CalendarResourceUtil.java#L45) to create the default calendar group resource for the site. Later in the process in the `CalendarStagedModelDataHandler` when the actually exported default calendar is imported, it creates this 'default' calendar again, creating a duplicate. The number of default notification templates is duplicated as well, because they are [always added](https://github.com/liferay/liferay-portal/blob/6eda0ad97e6c2994e0afe36594f738b9b677e3f6/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarLocalServiceImpl.java#L120-L123) on creating a calendar. 

The solution in this PR is not ideal, but should solve the issue. Preventing the calendar to be created on re-index would be challenging as it runs in its own thread. 

This check in fetching the existing calendar is there for some more reliability, because the finder is a LIKE sql query:
```
		if ((existingCalendar == null) ||
			!StringUtil.equals(
				existingCalendar.getName(calendar.getDefaultLanguageId()),
				calendar.getName(calendar.getDefaultLanguageId()))) {
```

### Test Coverage
Discovered and covered by `site.siteInitializer.spec.ts > Can export and import a site created with the Clarity site initializer including all exportable items`ed by site.siteInitializer.spec.ts > Can export and import a site created with the Clarity site initializer including all exportable items
