### PR TITLE
LPD-84052 Fix check

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -3874,13 +3874,14 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 			group.getCompanyId(), groupId, classNameId, classPK,
 			StringPool.BLANK, friendlyURL);
 
-		if (((classNameId <= 0) || (type == GroupConstants.TYPE_DEPOT) ||
-			 className.equals(Group.class.getName())) &&
-			!Objects.equals(group.getGroupKey(), groupKey)) {
+		if ((classNameId <= 0) || (type == GroupConstants.TYPE_DEPOT) ||
+			className.equals(Group.class.getName())) {
 
-			validateGroupKey(
-				group.getGroupId(), group.getCompanyId(), groupKey,
-				group.getType(), group.isSite());
+			if (!Objects.equals(group.getGroupKey(), groupKey)) {
+				validateGroupKey(
+					group.getGroupId(), group.getCompanyId(), groupKey,
+					group.getType(), group.isSite());
+			}
 		}
 		else if (className.equals(Organization.class.getName())) {
 			Organization organization =


### PR DESCRIPTION
This should fix the stable test failure `BundleSiteInitializerTest` as we don't "fallback" anymore to the latest else statement (replacing the groupKey) but the logic to avoid the check if the groupKeys are the same is still there

@jonathanmccann can you please verify it? 
@david-truong