### PR TITLE
LRCI-7229 Always run install-portal-snapshots twice to account for semver expectations in CI downstream builds

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -1338,14 +1338,14 @@ app.server.type=@{app.server.type}]]></echo>
 
 			<antcall inheritAll="false" target="compile" />
 
+			<antcall inheritAll="false" target="install-portal-snapshots" />
+
 			<if>
 				<and>
 					<equals arg1="@{app.server.type}" arg2="tomcat" />
 					<equals arg1="@{dist.type}" arg2="release" />
 				</and>
 				<then>
-					<antcall inheritAll="false" target="install-portal-snapshots" />
-
 					<lstopwatch action="start" name="prepare-test-build-dist.bundles.@{app.server.type}.dist" />
 
 					<ant antfile="build-test.xml" target="prepare-release-bundle" />
@@ -1355,8 +1355,6 @@ app.server.type=@{app.server.type}]]></echo>
 				<elseif>
 					<equals arg1="@{app.server.type}" arg2="weblogic" />
 					<then>
-						<antcall inheritAll="false" target="install-portal-snapshots" />
-
 						<antcall inheritAll="false" target="prepare-test-build-custom">
 							<param name="app.server.type" value="@{app.server.type}" />
 						</antcall>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7229