### PR TITLE
LPD-84763 Optimize ES index settings during full reindex. Set refresh…

### DIFF
--- a/modules/apps/portal-search/portal-search/build.gradle
+++ b/modules/apps/portal-search/portal-search/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 	compileOnly project(":apps:portal-background-task:portal-background-task-api")
 	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	compileOnly project(":apps:portal-search:portal-search-api")
+	compileOnly project(":apps:portal-search:portal-search-engine-adapter-api")
 	compileOnly project(":apps:portal-search:portal-search-rest-api")
 	compileOnly project(":apps:portal-search:portal-search-spi")
 	compileOnly project(":apps:portal-search:portal-search-web-api")

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchEngineInitializer.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchEngineInitializer.java
@@ -8,6 +8,8 @@ package com.liferay.portal.search.internal;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskThreadLocal;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
@@ -16,9 +18,15 @@ import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.ReindexCacheThreadLocal;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchEngineHelperUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
+import com.liferay.portal.search.engine.adapter.index.GetIndexIndexRequest;
+import com.liferay.portal.search.engine.adapter.index.GetIndexIndexResponse;
+import com.liferay.portal.search.engine.adapter.index.UpdateIndexSettingsIndexRequest;
 import com.liferay.portal.search.index.ConcurrentReindexManager;
+import com.liferay.portal.search.index.IndexNameBuilder;
 import com.liferay.portal.search.index.SyncReindexManager;
 
 import java.util.ArrayList;
@@ -42,13 +50,18 @@ public class SearchEngineInitializer implements Runnable {
 	public SearchEngineInitializer(
 		long companyId, ConcurrentReindexManager concurrentReindexManager,
 		String executionMode, ExecutorService executorService,
-		List<Indexer<?>> indexers, SyncReindexManager syncReindexManager) {
+		IndexNameBuilder indexNameBuilder, List<Indexer<?>> indexers,
+		JSONFactory jsonFactory, SearchEngineAdapter searchEngineAdapter,
+		SyncReindexManager syncReindexManager) {
 
 		_companyId = companyId;
 		_concurrentReindexManager = concurrentReindexManager;
 		_executionMode = executionMode;
 		_executorService = executorService;
+		_indexNameBuilder = indexNameBuilder;
 		_indexers = indexers;
+		_jsonFactory = jsonFactory;
+		_searchEngineAdapter = searchEngineAdapter;
 		_syncReindexManager = syncReindexManager;
 	}
 
@@ -92,6 +105,45 @@ public class SearchEngineInitializer implements Runnable {
 					" entities completed in ",
 					stopWatch.getTime() / Time.SECOND, " seconds"));
 		}
+	}
+
+	private SafeCloseable _configureIndexForBulkLoad(boolean fullMode)
+		throws Exception {
+
+		if (!fullMode) {
+			return () -> {
+			};
+		}
+
+		String indexName = _indexNameBuilder.getIndexName(_companyId);
+
+		GetIndexIndexResponse getIndexIndexResponse =
+			_searchEngineAdapter.execute(new GetIndexIndexRequest(indexName));
+
+		Map<String, String> settingsMap = getIndexIndexResponse.getSettings();
+
+		JSONObject indexSettingsJSONObject = _jsonFactory.createJSONObject(
+			settingsMap.get(indexName)
+		).getJSONObject(
+			"index"
+		);
+
+		String originalNumberOfReplicas = indexSettingsJSONObject.getString(
+			"number_of_replicas");
+		String originalRefreshInterval = GetterUtil.getString(
+			indexSettingsJSONObject.get("refresh_interval"), "1s");
+
+		_updateIndexSettings(
+			indexName,
+			"{\"index\":{\"number_of_replicas\":\"0\"," +
+				"\"refresh_interval\":\"-1\"}}");
+
+		return () -> _updateIndexSettings(
+			indexName,
+			StringBundler.concat(
+				"{\"index\":{\"number_of_replicas\":\"",
+				originalNumberOfReplicas, "\",\"refresh_interval\":\"",
+				originalRefreshInterval, "\"}}"));
 	}
 
 	private boolean _isExecuteConcurrentReindex() {
@@ -172,59 +224,65 @@ public class SearchEngineInitializer implements Runnable {
 			Map<String, Object> sharedReindexCacheMap =
 				new ConcurrentHashMap<>();
 
-			if (_indexers.size() == 1) {
-				Indexer<?> indexer = _indexers.get(0);
+			try (SafeCloseable safeCloseable = _configureIndexForBulkLoad(
+					fullMode)) {
 
-				indexerClassNames.add(indexer.getClassName());
+				if (_indexers.size() == 1) {
+					Indexer<?> indexer = _indexers.get(0);
 
-				try (SafeCloseable safeCloseable1 =
-						ReindexCacheThreadLocal.openReindexMode(
-							finalFullMode, sharedReindexCacheMap);
-					SafeCloseable safeCloseable2 = SearchContext.openBatchMode(
-						false)) {
-
-					reindex(indexer);
-				}
-			}
-			else {
-				long backgroundTaskId =
-					BackgroundTaskThreadLocal.getBackgroundTaskId();
-				List<FutureTask<Void>> futureTasks = new ArrayList<>();
-
-				for (Indexer<?> indexer : _indexers) {
 					indexerClassNames.add(indexer.getClassName());
 
-					FutureTask<Void> futureTask = new FutureTask<>(
-						new Callable<Void>() {
+					try (SafeCloseable safeCloseable1 =
+							ReindexCacheThreadLocal.openReindexMode(
+								finalFullMode, sharedReindexCacheMap);
+						SafeCloseable safeCloseable2 =
+							SearchContext.openBatchMode(false)) {
 
-							@Override
-							public Void call() throws Exception {
-								try (SafeCloseable safeCloseable1 =
-										BackgroundTaskThreadLocal.
-											setBackgroundTaskIdWithSafeCloseable(
-												backgroundTaskId);
-									SafeCloseable safeCloseable2 =
-										ReindexCacheThreadLocal.openReindexMode(
-											finalFullMode,
-											sharedReindexCacheMap);
-									SafeCloseable safeCloseable3 =
-										SearchContext.openBatchMode(false)) {
-
-									reindex(indexer);
-
-									return null;
-								}
-							}
-
-						});
-
-					_executorService.submit(futureTask);
-
-					futureTasks.add(futureTask);
+						reindex(indexer);
+					}
 				}
+				else {
+					long backgroundTaskId =
+						BackgroundTaskThreadLocal.getBackgroundTaskId();
+					List<FutureTask<Void>> futureTasks = new ArrayList<>();
 
-				for (FutureTask<Void> futureTask : futureTasks) {
-					futureTask.get();
+					for (Indexer<?> indexer : _indexers) {
+						indexerClassNames.add(indexer.getClassName());
+
+						FutureTask<Void> futureTask = new FutureTask<>(
+							new Callable<Void>() {
+
+								@Override
+								public Void call() throws Exception {
+									try (SafeCloseable safeCloseable1 =
+											BackgroundTaskThreadLocal.
+												setBackgroundTaskIdWithSafeCloseable(
+													backgroundTaskId);
+										SafeCloseable safeCloseable2 =
+											ReindexCacheThreadLocal.
+												openReindexMode(
+													finalFullMode,
+													sharedReindexCacheMap);
+										SafeCloseable safeCloseable3 =
+											SearchContext.openBatchMode(
+												false)) {
+
+										reindex(indexer);
+
+										return null;
+									}
+								}
+
+							});
+
+						_executorService.submit(futureTask);
+
+						futureTasks.add(futureTask);
+					}
+
+					for (FutureTask<Void> futureTask : futureTasks) {
+						futureTask.get();
+					}
 				}
 			}
 
@@ -258,6 +316,32 @@ public class SearchEngineInitializer implements Runnable {
 		_finished = true;
 	}
 
+	private void _updateIndexSettings(String indexName, String settings) {
+		try {
+			UpdateIndexSettingsIndexRequest updateIndexSettingsIndexRequest =
+				new UpdateIndexSettingsIndexRequest(indexName);
+
+			updateIndexSettingsIndexRequest.setSettings(settings);
+
+			_searchEngineAdapter.execute(updateIndexSettingsIndexRequest);
+
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					StringBundler.concat(
+						"[Reindex] [companyId=", _companyId,
+						"] Updated index settings for ", indexName, ": ",
+						settings));
+			}
+		}
+		catch (Exception exception) {
+			_log.error(
+				StringBundler.concat(
+					"[Reindex] [companyId=", _companyId,
+					"] Failed to update index settings: ", settings),
+				exception);
+		}
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		SearchEngineInitializer.class);
 
@@ -267,6 +351,9 @@ public class SearchEngineInitializer implements Runnable {
 	private final ExecutorService _executorService;
 	private boolean _finished;
 	private final List<Indexer<?>> _indexers;
+	private final IndexNameBuilder _indexNameBuilder;
+	private final JSONFactory _jsonFactory;
+	private final SearchEngineAdapter _searchEngineAdapter;
 	private final SyncReindexManager _syncReindexManager;
 
 }

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/ReindexPortalBackgroundTaskExecutor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/background/task/ReindexPortalBackgroundTaskExecutor.java
@@ -11,6 +11,7 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskThreadLocal;
+import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
@@ -21,7 +22,9 @@ import com.liferay.portal.kernel.search.SearchEngineHelper;
 import com.liferay.portal.kernel.search.background.task.ReindexBackgroundTaskConstants;
 import com.liferay.portal.kernel.search.background.task.ReindexStatusMessageSenderUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
 import com.liferay.portal.search.index.ConcurrentReindexManager;
+import com.liferay.portal.search.index.IndexNameBuilder;
 import com.liferay.portal.search.index.SyncReindexManager;
 import com.liferay.portal.search.internal.SearchEngineInitializer;
 
@@ -121,7 +124,8 @@ public class ReindexPortalBackgroundTaskExecutor
 			SearchEngineInitializer searchEngineInitializer =
 				new SearchEngineInitializer(
 					companyId, _concurrentReindexManagerSnapshot.get(),
-					executionMode, executorService, indexers,
+					executionMode, executorService, _indexNameBuilder, indexers,
+					_jsonFactory, _searchEngineAdapter,
 					_syncReindexManagerSnapshot.get());
 
 			searchEngineInitializer.reindex();
@@ -154,6 +158,15 @@ public class ReindexPortalBackgroundTaskExecutor
 		_syncReindexManagerSnapshot = new Snapshot<>(
 			ReindexPortalBackgroundTaskExecutor.class, SyncReindexManager.class,
 			null, true);
+
+	@Reference
+	private IndexNameBuilder _indexNameBuilder;
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
+	private SearchEngineAdapter _searchEngineAdapter;
 
 	@Reference
 	private SearchEngineHelper _searchEngineHelper;

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/SearchEngineInitializerTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/SearchEngineInitializerTest.java
@@ -100,7 +100,7 @@ public class SearchEngineInitializerTest {
 				executionMode,
 				_portalExecutorManager.getPortalExecutor(
 					SearchEngineInitializer.class.getName()),
-				indexers, _syncReindexManager);
+				null, indexers, null, null, _syncReindexManager);
 
 		searchEngineInitializer.reindex();
 	}


### PR DESCRIPTION
…_interval=-1 and number_of_replicas=0 before bulk indexing, then restore original values after reindex completes via SafeCloseable.