### PR TITLE
LPD-84672 Get Cluster Node Statistics for AWS OS

### DIFF
--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/cluster/StatsClusterRequestExecutor.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/cluster/StatsClusterRequestExecutor.java
@@ -10,6 +10,7 @@ import com.liferay.portal.search.engine.adapter.cluster.StatsClusterRequest;
 import com.liferay.portal.search.engine.adapter.cluster.StatsClusterResponse;
 import com.liferay.portal.search.opensearch2.internal.connection.OpenSearchConnectionManager;
 
+import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
 
@@ -40,16 +41,31 @@ public class StatsClusterRequestExecutor {
 			JsonObject jsonObject = _getClusterStatsJsonObject(
 				statsClusterRequest);
 
+			long availableInBytes = 0;
+			long totalInBytes = 0;
+
 			JsonObject nodesJsonObject = jsonObject.getJsonObject("nodes");
 
-			JsonObject fsJsonObject = nodesJsonObject.getJsonObject("fs");
+			if (nodesJsonObject != null) {
+				JsonObject fsJsonObject = nodesJsonObject.getJsonObject("fs");
 
-			long availableInBytes = fsJsonObject.getJsonNumber(
-				"available_in_bytes"
-			).longValue();
-			long totalInBytes = fsJsonObject.getJsonNumber(
-				"total_in_bytes"
-			).longValue();
+				if (fsJsonObject != null) {
+					JsonNumber availableInBytesJsonNumber =
+						fsJsonObject.getJsonNumber("available_in_bytes");
+
+					if (availableInBytesJsonNumber != null) {
+						availableInBytes =
+							availableInBytesJsonNumber.longValue();
+					}
+
+					JsonNumber totalInBytesJsonNumber =
+						fsJsonObject.getJsonNumber("total_in_bytes");
+
+					if (totalInBytesJsonNumber != null) {
+						totalInBytes = totalInBytesJsonNumber.longValue();
+					}
+				}
+			}
 
 			return new StatsClusterResponse(
 				availableInBytes,

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/cluster/StatsClusterRequestExecutor.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/cluster/StatsClusterRequestExecutor.java
@@ -5,7 +5,9 @@
 
 package com.liferay.portal.search.opensearch2.internal.search.engine.adapter.cluster;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.engine.adapter.cluster.StatsClusterRequest;
 import com.liferay.portal.search.engine.adapter.cluster.StatsClusterResponse;
 import com.liferay.portal.search.opensearch2.internal.connection.OpenSearchConnectionManager;
@@ -98,7 +100,7 @@ public class StatsClusterRequestExecutor {
 
 						if ((nodeIds != null) && (nodeIds.length > 0)) {
 							return "/_cluster/stats/nodes/" +
-								String.join(",", nodeIds);
+								StringUtil.merge(nodeIds, StringPool.COMMA);
 						}
 
 						return "/_cluster/stats";

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/cluster/StatsClusterRequestExecutor.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/cluster/StatsClusterRequestExecutor.java
@@ -6,22 +6,21 @@
 package com.liferay.portal.search.opensearch2.internal.search.engine.adapter.cluster;
 
 import com.liferay.portal.kernel.exception.SystemException;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.search.engine.adapter.cluster.StatsClusterRequest;
 import com.liferay.portal.search.engine.adapter.cluster.StatsClusterResponse;
 import com.liferay.portal.search.opensearch2.internal.connection.OpenSearchConnectionManager;
-import com.liferay.portal.search.opensearch2.internal.util.JsonpUtil;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
 
 import java.io.IOException;
 
-import java.util.Arrays;
+import java.util.Collections;
 
+import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.opensearch.OpenSearchClient;
-import org.opensearch.client.opensearch.cluster.ClusterStatsRequest;
-import org.opensearch.client.opensearch.cluster.ClusterStatsResponse;
-import org.opensearch.client.opensearch.cluster.OpenSearchClusterClient;
-import org.opensearch.client.opensearch.cluster.stats.ClusterFileSystem;
-import org.opensearch.client.opensearch.cluster.stats.ClusterNodes;
+import org.opensearch.client.transport.OpenSearchTransport;
+import org.opensearch.client.transport.endpoints.SimpleEndpoint;
 
 /**
  * @author Dylan Rebelak
@@ -38,44 +37,32 @@ public class StatsClusterRequestExecutor {
 		StatsClusterRequest statsClusterRequest) {
 
 		try {
-			ClusterStatsResponse clusterStatsResponse =
-				_getClusterStatsResponse(
-					_createClusterStatsRequest(statsClusterRequest),
-					statsClusterRequest);
+			JsonObject jsonObject = _getClusterStatsJsonObject(
+				statsClusterRequest);
 
-			ClusterNodes clusterNodes = clusterStatsResponse.nodes();
+			JsonObject nodesJsonObject = jsonObject.getJsonObject("nodes");
 
-			ClusterFileSystem clusterFileSystem = clusterNodes.fs();
+			JsonObject fsJsonObject = nodesJsonObject.getJsonObject("fs");
 
-			long availableInBytes = clusterFileSystem.availableInBytes();
-			long totalInBytes = clusterFileSystem.totalInBytes();
+			long availableInBytes = fsJsonObject.getJsonNumber(
+				"available_in_bytes"
+			).longValue();
+			long totalInBytes = fsJsonObject.getJsonNumber(
+				"total_in_bytes"
+			).longValue();
 
 			return new StatsClusterResponse(
 				availableInBytes,
 				ClusterHealthStatusTranslatorUtil.translate(
-					clusterStatsResponse.status()),
-				JsonpUtil.toString(clusterStatsResponse),
-				totalInBytes - availableInBytes);
+					jsonObject.getString("status")),
+				jsonObject.toString(), totalInBytes - availableInBytes);
 		}
 		catch (Exception exception) {
 			throw new SystemException(exception);
 		}
 	}
 
-	private ClusterStatsRequest _createClusterStatsRequest(
-		StatsClusterRequest statsClusterRequest) {
-
-		ClusterStatsRequest.Builder builder = new ClusterStatsRequest.Builder();
-
-		if (ArrayUtil.isNotEmpty(statsClusterRequest.getNodeIds())) {
-			builder.nodeId(Arrays.asList(statsClusterRequest.getNodeIds()));
-		}
-
-		return builder.build();
-	}
-
-	private ClusterStatsResponse _getClusterStatsResponse(
-		ClusterStatsRequest clusterStatsRequest,
+	private JsonObject _getClusterStatsJsonObject(
 		StatsClusterRequest statsClusterRequest) {
 
 		OpenSearchClient openSearchClient =
@@ -83,11 +70,19 @@ public class StatsClusterRequestExecutor {
 				statsClusterRequest.getConnectionId(),
 				statsClusterRequest.isPreferLocalCluster());
 
-		OpenSearchClusterClient openSearchClusterClient =
-			openSearchClient.cluster();
+		OpenSearchTransport openSearchTransport = openSearchClient._transport();
 
 		try {
-			return openSearchClusterClient.stats(clusterStatsRequest);
+			JsonValue jsonValue = openSearchTransport.performRequest(
+				null,
+				new SimpleEndpoint<>(
+					request -> "GET", request -> "/_cluster/stats",
+					request -> Collections.emptyMap(),
+					request -> Collections.emptyMap(), false,
+					JsonpDeserializer.jsonValueDeserializer()),
+				null);
+
+			return jsonValue.asJsonObject();
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/cluster/StatsClusterRequestExecutor.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/cluster/StatsClusterRequestExecutor.java
@@ -94,9 +94,9 @@ public class StatsClusterRequestExecutor {
 			JsonValue jsonValue = openSearchTransport.performRequest(
 				statsClusterRequest,
 				new SimpleEndpoint<>(
-					request -> "GET",
-					request -> {
-						String[] nodeIds = request.getNodeIds();
+					statsClusterEndpointRequest -> "GET",
+					statsClusterEndpointRequest -> {
+						String[] nodeIds = statsClusterEndpointRequest.getNodeIds();
 
 						if ((nodeIds != null) && (nodeIds.length > 0)) {
 							return "/_cluster/stats/nodes/" +
@@ -105,8 +105,8 @@ public class StatsClusterRequestExecutor {
 
 						return "/_cluster/stats";
 					},
-					request -> Collections.emptyMap(),
-					request -> Collections.emptyMap(), false,
+					statsClusterEndpointRequest -> Collections.emptyMap(),
+					statsClusterEndpointRequest -> Collections.emptyMap(), false,
 					JsonpDeserializer.jsonValueDeserializer()),
 				null);
 

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/cluster/StatsClusterRequestExecutor.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/cluster/StatsClusterRequestExecutor.java
@@ -74,9 +74,19 @@ public class StatsClusterRequestExecutor {
 
 		try {
 			JsonValue jsonValue = openSearchTransport.performRequest(
-				null,
+				statsClusterRequest,
 				new SimpleEndpoint<>(
-					request -> "GET", request -> "/_cluster/stats",
+					request -> "GET",
+					request -> {
+						String[] nodeIds = request.getNodeIds();
+
+						if ((nodeIds != null) && (nodeIds.length > 0)) {
+							return "/_cluster/stats/nodes/" +
+								String.join(",", nodeIds);
+						}
+
+						return "/_cluster/stats";
+					},
 					request -> Collections.emptyMap(),
 					request -> Collections.emptyMap(), false,
 					JsonpDeserializer.jsonValueDeserializer()),


### PR DESCRIPTION
Re-sent from https://github.com/brianchandotcom/liferay-portal/pull/172587

@rodrigoguedes
@liferay-search

Original pull request comment:
https://liferay.atlassian.net/browse/LPD-84672

What is this trying to solve?
AWS omits some operating system-related information, possibly for security reasons. This breaks the Opensearch specification regarding required fields in the endpoint https://opensearch/_cluster/stats, causing the error: Missing required property 'ClusterOperatingSystemName.name'

How am I fixing it?
The way the opensearch2 connector obtains statistics in the cluster was changed, no longer using native request classes from the opensearch-java library, and we started extracting JSON data manually.

Note
There was an attempt to use ApiTypeHelper.DANGEROUS_disableRequiredPropertiesCheck(true)* to prevent the suggested change in these PRs, but it didn't work. It seems that it didn't work because ThreadLocal was not synchronized, perhaps due to some OSGI issue.

*https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/8.19/missing-required-property.html (This method is also available in the opensearch-java library)

How can you verify that it works?
Creating an environment that uses AWS Opensearch 2 (Follow the guide https://liferay.atlassian.net/wiki/spaces/ENGSEARCH/pages/4712628357/Guide+Create+test+environment+with+Liferay+DXP+AWS+OpenSearch+Service)
Access the Liferay Portal > Control Panel > Search > Index Actions
Expected result:
The page is rendered without errors and the reindexing options are available.