### PR TITLE
LPD-84655 Fix test

### DIFF
--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/web/internal/display/context/test/FragmentServiceConfigurationDisplayContextTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/web/internal/display/context/test/FragmentServiceConfigurationDisplayContextTest.java
@@ -160,6 +160,10 @@ public class FragmentServiceConfigurationDisplayContextTest {
 				_company, _group, _layout);
 
 		mockHttpServletRequest.setAttribute(
+			JavaConstants.JAKARTA_PORTLET_REQUEST,
+			new MockLiferayPortletRenderRequest(mockHttpServletRequest));
+
+		mockHttpServletRequest.setAttribute(
 			JavaConstants.JAKARTA_PORTLET_CONFIG,
 			ProxyUtil.newProxyInstance(
 				LiferayPortletConfig.class.getClassLoader(),
@@ -171,9 +175,6 @@ public class FragmentServiceConfigurationDisplayContextTest {
 
 					return null;
 				}));
-		mockHttpServletRequest.setAttribute(
-			JavaConstants.JAKARTA_PORTLET_REQUEST,
-			new MockLiferayPortletRenderRequest(mockHttpServletRequest));
 		mockHttpServletRequest.setAttribute(
 			JavaConstants.JAKARTA_PORTLET_RESPONSE,
 			new MockLiferayPortletRenderResponse());


### PR DESCRIPTION
Previously sent in #172525

Added a line break to show that the order matters in this case as MockLiferayPortletRenderRequest sets JAKARTA_PORTLET_CONFIG in the servletRequest