### PR TITLE
Lpd 86007

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -353,6 +353,7 @@
     build.repository.private.password=
     build.repository.private.url=
     build.repository.private.username=
+    build.rests.baseline.enabled=true
     build.services.baseline.enabled=true
 
 ##

--- a/modules/apps/object/object-rest-api/bnd.bnd
+++ b/modules/apps/object/object-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object REST API
 Bundle-SymbolicName: com.liferay.object.rest.api
-Bundle-Version: 34.2.2
+Bundle-Version: 34.3.0
 Export-Package:\
 	com.liferay.object.rest.dto.v1_0,\
 	com.liferay.object.rest.dto.v1_0.util,\

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/dto/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 4.3.1
+version 4.4.0

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
@@ -47,12 +47,17 @@ import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.ResponseCode;
 import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.Schema;
 
 import java.io.File;
+import java.io.IOException;
 
 import java.net.URL;
 
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
@@ -73,6 +78,17 @@ import java.util.TreeSet;
 public class RESTBuilder {
 
 	public static void main(String[] args) throws Exception {
+		if ((args.length > 0) && args[0].startsWith("rest.config.dirs=")) {
+			List<String> baselineTasks = _processRESTConfigFiles(
+				args[0].substring("rest.config.dirs=".length()));
+
+			System.out.println(
+				"rest.builder.baseline.tasks=" +
+					StringUtil.merge(baselineTasks, StringPool.SPACE));
+
+			return;
+		}
+
 		RESTBuilderArgs restBuilderArgs = new RESTBuilderArgs();
 
 		JCommander jCommander = new JCommander(restBuilderArgs);
@@ -413,8 +429,148 @@ public class RESTBuilder {
 		}
 	}
 
+	private static String _getBaselineTask(
+		Path baseDirPath, Path restConfigYamlPath) {
+
+		try {
+			String content = new String(
+				Files.readAllBytes(restConfigYamlPath), StandardCharsets.UTF_8);
+
+			int index = content.indexOf("apiDir:");
+
+			if (index == -1) {
+				return null;
+			}
+
+			int startIndex = index + "apiDir:".length();
+
+			int endIndex = content.indexOf('\n', startIndex);
+
+			if (endIndex == -1) {
+				endIndex = content.length();
+			}
+
+			String apiDirValue = content.substring(startIndex, endIndex);
+
+			Path apiDir = restConfigYamlPath.resolveSibling(apiDirValue.trim());
+
+			Path apiModuleDir = apiDir.getParent();
+
+			while (apiModuleDir != null) {
+				if (Files.exists(apiModuleDir.resolve("bnd.bnd"))) {
+					break;
+				}
+
+				apiModuleDir = apiModuleDir.getParent();
+			}
+
+			if (apiModuleDir == null) {
+				return null;
+			}
+
+			Path relativePath = baseDirPath.relativize(
+				apiModuleDir.normalize());
+
+			String gradleProjectPath = StringUtil.replace(
+				relativePath.toString(), File.separatorChar, ':');
+
+			return ":" + gradleProjectPath + ":baseline";
+		}
+		catch (IOException ioException) {
+			return null;
+		}
+	}
+
 	private static void _printHelp(JCommander jCommander) {
 		jCommander.usage();
+	}
+
+	private static String _processRESTConfigFile(
+			Path baseDirPath, Path restConfigYamlPath)
+		throws Exception {
+
+		Path moduleDir = restConfigYamlPath.getParent();
+
+		System.err.println("Processing " + moduleDir.getFileName());
+
+		RESTBuilder restBuilder = new RESTBuilder(
+			null, moduleDir.toFile(), null, null, null);
+
+		restBuilder.build();
+
+		return _getBaselineTask(baseDirPath, restConfigYamlPath);
+	}
+
+	private static List<String> _processRESTConfigFiles(String baseDirName)
+		throws Exception {
+
+		Path baseDirPath = Paths.get(baseDirName);
+
+		List<Path> restConfigYamlPaths = new ArrayList<>();
+
+		Files.walkFileTree(
+			baseDirPath,
+			new SimpleFileVisitor<Path>() {
+
+				@Override
+				public FileVisitResult preVisitDirectory(
+						Path dir, BasicFileAttributes basicFileAttributes)
+					throws IOException {
+
+					String dirName = String.valueOf(dir.getFileName());
+
+					if (dirName.equals("build") || dirName.equals("classes") ||
+						dirName.equals("node_modules") ||
+						dirName.equals("src") ||
+						dirName.equals("test-classes") ||
+						dirName.startsWith(".")) {
+
+						return FileVisitResult.SKIP_SUBTREE;
+					}
+
+					return FileVisitResult.CONTINUE;
+				}
+
+				@Override
+				public FileVisitResult visitFile(
+					Path file, BasicFileAttributes basicFileAttributes) {
+
+					if (!Objects.equals(
+							String.valueOf(file.getFileName()),
+							"rest-config.yaml")) {
+
+						return FileVisitResult.CONTINUE;
+					}
+
+					Path moduleDir = file.getParent();
+
+					String moduleName = String.valueOf(moduleDir.getFileName());
+
+					if (!moduleName.endsWith("-rest-impl") ||
+						!Files.exists(moduleDir.resolve("build.gradle"))) {
+
+						return FileVisitResult.CONTINUE;
+					}
+
+					restConfigYamlPaths.add(file);
+
+					return FileVisitResult.SKIP_SIBLINGS;
+				}
+
+			});
+
+		List<String> baselineTasks = new ArrayList<>();
+
+		for (Path restConfigYamlPath : restConfigYamlPaths) {
+			String baselineTask = _processRESTConfigFile(
+				baseDirPath, restConfigYamlPath);
+
+			if (baselineTask != null) {
+				baselineTasks.add(baselineTask);
+			}
+		}
+
+		return baselineTasks;
 	}
 
 	private String _addClientVersionDescription(String yamlString) {
@@ -1865,7 +2021,7 @@ public class RESTBuilder {
 					!Objects.equals(propertySchema.getFormat(), "double") &&
 					!Objects.equals(propertySchema.getFormat(), "float")) {
 
-					System.out.println(
+					System.err.println(
 						StringBundler.concat(
 							"The property \"", entry1.getKey(), '.',
 							entry2.getKey(),
@@ -1887,7 +2043,7 @@ public class RESTBuilder {
 					requiredPropertySchemaNames) {
 
 				if (!propertySchemaNames.contains(requiredPropertySchemaName)) {
-					System.out.println(
+					System.err.println(
 						StringBundler.concat(
 							"The required property \"",
 							requiredPropertySchemaName, "\" is not defined in ",

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/util/FileUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/util/FileUtil.java
@@ -41,7 +41,7 @@ public class FileUtil {
 
 		Files.delete(file.toPath());
 
-		System.out.println("Deleting " + file.getCanonicalPath());
+		System.err.println("Deleting " + file.getCanonicalPath());
 	}
 
 	public static void deleteFiles(String dirName, List<File> files)
@@ -185,7 +185,7 @@ public class FileUtil {
 				file.toPath(), parsedContent.getBytes(StandardCharsets.UTF_8));
 
 			if (!oldContent.equals(parsedContent)) {
-				System.out.println("Writing " + file.getCanonicalPath());
+				System.err.println("Writing " + file.getCanonicalPath());
 			}
 		}
 		else {
@@ -193,7 +193,7 @@ public class FileUtil {
 				file.toPath(), content.getBytes(StandardCharsets.UTF_8));
 
 			if (!oldContent.equals(content)) {
-				System.out.println("Writing " + file.getCanonicalPath());
+				System.err.println("Writing " + file.getCanonicalPath());
 			}
 		}
 	}

--- a/portal-impl/build.xml
+++ b/portal-impl/build.xml
@@ -12,6 +12,13 @@
 	<property name="manifest.bundle.symbolic.name" value="com.liferay.portal.impl;singleton:=true" />
 	<property name="service.file" value="service.xml" />
 
+	<path id="rest.builder.classpath">
+		<fileset
+			dir="${sdk.dir}/dependencies/com.liferay.portal.tools.rest.builder/lib"
+			includes="*.jar"
+		/>
+	</path>
+
 	<path id="service.builder.classpath">
 		<fileset
 			dir="${sdk.dir}/dependencies/com.liferay.portal.tools.service.builder/lib"
@@ -227,6 +234,50 @@
 			<jvmarg value="-Dproject.dir=${project.dir}" />
 			<jvmarg value="-Dproject.modules.dir=${project.dir}/modules" />
 		</java>
+	</target>
+
+	<target name="build-rests">
+		<java
+			classname="com.liferay.portal.tools.rest.builder.RESTBuilder"
+			classpathref="rest.builder.classpath"
+			failonerror="true"
+			fork="${fork.mode}"
+			logError="true"
+			newenvironment="${fork.mode}"
+			outputproperty="rest.builder.batch.output"
+		>
+			<jvmarg if:true="${jvm.debug}" value="${jpda.settings}" />
+			<jvmarg if:true="${jvm.debug}" value="-Dfile.encoding=UTF-8" />
+			<jvmarg if:true="${jvm.debug}" value="-XX:MaxMetaspaceSize=512m" />
+			<jvmarg if:true="${jvm.debug}" value="-Xms512m" />
+			<jvmarg if:true="${jvm.debug}" value="-Xmx1024m" />
+			<jvmarg if:true="${jvm.debug}" value="-Xss2048k" />
+			<arg value="rest.config.dirs=${basedir}/../modules" />
+		</java>
+
+		<if>
+			<istrue value="${build.rests.baseline.enabled}" />
+			<then>
+				<propertyregex
+					input="${rest.builder.batch.output}"
+					override="true"
+					property="rest.builder.baseline.tasks"
+					regexp="rest\.builder\.baseline\.tasks=(.*)"
+					select="\1"
+				/>
+
+				<if>
+					<isset property="rest.builder.baseline.tasks" />
+					<then>
+						<gradle-execute dir="../modules" forcedcacheenabled="false" task="${rest.builder.baseline.tasks}">
+							<arg value="--continue" />
+							<arg value="--parallel" />
+							<arg value="--quiet" />
+						</gradle-execute>
+					</then>
+				</if>
+			</then>
+		</if>
 	</target>
 
 	<target name="build-service-counter">

--- a/portal-impl/build.xml
+++ b/portal-impl/build.xml
@@ -442,6 +442,7 @@
 					<isset property="service.builder.baseline.tasks" />
 					<then>
 						<gradle-execute dir="../modules" forcedcacheenabled="false" task="${service.builder.baseline.tasks}">
+							<arg value="--continue" />
 							<arg value="--parallel" />
 							<arg value="--quiet" />
 						</gradle-execute>


### PR DESCRIPTION
@brianchandotcom from now on the recommanded way of invoking RESTBuilder is ```ant -f portal-impl/build.xml build-rests```  the original gradle way still works, but it is much slower than this ant way.