### PR TITLE
LPD-86130 Capture Exception instead of IOException

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -758,11 +758,10 @@ public class UpgradeReport {
 
 			return rootDir;
 		}
-		catch (IOException ioException) {
+		catch (Exception exception) {
 			if (_log.isWarnEnabled()) {
 				_log.warn(
-					"Unable to get document library store root dir",
-					ioException);
+					"Unable to get document library store root dir", exception);
 			}
 		}
 


### PR DESCRIPTION
Manually forwarding from https://github.com/liferay-database-infra/liferay-portal/pull/3467 

There is a SF problem because a new SF version wasn't published yet, see this comment https://github.com/liferay-database-infra/liferay-portal/pull/3467#issuecomment-4248684686