### PR TITLE
LPD-83651 When Vocabulary is required for all asset types, I cannot create new files

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.object.service.impl;
 
+import com.liferay.asset.categories.thread.local.AssetVocabularyThreadLocal;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.constants.DepotRolesConstants;
@@ -961,18 +962,38 @@ public class ObjectEntryFolderLocalServiceImpl
 			ObjectEntryFolder objectEntryFolder, ServiceContext serviceContext)
 		throws PortalException {
 
-		_assetEntryLocalService.updateEntry(
-			serviceContext.getUserId(), objectEntryFolder.getGroupId(),
-			objectEntryFolder.getCreateDate(),
-			objectEntryFolder.getModifiedDate(),
-			ObjectEntryFolder.class.getName(),
-			objectEntryFolder.getObjectEntryFolderId(),
-			objectEntryFolder.getUuid(), 0,
-			serviceContext.getAssetCategoryIds(),
-			serviceContext.getAssetTagNames(), true,
-			objectEntryFolder.getStatus() == WorkflowConstants.STATUS_APPROVED,
-			null, null, objectEntryFolder.getCreateDate(), null, null,
-			objectEntryFolder.getName(), null, null, null, null, 0, 0, null);
+		DepotEntry depotEntry = _depotEntryLocalService.fetchGroupDepotEntry(
+			objectEntryFolder.getGroupId());
+
+		boolean originalSkipRequiredCategoryValidation =
+			AssetVocabularyThreadLocal.isSkipRequiredCategoryValidation();
+
+		if ((depotEntry != null) &&
+			(depotEntry.getType() == DepotConstants.TYPE_SPACE)) {
+
+			AssetVocabularyThreadLocal.setSkipRequiredCategoryValidation(true);
+		}
+
+		try {
+			_assetEntryLocalService.updateEntry(
+				serviceContext.getUserId(), objectEntryFolder.getGroupId(),
+				objectEntryFolder.getCreateDate(),
+				objectEntryFolder.getModifiedDate(),
+				ObjectEntryFolder.class.getName(),
+				objectEntryFolder.getObjectEntryFolderId(),
+				objectEntryFolder.getUuid(), 0,
+				serviceContext.getAssetCategoryIds(),
+				serviceContext.getAssetTagNames(), true,
+				objectEntryFolder.getStatus() ==
+					WorkflowConstants.STATUS_APPROVED,
+				null, null, objectEntryFolder.getCreateDate(), null, null,
+				objectEntryFolder.getName(), null, null, null, null, 0, 0,
+				null);
+		}
+		finally {
+			AssetVocabularyThreadLocal.setSkipRequiredCategoryValidation(
+				originalSkipRequiredCategoryValidation);
+		}
 	}
 
 	private void _updateObjectEntryFolderName(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -6611,6 +6611,9 @@ public class ObjectEntryLocalServiceImpl
 			}
 		}
 
+		boolean originalSkipRequiredCategoryValidation =
+			AssetVocabularyThreadLocal.isSkipRequiredCategoryValidation();
+
 		if (!objectDefinition.isEnableCategorization()) {
 			assetCategoryIds = null;
 			assetTagNames = null;
@@ -6635,7 +6638,8 @@ public class ObjectEntryLocalServiceImpl
 			}
 		}
 		finally {
-			AssetVocabularyThreadLocal.setSkipRequiredCategoryValidation(false);
+			AssetVocabularyThreadLocal.setSkipRequiredCategoryValidation(
+				originalSkipRequiredCategoryValidation);
 		}
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -6579,6 +6579,8 @@ public class ObjectEntryLocalServiceImpl
 		if (!objectDefinition.isEnableCategorization()) {
 			assetCategoryIds = null;
 			assetTagNames = null;
+
+			AssetVocabularyThreadLocal.setSkipRequiredCategoryValidation(true);
 		}
 
 		String mimeType = ContentTypes.TEXT_PLAIN;
@@ -6616,19 +6618,24 @@ public class ObjectEntryLocalServiceImpl
 			}
 		}
 
-		AssetEntry assetEntry = _assetEntryLocalService.updateEntry(
-			userId, objectEntry.getNonzeroGroupId(),
-			objectEntry.getCreateDate(), objectEntry.getModifiedDate(),
-			objectDefinition.getClassName(), objectEntry.getObjectEntryId(),
-			objectEntry.getUuid(), 0, assetCategoryIds, assetTagNames, true,
-			objectEntry.isApproved(), null, null, null, null, mimeType, title,
-			String.valueOf(objectEntry.getObjectEntryId()), null, null, null, 0,
-			0, priority, serviceContext);
+		try {
+			AssetEntry assetEntry = _assetEntryLocalService.updateEntry(
+				userId, objectEntry.getNonzeroGroupId(),
+				objectEntry.getCreateDate(), objectEntry.getModifiedDate(),
+				objectDefinition.getClassName(), objectEntry.getObjectEntryId(),
+				objectEntry.getUuid(), 0, assetCategoryIds, assetTagNames, true,
+				objectEntry.isApproved(), null, null, null, null, mimeType,
+				title, String.valueOf(objectEntry.getObjectEntryId()), null,
+				null, null, 0, 0, priority, serviceContext);
 
-		if (assetLinkEntryIds != null) {
-			_assetLinkLocalService.updateLinks(
-				userId, assetEntry.getEntryId(), assetLinkEntryIds,
-				AssetLinkConstants.TYPE_RELATED);
+			if (assetLinkEntryIds != null) {
+				_assetLinkLocalService.updateLinks(
+					userId, assetEntry.getEntryId(), assetLinkEntryIds,
+					AssetLinkConstants.TYPE_RELATED);
+			}
+		}
+		finally {
+			AssetVocabularyThreadLocal.setSkipRequiredCategoryValidation(false);
 		}
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -6576,13 +6576,6 @@ public class ObjectEntryLocalServiceImpl
 			_objectDefinitionPersistence.findByPrimaryKey(
 				objectEntry.getObjectDefinitionId());
 
-		if (!objectDefinition.isEnableCategorization()) {
-			assetCategoryIds = null;
-			assetTagNames = null;
-
-			AssetVocabularyThreadLocal.setSkipRequiredCategoryValidation(true);
-		}
-
 		String mimeType = ContentTypes.TEXT_PLAIN;
 		String title = StringPool.BLANK;
 
@@ -6616,6 +6609,13 @@ public class ObjectEntryLocalServiceImpl
 				serviceContext.setAttribute(
 					"assetTagScopeGroupId", group.getGroupId());
 			}
+		}
+
+		if (!objectDefinition.isEnableCategorization()) {
+			assetCategoryIds = null;
+			assetTagNames = null;
+
+			AssetVocabularyThreadLocal.setSkipRequiredCategoryValidation(true);
 		}
 
 		try {

--- a/modules/apps/object/object-test/build.gradle
+++ b/modules/apps/object/object-test/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:asset:asset-api")
 	testIntegrationImplementation project(":apps:asset:asset-display-page-api")
 	testIntegrationImplementation project(":apps:asset:asset-list-api")
+	testIntegrationImplementation project(":apps:asset:asset-test-util")
 	testIntegrationImplementation project(":apps:batch-engine:batch-engine-api")
 	testIntegrationImplementation project(":apps:blogs:blogs-api")
 	testIntegrationImplementation project(":apps:commerce:commerce-api")

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryFolderLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryFolderLocalServiceTest.java
@@ -6,6 +6,9 @@
 package com.liferay.object.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetCategoryConstants;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.model.DepotEntry;
@@ -103,6 +106,16 @@ public class ObjectEntryFolderLocalServiceTest {
 
 	@Before
 	public void setUp() throws Exception {
+		_depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext());
+
 		_group = GroupTestUtil.addGroup();
 
 		_objectDefinition = _addObjectDefinition();
@@ -251,6 +264,17 @@ public class ObjectEntryFolderLocalServiceTest {
 			_hasResourcePermission(
 				ObjectActionKeys.ADD_OBJECT_ENTRY_FOLDER, objectEntryFolder,
 				role));
+
+		AssetTestUtil.addVocabulary(
+			_depotEntry.getGroupId(), AssetCategoryConstants.ALL_CLASS_NAME_ID,
+			AssetCategoryConstants.ALL_CLASS_TYPE_PK, true);
+
+		_objectEntryFolderLocalService.addObjectEntryFolder(
+			StringUtil.randomString(), _depotEntry.getGroupId(),
+			TestPropsValues.getUserId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			RandomTestUtil.randomString(), null, StringUtil.randomString(),
+			new ServiceContext());
 	}
 
 	@FeatureFlag("LPD-17564")
@@ -1149,6 +1173,12 @@ public class ObjectEntryFolderLocalServiceTest {
 		return _objectEntryFolderLocalService.updateObjectEntryFolder(
 			objectEntryFolder);
 	}
+
+	@Inject
+	private AssetVocabularyLocalService _assetVocabularyLocalService;
+
+	@DeleteAfterTestRun
+	private DepotEntry _depotEntry;
 
 	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -9,10 +9,13 @@ import com.liferay.account.constants.AccountConstants;
 import com.liferay.account.model.AccountEntry;
 import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetCategoryConstants;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.kernel.service.AssetTagLocalService;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.asset.kernel.service.persistence.AssetEntryQuery;
+import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.commerce.currency.model.CommerceCurrency;
 import com.liferay.commerce.currency.test.util.CommerceCurrencyTestUtil;
 import com.liferay.commerce.model.CommerceOrder;
@@ -1786,6 +1789,38 @@ public class ObjectEntryLocalServiceTest {
 			0,
 			_counterLocalService.getCurrentId(
 				ObjectFieldUtil.getCounterName(objectField)));
+	}
+
+	@Test
+	public void testAddObjectEntryWithCategorization() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		AssetTestUtil.addVocabulary(
+			group.getGroupId(), AssetCategoryConstants.ALL_CLASS_NAME_ID,
+			AssetCategoryConstants.ALL_CLASS_TYPE_PK, true);
+
+		boolean originalEnableCategorization =
+			_siteObjectDefinition.isEnableCategorization();
+
+		_siteObjectDefinition = _enableCategorization(
+			true, _siteObjectDefinition);
+
+		AssertUtils.assertFailure(
+			PortalException.class, null,
+			() -> _addObjectEntry(
+				group.getGroupId(),
+				_siteObjectDefinition.getObjectDefinitionId(),
+				Collections.emptyMap()));
+
+		_siteObjectDefinition = _enableCategorization(
+			false, _siteObjectDefinition);
+
+		_addObjectEntry(
+			group.getGroupId(), _siteObjectDefinition.getObjectDefinitionId(),
+			Collections.emptyMap());
+
+		_siteObjectDefinition = _enableCategorization(
+			originalEnableCategorization, _siteObjectDefinition);
 	}
 
 	@Test
@@ -8001,6 +8036,15 @@ public class ObjectEntryLocalServiceTest {
 		return listTypeEntries;
 	}
 
+	private ObjectDefinition _enableCategorization(
+		boolean enable, ObjectDefinition objectDefinition) {
+
+		objectDefinition.setEnableCategorization(enable);
+
+		return _objectDefinitionLocalService.updateObjectDefinition(
+			objectDefinition);
+	}
+
 	private void _enableObjectEntryVersioning() {
 		_objectDefinition.setEnableObjectEntryVersioning(true);
 
@@ -9743,6 +9787,9 @@ public class ObjectEntryLocalServiceTest {
 
 	@Inject
 	private AssetTagLocalService _assetTagLocalService;
+
+	@Inject
+	private AssetVocabularyLocalService _assetVocabularyLocalService;
 
 	@Inject
 	private AttachmentManager _attachmentManager;

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/com/liferay/site/initializer/cms/internal/batch/02-object-definition.batch-engine-data.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/com/liferay/site/initializer/cms/internal/batch/02-object-definition.batch-engine-data.json
@@ -1020,7 +1020,7 @@
 		},
 		{
 			"className": "com.liferay.object.model.ObjectDefinition#P4T1",
-			"enableCategorization": true,
+			"enableCategorization": false,
 			"enableFormContainer": false,
 			"externalReferenceCode": "L_CMS_BULK_ACTION_TASK",
 			"label": {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/categories.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/categories.spec.ts
@@ -600,3 +600,68 @@ test.describe('Subcategory tests', () => {
 		}
 	);
 });
+
+test(
+	'Content can be saved when all asset subtypes are required in a vocabulary',
+	{tag: '@LPD-83651'},
+	async ({apiHelpers, contentsPage, page}) => {
+		const categoryName = getRandomString();
+
+		await apiHelpers.headlessAdminTaxonomy.postTaxonomyVocabularyTaxonomyCategory(
+			{
+				name: categoryName,
+				vocabularyId,
+			}
+		);
+
+		await contentsPage.goto();
+
+		await contentsPage.createContent('Basic Web Content');
+
+		const title = getRandomString();
+
+		await contentsPage.fillData([{label: 'Title', value: title}]);
+
+		await contentsPage.openSidePanel('Categorization');
+
+		const categoriesAutocomplete = page.getByPlaceholder('Add category');
+
+		await categoriesAutocomplete.fill(categoryName);
+
+		const option = page.getByRole('option', {name: categoryName});
+
+		await option.waitFor();
+		await option.click();
+
+		await contentsPage.saveContent();
+
+		await expect(
+			page.getByRole('link', {exact: true, name: `${title}`})
+		).toBeVisible();
+	}
+);
+
+test(
+	'Folder can be saved when all asset subtypes are required in a vocabulary',
+	{tag: '@LPD-83651'},
+	async ({apiHelpers, contentsPage, page}) => {
+		const categoryName = getRandomString();
+
+		await apiHelpers.headlessAdminTaxonomy.postTaxonomyVocabularyTaxonomyCategory(
+			{
+				name: categoryName,
+				vocabularyId,
+			}
+		);
+
+		await contentsPage.goto();
+
+		const folderName = getRandomString();
+
+		await contentsPage.createFolder(folderName, 'Default');
+
+		await expect(
+			page.getByRole('link', {exact: true, name: `${folderName}`})
+		).toBeVisible();
+	}
+);


### PR DESCRIPTION
When Vocabulary is required for all asset types, I cannot create new files

https://liferay.atlassian.net/browse/LPD-83651

Object Entries have underlying assets, so do Object Entry Folders. When a vocabulary exists that has a required all type, it will force validation, and then it will fail

# How am I fixing it?

We already have a thread local that bypasses category validation. Use this in the case of object entry folders, and those object definitions that don't have categorization enabled

# How can you verify that it works?

There are two provided Playwright Tests. Also, the following 4 scenarios. Please note that before the changes all scenarios failed

## Scenario 1

* Go to the CMS and create a vocabulary, it's important that "All asset types" is marked as required
* Go to contents and create a Basic Web Content 


## Scenario 2

* Go to the CMS and create a vocabulary, it's important that "All asset types" is marked as required
* Go to contents and create a Folder


## Scenario 3

* Go to the CMS and create a vocabulary, it's important that "All asset types" is marked as required
* Create a new Space

## Scenario 4

* For any folder, handle the propagation of default permissions