### PR TITLE
LPD-86417 Add Claude Code skills for the development workflow

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: commit
+description: Commit staged/unstaged changes with an auto-generated message. Analyzes the diff to produce a Jira-prefixed commit title and optional body. Use when the user asks to commit, wants to commit changes, or says /commit.
+argument-hint: "[optional message hint]"
+allowed-tools: [Bash, Read, Grep, Glob]
+---.
+
+# Commit Changes
+
+Create a well-crafted git commit for the current changes.
+
+## 1. Gather Context
+
+- If Claude modified or created files during this conversation, commit **only** those files. Stage them explicitly by name using `git add <file1> <file2> ...`. Do not include the user's own changes.
+- If Claude did **not** modify any files in this conversation, commit **all** changes — stage modified/deleted files (but NOT untracked files). If there are untracked files, ask the user whether to include them.
+
+Never use `git add -A` or `git add .`.
+
+If there are no changes at all (no staged, no unstaged, no untracked), tell the user there is nothing to commit and stop.
+
+## 2. Extract the Jira Ticket
+
+The ticket ID is a pattern like `LPD-12345`, `LCD-12345`, `LRCI-1234`, etc. (uppercase letters, hyphen, digits).
+
+1. **Branch name** — extract the ticket from the current branch name (e.g., branch `LPD-83847` → ticket `LPD-83847`).
+2. **Previous commits** — if the branch name has no ticket, look at the last 5 commit messages for a ticket prefix.
+3. **User argument** — if `$ARGUMENTS` contains a ticket ID, use that instead.
+4. **Not found** — if no ticket is found anywhere, ask the user for one.
+
+## 3. Analyze the Diff and Write the Commit Message
+
+Read and understand the actual code changes (the diff). Then compose the commit message:
+
+### Title (first line)
+
+Format: `<TICKET> <What is being fixed/added/improved>`
+
+- Start with the Jira ticket ID
+- Follow with a concise summary of **what** is being fixed or achieved — describe the problem or behavior change, not the code changes
+- Use sentence case (capitalize first word only)
+- No period at the end
+- Keep under 72 characters total (ticket + space + summary)
+- If a second Jira ticket is relevant (e.g., the change addresses a sub-task tracked elsewhere), include it after the first: `LPD-12345 LPD-67890 Summary`
+
+Examples of good titles:
+- `LPD-84627 Prevent dispatch trigger loss when analytics admin user is missing`
+- `LPD-83357 Add validation to prevent folder changes for CMS object definitions`
+- `LPD-83630 Fix typo`
+- `LCD-50509 Grant ArgoCD permission to correct namespace`
+
+### Body (optional)
+
+Add a body **only** if the title alone doesn't fully explain the change. Skip the body for trivial/obvious changes (typo fixes, simple renames, single-line changes).
+
+When included:
+- Separate from title with a blank line
+- Explain **why** the change is needed — describe the problem, the previous behavior, or the motivation, not the code changes themselves
+- Wrap lines at 72 characters
+- Use plain prose, not bullet points (match the repo convention)
+
+If `$ARGUMENTS` contains a hint or description (not a ticket ID), incorporate it into the message.
+
+## 4. Confirm and Commit
+
+Show the user the proposed commit message and ask for confirmation. If they approve (or say nothing needs changing), create the commit:
+
+```bash
+git commit -m "$(cat <<'EOF'
+<title>
+
+<body if applicable>
+EOF
+)"
+```
+
+If the user wants changes, adjust and re-confirm.
+
+## 5. Post-Commit
+
+Run `git status` to confirm the commit succeeded and show the result.

--- a/.claude/skills/jira-bug/SKILL.md
+++ b/.claude/skills/jira-bug/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: jira-bug
+description: Create a Jira bug ticket in the LPD project. Use when the user asks to create/file a Jira bug or LPD ticket.
+argument-hint: "[commit-hash-or-description]"
+allowed-tools: Bash(git *), Bash(curl *), Read, Grep, Glob
+---
+
+# Create a Jira Bug in LPD
+
+Create a bug ticket in the LPD Jira project using the REST API with credentials from `$JIRA_API_USER` and `$JIRA_API_TOKEN` environment variables.
+
+## Input
+
+If `$ARGUMENTS` is a commit hash, inspect the commit with `git show` to understand the fix and infer the bug it addresses. If it is a description, use that directly.
+
+## Gather Information
+
+Ask the user for any missing details:
+- **Summary** — short title describing the bug
+- **Steps to Reproduce** — clear, minimal steps
+- **Expected Behavior**
+- **Actual Behavior**
+
+## Required Fields
+
+The LPD project requires these fields. Use these defaults unless the user specifies otherwise:
+- **Affects Version**: `Master` (id: `16660`)
+- **Component**: Ask the user or infer from the code area. Common ones:
+  - `Headless Batch Engine API` (id: `16022`)
+  - `Data Integration > Export/Import` (id: `16131`)
+  - `Content Publishing > Resource Importer` (id: `15805`)
+  - If unsure, search components: `curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" "https://liferay.atlassian.net/rest/api/3/project/LPD/components" | python3 -c "import json,sys; [print(f'{c[\"id\"]:>6} {c[\"name\"]}') for c in json.load(sys.stdin) if 'SEARCH_TERM' in c['name'].lower()]"`
+- **Cross Cutting Properties** (`customfield_10979`): `None` (id: `14468`)
+
+## Create the Ticket
+
+Use the Jira REST API v3 to create the issue:
+
+```bash
+curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  "https://liferay.atlassian.net/rest/api/3/issue" \
+  -d '<JSON payload>'
+```
+
+Use Atlassian Document Format (ADF) for the description with sections: Description, Steps to Reproduce, Expected Behavior, Actual Behavior. Include a Fix section if a commit is referenced.
+
+## Output
+
+Return the ticket key and URL: `https://liferay.atlassian.net/browse/<KEY>`

--- a/.claude/skills/jira-task/SKILL.md
+++ b/.claude/skills/jira-task/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: jira-task
+description: Create a Jira task in the LPD project. Use when the user asks to create a Jira task or LPD task ticket.
+argument-hint: "[commit-hash-or-description]"
+allowed-tools: Bash(git *), Bash(curl *), Read, Grep, Glob
+---
+
+# Create a Jira Task in LPD
+
+Create a task ticket in the LPD Jira project using the REST API with credentials from `$JIRA_API_USER` and `$JIRA_API_TOKEN` environment variables.
+
+## Input
+
+If `$ARGUMENTS` is a commit hash, inspect the commit with `git show` to understand the work and infer the task. If it is a description, use that directly.
+
+## Gather Information
+
+Ask the user for any missing details:
+- **Summary** — short title describing the task
+- **Description** — what needs to be done and why
+
+## Required Fields
+
+The LPD project requires these fields. Use these defaults unless the user specifies otherwise:
+- **Issue Type**: `Task` (id: `10002`)
+- **Component**: Ask the user or infer from the code area. Common ones:
+  - `Headless Batch Engine API` (id: `16022`)
+  - `Data Integration > Export/Import` (id: `16131`)
+  - `Content Publishing > Resource Importer` (id: `15805`)
+  - If unsure, search components: `curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" "https://liferay.atlassian.net/rest/api/3/project/LPD/components" | python3 -c "import json,sys; [print(f'{c[\"id\"]:>6} {c[\"name\"]}') for c in json.load(sys.stdin) if 'SEARCH_TERM' in c['name'].lower()]"`
+
+Note: Unlike bugs, tasks do NOT require Affects Version or Cross Cutting Properties fields.
+
+## Create the Ticket
+
+Use the Jira REST API v3 to create the issue:
+
+```bash
+curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  "https://liferay.atlassian.net/rest/api/3/issue" \
+  -d '<JSON payload>'
+```
+
+Use Atlassian Document Format (ADF) for the description with sections: Description, Acceptance Criteria (if applicable). Include a Reference section if a commit is referenced.
+
+## Output
+
+Return the ticket key and URL: `https://liferay.atlassian.net/browse/<KEY>`

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: pr
+description: Create a GitHub pull request for the current branch, update the Jira ticket to In Review, and set the PR link. Use when the user asks to create a PR, send a PR, or says /pr.
+argument-hint: "[optional target-org/repo or message hint]"
+allowed-tools: [Bash, Read, Grep, Glob]
+---
+
+# Create Pull Request
+
+Create a GitHub PR for the current branch and update the Jira ticket.
+
+## 1. Gather Context
+
+If there are uncommitted changes, warn the user and stop — they should commit first (suggest `/commit`).
+
+## 2. Extract the Jira Ticket
+
+The ticket ID is a pattern like `LPD-12345`, `LCD-12345`, `LRCI-1234`, etc. (uppercase letters, hyphen, digits).
+
+1. **Branch name** — extract the ticket from the current branch name (e.g., branch `LPD-83847` → ticket `LPD-83847`).
+2. **Previous commits** — if the branch name has no ticket, look at the commit messages.
+3. **User argument** — if `$ARGUMENTS` contains a ticket ID, use that instead.
+4. **Not found** — if no ticket is found anywhere, ask the user for one.
+
+## 3. Determine the Target
+
+- **Fork owner**: If `$ARGUMENTS` specifies a GitHub org/user, use that. Otherwise, ask the user to choose from: `liferay-bpm`, `liferay-content-management`, `liferay-page-management`.
+- **Fork remote**: Use the user's remote (default: `origin`). Identify the GitHub username from the remote URL (e.g., `git@github.com:brianchandotcom/liferay-portal.git` → `brianchandotcom`).
+- **Target repo**: Default is `<fork-owner>/liferay-portal`. If `$ARGUMENTS` specifies a different `org/repo`, use that.
+- **Base branch**: `master`.
+- **Head**: `<github-username>:<branch-name>`.
+
+## 4. Push the Branch
+
+Push the branch to the user's remote if not already pushed or if there are new local commits:
+
+```bash
+git push -u origin <branch-name>
+```
+
+## 5. Analyze Changes and Create the PR
+
+Read the full diff (`git diff master...HEAD`) and all commit messages to understand what changed.
+
+### PR Title
+
+Keep it short (under 72 characters). Use the Jira ticket as prefix:
+
+```
+LPD-83847 Fix OutOfMemoryError during batch engine import
+```
+
+### PR Body
+
+Use this format:
+
+```markdown
+https://liferay.atlassian.net/browse/TICKET-ID
+
+**What is being fixed:** Explain the problem or bug that motivated the
+change. What was going wrong or what was missing.
+
+**How it is being fixed:** Explain the approach taken across all commits.
+Describe the key changes and why this approach was chosen. Write in plain
+prose, not bullet points.
+```
+
+### Create the PR
+
+```bash
+gh pr create --repo <target-org/repo> --head <username>:<branch> --base master --title "<title>" --body "$(cat <<'EOF'
+<body>
+EOF
+)"
+```
+
+Show the user the proposed title and body before creating. If they approve, proceed.
+
+## 6. Update Jira Ticket
+
+After the PR is created successfully, transition the Jira ticket to review and set the **Git Pull Request** field using the Jira REST API.
+
+### Determine the ticket type and resolve the target ticket
+
+LPD uses different workflows depending on the issue type. Check the issue type first:
+
+```bash
+curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" \
+  "https://liferay.atlassian.net/rest/api/3/issue/<TICKET>?fields=issuetype,subtasks"
+```
+
+- **Bug** (type id `10004`): Use the bug ticket directly. Transition to **In Review** uses id `71`.
+- **Technical Task** (subtask, type id `10153`): Use it directly. Transition to **In Peer Review** uses id `31`.
+- **Task** (parent, type id `10002`): Find its Technical Task subtask and use that subtask's key instead. All subsequent operations (transition, PR field, PR title, summary) should reference the **subtask's key**. Transition to **In Peer Review** uses id `31`.
+
+### Ensure the ticket is In Progress first
+
+Before transitioning to review, check the ticket's current status. If it is **not** already "In Progress", transition it to In Progress first. The transition ID depends on the issue type:
+
+- **Bug**: In Progress transition id is `61`
+- **Technical Task**: In Progress transition id is `41`
+
+```bash
+curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  "https://liferay.atlassian.net/rest/api/3/issue/<TARGET-TICKET>/transitions" \
+  -d '{
+    "transition": {"id": "<61-for-bug|41-for-task>"}
+  }'
+```
+
+### Transition to review
+
+For **Bug** tickets (In Review, id `71`):
+
+```bash
+curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  "https://liferay.atlassian.net/rest/api/3/issue/<BUG>/transitions" \
+  -d '{
+    "transition": {"id": "71"}
+  }'
+```
+
+For **Technical Task** tickets or subtask resolved from a Task (In Peer Review, id `31`):
+
+```bash
+curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  "https://liferay.atlassian.net/rest/api/3/issue/<TECHNICAL-TASK>/transitions" \
+  -d '{
+    "transition": {"id": "31"}
+  }'
+```
+
+Then set the Git Pull Request field on the target ticket:
+
+```bash
+curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" \
+  -X PUT \
+  -H "Content-Type: application/json" \
+  "https://liferay.atlassian.net/rest/api/3/issue/<TARGET-TICKET>" \
+  -d '{"fields": {"customfield_10201": "<PR-URL>"}}'
+```
+
+- `customfield_10201` = "Git Pull Request" text field
+
+If the transition fails (e.g., ticket is already in a later status), still try to set the PR field separately. Verify the update by fetching the ticket status and PR field.
+
+## 7. Summary
+
+Report back:
+- PR URL
+- Jira ticket status and link

--- a/.claude/skills/test-plan/SKILL.md
+++ b/.claude/skills/test-plan/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: test-plan
+description: Generate a targeted local test plan for branch changes. Use when the user wants to know what tests to run before merging, asks for a test plan, wants to validate their changes locally, or mentions running tests for their branch. This skill analyzes commits on top of master and produces a runnable shell script with unit, integration, playwright, and poshi tests that fit within a 20-minute local run budget.
+allowed-tools: [Read, Glob, Grep, Bash, Agent]
+---
+
+# Test Plan Generator
+
+You generate a runnable shell script that executes the tests most likely to break given the current branch's changes compared to master.
+
+The context: our test suite is massive — running it all takes hours. We merge aggressively and rely on a daily full test run (results within 24 hours of merge). This skill produces a focused test script (under 20 minutes) to mitigate risk before merging. It is not meant to catch everything — just the most likely breakages.
+
+## How This Project Organizes Tests
+
+Read the reference file for detailed test organization patterns:
+
+```
+${CLAUDE_SKILL_DIR}/references/test-organization.md
+```
+
+## Workflow
+
+### 1. Understand the Changes
+
+```bash
+git diff master...HEAD --name-only
+git log master..HEAD --oneline
+```
+
+Read the changed files to understand what the changes actually do — not just which files were touched, but what behavior changed. This understanding drives the test selection.
+
+### 2. Identify What Could Break
+
+Think about the blast radius of the changes:
+
+- **API/interface changes** (portal-kernel, *-api modules): anything that depends on the changed API could break. Search for consumers.
+- **Service implementation changes**: tests for that service, plus tests for features that depend on it.
+- **Shared infrastructure changes** (e.g., a registry, a framework class, a base class): all modules that use that infrastructure could break. Find representative tests across the affected modules.
+- **Mechanical/repetitive changes** (e.g., adding a property to 200 files): the core logic test is essential, but also include a representative sample of end-to-end tests from affected modules to verify the mechanical change doesn't break anything.
+- **Web layer changes**: playwright and poshi tests for the affected UI.
+
+The goal is not "find all tests in modules that were touched" — it's "find tests that exercise the code paths that changed."
+
+### 3. Find the Tests
+
+For each area that could break, search for test files. Use parallel Agent/Glob calls for speed. Read `${CLAUDE_SKILL_DIR}/references/test-organization.md` for the exact patterns and conventions.
+
+**Verify every test file you list actually exists** using Glob before including it.
+
+### 4. Prioritize for the 20-Minute Budget
+
+Apply this priority order:
+
+**Always include:**
+1. Unit tests for directly changed code — fast (~5-15s per class), highest signal
+2. Integration tests that directly test changed functionality
+3. Tests that exercise the core logic change end-to-end
+
+**Include if budget allows:**
+4. Representative integration tests from affected downstream modules — pick a few that cover different usage patterns rather than running all of them
+5. Playwright tests for affected web modules (~1-3 min per spec)
+
+**Include if still within budget:**
+6. Poshi tests (~2-5 min each)
+7. More downstream module tests for broader coverage
+
+When the change affects many modules (e.g., a framework change), don't try to test every single module. Pick a diverse sample that covers different usage patterns of the changed code.
+
+### 5. Write the Script
+
+Delete any existing `test.sh` in the repository root first, then write a new one. The script must be self-contained and runnable with `bash test.sh`. Use this structure:
+
+```bash
+#!/bin/bash
+#
+# Test plan for branch: <branch-name>
+# Generated: <date>
+# Estimated time: <X>m / 20m budget
+#
+# Changes: <N> commits, <N> files changed
+# Affected areas: <list of module groups/components>
+#
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+EXIT_CODE=0
+
+<test commands — one per line, no blank lines between them>
+
+exit $EXIT_CODE
+```
+
+**Critical rules for the script:**
+- Replace `<test commands>` with the actual test commands you discovered
+- Every command must be suffixed with `|| EXIT_CODE=1` so failures are recorded but execution continues. The script exits with `$EXIT_CODE` at the end — 0 if all passed, 1 if any failed.
+- Use `"$REPO_ROOT/gradlew" -p "$REPO_ROOT/modules"` for gradle tasks (gradlew is at the repo root)
+- Use `npx --prefix "$REPO_ROOT/modules/test/playwright" playwright test` for playwright
+- All test types (unit, integration, playwright, poshi) are included directly — the portal is assumed to be running
+- Add a single-line comment before each command explaining why it was selected — do not repeat the test or module name in the comment, just state the reason.
+
+After writing the script, run `chmod +x test.sh` to make it executable, and tell the user to run it with `./test.sh`.
+
+## Guidelines
+
+- Verify every test file exists using Glob before adding it to the script
+- If changes are purely cosmetic (formatting, comments), say so and generate a script that just exits 0 with a header explaining why

--- a/.claude/skills/test-plan/references/test-organization.md
+++ b/.claude/skills/test-plan/references/test-organization.md
@@ -1,0 +1,98 @@
+# Liferay Portal Test Organization Reference
+
+## Module Structure
+
+Standard module layout:
+```
+modules/apps/{module-group}/
+├── {module}-api/           # API/interfaces (rarely has tests)
+├── {module}-service/       # Implementation
+│   └── src/test/java/      # Unit tests live here
+├── {module}-test/          # Separate test module
+│   └── src/testIntegration/java/  # Integration tests live here
+├── {module}-web/           # Web/portlet layer
+├── {module}-web-test/      # Web integration tests (sometimes)
+├── {module}-test-util/     # Shared test utilities
+├── build.gradle
+└── test.properties         # Test-to-component mapping
+```
+
+## Test Type Details
+
+### Unit Tests
+
+- **Location**: `{module-group}/{module}-service/src/test/java/**/*Test.java`
+- **Also in**: `portal-impl/src/test/java/**/*Test.java` for core code
+- **Framework**: JUnit 4, Mockito
+- **Run command**: `cd modules && ../gradlew :apps:{module-group}:{module}-service:test`
+- **Run specific class**: `cd modules && ../gradlew :apps:{module-group}:{module}-service:test --tests "com.liferay.{package}.SomeTest"`
+- **Speed**: ~5-15 seconds per test class
+- **Naming**: Source file name + `Test` suffix (e.g., `BlogsEntryLocalServiceImpl.java` → `BlogsEntryLocalServiceImplTest.java`)
+
+### Integration Tests
+
+- **Location**: `{module-group}/{module}-test/src/testIntegration/java/**/*Test.java`
+- **Also in**: `{module-group}/{module}-web-test/src/testIntegration/java/` for web tests
+- **Framework**: Arquillian + JUnit bridge (`@RunWith(Arquillian.class)`)
+- **Run command**: `cd modules && ../gradlew :apps:{module-group}:{module}-test:testIntegration`
+- **Run specific class**: `cd modules && ../gradlew :apps:{module-group}:{module}-test:testIntegration --tests "com.liferay.{package}.SomeTest"`
+- **Speed**: ~30-120 seconds per test class (needs portal context)
+- **Note**: These require a running Liferay instance or will bootstrap one
+
+### Playwright Tests
+
+- **Location**: `modules/test/playwright/tests/{module-web}/**/*.spec.ts`
+- **Config**: `modules/test/playwright/playwright.config.ts` (imports per-module configs)
+- **Run all for a module**: `cd modules/test/playwright && npx playwright test tests/{module-web}/`
+- **Run specific file**: `cd modules/test/playwright && npx playwright test tests/{module-web}/main/someTest.spec.ts`
+- **Speed**: ~1-3 minutes per spec file
+- **Structure**: Each module directory typically has `main/config.ts` and `main/*.spec.ts`
+- **Coverage**: ~131 module directories, ~630 spec files
+
+### Poshi Functional Tests
+
+- **Location**: `portal-web/test/functional/com/liferay/portalweb/`
+- **Test files**: `tests/enduser/**/*.testcase` (~514 files)
+- **Macros**: `macros/*.macro` (~516 files)
+- **Speed**: ~2-5 minutes per test method
+- **Annotations**:
+  - `@component-name` — links to a component (e.g., `"portal-headless"`)
+  - `@priority` — 1-5 (5 = most critical)
+  - `testray.main.component.name` — component for test reporting
+- **Organization**: `tests/enduser/{category}/{subcategory}/` (categories: abtest, collaboration, contentdashboard, documentmanagement, exportimport, publications, staging, wem, etc.)
+
+## Mapping Source Changes to Tests
+
+### Direct mapping (same module)
+A change to `modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/util/PingbackMethodImpl.java` maps to:
+- Unit test: `modules/apps/blogs/blogs-service/src/test/java/com/liferay/blogs/internal/util/PingbackMethodImplTest.java`
+
+### Cross-module mapping (test module)
+A change to `modules/apps/blogs/blogs-service/` maps to:
+- Integration tests in: `modules/apps/blogs/blogs-test/src/testIntegration/java/`
+
+### Using test.properties for broader mapping
+Each module group has a `test.properties` at `modules/apps/{module-group}/test.properties` containing:
+
+```properties
+# Maps to poshi component name
+testray.main.component.name=Blogs
+
+# Defines which test classes run for this module's changes
+modules.includes.required.test.batch.class.names.includes[modules-unit][relevant][rule-name]=\
+    apps/blogs/**/*Test.java
+
+modules.includes.required.test.batch.class.names.includes[modules-integration-postgresql163][relevant][rule-name]=\
+    apps/blogs/**/*Test.java,\
+    apps/headless/headless-delivery/headless-delivery-test/**/BaseBlog*Test.java,\
+    apps/headless/headless-delivery/headless-delivery-test/**/Blog*Test.java
+```
+
+Use `testray.main.component.name` to find related poshi `.testcase` files by searching for matching `@component-name` or `testray.main.component.name` properties inside them.
+
+### Playwright mapping
+Map the module's web component name to its playwright directory:
+- Change in `modules/apps/blogs/blogs-web/` → tests in `modules/test/playwright/tests/blogs-web/`
+- Change in `modules/apps/document-library/document-library-web/` → tests in `modules/test/playwright/tests/document-library-web/`
+
+The directory name in `modules/test/playwright/tests/` matches the `-web` module name.


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86417

**What is being fixed:** The development workflow lacked Claude Code skills
for common tasks like committing, creating PRs, filing Jira bugs/tasks,
and generating test plans.

**How it is being fixed:** Added five Claude Code skills under
`.claude/skills/`: commit, pr, jira-bug, jira-task, and test-plan. Each
skill is defined as a SKILL.md file that instructs Claude Code how to
perform the task — auto-generating commit messages with Jira prefixes,
creating PRs with Jira integration, filing bugs and tasks via the Jira
REST API, and producing targeted test plans based on branch changes. The
test-plan skill also includes a reference document describing the
project's test organization.