### PR TITLE
PD-85354 Technical Task | Add view asset content page with new view asset fragment

### DIFF
--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_assets/05_view_asset/page-definition.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_assets/05_view_asset/page-definition.json
@@ -1,0 +1,29 @@
+{
+	"pageElement": {
+		"id": "400d9b25-f334-94d9-728d-fc4e2137f840",
+		"pageElements": [
+			{
+				"definition": {
+					"fragment": {
+						"key": "com.liferay.site.cms.site.initializer.internal.fragment.renderer.ViewAssetJSPFragmentRenderer"
+					},
+					"fragmentConfig": {
+					},
+					"fragmentFields": [
+					],
+					"indexed": true
+				},
+				"id": "ae728ea5-c7d1-c3e4-2db2-6e477c2a09aa",
+				"type": "Fragment"
+			}
+		],
+		"type": "Root"
+	},
+	"settings": {
+		"themeSettings": {
+			"lfr-theme:regular:show-footer": "false",
+			"lfr-theme:regular:show-header": "false"
+		}
+	},
+	"version": 1.1
+}

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_assets/05_view_asset/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_assets/05_view_asset/page.json
@@ -1,0 +1,33 @@
+{
+	"friendlyURL": "/view-asset",
+	"hidden": true,
+	"name": "View Asset",
+	"name_i18n": {
+		"en_US": "View Asset"
+	},
+	"permissions": [
+		{
+			"actionIds": [
+				"VIEW"
+			],
+			"roleName": "CMS Administrator",
+			"scope": 4
+		},
+		{
+			"actionIds": [
+			],
+			"roleName": "Guest",
+			"scope": 4
+		},
+		{
+			"actionIds": [
+				"VIEW"
+			],
+			"roleName": "User",
+			"scope": 4
+		}
+	],
+	"private": false,
+	"system": false,
+	"type": "Content"
+}

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_assets/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_assets/page.json
@@ -44,6 +44,13 @@
 			],
 			"roleName": "Guest",
 			"scope": 4
+		},
+		{
+			"actionIds": [
+				"VIEW"
+			],
+			"roleName": "User",
+			"scope": 4
 		}
 	],
 	"private": false,

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseDisplayContextTestCase.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseDisplayContextTestCase.java
@@ -53,10 +53,14 @@ public abstract class BaseDisplayContextTestCase {
 		mockHttpServletRequest = getMockHttpServletRequest();
 
 		themeDisplay = getThemeDisplay(mockHttpServletRequest);
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
 	}
 
 	protected ObjectDefinition addCustomObjectDefinition(
-			long objectFolderId, boolean active, boolean enableObjectEntryDraft,
+			long objectFolderId, boolean active, boolean enableComments,
+			boolean enableObjectEntryDraft,
 			List<ObjectDefinitionSetting> objectDefinitionSettings,
 			String scope, int status)
 		throws Exception {
@@ -64,8 +68,8 @@ public abstract class BaseDisplayContextTestCase {
 		ObjectDefinition objectDefinition =
 			objectDefinitionLocalService.addCustomObjectDefinition(
 				null, TestPropsValues.getUserId(), objectFolderId, null, true,
-				false, true, false, true, enableObjectEntryDraft, false, false,
-				false, null,
+				enableComments, true, false, true, enableObjectEntryDraft,
+				false, false, false, null,
 				Collections.singletonMap(
 					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
 				ObjectDefinitionTestUtil.getRandomName(), null, null,
@@ -116,6 +120,17 @@ public abstract class BaseDisplayContextTestCase {
 			objectDefinition.getObjectDefinitionSettings(),
 			Collections.emptyList(), Collections.emptyList(),
 			new ServiceContext());
+	}
+
+	protected ObjectDefinition addCustomObjectDefinition(
+			long objectFolderId, boolean active, boolean enableObjectEntryDraft,
+			List<ObjectDefinitionSetting> objectDefinitionSettings,
+			String scope, int status)
+		throws Exception {
+
+		return addCustomObjectDefinition(
+			objectFolderId, active, false, enableObjectEntryDraft,
+			objectDefinitionSettings, scope, status);
 	}
 
 	protected ObjectDefinition addCustomObjectDefinition(

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAssetDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAssetDisplayContextTest.java
@@ -245,7 +245,7 @@ public class ViewAssetDisplayContextTest extends BaseDisplayContextTestCase {
 			String.valueOf(objectEntry.getObjectEntryId()), role.getRoleId(),
 			objectEntryActionIds.toArray(String[]::new));
 
-		String backURL = "http://backurl";
+		String backURL = RandomTestUtil.randomString();
 
 		mockHttpServletRequest.setParameter("backURL", backURL);
 

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAssetDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAssetDisplayContextTest.java
@@ -1,0 +1,347 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.display.context.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.fragment.renderer.FragmentRenderer;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectDefinitionSettingConstants;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.definition.setting.builder.ObjectDefinitionSettingBuilder;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectEntryLocalServiceUtil;
+import com.liferay.object.service.ObjectEntryService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.editor.configuration.EditorConfiguration;
+import com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.portlet.LiferayWindowState;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.context.ContextUserReplace;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Mikel Lorza
+ */
+@FeatureFlag("LPD-17564")
+@RunWith(Arquillian.class)
+public class ViewAssetDisplayContextTest extends BaseDisplayContextTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testGetAdditionalProps() throws Exception {
+		_testGetAdditionalPropsWithoutCommentPermission();
+		_testGetAdditionalPropsWithoutPermissions();
+		_testGetAdditionalPropsWithPermissions();
+	}
+
+	private void _assertEquals(
+			Map<String, ?> expectedMap, Map<String, ?> actualMap)
+		throws Exception {
+
+		Assert.assertEquals(
+			actualMap.toString(), expectedMap.size(), actualMap.size());
+
+		JSONObject expectedJSONObject = _jsonFactory.createJSONObject(
+			expectedMap);
+		JSONObject actualJSONObject = _jsonFactory.createJSONObject(actualMap);
+
+		JSONAssert.assertEquals(
+			expectedJSONObject.toString(), actualJSONObject.toString(),
+			JSONCompareMode.STRICT);
+	}
+
+	private Map<String, Object> _getAdditionalProps(
+		String backURL, boolean commentPermission,
+		ObjectDefinition objectDefinition, ObjectEntry objectEntry) {
+
+		return HashMapBuilder.<String, Object>put(
+			"backURL", backURL
+		).put(
+			"className", objectDefinition.getClassName()
+		).put(
+			"commentsProps",
+			HashMapBuilder.<String, Object>put(
+				"addCommentURL",
+				StringBundler.concat(
+					themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
+					GroupConstants.CMS_FRIENDLY_URL,
+					"/add_content_item_comment")
+			).put(
+				"deleteCommentURL",
+				StringBundler.concat(
+					themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
+					GroupConstants.CMS_FRIENDLY_URL,
+					"/delete_content_item_comment")
+			).put(
+				"editCommentURL",
+				StringBundler.concat(
+					themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
+					GroupConstants.CMS_FRIENDLY_URL,
+					"/edit_content_item_comment")
+			).put(
+				"editorConfig",
+				() -> {
+					EditorConfiguration contentItemCommentEditorConfiguration =
+						EditorConfigurationFactoryUtil.getEditorConfiguration(
+							StringPool.BLANK, "contentItemCommentEditor",
+							StringPool.BLANK, Collections.emptyMap(),
+							themeDisplay,
+							RequestBackedPortletURLFactoryUtil.create(
+								mockHttpServletRequest));
+
+					Map<String, Object> data =
+						contentItemCommentEditorConfiguration.getData();
+
+					return data.get("editorConfig");
+				}
+			).put(
+				"getCommentsURL",
+				StringBundler.concat(
+					themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
+					GroupConstants.CMS_FRIENDLY_URL, "/get_asset_comments")
+			).build()
+		).put(
+			"contentViewURL",
+			StringBundler.concat(
+				themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
+				GroupConstants.CMS_FRIENDLY_URL,
+				"/edit_content_item?&p_l_mode=read&p_p_state=",
+				LiferayWindowState.POP_UP, "&redirect=",
+				themeDisplay.getURLCurrent(), "&objectEntryId=",
+				objectEntry.getObjectEntryId())
+		).put(
+			"getObjectEntryURL",
+			StringBundler.concat(
+				"/o", objectDefinition.getRESTContextPath(), "/scopes/",
+				objectEntry.getGroupId(), "/by-external-reference-code/",
+				objectEntry.getExternalReferenceCode(),
+				"?nestedFields=file.metadata,file.previewURL,file.thumbnailURL")
+		).put(
+			"hasCommentPermission", commentPermission
+		).build();
+	}
+
+	private Object _getViewAssetDisplayContext(
+			HttpServletRequest httpServletRequest)
+		throws Exception {
+
+		_fragmentRenderer.render(
+			null, httpServletRequest, new MockHttpServletResponse());
+
+		Object viewAssetDisplayContext = httpServletRequest.getAttribute(
+			"com.liferay.site.cms.site.initializer.internal.display.context." +
+				"ViewAssetDisplayContext");
+
+		Assert.assertNotNull(viewAssetDisplayContext);
+
+		return viewAssetDisplayContext;
+	}
+
+	private void _testGetAdditionalProps(
+			boolean commentPermission, List<String> objectEntryActionIds,
+			PermissionChecker permissionChecker, Role role)
+		throws Exception {
+
+		ObjectDefinition objectDefinition = addCustomObjectDefinition(
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			true, true, true,
+			Collections.singletonList(
+				new ObjectDefinitionSettingBuilder(
+				).name(
+					ObjectDefinitionSettingConstants.NAME_ACCEPT_ALL_GROUPS
+				).value(
+					StringPool.TRUE
+				).build()),
+			ObjectDefinitionConstants.SCOPE_DEPOT,
+			WorkflowConstants.STATUS_APPROVED);
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			TestPropsValues.getCompanyId(), ObjectDefinition.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(objectDefinition.getObjectDefinitionId()),
+			role.getRoleId(), new String[] {ActionKeys.VIEW});
+
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			Collections.singletonMap(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			null, DepotConstants.TYPE_ASSET_LIBRARY,
+			new ServiceContext() {
+				{
+					setCompanyId(group.getCompanyId());
+					setUserId(TestPropsValues.getUserId());
+				}
+			});
+
+		ObjectEntry objectEntry = ObjectEntryLocalServiceUtil.addObjectEntry(
+			depotEntry.getGroupId(), TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null, Collections.emptyMap(),
+			ServiceContextTestUtil.getServiceContext());
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			TestPropsValues.getCompanyId(), objectDefinition.getClassName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(objectEntry.getObjectEntryId()), role.getRoleId(),
+			objectEntryActionIds.toArray(String[]::new));
+
+		String backURL = "http://backurl";
+
+		mockHttpServletRequest.setParameter("backURL", backURL);
+
+		mockHttpServletRequest.setParameter(
+			"objectEntryId", String.valueOf(objectEntry.getObjectEntryId()));
+
+		themeDisplay.setPermissionChecker(permissionChecker);
+
+		_assertEquals(
+			_getAdditionalProps(
+				backURL, commentPermission, objectDefinition, objectEntry),
+			ReflectionTestUtil.invoke(
+				_getViewAssetDisplayContext(mockHttpServletRequest),
+				"getAdditionalProps", new Class<?>[0]));
+	}
+
+	private void _testGetAdditionalPropsWithoutCommentPermission()
+		throws Exception {
+
+		User user = UserTestUtil.addUser();
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user);
+
+		PermissionChecker permissionChecker =
+			PermissionCheckerFactoryUtil.create(user);
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				user, permissionChecker)) {
+
+			_testGetAdditionalProps(
+				false, Arrays.asList(ActionKeys.VIEW), permissionChecker, role);
+		}
+	}
+
+	private void _testGetAdditionalPropsWithoutPermissions() throws Exception {
+		User user = UserTestUtil.addUser();
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user);
+
+		PermissionChecker permissionChecker =
+			PermissionCheckerFactoryUtil.create(user);
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				user, permissionChecker)) {
+
+			_testGetAdditionalProps(
+				false, new ArrayList<>(), permissionChecker, role);
+		}
+		catch (Exception exception) {
+			Assert.assertTrue(
+				exception.getCause() instanceof
+					PrincipalException.MustHavePermission);
+		}
+	}
+
+	private void _testGetAdditionalPropsWithPermissions() throws Exception {
+		User user = UserTestUtil.addUser();
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user);
+
+		PermissionChecker permissionChecker =
+			PermissionCheckerFactoryUtil.create(user);
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				user, permissionChecker)) {
+
+			_testGetAdditionalProps(
+				true, Arrays.asList(ActionKeys.ADD_DISCUSSION, ActionKeys.VIEW),
+				permissionChecker, role);
+		}
+	}
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject(
+		filter = "component.name=com.liferay.site.cms.site.initializer.internal.fragment.renderer.ViewAssetJSPFragmentRenderer"
+	)
+	private FragmentRenderer _fragmentRenderer;
+
+	@Inject
+	private JSONFactory _jsonFactory;
+
+	@Inject
+	private ObjectEntryService _objectEntryService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -21,9 +21,6 @@ import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalServiceUtil;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.editor.configuration.EditorConfiguration;
-import com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -37,7 +34,6 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
-import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -53,6 +49,7 @@ import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.site.cms.site.initializer.internal.util.ActionUtil;
+import com.liferay.site.cms.site.initializer.internal.util.CommentUtil;
 import com.liferay.site.cms.site.initializer.internal.util.PermissionUtil;
 import com.liferay.translation.exporter.TranslationInfoItemFieldValuesExporter;
 import com.liferay.translation.exporter.TranslationInfoItemFieldValuesExporterRegistry;
@@ -197,46 +194,7 @@ public abstract class BaseSectionDisplayContext {
 			}
 		).put(
 			"commentsProps",
-			HashMapBuilder.<String, Object>put(
-				"addCommentURL",
-				StringBundler.concat(
-					themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
-					GroupConstants.CMS_FRIENDLY_URL,
-					"/add_content_item_comment")
-			).put(
-				"deleteCommentURL",
-				StringBundler.concat(
-					themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
-					GroupConstants.CMS_FRIENDLY_URL,
-					"/delete_content_item_comment")
-			).put(
-				"editCommentURL",
-				StringBundler.concat(
-					themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
-					GroupConstants.CMS_FRIENDLY_URL,
-					"/edit_content_item_comment")
-			).put(
-				"editorConfig",
-				() -> {
-					EditorConfiguration contentItemCommentEditorConfiguration =
-						EditorConfigurationFactoryUtil.getEditorConfiguration(
-							StringPool.BLANK, "contentItemCommentEditor",
-							StringPool.BLANK, Collections.emptyMap(),
-							themeDisplay,
-							RequestBackedPortletURLFactoryUtil.create(
-								httpServletRequest));
-
-					Map<String, Object> data =
-						contentItemCommentEditorConfiguration.getData();
-
-					return data.get("editorConfig");
-				}
-			).put(
-				"getCommentsURL",
-				StringBundler.concat(
-					themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
-					GroupConstants.CMS_FRIENDLY_URL, "/get_asset_comments")
-			).build()
+			CommentUtil.getCommentsProps(httpServletRequest, themeDisplay)
 		).put(
 			"contentViewURL",
 			StringBundler.concat(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAssetDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAssetDisplayContext.java
@@ -10,13 +10,9 @@ import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryService;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.editor.configuration.EditorConfiguration;
-import com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
-import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionRegistryUtil;
@@ -24,10 +20,10 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.site.cms.site.initializer.internal.util.CommentUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -60,46 +56,7 @@ public class ViewAssetDisplayContext {
 			"className", _objectDefinition.getClassName()
 		).put(
 			"commentsProps",
-			HashMapBuilder.<String, Object>put(
-				"addCommentURL",
-				StringBundler.concat(
-					_themeDisplay.getPortalURL(), _themeDisplay.getPathMain(),
-					GroupConstants.CMS_FRIENDLY_URL,
-					"/add_content_item_comment")
-			).put(
-				"deleteCommentURL",
-				StringBundler.concat(
-					_themeDisplay.getPortalURL(), _themeDisplay.getPathMain(),
-					GroupConstants.CMS_FRIENDLY_URL,
-					"/delete_content_item_comment")
-			).put(
-				"editCommentURL",
-				StringBundler.concat(
-					_themeDisplay.getPortalURL(), _themeDisplay.getPathMain(),
-					GroupConstants.CMS_FRIENDLY_URL,
-					"/edit_content_item_comment")
-			).put(
-				"editorConfig",
-				() -> {
-					EditorConfiguration contentItemCommentEditorConfiguration =
-						EditorConfigurationFactoryUtil.getEditorConfiguration(
-							StringPool.BLANK, "contentItemCommentEditor",
-							StringPool.BLANK, Collections.emptyMap(),
-							_themeDisplay,
-							RequestBackedPortletURLFactoryUtil.create(
-								_httpServletRequest));
-
-					Map<String, Object> data =
-						contentItemCommentEditorConfiguration.getData();
-
-					return data.get("editorConfig");
-				}
-			).put(
-				"getCommentsURL",
-				StringBundler.concat(
-					_themeDisplay.getPortalURL(), _themeDisplay.getPathMain(),
-					GroupConstants.CMS_FRIENDLY_URL, "/get_asset_comments")
-			).build()
+			CommentUtil.getCommentsProps(_httpServletRequest, _themeDisplay)
 		).put(
 			"contentViewURL",
 			StringBundler.concat(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAssetDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAssetDisplayContext.java
@@ -17,6 +17,9 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionRegistryUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -113,6 +116,18 @@ public class ViewAssetDisplayContext {
 				_objectEntry.getGroupId(), "/by-external-reference-code/",
 				_objectEntry.getExternalReferenceCode(),
 				"?nestedFields=file.metadata,file.previewURL,file.thumbnailURL")
+		).put(
+			"hasCommentPermission",
+			() -> {
+				ModelResourcePermission<ObjectEntry> modelResourcePermission =
+					ModelResourcePermissionRegistryUtil.
+						getModelResourcePermission(
+							_objectDefinition.getClassName());
+
+				return modelResourcePermission.contains(
+					_themeDisplay.getPermissionChecker(), _objectEntry,
+					ActionKeys.ADD_DISCUSSION);
+			}
 		).build();
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAssetDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAssetDisplayContext.java
@@ -1,0 +1,124 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.display.context;
+
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.editor.configuration.EditorConfiguration;
+import com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.portlet.LiferayWindowState;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * @author Mikel Lorza
+ */
+public class ViewAssetDisplayContext {
+
+	public ViewAssetDisplayContext(
+			HttpServletRequest httpServletRequest,
+			ObjectDefinitionLocalService objectDefinitionLocalService,
+			ObjectEntryService objectEntryService)
+		throws PortalException {
+
+		_httpServletRequest = httpServletRequest;
+
+		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		_objectEntry = objectEntryService.getObjectEntry(
+			ParamUtil.getLong(httpServletRequest, "objectEntryId"));
+
+		_objectDefinition = objectDefinitionLocalService.getObjectDefinition(
+			_objectEntry.getObjectDefinitionId());
+	}
+
+	public Map<String, Object> getAdditionalProps() throws PortalException {
+		return HashMapBuilder.<String, Object>put(
+			"backURL", ParamUtil.getString(_httpServletRequest, "backURL")
+		).put(
+			"className", _objectDefinition.getClassName()
+		).put(
+			"commentsProps",
+			HashMapBuilder.<String, Object>put(
+				"addCommentURL",
+				StringBundler.concat(
+					_themeDisplay.getPortalURL(), _themeDisplay.getPathMain(),
+					GroupConstants.CMS_FRIENDLY_URL,
+					"/add_content_item_comment")
+			).put(
+				"deleteCommentURL",
+				StringBundler.concat(
+					_themeDisplay.getPortalURL(), _themeDisplay.getPathMain(),
+					GroupConstants.CMS_FRIENDLY_URL,
+					"/delete_content_item_comment")
+			).put(
+				"editCommentURL",
+				StringBundler.concat(
+					_themeDisplay.getPortalURL(), _themeDisplay.getPathMain(),
+					GroupConstants.CMS_FRIENDLY_URL,
+					"/edit_content_item_comment")
+			).put(
+				"editorConfig",
+				() -> {
+					EditorConfiguration contentItemCommentEditorConfiguration =
+						EditorConfigurationFactoryUtil.getEditorConfiguration(
+							StringPool.BLANK, "contentItemCommentEditor",
+							StringPool.BLANK, Collections.emptyMap(),
+							_themeDisplay,
+							RequestBackedPortletURLFactoryUtil.create(
+								_httpServletRequest));
+
+					Map<String, Object> data =
+						contentItemCommentEditorConfiguration.getData();
+
+					return data.get("editorConfig");
+				}
+			).put(
+				"getCommentsURL",
+				StringBundler.concat(
+					_themeDisplay.getPortalURL(), _themeDisplay.getPathMain(),
+					GroupConstants.CMS_FRIENDLY_URL, "/get_asset_comments")
+			).build()
+		).put(
+			"contentViewURL",
+			StringBundler.concat(
+				_themeDisplay.getPortalURL(), _themeDisplay.getPathMain(),
+				GroupConstants.CMS_FRIENDLY_URL,
+				"/edit_content_item?&p_l_mode=read&p_p_state=",
+				LiferayWindowState.POP_UP, "&redirect=",
+				_themeDisplay.getURLCurrent(), "&objectEntryId=",
+				_objectEntry.getObjectEntryId())
+		).put(
+			"getObjectEntryURL",
+			StringBundler.concat(
+				"/o", _objectDefinition.getRESTContextPath(), "/scopes/",
+				_objectEntry.getGroupId(), "/by-external-reference-code/",
+				_objectEntry.getExternalReferenceCode(),
+				"?nestedFields=file.metadata,file.previewURL,file.thumbnailURL")
+		).build();
+	}
+
+	private final HttpServletRequest _httpServletRequest;
+	private final ObjectDefinition _objectDefinition;
+	private final ObjectEntry _objectEntry;
+	private final ThemeDisplay _themeDisplay;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewAssetJSPFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewAssetJSPFragmentRenderer.java
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.fragment.renderer;
+
+import com.liferay.fragment.renderer.FragmentRenderer;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.site.cms.site.initializer.internal.display.context.ViewAssetDisplayContext;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Mikel Lorza
+ */
+@Component(service = FragmentRenderer.class)
+public class ViewAssetJSPFragmentRenderer
+	extends BaseJSPSectionFragmentRenderer<ViewAssetDisplayContext> {
+
+	@Override
+	public String getLabelKey() {
+		return "view-asset";
+	}
+
+	@Override
+	protected ViewAssetDisplayContext getDisplayContext(
+			HttpServletRequest httpServletRequest)
+		throws PortalException {
+
+		return new ViewAssetDisplayContext(
+			httpServletRequest, _objectDefinitionLocalService,
+			_objectEntryService);
+	}
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryService _objectEntryService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/CommentUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/CommentUtil.java
@@ -5,22 +5,30 @@
 
 package com.liferay.site.cms.site.initializer.internal.util;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.comment.Comment;
 import com.liferay.portal.kernel.comment.CommentManagerUtil;
+import com.liferay.portal.kernel.editor.configuration.EditorConfiguration;
+import com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.ratings.kernel.model.RatingsStats;
 import com.liferay.ratings.kernel.service.RatingsStatsLocalServiceUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.Collections;
 import java.util.Date;
+import java.util.Map;
 
 /**
  * @author Víctor Galán
@@ -84,6 +92,47 @@ public class CommentUtil {
 				return parentComment.isRoot();
 			}
 		);
+	}
+
+	public static Map<String, Object> getCommentsProps(
+		HttpServletRequest httpServletRequest, ThemeDisplay themeDisplay) {
+
+		return HashMapBuilder.<String, Object>put(
+			"addCommentURL",
+			StringBundler.concat(
+				themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
+				GroupConstants.CMS_FRIENDLY_URL, "/add_content_item_comment")
+		).put(
+			"deleteCommentURL",
+			StringBundler.concat(
+				themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
+				GroupConstants.CMS_FRIENDLY_URL, "/delete_content_item_comment")
+		).put(
+			"editCommentURL",
+			StringBundler.concat(
+				themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
+				GroupConstants.CMS_FRIENDLY_URL, "/edit_content_item_comment")
+		).put(
+			"editorConfig",
+			() -> {
+				EditorConfiguration contentItemCommentEditorConfiguration =
+					EditorConfigurationFactoryUtil.getEditorConfiguration(
+						StringPool.BLANK, "contentItemCommentEditor",
+						StringPool.BLANK, Collections.emptyMap(), themeDisplay,
+						RequestBackedPortletURLFactoryUtil.create(
+							httpServletRequest));
+
+				Map<String, Object> data =
+					contentItemCommentEditorConfiguration.getData();
+
+				return data.get("editorConfig");
+			}
+		).put(
+			"getCommentsURL",
+			StringBundler.concat(
+				themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
+				GroupConstants.CMS_FRIENDLY_URL, "/get_asset_comments")
+		).build();
 	}
 
 	private static JSONObject _getAuthorJSONObject(

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/view_asset/ViewAsset.scss
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/view_asset/ViewAsset.scss
@@ -1,0 +1,5 @@
+$toolbar-height: 3.5rem;
+
+.view-asset-preview-container {
+	height: calc(100vh - #{$toolbar-height});
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/init.jsp
@@ -23,6 +23,7 @@ page import="com.liferay.site.cms.site.initializer.internal.display.context.Edit
 page import="com.liferay.site.cms.site.initializer.internal.display.context.ViewAllRelatedAssetsSectionDisplayContext" %><%@
 page import="com.liferay.site.cms.site.initializer.internal.display.context.ViewAllSectionDisplayContext" %><%@
 page import="com.liferay.site.cms.site.initializer.internal.display.context.ViewAllSpacesDisplayContext" %><%@
+page import="com.liferay.site.cms.site.initializer.internal.display.context.ViewAssetDisplayContext" %><%@
 page import="com.liferay.site.cms.site.initializer.internal.display.context.ViewBulkActionTaskReportDisplayContext" %><%@
 page import="com.liferay.site.cms.site.initializer.internal.display.context.ViewCategoriesDisplayContext" %><%@
 page import="com.liferay.site.cms.site.initializer.internal.display.context.ViewCategoryUsagesDisplayContext" %><%@

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/panels/CommentsPanel.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/panels/CommentsPanel.tsx
@@ -30,7 +30,7 @@ export default function CommentsPanel({
 	getCommentsURL,
 }: {
 	addCommentURL: string;
-	comments: Comment[];
+	comments?: Comment[];
 	deleteCommentURL: string;
 	editCommentURL: string;
 	editorConfig: LiferayEditorConfig;

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/index.ts
@@ -97,6 +97,7 @@ export {default as SpaceSettings} from './main_view/spaces/SpaceSettings';
 export {default as SpaceSummaryHeader} from './main_view/spaces/SpaceSummaryHeader';
 export {default as SpacesNavigation} from './main_view/spaces_navigation/SpacesNavigation';
 export {default as VersionHistoryToolbar} from './main_view/version_history/VersionHistoryToolbar';
+export {default as ViewAsset} from './main_view/view_asset/ViewAsset';
 
 // Structure Builder
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/view_asset/ViewAsset.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/view_asset/ViewAsset.tsx
@@ -18,6 +18,9 @@ import {ISearchAssetObjectEntry} from '../../common/types/AssetType';
 import {SharingPermission} from '../../common/types/SharingPermission';
 import CommentsPanel from '../../content_editor/components/panels/CommentsPanel';
 import ObjectEntryService from '../info_panel/services/ObjectEntryService';
+
+import '../../../css/view_asset/ViewAsset.scss';
+
 interface CommentsProps {
 	addCommentURL: string;
 	deleteCommentURL: string;
@@ -163,7 +166,7 @@ export default function ViewAsset({
 
 			<div className="h-100" ref={containerRef}>
 				<div className="d-flex h-100">
-					<div className="h-100 justify-content-center mx-6 preview-container py-4 w-100">
+					<div className="justify-content-center mx-6 view-asset-preview-container w-100">
 						<AssetPreview item={item} url={contentViewURL} />
 					</div>
 				</div>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/view_asset/ViewAsset.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/view_asset/ViewAsset.tsx
@@ -113,7 +113,10 @@ export default function ViewAsset({
 
 	if (!item) {
 		return (
-			<div className="align-items-center d-flex h-100 justify-content-center w-100">
+			<div
+				className="align-items-center d-flex h-100 justify-content-center w-100"
+				role="status"
+			>
 				<ClayLoadingIndicator />
 			</div>
 		);

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/view_asset/ViewAsset.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/view_asset/ViewAsset.tsx
@@ -15,7 +15,6 @@ import React, {useEffect, useMemo, useRef, useState} from 'react';
 import AssetPreview from '../../common/components/AssetPreview';
 import Toolbar from '../../common/components/Toolbar';
 import {ISearchAssetObjectEntry} from '../../common/types/AssetType';
-import {SharingPermission} from '../../common/types/SharingPermission';
 import CommentsPanel from '../../content_editor/components/panels/CommentsPanel';
 import ObjectEntryService from '../info_panel/services/ObjectEntryService';
 
@@ -35,6 +34,7 @@ interface ViewAssetProps {
 	commentsProps: CommentsProps;
 	contentViewURL: string;
 	getObjectEntryURL: string;
+	hasCommentPermission: boolean;
 }
 
 const ViewAssetCommentsPanel = ({
@@ -74,6 +74,7 @@ export default function ViewAsset({
 	commentsProps,
 	contentViewURL,
 	getObjectEntryURL,
+	hasCommentPermission,
 }: ViewAssetProps) {
 	const [itemState, setItemState] = useState<ISearchAssetObjectEntry | null>(
 		null
@@ -121,15 +122,12 @@ export default function ViewAsset({
 	const file = item.embedded.file;
 	const link = file?.link;
 
-	const showCommentsPanel =
-		item.actionIds?.includes(SharingPermission.Comment) ?? true;
-
 	return (
 		<>
 			<Toolbar backURL={backURL} title={item.title}>
 				<Toolbar.Item>
 					<div className="align-items-center c-gap-2 d-flex">
-						{showCommentsPanel && (
+						{hasCommentPermission && (
 							<ClayButtonWithIcon
 								aria-label={Liferay.Language.get(
 									'show-comments'
@@ -176,7 +174,7 @@ export default function ViewAsset({
 					onOpenChange={setOpenSidePanel}
 					open={openSidePanel}
 				>
-					{showCommentsPanel && (
+					{hasCommentPermission && (
 						<ViewAssetCommentsPanel
 							commentsProps={commentsProps}
 							item={item}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/view_asset/ViewAsset.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/view_asset/ViewAsset.tsx
@@ -1,0 +1,197 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ClayButtonWithIcon} from '@clayui/button';
+import {SidePanel} from '@clayui/core';
+import ClayIcon from '@clayui/icon';
+import ClayLink from '@clayui/link';
+import ClayLoadingIndicator from '@clayui/loading-indicator';
+import classNames from 'classnames';
+import {addParams} from 'frontend-js-web';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
+
+import AssetPreview from '../../common/components/AssetPreview';
+import Toolbar from '../../common/components/Toolbar';
+import {ISearchAssetObjectEntry} from '../../common/types/AssetType';
+import {SharingPermission} from '../../common/types/SharingPermission';
+import CommentsPanel from '../../content_editor/components/panels/CommentsPanel';
+import ObjectEntryService from '../info_panel/services/ObjectEntryService';
+interface CommentsProps {
+	addCommentURL: string;
+	deleteCommentURL: string;
+	editCommentURL: string;
+	editorConfig: any;
+	getCommentsURL: string;
+}
+
+interface ViewAssetProps {
+	backURL: string;
+	className: string;
+	commentsProps: CommentsProps;
+	contentViewURL: string;
+	getObjectEntryURL: string;
+}
+
+const ViewAssetCommentsPanel = ({
+	commentsProps,
+	item,
+}: {
+	commentsProps: CommentsProps;
+	item: ISearchAssetObjectEntry;
+}) => {
+	const {addCommentURL, editCommentURL, getCommentsURL} = commentsProps;
+	const {
+		embedded: {id},
+		entryClassName,
+	}: ISearchAssetObjectEntry = item;
+
+	const params = `?className=${encodeURIComponent(entryClassName)}&classPK=${id}`;
+
+	return (
+		<>
+			<h3 className="font-weight-semi-bold px-3 py-4 text-7">
+				{Liferay.Language.get('comments')}
+			</h3>
+
+			<CommentsPanel
+				{...commentsProps}
+				addCommentURL={addParams(params, addCommentURL)}
+				editCommentURL={addParams(params, editCommentURL)}
+				getCommentsURL={addParams(params, getCommentsURL)}
+			></CommentsPanel>
+		</>
+	);
+};
+
+export default function ViewAsset({
+	backURL,
+	className,
+	commentsProps,
+	contentViewURL,
+	getObjectEntryURL,
+}: ViewAssetProps) {
+	const [itemState, setItemState] = useState<ISearchAssetObjectEntry | null>(
+		null
+	);
+
+	useEffect(() => {
+		if (getObjectEntryURL) {
+			ObjectEntryService.getObjectEntry(getObjectEntryURL).then(
+				({data}) => {
+					if (data) {
+						setItemState(data as any);
+					}
+				}
+			);
+		}
+	}, [getObjectEntryURL]);
+
+	const item: ISearchAssetObjectEntry = useMemo(() => {
+		if (!itemState) {
+			return null;
+		}
+
+		if (!(itemState as any).embedded) {
+			return transformItem(itemState, className);
+		}
+
+		return itemState;
+	}, [className, itemState]);
+
+	const [openSidePanel, setOpenSidePanel] = useState(false);
+	const containerRef = useRef(null);
+
+	const handleClickComments = () => {
+		setOpenSidePanel(!openSidePanel);
+	};
+
+	if (!item) {
+		return (
+			<div className="align-items-center d-flex h-100 justify-content-center w-100">
+				<ClayLoadingIndicator />
+			</div>
+		);
+	}
+
+	const file = item.embedded.file;
+	const link = file?.link;
+
+	const showCommentsPanel =
+		item.actionIds?.includes(SharingPermission.Comment) ?? true;
+
+	return (
+		<>
+			<Toolbar backURL={backURL} title={item.title}>
+				<Toolbar.Item>
+					<div className="align-items-center c-gap-2 d-flex">
+						{showCommentsPanel && (
+							<ClayButtonWithIcon
+								aria-label={Liferay.Language.get(
+									'show-comments'
+								)}
+								borderless
+								className={classNames({
+									active: 'commentPanel',
+								})}
+								displayType="secondary"
+								onClick={handleClickComments}
+								symbol="message"
+							/>
+						)}
+
+						{link?.href && (
+							<div className="autofit-col pr-3">
+								<ClayLink
+									button
+									displayType="primary"
+									href={link.href}
+									small
+								>
+									<span className="inline-item inline-item-before">
+										<ClayIcon symbol="download" />
+									</span>
+
+									{Liferay.Language.get('download')}
+								</ClayLink>
+							</div>
+						)}
+					</div>
+				</Toolbar.Item>
+			</Toolbar>
+
+			<div className="h-100" ref={containerRef}>
+				<div className="d-flex h-100">
+					<div className="h-100 justify-content-center mx-6 preview-container py-4 w-100">
+						<AssetPreview item={item} url={contentViewURL} />
+					</div>
+				</div>
+
+				<SidePanel
+					containerRef={containerRef}
+					onOpenChange={setOpenSidePanel}
+					open={openSidePanel}
+				>
+					{showCommentsPanel && (
+						<ViewAssetCommentsPanel
+							commentsProps={commentsProps}
+							item={item}
+						/>
+					)}
+				</SidePanel>
+			</div>
+		</>
+	);
+}
+
+export function transformItem(item: any, className?: string) {
+	return {
+		...item,
+		embedded: item.embedded || {
+			file: item.file ?? undefined,
+			id: item.id,
+		},
+		entryClassName: className,
+	};
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_asset.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_asset.jsp
@@ -1,0 +1,19 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<%
+ViewAssetDisplayContext viewAssetDisplayContext = (ViewAssetDisplayContext)request.getAttribute(ViewAssetDisplayContext.class.getName());
+%>
+
+<div>
+	<react:component
+		module="{ViewAsset} from site-cms-site-initializer"
+		props="<%= viewAssetDisplayContext.getAdditionalProps() %>"
+	/>
+</div>

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/panels/CommentsPanel.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/panels/CommentsPanel.test.tsx
@@ -17,6 +17,19 @@ import CommentService, {
 } from '../../../../../src/main/resources/META-INF/resources/js/content_editor/services/CommentService';
 import {mockFetch} from '../../../__mocks__/frontend-js-web';
 
+jest.mock(
+	'../../../../../src/main/resources/META-INF/resources/js/content_editor/services/CommentService',
+	() => ({
+		__esModule: true,
+		default: {
+			addComment: jest.fn(),
+			deleteComment: jest.fn(),
+			editComment: jest.fn(),
+			getComments: jest.fn(),
+		},
+	})
+);
+
 jest.mock('@ckeditor/ckeditor5-react', () => ({
 	CKEditor: ({onChange, onReady}: any) => {
 		const mockEditor = {
@@ -103,6 +116,10 @@ describe('CommentsPanel', () => {
 	});
 
 	it('deletes the child comment', async () => {
+		(CommentService.deleteComment as jest.Mock).mockResolvedValue({
+			data: {},
+		});
+
 		renderComponent();
 
 		expect(screen.getByText('Parent comment')).toBeInTheDocument;
@@ -111,13 +128,10 @@ describe('CommentsPanel', () => {
 		await userEvent.click(screen.getAllByText('delete')[1]);
 
 		await waitFor(() => {
-			expect(mockFetch).toBeCalledWith(
-				'deleteCommentURL',
+			expect(CommentService.deleteComment).toBeCalledWith(
 				expect.objectContaining({
-					body: {
-						commentId: '2',
-					},
-					method: 'POST',
+					commentId: '2',
+					url: 'deleteCommentURL',
 				})
 			);
 
@@ -133,6 +147,10 @@ describe('CommentsPanel', () => {
 	});
 
 	it('deletes the parent comment', async () => {
+		(CommentService.deleteComment as jest.Mock).mockResolvedValue({
+			data: {},
+		});
+
 		renderComponent();
 
 		expect(screen.getByText('Parent comment')).toBeInTheDocument;
@@ -141,13 +159,10 @@ describe('CommentsPanel', () => {
 		await userEvent.click(screen.getAllByText('delete')[0]);
 
 		await waitFor(() => {
-			expect(mockFetch).toBeCalledWith(
-				'deleteCommentURL',
+			expect(CommentService.deleteComment).toBeCalledWith(
 				expect.objectContaining({
-					body: {
-						commentId: '1',
-					},
-					method: 'POST',
+					commentId: '1',
+					url: 'deleteCommentURL',
 				})
 			);
 
@@ -165,20 +180,19 @@ describe('CommentsPanel', () => {
 	it('shows a toast with the error when the request to delete a comment fails', async () => {
 		const error = 'Unexpected error deleting a comment';
 
-		(mockFetch as jest.Mock).mockRejectedValueOnce(new Error(error));
+		(CommentService.deleteComment as jest.Mock).mockResolvedValue({
+			error,
+		});
 
 		renderComponent();
 
 		await userEvent.click(screen.getAllByText('delete')[0]);
 
 		await waitFor(() => {
-			expect(mockFetch).toBeCalledWith(
-				'deleteCommentURL',
+			expect(CommentService.deleteComment).toBeCalledWith(
 				expect.objectContaining({
-					body: {
-						commentId: '1',
-					},
-					method: 'POST',
+					commentId: '1',
+					url: 'deleteCommentURL',
 				})
 			);
 
@@ -265,5 +279,30 @@ describe('CommentsPanel', () => {
 				})
 			);
 		});
+	});
+
+	it('fetches comments if they are not provided as props', async () => {
+		(CommentService.getComments as jest.Mock).mockResolvedValue({
+			data: initialComments,
+		});
+
+		render(
+			<CommentsPanel
+				addCommentURL="addCommentURL"
+				deleteCommentURL="deleteCommentURL"
+				editCommentURL="editCommentURL"
+				editorConfig={{}}
+				getCommentsURL="getCommentsURL"
+			/>
+		);
+
+		await waitFor(() => {
+			expect(CommentService.getComments).toHaveBeenCalledWith({
+				url: 'getCommentsURL',
+			});
+		});
+
+		expect(screen.getByText('Parent comment')).toBeInTheDocument();
+		expect(screen.getByText('Child comment')).toBeInTheDocument();
 	});
 });

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/view_asset/ViewAsset.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/view_asset/ViewAsset.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+
+// eslint-disable-next-line
+import {checkAccessibility} from '@liferay/layout-js-components-web/test/__lib__/index';
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import ObjectEntryService from '../../../../src/main/resources/META-INF/resources/js/main_view/info_panel/services/ObjectEntryService';
+import ViewAsset from '../../../../src/main/resources/META-INF/resources/js/main_view/view_asset/ViewAsset';
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/common/components/AssetPreview',
+	() =>
+		function AssetPreview() {
+			return <div data-testid="asset-preview" />;
+		}
+);
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/common/components/Toolbar',
+	() => {
+		const Toolbar = ({
+			children,
+			title,
+		}: {
+			children: React.ReactNode;
+			title: string;
+		}) => (
+			<div data-testid="toolbar">
+				<h1>{title}</h1>
+
+				{children}
+			</div>
+		);
+
+		Toolbar.Item = ({children}: {children: React.ReactNode}) => (
+			<div data-testid="toolbar-item">{children}</div>
+		);
+
+		return Toolbar;
+	}
+);
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/content_editor/components/panels/CommentsPanel',
+	() =>
+		function CommentsPanel() {
+			return <div data-testid="comments-panel" />;
+		}
+);
+
+const mockLiferayLanguageGet = jest.fn((key: string) => key);
+
+(global as any).Liferay = {
+	Language: {
+		get: mockLiferayLanguageGet,
+	},
+};
+
+const mockItem = {
+	actions: {},
+	dateCreated: '2023-01-01T00:00:00Z',
+	dateModified: '2023-01-01T00:00:00Z',
+	embedded: {
+		entryClassName: 'com.liferay.portal.kernel.model.DLFileEntry',
+		file: {
+			id: 456,
+			link: {
+				href: 'http://download-link',
+				label: 'Download',
+			},
+			name: 'test-file.png',
+		},
+		id: 123,
+	},
+	entryClassName: 'com.liferay.portal.kernel.model.DLFileEntry',
+	score: 1,
+	title: 'Mock Asset Title',
+};
+
+const defaultProps = {
+	backURL: '/back-url',
+	className: 'com.liferay.portal.kernel.model.DLFileEntry',
+	commentsProps: {
+		addCommentURL: '/add-comment',
+		deleteCommentURL: '/delete-comment',
+		editCommentURL: '/edit-comment',
+		editorConfig: {},
+		getCommentsURL: '/get-comments',
+	},
+	contentViewURL: '/content-view',
+	getObjectEntryURL: '/get-object-entry',
+	hasCommentPermission: true,
+};
+
+describe('ViewAsset', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		jest.spyOn(ObjectEntryService, 'getObjectEntry').mockResolvedValue({
+			data: mockItem,
+		} as any);
+	});
+
+	it('renders loading indicator initially', () => {
+		render(<ViewAsset {...defaultProps} />);
+
+		expect(screen.getByRole('status')).toBeInTheDocument();
+	});
+
+	it('renders content after fetching the item', async () => {
+		render(<ViewAsset {...defaultProps} />);
+
+		await waitFor(() => {
+			expect(screen.getByText('Mock Asset Title')).toBeInTheDocument();
+		});
+
+		expect(screen.getByTestId('asset-preview')).toBeInTheDocument();
+		expect(screen.getByTestId('toolbar')).toBeInTheDocument();
+	});
+
+	it('checks the accessibility', async () => {
+		const {container} = render(<ViewAsset {...defaultProps} />);
+
+		await waitFor(() => {
+			expect(screen.getByText('Mock Asset Title')).toBeInTheDocument();
+		});
+
+		await checkAccessibility({bestPractices: true, context: container});
+	});
+
+	it('renders download button when link is available', async () => {
+		render(<ViewAsset {...defaultProps} />);
+
+		await waitFor(() => {
+			expect(screen.getByText('download')).toBeInTheDocument();
+		});
+
+		const downloadLink = screen.getByRole('link', {name: /download/i});
+
+		expect(downloadLink).toHaveAttribute('href', 'http://download-link');
+	});
+
+	it('renders comments button when hasCommentPermission is true', async () => {
+		render(<ViewAsset {...defaultProps} />);
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole('button', {name: 'show-comments'})
+			).toBeInTheDocument();
+		});
+	});
+
+	it('does not render comments button when hasCommentPermission is false', async () => {
+		render(<ViewAsset {...defaultProps} hasCommentPermission={false} />);
+
+		await waitFor(() => {
+			expect(screen.getByText('Mock Asset Title')).toBeInTheDocument();
+		});
+
+		expect(
+			screen.queryByRole('button', {name: 'show-comments'})
+		).not.toBeInTheDocument();
+	});
+
+	it('opens side panel when clicking comments button', async () => {
+		render(<ViewAsset {...defaultProps} />);
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole('button', {name: 'show-comments'})
+			).toBeInTheDocument();
+		});
+
+		const commentsButton = screen.getByRole('button', {
+			name: 'show-comments',
+		});
+
+		await userEvent.click(commentsButton);
+
+		expect(screen.getByText('comments')).toBeInTheDocument();
+		expect(screen.getByTestId('comments-panel')).toBeInTheDocument();
+	});
+
+	it('transforms item if it does not have embedded property', async () => {
+		const itemWithoutEmbedded = {
+			file: mockItem.embedded.file,
+			id: mockItem.embedded.id,
+			title: 'Transformed Item Title',
+		};
+
+		jest.spyOn(ObjectEntryService, 'getObjectEntry').mockResolvedValue({
+			data: itemWithoutEmbedded,
+		} as any);
+
+		render(<ViewAsset {...defaultProps} />);
+
+		await waitFor(() => {
+			expect(
+				screen.getByText('Transformed Item Title')
+			).toBeInTheDocument();
+		});
+
+		expect(screen.getByTestId('asset-preview')).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
Hi @brianchandotcom ,

I am resending again with the changes related to this comment: https://github.com/brianchandotcom/liferay-portal/pull/173045#issuecomment-4262639595

regards!

https://liferay.atlassian.net/browse/LPD-85354

Add view asset content page with new view asset fragment

# How am I fixing it?

The purpose of this PR is to add a view where we can link from the shared content and notifications applications. For that this PR contains:

1. A new  content page to show an object entry.
2. A new view asset fragment to render(preview) the content or the shaed file  

This PR does not contain the change to modify the link from the shared content and notifications. 


# How can you verify that it works?

To test we have to follow these steps:

1. Deploy modules and initialize the cms with the new page with the configuration
2. Add a file and a content
3. Create a user to share the above assets
4. Go to file and content list and share the created file and content to the created user
5. If we share the file if we select download and view, the user would see and download the file, and if we select also comment the user would be able to add a comment to the asset. And, the same for the content but without the action of download.
6. Go to edit the content and get the id of the objectEntryId, log with the user and use the following url http://localhost:8080/web/cms/view-asset?objectEntryId={objectEntryId}

Also, we can test that the PR works runniung created tests: 

1. Added frontend tests
2. Added backend integration tests
