### PR TITLE
LPD-86436 Avoid NPE when mapping the User Profile Image to the image fragment

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-api/src/main/java/com/liferay/fragment/entry/processor/util/AnalyticsAttributesUtil.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-api/src/main/java/com/liferay/fragment/entry/processor/util/AnalyticsAttributesUtil.java
@@ -259,6 +259,10 @@ public class AnalyticsAttributesUtil {
 				FileEntry fileEntry = DLAppLocalServiceUtil.fetchFileEntry(
 					fileEntryId);
 
+				if (fileEntry == null) {
+					return StringPool.BLANK;
+				}
+
 				return fileEntry.getMimeType();
 			}
 			catch (PortalException portalException) {


### PR DESCRIPTION
Related Issue: https://liferay.atlassian.net/browse/LPD-86436