### PR TITLE
LPD-86109 Fixed FileNotFoundException at the end of upgrade process reporting

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -73,6 +73,10 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.felix.cm.PersistenceManager;
@@ -346,23 +350,27 @@ public class UpgradeReport {
 							"\"rootDir\" was not set";
 					}
 
-					_dlSize = 0;
+					FutureTask<Long> dlSizeFutureTask = new FutureTask<>(
+						() -> FileUtils.sizeOfDirectory(new File(_rootDir)));
 
 					try {
-						_dlSizeThread.start();
-						_dlSizeThread.join(
-							PropsValues.UPGRADE_REPORT_DL_STORAGE_SIZE_TIMEOUT *
-								Time.SECOND);
-					}
-					catch (Exception exception) {
-						_log.error(
-							"Unable to determine the document library size",
-							exception);
+						Thread dlSizeThread = new Thread(
+							dlSizeFutureTask, "Liferay DL Size Thread");
 
-						return "Unable to determine";
-					}
+						dlSizeThread.setDaemon(true);
 
-					if (_dlSizeThread.isAlive()) {
+						dlSizeThread.start();
+
+						long dlSize = dlSizeFutureTask.get(
+							PropsValues.UPGRADE_REPORT_DL_STORAGE_SIZE_TIMEOUT,
+							TimeUnit.SECONDS);
+
+						return LanguageUtil.formatStorageSize(
+							dlSize, LocaleUtil.US);
+					}
+					catch (TimeoutException timeoutException) {
+						dlSizeFutureTask.cancel(true);
+
 						if (_log.isInfoEnabled()) {
 							_log.info(
 								"Unable to determine the document library " +
@@ -370,11 +378,22 @@ public class UpgradeReport {
 										"manually.");
 						}
 
-						return "Unable to determine";
+						if (_log.isDebugEnabled()) {
+							_log.debug(timeoutException);
+						}
+					}
+					catch (ExecutionException executionException) {
+						_log.error(
+							"Unable to determine the document library size",
+							executionException.getCause());
+					}
+					catch (Exception exception) {
+						_log.error(
+							"Unable to determine the document library size",
+							exception);
 					}
 
-					return LanguageUtil.formatStorageSize(
-						_dlSize, LocaleUtil.US);
+					return "Unable to determine";
 				}
 			).build()
 		).put(
@@ -1007,22 +1026,11 @@ public class UpgradeReport {
 	private static final Snapshot<ReleaseManager> _releaseManagerSnapshot =
 		new Snapshot<>(UpgradeReport.class, ReleaseManager.class);
 
-	private double _dlSize;
-	private final Thread _dlSizeThread = new DLSizeThread();
 	private String _executionDateString;
 	private String _executionTimeString;
 	private final int _initialBuildNumber;
 	private Map<String, Long> _initialTableCounts;
 	private String _rootDir;
-
-	private class DLSizeThread extends Thread {
-
-		@Override
-		public void run() {
-			_dlSize = FileUtils.sizeOfDirectory(new File(_rootDir));
-		}
-
-	}
 
 	private class MessagesPrinter {
 

--- a/modules/apps/portal/portal-upgrade-impl/src/test/java/com/liferay/portal/upgrade/internal/report/UpgradeReportTest.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/test/java/com/liferay/portal/upgrade/internal/report/UpgradeReportTest.java
@@ -6,15 +6,22 @@
 package com.liferay.portal.upgrade.internal.report;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.db.DuplicateUniqueFinderRowsCleaner;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.tools.DBUpgrader;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
 import com.liferay.portal.upgrade.internal.recorder.UpgradeRecorder;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -48,11 +55,57 @@ public class UpgradeReportTest {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Before
-	public void setUp() {
+	public void setUp() throws Exception {
 		_dataAccessMockedStatic = Mockito.mockStatic(DataAccess.class);
+		_dbManagerUtilMockedStatic = Mockito.mockStatic(DBManagerUtil.class);
 		_dbUpgraderMockedStatic = Mockito.mockStatic(DBUpgrader.class);
+
 		_portalUpgradeProcessMockedStatic = Mockito.mockStatic(
 			PortalUpgradeProcess.class);
+
+		Connection connection = Mockito.mock(Connection.class);
+		DatabaseMetaData databaseMetaData = Mockito.mock(
+			DatabaseMetaData.class);
+		ResultSet tablesResultSet = Mockito.mock(ResultSet.class);
+
+		Mockito.when(
+			connection.getMetaData()
+		).thenReturn(
+			databaseMetaData
+		);
+
+		Mockito.when(
+			databaseMetaData.getTables(
+				Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any())
+		).thenReturn(
+			tablesResultSet
+		);
+
+		Mockito.when(
+			tablesResultSet.next()
+		).thenReturn(
+			false
+		);
+
+		_dataAccessMockedStatic.when(
+			DataAccess::getConnection
+		).thenReturn(
+			connection
+		);
+
+		DB db = Mockito.mock(DB.class);
+
+		_dbManagerUtilMockedStatic.when(
+			DBManagerUtil::getDB
+		).thenReturn(
+			db
+		);
+
+		Mockito.when(
+			db.getDBType()
+		).thenReturn(
+			DBType.MYSQL
+		);
 
 		MockitoAnnotations.initMocks(this);
 	}
@@ -60,6 +113,7 @@ public class UpgradeReportTest {
 	@After
 	public void tearDown() {
 		_dataAccessMockedStatic.close();
+		_dbManagerUtilMockedStatic.close();
 		_dbUpgraderMockedStatic.close();
 		_portalUpgradeProcessMockedStatic.close();
 	}
@@ -158,6 +212,36 @@ public class UpgradeReportTest {
 	}
 
 	@Test
+	public void testGetReportDataWhenDLRootDirIsInvalid() throws Exception {
+		Path tempFilePath = Files.createTempFile(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString());
+
+		try {
+			UpgradeReport upgradeReport = new UpgradeReport();
+
+			ReflectionTestUtil.setFieldValue(
+				upgradeReport, "_rootDir",
+				tempFilePath.toAbsolutePath(
+				).toString());
+
+			Map<String, Object> reportData = ReflectionTestUtil.invoke(
+				upgradeReport, "_getReportData",
+				new Class<?>[] {UpgradeRecorder.class}, _upgradeRecorder);
+
+			Map<String, Object> documentLibrary =
+				(Map<String, Object>)reportData.get("document.library");
+
+			Assert.assertNotNull(documentLibrary);
+
+			Assert.assertEquals(
+				"Unable to determine", documentLibrary.get("storage.size"));
+		}
+		finally {
+			Files.deleteIfExists(tempFilePath);
+		}
+	}
+
+	@Test
 	public void testGetTableCounts() throws Exception {
 		Connection connection = Mockito.mock(Connection.class);
 		ResultSet countResultSet = Mockito.mock(ResultSet.class);
@@ -232,6 +316,7 @@ public class UpgradeReportTest {
 	}
 
 	private MockedStatic<DataAccess> _dataAccessMockedStatic;
+	private MockedStatic<DBManagerUtil> _dbManagerUtilMockedStatic;
 	private MockedStatic<DBUpgrader> _dbUpgraderMockedStatic;
 	private MockedStatic<PortalUpgradeProcess>
 		_portalUpgradeProcessMockedStatic;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86109

**What is being fixed:** When the upgrade report calculates the document library size on a separate thread, an exception thrown inside that thread (for example, a `FileNotFoundException` when the document library folder is not readable) was not propagated to the main thread. The `_dlSize` field stayed at its initial `0` value, so the report displayed `Document library storage size: 0 B` instead of the expected `Unable to determine`.

**How it is being fixed:** The DL size calculation is now wrapped in a `FutureTask<Long>` running on a daemon thread, and the main thread reads the result via `FutureTask.get(timeout, TimeUnit.SECONDS)`. This makes the worker's outcome observable: on `TimeoutException` the task is cancelled, on `ExecutionException` the underlying cause is logged, and any other exception is also logged. In every failure path the method returns `"Unable to determine"`. A test was added covering `getReportData` when the DL directory is not readable.

Original work by @dmcisneroslf.

---

**Note on Source Formatter:**

`ant format-source-current-branch` reports one issue on `UpgradeReport.java:814` (`Use "resultSet.getInt" for count`). This is **not introduced by this PR** — line 814 is unchanged here. Git history shows it has flipped before:

- LPD-79450 changed it to `(long)resultSet.getInt("count")` to satisfy the SF rule.
- LPD-85235 changed it back to `resultSet.getLong("count")` to fix an overflow bug in `testGetTableCounts`.

There is a separate LPD in flight that updates the SF rule (`ResultSetGetCallCheck`) to allow `resultSet.getLong` for `count`, which will resolve this conflict.