### PR TITLE
LPD-86569 Capture IndexUpdaterUtil WARN in testUpdateIndexRetry

### DIFF
--- a/modules/apps/portal/portal-db-index-test/src/testIntegration/java/com/liferay/portal/db/index/test/IndexUpdaterUtilTest.java
+++ b/modules/apps/portal/portal-db-index-test/src/testIntegration/java/com/liferay/portal/db/index/test/IndexUpdaterUtilTest.java
@@ -206,9 +206,14 @@ public class IndexUpdaterUtilTest {
 
 			try (AutoCloseable autoCloseable =
 					() -> StartupHelperUtil.setUpgrading(upgrading);
-				LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-					DuplicateUniqueFinderRowsCleaner.class.getName(),
-					LoggerTestUtil.INFO)) {
+				LogCapture duplicateUniqueFinderRowsCleanerLogCapture =
+					LoggerTestUtil.configureLog4JLogger(
+						DuplicateUniqueFinderRowsCleaner.class.getName(),
+						LoggerTestUtil.INFO);
+				LogCapture indexUpdaterUtilLogCapture =
+					LoggerTestUtil.configureLog4JLogger(
+						IndexUpdaterUtil.class.getName(),
+						LoggerTestUtil.WARN)) {
 
 				ReflectionTestUtil.invoke(
 					IndexUpdaterUtil.class, "_updateIndexes",
@@ -216,7 +221,8 @@ public class IndexUpdaterUtilTest {
 					"create unique index IX_TestTable on TestTable(column3" +
 						"[$COLUMN_LENGTH:255$], column4[$COLUMN_LENGTH:255$])");
 
-				List<LogEntry> logEntries = logCapture.getLogEntries();
+				List<LogEntry> logEntries =
+					duplicateUniqueFinderRowsCleanerLogCapture.getLogEntries();
 
 				Assert.assertEquals(
 					logEntries.toString(), 1, logEntries.size());
@@ -228,6 +234,18 @@ public class IndexUpdaterUtilTest {
 						logEntry.getMessage(),
 						"Deleted row from table TestTable due to duplicate " +
 							"values in finder columns column3, column4"));
+
+				logEntries = indexUpdaterUtilLogCapture.getLogEntries();
+
+				Assert.assertEquals(
+					logEntries.toString(), 1, logEntries.size());
+
+				logEntry = logEntries.get(0);
+
+				Assert.assertEquals(
+					"Deleted duplicate records from table TestTable before " +
+						"retrying unique index creation",
+					logEntry.getMessage());
 			}
 
 			try (Connection connection = DataAccess.getConnection();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86569

**What is being fixed:** Since commit e51720283fd32 (LPD-83003), IndexUpdaterUtil emits a new WARN ("Deleted duplicate records from table TestTable before retrying unique index creation") whenever _deleteDuplicates returns true before retrying unique index creation. testUpdateIndexRetry deliberately exercises that retry path — it inserts two duplicate rows and expects the unique index creation to fail, trigger duplicate cleanup, and succeed on retry — but its LogCapture was configured only for DuplicateUniqueFinderRowsCleaner. As a result, the new IndexUpdaterUtil WARN leaked into the CI log on every run.

**How it is being fixed:** Add a second LogCapture for IndexUpdaterUtil (at WARN level) to testUpdateIndexRetry, following the dual-LogCapture pattern already used in testUpdateIndexUnpopulatedColumn, and assert that exactly one entry is captured with the expected "Deleted duplicate records from table TestTable before retrying unique index creation" message. The WARN is now both suppressed from CI output and verified as part of the test's contract.