### PR TITLE
LPD-87141 Add start-work skill

### DIFF
--- a/.claude/skills/start-work/SKILL.md
+++ b/.claude/skills/start-work/SKILL.md
@@ -1,0 +1,50 @@
+---
+argument-hint: "<ticket-key-or-url>"
+description: Start work on a Jira ticket.
+name: start-work
+---
+
+# Start Work on a Jira Ticket
+
+Prepare a Liferay ticket for development. Drive every Jira interaction through the Jira Cloud REST API at `liferay.atlassian.net`, authenticated with `${JIRA_API_USER}` / `${JIRA_API_TOKEN}`.
+
+## 1. Resolve the ticket
+
+Accept a key (`LPD-86295`) or a browse URL from `${ARGUMENTS}`. Ask the user when nothing is supplied.
+
+## 2. Prerequisites
+
+Abort when the working tree has uncommitted changes.
+
+## 3. Determine the target
+
+Fetch the ticket (issue type, current assignee, subtasks) and resolve the **target** — the ticket where the branch and active work state live:
+
+- **Bug** (`10004`) — the bug itself. There is no child.
+- **Story** (`10001`) or **Task** (`10002`) — the **Technical Task** (`10153`) subtask. Jira auto-creates it when the parent is moved to an in-progress status, so the target does not exist yet and must be resolved after step 4. It may exist from a previous attempt, in which case it becomes the target.
+
+## 4. Start work on the parent
+
+Assign the parent to the user and transition it using the id below. If the parent is already in an in-progress status by a different user, refuse to continue.
+
+| Parent type | Destination            | Transition id |
+| ----------- | ---------------------- | ------------- |
+| Bug         | In Progress            | `61`          |
+| Story       | Ready for Development  | `41`          |
+| Task        | In Progress            | `21`          |
+
+## 5. Start work on the child
+
+Skip for **Bug**. For **Story** / **Task**, re-fetch the parent's subtasks until the Technical Task appears, then assign it to the user and transition it:
+
+| Child type     | Destination | Transition id |
+| -------------- | ----------- | ------------- |
+| Technical Task | In Progress | `41`          |
+
+## 6. Create a git branch
+
+Branch off the current HEAD, named after the **target** key. When the branch already exists, check it out instead.
+
+## 7. Make a plan
+
+Enter plan mode and read the tickets (both parent and child) to make the plan.


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87141

**What is being fixed:** Starting work on a Jira ticket is a repetitive
ritual — assign yourself, transition the parent (and the Technical Task
subtask for Stories/Tasks) to the right in-progress status, and create a
branch named after the target key.

**How it is being fixed:** Adds a `start-work` skill that drives the flow
through the Jira REST API. It accepts a key or browse URL, aborts on a
dirty tree, assigns and transitions the parent, waits for Jira to
auto-create the Technical Task subtask (for Stories/Tasks) and transitions
it too, then creates or checks out a branch named after the target key and
enters plan mode where Claude reads the ticket and drafts a plan so work
can start immediately.

**Example:**

Say LPD-54321 is a Story: *"Add REST endpoint to export user audit logs as
CSV."*

    > /start-work LPD-54321

    Fetched LPD-54321 — Story, status Open.
    Assigned LPD-54321 to Alejandro Tardín.
    Transitioned LPD-54321: Open → Ready for Development.
    Waiting for Technical Task subtask... found LPD-54322.
    Assigned LPD-54322 to Alejandro Tardín.
    Transitioned LPD-54322: Open → In Progress.
    Created branch LPD-54322 off master.

    Entering plan mode. Reading LPD-54321 and LPD-54322...

    Plan:
      1. Add a new resource under
         modules/apps/portal-security-audit/portal-security-audit-rest-impl
         exposing GET /audit-logs/export with a `format=csv` query param.
      2. Stream the CSV response from AuditEventLocalService to avoid
         loading the full result set in memory.
      3. Guard the endpoint behind the existing `AUDIT_VIEW` permission
         and scope results to the caller's company.
      4. Add an integration test covering a happy-path export, an empty
         result set, and the permission-denied case.

    Ready to implement. Approve the plan to start writing code.