### PR TITLE
LPD-87214 Make Service Builder regen idempotent on Javadoc FQNs

### DIFF
--- a/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
+++ b/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
@@ -8609,6 +8609,10 @@ public class ServiceBuilder {
 
 		content = header + "\n\n" + content;
 
+		String fileName = _normalize(file.toString());
+
+		_pendingContents.put(fileName, content);
+
 		if (oldContent != null) {
 			int index = oldContent.lastIndexOf(
 				_LIFERAY_SERVICE_BUILDER_HASH_PREFIX);
@@ -8624,8 +8628,6 @@ public class ServiceBuilder {
 				}
 			}
 		}
-
-		String fileName = _normalize(file.toString());
 
 		int startIndex = 0;
 
@@ -8663,8 +8665,6 @@ public class ServiceBuilder {
 
 		_pendingWrites.add(
 			new Object[] {file, packagePath, content, modifiedFileNames});
-
-		_pendingContents.put(fileName, content);
 	}
 
 	private static final int _DEFAULT_COLUMN_MAX_LENGTH = 75;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87214

**What is being fixed:** A single pass of the canonical Service Builder regen sequence (`gw clean deploy` on `modules/util/portal-tools-service-builder`, then `ant build-services` in `portal-impl`) was leaving ~1000 generated files out of sync with the stable form that a second pass produced. The diff was cosmetic — Javadoc references to `QueryUtil#ALL_POS` and `<EntityName>ModelImpl` inside `<code>` tags on `*Persistence` interfaces and `*Util` classes oscillated between fully-qualified and simple names across passes, breaking the idiom that one regen pass should produce stable output.

**How it is being fixed:** The flake came from `ServiceBuilder._write` returning early on a hash match without populating `_pendingContents`. Consumers like `_createPersistence` that call `_getJavaClass` on the `*PersistenceImpl` to extract Javadoc via QDox then fell back to the on-disk file, which had already been through `JavaParser`'s `stripFullyQualifiedClassNames`, so the extracted Javadoc was the simple form. On the first pass pending was populated (FQN from the template); on later passes it was empty (simple from disk). Moving `_pendingContents.put` above the hash check makes `_getJavaClass` always see the pre-parse template content regardless of whether the file actually needs to be rewritten, so Javadoc extraction is stable across passes. The regenerate commits apply the now-idempotent output: files that do not import the referenced classes (for example `*Persistence` interfaces and `*Util` classes) preserve the FQN form emitted by the template, matching the convention already in place for `*BaseImpl` and `*LocalService`. A second regen on top of these commits produces no diff.