### PR TITLE
LPD-84021 Restore the double close in testCloseIsIdempotent: the second call is the intended assertion that verifies close() is idempotent and does not emit a duplicate "finished." log.

### DIFF
--- a/portal-kernel/test/unit/com/liferay/portal/kernel/upgrade/recorder/UpgradeLogProgressTrackerTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/upgrade/recorder/UpgradeLogProgressTrackerTest.java
@@ -130,6 +130,7 @@ public class UpgradeLogProgressTrackerTest {
 					Long.valueOf(1L), lastKnownProgresses.get(registryKey));
 
 				wrappedResultSet.close();
+				wrappedResultSet.close();
 
 				Assert.assertNull(lastKnownProgresses.get(registryKey));
 


### PR DESCRIPTION
Hi @brianchandotcom,

Thanks for catching that, but the duplicate `close()` is actually intentional. The test is named `testCloseIsIdempotent`, and its purpose is to verify that a second `ResultSet.close()` does not produce a second `"… finished."` log line.

`ResultSet.close()` is idempotent per the JDBC specification, and in practice a second close does happen when a caller combines try-with-resources with an explicit `close()` in a `finally` block, or when wrappers add defensive close chains.

The production `close()` branch in `UpgradeLogProgressTracker` gates the log on `_lastKnownProgresses.remove(_registryKey) != null`: the first call returns the previous value and logs, the second call returns `null` and stays silent. The double-close assertion is what verifies this, since a test with a single `close()` would pass either way.

Without the second call, this test would only assert that a single close removes the entry and logs once, which is already covered by neighboring tests. The second call is what makes it actually exercise the idempotency it describes.

Best regards,
István