### PR TITLE
LPD-86505 Fix BundleSiteInitializerTest failure by approving imported layouts

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
@@ -2009,6 +2009,14 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 		_updateLayoutPageTemplateStructure(draftLayout, layoutStructure);
 
 		_layoutLocalService.copyLayoutContent(draftLayout, layout);
+
+		_layoutLocalService.updateStatus(
+			userId, draftLayout.getPlid(), WorkflowConstants.STATUS_APPROVED,
+			ServiceContextThreadLocal.getServiceContext());
+
+		_layoutLocalService.updateStatus(
+			userId, plid, WorkflowConstants.STATUS_APPROVED,
+			ServiceContextThreadLocal.getServiceContext());
 	}
 
 	private boolean _processPageElement(

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
@@ -2008,15 +2008,7 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 
 		_updateLayoutPageTemplateStructure(draftLayout, layoutStructure);
 
-		_layoutLocalService.copyLayoutContent(draftLayout, layout);
-
-		_layoutLocalService.updateStatus(
-			userId, draftLayout.getPlid(), WorkflowConstants.STATUS_APPROVED,
-			ServiceContextThreadLocal.getServiceContext());
-
-		_layoutLocalService.updateStatus(
-			userId, plid, WorkflowConstants.STATUS_APPROVED,
-			ServiceContextThreadLocal.getServiceContext());
+		_publishLayout(draftLayout, layout, userId);
 	}
 
 	private boolean _processPageElement(
@@ -2127,6 +2119,20 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 								"values-in-its-page-definition")));
 			}
 		}
+	}
+
+	private void _publishLayout(Layout draftLayout, Layout layout, long userId)
+		throws Exception {
+
+		_layoutLocalService.copyLayoutContent(draftLayout, layout);
+
+		_layoutLocalService.updateStatus(
+			userId, draftLayout.getPlid(), WorkflowConstants.STATUS_APPROVED,
+			ServiceContextThreadLocal.getServiceContext());
+
+		_layoutLocalService.updateStatus(
+			userId, layout.getPlid(), WorkflowConstants.STATUS_APPROVED,
+			ServiceContextThreadLocal.getServiceContext());
 	}
 
 	private String _toTypeName(int layoutPageTemplateEntryType) {

--- a/modules/apps/layout/layout-page-template-admin-web-test/build.gradle
+++ b/modules/apps/layout/layout-page-template-admin-web-test/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:layout:layout-page-template-test-util")
 	testIntegrationImplementation project(":apps:layout:layout-set-prototype-api")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
+	testIntegrationImplementation project(":apps:layout:layout-utility-page-api")
 	testIntegrationImplementation project(":apps:object:object-api")
 	testIntegrationImplementation project(":apps:object:object-test-util")
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
@@ -60,6 +60,8 @@ import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.layout.util.structure.RowStyledLayoutStructureItem;
+import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
+import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalService;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
@@ -1050,6 +1052,44 @@ public class LayoutsImporterTest {
 		finally {
 			ServiceContextThreadLocal.popServiceContext();
 		}
+	}
+
+	@Test
+	@TestInfo("LPD-86505")
+	public void testImportUtilityPageEntryIsApprovedAndCanBeSetAsDefault()
+		throws Exception {
+
+		ServiceContextThreadLocal.pushServiceContext(_serviceContext1);
+
+		try {
+			_layoutsImporter.importFile(
+				TestPropsValues.getUserId(), _group1.getGroupId(),
+				LayoutPageTemplateConstants.
+					PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
+				_getFile(_RESOURCES_PATH_UTILITY_PAGES),
+				LayoutsImportStrategy.OVERWRITE, true);
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
+
+		LayoutUtilityPageEntry layoutUtilityPageEntry =
+			_layoutUtilityPageEntryLocalService.
+				getLayoutUtilityPageEntryByExternalReferenceCode(
+					"test-default-utility-page", _group1.getGroupId());
+
+		Layout layout = _layoutLocalService.getLayout(
+			layoutUtilityPageEntry.getPlid());
+
+		Assert.assertTrue(layout.isPublished());
+
+		layoutUtilityPageEntry =
+			_layoutUtilityPageEntryLocalService.
+				setDefaultLayoutUtilityPageEntry(
+					layoutUtilityPageEntry.getLayoutUtilityPageEntryId());
+
+		Assert.assertTrue(
+			layoutUtilityPageEntry.isDefaultLayoutUtilityPageEntry());
 	}
 
 	@Test
@@ -2481,6 +2521,10 @@ public class LayoutsImporterTest {
 		"com/liferay/layout/page/template/admin/web/internal/importer/test" +
 			"/dependencies/page-templates";
 
+	private static final String _RESOURCES_PATH_UTILITY_PAGES =
+		"com/liferay/layout/page/template/admin/web/internal/importer/test" +
+			"/dependencies/utility-pages";
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		LayoutsImporterTest.class);
 
@@ -2552,6 +2596,10 @@ public class LayoutsImporterTest {
 
 	@Inject
 	private LayoutStructureProvider _layoutStructureProvider;
+
+	@Inject
+	private LayoutUtilityPageEntryLocalService
+		_layoutUtilityPageEntryLocalService;
 
 	@Inject
 	private Portal _portal;

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/importer/test/dependencies/utility-pages/default-utility-page/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/importer/test/dependencies/utility-pages/default-utility-page/page-definition.json
@@ -1,0 +1,20 @@
+{
+	"pageElement": {
+		"pageElements": [
+			{
+				"definition": {
+					"indexed": true,
+					"layout": {
+					}
+				},
+				"type": "Section"
+			}
+		],
+		"type": "Root"
+	},
+	"settings": {
+		"colorSchemeName": "01",
+		"themeName": "Classic"
+	},
+	"version": 1.1
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/importer/test/dependencies/utility-pages/default-utility-page/utility-page.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/importer/test/dependencies/utility-pages/default-utility-page/utility-page.json
@@ -1,0 +1,6 @@
+{
+	"defaultTemplate": false,
+	"externalReferenceCode": "test-default-utility-page",
+	"name": "Test Default Utility Page",
+	"type": "ErrorCode404"
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86505

Follow-up to #173255. The original PR is merged here but the sync to liferay/liferay-portal master is blocked by `BundleSiteInitializerTest` failing, as discussed in https://liferay.slack.com/archives/CLCD3DQLF/p1776968780715329.

**What is being fixed:** After #173255 landed, master pages and utility pages imported through site initializers were left in a non-approved state, which made `setDefaultLayoutUtilityPageEntry` fail with `DefaultLayoutUtilityPageEntryException` during `BundleSiteInitializer._setDefaultLayoutUtilityPageEntries`. The removal of the `_updateLayouts` helper dropped the `updateStatus(STATUS_APPROVED)` step that callers of the import path implicitly relied on.

**How it is being fixed:** Restore the `updateStatus(STATUS_APPROVED)` step on both the draft and live layouts after `copyLayoutContent` in `_processPageDefinition`, and extract the sequence into a small `_publishLayout` helper for clarity. A regression integration test in `LayoutsImporterTest` imports a utility page and asserts `setDefaultLayoutUtilityPageEntry` succeeds.

Verified locally:

- `BundleSiteInitializerTest` (3 tests) fails with `DefaultLayoutUtilityPageEntryException` at `master` without this fix, and passes once this fix is applied on top.
- `LayoutsImporterTest` compiles and runs with the new regression test.