### PR TITLE
LPD-87421 Null-guard missing "extensions" aggregation in ExtensionSelectionFDSFilter

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ExtensionSelectionFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ExtensionSelectionFDSFilter.java
@@ -28,6 +28,7 @@ import com.liferay.portal.search.searcher.SearchResponse;
 import com.liferay.portal.search.searcher.Searcher;
 import com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializerFDSNames;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -118,6 +119,10 @@ public class ExtensionSelectionFDSFilter extends BaseSelectionFDSFilter {
 		TermsAggregationResult termsAggregationResult =
 			(TermsAggregationResult)searchResponse.getAggregationResult(
 				"extensions");
+
+		if (termsAggregationResult == null) {
+			return Collections.emptyList();
+		}
 
 		return TransformUtil.transform(
 			termsAggregationResult.getBuckets(), Bucket::getKey);


### PR DESCRIPTION
## Summary

- Fix `NullPointerException` in `ExtensionSelectionFDSFilter._getExistingFileExtensions` when `searchResponse.getAggregationResult("extensions")` returns null (no indexed ObjectEntry documents with the `extension` field).
- Breaks CMS → All and CMS → Files with "An unexpected error occurred" on fresh bundles.

## Test plan

- [ ] Load CMS → Files on a fresh bundle with empty ObjectEntry index — page renders, filter list is empty.
- [ ] Load CMS → Files after uploading files — filter list is populated with their extensions.
- [ ] Load CMS → All — page renders, no NPE in `liferay.<date>.log`.

Jira: https://liferay.atlassian.net/browse/LPD-87421