### PR TITLE
LPD-87435 Fix compile errors in Service Builder compat modules

### DIFF
--- a/modules/util/portal-tools-service-builder-test-compat700-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat700/service/persistence/impl/CacheDisabledEntryPersistenceImpl.java
+++ b/modules/util/portal-tools-service-builder-test-compat700-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat700/service/persistence/impl/CacheDisabledEntryPersistenceImpl.java
@@ -1180,6 +1180,9 @@ public class CacheDisabledEntryPersistenceImpl
 	private static final String _SQL_COUNT_CACHEDISABLEDENTRY =
 		"SELECT COUNT(cacheDisabledEntry) FROM CacheDisabledEntry cacheDisabledEntry";
 
+	private static final String _SQL_COUNT_CACHEDISABLEDENTRY_WHERE =
+		"SELECT COUNT(cacheDisabledEntry) FROM CacheDisabledEntry cacheDisabledEntry WHERE ";
+
 	private static final String _ORDER_BY_ENTITY_ALIAS = "cacheDisabledEntry.";
 
 	private static final String _NO_SUCH_ENTITY_WITH_PRIMARY_KEY =
@@ -1192,4 +1195,4 @@ public class CacheDisabledEntryPersistenceImpl
 		CacheDisabledEntryPersistenceImpl.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2002552806
+// LIFERAY-SERVICE-BUILDER-HASH:1694423353

--- a/modules/util/portal-tools-service-builder-test-compat700-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat700/service/persistence/impl/ConvertNullEntryPersistenceImpl.java
+++ b/modules/util/portal-tools-service-builder-test-compat700-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat700/service/persistence/impl/ConvertNullEntryPersistenceImpl.java
@@ -1167,6 +1167,9 @@ public class ConvertNullEntryPersistenceImpl
 	private static final String _SQL_COUNT_CONVERTNULLENTRY =
 		"SELECT COUNT(convertNullEntry) FROM ConvertNullEntry convertNullEntry";
 
+	private static final String _SQL_COUNT_CONVERTNULLENTRY_WHERE =
+		"SELECT COUNT(convertNullEntry) FROM ConvertNullEntry convertNullEntry WHERE ";
+
 	private static final String _ORDER_BY_ENTITY_ALIAS = "convertNullEntry.";
 
 	private static final String _NO_SUCH_ENTITY_WITH_PRIMARY_KEY =
@@ -1179,4 +1182,4 @@ public class ConvertNullEntryPersistenceImpl
 		ConvertNullEntryPersistenceImpl.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1043281036
+// LIFERAY-SERVICE-BUILDER-HASH:351925035

--- a/modules/util/portal-tools-service-builder-test-compat710-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat710/service/persistence/impl/CacheDisabledEntryPersistenceImpl.java
+++ b/modules/util/portal-tools-service-builder-test-compat710-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat710/service/persistence/impl/CacheDisabledEntryPersistenceImpl.java
@@ -1125,6 +1125,9 @@ public class CacheDisabledEntryPersistenceImpl
 	private static final String _SQL_COUNT_CACHEDISABLEDENTRY =
 		"SELECT COUNT(cacheDisabledEntry) FROM CacheDisabledEntry cacheDisabledEntry";
 
+	private static final String _SQL_COUNT_CACHEDISABLEDENTRY_WHERE =
+		"SELECT COUNT(cacheDisabledEntry) FROM CacheDisabledEntry cacheDisabledEntry WHERE ";
+
 	private static final String _ORDER_BY_ENTITY_ALIAS = "cacheDisabledEntry.";
 
 	private static final String _NO_SUCH_ENTITY_WITH_PRIMARY_KEY =
@@ -1137,4 +1140,4 @@ public class CacheDisabledEntryPersistenceImpl
 		CacheDisabledEntryPersistenceImpl.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:933762783
+// LIFERAY-SERVICE-BUILDER-HASH:-1160868930

--- a/modules/util/portal-tools-service-builder-test-compat710-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat710/service/persistence/impl/ConvertNullEntryPersistenceImpl.java
+++ b/modules/util/portal-tools-service-builder-test-compat710-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat710/service/persistence/impl/ConvertNullEntryPersistenceImpl.java
@@ -1112,6 +1112,9 @@ public class ConvertNullEntryPersistenceImpl
 	private static final String _SQL_COUNT_CONVERTNULLENTRY =
 		"SELECT COUNT(convertNullEntry) FROM ConvertNullEntry convertNullEntry";
 
+	private static final String _SQL_COUNT_CONVERTNULLENTRY_WHERE =
+		"SELECT COUNT(convertNullEntry) FROM ConvertNullEntry convertNullEntry WHERE ";
+
 	private static final String _ORDER_BY_ENTITY_ALIAS = "convertNullEntry.";
 
 	private static final String _NO_SUCH_ENTITY_WITH_PRIMARY_KEY =
@@ -1124,4 +1127,4 @@ public class ConvertNullEntryPersistenceImpl
 		ConvertNullEntryPersistenceImpl.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-107602603
+// LIFERAY-SERVICE-BUILDER-HASH:-454292556

--- a/modules/util/portal-tools-service-builder-test-compat720-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat720/service/persistence/impl/CacheDisabledEntryPersistenceImpl.java
+++ b/modules/util/portal-tools-service-builder-test-compat720-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat720/service/persistence/impl/CacheDisabledEntryPersistenceImpl.java
@@ -962,6 +962,9 @@ public class CacheDisabledEntryPersistenceImpl
 	private static final String _SQL_COUNT_CACHEDISABLEDENTRY =
 		"SELECT COUNT(cacheDisabledEntry) FROM CacheDisabledEntry cacheDisabledEntry";
 
+	private static final String _SQL_COUNT_CACHEDISABLEDENTRY_WHERE =
+		"SELECT COUNT(cacheDisabledEntry) FROM CacheDisabledEntry cacheDisabledEntry WHERE ";
+
 	private static final String _ORDER_BY_ENTITY_ALIAS = "cacheDisabledEntry.";
 
 	private static final String _NO_SUCH_ENTITY_WITH_PRIMARY_KEY =
@@ -974,4 +977,4 @@ public class CacheDisabledEntryPersistenceImpl
 		CacheDisabledEntryPersistenceImpl.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:952835262
+// LIFERAY-SERVICE-BUILDER-HASH:-93194019

--- a/modules/util/portal-tools-service-builder-test-compat720-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat720/service/persistence/impl/ConvertNullEntryPersistenceImpl.java
+++ b/modules/util/portal-tools-service-builder-test-compat720-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat720/service/persistence/impl/ConvertNullEntryPersistenceImpl.java
@@ -953,6 +953,9 @@ public class ConvertNullEntryPersistenceImpl
 	private static final String _SQL_COUNT_CONVERTNULLENTRY =
 		"SELECT COUNT(convertNullEntry) FROM ConvertNullEntry convertNullEntry";
 
+	private static final String _SQL_COUNT_CONVERTNULLENTRY_WHERE =
+		"SELECT COUNT(convertNullEntry) FROM ConvertNullEntry convertNullEntry WHERE ";
+
 	private static final String _ORDER_BY_ENTITY_ALIAS = "convertNullEntry.";
 
 	private static final String _NO_SUCH_ENTITY_WITH_PRIMARY_KEY =
@@ -965,4 +968,4 @@ public class ConvertNullEntryPersistenceImpl
 		ConvertNullEntryPersistenceImpl.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:240343760
+// LIFERAY-SERVICE-BUILDER-HASH:-1479913361

--- a/modules/util/portal-tools-service-builder-test-compat730-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat730/service/persistence/impl/CacheDisabledEntryPersistenceImpl.java
+++ b/modules/util/portal-tools-service-builder-test-compat730-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat730/service/persistence/impl/CacheDisabledEntryPersistenceImpl.java
@@ -898,6 +898,9 @@ public class CacheDisabledEntryPersistenceImpl
 	private static final String _SQL_COUNT_CACHEDISABLEDENTRY =
 		"SELECT COUNT(cacheDisabledEntry) FROM CacheDisabledEntry cacheDisabledEntry";
 
+	private static final String _SQL_COUNT_CACHEDISABLEDENTRY_WHERE =
+		"SELECT COUNT(cacheDisabledEntry) FROM CacheDisabledEntry cacheDisabledEntry WHERE ";
+
 	private static final String _ORDER_BY_ENTITY_ALIAS = "cacheDisabledEntry.";
 
 	private static final String _NO_SUCH_ENTITY_WITH_PRIMARY_KEY =
@@ -1012,4 +1015,4 @@ public class CacheDisabledEntryPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1434253572
+// LIFERAY-SERVICE-BUILDER-HASH:-709388219

--- a/modules/util/portal-tools-service-builder-test-compat730-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat730/service/persistence/impl/ConvertNullEntryPersistenceImpl.java
+++ b/modules/util/portal-tools-service-builder-test-compat730-service/src/main/java/com/liferay/portal/tools/service/builder/test/compat730/service/persistence/impl/ConvertNullEntryPersistenceImpl.java
@@ -891,6 +891,9 @@ public class ConvertNullEntryPersistenceImpl
 	private static final String _SQL_COUNT_CONVERTNULLENTRY =
 		"SELECT COUNT(convertNullEntry) FROM ConvertNullEntry convertNullEntry";
 
+	private static final String _SQL_COUNT_CONVERTNULLENTRY_WHERE =
+		"SELECT COUNT(convertNullEntry) FROM ConvertNullEntry convertNullEntry WHERE ";
+
 	private static final String _ORDER_BY_ENTITY_ALIAS = "convertNullEntry.";
 
 	private static final String _NO_SUCH_ENTITY_WITH_PRIMARY_KEY =
@@ -1004,4 +1007,4 @@ public class ConvertNullEntryPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-874342458
+// LIFERAY-SERVICE-BUILDER-HASH:1050154375

--- a/modules/util/portal-tools-service-builder-test-compat740-service/build.gradle
+++ b/modules/util/portal-tools-service-builder-test-compat740-service/build.gradle
@@ -15,6 +15,13 @@ buildService {
 }
 
 dependencies {
-	compileOnly group: "com.liferay.portal", name: "release.portal.api", version: "7.4.3.132"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	compileOnly project(":apps:portal:portal-aop-api")
+	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-io")
+	compileOnly project(":core:petra:petra-lang")
+	compileOnly project(":core:petra:petra-sql-dsl-api")
+	compileOnly project(":core:petra:petra-string")
 	compileOnly project(":util:portal-tools-service-builder-test-compat740-api")
 }

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
@@ -3248,7 +3248,7 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 
 	private static final String _SQL_COUNT_${entity.alias?upper_case} = "SELECT COUNT(${entity.alias}) FROM ${entity.name} ${entity.alias}";
 
-	<#if entity.hasCollectionEntityFinder()>
+	<#if entity.hasCollectionEntityFinder() || (serviceBuilder.isVersionLTE_7_3_0() && (entity.entityFinders?size != 0))>
 		private static final String _SQL_COUNT_${entity.alias?upper_case}_WHERE = "SELECT COUNT(${entity.alias}) FROM ${entity.name} ${entity.alias} WHERE ";
 	</#if>
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87435

**What is being fixed:** Two compile errors in the Service Builder
compatibility test modules introduced by the LPD-87435 finder-delegation
work. First, regenerated compat700–730 PersistenceImpls referenced
`_SQL_COUNT_*_WHERE` constants that were no longer emitted, breaking
compilation for entities like `ConvertNullEntry` and `CacheDisabledEntry`
that have only unique finders on DTD ≤ 7.3.0. Second, compat740-service
declared a dependency on `release.portal.api:7.4.3.132` that predates the
new `CollectionPersistenceFinder`, `FinderColumn`, and
`UniquePersistenceFinder` helper classes, so its regenerated
PersistenceImpls could not resolve those classes either.

**How it is being fixed:** Expanded the `persistence_impl.ftl` gate for
the `_SQL_COUNT_*_WHERE` constant to also emit it whenever an entity has
any finders and targets DTD ≤ 7.3.0, since unique finders on those DTDs
still take the legacy count-by-query path. Then regenerated compat700–730
to restore the constant in the affected files. For compat740-service,
replaced the released `release.portal.api` artifact with the current
`com.liferay.portal.kernel` snapshot plus the smaller dependencies the
generated DSL, AOP, OSGi, and petra references actually need.