### PR TITLE
LPD-87558 Add format-source skill with 18 manual rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,7 +16,7 @@ This is Liferay Portal's main source code repository.
 - `modules/apps` — Most of the OSGi modules. This is where most development happens.
 - `modules/core` — Core OSGi infrastructure modules.
 - `modules/dxp/apps` — DXP-only (commercial) OSGi modules.
-- `modules/sdk` — Gradle plugins used throughout the build (source formatter, service builder, etc.).
+- `modules/sdk` — Gradle plugins used throughout the build (service builder, source formatter, etc.).
 - `modules/util` — Custom build tools like rest-builder, service-builder, and source formatter.
 
 ## Development
@@ -115,19 +115,7 @@ Functional tests are a last resort, reserved for complete UI flows that cannot b
 
 ### Format Source
 
-All the code is strictly formatted using source formatter. Code should be formatted before every commit. This is how it works:
-
-Run for a specific module:
-
-```bash
-cd <module-root> && <gradlew> formatSource
-```
-
-Run across the entire codebase:
-
-```bash
-cd <repo-root>/portal-impl && ant format-source-current-branch
-```
+Run `/format-source` (the `format-source` skill) before every commit. See `.claude/skills/format-source/SKILL.md` for details.
 
 # Skills
 

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 
-allowed-tools: [Bash, Glob, Grep, Read]
+allowed-tools: [Bash, Glob, Grep, Read, Skill]
 argument-hint: "[optional message hint]"
 description: Create a Git commit with a Jira-prefixed message derived from the staged diff. Use when the user asks to commit, wants to commit changes, or invokes /commit.
 name: commit
@@ -11,7 +11,11 @@ name: commit
 
 Compose a well-crafted Git commit for the current set of changes.
 
-## 1. Gather Context
+## 1. Format Source
+
+Before composing the commit, invoke the `format-source` skill to ensure all changes follow Liferay's coding standards (both the automatic formatter and the manual rules). After it completes, any edits the formatter applied are part of what gets committed.
+
+## 2. Gather Context
 
 - When Claude modified or created files during this conversation, commit **only** those files. Stage them explicitly by name with `git add <file1> <file2> ...`. Do not include the user's own changes.
 - When Claude did **not** modify any files in this conversation, commit **all** changes. Stage modified and deleted files, but leave untracked files alone. When untracked files exist, ask the user whether to include them.
@@ -20,7 +24,7 @@ Never use `git add -A` or `git add .`.
 
 When nothing is staged, unstaged, or untracked, inform the user that there is nothing to commit and stop.
 
-## 2. Extract the Jira Ticket
+## 3. Extract the Jira Ticket
 
 The ticket ID follows the pattern `LPD-12345`, `LCD-12345`, `LRCI-1234`, and similar forms (uppercase letters, hyphen, digits). Resolve the ticket in this order:
 
@@ -32,7 +36,7 @@ The ticket ID follows the pattern `LPD-12345`, `LCD-12345`, `LRCI-1234`, and sim
 
 1. **Fallback** — when no ticket surfaces, prompt the user for one.
 
-## 3. Compose the Commit Message
+## 4. Compose the Commit Message
 
 Read the diff, understand the actual behavior change, then compose the message.
 
@@ -67,7 +71,7 @@ When a body is warranted:
 
 When `${ARGUMENTS}` carries a hint or description rather than a ticket ID, incorporate it into the message.
 
-## 4. Confirm and Commit
+## 5. Confirm and Commit
 
 Present the proposed commit message to the user and request confirmation. Once they approve, create the commit:
 
@@ -84,6 +88,6 @@ git commit --message "${COMMIT_MESSAGE}"
 
 When the user requests changes, revise the message and reconfirm.
 
-## 5. Post-Commit
+## 6. Post-Commit
 
 Run `git status` to confirm the commit succeeded, then display the result.

--- a/.claude/skills/format-source-add-rule/SKILL.md
+++ b/.claude/skills/format-source-add-rule/SKILL.md
@@ -1,0 +1,59 @@
+---
+
+description: Add a new rule to the format-source skill, derived from a Git commit.
+name: format-source-add-rule
+
+---
+
+# Format Source: Add Rule
+
+Add a new rule to the `format-source` skill, derived from a Git commit. Anyone can use this to encode a convention they spotted in someone's commit. Rules can apply to any file type the source formatter handles — Java, `.properties`, XML, JSP, Markdown, Gradle, `.gitignore`, YAML, and so on. Do not bias toward Java.
+
+## Inputs
+
+- A Git commit SHA.
+
+- Optional: a hint about which aspect of the commit to encode. Commits often touch multiple things; a hint narrows the scope.
+
+## Workflow
+
+### Inspect the Commit
+
+Inspect the commit's full diff. Identify a single, learnable formatting pattern — something a future reviewer could apply mechanically to other code. Stop and ask the user to clarify when:
+
+- Multiple distinct rules are present. Ask the user to pick one, or run the skill once per rule.
+
+- The commit mixes formatting changes with logic or refactoring changes that cannot be separated.
+
+- The pattern is not generalizable beyond the specific file or context.
+
+### Check for Duplicates
+
+Read the existing rules in `.claude/skills/format-source/SKILL.md` and compare against the pattern from the previous step. If the pattern duplicates or substantially overlaps an existing rule, flag it to the user and ask whether to skip, refine the existing rule, or proceed anyway.
+
+### Write the Rule
+
+Find the next rule number in `.claude/skills/format-source/SKILL.md`, then append the new rule at the end of the file using this exact markdown template:
+
+````markdown
+### Rule <next-number>: <Title Case name, for example "Method Parameter Ordering">
+
+**Why:** <one-sentence explanation of what consistency the rule buys, not what the rule does>
+
+**Examples:**
+
+```diff
+
+- <one or more before lines demonstrating the rule, using abstract identifiers — not the commit's literal code>
++ <matching after lines>
+
+```
+````
+
+Use abstract identifiers in the diff rather than the verbatim names from the commit — for example `methodA`, `fieldB`, `Foo` for Java; `some.property`, `myTag`, `someKey` for properties, XML, YAML, or Markdown. The examples should illustrate the general pattern; reproducing the commit's exact text overfits the rule to one case and makes future readers match on names rather than the underlying pattern.
+
+For rules with nuance, use several diff blocks for each additional case. Add a single line of prose before the diff block when a diff alone is unclear.
+
+### Self-Test the Rule
+
+Validate that the appended rule reproduces the input commit when applied to the commit's parent state. To do this, create a new branch at the commit's parent and run `/format-source` scoped to only the files touched by the commit, applying only the manual rules (skip the automatic formatter). Compare the result with the commit. If the rule does not produce an equivalent change, revise the rule and repeat until it does.

--- a/.claude/skills/format-source/SKILL.md
+++ b/.claude/skills/format-source/SKILL.md
@@ -38,3 +38,362 @@ Skip generated files. The automatic formatter already does this via `BaseSourceP
 These files are overwritten on the next build, so manual edits are lost and only pollute the diff.
 
 ## Rules
+
+### Rule 1: Chained Method Call Ordering
+
+**Why:** Consistent method order in chained calls makes it easier to scan for a specific call and reduces churn when new methods are added to the chain.
+
+**Examples:**
+
+```diff
+ Foo foo = builder.start(
+ 	arg
+-).gamma(
+-	gammaArg
+ ).alpha(
+ 	alphaArg
+ ).beta(
+ 	betaArg
++).gamma(
++	gammaArg
+ ).build();
+```
+
+### Rule 2: Method Parameter Ordering
+
+**Why:** Consistent parameter order makes call sites easier to scan and reduces churn when new parameters are added.
+
+**Examples:**
+
+```diff
+ private void process(
+-	String charlie, long alpha, String beta,
++	long alpha, String beta, String charlie,
+ 	Object delta) {
+```
+
+### Rule 3: Sequential Assertion Ordering
+
+**Why:** Consistent assertion order makes test failures easier to locate and reduces churn when new cases are added.
+
+**Examples:**
+
+```diff
+ Assert.assertEquals(1L, map.get("apple"));
+-Assert.assertEquals(3L, map.get("cherry"));
+ Assert.assertEquals(2L, map.get("banana"));
++Assert.assertEquals(3L, map.get("cherry"));
+```
+
+### Rule 4: Local Variable Declaration Ordering
+
+**Why:** Consistent declaration order makes it easier to find a variable and reduces churn when new locals are added.
+
+**Examples:**
+
+```diff
+-Map<X, Y> beta = new HashMap<>();
+-
+ boolean alpha = check();
++Map<X, Y> beta = new HashMap<>();
+```
+
+### Rule 5: Variable Name Type Suffix
+
+**Why:** A type suffix makes the variable's type readable at the use site and prevents a generic local from shadowing a same-named string key, field, or call argument in scope.
+
+**Examples:**
+
+Strings and other reference types like `Date`, `JSONObject` get a type suffix.
+
+```diff
+-String foo = result.toString();
++String fooString = result.toString();
+```
+
+`int`, `long`, `boolean` keep descriptive names without a type suffix.
+
+```diff
+-int countInt = items.size();
+-long timeLong = System.currentTimeMillis();
+-boolean enabledBoolean = config.isEnabled();
++int count = items.size();
++long time = System.currentTimeMillis();
++boolean enabled = config.isEnabled();
+```
+
+Lists prefer a plural name; the `List` suffix is acceptable when no natural plural exists.
+
+```diff
+-List<Item> itemList = repository.findAll();
++List<Item> items = repository.findAll();
+```
+
+Maps prefer a descriptive name; the `Map` suffix is acceptable when no natural descriptor exists.
+
+```diff
+-Map<String, Item> itemMap = loadIndex();
++Map<String, Item> itemsByKey = loadIndex();
+```
+
+### Rule 6: Acronym Capitalization in Identifiers
+
+**Why:** Treating acronyms as fully uppercase tokens keeps method, field, and variable names visually consistent with the surrounding API and avoids drift between camelCase and CamelCase variants for the same concept.
+
+**Examples:**
+
+```diff
+-public String getUrl() {
++public String getURL() {
+ 	return _url;
+ }
+```
+
+```diff
+-foo.getHtmlContent();
+-bar.parseXmlString();
++foo.getHTMLContent();
++bar.parseXMLString();
+```
+
+### Rule 7: Quote Literal Tokens in Messages
+
+**Why:** Wrapping literal identifiers, header values, content types, and similar tokens in double quotes inside log and exception messages separates the literal from the surrounding prose, so a reader can tell at a glance which words come from the data and which from the sentence.
+
+**Examples:**
+
+```diff
+ throw new IllegalArgumentException(
+-	"Request body has no application/json content");
++	"Request body has no \"application/json\" content");
+```
+
+```diff
+-_log.warn("Missing header X-Custom-Header for request");
++_log.warn("Missing header \"X-Custom-Header\" for request");
+```
+
+Use escaped double quotes, not single quotes, to wrap the token.
+
+```diff
+-throw new IllegalArgumentException("Missing 'paths' object");
++throw new IllegalArgumentException("Missing \"paths\" object");
+```
+
+### Rule 8: Generic Index Variable Name
+
+**Why:** When a method scope holds a single `int` index returned from `indexOf` or similar, naming it plainly `index` is shorter than a qualified name and matches the dominant convention; reuse the same `index` slot for sequential lookups in the same scope rather than introducing parallel qualified names.
+
+**Examples:**
+
+```diff
+-int spaceIndex = endpoint.indexOf(' ');
++int index = endpoint.indexOf(' ');
+
+-String prefix = endpoint.substring(0, spaceIndex);
+-String suffix = endpoint.substring(spaceIndex + 1);
++String prefix = endpoint.substring(0, index);
++String suffix = endpoint.substring(index + 1);
+```
+
+When the value is reused for a second lookup in the same scope, reassign `index` rather than introducing a new variable.
+
+```diff
+-int firstSlashIndex = path.indexOf('/', 1);
+-int secondSlashIndex = path.indexOf('/', firstSlashIndex + 1);
++int index = path.indexOf('/', 1);
++index = path.indexOf('/', index + 1);
+```
+
+### Rule 9: Map Entry Loop Naming
+
+**Why:** Naming the loop variable `entry` and the extracted parts after the data they hold (typically `key`/`name` and `value`) keeps every map iteration readable in the same shape, regardless of the surrounding domain.
+
+**Examples:**
+
+```diff
+-for (Map.Entry<String, Object> argumentEntry : arguments.entrySet()) {
+-	String paramName = argumentEntry.getKey();
+-	Object paramValue = argumentEntry.getValue();
++for (Map.Entry<String, Object> entry : arguments.entrySet()) {
++	String name = entry.getKey();
++	Object value = entry.getValue();
+```
+
+### Rule 10: Test Method Predicate Phrasing
+
+**Why:** Phrasing the predicate clause of a test method as `<property>Is<state>` rather than `<subject>Has<state><property>` makes a sorted method list group together by the property under test, and reads as a complete subject-verb-complement sentence.
+
+**Examples:**
+
+```diff
+-public void testGetFooWhenBarHasNullBaz() throws Exception {
++public void testGetFooWhenBarBazIsNull() throws Exception {
+```
+
+```diff
+-public void testGetFooWhenBarHasValidBaz() throws Exception {
++public void testGetFooWhenBarBazIsValid() throws Exception {
+```
+
+### Rule 11: Drop Redundant Nonnull Assertion Before Specific Assertions
+
+**Why:** A subsequent assertion that calls a method on the same reference would already throw a `NullPointerException` if the value were null, so the explicit nonnull check adds noise without adding coverage.
+
+**Examples:**
+
+```diff
+ Foo foo = service.findFoo();
+
+-Assert.assertNotNull(foo);
+ Assert.assertEquals("expected", foo.getName());
+ Assert.assertEquals(1L, foo.getId());
+```
+
+### Rule 12: Inline Single-Use Local Variables
+
+**Why:** A local that is computed once and immediately handed to a single call site adds a name without adding meaning, so passing the expression directly removes a hop the reader otherwise has to follow.
+
+**Examples:**
+
+```diff
+-Foo foo = makeFoo(arg);
+-
+-bar.consume(foo);
++bar.consume(makeFoo(arg));
+```
+
+```diff
+-FooSchema fooSchema = computeSchema(args, root);
+-
+ return Bar.builder(
+ ).name(
+ 	"x"
+ ).inputSchema(
+-	fooSchema
++	computeSchema(args, root)
+ ).build();
+```
+
+### Rule 13: Drop Narrative Assertion Messages
+
+**Why:** A verbose explanatory message on `Assert.assertTrue` or `Assert.assertFalse` mostly restates what the predicate already shows; removing it lets the failing line and stack frame carry the diagnostic, and shortens the test.
+
+**Examples:**
+
+```diff
+-Assert.assertTrue(
+-	StringBundler.concat(
+-		"Lookup must use the entity's ", id,
+-		". Actual filter was: ", filterString),
+-	filterString.contains("(id=" + id + ")"));
++Assert.assertTrue(filterString.contains("(id=" + id + ")"));
+```
+
+### Rule 14: Declare Locals Next to First Use
+
+**Why:** Declaring a local right before the statement that consumes it keeps related lines together and removes the need to scan back to a top-of-method block to recall what each value means.
+
+**Examples:**
+
+```diff
+-long alpha = randomLong();
+-String beta = "https://example.com";
+-String gamma = randomString();
+-
+ Foo foo = Mockito.mock(Foo.class);
+
++long alpha = randomLong();
++
+ Mockito.when(
+ 	foo.getAlpha()
+ ).thenReturn(
+ 	alpha
+ );
+
++String beta = "https://example.com";
++
+ Mockito.when(
+ 	foo.getBeta()
+ ).thenReturn(
+ 	beta
+ );
+```
+
+### Rule 15: Avoid Unboxing in Assertion Comparisons
+
+**Why:** Calling `.longValue()`, `.intValue()`, or similar on the actual value forces a chain on the line being asserted; matching the boxed type on the expected side keeps the comparison readable on a single call.
+
+**Examples:**
+
+```diff
+-Assert.assertEquals(
+-	0L,
+-	threadLocal.getValue(
+-	).longValue());
++Assert.assertEquals(Long.valueOf(0), threadLocal.getValue());
+```
+
+### Rule 16: Keep Default Override Adjacent to Declaration
+
+**Why:** When a local is declared and then immediately patched if its initial value is null or otherwise unsuitable, keeping the `if` directly after the declaration treats the pair as one logical "compute alpha" step and avoids splitting it across an unrelated declaration block.
+
+**Examples:**
+
+```diff
+ String alpha = source.getAlpha();
++
++if (alpha == null) {
++	alpha = fallback.getAlpha();
++}
++
+ String beta = null;
+ String gamma = null;
+ Date delta = source.getDelta();
+-
+-if (alpha == null) {
+-	alpha = fallback.getAlpha();
+-}
+```
+
+### Rule 17: Sort Sequential Setter Calls on Same Object
+
+**Why:** When the same object is configured by a contiguous block of setter calls, ordering the calls alphabetically by method name (and then by argument) makes the configuration easier to scan and matches the convention used for assertions and declarations.
+
+**Examples:**
+
+```diff
+ Foo foo = new Foo();
+
+-foo.setGamma(gamma);
+ foo.setAlpha(alpha);
+ foo.setBeta(beta);
++foo.setGamma(gamma);
+```
+
+### Rule 18: Use Complete Sentences in User-Facing Messages
+
+**Why:** Status, error, and notification strings that omit the linking verb read as fragments and translate poorly; restoring the auxiliary (`is`, `are`, `was`, `were`) turns the message into a complete sentence and matches the dominant phrasing already used across language files, log statements, and shell echoes.
+
+**Examples:**
+
+The rule applies to language property values.
+
+```diff
+-foo-not-allowed=Foo not allowed.
++foo-is-not-allowed=Foo is not allowed.
+```
+
+It applies to shell script messages.
+
+```diff
+-		_log "Resource ${name} created successfully."
++		_log "Resource ${name} was created successfully."
+```
+
+It applies to workflow and other YAML scripted output.
+
+```diff
+-                        echo "No entries found for ${id}."
++                        echo "No entries were found for ${id}."
+```

--- a/.claude/skills/format-source/SKILL.md
+++ b/.claude/skills/format-source/SKILL.md
@@ -1,0 +1,142 @@
+---
+
+name: format-source
+description: Format Java source files changed on the current branch to align with Liferay's coding standards, then run formatSource (./gradlew formatSource or ant format-source-current-branch) and fix any reported violations. Must be run before every commit. Use when the user asks to format source, fix code style, or run formatSource on Java files.
+
+---
+
+# Format Source
+
+Format Java source files to align with Liferay's coding style patterns. This must be run before every commit.
+
+## Workflow
+
+### Phase 1: Identify Files to Format
+
+Get all Java files changed on the current branch relative to master:
+
+```bash
+git diff --name-only master...HEAD | grep '\.java$'
+```
+
+If the command returns no files, inform the user and stop.
+
+### Phase 2: Apply Formatting Rules
+
+For each Java file, analyze and propose corrections. Read the full file before making any judgements.
+
+---
+
+#### Rule 1: Method Parameter Ordering
+
+Method parameters must be sorted **alphabetically by parameter name** (case-insensitive, ignoring leading underscores).
+
+**Default: alphabetical sort**
+
+```java
+// Before
+public void process(String userId, long companyId, Date createDate)
+
+// After
+public void process(long companyId, Date createDate, String userId)
+```
+
+**Exception: Service module entity CRUD methods**
+
+When ALL of these conditions hold, use service.xml field order instead of alphabetical:
+
+1. The class is inside a `*-service` module (module directory ends with `-service`)
+
+1. A `service.xml` exists at the module root
+
+1. The method is a CRUD method for an entity defined in that `service.xml` — meaning the method name contains the entity name (e.g., `addAnalyticsMessage`, `updateAnalyticsMessage`, `deleteAnalyticsMessage`)
+
+1. The parameters (by name) are a subset of the fields declared in that entity's `<column>` elements
+
+When the exception applies, order parameters to match the field declaration order in `service.xml` (top to bottom within the entity's `<column>` list), skipping fields that aren't parameters.
+
+**How to determine if the exception applies:**
+
+```bash
+# 1. Find the module root (directory containing bnd.bnd or build.gradle)
+# 2. Check for service.xml at module root
+find <module-root> -maxdepth 1 -name "service.xml"
+
+# 3. Parse entity names and their column order from service.xml
+grep -E '<entity name=|<column name=' <module-root>/service.xml
+```
+
+**Example:**
+
+service.xml declares for `AnalyticsMessage`:
+
+```xml
+<column name="companyId" />
+<column name="userId" />
+<column name="userName" />
+<column name="createDate" />
+<column name="body" />
+```
+
+Method `addAnalyticsMessage(long userId, byte[] body, long companyId)` → exception applies → reorder to `(long companyId, long userId, byte[] body)`.
+
+**When to skip a method entirely:**
+- Parameters don't correspond to entity fields (e.g., `start`, `end`, `orderByComparator` — these are pagination/query params, not entity fields)
+- The method name doesn't clearly target a single entity from `service.xml`
+- The parameter names are ambiguous (could belong to multiple entities)
+
+---
+
+### Phase 3: Apply Changes
+
+For each file with required changes, apply them directly using the Edit tool. Update:
+
+1. The method **declaration** (signature in the class body)
+
+1. If the method overrides an interface or base class defined in the same codebase, update that signature too
+
+When editing, change only the parameter list order. Do not reformat other parts of the method, add/remove whitespace beyond what's needed, or alter logic.
+
+After processing all files, print a summary of every change made:
+- File path (relative to repo root)
+- Method signature before → after
+- Which rule applied (alphabetical / service.xml field order for `EntityName`)
+
+If no changes were needed, say so.
+
+### Phase 6: Run formatSource
+
+After applying all changes, run formatSource. Use the branch-wide command when multiple modules are affected, or the module-specific command otherwise:
+
+```bash
+# For a specific module
+cd <module-root> && <gradlew> formatSource
+
+# Across the entire codebase (current branch)
+cd <repo-root>/portal-impl && ant format-source-current-branch
+```
+
+### Phase 7: Fix formatSource Issues
+
+Parse the output of the formatSource run. If it reports formatting violations:
+
+1. Read each flagged file
+
+1. Apply the exact fixes indicated (e.g. incorrect whitespace, import ordering, brace style)
+
+1. Re-run formatSource to confirm the fixes are clean — prefer `ant format-source-current-branch` for branch-wide verification, or `<gradlew> formatSource` scoped to the affected module
+
+Repeat until formatSource exits with no errors. Report the final outcome to the user.
+
+---
+
+## Edge Cases and Guardrails
+
+- **Overloaded methods**: Treat each overload independently.
+- **Constructors**: Apply the same alphabetical rule (no service.xml exception for constructors).
+- **Annotations on parameters**: Keep annotations attached to their parameter when reordering.
+- **`throws` clause**: Do not touch it.
+- **Multi-line signatures**: Preserve the original line-break style after reordering.
+- **Generated files**: Skip files in `build/`, `**/generated/**`, or any file with a `@Generated` annotation.
+- **Interface files**: If the method being reordered is declared in an interface (`*LocalService.java`, `*Service.java`, `*Persistence.java`) that was auto-generated by Service Builder, do NOT edit it — those are regenerated on build. Only edit hand-written `*Impl` files and other non-generated sources.
+- **When unsure**: Flag the method as "needs manual review" in the proposal instead of guessing.

--- a/.claude/skills/format-source/SKILL.md
+++ b/.claude/skills/format-source/SKILL.md
@@ -1,142 +1,40 @@
 ---
 
+description: Format source files to align with Liferay's coding standards.
 name: format-source
-description: Format Java source files changed on the current branch to align with Liferay's coding standards, then run formatSource (./gradlew formatSource or ant format-source-current-branch) and fix any reported violations. Must be run before every commit. Use when the user asks to format source, fix code style, or run formatSource on Java files.
 
 ---
 
 # Format Source
 
-Format Java source files to align with Liferay's coding style patterns. This must be run before every commit.
+All the code is strictly formatted using source formatter. This is how it works:
 
-## Workflow
-
-### Phase 1: Identify Files to Format
-
-Get all Java files changed on the current branch relative to master:
+Run for a specific module:
 
 ```bash
-git diff --name-only master...HEAD | grep '\.java$'
-```
-
-If the command returns no files, inform the user and stop.
-
-### Phase 2: Apply Formatting Rules
-
-For each Java file, analyze and propose corrections. Read the full file before making any judgements.
-
----
-
-#### Rule 1: Method Parameter Ordering
-
-Method parameters must be sorted **alphabetically by parameter name** (case-insensitive, ignoring leading underscores).
-
-**Default: alphabetical sort**
-
-```java
-// Before
-public void process(String userId, long companyId, Date createDate)
-
-// After
-public void process(long companyId, Date createDate, String userId)
-```
-
-**Exception: Service module entity CRUD methods**
-
-When ALL of these conditions hold, use service.xml field order instead of alphabetical:
-
-1. The class is inside a `*-service` module (module directory ends with `-service`)
-
-1. A `service.xml` exists at the module root
-
-1. The method is a CRUD method for an entity defined in that `service.xml` — meaning the method name contains the entity name (e.g., `addAnalyticsMessage`, `updateAnalyticsMessage`, `deleteAnalyticsMessage`)
-
-1. The parameters (by name) are a subset of the fields declared in that entity's `<column>` elements
-
-When the exception applies, order parameters to match the field declaration order in `service.xml` (top to bottom within the entity's `<column>` list), skipping fields that aren't parameters.
-
-**How to determine if the exception applies:**
-
-```bash
-# 1. Find the module root (directory containing bnd.bnd or build.gradle)
-# 2. Check for service.xml at module root
-find <module-root> -maxdepth 1 -name "service.xml"
-
-# 3. Parse entity names and their column order from service.xml
-grep -E '<entity name=|<column name=' <module-root>/service.xml
-```
-
-**Example:**
-
-service.xml declares for `AnalyticsMessage`:
-
-```xml
-<column name="companyId" />
-<column name="userId" />
-<column name="userName" />
-<column name="createDate" />
-<column name="body" />
-```
-
-Method `addAnalyticsMessage(long userId, byte[] body, long companyId)` → exception applies → reorder to `(long companyId, long userId, byte[] body)`.
-
-**When to skip a method entirely:**
-- Parameters don't correspond to entity fields (e.g., `start`, `end`, `orderByComparator` — these are pagination/query params, not entity fields)
-- The method name doesn't clearly target a single entity from `service.xml`
-- The parameter names are ambiguous (could belong to multiple entities)
-
----
-
-### Phase 3: Apply Changes
-
-For each file with required changes, apply them directly using the Edit tool. Update:
-
-1. The method **declaration** (signature in the class body)
-
-1. If the method overrides an interface or base class defined in the same codebase, update that signature too
-
-When editing, change only the parameter list order. Do not reformat other parts of the method, add/remove whitespace beyond what's needed, or alter logic.
-
-After processing all files, print a summary of every change made:
-- File path (relative to repo root)
-- Method signature before → after
-- Which rule applied (alphabetical / service.xml field order for `EntityName`)
-
-If no changes were needed, say so.
-
-### Phase 6: Run formatSource
-
-After applying all changes, run formatSource. Use the branch-wide command when multiple modules are affected, or the module-specific command otherwise:
-
-```bash
-# For a specific module
 cd <module-root> && <gradlew> formatSource
+```
 
-# Across the entire codebase (current branch)
+Run across the entire codebase:
+
+```bash
 cd <repo-root>/portal-impl && ant format-source-current-branch
 ```
 
-### Phase 7: Fix formatSource Issues
+If there are issues to be fixed in the current branch, the formatter will list them. Fix them.
 
-Parse the output of the formatSource run. If it reports formatting violations:
+In addition to the automatic formatter, there is a set of manual rules that the formatter does not catch. The full workflow is to run the formatter, apply the manual rules, then rerun the formatter to clean up any fallout from the manual edits.
 
-1. Read each flagged file
+Skip generated files. The automatic formatter already does this via `BaseSourceProcessor.hasGeneratedTag`; apply the same rule to manual edits. A file is generated when it contains any of these unquoted markers:
 
-1. Apply the exact fixes indicated (e.g. incorrect whitespace, import ordering, brace style)
+- `@generated` — Service Builder, REST Builder, taglib generator (Java, by far the most common; ~18k files)
 
-1. Re-run formatSource to confirm the fixes are clean — prefer `ant format-source-current-branch` for branch-wide verification, or `<gradlew> formatSource` scoped to the affected module
+- `$ANTLR` — ANTLR-generated lexers and parsers
 
-Repeat until formatSource exits with no errors. Report the final outcome to the user.
+- `# This is a generated file.` — generated scripts
 
----
+- `## Autogenerated` — generated Markdown and config
 
-## Edge Cases and Guardrails
+These files are overwritten on the next build, so manual edits are lost and only pollute the diff.
 
-- **Overloaded methods**: Treat each overload independently.
-- **Constructors**: Apply the same alphabetical rule (no service.xml exception for constructors).
-- **Annotations on parameters**: Keep annotations attached to their parameter when reordering.
-- **`throws` clause**: Do not touch it.
-- **Multi-line signatures**: Preserve the original line-break style after reordering.
-- **Generated files**: Skip files in `build/`, `**/generated/**`, or any file with a `@Generated` annotation.
-- **Interface files**: If the method being reordered is declared in an interface (`*LocalService.java`, `*Service.java`, `*Persistence.java`) that was auto-generated by Service Builder, do NOT edit it — those are regenerated on build. Only edit hand-written `*Impl` files and other non-generated sources.
-- **When unsure**: Flag the method as "needs manual review" in the proposal instead of guessing.
+## Rules


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87558

**How to use it:**

- `/format-source` — Runs the automatic formatter, applies the manual rules, then reruns the formatter to clean up any fallout. The `/commit` skill invokes it as a first step, so plain `/commit` already covers it.

- `/format-source-add-rule <commit-sha>` — Inspects the commit, picks one learnable pattern, checks for duplicates against the existing ruleset, appends a templated entry with abstract identifiers, and self-tests the rule by replaying the commit through `/format-source`. Pass an optional hint when the commit touches multiple things and you want to scope the rule to one of them.

The seeded ruleset comes from running `/format-source-add-rule` against the latest 100 commits by Brian Chan.