### PR TITLE
LPD-86255 Improve error message when a structure already exists

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/jaxrs/exception/mapper/BaseExceptionMapper.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/jaxrs/exception/mapper/BaseExceptionMapper.java
@@ -5,8 +5,6 @@
 
 package com.liferay.portal.vulcan.jaxrs.exception.mapper;
 
-import com.liferay.petra.string.StringUtil;
-
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
@@ -32,13 +30,7 @@ public abstract class BaseExceptionMapper<T extends Throwable>
 		String type = problem.getType();
 
 		if (type != null) {
-			String[] segments = type.split("\\.");
-
-			String exceptionType = segments[segments.length - 1];
-
-			if (exceptionType != null) {
-				problem.setType(StringUtil.replace(exceptionType, '$', '.'));
-			}
+			problem.setType(ExceptionMapperUtil.getExceptionType(type));
 		}
 
 		return Response.status(

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/jaxrs/exception/mapper/ExceptionMapperUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/jaxrs/exception/mapper/ExceptionMapperUtil.java
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.vulcan.jaxrs.exception.mapper;
+
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringUtil;
+
+import java.util.List;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class ExceptionMapperUtil {
+
+	public static String getExceptionType(String className) {
+		if (className == null) {
+			return null;
+		}
+
+		List<String> segments = StringUtil.split(className, CharPool.PERIOD);
+
+		if (segments.isEmpty()) {
+			return className;
+		}
+
+		return StringUtil.replace(
+			segments.get(segments.size() - 1), CharPool.DOLLAR,
+			CharPool.PERIOD);
+	}
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/UpdateStructureStrutsAction.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/UpdateStructureStrutsAction.java
@@ -12,8 +12,6 @@ import com.liferay.object.admin.rest.resource.v1_0.ObjectRelationshipResource;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
-import com.liferay.petra.string.CharPool;
-import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -33,6 +31,7 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.ExceptionMapperUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -100,19 +99,10 @@ public class UpdateStructureStrutsAction implements StrutsAction {
 				throwable = throwable.getCause();
 			}
 
-			// See com.liferay.portal.vulcan.jaxrs.exception
-			// .mapper.BaseExceptionMapper#toResponse
-
-			Class<?> clazz = throwable.getClass();
-
-			List<String> segments = StringUtil.split(
-				clazz.getName(), CharPool.PERIOD);
-
 			jsonObject.put(
 				"type",
-				StringUtil.replace(
-					segments.get(segments.size() - 1), CharPool.DOLLAR,
-					CharPool.PERIOD));
+				ExceptionMapperUtil.getExceptionType(
+					throwable.getClass().getName()));
 
 			if (_log.isWarnEnabled()) {
 				_log.warn(exception);

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/UpdateStructureStrutsAction.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/UpdateStructureStrutsAction.java
@@ -100,22 +100,19 @@ public class UpdateStructureStrutsAction implements StrutsAction {
 				throwable = throwable.getCause();
 			}
 
-			if (throwable != null) {
+			// See com.liferay.portal.vulcan.jaxrs.exception
+			// .mapper.BaseExceptionMapper#toResponse
 
-				// See com.liferay.portal.vulcan.jaxrs.exception
-				// .mapper.BaseExceptionMapper#toResponse
+			Class<?> clazz = throwable.getClass();
 
-				Class<?> clazz = throwable.getClass();
+			List<String> segments = StringUtil.split(
+				clazz.getName(), CharPool.PERIOD);
 
-				List<String> segments = StringUtil.split(
-					clazz.getName(), CharPool.PERIOD);
-
-				jsonObject.put(
-					"type",
-					StringUtil.replace(
-						segments.get(segments.size() - 1), CharPool.DOLLAR,
-						CharPool.PERIOD));
-			}
+			jsonObject.put(
+				"type",
+				StringUtil.replace(
+					segments.get(segments.size() - 1), CharPool.DOLLAR,
+					CharPool.PERIOD));
 
 			if (_log.isWarnEnabled()) {
 				_log.warn(exception);

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/UpdateStructureStrutsAction.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/UpdateStructureStrutsAction.java
@@ -12,6 +12,8 @@ import com.liferay.object.admin.rest.resource.v1_0.ObjectRelationshipResource;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -91,6 +93,29 @@ public class UpdateStructureStrutsAction implements StrutsAction {
 				_language.get(
 					httpServletRequest.getLocale(),
 					"an-unexpected-error-occurred"));
+
+			Throwable throwable = exception;
+
+			while (throwable.getCause() != null) {
+				throwable = throwable.getCause();
+			}
+
+			if (throwable != null) {
+
+				// See com.liferay.portal.vulcan.jaxrs.exception
+				// .mapper.BaseExceptionMapper#toResponse
+
+				Class<?> clazz = throwable.getClass();
+
+				List<String> segments = StringUtil.split(
+					clazz.getName(), CharPool.PERIOD);
+
+				jsonObject.put(
+					"type",
+					StringUtil.replace(
+						segments.get(segments.size() - 1), CharPool.DOLLAR,
+						CharPool.PERIOD));
+			}
 
 			if (_log.isWarnEnabled()) {
 				_log.warn(exception);

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/ApiHelper.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/ApiHelper.ts
@@ -27,11 +27,13 @@ export type RequestResult<T> =
 			data: null;
 			error: string;
 			status?: string | null;
+			type?: string | null;
 	  }
 	| {
 			data: T;
 			error: null;
 			status?: string | null;
+			type?: string | null;
 	  };
 
 async function deleteRequest(url: string) {
@@ -54,7 +56,7 @@ async function handleRequest<T>(
 		}
 
 		if (!response.ok) {
-			const {message, status, title} = await response.json();
+			const {message, status, title, type} = await response.json();
 
 			let error = title ?? message ?? UNEXPECTED_ERROR_MESSAGE;
 
@@ -66,6 +68,7 @@ async function handleRequest<T>(
 				data: null,
 				error,
 				status,
+				type,
 			};
 		}
 
@@ -77,13 +80,14 @@ async function handleRequest<T>(
 			};
 		}
 
-		const data: T | {error: string} = await response.json();
+		const data: T | {error: string; type?: string} = await response.json();
 
 		if (data && typeof data === 'object' && 'error' in data) {
 			return {
 				data: null,
 				error: data.error || UNEXPECTED_ERROR_MESSAGE,
 				status: null,
+				type: data.type ?? null,
 			};
 		}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/StructureService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/StructureService.ts
@@ -11,6 +11,26 @@ import buildObjectRelationships from '../../structure_builder/utils/buildObjectR
 import getRandomId from '../../structure_builder/utils/getRandomId';
 import ApiHelper from './ApiHelper';
 
+export type StructureServiceError = 'in-use' | 'unexpected';
+
+const NAME_COLLISION_EXCEPTION_TYPES = [
+	'ObjectDefinitionFriendlyURLSeparatorException',
+	'ObjectDefinitionNameException',
+];
+
+function classifyError(type?: string | null): StructureServiceError {
+	if (
+		type &&
+		NAME_COLLISION_EXCEPTION_TYPES.some((collisionType) =>
+			type.startsWith(collisionType)
+		)
+	) {
+		return 'in-use';
+	}
+
+	return 'unexpected';
+}
+
 async function createStructure({
 	children,
 	erc = getRandomId(),
@@ -34,18 +54,13 @@ async function createStructure({
 	const objectDefinitions = buildGroupObjectDefinitions({children});
 
 	for (const objectDefinition of objectDefinitions) {
-		const {error} = await ApiHelper.put(
+		const {error, type} = await ApiHelper.put(
 			`/o/object-admin/v1.0/object-definitions/by-external-reference-code/${objectDefinition.externalReferenceCode}`,
 			objectDefinition
 		);
 
 		if (error) {
-			return {
-				data: null,
-				error: Liferay.Language.get(
-					'an-unexpected-error-occurred-while-saving-or-publishing-the-content-structure'
-				),
-			};
+			return {data: null, error: classifyError(type)};
 		}
 	}
 
@@ -61,18 +76,13 @@ async function createStructure({
 		workflows,
 	});
 
-	const {data, error} = await ApiHelper.post<{id: number}>(
+	const {data, error, type} = await ApiHelper.post<{id: number}>(
 		'/o/object-admin/v1.0/object-definitions',
 		mainObjectDefinition
 	);
 
 	if (error) {
-		return {
-			data: null,
-			error: Liferay.Language.get(
-				'an-unexpected-error-occurred-while-saving-or-publishing-the-content-structure'
-			),
-		};
+		return {data: null, error: classifyError(type)};
 	}
 
 	const objectRelationships = buildObjectRelationships({
@@ -81,18 +91,13 @@ async function createStructure({
 	});
 
 	for (const objectRelationship of objectRelationships) {
-		const {error} = await ApiHelper.post(
+		const {error, type} = await ApiHelper.post(
 			`/o/object-admin/v1.0/object-definitions/by-external-reference-code/${objectRelationship.objectDefinitionExternalReferenceCode1}/object-relationships`,
 			objectRelationship
 		);
 
 		if (error) {
-			return {
-				data: null,
-				error: Liferay.Language.get(
-					'an-unexpected-error-occurred-while-saving-or-publishing-the-content-structure'
-				),
-			};
+			return {data: null, error: classifyError(type)};
 		}
 	}
 
@@ -174,12 +179,8 @@ async function updateStructure({
 		`${pathMain}/cms/update-structure`
 	);
 
-	if (response?.error) {
-		return {
-			error: Liferay.Language.get(
-				'an-unexpected-error-occurred-while-saving-or-publishing-the-content-structure'
-			),
-		};
+	if (response.error !== null) {
+		return {error: classifyError(response.type)};
 	}
 
 	return response;

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/buildStructureErrorAction.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/buildStructureErrorAction.ts
@@ -1,0 +1,37 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {StructureServiceError} from '../../common/services/StructureService';
+import {Action} from '../contexts/StateContext';
+import {Structure} from '../types/Structure';
+import {Uuid} from '../types/Uuid';
+
+export default function buildStructureErrorAction({
+	error,
+	previousStatus,
+	uuid,
+}: {
+	error: StructureServiceError;
+	previousStatus: Structure['status'];
+	uuid: Uuid;
+}): Action {
+	if (error === 'in-use') {
+		return {
+			error: 'in-use',
+			property: 'name',
+			status: previousStatus,
+			type: 'add-error',
+			uuid,
+		};
+	}
+
+	return {
+		error: 'unexpected',
+		property: 'global',
+		status: previousStatus,
+		type: 'add-error',
+		uuid,
+	};
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/handlePublishStructure.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/handlePublishStructure.tsx
@@ -11,7 +11,9 @@ import {addParams, navigate, sub} from 'frontend-js-web';
 import React, {Dispatch} from 'react';
 
 import SpaceService from '../../common/services/SpaceService';
-import StructureService from '../../common/services/StructureService';
+import StructureService, {
+	StructureServiceError,
+} from '../../common/services/StructureService';
 import {ObjectDefinitions} from '../../common/types/ObjectDefinition';
 import {Space} from '../../common/types/Space';
 import {config} from '../config';
@@ -30,6 +32,7 @@ import selectStructureStatus from '../selectors/selectStructureStatus';
 import selectStructureUuid from '../selectors/selectStructureUuid';
 import selectStructureWorkflows from '../selectors/selectStructureWorkflows';
 import DisplayPageService from '../services/DisplayPageService';
+import buildStructureErrorAction from './buildStructureErrorAction';
 
 type Props = {
 	dispatch: Dispatch<Action>;
@@ -258,14 +261,8 @@ export default async function handlePublishStructure({
 
 	const previousStatus = state.structure.status;
 
-	const onError = () =>
-		dispatch({
-			error: 'unexpected',
-			property: 'global',
-			status: previousStatus,
-			type: 'add-error',
-			uuid,
-		});
+	const onError = (error: StructureServiceError) =>
+		dispatch(buildStructureErrorAction({error, previousStatus, uuid}));
 
 	dispatch({status: 'publishing', type: 'set-structure-status'});
 
@@ -281,7 +278,7 @@ export default async function handlePublishStructure({
 		});
 
 		if (error) {
-			onError();
+			onError(error);
 
 			return;
 		}
@@ -305,7 +302,7 @@ export default async function handlePublishStructure({
 		});
 
 		if (error) {
-			onError();
+			onError(error);
 
 			return;
 		}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/handleSaveStructure.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/handleSaveStructure.ts
@@ -6,7 +6,9 @@
 import {openToast} from 'frontend-js-components-web';
 import {Dispatch} from 'react';
 
-import StructureService from '../../common/services/StructureService';
+import StructureService, {
+	StructureServiceError,
+} from '../../common/services/StructureService';
 import {Action, State} from '../contexts/StateContext';
 import selectHistory from '../selectors/selectHistory';
 import selectStructureChildren from '../selectors/selectStructureChildren';
@@ -19,6 +21,7 @@ import selectStructureSpaces from '../selectors/selectStructureSpaces';
 import selectStructureStatus from '../selectors/selectStructureStatus';
 import selectStructureUuid from '../selectors/selectStructureUuid';
 import selectStructureWorkflows from '../selectors/selectStructureWorkflows';
+import buildStructureErrorAction from './buildStructureErrorAction';
 
 type Props = {
 	dispatch: Dispatch<Action>;
@@ -51,14 +54,8 @@ export default async function handleSaveStructure({
 
 	const previousStatus = state.structure.status;
 
-	const onError = () =>
-		dispatch({
-			error: 'unexpected',
-			property: 'global',
-			status: previousStatus,
-			type: 'add-error',
-			uuid,
-		});
+	const onError = (error: StructureServiceError) =>
+		dispatch(buildStructureErrorAction({error, previousStatus, uuid}));
 
 	dispatch({status: 'saving', type: 'set-structure-status'});
 
@@ -74,7 +71,7 @@ export default async function handleSaveStructure({
 		});
 
 		if (error) {
-			onError();
+			onError(error);
 
 			return;
 		}
@@ -96,7 +93,7 @@ export default async function handleSaveStructure({
 		});
 
 		if (error) {
-			onError();
+			onError(error);
 
 			return;
 		}

--- a/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/frontendValidations.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/frontendValidations.spec.ts
@@ -498,3 +498,92 @@ test(
 		await expect(modal).not.toBeVisible();
 	}
 );
+
+test(
+	'Shows an inline "name in use" error when the backend reports a friendly URL separator conflict',
+	{tag: '@LPD-86255'},
+	async ({page, structureBuilderPage}) => {
+		await page.route(
+			'**/o/object-admin/v1.0/object-definitions',
+			async (route) => {
+				if (route.request().method() !== 'POST') {
+					await route.fallback();
+
+					return;
+				}
+
+				await route.fulfill({
+					body: JSON.stringify({
+						detail: '[{"fieldName":"friendlyURLSeparator","message":"Other asset types may use this prefix."}]',
+						status: 'BAD_REQUEST',
+						title: 'Other asset types may use this prefix.',
+						type: 'ObjectDefinitionFriendlyURLSeparatorException',
+					}),
+					headers: {'Content-Type': 'application/json'},
+					status: 400,
+				});
+			}
+		);
+
+		await structureBuilderPage.goToCreateStructure();
+
+		await structureBuilderPage.enableForAllSpaces();
+
+		await structureBuilderPage.changeStructureSettings({
+			label: `Structure${getRandomInt()}`,
+			name: `Structure${getRandomInt()}`,
+		});
+
+		await structureBuilderPage.addField('Text');
+
+		await structureBuilderPage.selectStructure();
+
+		await structureBuilderPage.publishButton.click();
+
+		await expect(
+			page.getByText('This name is already in use. Try another one.')
+		).toBeVisible();
+
+		await expect(
+			page.getByText('Other asset types may use this prefix.')
+		).not.toBeVisible();
+	}
+);
+
+test(
+	'Shows an inline "name in use" error when updating a structure and the backend reports a friendly URL separator conflict',
+	{tag: '@LPD-86255'},
+	async ({page, structureBuilderPage, structuresPage}) => {
+		const label = `Structure${getRandomInt()}`;
+
+		await structureBuilderPage.createStructureFromData({
+			label,
+			page: structureBuilderPage,
+		});
+
+		await structuresPage.goto();
+
+		await structuresPage.execItemAction({action: 'Edit', filter: label});
+
+		await page.route('**/cms/update-structure', async (route) => {
+			await route.fulfill({
+				body: JSON.stringify({
+					error: 'An unexpected error occurred',
+					type: 'ObjectDefinitionFriendlyURLSeparatorException',
+				}),
+				headers: {'Content-Type': 'application/json'},
+				status: 200,
+			});
+		});
+
+		await structureBuilderPage.publishButton.click();
+
+		await expect(
+			page.getByText('This name is already in use. Try another one.')
+		).toBeVisible();
+
+		await expect(
+			page.getByText('Other asset types may use this prefix.')
+		).not.toBeVisible();
+	}
+);


### PR DESCRIPTION
# What is this trying to solve?

> [!NOTE]
> This is a followup to https://github.com/liferay-content-management/liferay-portal/pull/8106 addressing https://github.com/brianchandotcom/liferay-portal/pull/173390#issuecomment-4304182574.

https://liferay.atlassian.net/browse/LPD-86255

When creating CMS structures, if the friendly url conflicts with an already existing one, a generic error is displayed.

# How am I fixing it?

By treating it as a regular name conflict.

> [!NOTE]
> The friendly url is autogenerated and hidden to the end user (no UI), so displaying a message mentioning the friendly url would be even more confusing. As the only way to control the friendly url is indirectly through the name, treating it as a regular name conflict is the only short term choice.

# How can you verify that it works?

Run the included playwright tests.