### PR TITLE
LPD-86074 Edit url for cms objects don't go to the cms

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/constants/ObjectPortletKeys.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/constants/ObjectPortletKeys.java
@@ -10,6 +10,10 @@ package com.liferay.object.constants;
  */
 public class ObjectPortletKeys {
 
+	public static final String CMS_OBJECT_ENTRY =
+		"com_liferay_site_cms_site_initializer_internal_portlet_" +
+			"CMSObjectEntryPortlet";
+
 	public static final String LIST_TYPE_DEFINITIONS =
 		"com_liferay_object_web_internal_list_type_portlet_portlet_" +
 			"ListTypeDefinitionsPortlet";

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRenderer.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRenderer.java
@@ -7,14 +7,12 @@ package com.liferay.object.web.internal.asset.model;
 
 import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.asset.kernel.model.BaseJSPAssetRenderer;
-import com.liferay.depot.constants.DepotConstants;
-import com.liferay.depot.model.DepotEntry;
-import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.constants.ObjectPortletKeys;
 import com.liferay.object.constants.ObjectWebKeys;
 import com.liferay.object.display.context.ObjectEntryDisplayContextFactory;
 import com.liferay.object.field.util.ObjectFieldUtil;
@@ -63,19 +61,15 @@ public class ObjectEntryAssetRenderer
 	extends BaseJSPAssetRenderer<ObjectEntry> implements TrashRenderer {
 
 	public ObjectEntryAssetRenderer(
-			AssetDisplayPageFriendlyURLProvider
-				assetDisplayPageFriendlyURLProvider,
-			DepotEntryLocalService depotEntryLocalService,
-			DLAppLocalService dlAppLocalService, DLURLHelper dlURLHelper,
-			ObjectDefinition objectDefinition, ObjectEntry objectEntry,
-			ObjectEntryDisplayContextFactory objectEntryDisplayContextFactory,
-			ObjectEntryService objectEntryService,
-			ObjectFieldLocalService objectFieldLocalService)
-		throws PortalException {
+		AssetDisplayPageFriendlyURLProvider assetDisplayPageFriendlyURLProvider,
+		DLAppLocalService dlAppLocalService, DLURLHelper dlURLHelper,
+		ObjectDefinition objectDefinition, ObjectEntry objectEntry,
+		ObjectEntryDisplayContextFactory objectEntryDisplayContextFactory,
+		ObjectEntryService objectEntryService,
+		ObjectFieldLocalService objectFieldLocalService) {
 
 		_assetDisplayPageFriendlyURLProvider =
 			assetDisplayPageFriendlyURLProvider;
-		_depotEntryLocalService = depotEntryLocalService;
 		_dlAppLocalService = dlAppLocalService;
 		_dlURLHelper = dlURLHelper;
 		_objectDefinition = objectDefinition;
@@ -199,18 +193,29 @@ public class ObjectEntryAssetRenderer
 	}
 
 	@Override
-	public PortletURL getURLEdit(HttpServletRequest httpServletRequest)
-		throws Exception {
-
+	public PortletURL getURLEdit(HttpServletRequest httpServletRequest) {
 		Group group = GroupLocalServiceUtil.fetchGroup(
 			_objectEntry.getGroupId());
 
-		if ((group != null) && group.isCompany()) {
-			ThemeDisplay themeDisplay =
-				(ThemeDisplay)httpServletRequest.getAttribute(
-					WebKeys.THEME_DISPLAY);
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
 
+		if ((group != null) && group.isCompany()) {
 			group = themeDisplay.getScopeGroup();
+		}
+
+		if (_objectDefinition.isCMS()) {
+			return PortletURLBuilder.create(
+				PortalUtil.getControlPanelPortletURL(
+					httpServletRequest, group,
+					ObjectPortletKeys.CMS_OBJECT_ENTRY, 0, 0,
+					PortletRequest.RENDER_PHASE)
+			).setRedirect(
+				themeDisplay.getURLCurrent()
+			).setParameter(
+				"objectEntryId", _objectEntry.getObjectEntryId()
+			).buildPortletURL();
 		}
 
 		return PortletURLBuilder.create(
@@ -228,9 +233,8 @@ public class ObjectEntryAssetRenderer
 
 	@Override
 	public PortletURL getURLEdit(
-			LiferayPortletRequest liferayPortletRequest,
-			LiferayPortletResponse liferayPortletResponse)
-		throws Exception {
+		LiferayPortletRequest liferayPortletRequest,
+		LiferayPortletResponse liferayPortletResponse) {
 
 		return getURLEdit(
 			PortalUtil.getHttpServletRequest(liferayPortletRequest));
@@ -245,12 +249,7 @@ public class ObjectEntryAssetRenderer
 			return null;
 		}
 
-		DepotEntry depotEntry = _depotEntryLocalService.fetchGroupDepotEntry(
-			_objectEntry.getGroupId());
-
-		if ((depotEntry == null) ||
-			(depotEntry.getType() != DepotConstants.TYPE_SPACE)) {
-
+		if (!_objectDefinition.isCMS()) {
 			return getURLViewInContext(themeDisplay, StringPool.BLANK);
 		}
 
@@ -330,9 +329,7 @@ public class ObjectEntryAssetRenderer
 	}
 
 	@Override
-	public boolean hasEditPermission(PermissionChecker permissionChecker)
-		throws PortalException {
-
+	public boolean hasEditPermission(PermissionChecker permissionChecker) {
 		try {
 			return _objectEntryService.hasModelResourcePermission(
 				_objectEntry, ActionKeys.UPDATE);
@@ -347,9 +344,7 @@ public class ObjectEntryAssetRenderer
 	}
 
 	@Override
-	public boolean hasViewPermission(PermissionChecker permissionChecker)
-		throws PortalException {
-
+	public boolean hasViewPermission(PermissionChecker permissionChecker) {
 		try {
 			return _objectEntryService.hasModelResourcePermission(
 				_objectEntry, ActionKeys.VIEW);
@@ -418,7 +413,6 @@ public class ObjectEntryAssetRenderer
 
 	private final AssetDisplayPageFriendlyURLProvider
 		_assetDisplayPageFriendlyURLProvider;
-	private final DepotEntryLocalService _depotEntryLocalService;
 	private final DLAppLocalService _dlAppLocalService;
 	private final DLURLHelper _dlURLHelper;
 	private final ObjectDefinition _objectDefinition;

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRendererFactory.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRendererFactory.java
@@ -8,7 +8,6 @@ package com.liferay.object.web.internal.asset.model;
 import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.asset.kernel.model.AssetRenderer;
 import com.liferay.asset.kernel.model.BaseAssetRendererFactory;
-import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.object.constants.ObjectDefinitionConstants;
@@ -44,7 +43,6 @@ public class ObjectEntryAssetRendererFactory
 
 	public ObjectEntryAssetRendererFactory(
 		AssetDisplayPageFriendlyURLProvider assetDisplayPageFriendlyURLProvider,
-		DepotEntryLocalService depotEntryLocalService,
 		DLAppLocalService dlAppLocalService, DLURLHelper dlURLHelper,
 		ObjectDefinition objectDefinition,
 		ObjectEntryDisplayContextFactory objectEntryDisplayContextFactory,
@@ -59,7 +57,6 @@ public class ObjectEntryAssetRendererFactory
 
 		_assetDisplayPageFriendlyURLProvider =
 			assetDisplayPageFriendlyURLProvider;
-		_depotEntryLocalService = depotEntryLocalService;
 		_dlAppLocalService = dlAppLocalService;
 		_dlURLHelper = dlURLHelper;
 		_objectDefinition = objectDefinition;
@@ -80,8 +77,8 @@ public class ObjectEntryAssetRendererFactory
 
 		ObjectEntryAssetRenderer objectEntryAssetRenderer =
 			new ObjectEntryAssetRenderer(
-				_assetDisplayPageFriendlyURLProvider, _depotEntryLocalService,
-				_dlAppLocalService, _dlURLHelper, _objectDefinition,
+				_assetDisplayPageFriendlyURLProvider, _dlAppLocalService,
+				_dlURLHelper, _objectDefinition,
 				_objectEntryLocalService.getObjectEntry(classPK),
 				_objectEntryDisplayContextFactory, _objectEntryService,
 				_objectFieldLocalService);
@@ -119,8 +116,7 @@ public class ObjectEntryAssetRendererFactory
 
 	@Override
 	public boolean hasPermission(
-			PermissionChecker permissionChecker, long classPK, String actionId)
-		throws Exception {
+		PermissionChecker permissionChecker, long classPK, String actionId) {
 
 		if (Objects.equals(actionId, ActionKeys.DOWNLOAD) &&
 			_objectDefinition.isCMS()) {
@@ -187,7 +183,6 @@ public class ObjectEntryAssetRendererFactory
 
 	private final AssetDisplayPageFriendlyURLProvider
 		_assetDisplayPageFriendlyURLProvider;
-	private final DepotEntryLocalService _depotEntryLocalService;
 	private final DLAppLocalService _dlAppLocalService;
 	private final DLURLHelper _dlURLHelper;
 	private final ObjectDefinition _objectDefinition;

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -12,7 +12,6 @@ import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.asset.util.AssetHelper;
-import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.exception.FileExtensionException;
 import com.liferay.document.library.kernel.exception.FileSizeException;
 import com.liferay.document.library.kernel.exception.InvalidFileException;
@@ -248,11 +247,11 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			_bundleContext.registerService(
 				AssetRendererFactory.class,
 				new ObjectEntryAssetRendererFactory(
-					_assetDisplayPageFriendlyURLProvider,
-					_depotEntryLocalService, _dlAppLocalService, _dlURLHelper,
-					objectDefinition, _objectEntryDisplayContextFactory,
-					_objectEntryLocalService, _objectEntryService,
-					_objectFieldLocalService, _servletContext),
+					_assetDisplayPageFriendlyURLProvider, _dlAppLocalService,
+					_dlURLHelper, objectDefinition,
+					_objectEntryDisplayContextFactory, _objectEntryLocalService,
+					_objectEntryService, _objectFieldLocalService,
+					_servletContext),
 				HashMapDictionaryBuilder.<String, Object>put(
 					"company.id", objectDefinition.getCompanyId()
 				).put(
@@ -769,9 +768,6 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 	@Reference(target = "(upload.response.handler.system.default=true)")
 	private UploadResponseHandler _defaultUploadResponseHandler;
-
-	@Reference
-	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Reference(
 		target = "(info.item.capability.key=" + DisplayPageInfoItemCapability.KEY + ")"

--- a/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRendererFactoryTest.java
+++ b/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRendererFactoryTest.java
@@ -6,7 +6,6 @@
 package com.liferay.object.web.internal.asset.model;
 
 import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
-import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.object.constants.ObjectDefinitionConstants;
@@ -49,8 +48,8 @@ public class ObjectEntryAssetRendererFactoryTest {
 		languageUtil.setLanguage(new LanguageImpl());
 
 		_objectEntryAssetRendererFactory = new ObjectEntryAssetRendererFactory(
-			_assetDisplayPageFriendlyURLProvider, _depotEntryLocalService,
-			_dlAppLocalService, _dlURLHelper, _objectDefinition,
+			_assetDisplayPageFriendlyURLProvider, _dlAppLocalService,
+			_dlURLHelper, _objectDefinition,
 			_objectEntryDisplayContextFactoryImpl, _objectEntryLocalService,
 			_objectEntryService, _objectFieldLocalService, _servletContext);
 
@@ -70,7 +69,7 @@ public class ObjectEntryAssetRendererFactoryTest {
 	}
 
 	@Test
-	public void testGetTypeName() throws Exception {
+	public void testGetTypeName() {
 		Mockito.when(
 			_objectDefinition.isCMS()
 		).thenReturn(
@@ -95,7 +94,7 @@ public class ObjectEntryAssetRendererFactoryTest {
 	}
 
 	@Test
-	public void testIsActive() throws Exception {
+	public void testIsActive() {
 		Mockito.when(
 			_objectDefinition.getCompanyId()
 		).thenReturn(
@@ -118,7 +117,7 @@ public class ObjectEntryAssetRendererFactoryTest {
 	}
 
 	@Test
-	public void testIsSelectable() throws Exception {
+	public void testIsSelectable() {
 		Mockito.when(
 			_objectDefinition.getScope()
 		).thenReturn(
@@ -139,8 +138,6 @@ public class ObjectEntryAssetRendererFactoryTest {
 	private final AssetDisplayPageFriendlyURLProvider
 		_assetDisplayPageFriendlyURLProvider = Mockito.mock(
 			AssetDisplayPageFriendlyURLProvider.class);
-	private final DepotEntryLocalService _depotEntryLocalService = Mockito.mock(
-		DepotEntryLocalService.class);
 	private final DLAppLocalService _dlAppLocalService = Mockito.mock(
 		DLAppLocalService.class);
 	private final DLURLHelper _dlURLHelper = Mockito.mock(DLURLHelper.class);

--- a/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRendererTest.java
+++ b/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRendererTest.java
@@ -7,14 +7,12 @@ package com.liferay.object.web.internal.asset.model;
 
 import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.asset.kernel.model.AssetRenderer;
-import com.liferay.depot.constants.DepotConstants;
-import com.liferay.depot.model.DepotEntry;
-import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.constants.ObjectPortletKeys;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
@@ -33,12 +31,17 @@ import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.portlet.PortletRequest;
+import jakarta.portlet.PortletURL;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -132,7 +135,7 @@ public class ObjectEntryAssetRendererTest {
 	}
 
 	@Test
-	public void testGetURLDownload() throws Exception {
+	public void testGetURLDownload() {
 		Mockito.when(
 			_objectDefinition.isCMS()
 		).thenReturn(
@@ -150,6 +153,80 @@ public class ObjectEntryAssetRendererTest {
 						setPermissionChecker(_permissionChecker);
 					}
 				}));
+	}
+
+	@Test
+	public void testGetURLEdit() throws Exception {
+		Mockito.when(
+			_objectDefinition.isCMS()
+		).thenReturn(
+			true
+		);
+
+		String portletId = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_objectDefinition.getPortletId()
+		).thenReturn(
+			portletId
+		);
+
+		HttpServletRequest httpServletRequest = Mockito.mock(
+			HttpServletRequest.class);
+
+		Mockito.when(
+			httpServletRequest.getAttribute(WebKeys.THEME_DISPLAY)
+		).thenReturn(
+			Mockito.mock(ThemeDisplay.class)
+		);
+
+		try (MockedStatic<GroupLocalServiceUtil>
+				groupLocalServiceUtilMockedStatic = Mockito.mockStatic(
+					GroupLocalServiceUtil.class);
+			MockedStatic<PortalUtil> portalUtilMockedStatic =
+				Mockito.mockStatic(PortalUtil.class)) {
+
+			PortletURL cmsObjectEntryPortletURL = Mockito.mock(
+				PortletURL.class);
+
+			portalUtilMockedStatic.when(
+				() -> PortalUtil.getControlPanelPortletURL(
+					Mockito.eq(httpServletRequest), Mockito.any(),
+					Mockito.eq(ObjectPortletKeys.CMS_OBJECT_ENTRY),
+					Mockito.anyLong(), Mockito.anyLong(),
+					Mockito.eq(PortletRequest.RENDER_PHASE))
+			).thenReturn(
+				cmsObjectEntryPortletURL
+			);
+
+			PortletURL objectEntryPortletURL = Mockito.mock(PortletURL.class);
+
+			portalUtilMockedStatic.when(
+				() -> PortalUtil.getControlPanelPortletURL(
+					Mockito.eq(httpServletRequest), Mockito.any(),
+					Mockito.eq(portletId), Mockito.anyLong(), Mockito.anyLong(),
+					Mockito.eq(PortletRequest.RENDER_PHASE))
+			).thenReturn(
+				objectEntryPortletURL
+			);
+
+			AssetRenderer<ObjectEntry> assetRenderer =
+				_getObjectEntryAssetRenderer();
+
+			Assert.assertSame(
+				cmsObjectEntryPortletURL,
+				assetRenderer.getURLEdit(httpServletRequest));
+
+			Mockito.when(
+				_objectDefinition.isCMS()
+			).thenReturn(
+				false
+			);
+
+			Assert.assertSame(
+				objectEntryPortletURL,
+				assetRenderer.getURLEdit(httpServletRequest));
+		}
 	}
 
 	@Test
@@ -282,18 +359,10 @@ public class ObjectEntryAssetRendererTest {
 			_objectEntry
 		).getObjectEntryId();
 
-		DepotEntry depotEntry = Mockito.mock(DepotEntry.class);
-
-		Mockito.doReturn(
-			DepotConstants.TYPE_SPACE
-		).when(
-			depotEntry
-		).getType();
-
 		Mockito.when(
-			_depotEntryLocalService.fetchGroupDepotEntry(Mockito.anyLong())
+			_objectDefinition.isCMS()
 		).thenReturn(
-			depotEntry
+			true
 		);
 
 		if (editable) {
@@ -345,12 +414,10 @@ public class ObjectEntryAssetRendererTest {
 		return friendlyURL;
 	}
 
-	private AssetRenderer<ObjectEntry> _getObjectEntryAssetRenderer()
-		throws Exception {
-
+	private AssetRenderer<ObjectEntry> _getObjectEntryAssetRenderer() {
 		return new ObjectEntryAssetRenderer(
-			_assetDisplayPageFriendlyURLProvider, _depotEntryLocalService,
-			_dlAppLocalService, _dlURLHelper, _objectDefinition, _objectEntry,
+			_assetDisplayPageFriendlyURLProvider, _dlAppLocalService,
+			_dlURLHelper, _objectDefinition, _objectEntry,
 			_objectEntryDisplayContextFactoryImpl, _objectEntryService,
 			_objectFieldLocalService);
 	}
@@ -417,7 +484,7 @@ public class ObjectEntryAssetRendererTest {
 		);
 	}
 
-	private void _setUpObjectFieldUtilMockedStatic() throws Exception {
+	private void _setUpObjectFieldUtilMockedStatic() {
 		_objectFieldUtilMockedStatic.when(
 			() -> ObjectFieldUtil.getAttachmentDownloadURL(
 				Mockito.eq(_dlURLHelper), Mockito.eq(_fileEntry),
@@ -479,8 +546,6 @@ public class ObjectEntryAssetRendererTest {
 	private final AssetDisplayPageFriendlyURLProvider
 		_assetDisplayPageFriendlyURLProvider = Mockito.mock(
 			AssetDisplayPageFriendlyURLProvider.class);
-	private final DepotEntryLocalService _depotEntryLocalService = Mockito.mock(
-		DepotEntryLocalService.class);
 	private final DLAppLocalService _dlAppLocalService = Mockito.mock(
 		DLAppLocalService.class);
 	private final DLURLHelper _dlURLHelper = Mockito.mock(DLURLHelper.class);

--- a/modules/apps/site/site-cms-site-initializer/jest-setup.config.ts
+++ b/modules/apps/site/site-cms-site-initializer/jest-setup.config.ts
@@ -82,4 +82,7 @@ class MockBroadcastChannel {
 		formatStorage: (size: number) => `${size / 1024} KB`,
 	},
 	authToken: 'mocked-auth-token',
+	detach: () => {},
+	fire: () => {},
+	on: () => {},
 };

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/portlet/CMSObjectEntryPortlet.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/portlet/CMSObjectEntryPortlet.java
@@ -1,0 +1,144 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.portlet;
+
+import com.liferay.fragment.listener.FragmentEntryLinkListenerRegistry;
+import com.liferay.fragment.renderer.FragmentRendererRegistry;
+import com.liferay.fragment.service.FragmentEntryLinkService;
+import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.info.search.InfoSearchClassMapperRegistry;
+import com.liferay.layout.manager.FormManager;
+import com.liferay.object.constants.ObjectPortletKeys;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryService;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.site.cms.site.initializer.internal.util.ActionUtil;
+
+import jakarta.portlet.Portlet;
+import jakarta.portlet.PortletException;
+import jakarta.portlet.RenderRequest;
+import jakarta.portlet.RenderResponse;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+import java.util.Objects;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(
+	property = {
+		"com.liferay.portlet.display-category=category.hidden",
+		"com.liferay.portlet.preferences-owned-by-group=true",
+		"com.liferay.portlet.private-request-attributes=false",
+		"com.liferay.portlet.private-session-attributes=false",
+		"com.liferay.portlet.single-page-application=false",
+		"jakarta.portlet.display-name=CMS Object Entry",
+		"jakarta.portlet.expiration-cache=0",
+		"jakarta.portlet.name=" + ObjectPortletKeys.CMS_OBJECT_ENTRY,
+		"jakarta.portlet.resource-bundle=content.Language",
+		"jakarta.portlet.security-role-ref=power-user,user",
+		"jakarta.portlet.version=4.0"
+	},
+	service = Portlet.class
+)
+public class CMSObjectEntryPortlet extends MVCPortlet {
+
+	@Override
+	public void render(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws IOException, PortletException {
+
+		try {
+			HttpServletRequest httpServletRequest =
+				_portal.getHttpServletRequest(renderRequest);
+
+			ObjectEntry objectEntry = _objectEntryService.getObjectEntry(
+				ParamUtil.getLong(renderRequest, "objectEntryId"));
+
+			String editURL = ActionUtil.getEditURL(
+				_formManager, _fragmentEntryLinkListenerRegistry,
+				_fragmentEntryLinkService, _fragmentRendererRegistry,
+				httpServletRequest,
+				String.valueOf(objectEntry.getObjectEntryId()),
+				_infoItemServiceRegistry, _infoSearchClassMapperRegistry,
+				_objectDefinitionLocalService.getObjectDefinition(
+					objectEntry.getObjectDefinitionId()));
+
+			String layoutMode = ParamUtil.getString(
+				httpServletRequest, "p_l_mode");
+
+			if (Objects.equals(layoutMode, Constants.READ)) {
+				editURL = HttpComponentsUtil.addParameter(
+					editURL, "p_l_mode", layoutMode);
+			}
+
+			String windowState = ParamUtil.getString(
+				httpServletRequest, "p_p_state");
+
+			if (Validator.isNotNull(windowState)) {
+				editURL = HttpComponentsUtil.addParameter(
+					editURL, "p_p_state", windowState);
+			}
+
+			int version = ParamUtil.getInteger(httpServletRequest, "version");
+
+			if (version > 0) {
+				editURL = HttpComponentsUtil.addParameter(
+					editURL, "version", version);
+			}
+
+			HttpServletResponse httpServletResponse =
+				_portal.getHttpServletResponse(renderResponse);
+
+			httpServletResponse.sendRedirect(editURL);
+		}
+		catch (Exception exception) {
+			throw new PortletException(exception);
+		}
+	}
+
+	@Reference
+	private FormManager _formManager;
+
+	@Reference
+	private FragmentEntryLinkListenerRegistry
+		_fragmentEntryLinkListenerRegistry;
+
+	@Reference
+	private FragmentEntryLinkService _fragmentEntryLinkService;
+
+	@Reference
+	private FragmentRendererRegistry _fragmentRendererRegistry;
+
+	@Reference
+	private InfoItemServiceRegistry _infoItemServiceRegistry;
+
+	@Reference
+	private InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryService _objectEntryService;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/EditContentItemStrutsAction.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/EditContentItemStrutsAction.java
@@ -43,8 +43,6 @@ public class EditContentItemStrutsAction implements StrutsAction {
 			HttpServletResponse httpServletResponse)
 		throws Exception {
 
-		String redirect = ParamUtil.getString(httpServletRequest, "redirect");
-
 		ObjectEntry objectEntry = _objectEntryService.getObjectEntry(
 			ParamUtil.getLong(httpServletRequest, "objectEntryId"));
 
@@ -56,16 +54,9 @@ public class EditContentItemStrutsAction implements StrutsAction {
 			_objectDefinitionLocalService.getObjectDefinition(
 				objectEntry.getObjectDefinitionId()));
 
-		if (Validator.isNotNull(redirect)) {
-			editURL = HttpComponentsUtil.addParameter(
-				editURL, "redirect", redirect);
-		}
-
 		String layoutMode = ParamUtil.getString(httpServletRequest, "p_l_mode");
 
-		if (Validator.isNotNull(layoutMode) &&
-			Objects.equals(layoutMode, Constants.READ)) {
-
+		if (Objects.equals(layoutMode, Constants.READ)) {
 			editURL = HttpComponentsUtil.addParameter(
 				editURL, "p_l_mode", layoutMode);
 		}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
@@ -517,15 +517,6 @@ public class ActionUtil {
 			GroupConstants.CMS_FRIENDLY_URL, "/add-space-members");
 	}
 
-	public static String getBaseBulkActionTaskReportURL(
-		String className, ThemeDisplay themeDisplay) {
-
-		return StringBundler.concat(
-			themeDisplay.getPathFriendlyURLPublic(),
-			GroupConstants.CMS_FRIENDLY_URL, "/e/bulk-action-task/",
-			PortalUtil.getClassNameId(className));
-	}
-
 	public static String getBaseSpaceSettingsURL(ThemeDisplay themeDisplay) {
 		return StringBundler.concat(
 			themeDisplay.getPathFriendlyURLPublic(),
@@ -1178,7 +1169,7 @@ public class ActionUtil {
 			0, contributedRendererKey, fragmentEntry.getType(), serviceContext);
 	}
 
-	private static LayoutStructure _addInputFragmentEntryLink(
+	private static void _addInputFragmentEntryLink(
 			List<FragmentEntryLink> addedFragmentEntryLinks,
 			JSONObject configurationJSONObject, FormManager formManager,
 			String fragmentEntryKey, InfoField<?> infoField, Layout layout,
@@ -1189,7 +1180,7 @@ public class ActionUtil {
 		throws Exception {
 
 		if (infoField == null) {
-			return layoutStructure;
+			return;
 		}
 
 		FragmentStyledLayoutStructureItem fragmentStyledLayoutStructureItem =
@@ -1199,7 +1190,7 @@ public class ActionUtil {
 				serviceContext);
 
 		if (fragmentStyledLayoutStructureItem == null) {
-			return layoutStructure;
+			return;
 		}
 
 		fragmentStyledLayoutStructureItem.updateItemConfig(
@@ -1230,8 +1221,6 @@ public class ActionUtil {
 		if (fragmentEntryLink != null) {
 			addedFragmentEntryLinks.add(fragmentEntryLink);
 		}
-
-		return layoutStructure;
 	}
 
 	private static LayoutStructure _addInputFragmentEntryLinks(

--- a/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/ContentEditorToolbar.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/content_editor/components/ContentEditorToolbar.test.tsx
@@ -91,6 +91,9 @@ describe('ContentEditorToolbar', () => {
 					return result;
 				}),
 			},
+			detach: jest.fn(),
+			fire: jest.fn(),
+			on: jest.fn(),
 		};
 	});
 

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/mocks/index.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/info_panel/mocks/index.ts
@@ -4,6 +4,12 @@
  */
 
 export const CONTENT_OBJECT_ENTRY = {
+	actions: {
+		versions: {
+			href: 'http://localhost:8080/o/cms/basic-web-contents/scopes/36030/by-external-reference-code/3fd76346-c116-ff19-e398-d7508ca98962/versions',
+			method: 'GET',
+		},
+	},
 	dateCreated: '2026-02-18T17:15:35Z',
 	dateModified: '2026-02-18T17:15:51Z',
 	description: 'content: Example content, title: My Web Content',
@@ -134,6 +140,12 @@ export const CONTENT_OBJECT_ENTRY = {
 };
 
 export const DOCUMENT_OBJECT_ENTRY = {
+	actions: {
+		versions: {
+			href: 'http://localhost:8080/o/cms/basic-documents/scopes/36030/by-external-reference-code/a6d58af4-04a9-63e3-b3fc-002948d514c6/versions',
+			method: 'GET',
+		},
+	},
 	dateCreated: '2026-02-18T17:20:12Z',
 	dateModified: '2026-02-18T17:20:41Z',
 	description: 'file: orange_cat.jpeg, title: My file',

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
@@ -375,6 +375,32 @@ test(
 	}
 );
 
+test(
+	'Publishing a new or edited basic web content redirects back to the CMS contents listing',
+	{tag: '@LPD-86074'},
+	async ({contentsPage, page}) => {
+		await contentsPage.goto();
+
+		await contentsPage.createContent('Basic Web Content');
+
+		const title = getRandomString();
+
+		await page.getByLabel('Title').fill(title);
+
+		await contentsPage.saveContent();
+
+		await expect(page).toHaveURL(/\/web\/cms\/contents$/);
+
+		await contentsPage.editContent(title);
+
+		await contentsPage.saveContent();
+
+		await expect(page).toHaveURL(/\/web\/cms\/contents$/);
+
+		await contentsPage.deleteContent(title);
+	}
+);
+
 test.describe('Comments Panel', () => {
 	const addComment = async ({
 		content = 'New Comment',


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-86074

> [!NOTE]
> This is a followup to https://github.com/brianchandotcom/liferay-portal/pull/173514 and https://github.com/brianchandotcom/liferay-portal/pull/173561.
> I've moved the key to the object-api module as suggested in https://github.com/brianchandotcom/liferay-portal/pull/173561#issuecomment-4326608021.

When trying to access the edit url of an object entry through the asset framework, objects created through the cms should redirect the user to the cms, not the generic object edit url.

# How am I fixing it?

By explicitly checking for cms-ness of objects, and redirecting to the corret page.

# How can you verify that it works?

Run the included unit tests.