### PR TITLE
LPD-87141 Transition Story to In Development on start-work

### DIFF
--- a/.claude/skills/start-work/SKILL.md
+++ b/.claude/skills/start-work/SKILL.md
@@ -27,13 +27,15 @@ Fetch the ticket (issue type, current assignee, subtasks) and resolve the **targ
 
 ## 4. Start Work on the Parent
 
-Assign the parent to the user and transition it using the ID below. If the parent is already in an in-progress status by a different user, refuse to continue.
+Assign the parent to the user and apply the transitions below. If the parent is already in an in-progress status by a different user, refuse to continue.
 
-| Parent Type | Destination | Transition ID |
-| ----------- | ---------------------- | ------------- |
+| Parent Type | Destination | Transition IDs |
+| ----------- | -------------- | --------------- |
 | Bug | In Progress | `61` |
-| Story | Ready for Development | `41` |
+| Story | In Development | `41`, then `61` |
 | Task | In Progress | `21` |
+
+For a Story, apply the two transitions in sequence: `41` moves it to **Ready for Development**, which triggers Jira to autocreate the **Technical Task** subtask, then `61` moves it to **In Development**.
 
 ## 5. Start Work on the Child
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87141

**What is being fixed:** The `start-work` skill stopped at moving the parent Story to "Ready for Development" (transition `41`), leaving the Story itself in an intermediate status while the Technical Task subtask was driven all the way to "In Progress". This was inconsistent with how Bugs and Tasks are handled, where the parent ends in an active in-progress status, and meant the Story dashboard view did not reflect that work was actually under way.

**How it is being fixed:** The Story row in the parent transition table now ends at "In Development" by chaining transitions `41` (which triggers Jira to autocreate the Technical Task subtask) and `61` (which moves the Story from "Ready for Development" to "In Development"). A clarifying sentence under the table explains why the two transitions must run in sequence. Bug and Task rows are unchanged.