### PR TITLE
LPD-80665 Validate JCE Provider Order (FIPS properties)

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7496,6 +7496,47 @@
     feature.flag.LRAC-14771.system=true
 
 ##
+## FIPS
+##
+
+    #
+    # Set this to true to enable FIPS compliant mode. When enabled, the portal
+    # validates the JCE provider registration order against the configured
+    # "fips.security.providers" and runs cryptographic Known-Answer Tests at startup. Any
+    # violation aborts startup.
+    #
+    # Env: LIFERAY_FIPS_PERIOD_ENABLED
+    #
+    fips.enabled=false
+
+    #
+    # Set the allowed JCE providers for FIPS mode. Configure one entry per
+    # supported FIPS provider. The name in brackets is the FIPS provider, which
+    # must appear first in its list.
+    #
+    # BouncyCastle FIPS:
+    #    fips.security.providers[BCFIPS]=\
+    #        BCFIPS,\
+    #        BCJSSE,\
+    #        SUN,\
+    #        XMLDSig,\
+    #        SunJGSS,\
+    #        SunSASL,\
+    #        JdkSASL
+    #
+    # Amazon Corretto Crypto Provider FIPS:
+    #    fips.security.providers[AmazonCorrettoCryptoProvider]=\
+    #        AmazonCorrettoCryptoProvider,\
+    #        SUN,\
+    #        SunRsaSign,\
+    #        SunEC,\
+    #        SunJSSE,\
+    #        SunJCE,\
+    #        SunJGSS,\
+    #        SunSASL,\
+    #        JdkSASL
+
+##
 ## HTTP
 ##
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1072,6 +1072,11 @@ public interface PropsKeys {
 		FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_ORGANIZATION_STATUS =
 			"field.enable.com.liferay.portal.kernel.model.Organization.status";
 
+	public static final String FIPS_ENABLED = "fips.enabled";
+
+	public static final String FIPS_SECURITY_PROVIDERS =
+		"fips.security.providers";
+
 	public static final String FULL_PAGE_DISPLAYABLE = "full.page.displayable";
 
 	public static final String GLOBAL_SHUTDOWN_EVENTS =

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
@@ -876,6 +876,9 @@ public class PropsValues {
 					PropsKeys.
 						FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_ORGANIZATION_STATUS));
 
+	public static final boolean FIPS_ENABLED = GetterUtil.getBoolean(
+		PropsUtil.get(PropsKeys.FIPS_ENABLED));
+
 	public static final String[] GLOBAL_SHUTDOWN_EVENTS = PropsUtil.getArray(
 		PropsKeys.GLOBAL_SHUTDOWN_EVENTS);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 97.1.0
+version 97.2.0


### PR DESCRIPTION
Opening this directly since `ci:test:sf` is not properly working at the [original PR](https://github.com/liferay-appsec/liferay-portal/pull/2799).

[LPD-80665](https://liferay.atlassian.net/browse/LPD-80665)