### PR TITLE
LCD-51147 Validate deployment_name and region in setup_aws.sh

### DIFF
--- a/cloud/scripts/setup_aws.sh
+++ b/cloud/scripts/setup_aws.sh
@@ -34,14 +34,14 @@ function main {
 	then
 		if ! jq --exit-status '.variables.deployment_name' "${1}" &> /dev/null
 		then
-			echo "Configuration is missing required key: variables.deployment_name." >&2
+			echo "The configuration JSON file must contain a key named \"variables.deployment_name\"." >&2
 
 			exit 1
 		fi
 
 		if ! jq --exit-status '.variables.region' "${1}" &> /dev/null
 		then
-			echo "Configuration is missing required key: variables.region." >&2
+			echo "The configuration JSON file must contain a key named \"variables.region\"." >&2
 
 			exit 1
 		fi

--- a/cloud/scripts/setup_aws.sh
+++ b/cloud/scripts/setup_aws.sh
@@ -32,6 +32,20 @@ function main {
 
 	if jq --exit-status '.variables.tfstate_bucket_name' "${1}" &> /dev/null
 	then
+		if ! jq --exit-status '.variables.deployment_name' "${1}" &> /dev/null
+		then
+			echo "Configuration is missing required key: variables.deployment_name." >&2
+
+			exit 1
+		fi
+
+		if ! jq --exit-status '.variables.region' "${1}" &> /dev/null
+		then
+			echo "Configuration is missing required key: variables.region." >&2
+
+			exit 1
+		fi
+
 		bucket_name="$(jq --raw-output '.variables.tfstate_bucket_name' "${1}")"
 		deployment_name="$(jq --raw-output '.variables.deployment_name' "${1}")"
 		region="$(jq --raw-output '.variables.region' "${1}")"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LCD-51147

**What is being fixed:**

In cloud/scripts/setup_aws.sh, the configuration gate that provisioned the remote tfstate S3 bucket only validated the presence of variables.tfstate_bucket_name before reading variables.deployment_name and variables.region via jq --raw-output. When either of those latter two keys was absent, jq returned the literal string "null", which propagated downstream into S3 bucket creation and Terraform backend configuration. Users whose configuration was missing a required key saw confusing AWS errors deep in the apply rather than a clear validation failure at the shell layer.

**How it is being fixed:**

Add two jq --exit-status guards inside the existing tfstate_bucket_name branch, each checking that the corresponding key exists and each exiting with a specific error message to stderr naming the missing key if it does not. The inline placement and style match the file's existing validation patterns: period-terminated stderr messages, blank line before exit 1, tab indentation. No changes are made to setup_gcp.sh, which has no tfstate flow and therefore no equivalent bug.