### PR TITLE
LCD-51135 Trigger terraform CI on workflow changes

### DIFF
--- a/.github/workflows/ci-test-cloud-terraform.yaml
+++ b/.github/workflows/ci-test-cloud-terraform.yaml
@@ -37,9 +37,11 @@ jobs:
 on:
     pull_request:
         paths:
+            -   .github/workflows/ci-test-cloud-terraform.yaml
             -   cloud/terraform/**
     push:
         branches:
             -   master
         paths:
+            -   .github/workflows/ci-test-cloud-terraform.yaml
             -   cloud/terraform/**


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LCD-51135

**What is being fixed:**

The ci-test-cloud-terraform.yaml workflow's pull_request and push paths filters do not include the workflow file itself, so changes to its own steps do not re-run the action.

**How it is being fixed:**

The workflow file's own path is added to both pull_request and push paths filters, alongside the existing cloud/terraform/** entry, so step-only changes to ci-test-cloud-terraform.yaml re-trigger the action.