### PR TITLE
LCD-51128 Replace helm chart CI with per-chart matrix

### DIFF
--- a/.github/workflows/ci-test-cloud-helm-chart.yaml
+++ b/.github/workflows/ci-test-cloud-helm-chart.yaml
@@ -26,7 +26,8 @@ jobs:
 
                     helm template liferay . | kubeconform --strict --summary \
                         -schema-location default \
-                        -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+                        -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+                        -skip ClusterProviderConfig,LiferayInfrastructure
                 working-directory: ./cloud/helm/${{matrix.chart}}
         strategy:
             fail-fast: false

--- a/.github/workflows/ci-test-cloud-helm-chart.yaml
+++ b/.github/workflows/ci-test-cloud-helm-chart.yaml
@@ -8,14 +8,38 @@ jobs:
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v4
-            -   name: Create Kind cluster
-                run: kind create cluster
-            -   name: Run Helm test
+            -   name: Install Helm
+                uses: azure/setup-helm@v4
+            -   name: Set up kubeconform
+                uses: bmuschko/setup-kubeconform@v1
+                with:
+                    kubeconform-version: "0.7.0"
+            -   name: Update Helm dependencies
+                run: helm dependency update --skip-refresh
+                working-directory: ./cloud/helm/${{matrix.chart}}
+            -   name: Lint Helm chart
+                run: helm lint .
+                working-directory: ./cloud/helm/${{matrix.chart}}
+            -   name: Render and validate Helm chart
                 run: |
-                    helm upgrade -i liferay --wait .
+                    set -o pipefail
 
-                    helm test liferay
-                working-directory: ./cloud/helm
+                    helm template liferay . | kubeconform --strict --summary \
+                        -schema-location default \
+                        -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+                working-directory: ./cloud/helm/${{matrix.chart}}
+        strategy:
+            fail-fast: false
+            matrix:
+                chart:
+                    -   aws
+                    -   aws-infrastructure
+                    -   aws-infrastructure-provider
+                    -   aws-marketplace
+                    -   default
+                    -   gcp
+                    -   gcp-infrastructure
+                    -   gcp-infrastructure-provider
 on:
     pull_request:
         paths:

--- a/cloud/helm/gcp-infrastructure/templates/database-root-password.yaml
+++ b/cloud/helm/gcp-infrastructure/templates/database-root-password.yaml
@@ -7,8 +7,10 @@ metadata:
     name: {{ .Release.Name }}-db-root-password-generator
     namespace: {{ .Release.Namespace }}
 spec:
+    allowRepeat: false
     digits: 5
     length: 24
+    noUpper: false
     symbolCharacters: -_$@
     symbols: 2
 ---


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LCD-51128

**What is being fixed:**

The current ci-test-cloud-helm-chart.yaml runs `helm upgrade -i liferay --wait .` in cloud/helm, which has no Chart.yaml. The step tests nothing.

**How it is being fixed:**

Replace it with a per-chart matrix that runs `helm dependency update`, `helm lint`, then pipes `helm template` into kubeconform with strict validation. Uses `bmuschko/setup-kubeconform@v1` for the install. Skips `ClusterProviderConfig` and `LiferayInfrastructure` (kinds with no schemas in the datreeio catalog). Also adds the missing required `allowRepeat` and `noUpper` fields to the gcp-infrastructure Password resource so its leg validates clean. Verified locally with act on all 8 chart legs.