### PR TITLE
LCD-51136 Add tflint and Checkov to terraform CI

### DIFF
--- a/.github/workflows/ci-test-cloud-terraform.yaml
+++ b/.github/workflows/ci-test-cloud-terraform.yaml
@@ -12,7 +12,7 @@ jobs:
                 uses: hashicorp/setup-terraform@v3
                 with:
                     terraform_version: 1.5.7
-            -   name: Setup tflint
+            -   name: Setup TFLint
                 uses: terraform-linters/setup-tflint@v4
             -   name: Initialize Terraform
                 run: terraform init -backend=false -input=false
@@ -20,7 +20,7 @@ jobs:
             -   name: Validate Terraform
                 run: terraform validate
                 working-directory: ./cloud/terraform/${{matrix.stack}}
-            -   name: Run tflint
+            -   name: Run TFLint
                 run: |
                     tflint --init
                     tflint

--- a/.github/workflows/ci-test-cloud-terraform.yaml
+++ b/.github/workflows/ci-test-cloud-terraform.yaml
@@ -3,7 +3,7 @@ defaults:
         shell: bash
 jobs:
     test-cloud-terraform:
-        if: ${{github.repository == 'cloudnative-team/liferay-portal'}}
+        if: ${{(github.event_name == 'pull_request' && github.repository == 'cloudnative-team/liferay-portal') || (github.event_name == 'push' && github.repository == 'liferay/liferay-portal')}}
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout code

--- a/.github/workflows/ci-test-cloud-terraform.yaml
+++ b/.github/workflows/ci-test-cloud-terraform.yaml
@@ -12,12 +12,25 @@ jobs:
                 uses: hashicorp/setup-terraform@v3
                 with:
                     terraform_version: 1.5.7
+            -   name: Setup tflint
+                uses: terraform-linters/setup-tflint@v4
             -   name: Initialize Terraform
                 run: terraform init -backend=false -input=false
                 working-directory: ./cloud/terraform/${{matrix.stack}}
             -   name: Validate Terraform
                 run: terraform validate
                 working-directory: ./cloud/terraform/${{matrix.stack}}
+            -   name: Run tflint
+                run: |
+                    tflint --init
+                    tflint
+                working-directory: ./cloud/terraform/${{matrix.stack}}
+            -   name: Run Checkov
+                uses: bridgecrewio/checkov-action@v12
+                with:
+                    directory: ./cloud/terraform/${{matrix.stack}}
+                    framework: terraform
+                    soft_fail: true
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/ci-test-cloud-terraform.yaml
+++ b/.github/workflows/ci-test-cloud-terraform.yaml
@@ -8,11 +8,11 @@ jobs:
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v4
-            -   name: Setup Terraform
+            -   name: Set up Terraform
                 uses: hashicorp/setup-terraform@v3
                 with:
                     terraform_version: 1.5.7
-            -   name: Setup TFLint
+            -   name: Set up TFLint
                 uses: terraform-linters/setup-tflint@v4
             -   name: Initialize Terraform
                 run: terraform init -backend=false -input=false

--- a/cloud/terraform/aws/ecr/providers.tf
+++ b/cloud/terraform/aws/ecr/providers.tf
@@ -14,4 +14,5 @@ terraform {
 			version="~> 6.14.1"
 		}
 	}
+	required_version=">=1.5.0"
 }

--- a/cloud/terraform/aws/grafana/providers.tf
+++ b/cloud/terraform/aws/grafana/providers.tf
@@ -10,4 +10,5 @@ terraform {
 			version="~> 3.15.2"
 		}
 	}
+	required_version=">=1.5.0"
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LCD-51136

**What is being fixed:**

The ci-test-cloud-terraform.yaml workflow runs terraform validate across the 12 leaf stacks under cloud/terraform/ but does not check for terraform linting issues or static security misconfigurations. The workflow's repository gate also fires only on cloudnative-team/liferay-portal, so push-to-master events on liferay/liferay-portal are skipped.

**How it is being fixed:**

Three steps are added: Set up TFLint pulls terraform-linters/setup-tflint@v4 before terraform init, Run TFLint invokes tflint --init && tflint per stack so that stack-local .tflint.hcl files auto-discover plugins, and Run Checkov invokes bridgecrewio/checkov-action@v12 against the stack directory with framework: terraform. The job-level if: gate is refined to be event-aware: pull_request events check cloudnative-team/liferay-portal and push events check liferay/liferay-portal. To keep tflint's terraform_required_version rule quiet on every stack, required_version=">=1.5.0" is also added to cloud/terraform/aws/ecr/providers.tf and cloud/terraform/aws/grafana/providers.tf; every other aws and gcp stack already sets this. Checkov runs with soft_fail: true so the initial merge is not blocked by legitimate pre-existing security findings; LCD-51167 tracks triaging those findings and re-enabling hard failures. LCD-51166 covers adding cloud/terraform/aws/.tflint.hcl to extend tflint coverage across AWS stacks, and LCD-51168 covers bumping the workflow's terraform_version pin to unblock the aws/eks matrix leg.