### PR TITLE
LPD-87558 Auto commit when adding an sf rule

### DIFF
--- a/.claude/skills/format-source-add-rule/SKILL.md
+++ b/.claude/skills/format-source-add-rule/SKILL.md
@@ -57,3 +57,11 @@ For rules with nuance, use several diff blocks for each additional case. Add a s
 ### Self-Test the Rule
 
 Validate that the appended rule reproduces the input commit when applied to the commit's parent state. To do this, create a new branch at the commit's parent and run `/format-source` scoped to only the files touched by the commit, applying only the manual rules (skip the automatic formatter). Compare the result with the commit. If the rule does not produce an equivalent change, revise the rule and repeat until it does.
+
+### Commit the Rule
+
+After the self-test passes, stage only `.claude/skills/format-source/SKILL.md` and invoke the `commit` skill with this commit message format:
+
+```
+<ticket> Add rule derived from <sha>
+```

--- a/.claude/skills/format-source/SKILL.md
+++ b/.claude/skills/format-source/SKILL.md
@@ -397,3 +397,27 @@ It applies to workflow and other YAML scripted output.
 -                        echo "No entries found for ${id}."
 +                        echo "No entries were found for ${id}."
 ```
+
+### Rule 19: Use "Delete" for Helpers That Delete Entities
+
+**Why:** Liferay's persistence APIs spell entity destruction as `delete*` (`deleteUser`, `deleteEntry`); naming a private helper `_delete*` when its body calls a `delete*` service keeps the helper's verb aligned with the operation it performs.
+
+**Examples:**
+
+```diff
+-private void _removeStaleFoos(Map<Long, List<String>> deletedIdsMap)
++private void _deleteStaleFoos(Map<Long, List<String>> deletedIdsMap)
+ 		throws Exception {
+
+ 	...
+
+ 	_fooLocalService.deleteFoo(foo);
+ }
+```
+
+Update the call sites at the same time.
+
+```diff
+-_removeStaleFoos(deletedIdsMap);
++_deleteStaleFoos(deletedIdsMap);
+```

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -41,7 +41,7 @@ The ticket key follows the pattern `LPD-12345`, `LCD-12345`, `LRCI-1234`, and si
 
 ### Target Repository
 
-The target repository defaults to `<fork-owner>/liferay-portal`. When `${ARGUMENTS}` names a different `org/repo`, use that; otherwise, ask the user to choose `<fork-owner>` from one of the team forks:
+The target repository defaults to `<fork-owner>/liferay-portal`. When `${ARGUMENTS}` names a different `org/repo`, use that; when it matches an alias below, expand the alias; otherwise, ask the user to choose `<fork-owner>` from one of the team forks:
 
 - `liferay-ac`
 - `liferay-appsec`
@@ -57,6 +57,10 @@ The target repository defaults to `<fork-owner>/liferay-portal`. When `${ARGUMEN
 - `liferay-platform-experience`
 - `liferay-search`
 - `liferay-site-management`
+
+The following short aliases resolve to a target repository:
+
+- `brian` → `brianchandotcom/liferay-portal`
 
 The pull request head is `<github-username>:<branch-name>` (the GitHub username is read from the user's `origin` remote URL — e.g., `git@github.com:brianchandotcom/liferay-portal.git` yields `brianchandotcom`), and the base is `master`.
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87558

## What is being fixed

This PR makes the format-source-add-rule skill auto-commit the rule
once the self-test passes, adds one more rule to the format-source
skill (derived from one of brian's commits), and adds a `brian` alias
to the pr skill that resolves to `brianchandotcom/liferay-portal`.

## Why are there no tests?

All changes are markdown updates to skill instructions; there is no
executable code to test.