### PR TITLE
LPD-88020 Streamline worktree and start-work integration

### DIFF
--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -1,21 +1,35 @@
 #!/usr/bin/env bash
-set -euo pipefail
 
-input=$(cat)
-name=$(jq --raw-output '.name' <<< "${input}")
-cwd=$(jq --raw-output '.cwd' <<< "${input}")
+set -o errexit
+set -o nounset
+set -o pipefail
 
-if [[ "${name}" == "null" || "${cwd}" == "null" ]]; then
-	echo "WorktreeCreate hook: missing name or cwd in input: ${input}" >&2
+function _die {
+	echo "WorktreeCreate hook: ${*}" >&2
+
 	exit 1
-fi
+}
 
-target_path="$(dirname "${cwd}")/liferay-portal-${name}"
+function main {
+	local cwd
+	local input
+	local name
+	local target_path
 
-if git -C "${cwd}" show-ref --quiet --verify "refs/heads/${name}"; then
-	git -C "${cwd}" worktree add "${target_path}" "${name}" >&2
-else
-	git -C "${cwd}" worktree add -b "${name}" "${target_path}" HEAD >&2
-fi
+	input="$(cat)"
 
-echo "${target_path}"
+	name="$(jq --exit-status --raw-output '.name' <<< "${input}")" || _die "missing name in input: ${input}"
+	cwd="$(jq --exit-status --raw-output '.cwd' <<< "${input}")" || _die "missing cwd in input: ${input}"
+
+	target_path="$(dirname "${cwd}")/liferay-portal-${name}"
+
+	if git -C "${cwd}" show-ref --quiet --verify "refs/heads/${name}"; then
+		git -C "${cwd}" worktree add "${target_path}" "${name}" >&2
+	else
+		git -C "${cwd}" worktree add -b "${name}" "${target_path}" HEAD >&2
+	fi
+
+	echo "${target_path}"
+}
+
+main "$@"

--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+input=$(cat)
+name=$(jq --raw-output '.name' <<< "${input}")
+cwd=$(jq --raw-output '.cwd' <<< "${input}")
+
+if [[ "${name}" == "null" || "${cwd}" == "null" ]]; then
+	echo "WorktreeCreate hook: missing name or cwd in input: ${input}" >&2
+	exit 1
+fi
+
+target_path="$(dirname "${cwd}")/liferay-portal-${name}"
+
+if git -C "${cwd}" show-ref --quiet --verify "refs/heads/${name}"; then
+	git -C "${cwd}" worktree add "${target_path}" "${name}" >&2
+else
+	git -C "${cwd}" worktree add -b "${name}" "${target_path}" HEAD >&2
+fi
+
+echo "${target_path}"

--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -21,7 +21,7 @@ function main {
 	name="$(jq --exit-status --raw-output '.name' <<< "${input}")" || _die "missing name in input: ${input}"
 	cwd="$(jq --exit-status --raw-output '.cwd' <<< "${input}")" || _die "missing cwd in input: ${input}"
 
-	target_path="$(dirname "${cwd}")/liferay-portal-${name}"
+	target_path="$(git -C "${cwd}" rev-parse --show-toplevel)/../liferay-portal-${name}"
 
 	if git -C "${cwd}" show-ref --quiet --verify "refs/heads/${name}"; then
 		git -C "${cwd}" worktree add "${target_path}" "${name}" >&2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,16 @@
 					}
 				]
 			}
+		],
+		"WorktreeRemove": [
+			{
+				"hooks": [
+					{
+						"command": "git worktree remove \"$(jq --raw-output '.worktree_path')\"",
+						"type": "command"
+					}
+				]
+			}
 		]
 	}
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,5 +2,17 @@
 	"attribution": {
 		"commit": "",
 		"pr": ""
+	},
+	"hooks": {
+		"WorktreeCreate": [
+			{
+				"hooks": [
+					{
+						"command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/worktree-create.sh",
+						"type": "command"
+					}
+				]
+			}
+		]
 	}
 }

--- a/.claude/skills/format-source/SKILL.md
+++ b/.claude/skills/format-source/SKILL.md
@@ -21,6 +21,8 @@ Run across the entire codebase:
 cd <repo-root>/portal-impl && ant format-source-current-branch
 ```
 
+`ant format-source-current-branch` only inspects committed files, so run it after creating the commit and amend any formatter changes or fixes into that commit.
+
 In both cases, if there are issues to be fixed, the formatter will list them. Fix them.
 
 In addition to the automatic formatter, there is a set of manual rules that the formatter does not catch. The full workflow is to run the formatter, apply the manual rules, then rerun the formatter to clean up any fallout from the manual edits.

--- a/.claude/skills/format-source/SKILL.md
+++ b/.claude/skills/format-source/SKILL.md
@@ -7,7 +7,7 @@ name: format-source
 
 # Format Source
 
-All the code is strictly formatted using the source formatter. This is how it works:
+All the code is strictly formatted using the source formatter (Java, JavaScript, JSON, JSP, Markdown, properties, shell, XML, YAML, and others). This is how it works:
 
 Run for a specific module:
 

--- a/.claude/skills/start-work/SKILL.md
+++ b/.claude/skills/start-work/SKILL.md
@@ -47,7 +47,7 @@ Skip for **Bug**. For **Story** / **Task**, refetch the parent's subtasks until 
 
 ## 6. Create a Git Branch
 
-Branch off the current HEAD, named after the **target** key. When the branch already exists, check it out instead.
+Branch off the current HEAD, named after the **target** key. When the branch already exists, check it out instead. When `${PWD}` matches `*/liferay-portal-<name>`, the session is running inside a Liferay worktree that already has branch `<name>` checked out — skip this step and invoke the `worktree-setup` skill (action `new`) instead to provision the bundle, ports, and database.
 
 ## 7. Make a Plan
 

--- a/.claude/skills/start-work/SKILL.md
+++ b/.claude/skills/start-work/SKILL.md
@@ -12,7 +12,7 @@ Prepare a Liferay ticket for development. Drive every Jira interaction through t
 
 ## 1. Resolve the Ticket
 
-Accept a key (`LPD-86295`) or a browse URL from `${ARGUMENTS}`. Ask the user when nothing is supplied.
+Accept a key (`LPD-86295`) or a browse URL from `${ARGUMENTS}`. When nothing is supplied and `${PWD}` matches `*/liferay-portal-<KEY>` where `<KEY>` matches the Jira pattern `[A-Z]+-[0-9]+`, derive the key from the directory name. Otherwise ask the user.
 
 ## 2. Prerequisites
 

--- a/.claude/skills/worktree-setup/SKILL.md
+++ b/.claude/skills/worktree-setup/SKILL.md
@@ -82,7 +82,7 @@ app.server.parent.dir=${project.dir}/bundle
 Check whether a bundle already exists by looking for a `tomcat-*` directory inside the resolved bundle parent directory (see step 4a).
 
 - **Bundle exists:** Skip `ant all`. Inform the user the existing bundle will be reused. If the user explicitly requests a rebuild, run `ant all`.
-- **No bundle:** Run `ant all`:
+- **No bundle:** Before running `ant all`, try to reuse the main worktree's bundle. Locate the `liferay-portal` worktree (no suffix) via `git worktree list --porcelain`, resolve its bundle directory using the same logic as step 4a, and read `.githash` from it. When that hash equals `git rev-parse HEAD` in the current worktree, or when the user explicitly asks to copy or reuse the main bundle, reuse it into `<WORKTREE_DIR>/bundle` and skip `ant all`. Always reuse by making a full copy — never by symlinking or sharing the folder. Otherwise run it:
 
 ```bash
 cd <WORKTREE_DIR> && ant all

--- a/.claude/skills/worktree-setup/SKILL.md
+++ b/.claude/skills/worktree-setup/SKILL.md
@@ -248,6 +248,8 @@ Print a table of all assigned ports, the DB name, the Liferay URL, and the Glowr
 
 ### 5. Start
 
+Start Tomcat in the background so the call does not block:
+
 ```bash
 <BUNDLE>/tomcat-*/bin/catalina.sh start
 ```

--- a/.claude/skills/worktree-setup/SKILL.md
+++ b/.claude/skills/worktree-setup/SKILL.md
@@ -55,7 +55,11 @@ Rule: strip `liferay-portal-` prefix, lowercase, replace nonalphanumeric with `_
 
 ## Full Setup
 
-### 1. Create the Worktree
+### 1. Locate or Create the Worktree
+
+If the current working directory matches `*/liferay-portal-<name>`, the worktree already exists (either created by `claude --worktree <name>` through the **WorktreeCreate** hook, or by a previous manual run). Use the current cwd as `<WORKTREE_DIR>` and the directory name as `<DIR_NAME>`, then continue.
+
+Otherwise, create one off `master`:
 
 ```bash
 git worktree add -b <BRANCH> ../<DIR_NAME> master

--- a/.claude/skills/worktree-setup/SKILL.md
+++ b/.claude/skills/worktree-setup/SKILL.md
@@ -86,7 +86,7 @@ Check whether a bundle already exists by looking for a `tomcat-*` directory insi
 - **No bundle:** Before running `ant all`, try to reuse the main worktree's bundle. Locate the `liferay-portal` worktree (no suffix) via `git worktree list --porcelain`, resolve its bundle directory using the same logic as step 4a, and read `.githash` from it. When that hash equals `git rev-parse HEAD` in the current worktree, or when the user explicitly asks to copy or reuse the main bundle, reuse it into `<WORKTREE_DIR>/bundle` and skip `ant all`. Always reuse by making a full copy — never by symlinking or sharing the folder. Otherwise run it:
 
 ```bash
-cd <WORKTREE_DIR> && ant all
+cd <WORKTREE_DIR> && ant setup-profile-dxp && ant all
 ```
 
 If `ant all` fails, stop and surface the full error to the user — do not continue to port configuration.

--- a/.claude/skills/worktree-setup/SKILL.md
+++ b/.claude/skills/worktree-setup/SKILL.md
@@ -32,6 +32,7 @@ Parse `${ARGUMENTS}` and conversation context:
 | Tomcat Shutdown | 8005 | `tomcat-*/conf/server.xml` |
 | Tomcat AJP | 8009 | `tomcat-*/conf/server.xml` |
 | HTTPS Redirect | 8443 | `tomcat-*/conf/server.xml` |
+| JPDA Debug | 8000 | `tomcat-*/bin/setenv.sh` |
 | OSGi Console | 11311 | `tomcat-*/webapps/ROOT/WEB-INF/classes/portal-developer.properties` |
 | ES Sidecar HTTP | 9201 | `osgi/configs/...ElasticsearchConfiguration.config` |
 | ES Transport | 9301 | `osgi/configs/...ElasticsearchConfiguration.config` |
@@ -108,7 +109,7 @@ If `ant all` fails, stop and surface the full error to the user — do not conti
 
 1. If `.worktree-port-offset` exists in the bundle dir, read it
 
-1. Otherwise, scan ports starting from offset=1: for each candidate offset, check if ports `8080+N`, `8005+N`, `11311+N`, `9201+N`, `9301+N`, `4000+N` are all free using `nc -z localhost <port>`. First offset where ALL are free wins.
+1. Otherwise, scan ports starting from offset=1: for each candidate offset, check if ports `8080+N`, `8005+N`, `8000+N`, `11311+N`, `9201+N`, `9301+N`, `4000+N` are all free using `nc -z localhost <port>`. First offset where ALL are free wins.
 
 1. Save the chosen offset to `<BUNDLE_DIR>/.worktree-port-offset`
 
@@ -143,7 +144,19 @@ Use `"${SED_INPLACE[@]}"` in place of `sed -i` for all subsequent calls:
 
 Skip if target HTTP port is already present (idempotent).
 
-#### 4d. Patch portal-developer.properties
+#### 4d. Patch setenv.sh
+
+File: `<TOMCAT>/bin/setenv.sh`
+
+Replace the JPDA debug port (this file gets **wiped on rebuild**):
+
+```bash
+"${SED_INPLACE[@]}" 's/^JPDA_ADDRESS="[0-9]*"/JPDA_ADDRESS="<8000+N>"/' <TOMCAT>/bin/setenv.sh
+```
+
+Skip if the target value is already present.
+
+#### 4e. Patch portal-developer.properties
 
 File: `<TOMCAT>/webapps/ROOT/WEB-INF/classes/portal-developer.properties`
 
@@ -155,7 +168,7 @@ module.framework.properties.osgi.console=<11311+N>
 
 Use `"${SED_INPLACE[@]}" 's/osgi\.console=[0-9]*/osgi.console=<TARGET>/'` to handle any current value.
 
-#### 4e. Create OSGi Config Files
+#### 4f. Create OSGi Config Files
 
 These get **wiped on rebuild** — always overwrite.
 
@@ -185,7 +198,7 @@ port="<32763+N>"
 port="<42763+N>"
 ```
 
-#### 4f. Patch glowroot/admin.json
+#### 4g. Patch glowroot/admin.json
 
 File: `<BUNDLE>/glowroot/admin.json`
 
@@ -195,7 +208,7 @@ Use `jq` to set `.web.port` to `4000+N`. Skip if already correct (survives rebui
 jq '.web.port = <TARGET>' admin.json > admin.json.tmp && mv admin.json.tmp admin.json
 ```
 
-#### 4g. Patch portal-ext.properties
+#### 4h. Patch portal-ext.properties
 
 File: `<BUNDLE>/portal-ext.properties`
 
@@ -213,7 +226,7 @@ users.reminder.queries.enabled=false
 
 **Important:** The property is `portal.instance.inet.socket.address` (with `inet`), NOT `portal.instance.http.socket.address`. Also remove any old `portal.instance.http.socket.address` lines.
 
-#### 4h. Configure MySQL Database
+#### 4i. Configure MySQL Database
 
 Derive the DB name from the worktree directory (see Database Naming above).
 
@@ -236,22 +249,22 @@ mysql --execute 'CREATE DATABASE IF NOT EXISTS <DB_NAME> CHARACTER SET utf8mb4 C
 
 If `mysql` CLI is unavailable or fails, print the command for the user to run manually. Show errors — never swallow them with `2>/dev/null`.
 
-#### 4i. Clear OSGi State
+#### 4j. Clear OSGi State
 
 ```bash
 rm -rf <BUNDLE>/osgi/state
 ```
 
-#### 4j. Print Summary
+#### 4k. Print Summary
 
 Print a table of all assigned ports, the DB name, the Liferay URL, and the Glowroot URL.
 
 ### 5. Start
 
-Start Tomcat in the background so the call does not block:
+Start Tomcat with the JPDA debugger attached. `jpda run` is a foreground command, so run it in the background so the call does not block:
 
 ```bash
-<BUNDLE>/tomcat-*/bin/catalina.sh start
+<BUNDLE>/tomcat-*/bin/catalina.sh jpda run
 ```
 
 Tell the user how to follow the log:
@@ -269,6 +282,7 @@ After `ant all` rebuilds, rerun the Configure Ports steps. The saved offset is r
 | server.xml | Yes | Skip if already patched |
 | glowroot/admin.json | Yes | Skip if already patched |
 | portal-ext.properties | Yes | Skip if already correct |
+| setenv.sh | **No** | Always reapply |
 | portal-developer.properties | **No** | Always reapply |
 | osgi/configs/* | **No** | Always overwrite |
 

--- a/.claude/skills/worktree-setup/SKILL.md
+++ b/.claude/skills/worktree-setup/SKILL.md
@@ -249,13 +249,7 @@ mysql --execute 'CREATE DATABASE IF NOT EXISTS <DB_NAME> CHARACTER SET utf8mb4 C
 
 If `mysql` CLI is unavailable or fails, print the command for the user to run manually. Show errors — never swallow them with `2>/dev/null`.
 
-#### 4j. Clear OSGi State
-
-```bash
-rm -rf <BUNDLE>/osgi/state
-```
-
-#### 4k. Print Summary
+#### 4j. Print Summary
 
 Print a table of all assigned ports, the DB name, the Liferay URL, and the Glowroot URL.
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88020

This uses Claude Code's [worktree feature](https://code.claude.com/docs/en/common-workflows#run-parallel-claude-code-sessions-with-git-worktrees) to spin up a fully provisioned Liferay worktree with a single command.

Usage:

```bash
claude --worktree LPD-1234 "start work"
```

Expected output:

- Sibling worktree at `../liferay-portal-LPD-1234` checked out on branch `LPD-1234`.
- LPD-1234 transitioned to In Progress on Jira.
- Bundle reused from the main worktree when its `.githash` matches `HEAD`, otherwise built with `ant setup-profile-dxp && ant all`.
- Free port offset picked and bundle configured (`server.xml`, OSGi configs, `portal-ext.properties`, glowroot).
- MySQL database `lportal_lpd_1234` created.
- Tomcat started in the background with the JPDA debugger attached on offset+8000.