### PR TITLE
LPD-79678 Defer Liferay.ThemeDisplay.getTimeZone() calls to runtime i…

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/ReviewDateRenderer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/ReviewDateRenderer.tsx
@@ -5,29 +5,41 @@
 
 import React, {useMemo} from 'react';
 
-const DATE_OPTIONS: Intl.DateTimeFormatOptions = {
-	day: 'numeric',
-	month: 'short',
-	timeZone: Liferay.ThemeDisplay.getTimeZone(),
-	year: 'numeric',
-};
+function getDateOptions(): Intl.DateTimeFormatOptions {
+	return {
+		day: 'numeric',
+		month: 'short',
+		timeZone: Liferay.ThemeDisplay.getTimeZone(),
+		year: 'numeric',
+	};
+}
 
-const CALENDAR_DAY_OPTIONS: Intl.DateTimeFormatOptions = {
-	day: '2-digit',
-	month: '2-digit',
-	timeZone: Liferay.ThemeDisplay.getTimeZone(),
-	year: 'numeric',
-};
+function getCalendarDayOptions(): Intl.DateTimeFormatOptions {
+	return {
+		day: '2-digit',
+		month: '2-digit',
+		timeZone: Liferay.ThemeDisplay.getTimeZone(),
+		year: 'numeric',
+	};
+}
 
-const CALENDAR_DAY_FORMATTER = new Intl.DateTimeFormat(
-	'en-US',
-	CALENDAR_DAY_OPTIONS
-);
+let _calendarDayFormatter: Intl.DateTimeFormat | null = null;
+
+function getCalendarDayFormatter(): Intl.DateTimeFormat {
+	if (!_calendarDayFormatter) {
+		_calendarDayFormatter = new Intl.DateTimeFormat(
+			'en-US',
+			getCalendarDayOptions()
+		);
+	}
+
+	return _calendarDayFormatter;
+}
 
 function getCalendarDayKey(date: Date): number {
 	const parts: Record<string, string> = {};
 
-	for (const part of CALENDAR_DAY_FORMATTER.formatToParts(date)) {
+	for (const part of getCalendarDayFormatter().formatToParts(date)) {
 		parts[part.type] = part.value;
 	}
 
@@ -50,7 +62,7 @@ const ReviewDateRenderer = ({
 	const locale = Liferay.ThemeDisplay.getBCP47LanguageId();
 
 	const formatter = useMemo(
-		() => new Intl.DateTimeFormat(locale, DATE_OPTIONS),
+		() => new Intl.DateTimeFormat(locale, getDateOptions()),
 		[locale]
 	);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-79678

Defers Liferay.ThemeDisplay.getTimeZone() calls in ReviewDateRenderer.tsx from module-load time to runtime, fixing a downstream Jest failure where site-dsr-site-initializer/ActivityLog.spec.tsx (transitively imports the renderer) crashed with TypeError: Liferay.ThemeDisplay.getTimeZone is not a function because Jest doesn't stub Liferay.ThemeDisplay. This fixes the stable failure mentioned here https://liferay.slack.com/archives/CLCD3DQLF/p1777991309104269