### PR TITLE
Revert LPD-88242

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -138,7 +138,7 @@
 		name="xmltask"
 	/>
 
-	<condition property="build.profile" value="dxp">
+	<condition property="build.profile" value="portal">
 		<not>
 			<isset property="build.profile" />
 		</not>

--- a/build.properties
+++ b/build.properties
@@ -348,7 +348,7 @@
     build.patcher.replace.release.info.tokens=false
     build.performance.logger.enabled=false
     build.portal.license.enterprise.app.module.version=1.0.18
-    build.profile=dxp
+    build.profile=portal
     build.repository.local.dir=${project.dir}/.m2
     build.repository.private.password=
     build.repository.private.url=

--- a/portal-impl/build.xml
+++ b/portal-impl/build.xml
@@ -178,7 +178,7 @@
 		<delete dir="${project.dir}/tmp/license-reports" quiet="true" />
 
 		<gradle-execute dir="${project.dir}/modules" task="generateLicenseReport">
-			<arg value="-Dbuild.profile=dxp" />
+			<arg value="-Dbuild.profile=portal" />
 			<arg value="-Dlicense.report.enabled=true" />
 			<arg value="-Dlicense.report.output.dir=${project.dir}/tmp/license-reports" />
 			<arg value="-Dlicense.report.override.properties.file=${project.dir}/lib/license-override.properties" />


### PR DESCRIPTION
Reverting this change as it ultimately leaves the `liferay-portal` in a broken state when it comes to the build (i.e. breaks `ant all` in certain cases). Will need to work with Release and CI teams to make this work with minimal breakage.

cc: @tinatian, @vicnate5 