### PR TITLE
LPD-86359 Headless API Error for Custom Object Relationship when using a custom context

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/RelatedObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/RelatedObjectEntryResourceImpl.java
@@ -284,12 +284,12 @@ public class RelatedObjectEntryResourceImpl
 
 		String path = uri.getPath();
 
-		String oPath = Portal.PATH_MODULE + "/";
+		String modulePath = Portal.PATH_MODULE + "/";
 
-		int beginIndex = path.indexOf(oPath) + oPath.length();
+		int index = path.indexOf(modulePath) + modulePath.length();
 
 		String applicationPath = path.substring(
-			beginIndex, path.indexOf("/", beginIndex));
+			index, path.indexOf("/", index));
 
 		String restContextPath = applicationPath + "/v1.0/" + previousPath;
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/RelatedObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/RelatedObjectEntryResourceImpl.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.service.PersistedModelLocalServiceRegistryUtil;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
@@ -283,7 +284,14 @@ public class RelatedObjectEntryResourceImpl
 
 		String path = uri.getPath();
 
-		String restContextPath = path.split("/")[2] + "/v1.0/" + previousPath;
+		String oPath = Portal.PATH_MODULE + "/";
+
+		int beginIndex = path.indexOf(oPath) + oPath.length();
+
+		String applicationPath = path.substring(
+			beginIndex, path.indexOf("/", beginIndex));
+
+		String restContextPath = applicationPath + "/v1.0/" + previousPath;
 
 		for (ObjectDefinition systemObjectDefinition :
 				_objectDefinitionLocalService.

--- a/modules/apps/object/object-rest-impl/src/test/java/com/liferay/object/rest/internal/resource/v1_0/RelatedObjectEntryResourceImplTest.java
+++ b/modules/apps/object/object-rest-impl/src/test/java/com/liferay/object/rest/internal/resource/v1_0/RelatedObjectEntryResourceImplTest.java
@@ -1,0 +1,149 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.rest.internal.resource.v1_0;
+
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.system.JaxRsApplicationDescriptor;
+import com.liferay.object.system.SystemObjectDefinitionManager;
+import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.net.URI;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Gábor Komáromi
+ */
+public class RelatedObjectEntryResourceImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		ReflectionTestUtil.setFieldValue(
+			_relatedObjectEntryResourceImpl, "_objectDefinitionLocalService",
+			_objectDefinitionLocalService);
+		ReflectionTestUtil.setFieldValue(
+			_relatedObjectEntryResourceImpl,
+			"_systemObjectDefinitionManagerRegistry",
+			_systemObjectDefinitionManagerRegistry);
+		ReflectionTestUtil.setFieldValue(
+			_relatedObjectEntryResourceImpl, "_uriInfo", _uriInfo);
+	}
+
+	@Test
+	public void testGetSystemObjectDefinitionManagerWithCustomContextPath()
+		throws Exception {
+
+		SystemObjectDefinitionManager systemObjectDefinitionManager =
+			_mockSystemObjectDefinitionManager(
+				"/myportal/o/headless-admin-user/");
+
+		Object result = ReflectionTestUtil.invoke(
+			_relatedObjectEntryResourceImpl,
+			"_getSystemObjectDefinitionManager",
+			new Class<?>[] {long.class, String.class}, _companyId,
+			"user-accounts");
+
+		Assert.assertSame(systemObjectDefinitionManager, result);
+	}
+
+	@Test
+	public void testGetSystemObjectDefinitionManagerWithRootContextPath()
+		throws Exception {
+
+		SystemObjectDefinitionManager systemObjectDefinitionManager =
+			_mockSystemObjectDefinitionManager("/o/headless-admin-user/");
+
+		Object result = ReflectionTestUtil.invoke(
+			_relatedObjectEntryResourceImpl,
+			"_getSystemObjectDefinitionManager",
+			new Class<?>[] {long.class, String.class}, _companyId,
+			"user-accounts");
+
+		Assert.assertSame(systemObjectDefinitionManager, result);
+	}
+
+	private SystemObjectDefinitionManager _mockSystemObjectDefinitionManager(
+			String basePath)
+		throws Exception {
+
+		JaxRsApplicationDescriptor jaxRsApplicationDescriptor = Mockito.mock(
+			JaxRsApplicationDescriptor.class);
+		ObjectDefinition objectDefinition = Mockito.mock(ObjectDefinition.class);
+		SystemObjectDefinitionManager systemObjectDefinitionManager = Mockito.mock(
+			SystemObjectDefinitionManager.class);
+
+		Mockito.when(
+			_uriInfo.getBaseUri()
+		).thenReturn(
+			URI.create("http://localhost:8080" + basePath)
+		);
+
+		Mockito.when(
+			_objectDefinitionLocalService.
+				getUnmodifiableSystemObjectDefinitions(_companyId)
+		).thenReturn(
+			Collections.singletonList(objectDefinition)
+		);
+
+		Mockito.when(
+			objectDefinition.getName()
+		).thenReturn(
+			"User"
+		);
+
+		Mockito.when(
+			_systemObjectDefinitionManagerRegistry.
+				getSystemObjectDefinitionManager("User")
+		).thenReturn(
+			systemObjectDefinitionManager
+		);
+
+		Mockito.when(
+			systemObjectDefinitionManager.getJaxRsApplicationDescriptor()
+		).thenReturn(
+			jaxRsApplicationDescriptor
+		);
+
+		Mockito.when(
+			jaxRsApplicationDescriptor.getRESTContextPath()
+		).thenReturn(
+			"headless-admin-user/v1.0/user-accounts"
+		);
+
+		return systemObjectDefinitionManager;
+	}
+
+	private static final long _companyId = RandomTestUtil.randomLong();
+
+	private final ObjectDefinitionLocalService _objectDefinitionLocalService =
+		Mockito.mock(ObjectDefinitionLocalService.class);
+	private final RelatedObjectEntryResourceImpl
+		_relatedObjectEntryResourceImpl = new RelatedObjectEntryResourceImpl();
+	private final SystemObjectDefinitionManagerRegistry
+		_systemObjectDefinitionManagerRegistry = Mockito.mock(
+			SystemObjectDefinitionManagerRegistry.class);
+	private final UriInfo _uriInfo = Mockito.mock(UriInfo.class);
+
+}

--- a/modules/apps/object/object-rest-impl/src/test/java/com/liferay/object/rest/internal/resource/v1_0/RelatedObjectEntryResourceImplTest.java
+++ b/modules/apps/object/object-rest-impl/src/test/java/com/liferay/object/rest/internal/resource/v1_0/RelatedObjectEntryResourceImplTest.java
@@ -62,7 +62,7 @@ public class RelatedObjectEntryResourceImplTest {
 		Object result = ReflectionTestUtil.invoke(
 			_relatedObjectEntryResourceImpl,
 			"_getSystemObjectDefinitionManager",
-			new Class<?>[] {long.class, String.class}, _companyId,
+			new Class<?>[] {long.class, String.class}, _COMPANY_ID,
 			"user-accounts");
 
 		Assert.assertSame(systemObjectDefinitionManager, result);
@@ -78,7 +78,7 @@ public class RelatedObjectEntryResourceImplTest {
 		Object result = ReflectionTestUtil.invoke(
 			_relatedObjectEntryResourceImpl,
 			"_getSystemObjectDefinitionManager",
-			new Class<?>[] {long.class, String.class}, _companyId,
+			new Class<?>[] {long.class, String.class}, _COMPANY_ID,
 			"user-accounts");
 
 		Assert.assertSame(systemObjectDefinitionManager, result);
@@ -90,9 +90,10 @@ public class RelatedObjectEntryResourceImplTest {
 
 		JaxRsApplicationDescriptor jaxRsApplicationDescriptor = Mockito.mock(
 			JaxRsApplicationDescriptor.class);
-		ObjectDefinition objectDefinition = Mockito.mock(ObjectDefinition.class);
-		SystemObjectDefinitionManager systemObjectDefinitionManager = Mockito.mock(
-			SystemObjectDefinitionManager.class);
+		ObjectDefinition objectDefinition = Mockito.mock(
+			ObjectDefinition.class);
+		SystemObjectDefinitionManager systemObjectDefinitionManager =
+			Mockito.mock(SystemObjectDefinitionManager.class);
 
 		Mockito.when(
 			_uriInfo.getBaseUri()
@@ -102,7 +103,7 @@ public class RelatedObjectEntryResourceImplTest {
 
 		Mockito.when(
 			_objectDefinitionLocalService.
-				getUnmodifiableSystemObjectDefinitions(_companyId)
+				getUnmodifiableSystemObjectDefinitions(_COMPANY_ID)
 		).thenReturn(
 			Collections.singletonList(objectDefinition)
 		);
@@ -135,7 +136,7 @@ public class RelatedObjectEntryResourceImplTest {
 		return systemObjectDefinitionManager;
 	}
 
-	private static final long _companyId = RandomTestUtil.randomLong();
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
 
 	private final ObjectDefinitionLocalService _objectDefinitionLocalService =
 		Mockito.mock(ObjectDefinitionLocalService.class);

--- a/modules/apps/object/object-rest-impl/src/test/java/com/liferay/object/rest/internal/resource/v1_0/RelatedObjectEntryResourceImplTest.java
+++ b/modules/apps/object/object-rest-impl/src/test/java/com/liferay/object/rest/internal/resource/v1_0/RelatedObjectEntryResourceImplTest.java
@@ -96,12 +96,6 @@ public class RelatedObjectEntryResourceImplTest {
 			Mockito.mock(SystemObjectDefinitionManager.class);
 
 		Mockito.when(
-			_uriInfo.getBaseUri()
-		).thenReturn(
-			URI.create("http://localhost:8080" + basePath)
-		);
-
-		Mockito.when(
 			_objectDefinitionLocalService.
 				getUnmodifiableSystemObjectDefinitions(_COMPANY_ID)
 		).thenReturn(
@@ -131,6 +125,12 @@ public class RelatedObjectEntryResourceImplTest {
 			jaxRsApplicationDescriptor.getRESTContextPath()
 		).thenReturn(
 			"headless-admin-user/v1.0/user-accounts"
+		);
+
+		Mockito.when(
+			_uriInfo.getBaseUri()
+		).thenReturn(
+			URI.create("http://localhost:8080" + basePath)
 		);
 
 		return systemObjectDefinitionManager;


### PR DESCRIPTION
What is being fixed:
Resolving related system object entries can fail when the request is served under a custom context root, because the REST context path is built from a fixed URI path segment index. This works for base paths like /o/headless-admin-user/, but breaks for prefixed paths such as /myportal/o/headless-admin-user/, causing the wrong REST context path to be derived and preventing the correct SystemObjectDefinitionManager from being resolved.

How it is being fixed:
Updating RelatedObjectEntryResourceImpl to derive the application path by locating the "o" segment in the request base URI instead of assuming a fixed position in the path. This makes REST context path resolution work for both root and custom context roots. Adding tests covering both /o/headless-admin-user/ and /myportal/o/headless-admin-user/ to verify that _getSystemObjectDefinitionManager resolves the expected system object definition manager in both cases.

contains changes suggested in : https://github.com/brianchandotcom/liferay-portal/pull/174058#issuecomment-4380667718