### PR TITLE
LPD-89170 Improve playwright tests

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
@@ -1098,7 +1098,7 @@ test(
 				.locator('tr', {hasText: title})
 				.or(page.locator('.card-row', {hasText: title}))
 				.locator('.cell-embedded-status')
-		).toHaveText('draft');
+		).toHaveText(/draft/i);
 
 		// Delete content
 
@@ -1185,7 +1185,7 @@ test.describe('Schedule Publication', () => {
 					.locator('tr', {hasText: title})
 					.or(page.locator('.card-row', {hasText: title}))
 					.locator('.cell-embedded-status')
-			).toHaveText('scheduled');
+			).toHaveText(/scheduled/i);
 
 			await contentsPage.viewShowDetails(title);
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
@@ -212,7 +212,7 @@ test(
 
 		await contentsPage.editContent(blogTitle);
 
-		expect(page.getByPlaceholder('New Blog')).toHaveValue(blogTitle);
+		await expect(page.getByPlaceholder('New Blog')).toHaveValue(blogTitle);
 
 		// Delete content
 
@@ -1189,8 +1189,8 @@ test.describe('Schedule Publication', () => {
 
 			await contentsPage.viewShowDetails(title);
 
-			expect(page.getByText('Display Date')).toBeVisible();
-			expect(page.getByText(`10/31/${nextYear}`)).toBeVisible();
+			await expect(page.getByText('Display Date')).toBeVisible();
+			await expect(page.getByText(`10/31/${nextYear}`)).toBeVisible();
 
 			// Delete content
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/allspaces.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/allspaces.spec.ts
@@ -39,8 +39,12 @@ test(
 		await test.step('Check the space is visible in All Spaces and left panel', async () => {
 			await page.goto(PORTLET_URLS.cmsAllSpaces);
 
-			expect(page.getByRole('menuitem', {name: spaceName})).toBeVisible();
-			expect(page.getByRole('link', {name: spaceName})).toBeVisible();
+			await expect(
+				page.getByRole('menuitem', {name: spaceName})
+			).toBeVisible();
+			await expect(
+				page.getByRole('link', {name: spaceName})
+			).toBeVisible();
 		});
 
 		await test.step('delete space from All Spaces', async () => {
@@ -55,10 +59,12 @@ test(
 		});
 
 		await test.step('Check the space is not visible in All Spaces nor in the left Spaces panel', async () => {
-			expect(
+			await expect(
 				page.getByRole('menuitem', {name: spaceName})
 			).not.toBeVisible();
-			expect(page.getByRole('link', {name: spaceName})).not.toBeVisible();
+			await expect(
+				page.getByRole('link', {name: spaceName})
+			).not.toBeVisible();
 		});
 	}
 );
@@ -81,8 +87,12 @@ test(
 		await test.step('Check the space is visible in All Spaces and left panel', async () => {
 			await page.goto(PORTLET_URLS.cmsAllSpaces);
 
-			expect(page.getByRole('menuitem', {name: spaceName})).toBeVisible();
-			expect(page.getByRole('link', {name: spaceName})).toBeVisible();
+			await expect(
+				page.getByRole('menuitem', {name: spaceName})
+			).toBeVisible();
+			await expect(
+				page.getByRole('link', {name: spaceName})
+			).toBeVisible();
 		});
 
 		await test.step(`Go to View Connected Sites modal and connect the space to ${siteName} site`, async () => {
@@ -104,9 +114,11 @@ test(
 				`Success:Site ${siteName} was successfully connected to the space.`
 			);
 
-			expect(page.getByRole('button', {name: 'Connect'})).toBeDisabled();
+			await expect(
+				page.getByRole('button', {name: 'Connect'})
+			).toBeDisabled();
 
-			expect(page.getByText(siteName)).toBeVisible();
+			await expect(page.getByText(siteName)).toBeVisible();
 		});
 	}
 );

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/allspaces.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/allspaces.spec.ts
@@ -48,7 +48,9 @@ test(
 		});
 
 		await test.step('delete space from All Spaces', async () => {
-			await page.getByRole('cell', {name: 'Actions'}).nth(2).click();
+			await page
+				.getByRole('button', {name: `${spaceName} Actions`})
+				.click();
 			await page.getByRole('menuitem', {name: 'Delete'}).click();
 			await page.getByRole('button', {name: 'Delete'}).click();
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceSummary.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceSummary.spec.ts
@@ -58,7 +58,7 @@ test(
 				)
 			).toBeVisible();
 
-			expect(page.getByText(file1Title)).toBeVisible();
+			await expect(page.getByText(file1Title)).toBeVisible();
 		}
 		finally {
 			await apiHelpers.objectEntry.deleteObjectEntry(
@@ -115,7 +115,7 @@ test(
 		await spaceSummaryPage.viewAllFilesLink.click();
 
 		await expect(page.getByRole('link', {name: spaceName})).toBeVisible();
-		expect(page.getByRole('link', {name: 'Files'})).toBeVisible();
+		await expect(page.getByRole('link', {name: 'Files'})).toBeVisible();
 	}
 );
 
@@ -200,7 +200,7 @@ test(
 		await spaceSummaryPage.viewAllContentLink.click();
 
 		await expect(page.getByRole('link', {name: spaceName})).toBeVisible();
-		expect(page.getByRole('link', {name: 'Contents'})).toBeVisible();
+		await expect(page.getByRole('link', {name: 'Contents'})).toBeVisible();
 	}
 );
 
@@ -307,7 +307,7 @@ test(
 
 		await spaceSummaryPage.goto(spaceName);
 
-		expect(globalSiteLocator).not.toBeVisible();
+		await expect(globalSiteLocator).not.toBeVisible();
 
 		await spaceSummaryPage.connectSite(siteName);
 
@@ -322,7 +322,7 @@ test(
 			.click();
 		await page.getByRole('menuitem', {name: 'Disconnect'}).click();
 
-		expect(globalSiteLocator).not.toBeVisible();
+		await expect(globalSiteLocator).not.toBeVisible();
 	}
 );
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/versions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/versions.spec.ts
@@ -189,7 +189,7 @@ async function testCanViewVersion(
 	title: string,
 	view: 'Table' | 'Gallery'
 ) {
-	expect(page.getByRole('heading', {name: title})).toBeVisible();
+	await expect(page.getByRole('heading', {name: title})).toBeVisible();
 
 	if (view === 'Table') {
 		assetsPage.execItemAction({action: 'View History', filter: title});

--- a/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/pages/StructureBuilderPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/pages/StructureBuilderPage.ts
@@ -454,10 +454,7 @@ export class StructureBuilderPage {
 	}) {
 		await page.goToCreateStructure();
 
-		if (!spaces) {
-			await page.enableForAllSpaces();
-		}
-		else {
+		if (spaces) {
 			await this.selectSpaces(spaces);
 		}
 


### PR DESCRIPTION
Several improvements to site-cms-site-initializer Playwright specs - Add missing await on expect assertions that were silently passing without running. - Replace brittle .nth(2) Actions cell selector with the row-named Actions button. - Match content status case-insensitively to survive UI casing changes. - Drop a redundant enableForAllSpaces call that duplicated the default UI state.