### PR TITLE
LPD-89191 Modernize ResolvedCommentsToggle and UnsafeHTML jest tests

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/UnsafeHTML.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/UnsafeHTML.test.js
@@ -4,14 +4,12 @@
  */
 
 import '@testing-library/jest-dom';
-import {cleanup, render} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
 import React, {useState} from 'react';
 
 import UnsafeHTML from '../../../../src/main/resources/META-INF/resources/page_editor/app/components/UnsafeHTML';
 
 describe('UnsafeHTML', () => {
-	afterEach(cleanup);
-
 	it('renders the given HTML markup', () => {
 		const {container} = render(
 			<UnsafeHTML markup="<h1>Hello <strong>Gürjen</strong></h1>" />
@@ -91,7 +89,7 @@ describe('UnsafeHTML', () => {
 			},
 		]);
 
-		const {getByTestId} = render(
+		render(
 			<UnsafeHTML
 				getPortals={getPortals}
 				markup={`
@@ -103,7 +101,7 @@ describe('UnsafeHTML', () => {
 			/>
 		);
 
-		const portalContent = getByTestId('portal-content');
+		const portalContent = screen.getByTestId('portal-content');
 
 		expect(portalContent).toBeInTheDocument();
 		expect(portalContent.innerHTML).toBe('Some portal 123');

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/comments/components/ResolvedCommentsToggle.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/comments/components/ResolvedCommentsToggle.test.js
@@ -4,7 +4,8 @@
  */
 
 import '@testing-library/jest-dom';
-import {cleanup, fireEvent, render} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import {toggleShowResolvedComments} from '../../../../../../src/main/resources/META-INF/resources/page_editor/app/actions/index';
@@ -12,13 +13,13 @@ import {StoreAPIContextProvider} from '../../../../../../src/main/resources/META
 import ResolvedCommentsToggle from '../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/comments/components/ResolvedCommentsToggle';
 
 const renderComponent = (state = {}, dispatch) => {
-	const {getByLabelText} = render(
+	render(
 		<StoreAPIContextProvider dispatch={dispatch} getState={() => state}>
 			<ResolvedCommentsToggle />
 		</StoreAPIContextProvider>
 	);
 
-	return getByLabelText('show-resolved-comments');
+	return screen.getByLabelText('show-resolved-comments');
 };
 
 const RESOLVED_COMMENTS_STATE = {
@@ -28,16 +29,12 @@ const RESOLVED_COMMENTS_STATE = {
 };
 
 describe('ResolvedCommentsToggle', () => {
-	afterEach(cleanup);
-
 	it('is unchecked by default', () => {
-		expect(renderComponent().checked).toBe(false);
+		expect(renderComponent()).not.toBeChecked();
 	});
 
-	it('is cheched if showResolvedComments is true', () => {
-		expect(renderComponent({showResolvedComments: true}).checked).toBe(
-			true
-		);
+	it('is checked if showResolvedComments is true', () => {
+		expect(renderComponent({showResolvedComments: true})).toBeChecked();
 	});
 
 	it('is disabled if there are no resolved comments', () => {
@@ -48,11 +45,11 @@ describe('ResolvedCommentsToggle', () => {
 		expect(renderComponent(RESOLVED_COMMENTS_STATE)).not.toBeDisabled();
 	});
 
-	it('dispatches toggleShowResolvedComments on change', () => {
+	it('dispatches toggleShowResolvedComments on change', async () => {
 		const dispatch = jest.fn();
 		const checkbox = renderComponent(RESOLVED_COMMENTS_STATE, dispatch);
 
-		fireEvent.click(checkbox);
+		await userEvent.click(checkbox);
 
 		expect(dispatch).toHaveBeenCalledWith(
 			toggleShowResolvedComments({showResolvedComments: true})


### PR DESCRIPTION
Switch the two tests to the recommended React Testing Library patterns: use screen.* instead of destructuring queries from render, drop the redundant afterEach cleanup since RTL auto-cleans with Jest, replace .checked direct property access with toBeChecked / not.toBeChecked matchers from jest-dom, switch fireEvent.click to userEvent.click to match the convention used elsewhere in this module, and fix a typo in a test name.