### PR TITLE
LCD-51175 Add AWS tflint config and load per-cloud configs in CI

### DIFF
--- a/.github/workflows/ci-test-cloud-terraform.yaml
+++ b/.github/workflows/ci-test-cloud-terraform.yaml
@@ -22,13 +22,18 @@ jobs:
                 working-directory: ./cloud/terraform/${{matrix.stack}}
             -   name: Run TFLint
                 run: |
-                    STACK="${{matrix.stack}}"
-                    CLOUD="${STACK%%/*}"
-                    CONFIG="${GITHUB_WORKSPACE}/cloud/terraform/${CLOUD}/.tflint.hcl"
+                    function main {
+                        local cloud="${{matrix.stack}}"
+                        cloud="${cloud%%/*}"
 
-                    tflint --init --config="${CONFIG}"
+                        local config="${GITHUB_WORKSPACE}/cloud/terraform/${cloud}/.tflint.hcl"
 
-                    tflint --config="${CONFIG}"
+                        tflint --config="${config}" --init
+
+                        tflint --config="${config}"
+                    }
+
+                    main
                 working-directory: ./cloud/terraform/${{matrix.stack}}
             -   name: Run Checkov
                 uses: bridgecrewio/checkov-action@v12

--- a/.github/workflows/ci-test-cloud-terraform.yaml
+++ b/.github/workflows/ci-test-cloud-terraform.yaml
@@ -22,8 +22,11 @@ jobs:
                 working-directory: ./cloud/terraform/${{matrix.stack}}
             -   name: Run TFLint
                 run: |
-                    tflint --init
-                    tflint
+                    stack=${{matrix.stack}}
+                    cloud=${stack%%/*}
+                    config=$GITHUB_WORKSPACE/cloud/terraform/$cloud/.tflint.hcl
+                    tflint --init --config=$config
+                    tflint --config=$config
                 working-directory: ./cloud/terraform/${{matrix.stack}}
             -   name: Run Checkov
                 uses: bridgecrewio/checkov-action@v12

--- a/.github/workflows/ci-test-cloud-terraform.yaml
+++ b/.github/workflows/ci-test-cloud-terraform.yaml
@@ -22,11 +22,13 @@ jobs:
                 working-directory: ./cloud/terraform/${{matrix.stack}}
             -   name: Run TFLint
                 run: |
-                    stack=${{matrix.stack}}
-                    cloud=${stack%%/*}
-                    config=$GITHUB_WORKSPACE/cloud/terraform/$cloud/.tflint.hcl
-                    tflint --init --config=$config
-                    tflint --config=$config
+                    STACK="${{matrix.stack}}"
+                    CLOUD="${STACK%%/*}"
+                    CONFIG="${GITHUB_WORKSPACE}/cloud/terraform/${CLOUD}/.tflint.hcl"
+
+                    tflint --init --config="${CONFIG}"
+
+                    tflint --config="${CONFIG}"
                 working-directory: ./cloud/terraform/${{matrix.stack}}
             -   name: Run Checkov
                 uses: bridgecrewio/checkov-action@v12

--- a/cloud/terraform/aws/.tflint.hcl
+++ b/cloud/terraform/aws/.tflint.hcl
@@ -1,0 +1,13 @@
+config {
+	call_module_type="all"
+	force=false
+}
+plugin "aws" {
+	enabled=true
+	source="github.com/terraform-linters/tflint-ruleset-aws"
+	version="0.47.0"
+}
+plugin "terraform" {
+	enabled=true
+	preset="recommended"
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LCD-51175

**What is being fixed:** LCD-51136 wired tflint into terraform CI, but tflint only looks for `.tflint.hcl` in the current working directory and the home directory; it does not walk up the tree. With no per-cloud config installed in the working directory, the AWS tflint runs without the AWS ruleset enabled.

**How it is being fixed:** Adds `cloud/terraform/aws/.tflint.hcl` enabling the aws ruleset (pinned at 0.47.0) and the recommended terraform preset, and updates the `Run TFLint` step in `.github/workflows/ci-test-cloud-terraform.yaml` to derive the cloud name from the matrix stack and load the matching config via `tflint --config`. The step's bash is wrapped in `function main` with local vars to keep the variables out of the global scope.