### PR TITLE
LPD-82927 Skip hash line for once-only generated files

### DIFF
--- a/modules/apps/analytics/analytics-rest-test/src/testIntegration/java/com/liferay/analytics/rest/resource/v1_0/test/GraphQLResourceTest.java
+++ b/modules/apps/analytics/analytics-rest-test/src/testIntegration/java/com/liferay/analytics/rest/resource/v1_0/test/GraphQLResourceTest.java
@@ -17,5 +17,3 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class GraphQLResourceTest extends BaseGraphQLResourceTestCase {
 }
-
-// LIFERAY-REST-BUILDER-HASH:160153401

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/model/impl/CommerceOrderAttachmentImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/model/impl/CommerceOrderAttachmentImpl.java
@@ -11,5 +11,3 @@ package com.liferay.commerce.model.impl;
 public class CommerceOrderAttachmentImpl
 	extends CommerceOrderAttachmentBaseImpl {
 }
-
-// LIFERAY-SERVICE-BUILDER-HASH:-395984265

--- a/modules/apps/cookies/cookies-uad/src/main/java/com/liferay/cookies/uad/anonymizer/CookiesConsentPreferenceUADAnonymizer.java
+++ b/modules/apps/cookies/cookies-uad/src/main/java/com/liferay/cookies/uad/anonymizer/CookiesConsentPreferenceUADAnonymizer.java
@@ -16,5 +16,3 @@ import org.osgi.service.component.annotations.Component;
 public class CookiesConsentPreferenceUADAnonymizer
 	extends BaseCookiesConsentPreferenceUADAnonymizer {
 }
-
-// LIFERAY-SERVICE-BUILDER-HASH:-1939853248

--- a/modules/apps/cookies/cookies-uad/src/main/java/com/liferay/cookies/uad/exporter/CookiesConsentPreferenceUADExporter.java
+++ b/modules/apps/cookies/cookies-uad/src/main/java/com/liferay/cookies/uad/exporter/CookiesConsentPreferenceUADExporter.java
@@ -16,5 +16,3 @@ import org.osgi.service.component.annotations.Component;
 public class CookiesConsentPreferenceUADExporter
 	extends BaseCookiesConsentPreferenceUADExporter {
 }
-
-// LIFERAY-SERVICE-BUILDER-HASH:-767519162

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-service/src/main/java/com/liferay/osb/patcher/service/impl/PatcherFixServiceImpl.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-service/src/main/java/com/liferay/osb/patcher/service/impl/PatcherFixServiceImpl.java
@@ -56,5 +56,3 @@ public class PatcherFixServiceImpl extends PatcherFixServiceBaseImpl {
 	private RoleLocalService _roleLocalService;
 
 }
-
-// LIFERAY-SERVICE-BUILDER-HASH:1619952532

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
@@ -1146,7 +1146,8 @@ public class RESTBuilder {
 
 		FreeMarkerUtil.processTemplate(
 			_copyrightFile, FileUtil.getCopyrightYear(file),
-			"dto_action_metadata_provider", context, file, _modifiedFiles);
+			"dto_action_metadata_provider", context, file, _modifiedFiles,
+			false);
 	}
 
 	private void _createDTOActionProviderFile(
@@ -1387,7 +1388,7 @@ public class RESTBuilder {
 
 		FreeMarkerUtil.processTemplate(
 			_copyrightFile, FileUtil.getCopyrightYear(file), "resource_impl",
-			context, file, _modifiedFiles);
+			context, file, _modifiedFiles, false);
 	}
 
 	private void _createResourceTestFile(
@@ -1410,7 +1411,7 @@ public class RESTBuilder {
 
 		FreeMarkerUtil.processTemplate(
 			_copyrightFile, FileUtil.getCopyrightYear(file), "resource_test",
-			context, file, _modifiedFiles);
+			context, file, _modifiedFiles, false);
 	}
 
 	private String _fixOpenAPIContentApplicationXML(

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/FreeMarkerUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/FreeMarkerUtil.java
@@ -37,13 +37,25 @@ public class FreeMarkerUtil {
 		throws Exception {
 
 		processTemplate(
-			copyrightFile, copyrightYear, name, context, outputFile, null);
+			copyrightFile, copyrightYear, name, context, outputFile, null,
+			true);
 	}
 
 	public static void processTemplate(
 			File copyrightFile, String copyrightYear, String name,
 			Map<String, Object> context, File outputFile,
 			Collection<File> modifiedFiles)
+		throws Exception {
+
+		processTemplate(
+			copyrightFile, copyrightYear, name, context, outputFile,
+			modifiedFiles, true);
+	}
+
+	public static void processTemplate(
+			File copyrightFile, String copyrightYear, String name,
+			Map<String, Object> context, File outputFile,
+			Collection<File> modifiedFiles, boolean addHash)
 		throws Exception {
 
 		String content = processTemplate(
@@ -53,7 +65,7 @@ public class FreeMarkerUtil {
 			content = _removeUnusedSchemaImports(content, context);
 		}
 
-		FileUtil.write(outputFile, content, modifiedFiles);
+		FileUtil.write(outputFile, content, modifiedFiles, addHash);
 	}
 
 	private static int _indexOfStandalone(

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/util/FileUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/util/FileUtil.java
@@ -146,11 +146,19 @@ public class FileUtil {
 	}
 
 	public static void write(File file, String content) throws Exception {
-		write(file, content, null);
+		write(file, content, null, true);
 	}
 
 	public static void write(
 			File file, String content, Collection<File> modifiedFiles)
+		throws Exception {
+
+		write(file, content, modifiedFiles, true);
+	}
+
+	public static void write(
+			File file, String content, Collection<File> modifiedFiles,
+			boolean addHash)
 		throws Exception {
 
 		if (!file.exists()) {
@@ -168,15 +176,17 @@ public class FileUtil {
 		if (StringUtil.endsWith(file.getName(), ".java")) {
 			int contentHash = content.hashCode();
 
-			int index = oldContent.lastIndexOf(
-				_LIFERAY_REST_BUILDER_HASH_PREFIX);
+			if (addHash) {
+				int index = oldContent.lastIndexOf(
+					_LIFERAY_REST_BUILDER_HASH_PREFIX);
 
-			if (index != -1) {
-				String hashLine = oldContent.substring(
-					index + _LIFERAY_REST_BUILDER_HASH_PREFIX.length());
+				if (index != -1) {
+					String hashLine = oldContent.substring(
+						index + _LIFERAY_REST_BUILDER_HASH_PREFIX.length());
 
-				if (GetterUtil.getInteger(hashLine) == contentHash) {
-					return;
+					if (GetterUtil.getInteger(hashLine) == contentHash) {
+						return;
+					}
 				}
 			}
 
@@ -185,8 +195,12 @@ public class FileUtil {
 
 			JavaParser.parse(file, 80);
 
-			String parsedContent =
-				read(file) + _LIFERAY_REST_BUILDER_HASH_PREFIX + contentHash;
+			String parsedContent = read(file);
+
+			if (addHash) {
+				parsedContent +=
+					_LIFERAY_REST_BUILDER_HASH_PREFIX + contentHash;
+			}
 
 			Files.write(
 				file.toPath(), parsedContent.getBytes(StandardCharsets.UTF_8));

--- a/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
+++ b/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
@@ -3231,7 +3231,7 @@ public class ServiceBuilder {
 			_pendingContents.put(_normalize(modelFile.toString()), content);
 		}
 		else {
-			_write(modelFile, content, _modifiedFileNames);
+			_write(modelFile, content, _modifiedFileNames, false);
 		}
 	}
 
@@ -4244,7 +4244,7 @@ public class ServiceBuilder {
 
 		String content = _processTemplate(_tplServiceImpl, context);
 
-		_write(file, content, _modifiedFileNames);
+		_write(file, content, _modifiedFileNames, false);
 	}
 
 	private void _createServicePropsUtil() throws Exception {
@@ -4969,7 +4969,7 @@ public class ServiceBuilder {
 
 		String content = _processTemplate(_TPL_UAD_ANOYMIZER, context);
 
-		_write(file, content, _modifiedFileNames);
+		_write(file, content, _modifiedFileNames, false);
 	}
 
 	private void _createUADBnd(String uadApplicationName) throws Exception {
@@ -5046,7 +5046,7 @@ public class ServiceBuilder {
 
 		String content = _processTemplate(_TPL_UAD_DISPLAY, context);
 
-		_write(file, content, _modifiedFileNames);
+		_write(file, content, _modifiedFileNames, false);
 	}
 
 	private void _createUADExporter(Entity entity) throws Exception {
@@ -5065,7 +5065,7 @@ public class ServiceBuilder {
 
 		String content = _processTemplate(_TPL_UAD_EXPORTER, context);
 
-		_write(file, content, _modifiedFileNames);
+		_write(file, content, _modifiedFileNames, false);
 	}
 
 	private void _deleteFile(String fileName) {
@@ -8095,14 +8095,18 @@ public class ServiceBuilder {
 							Set<String> modifiedFileNames =
 								(Set<String>)pendingWrite[3];
 
+							boolean addHash = (Boolean)pendingWrite[4];
+
 							String parsedContent = JavaParser.parse(
 								file, packagePath, content, _MAX_LINE_LENGTH,
 								false);
 
-							parsedContent =
-								parsedContent +
-									_LIFERAY_SERVICE_BUILDER_HASH_PREFIX +
-										content.hashCode();
+							if (addHash) {
+								parsedContent =
+									parsedContent +
+										_LIFERAY_SERVICE_BUILDER_HASH_PREFIX +
+											content.hashCode();
+							}
 
 							ToolsUtil.writeFileRaw(
 								file, parsedContent, modifiedFileNames);
@@ -8590,6 +8594,14 @@ public class ServiceBuilder {
 			File file, String content, Set<String> modifiedFileNames)
 		throws Exception {
 
+		_write(file, content, modifiedFileNames, true);
+	}
+
+	private void _write(
+			File file, String content, Set<String> modifiedFileNames,
+			boolean addHash)
+		throws Exception {
+
 		SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy");
 
 		String year = simpleDateFormat.format(new Date());
@@ -8616,7 +8628,7 @@ public class ServiceBuilder {
 
 		_pendingContents.put(fileName, content);
 
-		if (oldContent != null) {
+		if (addHash && (oldContent != null)) {
 			int index = oldContent.lastIndexOf(
 				_LIFERAY_SERVICE_BUILDER_HASH_PREFIX);
 
@@ -8667,7 +8679,9 @@ public class ServiceBuilder {
 			CharPool.SLASH, CharPool.PERIOD);
 
 		_pendingWrites.add(
-			new Object[] {file, packagePath, content, modifiedFileNames});
+			new Object[] {
+				file, packagePath, content, modifiedFileNames, addHash
+			});
 	}
 
 	private static final int _DEFAULT_COLUMN_MAX_LENGTH = 75;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-82927

## What is being fixed

Per @brianchandotcom's report on PR #174279, the `LIFERAY-REST-BUILDER-HASH` and `LIFERAY-SERVICE-BUILDER-HASH` comments are added to every Java file written through the builders, including files that the builder only generates once and never regenerates (skipped on subsequent runs via `if (file.exists()) return;`, or post-processed via `writeFileRaw` which preserves the stale hash). For those files the hash never refreshes, leaving stale metadata in code that developers actively maintain.

Example: `site-dsr-analytics-rest-test/.../DocumentMetricResourceTest.java` was generated once and now permanently carries `// LIFERAY-REST-BUILDER-HASH:-977557435`.

## How it is being fixed

Plumb an `addHash` flag through `FileUtil.write` / `_write` so the once-only generators can opt out. The default for regenerated files stays `true`, so existing behavior is preserved for everything else. The once-only entrances now pass `false`:

REST Builder:
- `_createDTOActionMetadataProviderFile`
- `_createResourceImplFile`
- `_createResourceTestFile`

Service Builder:
- `_createServiceImpl` (regular and Local)
- `_createExtendedModelImpl` (only the first-creation branch — the migration branch already uses `writeFileRaw`)
- `_createUADAnonymizer`
- `_createUADDisplay`
- `_createUADExporter`

The second commit removes the stale hash lines from the five files in the repo that were already affected: `GraphQLResourceTest.java`, `PatcherFixServiceImpl.java`, `CookiesConsentPreferenceUADAnonymizer.java`, `CookiesConsentPreferenceUADExporter.java`, and `CommerceOrderAttachmentImpl.java`.

## Why are there no tests?

This is a Service Builder / REST Builder tooling change. The fix is end-to-end verified by the second commit: regenerating any of the previously-affected once-only files now produces output without the stale hash line. Adding a dedicated unit test for the builder's hash-emission flag would be disproportionate to a one-line guard.