### PR TITLE
LPD-88404 Fix stagingUseCase test locators

### DIFF
--- a/modules/test/playwright/tests/export-import-web/main/pages/StagingPage.ts
+++ b/modules/test/playwright/tests/export-import-web/main/pages/StagingPage.ts
@@ -213,10 +213,7 @@ export class StagingPage {
 	}
 
 	async gotoTemplatePage() {
-		await this.page
-			.getByText('Staging Open Applications')
-			.getByLabel('Options')
-			.click();
+		await this.page.locator('.portlet-options').click();
 		await this.page
 			.getByRole('menuitem', {name: 'Publish Templates'})
 			.click();

--- a/modules/test/playwright/tests/journal-web/main/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/main/pages/JournalEditArticlePage.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {FrameLocator, Locator, Page, expect} from '@playwright/test';
+import {Locator, Page, expect} from '@playwright/test';
 
 import {clickAndExpectToBeHidden} from '../../../../utils/clickAndExpectToBeHidden';
 import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVisible';
@@ -20,7 +20,6 @@ export class JournalEditArticlePage {
 	readonly changesSavedIndicator: Locator;
 	readonly clearButton: Locator;
 	readonly content: Locator;
-	readonly contentFrame: FrameLocator;
 	readonly defaultTemplateButton: Locator;
 	readonly duplicateButton: Locator;
 	readonly friendlyURLInput: Locator;
@@ -49,9 +48,6 @@ export class JournalEditArticlePage {
 
 		this.clearButton = page.getByRole('button', {name: 'Clear'});
 		this.content = page.getByText('Content', {exact: true});
-		this.contentFrame = page.frameLocator(
-			'internal:role=application[name="Content,"i] >> iframe[title="editor"]'
-		);
 		this.defaultTemplateButton = page.getByRole('button', {
 			name: 'Default Template',
 		});
@@ -294,9 +290,13 @@ export class JournalEditArticlePage {
 	}
 
 	async editURL(title: string, url: string) {
-		await this.contentFrame.getByRole('link', {name: title}).dblclick();
-		await this.page.getByLabel('URL*').fill(url);
-		await this.page.getByLabel('OK').click();
+		await this.page
+			.locator('.ck-content')
+			.getByRole('link', {name: title})
+			.click();
+		await this.page.getByRole('button', {name: 'Edit link'}).click();
+		await this.page.getByRole('textbox', {name: 'Link URL'}).fill(url);
+		await this.page.getByRole('button', {name: 'Update'}).click();
 	}
 
 	async fillContent(content: string) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88404
https://liferay.atlassian.net/browse/LPD-88403

## What is being fixed

Two acceptance test failures in `stagingUseCase.spec.ts`:

- "Cannot publish if linked file does not exist" (LPD-88404): `editURL` was built for CKEditor 4's iframe + modal dialog. After LPD-81886 the default rich text field renders CKEditor 5 (no iframe), so `frameLocator('iframe[title="editor"]')` timed out at 90s.

- "Staging publish template with smoke" (LPD-88403): the locator `getByText('Staging Open Applications').getByLabel('Options')` no longer matches the page header — "Staging" (heading) and "Open Applications Menu" (button) are now in separate accessible parents.

## How it is being fixed

`JournalEditArticlePage.editURL` now uses the CKEditor 5 link balloon: click the link inside `.ck-content`, click "Edit link", fill "Link URL", click "Update". The unused `contentFrame: FrameLocator` field is removed.

`StagingPage.gotoTemplatePage` targets the page-level options trigger via `.portlet-options`, the class Liferay's `<liferay-frontend:icon-options>` taglib applies on every portlet options menu. On a maximized control panel page only one exists.

## Why are there no tests?

The change is the test fix itself; no production code is modified.
