### PR TITLE
LPD-85590 Avoid spurious error toast on customized status page

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/servlet/CTReviewChangesServlet.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/servlet/CTReviewChangesServlet.java
@@ -14,7 +14,6 @@ import com.liferay.portal.kernel.model.Ticket;
 import com.liferay.portal.kernel.model.TicketConstants;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.TicketLocalService;
-import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -62,12 +61,9 @@ public class CTReviewChangesServlet extends HttpServlet {
 		Ticket ticket = _getTicket(httpServletRequest);
 
 		if (ticket == null) {
-			SessionErrors.add(httpServletRequest, NoSuchTicketException.class);
-
-			httpServletResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);
-
-			httpServletResponse.sendRedirect(
-				Portal.PATH_MAIN + "/portal/status");
+			_portal.sendError(
+				new NoSuchTicketException(), httpServletRequest,
+				httpServletResponse);
 
 			return;
 		}

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/display/context/StatusDisplayContext.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/display/context/StatusDisplayContext.java
@@ -42,7 +42,7 @@ public class StatusDisplayContext {
 
 	public Exception getException() {
 		return (Exception)_httpServletRequest.getAttribute(
-			WebKeys.STATUS_EXCEPTION);
+			WebKeys.PORTAL_STATUS_EXCEPTION);
 	}
 
 	public boolean isNoSuchResourceException() {

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/display/context/StatusDisplayContext.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/display/context/StatusDisplayContext.java
@@ -9,7 +9,6 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
@@ -17,6 +16,7 @@ import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -40,6 +40,11 @@ public class StatusDisplayContext {
 			HttpComponentsUtil.decodeURL(themeDisplay.getPortalURL() + url));
 	}
 
+	public Exception getException() {
+		return (Exception)_httpServletRequest.getAttribute(
+			WebKeys.STATUS_EXCEPTION);
+	}
+
 	public boolean isNoSuchResourceException() {
 		if (GetterUtil.getBoolean(
 				_httpServletRequest.getAttribute(
@@ -48,45 +53,56 @@ public class StatusDisplayContext {
 			return true;
 		}
 
-		for (String key : SessionErrors.keySet(_httpServletRequest)) {
-			key = key.substring(key.lastIndexOf(StringPool.PERIOD) + 1);
+		Exception exception = getException();
 
-			if (key.startsWith("NoSuch") && key.endsWith("Exception")) {
+		if (exception != null) {
+			Class<?> clazz = exception.getClass();
+
+			String name = clazz.getName();
+
+			name = name.substring(name.lastIndexOf(StringPool.PERIOD) + 1);
+
+			if (_isNoSuchExceptionName(name)) {
 				return true;
 			}
 		}
 
-		String exception = ParamUtil.getString(
+		String exceptionParam = ParamUtil.getString(
 			_httpServletRequest, "exception");
 
-		if (Validator.isNotNull(exception)) {
-			exception = exception.substring(
-				exception.lastIndexOf(StringPool.PERIOD) + 1);
+		if (Validator.isNotNull(exceptionParam) &&
+			_isNoSuchExceptionName(
+				exceptionParam.substring(
+					exceptionParam.lastIndexOf(StringPool.PERIOD) + 1))) {
 
-			if (exception.startsWith("NoSuch") &&
-				exception.endsWith("Exception")) {
-
-				return true;
-			}
+			return true;
 		}
 
 		return false;
 	}
 
-	public void logSessionErrors() {
-		for (String key : SessionErrors.keySet(_httpServletRequest)) {
-			Object value = SessionErrors.get(_httpServletRequest, key);
+	public void logException() {
+		Exception exception = getException();
 
-			if (value instanceof Exception) {
-				Exception exception = (Exception)value;
-
-				_log.error("Error: " + exception.getMessage());
-
-				if (_log.isDebugEnabled()) {
-					_log.debug(exception);
-				}
-			}
+		if (exception == null) {
+			return;
 		}
+
+		_log.error("Error: " + exception.getMessage());
+
+		if (_log.isDebugEnabled()) {
+			_log.debug(exception);
+		}
+	}
+
+	private boolean _isNoSuchExceptionName(String simpleName) {
+		if (simpleName.startsWith("NoSuch") &&
+			simpleName.endsWith("Exception")) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/struts/StatusStrutsAction.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/struts/StatusStrutsAction.java
@@ -66,7 +66,12 @@ public class StatusStrutsAction implements StrutsAction {
 		PipingServletResponse pipingServletResponse = new PipingServletResponse(
 			httpServletResponse, unsyncStringWriter);
 
-		SessionErrors.clear(httpServletRequest);
+		Exception exception = (Exception)httpServletRequest.getAttribute(
+			WebKeys.PORTAL_STATUS_EXCEPTION);
+
+		if (exception != null) {
+			SessionErrors.remove(httpServletRequest, exception.getClass());
+		}
 
 		requestDispatcher.include(httpServletRequest, pipingServletResponse);
 

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/struts/StatusStrutsAction.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/struts/StatusStrutsAction.java
@@ -66,9 +66,9 @@ public class StatusStrutsAction implements StrutsAction {
 		PipingServletResponse pipingServletResponse = new PipingServletResponse(
 			httpServletResponse, unsyncStringWriter);
 
-		requestDispatcher.include(httpServletRequest, pipingServletResponse);
-
 		SessionErrors.clear(httpServletRequest);
+
+		requestDispatcher.include(httpServletRequest, pipingServletResponse);
 
 		Document document = null;
 

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/resources/META-INF/resources/init.jsp
@@ -17,7 +17,6 @@ page import="com.liferay.layout.utility.page.status.internal.display.context.Sta
 page import="com.liferay.portal.kernel.exception.PortalException" %><%@
 page import="com.liferay.portal.kernel.exception.SystemException" %><%@
 page import="com.liferay.portal.kernel.security.auth.PrincipalException" %><%@
-page import="com.liferay.portal.kernel.servlet.SessionErrors" %><%@
 page import="com.liferay.portal.kernel.templateparser.TransformException" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/resources/META-INF/resources/internal_server_error.jsp
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/resources/META-INF/resources/internal_server_error.jsp
@@ -22,7 +22,7 @@
 	<code class="lfr-url-error"><%= statusDisplayContext.getEscapedURL(themeDisplay) %></code>
 
 	<%
-	statusDisplayContext.logSessionErrors();
+	statusDisplayContext.logException();
 	%>
 
 </liferay-layout:render-layout-utility-page-entry>

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/resources/META-INF/resources/status.jsp
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/resources/META-INF/resources/status.jsp
@@ -21,10 +21,14 @@
 	if (status > 0) {
 		response.setStatus(status);
 	}
+
+	Exception statusException = statusDisplayContext.getException();
+
+	Class<?> statusExceptionClass = (statusException == null) ? null : statusException.getClass();
 	%>
 
 	<c:choose>
-		<c:when test="<%= SessionErrors.contains(request, PrincipalException.getNestedClasses()) %>">
+		<c:when test="<%= statusException instanceof PrincipalException %>">
 			<clay:alert
 				displayType="danger"
 				message="forbidden"
@@ -40,7 +44,7 @@
 
 			<a href="javascript:history.go(-1);">&laquo; <liferay-ui:message key="back" /></a>
 		</c:when>
-		<c:when test="<%= SessionErrors.contains(request, PortalException.class.getName()) || SessionErrors.contains(request, SystemException.class.getName()) %>">
+		<c:when test="<%= (statusExceptionClass == PortalException.class) || (statusExceptionClass == SystemException.class) %>">
 			<clay:alert
 				displayType="danger"
 				message="internal-server-error"
@@ -56,7 +60,7 @@
 
 			<a href="javascript:history.go(-1);">&laquo; <liferay-ui:message key="back" /></a>
 		</c:when>
-		<c:when test="<%= SessionErrors.contains(request, TransformException.class.getName()) %>">
+		<c:when test="<%= statusExceptionClass == TransformException.class %>">
 			<clay:alert
 				displayType="danger"
 				message="internal-server-error"
@@ -71,7 +75,7 @@
 			<br /><br />
 
 			<%
-			TransformException te = (TransformException)SessionErrors.get(request, TransformException.class.getName());
+			TransformException te = (TransformException)statusException;
 			%>
 
 			<div>
@@ -116,7 +120,7 @@
 				<code class="lfr-url-error"><%= statusDisplayContext.getEscapedURL(themeDisplay) %></code>
 
 				<%
-				statusDisplayContext.logSessionErrors();
+				statusDisplayContext.logException();
 				%>
 
 			</liferay-layout:render-layout-utility-page-entry>
@@ -134,7 +138,7 @@
 			<code class="lfr-url-error"><%= statusDisplayContext.getEscapedURL(themeDisplay) %></code>
 
 			<%
-			statusDisplayContext.logSessionErrors();
+			statusDisplayContext.logException();
 			%>
 
 			<hr class="separator" />

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/test/java/com/liferay/layout/utility/page/status/internal/struts/StatusStrutsActionTest.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/test/java/com/liferay/layout/utility/page/status/internal/struts/StatusStrutsActionTest.java
@@ -70,6 +70,51 @@ public class StatusStrutsActionTest {
 	}
 
 	@Test
+	@TestInfo("LPD-85590")
+	public void testExecuteRemovesSeededPortalStatusExceptionFromSessionErrors()
+		throws Exception {
+
+		String bodyContentInit = _HTML_INIT + RandomTestUtil.randomString();
+		String bodyContentEnd = RandomTestUtil.randomString() + _HTML_END;
+
+		String expected = StringBundler.concat(
+			bodyContentInit, "\n  <div id=\"content\">\n   ",
+			_STATUS_PAGE_CONTENT, "\n  </div>", bodyContentEnd);
+		String html = StringBundler.concat(
+			bodyContentInit, "<div id=\"content\">",
+			RandomTestUtil.randomString(), "</div>", bodyContentEnd);
+
+		_sessionErrorsMockedStatic.clearInvocations();
+
+		_testExecute(expected, html);
+
+		_sessionErrorsMockedStatic.verifyNoInteractions();
+
+		Exception exception = new Exception();
+
+		Mockito.when(
+			_httpServletRequest.getAttribute(WebKeys.PORTAL_STATUS_EXCEPTION)
+		).thenReturn(
+			exception
+		);
+
+		_sessionErrorsMockedStatic.clearInvocations();
+
+		try {
+			_testExecute(expected, html);
+
+			_sessionErrorsMockedStatic.verify(
+				() -> SessionErrors.remove(
+					_httpServletRequest, Exception.class));
+		}
+		finally {
+			Mockito.reset(_httpServletRequest);
+
+			_setUpHttpServletRequest();
+		}
+	}
+
+	@Test
 	public void testExecuteWithThemeContainingElementWithIdContent()
 		throws Exception {
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -6075,7 +6075,12 @@ public class PortalImpl implements Portal {
 
 			httpServletResponse.setStatus(status);
 
-			SessionErrors.add(httpSession, exception.getClass(), exception);
+			if (exception != null) {
+				httpServletRequest.setAttribute(
+					WebKeys.STATUS_EXCEPTION, exception);
+
+				SessionErrors.add(httpSession, exception.getClass(), exception);
+			}
 
 			ServletContext servletContext = httpSession.getServletContext();
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -6075,12 +6075,9 @@ public class PortalImpl implements Portal {
 
 			httpServletResponse.setStatus(status);
 
-			if (exception != null) {
-				httpServletRequest.setAttribute(
-					WebKeys.STATUS_EXCEPTION, exception);
+			httpServletRequest.setAttribute(WebKeys.STATUS_EXCEPTION, exception);
 
-				SessionErrors.add(httpSession, exception.getClass(), exception);
-			}
+			SessionErrors.add(httpSession, exception.getClass(), exception);
 
 			ServletContext servletContext = httpSession.getServletContext();
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -6075,7 +6075,8 @@ public class PortalImpl implements Portal {
 
 			httpServletResponse.setStatus(status);
 
-			httpServletRequest.setAttribute(WebKeys.STATUS_EXCEPTION, exception);
+			httpServletRequest.setAttribute(
+				WebKeys.PORTAL_STATUS_EXCEPTION, exception);
 
 			SessionErrors.add(httpSession, exception.getClass(), exception);
 

--- a/portal-impl/test/unit/com/liferay/portal/util/PortalImplUnitTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/util/PortalImplUnitTest.java
@@ -888,7 +888,7 @@ public class PortalImplUnitTest {
 
 		Assert.assertSame(
 			noSuchImageException,
-			mockHttpServletRequest.getAttribute(WebKeys.STATUS_EXCEPTION));
+			mockHttpServletRequest.getAttribute(WebKeys.PORTAL_STATUS_EXCEPTION));
 	}
 
 	@Test

--- a/portal-impl/test/unit/com/liferay/portal/util/PortalImplUnitTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/util/PortalImplUnitTest.java
@@ -5,9 +5,11 @@
 
 package com.liferay.portal.util;
 
+import com.liferay.layout.utility.page.kernel.StatusLayoutUtilityPageEntryRequestContributorRegistryUtil;
 import com.liferay.petra.io.BigEndianCodec;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.NoSuchImageException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
@@ -21,7 +23,10 @@ import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.servlet.DummyHttpServletResponse;
 import com.liferay.portal.kernel.servlet.DynamicServletRequest;
 import com.liferay.portal.kernel.servlet.PersistentHttpServletRequestWrapper;
+import com.liferay.portal.kernel.servlet.PortalSessionThreadLocal;
+import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upgrade.MockPortletPreferences;
@@ -56,8 +61,12 @@ import jakarta.portlet.PortletException;
 import jakarta.portlet.PortletMode;
 import jakarta.portlet.WindowState;
 
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -811,6 +820,75 @@ public class PortalImplUnitTest {
 
 			Assert.assertFalse(_portalImpl.isValidResourceId("%view.jsp"));
 		}
+	}
+
+	@Test
+	@TestInfo("LPD-85590")
+	public void testSendErrorPassesExceptionViaRequestAttributeAndSessionErrors()
+		throws Exception {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		HttpServletResponse mockHttpServletResponse = Mockito.mock(
+			HttpServletResponse.class);
+
+		Mockito.when(
+			mockHttpServletResponse.isCommitted()
+		).thenReturn(
+			false
+		);
+
+		HttpSession mockHttpSession = Mockito.mock(HttpSession.class);
+
+		ServletContext mockServletContext = Mockito.mock(ServletContext.class);
+
+		Mockito.when(
+			mockHttpSession.getServletContext()
+		).thenReturn(
+			mockServletContext
+		);
+
+		Mockito.when(
+			mockServletContext.getRequestDispatcher(Mockito.anyString())
+		).thenReturn(
+			Mockito.mock(RequestDispatcher.class)
+		);
+
+		mockHttpServletRequest.setSession(mockHttpSession);
+
+		NoSuchImageException noSuchImageException = new NoSuchImageException();
+
+		try (MockedStatic<PortalSessionThreadLocal>
+				portalSessionThreadLocalMockedStatic = Mockito.mockStatic(
+					PortalSessionThreadLocal.class);
+			MockedStatic<SessionErrors> sessionErrorsMockedStatic =
+				Mockito.mockStatic(SessionErrors.class);
+			MockedStatic
+				<StatusLayoutUtilityPageEntryRequestContributorRegistryUtil>
+					statusLayoutUtilityPageEntryRequestContributorRegistryUtilMockedStatic =
+						Mockito.mockStatic(
+							StatusLayoutUtilityPageEntryRequestContributorRegistryUtil.class)) {
+
+			portalSessionThreadLocalMockedStatic.when(
+				PortalSessionThreadLocal::getHttpSession
+			).thenReturn(
+				mockHttpSession
+			);
+
+			_portalImpl.sendError(
+				0, noSuchImageException, mockHttpServletRequest,
+				mockHttpServletResponse);
+
+			sessionErrorsMockedStatic.verify(
+				() -> SessionErrors.add(
+					mockHttpSession, NoSuchImageException.class,
+					noSuchImageException));
+		}
+
+		Assert.assertSame(
+			noSuchImageException,
+			mockHttpServletRequest.getAttribute(WebKeys.STATUS_EXCEPTION));
 	}
 
 	@Test

--- a/portal-impl/test/unit/com/liferay/portal/util/PortalImplUnitTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/util/PortalImplUnitTest.java
@@ -9,7 +9,6 @@ import com.liferay.layout.utility.page.kernel.StatusLayoutUtilityPageEntryReques
 import com.liferay.petra.io.BigEndianCodec;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.exception.NoSuchImageException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
@@ -832,7 +831,7 @@ public class PortalImplUnitTest {
 
 		mockHttpServletRequest.setSession(mockHttpSession);
 
-		NoSuchImageException noSuchImageException = new NoSuchImageException();
+		Exception exception = new Exception();
 
 		try (MockedStatic<PortalSessionThreadLocal>
 				portalSessionThreadLocalMockedStatic = Mockito.mockStatic(
@@ -852,17 +851,16 @@ public class PortalImplUnitTest {
 			);
 
 			_portalImpl.sendError(
-				0, noSuchImageException, mockHttpServletRequest,
+				0, exception, mockHttpServletRequest,
 				new MockHttpServletResponse());
 
 			sessionErrorsMockedStatic.verify(
 				() -> SessionErrors.add(
-					mockHttpSession, NoSuchImageException.class,
-					noSuchImageException));
+					mockHttpSession, Exception.class, exception));
 		}
 
 		Assert.assertSame(
-			noSuchImageException,
+			exception,
 			mockHttpServletRequest.getAttribute(WebKeys.PORTAL_STATUS_EXCEPTION));
 	}
 

--- a/portal-impl/test/unit/com/liferay/portal/util/PortalImplUnitTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/util/PortalImplUnitTest.java
@@ -61,11 +61,8 @@ import jakarta.portlet.PortletException;
 import jakarta.portlet.PortletMode;
 import jakarta.portlet.WindowState;
 
-import jakarta.servlet.RequestDispatcher;
-import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
-import jakarta.servlet.http.HttpSession;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -89,6 +86,7 @@ import org.osgi.framework.ServiceRegistration;
 
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
 
 /**
  * @author Miguel Pastor
@@ -830,21 +828,7 @@ public class PortalImplUnitTest {
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest();
 
-		HttpSession mockHttpSession = Mockito.mock(HttpSession.class);
-
-		ServletContext mockServletContext = Mockito.mock(ServletContext.class);
-
-		Mockito.when(
-			mockHttpSession.getServletContext()
-		).thenReturn(
-			mockServletContext
-		);
-
-		Mockito.when(
-			mockServletContext.getRequestDispatcher(Mockito.anyString())
-		).thenReturn(
-			Mockito.mock(RequestDispatcher.class)
-		);
+		MockHttpSession mockHttpSession = new MockHttpSession();
 
 		mockHttpServletRequest.setSession(mockHttpSession);
 

--- a/portal-impl/test/unit/com/liferay/portal/util/PortalImplUnitTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/util/PortalImplUnitTest.java
@@ -65,7 +65,6 @@ import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
 import java.util.Arrays;
@@ -89,6 +88,7 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 /**
  * @author Miguel Pastor
@@ -830,15 +830,6 @@ public class PortalImplUnitTest {
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest();
 
-		HttpServletResponse mockHttpServletResponse = Mockito.mock(
-			HttpServletResponse.class);
-
-		Mockito.when(
-			mockHttpServletResponse.isCommitted()
-		).thenReturn(
-			false
-		);
-
 		HttpSession mockHttpSession = Mockito.mock(HttpSession.class);
 
 		ServletContext mockServletContext = Mockito.mock(ServletContext.class);
@@ -878,7 +869,7 @@ public class PortalImplUnitTest {
 
 			_portalImpl.sendError(
 				0, noSuchImageException, mockHttpServletRequest,
-				mockHttpServletResponse);
+				new MockHttpServletResponse());
 
 			sessionErrorsMockedStatic.verify(
 				() -> SessionErrors.add(

--- a/portal-impl/test/unit/com/liferay/portal/util/PortalImplUnitTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/util/PortalImplUnitTest.java
@@ -854,14 +854,15 @@ public class PortalImplUnitTest {
 				0, exception, mockHttpServletRequest,
 				new MockHttpServletResponse());
 
+			Assert.assertSame(
+				exception,
+				mockHttpServletRequest.getAttribute(
+					WebKeys.PORTAL_STATUS_EXCEPTION));
+
 			sessionErrorsMockedStatic.verify(
 				() -> SessionErrors.add(
 					mockHttpSession, Exception.class, exception));
 		}
-
-		Assert.assertSame(
-			exception,
-			mockHttpServletRequest.getAttribute(WebKeys.PORTAL_STATUS_EXCEPTION));
 	}
 
 	@Test

--- a/portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java
@@ -453,6 +453,9 @@ public interface WebKeys {
 	public static final String PORTAL_SERVLET_URL_PATTERNS =
 		"PORTAL_SERVLET_URL_PATTERNS";
 
+	public static final String PORTAL_STATUS_EXCEPTION =
+		"PORTAL_STATUS_EXCEPTION";
+
 	public static final String PORTLET_AJAX_RENDER = "PORTLET_AJAX_RENDER";
 
 	public static final String PORTLET_BREADCRUMBS =
@@ -625,8 +628,6 @@ public interface WebKeys {
 	public static final String STALE_SESSION = "STALE_SESSION";
 
 	public static final String STARTUP_FINISHED = "STARTUP_FINISHED";
-
-	public static final String STATUS_EXCEPTION = "STATUS_EXCEPTION";
 
 	public static final String SUBJECT = "SUBJECT";
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java
@@ -626,6 +626,8 @@ public interface WebKeys {
 
 	public static final String STARTUP_FINISHED = "STARTUP_FINISHED";
 
+	public static final String STATUS_EXCEPTION = "STATUS_EXCEPTION";
+
 	public static final String SUBJECT = "SUBJECT";
 
 	public static final String TAB_INDEX = "TAB_INDEX";


### PR DESCRIPTION
Opening this PR manually because the automatic forward from https://github.com/liferay-page-management/liferay-portal/pull/18456 reported a merge conflict (https://github.com/liferay-page-management/liferay-portal/pull/18456#issuecomment-4408052248). This branch is the same content as #18456 rebased on top of `brianchandotcom/master`, so the merge here is clean.

---

https://liferay.atlassian.net/browse/LPD-85590

Forwarded from https://github.com/liferay-page-management/liferay-portal/pull/18446 (originally by @MarianoAlvaroSaiz and @ben-demetrius). The five original commits are kept as-is; this branch adds a few small follow-ups on top.

**What is being fixed:** A customer-configured status utility page (e.g. the default 404 page under Site Builder > Pages > Utility Pages) shows a spurious "Your request failed to complete" toast on top of the status page. The toast is fired by `<liferay-ui:error/>` in embedded portlets, because `PortalImpl.sendError` seeds the HSR-scoped `SessionErrors` namespace with the routing exception and `MultiSessionErrors` picks it up.

**How it is being fixed:** `PortalImpl.sendError` now publishes the routing exception on a new request attribute, `WebKeys.PORTAL_STATUS_EXCEPTION` (kept alongside the existing `SessionErrors.add` for back-compat with consumers of the HSR-scope entry, e.g. customer pages reachable via `LAYOUT_FRIENDLY_URL_PAGE_NOT_FOUND`). The status utility page reads the exception from that attribute instead of iterating `SessionErrors`, and `StatusStrutsAction` surgically removes only the seeded entry before rendering, so embedded portlets see an empty `MultiSessionErrors` while other HSR-scope entries remain available.

**Follow-ups added on top of the original commits:**

- Drop the now-dead `exception != null` guard in `PortalImpl.sendError`. The method already dereferences `exception` unconditionally a few lines earlier, and a scan of all callers confirms none can pass null.
- Rename `WebKeys.STATUS_EXCEPTION` to `WebKeys.PORTAL_STATUS_EXCEPTION` to disambiguate from workflow / asset publication / HTTP status.
- Switch `StatusStrutsAction` from `SessionErrors.clear` (drops the whole HSR-scope) to a surgical `SessionErrors.remove(httpServletRequest, exception.getClass())` so unrelated HSR-scope entries survive the include.
- Tighten the unit test in `PortalImplUnitTest`: `MockHttpServletResponse`/`MockHttpSession` instead of `Mockito.mock`, generic `Exception` instead of `NoSuchImageException`, and the request-attribute assert moved inside the try-with-resources.
- One extra unit test in `StatusStrutsActionTest` covering both branches of the surgical-remove behavior.
