### PR TITLE
LRDOCS-16599 Add build-from-source instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,116 @@
-# The Liferay Development Team
+# Liferay DXP
 
-Liferay Portal is produced by the worldwide Liferay engineering team and represents many hours of development, testing, writing documentation, and working with the wider Liferay community of customers, partners, and open source developers. We are glad you have chosen Liferay Portal and hope that it meets or exceeds your expectations!
+This `liferay-portal` repository contains the source code for
+[Liferay DXP](https://www.liferay.com/products/dxp), Liferay's Java-based digital
+experience platform. Liferay Portal and Liferay DXP are now a single product.
+Building this repository produces a Liferay DXP bundle. The platform is
+maintained by Liferay engineering and a global community of contributors.
 
-In addition to Liferay's engineering staff, a special thanks goes to the many open source developers who volunteer their time and energy to help with the release, with bug fixing, idea generation, documentation, translations, or other contributions that helped improve this release.
+## Getting Liferay DXP
+
+Three ways to run Liferay DXP:
+
+* **Build from source** (this repository): Get the latest unreleased fixes,
+customize the platform, or contribute changes upstream. Build instructions are
+below.
+
+* **[Liferay DXP Free Tier](https://www.liferay.com/downloads-community)**: The
+fastest way to run Liferay DXP. Register for a Free Tier license and download a
+ready-to-run bundle. Recommended for evaluation and most non-production use.
+Includes clustering up to 3 nodes.
+
+* **Liferay DXP Enterprise Subscription**: Adds enterprise features
+(multi-factor authentication, SAML, advanced analytics, production-scale
+clustering), certified releases, and Liferay Support.
+[Contact sales](https://www.liferay.com/contact-sales).
+
+If you previously ran Liferay Portal CE, the recommended upgrade path is
+[Liferay DXP Free Tier](https://www.liferay.com/downloads-community). You can
+also build Liferay DXP from this repository.
+
+## Building Liferay DXP from Source
+
+### Prerequisites
+
+Install these tools before building:
+
+* JDK 17 (or JDK 21)
+* [Apache Ant](https://ant.apache.org/) 1.10.14 or higher
+* [Git](https://git-scm.com/)
+* [Liferay Blade CLI](https://learn.liferay.com/w/dxp/development/tooling/blade-cli)
+(only needed if you plan to build client extensions or OSGi modules)
+
+The build uses the included Gradle wrapper, so you don't need to install Gradle
+separately.
+
+### Build Steps
+
+1. Create a working directory and `cd` into it. You clone two repositories
+side-by-side here:
+
+	```bash
+	mkdir liferay-dev
+	cd liferay-dev
+	```
+
+1. (Recommended) Clone
+[`liferay-binaries-cache-2020`](https://github.com/liferay/liferay-binaries-cache-2020)
+to speed up builds. Without it, the build downloads dependencies on demand.
+
+	```bash
+	git clone https://github.com/liferay/liferay-binaries-cache-2020 --branch master --single-branch --depth 1
+	```
+
+1. Fork [`liferay/liferay-portal`](https://github.com/liferay/liferay-portal) on
+GitHub, then clone your fork next to `liferay-binaries-cache-2020`:
+
+	```bash
+	git clone https://github.com/<your-github-user>/liferay-portal
+	cd liferay-portal
+	```
+
+1. Add the upstream repository so you can fetch changes from
+`liferay/liferay-portal`:
+
+	```bash
+	git remote add upstream https://github.com/liferay/liferay-portal
+	```
+
+1. Build:
+
+	```bash
+	ant all
+	```
+
+	The bundle is unpacked into `../bundles/` and contains a Tomcat application
+	server with Liferay DXP deployed.
+
+1. Start the bundle:
+
+	```bash
+	../bundles/tomcat-<version>/bin/startup.sh
+	```
+
+	Then visit `http://localhost:8080`.
+
+For more details, including IDE setup, deploying core changes, deploying
+modules, and submitting pull requests, see
+[Building Liferay DXP from Source](https://learn.liferay.com/w/reference/contributing-to-liferay-development/building-liferay-source)
+on Liferay Learn.
+
+## Modules
+
+Liferay DXP includes hundreds of OSGi modules under [`modules/`](modules/). The
+build system, marker files, and Gradle conventions used by these modules are
+documented in [`modules/README.md`](modules/README.md).
+
+## Contributing
+
+Contributions are welcome. See [`CONTRIBUTING.md`](CONTRIBUTING.md) to get
+started.
 
 ## License
 
 `SPDX-License-Identifier: (LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06)`
 
-See `LICENSING.md` for details.
+See [`LICENSING.md`](LICENSING.md) for details.


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRDOCS-16599

## What is being fixed

The README was an 11-line thank-you and license pointer with no guidance for getting started. With Liferay Portal and Liferay DXP now a single product built from this repository, external developers arriving at the GitHub project had no in-repo path to a runnable bundle and no signpost to the alternatives (DXP Free Tier or Enterprise Subscription).

## How it is being fixed

The README opens with a "Getting Liferay DXP" section that names the three supported paths (build from source, DXP Free Tier, and Enterprise Subscription) and then walks through the ant all build. Markdown follows liferay-portal conventions (asterisk bullets, tab-indented code blocks, angle-bracket placeholders, ~80-column wrap). The full reference for IDE setup, deploying core changes, deploying modules, and submitting pull requests lives on Liferay Learn and is linked from the README.