### PR TITLE
LPD-89406 Rotate CompanyInfo.key_ in place during upgrade instead of nulling

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgraderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgraderTest.java
@@ -13,6 +13,7 @@ import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.encryptor.EncryptorUtil;
 import com.liferay.portal.kernel.model.ReleaseConstants;
@@ -217,7 +218,8 @@ public class DBUpgraderTest {
 
 		try (PreparedStatement preparedStatement = _connection.prepareStatement(
 				"select companyId, key_ from CompanyInfo");
-			 ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			ResultSet resultSet = preparedStatement.executeQuery()) {
 
 			while (resultSet.next()) {
 				originalKeys.put(
@@ -239,34 +241,32 @@ public class DBUpgraderTest {
 			try (PreparedStatement preparedStatement =
 					_connection.prepareStatement(
 						"select companyId, key_ from CompanyInfo");
-				 ResultSet resultSet = preparedStatement.executeQuery()) {
+
+				ResultSet resultSet = preparedStatement.executeQuery()) {
 
 				while (resultSet.next()) {
-					long companyId = resultSet.getLong("companyId");
 					String key = resultSet.getString("key_");
 
-					Assert.assertNotNull(
-						"key_ must not be null for companyId " + companyId,
-						key);
-					Assert.assertNotNull(
-						"key_ must deserialize to a valid Key for companyId " +
-							companyId,
-						EncryptorUtil.deserializeKey(key));
+					Assert.assertNotNull(key);
+					Assert.assertNotNull(EncryptorUtil.deserializeKey(key));
 				}
 			}
 		}
 		finally {
-			for (Map.Entry<Long, String> entry : originalKeys.entrySet()) {
-				try (PreparedStatement preparedStatement =
-						_connection.prepareStatement(
-							"update CompanyInfo set key_ = ? where " +
-								"companyId = ?")) {
+			String sql = "update CompanyInfo set key_ = ? where companyId = ?";
 
+			try (PreparedStatement preparedStatement =
+					AutoBatchPreparedStatementUtil.autoBatch(
+						_connection, sql)) {
+
+				for (Map.Entry<Long, String> entry : originalKeys.entrySet()) {
 					preparedStatement.setString(1, entry.getValue());
 					preparedStatement.setLong(2, entry.getKey());
 
-					preparedStatement.executeUpdate();
+					preparedStatement.addBatch();
 				}
+
+				preparedStatement.executeBatch();
 			}
 		}
 	}

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgraderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgraderTest.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.encryptor.EncryptorUtil;
 import com.liferay.portal.kernel.model.ReleaseConstants;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -38,7 +39,9 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.junit.After;
@@ -205,6 +208,66 @@ public class DBUpgraderTest {
 			List<LogEntry> logEntries = logCapture.getLogEntries();
 
 			Assert.assertEquals(logEntries.toString(), 0, logEntries.size());
+		}
+	}
+
+	@Test
+	public void testUpdateCompanyKey() throws Exception {
+		Map<Long, String> originalKeys = new HashMap<>();
+
+		try (PreparedStatement preparedStatement = _connection.prepareStatement(
+				"select companyId, key_ from CompanyInfo");
+			 ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			while (resultSet.next()) {
+				originalKeys.put(
+					resultSet.getLong("companyId"),
+					resultSet.getString("key_"));
+			}
+		}
+
+		try (PreparedStatement preparedStatement = _connection.prepareStatement(
+				"update CompanyInfo set key_ = null")) {
+
+			preparedStatement.executeUpdate();
+		}
+
+		try {
+			ReflectionTestUtil.invoke(
+				DBUpgrader.class, "_updateCompanyKey", new Class<?>[0]);
+
+			try (PreparedStatement preparedStatement =
+					_connection.prepareStatement(
+						"select companyId, key_ from CompanyInfo");
+				 ResultSet resultSet = preparedStatement.executeQuery()) {
+
+				while (resultSet.next()) {
+					long companyId = resultSet.getLong("companyId");
+					String key = resultSet.getString("key_");
+
+					Assert.assertNotNull(
+						"key_ must not be null for companyId " + companyId,
+						key);
+					Assert.assertNotNull(
+						"key_ must deserialize to a valid Key for companyId " +
+							companyId,
+						EncryptorUtil.deserializeKey(key));
+				}
+			}
+		}
+		finally {
+			for (Map.Entry<Long, String> entry : originalKeys.entrySet()) {
+				try (PreparedStatement preparedStatement =
+						_connection.prepareStatement(
+							"update CompanyInfo set key_ = ? where " +
+								"companyId = ?")) {
+
+					preparedStatement.setString(1, entry.getValue());
+					preparedStatement.setLong(2, entry.getKey());
+
+					preparedStatement.executeUpdate();
+				}
+			}
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.dependency.manager.DependencyManagerSyncUtil;
+import com.liferay.portal.kernel.encryptor.EncryptorUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -60,6 +61,8 @@ import com.liferay.util.dao.orm.CustomSQLUtil;
 import java.io.InputStream;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import java.util.Collection;
@@ -618,9 +621,26 @@ public class DBUpgrader {
 	}
 
 	private static void _updateCompanyKey() throws Exception {
-		DB db = DBManagerUtil.getDB();
+		try (Connection connection = DataAccess.getConnection();
+			 PreparedStatement selectPreparedStatement =
+				 connection.prepareStatement(
+					 "select companyId from CompanyInfo");
+			 ResultSet resultSet = selectPreparedStatement.executeQuery();
+			 PreparedStatement updatePreparedStatement =
+				 connection.prepareStatement(
+					 "update CompanyInfo set key_ = ? where companyId = ?")) {
 
-		db.runSQL("update CompanyInfo set key_ = null");
+			while (resultSet.next()) {
+				long companyId = resultSet.getLong("companyId");
+
+				updatePreparedStatement.setString(
+					1,
+					EncryptorUtil.serializeKey(EncryptorUtil.generateKey()));
+				updatePreparedStatement.setLong(2, companyId);
+
+				updatePreparedStatement.executeUpdate();
+			}
+		}
 	}
 
 	private static final String _CLASS_NAME =

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -16,9 +16,9 @@ import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.cache.CacheRegistryUtil;
 import com.liferay.portal.kernel.cache.PortalCacheHelperUtil;
 import com.liferay.portal.kernel.cache.PortalCacheManagerNames;
-import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.dependency.manager.DependencyManagerSyncUtil;
 import com.liferay.portal.kernel.encryptor.EncryptorUtil;
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.module.util.ServiceLatch;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalServiceUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceComponentLocalServiceUtil;
 import com.liferay.portal.kernel.service.configuration.ServiceComponentConfiguration;
 import com.liferay.portal.kernel.upgrade.recorder.UpgradeLogProgressTracker;
@@ -62,7 +63,6 @@ import java.io.InputStream;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import java.util.Collection;
@@ -622,24 +622,24 @@ public class DBUpgrader {
 
 	private static void _updateCompanyKey() throws Exception {
 		try (Connection connection = DataAccess.getConnection();
-			 PreparedStatement selectPreparedStatement =
-				 connection.prepareStatement(
-					 "select companyId from CompanyInfo");
-			 ResultSet resultSet = selectPreparedStatement.executeQuery();
-			 PreparedStatement updatePreparedStatement =
-				 connection.prepareStatement(
-					 "update CompanyInfo set key_ = ? where companyId = ?")) {
 
-			while (resultSet.next()) {
-				long companyId = resultSet.getLong("companyId");
+			PreparedStatement preparedStatement =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"update CompanyInfo set key_ = ? where companyId = ?")) {
 
-				updatePreparedStatement.setString(
-					1,
-					EncryptorUtil.serializeKey(EncryptorUtil.generateKey()));
-				updatePreparedStatement.setLong(2, companyId);
+			CompanyLocalServiceUtil.forEachCompany(
+				company -> {
+					preparedStatement.setString(
+						1,
+						EncryptorUtil.serializeKey(
+							EncryptorUtil.generateKey()));
+					preparedStatement.setLong(2, company.getCompanyId());
 
-				updatePreparedStatement.executeUpdate();
-			}
+					preparedStatement.addBatch();
+				});
+
+			preparedStatement.executeBatch();
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/productnavigation/ProductMenu.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/productnavigation/ProductMenu.macro
@@ -85,6 +85,13 @@ definition {
 	macro gotoPortlet(site = null, portlet = null, category = null) {
 		if (IsElementNotPresent(locator1 = "ProductMenu#TOGGLE")) {
 			ApplicationsMenu.gotoSite(site = ${site});
+
+			if (isSet(site)) {
+				var siteNameURL = StringUtil.replace(${site}, " ", "-");
+				var siteNameURL = StringUtil.lowerCase(${siteNameURL});
+
+				Navigator.openWithAppendToBaseURL(urlAppend = "group/${siteNameURL}/~/control_panel/manage");
+			}
 		}
 
 		ProductMenuHelper.openProductMenu();

--- a/portal-web/test/functional/com/liferay/portalweb/macros/productnavigation/ProductMenu.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/productnavigation/ProductMenu.macro
@@ -88,6 +88,7 @@ definition {
 
 			if (isSet(site)) {
 				var siteNameURL = StringUtil.replace(${site}, " ", "-");
+
 				var siteNameURL = StringUtil.lowerCase(${siteNameURL});
 
 				Navigator.openWithAppendToBaseURL(urlAppend = "group/${siteNameURL}/~/control_panel/manage");

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/applicationsmenu/ApplicationsMenu.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/applicationsmenu/ApplicationsMenu.path
@@ -57,7 +57,7 @@
 </tr>
 <tr>
 	<td>VIEW_ALL_LINK</td>
-	<td>//ul[@role='menu' and contains(@class, 'sites-list')]//button[@role='menuitem' and contains(.,'View All')]</td>
+	<td>//ul[@role='menu' and contains(@class, 'sites-list')]//*[@role='menuitem' and contains(.,'View All')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89406

**What is being fixed:** `DBUpgrader._updateCompanyKey()` was nulling every `CompanyInfo.key_` row with a bare `UPDATE CompanyInfo SET key_ = null` on every upgrade. LPD-67042 introduced `EncryptorUtil.encryptUnencoded()` — which has no null guard — into a code path triggered during post-upgrade reindex. When `key_` is null at that point, the call throws an NPE, causing the reindex to fail and active users to disappear from the Admin Users list after upgrade.

**How it is being fixed:** Instead of nulling, `_updateCompanyKey()` now rotates the key in place. It iterates over every company with `CompanyLocalServiceUtil.forEachCompany()`, generates a fresh AES key per company via `EncryptorUtil.generateKey()`, serializes it with `EncryptorUtil.serializeKey()`, and writes the new value using `AutoBatchPreparedStatementUtil.autoBatch()`. The key rotation intent is preserved but the null window that triggered the NPE is eliminated. An integration test in `DBUpgraderTest` verifies that after calling `_updateCompanyKey()` no `CompanyInfo` row has a null `key_`.