### PR TITLE
LPD-89119 Add content selector to the Data Selection step

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/NewImport.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/NewImport.tsx
@@ -35,7 +35,9 @@ export function NewImport({
 					name: '',
 				}}
 				isStepValid={(values) =>
-					values.fileSelector instanceof File && !!values.name.trim()
+					values.fileSelector instanceof File &&
+					!!values.name.trim() &&
+					!!importPreview
 				}
 				title={Liferay.Language.get('setup')}
 			>
@@ -49,6 +51,10 @@ export function NewImport({
 				description={Liferay.Language.get(
 					'select-the-data-from-your-file-that-you-would-like-to-import'
 				)}
+				initialValues={{
+					contentSelection: undefined,
+				}}
+				isStepValid={(values) => !!values.contentSelection}
 				title={Liferay.Language.get('data-selection')}
 			>
 				<DataSelectionStep importPreview={importPreview} />

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/DataSelectionStep.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/DataSelectionStep.tsx
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import ClayLayout from '@clayui/layout';
 import React from 'react';
 
+import {FormikFieldContentSelector} from '../../../components/forms/formik';
 import {ImportPreview} from '../../../types/exportImportPreview';
 import FileSummary from './FileSummary';
 
@@ -22,9 +22,10 @@ export default function DataSelectionStep({
 		<>
 			<FileSummary importPreview={importPreview} />
 
-			<ClayLayout.Sheet>
-				{Liferay.Language.get('Portlets')}
-			</ClayLayout.Sheet>
+			<FormikFieldContentSelector
+				name="contentSelection"
+				sections={importPreview.portletDataHandlerSections}
+			/>
 		</>
 	);
 }

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/FileSelectionStep.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/FileSelectionStep.tsx
@@ -41,6 +41,7 @@ export default function FileSelectionStep({
 		}
 
 		if (!currentFile) {
+			setFieldValue('contentSelection', undefined);
 			setImportPreview(undefined);
 		}
 	}, [values.fileSelector, values.name, setFieldValue, setImportPreview]);

--- a/modules/apps/export-import/export-import-web/test/revamp/js/mocks/mockPortletDataHandlerSections.ts
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/mocks/mockPortletDataHandlerSections.ts
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {ExportPreview} from '../../../../src/main/resources/META-INF/resources/revamp/js/types/exportImportPreview';
 import {PortletDataHandlerSection} from '../../../../src/main/resources/META-INF/resources/revamp/js/types/portletDataHandler';
 
-const sections: PortletDataHandlerSection[] = [
+export const mockPortletDataHandlerSections: PortletDataHandlerSection[] = [
 	{
 		label: 'Design',
 		name: 'category.site_administration.design',
@@ -140,8 +139,3 @@ const sections: PortletDataHandlerSection[] = [
 		],
 	},
 ];
-
-export const mockExportPreview: ExportPreview = {
-	additionCount: 42,
-	portletDataHandlerSections: sections,
-};

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/NewExport.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/NewExport.test.tsx
@@ -11,7 +11,7 @@ import fetch from 'jest-fetch-mock';
 import React from 'react';
 
 import {NewExport} from '../../../../../src/main/resources/META-INF/resources/revamp/js/pages/export/NewExport';
-import {mockExportPreview} from '../../mocks/mockExportPreview';
+import {mockPortletDataHandlerSections} from '../../mocks/mockPortletDataHandlerSections';
 
 const renderComponent = () => {
 	return render(
@@ -25,7 +25,12 @@ const renderComponent = () => {
 describe('NewExport', () => {
 	beforeEach(() => {
 		fetch.resetMocks();
-		fetch.mockResponse(JSON.stringify(mockExportPreview));
+		fetch.mockResponse(
+			JSON.stringify({
+				additionCount: 42,
+				portletDataHandlerSections: mockPortletDataHandlerSections,
+			})
+		);
 	});
 
 	it('renders the export form', async () => {

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/NewImport.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/NewImport.test.tsx
@@ -10,6 +10,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import {NewImport} from '../../../../../src/main/resources/META-INF/resources/revamp/js/pages/import/NewImport';
+import {mockPortletDataHandlerSections} from '../../mocks/mockPortletDataHandlerSections';
 
 jest.mock('frontend-js-web', () => {
 	const actual = jest.requireActual('frontend-js-web');
@@ -36,7 +37,7 @@ jest.mock(
 					fileEntryId: 1,
 					fileName: 'site.lar',
 					fileSize: 4096,
-					portletDataHandlerSections: [],
+					portletDataHandlerSections: mockPortletDataHandlerSections,
 				},
 				error: null,
 			})
@@ -195,7 +196,7 @@ describe('NewImport', () => {
 		expect(nameInput).toHaveValue('');
 	});
 
-	it('forwards the upload metadata to the FileSummary card on the Data Selection step', async () => {
+	it('shows the file summary and the lar contents on the Data Selection step after uploading a file and clicking Continue', async () => {
 		renderComponent();
 
 		await user.type(screen.getByLabelText(/^name/i), 'My import');
@@ -215,5 +216,8 @@ describe('NewImport', () => {
 		expect(screen.getByText('Test User')).toBeInTheDocument();
 		expect(screen.getByText('5 days ago')).toBeInTheDocument();
 		expect(screen.getByText('4 KB')).toBeInTheDocument();
+
+		expect(screen.getByText('Design')).toBeInTheDocument();
+		expect(screen.getByText('Theme Settings')).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
Sent from: https://github.com/liferay-headless/liferay-portal/pull/3748

https://liferay.atlassian.net/browse/LPD-89119

## What is being added

The Data Selection step of the new import wizard rendered only the FileSummary card and did not surface the portletDataHandler sections returned by the import preview, so users had no way to choose which content to bring in. The step also did not gate advancement, letting the wizard move on without any selection.

## How it is being implemented

Render the FormikFieldContentSelector below the FileSummary, sourcing its sections directly from `importPreview.portletDataHandlerSections` — the same shape the export side already consumes. Wire the wizard step's `initialValues` and `isStepValid` in `NewImport` so the step starts with no selection and advances only once a content type is chosen.

## Screenshot
<img width="3312" height="2001" alt="image" src="https://github.com/user-attachments/assets/8a8d06ab-9881-4f17-a49b-7c14e9121492" />