### PR TITLE
LPD-88642 Remove unused nodeName parameter from _assertAllCachesEmpty

### DIFF
--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/CacheReplicatorEntryTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/CacheReplicatorEntryTest.java
@@ -145,7 +145,7 @@ public class CacheReplicatorEntryTest implements Serializable {
 
 					Assert.assertTrue(TestPortalCacheListener.await());
 
-					_assertAllCachesEmpty("Node 1");
+					_assertAllCachesEmpty();
 
 					Assert.assertArrayEquals(
 						"Node 1 listener events mismatch", events,
@@ -166,7 +166,7 @@ public class CacheReplicatorEntryTest implements Serializable {
 				() -> {
 					Assert.assertTrue(TestPortalCacheListener.await());
 
-					_assertAllCachesEmpty("Node 2");
+					_assertAllCachesEmpty();
 
 					Assert.assertArrayEquals(
 						"Node 2 listener events mismatch", events,
@@ -349,7 +349,7 @@ public class CacheReplicatorEntryTest implements Serializable {
 
 	}
 
-	private void _assertAllCachesEmpty(String nodeName) {
+	private void _assertAllCachesEmpty() {
 		for (PortalCache<Serializable, Serializable> portalCache :
 				_getAllRelatedPortalCaches(false)) {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88642

## What is being fixed

The private `_assertAllCachesEmpty(String nodeName)` helper in
`CacheReplicatorEntryTest` accepts a `nodeName` argument that is never
read inside the method body. The assertion message overload is no
longer in use, so the parameter is dead weight at both call sites.

## How it is being fixed

Drop the `String nodeName` parameter from the declaration, and remove
the `"Node 1"` / `"Node 2"` arguments at the two call sites inside the
node 1 and node 2 cluster lambdas.

## Why are there no tests?

This is a pure refactor: the parameter was unused, so the method's
behavior is unchanged. `CacheReplicatorEntryTest.testClearCacheReplicatorMessageCount`
continues to exercise the helper at both call sites and would catch
any regression.