### PR TITLE
LPD-89494 Fix WCAG 2.0 accessibility issue in collection filter label elements

### DIFF
--- a/modules/apps/fragment/fragment-collection-filter-category/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/fragment/fragment-collection-filter-category/src/main/resources/META-INF/resources/page.jsp
@@ -8,9 +8,9 @@
 <%@ include file="/init.jsp" %>
 
 <div class="form-group form-group-sm">
-	<label class="control-label <%= fragmentCollectionFilterCategoryDisplayContext.isShowLabel() ? "" : "sr-only" %>">
+	<span class="control-label <%= fragmentCollectionFilterCategoryDisplayContext.isShowLabel() ? "" : "sr-only" %>">
 		<%= fragmentCollectionFilterCategoryDisplayContext.getLabel() %>
-	</label>
+	</span>
 
 	<div>
 		<clay:button

--- a/modules/apps/fragment/fragment-collection-filter-tags/build.gradle
+++ b/modules/apps/fragment/fragment-collection-filter-tags/build.gradle
@@ -12,4 +12,6 @@ dependencies {
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-io")
 	compileOnly project(":core:petra:petra-string")
+	testImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	testImplementation project(":apps:info:info-api")
 }

--- a/modules/apps/fragment/fragment-collection-filter-tags/src/main/java/com/liferay/fragment/collection/filter/tags/display/context/FragmentCollectionFilterTagsDisplayContext.java
+++ b/modules/apps/fragment/fragment-collection-filter-tags/src/main/java/com/liferay/fragment/collection/filter/tags/display/context/FragmentCollectionFilterTagsDisplayContext.java
@@ -44,6 +44,10 @@ public class FragmentCollectionFilterTagsDisplayContext {
 			WebKeys.THEME_DISPLAY);
 	}
 
+	public String getFragmentEntryLinkNamespace() {
+		return _fragmentRendererContext.getFragmentElementId();
+	}
+
 	public String getHelpText() {
 		String helpText = GetterUtil.getString(_getFieldValue("helpText"));
 
@@ -79,6 +83,8 @@ public class FragmentCollectionFilterTagsDisplayContext {
 		).put(
 			"fragmentEntryLinkId",
 			String.valueOf(_fragmentEntryLink.getFragmentEntryLinkId())
+		).put(
+			"fragmentEntryLinkNamespace", getFragmentEntryLinkNamespace()
 		).put(
 			"groupIds",
 			ArrayUtil.toStringArray(

--- a/modules/apps/fragment/fragment-collection-filter-tags/src/main/resources/META-INF/resources/js/index.tsx
+++ b/modules/apps/fragment/fragment-collection-filter-tags/src/main/resources/META-INF/resources/js/index.tsx
@@ -15,6 +15,7 @@ import React, {useCallback, useState} from 'react';
 interface IProps {
 	disabled: boolean;
 	fragmentEntryLinkId: string;
+	fragmentEntryLinkNamespace: string;
 	groupIds: Array<string>;
 	helpText: string;
 	label: string;
@@ -25,6 +26,7 @@ interface IProps {
 export function SelectTags({
 	disabled,
 	fragmentEntryLinkId,
+	fragmentEntryLinkNamespace,
 	groupIds,
 	helpText,
 	label,
@@ -65,6 +67,7 @@ export function SelectTags({
 			formGroupClassName="mb-0"
 			groupIds={groupIds}
 			helpText={helpText}
+			inputName={fragmentEntryLinkNamespace}
 			inputValue={inputValue}
 			label={label}
 			onInputValueChange={disabled ? () => {} : setInputValue}

--- a/modules/apps/fragment/fragment-collection-filter-tags/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/fragment/fragment-collection-filter-tags/src/main/resources/META-INF/resources/page.jsp
@@ -15,9 +15,9 @@
 
 <div class="form-group form-group-sm mb-0">
 	<div role="presentation">
-		<label class="control-label <%= fragmentCollectionFilterTagsDisplayContext.isShowLabel() ? "" : "sr-only" %>">
+		<span class="control-label <%= fragmentCollectionFilterTagsDisplayContext.isShowLabel() ? "" : "sr-only" %>">
 			<%= fragmentCollectionFilterTagsDisplayContext.getLabel() %>
-		</label>
+		</span>
 
 		<input class="form-control form-control-sm tag-filter-input w-100" type="text" />
 

--- a/modules/apps/fragment/fragment-collection-filter-tags/src/test/java/com/liferay/fragment/collection/filter/tags/display/context/FragmentCollectionFilterTagsDisplayContextTest.java
+++ b/modules/apps/fragment/fragment-collection-filter-tags/src/test/java/com/liferay/fragment/collection/filter/tags/display/context/FragmentCollectionFilterTagsDisplayContextTest.java
@@ -1,0 +1,60 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.collection.filter.tags.display.context;
+
+import com.liferay.fragment.renderer.FragmentRendererContext;
+import com.liferay.fragment.util.configuration.FragmentEntryConfigurationParser;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Georgel Pop
+ */
+public class FragmentCollectionFilterTagsDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	@TestInfo("LPD-89494")
+	public void testGetFragmentEntryLinkNamespace() {
+		FragmentRendererContext fragmentRendererContext = Mockito.mock(
+			FragmentRendererContext.class);
+
+		String namespace = RandomTestUtil.randomString();
+
+		Mockito.when(
+			fragmentRendererContext.getFragmentElementId()
+		).thenReturn(
+			namespace
+		);
+
+		FragmentCollectionFilterTagsDisplayContext
+			fragmentCollectionFilterTagsDisplayContext =
+				new FragmentCollectionFilterTagsDisplayContext(
+					null, Mockito.mock(FragmentEntryConfigurationParser.class),
+					fragmentRendererContext,
+					Mockito.mock(HttpServletRequest.class));
+
+		Assert.assertEquals(
+			namespace,
+			fragmentCollectionFilterTagsDisplayContext.
+				getFragmentEntryLinkNamespace());
+	}
+
+}


### PR DESCRIPTION
## Summary
- Replace `<label>` with `<span>` in the category collection filter (the associated control is a Clay button, not an `<input>`)
- Replace `<label>` with `<span>` in the tags collection filter and pass `fragmentEntryLinkNamespace` as `inputName` to `AssetTagsSelector` so its internally rendered `<label htmlFor>` and `<input id>` are properly linked
- Add unit test for `FragmentCollectionFilterTagsDisplayContext#getFragmentEntryLinkNamespace()`

## Test plan
- [ ] Open a page with a Collection Filter (Category) fragment — verify no orphaned `<label>` in the DOM
- [ ] Open a page with a Collection Filter (Tags) fragment — verify the `<label for>` and `<input id>` attributes share the same value