### PR TITLE
LPD-90194 Stabilize dateTime seeds in object entry manager tests

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -2310,13 +2310,16 @@ public class DefaultObjectEntryManagerImplTest
 		LocalDateTime localDateTime = nowLocalDateTime.truncatedTo(
 			ChronoUnit.MILLIS);
 
+		String localDateTimeString = localDateTime.format(
+			DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS"));
+
 		assertEquals(
 			_defaultObjectEntryManager.addObjectEntry(
 				dtoConverterContext, _objectDefinition2,
 				new ObjectEntry() {
 					{
 						properties = HashMapBuilder.<String, Object>put(
-							"dateTimeObjectFieldName", localDateTime
+							"dateTimeObjectFieldName", localDateTimeString
 						).build();
 					}
 				},
@@ -2324,10 +2327,7 @@ public class DefaultObjectEntryManagerImplTest
 			new ObjectEntry() {
 				{
 					properties = HashMapBuilder.<String, Object>put(
-						"dateTimeObjectFieldName",
-						localDateTime.format(
-							DateTimeFormatter.ofPattern(
-								"yyyy-MM-dd'T'HH:mm:ss.SSS"))
+						"dateTimeObjectFieldName", localDateTimeString
 					).build();
 				}
 			});
@@ -7574,8 +7574,6 @@ public class DefaultObjectEntryManagerImplTest
 
 	@Test
 	public void testPartialUpdateObjectEntry() throws Exception {
-		LocalDateTime nowLocalDateTime = LocalDateTime.now();
-
 		ObjectEntry objectEntry1 = _defaultObjectEntryManager.addObjectEntry(
 			dtoConverterContext, _objectDefinition2,
 			new ObjectEntry() {
@@ -7585,7 +7583,13 @@ public class DefaultObjectEntryManagerImplTest
 						_simpleDateFormat.format(RandomTestUtil.nextDate())
 					).put(
 						"dateTimeObjectFieldName",
-						nowLocalDateTime.truncatedTo(ChronoUnit.MILLIS)
+						LocalDateTime.now(
+						).truncatedTo(
+							ChronoUnit.MILLIS
+						).format(
+							DateTimeFormatter.ofPattern(
+								"yyyy-MM-dd'T'HH:mm:ss.SSS")
+						)
 					).put(
 						"decimalObjectFieldName", RandomTestUtil.randomDouble()
 					).put(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90194

## What is being fixed

`com.liferay.object.rest.internal.manager.v1_0.test.DefaultObjectEntryManagerImplTest.testPartialUpdateObjectEntry` flakes with `java.time.format.DateTimeParseException: Text '2026-05-13T16:39:34' could not be parsed at index 19`. The test seeds `dateTimeObjectFieldName` with a raw `LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS)`. When "now" lands on a whole second, `LocalDateTime.toString()` omits the fractional component and produces a 19-character string with no `.SSS`; the framework reparses it with a strict `yyyy-MM-dd'T'HH:mm:ss.SSS` formatter and throws. The same pattern is present in `testAddObjectEntryWithDynamicObjectFieldValues` and would flake for the same reason.

## How it is being fixed

Pre-format the seeded value as a string in `yyyy-MM-dd'T'HH:mm:ss.SSS`, mirroring the formatter the assertion expectation already uses. The framework then receives a deterministic input that always parses cleanly. Both flake-prone seeds are converted in one go.

## Why are there no tests?

The change is entirely within existing test code, making an already-covered scenario deterministic; no new test surface is added. Both touched methods were rerun locally and pass.