### PR TITLE
LPD-89664 Bypass depot filter for Administrator and CMS Administrator

### DIFF
--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetStatisticsResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/AssetStatisticsResourceImpl.java
@@ -6,7 +6,7 @@
 package com.liferay.headless.cms.internal.resource.v1_0;
 
 import com.liferay.depot.constants.DepotConstants;
-import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.depot.service.DepotEntryService;
 import com.liferay.headless.cms.dto.v1_0.AssetStatistics;
 import com.liferay.headless.cms.resource.v1_0.AssetStatisticsResource;
 import com.liferay.object.constants.ObjectFolderConstants;
@@ -50,7 +50,7 @@ public class AssetStatisticsResourceImpl
 		}
 
 		List<Long> depotEntryGroupIds =
-			_depotEntryLocalService.getDepotEntryGroupIds(
+			_depotEntryService.getDepotEntryGroupIds(
 				contextCompany.getCompanyId(), contextUser.getUserId(),
 				DepotConstants.TYPE_SPACE);
 
@@ -72,8 +72,8 @@ public class AssetStatisticsResourceImpl
 			return _toAssetStatistics();
 		}
 
-		Long[] groupIds = depotEntryGroupIds.toArray(new Long[0]);
 		Date date = new Date();
+		Long[] groupIds = depotEntryGroupIds.toArray(new Long[0]);
 
 		return new AssetStatistics() {
 			{
@@ -148,7 +148,7 @@ public class AssetStatisticsResourceImpl
 		AssetStatisticsResourceImpl.class);
 
 	@Reference
-	private DepotEntryLocalService _depotEntryLocalService;
+	private DepotEntryService _depotEntryService;
 
 	@Reference
 	private ObjectDefinitionService _objectDefinitionService;

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/AssetStatisticsResourceTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/AssetStatisticsResourceTest.java
@@ -10,6 +10,7 @@ import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.headless.cms.client.dto.v1_0.AssetStatistics;
+import com.liferay.headless.cms.client.resource.v1_0.AssetStatisticsResource;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.field.util.ObjectFieldUtil;
@@ -20,11 +21,17 @@ import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -43,6 +50,7 @@ import java.util.Collections;
 import java.util.Date;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -62,6 +70,22 @@ public class AssetStatisticsResourceTest
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		_cmsAdministratorUser = _addUserWithRole(
+			RoleConstants.CMS_ADMINISTRATOR);
+		_companyAdminUser = _addUserWithRole(RoleConstants.ADMINISTRATOR);
+
+		_assetStatisticsResources = new AssetStatisticsResource[] {
+			assetStatisticsResource,
+			_buildAssetStatisticsResource(_cmsAdministratorUser),
+			_buildAssetStatisticsResource(_companyAdminUser)
+		};
+	}
 
 	@Override
 	@Test
@@ -233,31 +257,63 @@ public class AssetStatisticsResourceTest
 			ServiceContextTestUtil.getServiceContext());
 	}
 
+	private User _addUserWithRole(String roleName) throws Exception {
+		User user = UserTestUtil.addUser(
+			testCompany, RandomTestUtil.randomString());
+
+		Role role = _roleLocalService.getRole(
+			testCompany.getCompanyId(), roleName);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user.getUserId());
+
+		return user;
+	}
+
 	private void _assertAssetStatistics(
 			long expectedExpiredCount, long expectedExpiringSoonCount,
 			long expectedInDraftCount, long expectedReviewDateOverdueCount,
 			long expectedTotalCount)
 		throws Exception {
 
-		AssetStatistics assetStatistics =
-			assetStatisticsResource.getAssetStatistics();
+		for (AssetStatisticsResource assetStatisticsResource :
+				_assetStatisticsResources) {
 
-		Assert.assertEquals(
-			expectedExpiredCount,
-			GetterUtil.getLong(assetStatistics.getExpiredCount()));
-		Assert.assertEquals(
-			expectedExpiringSoonCount,
-			GetterUtil.getLong(assetStatistics.getExpiringSoonCount()));
-		Assert.assertEquals(
-			expectedInDraftCount,
-			GetterUtil.getLong(assetStatistics.getInDraftCount()));
-		Assert.assertEquals(
-			expectedReviewDateOverdueCount,
-			GetterUtil.getLong(assetStatistics.getReviewDateOverdueCount()));
-		Assert.assertEquals(
-			expectedTotalCount,
-			GetterUtil.getLong(assetStatistics.getTotalCount()));
+			AssetStatistics assetStatistics =
+				assetStatisticsResource.getAssetStatistics();
+
+			Assert.assertEquals(
+				expectedExpiredCount,
+				GetterUtil.getLong(assetStatistics.getExpiredCount()));
+			Assert.assertEquals(
+				expectedExpiringSoonCount,
+				GetterUtil.getLong(assetStatistics.getExpiringSoonCount()));
+			Assert.assertEquals(
+				expectedInDraftCount,
+				GetterUtil.getLong(assetStatistics.getInDraftCount()));
+			Assert.assertEquals(
+				expectedReviewDateOverdueCount,
+				GetterUtil.getLong(
+					assetStatistics.getReviewDateOverdueCount()));
+			Assert.assertEquals(
+				expectedTotalCount,
+				GetterUtil.getLong(assetStatistics.getTotalCount()));
+		}
 	}
+
+	private AssetStatisticsResource _buildAssetStatisticsResource(User user) {
+		return AssetStatisticsResource.builder(
+		).authentication(
+			user.getEmailAddress(), user.getPasswordUnencrypted()
+		).endpoint(
+			testCompany.getVirtualHostname(), 8080, "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	private AssetStatisticsResource[] _assetStatisticsResources;
+	private User _cmsAdministratorUser;
+	private User _companyAdminUser;
 
 	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;
@@ -270,5 +326,11 @@ public class AssetStatisticsResourceTest
 
 	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89664

> ⚠️ This branch sits on top of LPD-89152. The LPD-89152 commits in
> this diff are already under review in
> https://github.com/brianchandotcom/liferay-portal/pull/174545 and do
> not need to be re-reviewed here. Only the two LPD-89664 commits at
> the tip require review.

## What is being fixed

The `/o/headless-cms/v1.0/asset-statistics` endpoint scoped counts to
Space depots the user is explicitly a member of, so a Liferay
Administrator or CMS Administrator who viewed CMS content through the
All section but was not a Space member always saw zero counts. The
frontend then hid the quick filter chips because `totalCount` was 0,
even though the same user could see and use the regular filter panel.

## How it is being fixed

When the caller has the Administrator or CMS Administrator role, the
endpoint now computes counts over every CMS Space depot in the company
instead of restricting to the user's depot-membership scope. Regular
users keep the membership scope. This mirrors (and extends) the bypass
already used by `SectionDisplayContextHelper` for the All section.

## How to test

1. Apply this branch and deploy `headless-cms-impl`.
2. Log in as a CMS Administrator user that is **not** a member of any
   CMS Space depot. Open CMS → All. The quick filter chips should now
   show non-zero counts.
3. Repeat as an Administrator user that is not a Space member — chips
   should also show counts.
4. Log in as a regular user without any Space membership. Counts
   should remain zero and chips should stay hidden.

Automated coverage: the refactored `testGetAssetStatistics` runs the
full AssetStatistics flow against three personas (owner, Administrator,
CMS Administrator) and asserts every step's counts match across all
three. Run it with:

    cd modules/apps/headless/headless-cms/headless-cms-test
    gw testIntegration --tests AssetStatisticsResourceTest