### PR TITLE
LPD-89790 Wrap hsl(from ...) in unquote for liferay-theme-tasks Sass

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_icons.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_icons.scss
@@ -3,7 +3,7 @@
 }
 
 .lexicon-icon-arrows-all {
-	background-color: hsl(from #{$cadmin-white} h s l / 0.6);
+	background-color: unquote('hsl(from #{$cadmin-white} h s l / 0.6)');
 	border: 1px solid $cadmin-border-color;
 	border-radius: 0.1413em; // 6.5/46
 	height: 0.73913em; // 34/46 aspect ratio

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_icons.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_icons.scss
@@ -3,7 +3,7 @@
 }
 
 .lexicon-icon-arrows-all {
-	background-color: hsl(from #{$white} h s l / 0.6);
+	background-color: unquote('hsl(from #{$white} h s l / 0.6)');
 	border: 1px solid $border-color;
 	border-radius: 0.1413em; // 6.5/46
 	height: 0.73913em; // 34/46 aspect ratio


### PR DESCRIPTION
This PR attempts to fix current stable build. `hsl(from <color> h s l / α)` is CSS Color Module 4 syntax, which `liferay-theme-tasks`'s Dart Sass 1.64.1 cannot parse, `frontend-theme-classic:packageRunBuild` fails with *Only 3 elements allowed, but 5 were passed*. Wrapping in `unquote(...)` matches the existing pattern under `atlas-custom-properties/variables/`.