### PR TITLE
LPD-88934 Sanitize control characters in LiferayXmlLayout XML output

### DIFF
--- a/modules/apps/portal/portal-log4j-test/src/testIntegration/java/com/liferay/portal/log4j/test/PortalLog4jTest.java
+++ b/modules/apps/portal/portal-log4j-test/src/testIntegration/java/com/liferay/portal/log4j/test/PortalLog4jTest.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.StringLayout;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.appender.OutputStreamManager;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
@@ -484,7 +485,9 @@ public class PortalLog4jTest {
 
 		// <log4j:properties>...</log4j:properties>
 
-		if (expectedLogContextMessage != null) {
+		if ((expectedLogContextMessage != null) &&
+			!Objects.equals(expectedLogContextMessage, "{}")) {
+
 			int propertiesCloseLineIndex = outputLines.length - 2;
 
 			Assert.assertEquals(
@@ -711,41 +714,77 @@ public class PortalLog4jTest {
 				},
 				new HashMapDictionary());
 
-		PatternLayout.Builder builder = PatternLayout.newBuilder();
+		PatternLayout.Builder patternLayoutBuilder = PatternLayout.newBuilder();
 
-		builder.withPattern(
+		patternLayoutBuilder.withPattern(
 			"%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p [%t][%c{1}:%L] %m%n %X");
 
-		UnsyncStringWriter unsyncStringWriter = new UnsyncStringWriter();
+		UnsyncStringWriter textUnsyncStringWriter = new UnsyncStringWriter();
 
-		Appender logContextWriterAppender = WriterAppender.createAppender(
-			builder.build(), null, unsyncStringWriter,
-			"logContextWriterAppender", false, false);
+		Appender textLogContextWriterAppender = WriterAppender.createAppender(
+			patternLayoutBuilder.build(), null, textUnsyncStringWriter,
+			"textLogContextWriterAppender", false, false);
 
-		logContextWriterAppender.start();
+		textLogContextWriterAppender.start();
+
+		Logger rootLogger = (Logger)LogManager.getRootLogger();
+
+		Map<String, Appender> rootAppenders = rootLogger.getAppenders();
+
+		Appender xmlFileAppender = rootAppenders.get("XML_FILE");
+
+		Class<?> liferayXmlLayoutClass = xmlFileAppender.getLayout(
+		).getClass();
+
+		Object liferayXmlLayoutBuilder = ReflectionTestUtil.invoke(
+			liferayXmlLayoutClass, "newBuilder", new Class<?>[0]);
+
+		ReflectionTestUtil.setFieldValue(
+			liferayXmlLayoutBuilder, "_locationInfo", true);
+		ReflectionTestUtil.setFieldValue(
+			liferayXmlLayoutBuilder, "_properties", true);
+
+		StringLayout liferayXmlLayout = ReflectionTestUtil.invoke(
+			liferayXmlLayoutBuilder, "build", new Class<?>[0]);
+
+		UnsyncStringWriter xmlUnsyncStringWriter = new UnsyncStringWriter();
+
+		Appender xmlLogContextWriterAppender = WriterAppender.createAppender(
+			liferayXmlLayout, null, xmlUnsyncStringWriter,
+			"xmlLogContextWriterAppender", false, false);
+
+		xmlLogContextWriterAppender.start();
 
 		Logger logger = (Logger)LogManager.getLogger(PortalLog4jTest.class);
 
-		logger.addAppender(logContextWriterAppender);
+		logger.addAppender(textLogContextWriterAppender);
+		logger.addAppender(xmlLogContextWriterAppender);
 
 		try {
 			_testLogOutputWithLogContext(
-				"DEBUG", logContextMessage, unsyncStringWriter);
+				"DEBUG", logContextMessage, textUnsyncStringWriter,
+				xmlUnsyncStringWriter);
 			_testLogOutputWithLogContext(
-				"ERROR", logContextMessage, unsyncStringWriter);
+				"ERROR", logContextMessage, textUnsyncStringWriter,
+				xmlUnsyncStringWriter);
 			_testLogOutputWithLogContext(
-				"FATAL", logContextMessage, unsyncStringWriter);
+				"FATAL", logContextMessage, textUnsyncStringWriter,
+				xmlUnsyncStringWriter);
 			_testLogOutputWithLogContext(
-				"INFO", logContextMessage, unsyncStringWriter);
+				"INFO", logContextMessage, textUnsyncStringWriter,
+				xmlUnsyncStringWriter);
 			_testLogOutputWithLogContext(
-				"TRACE", logContextMessage, unsyncStringWriter);
+				"TRACE", logContextMessage, textUnsyncStringWriter,
+				xmlUnsyncStringWriter);
 			_testLogOutputWithLogContext(
-				"WARN", logContextMessage, unsyncStringWriter);
+				"WARN", logContextMessage, textUnsyncStringWriter,
+				xmlUnsyncStringWriter);
 		}
 		finally {
 			serviceRegistration.unregister();
 
-			logger.removeAppender(logContextWriterAppender);
+			logger.removeAppender(textLogContextWriterAppender);
+			logger.removeAppender(xmlLogContextWriterAppender);
 
 			_unsyncStringWriter.reset();
 
@@ -760,7 +799,8 @@ public class PortalLog4jTest {
 
 	private void _testLogOutputWithLogContext(
 		String level, String logContextMessage,
-		UnsyncStringWriter unsyncStringWriter) {
+		UnsyncStringWriter textUnsyncStringWriter,
+		UnsyncStringWriter xmlUnsyncStringWriter) {
 
 		String message = level + " message";
 
@@ -768,9 +808,13 @@ public class PortalLog4jTest {
 
 		_assertTextLog(
 			level, message, null, logContextMessage,
-			unsyncStringWriter.toString());
+			textUnsyncStringWriter.toString());
+		_assertXmlLog(
+			level, message, null, logContextMessage,
+			xmlUnsyncStringWriter.toString());
 
-		unsyncStringWriter.reset();
+		textUnsyncStringWriter.reset();
+		xmlUnsyncStringWriter.reset();
 	}
 
 	private static final int _BUFFER_SIZE = 8192;

--- a/modules/apps/portal/portal-log4j-test/src/testIntegration/java/com/liferay/portal/log4j/test/PortalLog4jTest.java
+++ b/modules/apps/portal/portal-log4j-test/src/testIntegration/java/com/liferay/portal/log4j/test/PortalLog4jTest.java
@@ -148,10 +148,21 @@ public class PortalLog4jTest {
 
 	@Test
 	public void testLogOutputWithCDATAClosingSequence() throws Exception {
-		for (String level : _LEVELS) {
-			_testLogOutput(
-				level, "before]]>after", null, "before]]>]]&gt;<![CDATA[after",
-				null);
+		String cdataClose = "]]>";
+		String escapedCdataClose = "]]>]]&gt;<![CDATA[";
+
+		try {
+			ThreadContext.push("ndc:" + cdataClose);
+
+			for (String level : _LEVELS) {
+				_testLogOutput(
+					level, "before" + cdataClose + "after", null,
+					"before" + escapedCdataClose + "after",
+					"ndc:" + escapedCdataClose, null);
+			}
+		}
+		finally {
+			ThreadContext.pop();
 		}
 	}
 
@@ -728,12 +739,13 @@ public class PortalLog4jTest {
 			String level, String message, Throwable throwable)
 		throws Exception {
 
-		_testLogOutput(level, message, throwable, null, null);
+		_testLogOutput(level, message, throwable, null, null, null);
 	}
 
 	private void _testLogOutput(
 			String level, String message, Throwable throwable,
-			String expectedXmlMessage, String expectedXmlThread)
+			String expectedXmlMessage, String expectedXmlNdc,
+			String expectedXmlThread)
 		throws Exception {
 
 		_outputLog(level, message, throwable);
@@ -747,8 +759,8 @@ public class PortalLog4jTest {
 				new String(Files.readAllBytes(_textLogFilePath)));
 
 			_assertXmlLog(
-				level, message, throwable, null, expectedXmlMessage, null,
-				expectedXmlThread,
+				level, message, throwable, null, expectedXmlMessage,
+				expectedXmlNdc, expectedXmlThread,
 				new String(Files.readAllBytes(_xmlLogFilePath)));
 		}
 		finally {

--- a/modules/apps/portal/portal-log4j-test/src/testIntegration/java/com/liferay/portal/log4j/test/PortalLog4jTest.java
+++ b/modules/apps/portal/portal-log4j-test/src/testIntegration/java/com/liferay/portal/log4j/test/PortalLog4jTest.java
@@ -385,17 +385,9 @@ public class PortalLog4jTest {
 
 	private void _assertXmlLog(
 		String expectedLevel, String expectedMessage,
-		Throwable expectedThrowable, String actualOutput) {
-
-		_assertXmlLog(
-			expectedLevel, expectedMessage, expectedThrowable, null,
-			actualOutput);
-	}
-
-	private void _assertXmlLog(
-		String expectedLevel, String expectedMessage,
 		Throwable expectedThrowable, String expectedLogContextMessage,
-		String actualOutput) {
+		String expectedXmlMessage, String expectedXmlNdc,
+		String expectedXmlThread, String actualOutput) {
 
 		String[] outputLines = StringUtil.splitLines(actualOutput);
 
@@ -449,7 +441,10 @@ public class PortalLog4jTest {
 		Thread currentThread = Thread.currentThread();
 
 		String expectedLog4JEventThread = StringBundler.concat(
-			"thread=\"", currentThread.getName(), StringPool.QUOTE);
+			"thread=\"",
+			(expectedXmlThread != null) ? expectedXmlThread :
+				currentThread.getName(),
+			StringPool.QUOTE);
 
 		Assert.assertEquals(
 			expectedLog4JEventThread,
@@ -459,18 +454,40 @@ public class PortalLog4jTest {
 
 		Assert.assertEquals(
 			StringBundler.concat(
-				"<log4j:message><![CDATA[", expectedMessage,
+				"<log4j:message><![CDATA[",
+				(expectedXmlMessage != null) ? expectedXmlMessage :
+					expectedMessage,
 				"]]></log4j:message>"),
 			outputLines[1]);
+
+		// <log4j:NDC>...</log4j:NDC>
+
+		if (expectedXmlNdc != null) {
+			String expectedNdcLine = StringBundler.concat(
+				"<log4j:NDC><![CDATA[", expectedXmlNdc, "]]></log4j:NDC>");
+
+			boolean found = false;
+
+			for (String outputLine : outputLines) {
+				if (Objects.equals(outputLine, expectedNdcLine)) {
+					found = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(found);
+		}
 
 		// <log4j:throwable>...</log4j:throwable>
 
 		if (expectedThrowable != null) {
 			Class<?> expectedThrowableClass = expectedThrowable.getClass();
 
-			Assert.assertEquals(
-				"<log4j:throwable><![CDATA[" + expectedThrowableClass.getName(),
-				outputLines[2]);
+			Assert.assertTrue(
+				outputLines[2].startsWith(
+					"<log4j:throwable><![CDATA[" +
+						expectedThrowableClass.getName()));
 
 			String actualFirstPrefixStackTraceElement = outputLines[3].trim();
 
@@ -661,6 +678,14 @@ public class PortalLog4jTest {
 			String level, String message, Throwable throwable)
 		throws Exception {
 
+		_testLogOutput(level, message, throwable, null, null);
+	}
+
+	private void _testLogOutput(
+			String level, String message, Throwable throwable,
+			String expectedXmlMessage, String expectedXmlThread)
+		throws Exception {
+
 		_outputLog(level, message, throwable);
 
 		try {
@@ -672,7 +697,8 @@ public class PortalLog4jTest {
 				new String(Files.readAllBytes(_textLogFilePath)));
 
 			_assertXmlLog(
-				level, message, throwable,
+				level, message, throwable, null, expectedXmlMessage, null,
+				expectedXmlThread,
 				new String(Files.readAllBytes(_xmlLogFilePath)));
 		}
 		finally {
@@ -690,6 +716,17 @@ public class PortalLog4jTest {
 	private void _testLogOutputWithLogContext(
 			Map<String, String> contexts, String logContextMessage,
 			String logContextName)
+		throws Exception {
+
+		_testLogOutputWithLogContext(
+			contexts, logContextMessage, logContextMessage, null, null,
+			logContextName);
+	}
+
+	private void _testLogOutputWithLogContext(
+			Map<String, String> contexts, String logContextMessage,
+			String expectedXmlLogContextMessage, String expectedXmlNdc,
+			String expectedXmlThread, String logContextName)
 		throws Exception {
 
 		Bundle bundle = FrameworkUtil.getBundle(PortalLog4jTest.class);
@@ -762,22 +799,28 @@ public class PortalLog4jTest {
 
 		try {
 			_testLogOutputWithLogContext(
-				"DEBUG", logContextMessage, textUnsyncStringWriter,
+				"DEBUG", logContextMessage, expectedXmlLogContextMessage,
+				expectedXmlNdc, expectedXmlThread, textUnsyncStringWriter,
 				xmlUnsyncStringWriter);
 			_testLogOutputWithLogContext(
-				"ERROR", logContextMessage, textUnsyncStringWriter,
+				"ERROR", logContextMessage, expectedXmlLogContextMessage,
+				expectedXmlNdc, expectedXmlThread, textUnsyncStringWriter,
 				xmlUnsyncStringWriter);
 			_testLogOutputWithLogContext(
-				"FATAL", logContextMessage, textUnsyncStringWriter,
+				"FATAL", logContextMessage, expectedXmlLogContextMessage,
+				expectedXmlNdc, expectedXmlThread, textUnsyncStringWriter,
 				xmlUnsyncStringWriter);
 			_testLogOutputWithLogContext(
-				"INFO", logContextMessage, textUnsyncStringWriter,
+				"INFO", logContextMessage, expectedXmlLogContextMessage,
+				expectedXmlNdc, expectedXmlThread, textUnsyncStringWriter,
 				xmlUnsyncStringWriter);
 			_testLogOutputWithLogContext(
-				"TRACE", logContextMessage, textUnsyncStringWriter,
+				"TRACE", logContextMessage, expectedXmlLogContextMessage,
+				expectedXmlNdc, expectedXmlThread, textUnsyncStringWriter,
 				xmlUnsyncStringWriter);
 			_testLogOutputWithLogContext(
-				"WARN", logContextMessage, textUnsyncStringWriter,
+				"WARN", logContextMessage, expectedXmlLogContextMessage,
+				expectedXmlNdc, expectedXmlThread, textUnsyncStringWriter,
 				xmlUnsyncStringWriter);
 		}
 		finally {
@@ -799,7 +842,8 @@ public class PortalLog4jTest {
 
 	private void _testLogOutputWithLogContext(
 		String level, String logContextMessage,
-		UnsyncStringWriter textUnsyncStringWriter,
+		String expectedXmlLogContextMessage, String expectedXmlNdc,
+		String expectedXmlThread, UnsyncStringWriter textUnsyncStringWriter,
 		UnsyncStringWriter xmlUnsyncStringWriter) {
 
 		String message = level + " message";
@@ -810,7 +854,8 @@ public class PortalLog4jTest {
 			level, message, null, logContextMessage,
 			textUnsyncStringWriter.toString());
 		_assertXmlLog(
-			level, message, null, logContextMessage,
+			level, message, null, expectedXmlLogContextMessage, null,
+			expectedXmlNdc, expectedXmlThread,
 			xmlUnsyncStringWriter.toString());
 
 		textUnsyncStringWriter.reset();

--- a/modules/apps/portal/portal-log4j-test/src/testIntegration/java/com/liferay/portal/log4j/test/PortalLog4jTest.java
+++ b/modules/apps/portal/portal-log4j-test/src/testIntegration/java/com/liferay/portal/log4j/test/PortalLog4jTest.java
@@ -268,6 +268,16 @@ public class PortalLog4jTest {
 		String expectedLevel, String expectedMessage,
 		Throwable expectedThrowable, String actualOutput) {
 
+		_assertTextLog(
+			expectedLevel, expectedMessage, expectedThrowable, null,
+			actualOutput);
+	}
+
+	private void _assertTextLog(
+		String expectedLevel, String expectedMessage,
+		Throwable expectedThrowable, String expectedLogContextMessage,
+		String actualOutput) {
+
 		String[] outputLines = StringUtil.splitLines(actualOutput);
 
 		Assert.assertTrue(
@@ -334,6 +344,17 @@ public class PortalLog4jTest {
 		Assert.assertEquals(
 			String.valueOf(expectedMessage), messageLine.trim());
 
+		int outputLineIndex = 1;
+
+		// Log context
+
+		if (expectedLogContextMessage != null) {
+			Assert.assertEquals(
+				expectedLogContextMessage, outputLines[outputLineIndex].trim());
+
+			outputLineIndex++;
+		}
+
 		// Throwable
 
 		if (expectedThrowable != null) {
@@ -342,9 +363,10 @@ public class PortalLog4jTest {
 			Assert.assertEquals(
 				expectedThrowableClass.getName() + ": " +
 					expectedThrowable.getMessage(),
-				outputLines[1]);
+				outputLines[outputLineIndex]);
 
-			String actualFirstPrefixStackTraceElement = outputLines[2].trim();
+			String actualFirstPrefixStackTraceElement =
+				outputLines[outputLineIndex + 1].trim();
 
 			Assert.assertTrue(
 				"A throwable should be logged and the first stack should be " +
@@ -357,6 +379,16 @@ public class PortalLog4jTest {
 	private void _assertXmlLog(
 		String expectedLevel, String expectedMessage,
 		Throwable expectedThrowable, String actualOutput) {
+
+		_assertXmlLog(
+			expectedLevel, expectedMessage, expectedThrowable, null,
+			actualOutput);
+	}
+
+	private void _assertXmlLog(
+		String expectedLevel, String expectedMessage,
+		Throwable expectedThrowable, String expectedLogContextMessage,
+		String actualOutput) {
 
 		String[] outputLines = StringUtil.splitLines(actualOutput);
 
@@ -442,9 +474,68 @@ public class PortalLog4jTest {
 					"at " + PortalLog4jTest.class.getName()));
 		}
 
+		int locationInfoLineIndex = outputLines.length - 2;
+
+		// <log4j:properties>...</log4j:properties>
+
+		if (expectedLogContextMessage != null) {
+			int propertiesCloseLineIndex = outputLines.length - 2;
+
+			Assert.assertEquals(
+				"</log4j:properties>", outputLines[propertiesCloseLineIndex]);
+
+			int propertiesOpenLineIndex = -1;
+
+			for (int i = propertiesCloseLineIndex - 1; i >= 0; i--) {
+				if (Objects.equals(outputLines[i], "<log4j:properties>")) {
+					propertiesOpenLineIndex = i;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(
+				"<log4j:properties> should be present",
+				propertiesOpenLineIndex >= 0);
+
+			StringBundler sb = new StringBundler();
+
+			sb.append(StringPool.OPEN_CURLY_BRACE);
+
+			for (int i = propertiesOpenLineIndex + 1;
+				 i < propertiesCloseLineIndex; i++) {
+
+				String dataLine = outputLines[i];
+
+				int nameStart =
+					dataLine.indexOf("name=\"") + "name=\"".length();
+
+				int nameEnd = dataLine.indexOf(StringPool.QUOTE, nameStart);
+
+				int valueStart =
+					dataLine.indexOf("value=\"", nameEnd) + "value=\"".length();
+
+				int valueEnd = dataLine.indexOf(StringPool.QUOTE, valueStart);
+
+				if (i > (propertiesOpenLineIndex + 1)) {
+					sb.append(", ");
+				}
+
+				sb.append(dataLine.substring(nameStart, nameEnd));
+				sb.append(StringPool.EQUAL);
+				sb.append(dataLine.substring(valueStart, valueEnd));
+			}
+
+			sb.append(StringPool.CLOSE_CURLY_BRACE);
+
+			Assert.assertEquals(expectedLogContextMessage, sb.toString());
+
+			locationInfoLineIndex = propertiesOpenLineIndex - 1;
+		}
+
 		// <log4j:locationInfo />
 
-		String log4JLocationInfoLine = outputLines[outputLines.length - 2];
+		String log4JLocationInfoLine = outputLines[locationInfoLineIndex];
 
 		String log4JLocationInfo = log4JLocationInfoLine.substring(
 			log4JLocationInfoLine.indexOf(StringPool.SPACE),

--- a/modules/apps/portal/portal-log4j-test/src/testIntegration/java/com/liferay/portal/log4j/test/PortalLog4jTest.java
+++ b/modules/apps/portal/portal-log4j-test/src/testIntegration/java/com/liferay/portal/log4j/test/PortalLog4jTest.java
@@ -147,6 +147,70 @@ public class PortalLog4jTest {
 	}
 
 	@Test
+	public void testLogOutputWithCDATAClosingSequence() throws Exception {
+		for (String level : _LEVELS) {
+			_testLogOutput(
+				level, "before]]>after", null, "before]]>]]&gt;<![CDATA[after",
+				null);
+		}
+	}
+
+	@Test
+	public void testLogOutputWithForbiddenXML10Chars() throws Exception {
+		String forbiddenCharString = String.valueOf((char)1);
+
+		String key = "key:" + forbiddenCharString;
+		String value = "value:" + forbiddenCharString;
+
+		String logContextName = "ForbiddenCharsLogContext";
+
+		Thread currentThread = Thread.currentThread();
+
+		String originalThreadName = currentThread.getName();
+
+		try {
+			currentThread.setName("thread:" + forbiddenCharString);
+
+			ThreadContext.push("ndc:" + forbiddenCharString);
+
+			_testLogOutputWithLogContext(
+				HashMapBuilder.put(
+					key, value
+				).build(),
+				StringBundler.concat(
+					StringPool.OPEN_CURLY_BRACE, logContextName,
+					StringPool.PERIOD, key, StringPool.EQUAL, value,
+					StringPool.CLOSE_CURLY_BRACE),
+				"{ForbiddenCharsLogContext.key: =value: }", "ndc:", "thread: ",
+				logContextName);
+		}
+		finally {
+			currentThread.setName(originalThreadName);
+
+			ThreadContext.pop();
+		}
+	}
+
+	@Test
+	public void testLogOutputWithHTMLSpecialChars() throws Exception {
+		Thread currentThread = Thread.currentThread();
+
+		String originalThreadName = currentThread.getName();
+
+		try {
+			currentThread.setName("thread:<>&\"");
+
+			for (String level : _LEVELS) {
+				_testLogOutput(
+					level, "message", null, null, "thread:&lt;&gt;&amp;&quot;");
+			}
+		}
+		finally {
+			currentThread.setName(originalThreadName);
+		}
+	}
+
+	@Test
 	public void testLogOutputWithLogContext() throws Exception {
 		String key1 = "test.key.1";
 		String key2 = "test.key.2";
@@ -234,75 +298,6 @@ public class PortalLog4jTest {
 			Collections.emptyMap(),
 			StringPool.OPEN_CURLY_BRACE + StringPool.CLOSE_CURLY_BRACE,
 			"TestLogContext");
-	}
-
-	@Test
-	public void testXMLLogOutputWithCDATAClosingSequence() throws Exception {
-		_testLogOutput(
-			"INFO", "before]]>after", null, "before]]>]]&gt;<![CDATA[after",
-			null);
-	}
-
-	@Test
-	public void testXMLLogOutputWithForbiddenXML10Chars() throws Exception {
-		String forbiddenCharString = String.valueOf((char)1);
-
-		String originalThreadNameString = Thread.currentThread(
-		).getName();
-
-		Thread.currentThread(
-		).setName(
-			"thread:" + forbiddenCharString
-		);
-
-		ThreadContext.push("ndc:" + forbiddenCharString);
-
-		String key = "key:" + forbiddenCharString;
-		String logContextName = "ForbiddenCharsLogContext";
-		String value = "value:" + forbiddenCharString;
-
-		try {
-			_testLogOutputWithLogContext(
-				HashMapBuilder.put(
-					key, value
-				).build(),
-				StringBundler.concat(
-					StringPool.OPEN_CURLY_BRACE, logContextName,
-					StringPool.PERIOD, key, StringPool.EQUAL, value,
-					StringPool.CLOSE_CURLY_BRACE),
-				"{ForbiddenCharsLogContext.key: =value: }", "ndc:", "thread: ",
-				logContextName);
-		}
-		finally {
-			Thread.currentThread(
-			).setName(
-				originalThreadNameString
-			);
-
-			ThreadContext.pop();
-		}
-	}
-
-	@Test
-	public void testXMLLogOutputWithHTMLSpecialChars() throws Exception {
-		String originalThreadNameString = Thread.currentThread(
-		).getName();
-
-		Thread.currentThread(
-		).setName(
-			"thread:<>&\""
-		);
-
-		try {
-			_testLogOutput(
-				"INFO", "message", null, null, "thread:&lt;&gt;&amp;&quot;");
-		}
-		finally {
-			Thread.currentThread(
-			).setName(
-				originalThreadNameString
-			);
-		}
 	}
 
 	private static Path _initFileAppender(
@@ -576,17 +571,18 @@ public class PortalLog4jTest {
 			for (int i = propertiesOpenLineIndex + 1;
 				 i < propertiesCloseLineIndex; i++) {
 
-				Matcher dataMatcher = _dataPattern.matcher(outputLines[i]);
+				Matcher nameValueMatcher = _nameValuePattern.matcher(
+					outputLines[i]);
 
-				Assert.assertTrue(dataMatcher.find());
+				Assert.assertTrue(nameValueMatcher.find());
 
 				if (i > (propertiesOpenLineIndex + 1)) {
 					sb.append(", ");
 				}
 
-				sb.append(dataMatcher.group(1));
+				sb.append(nameValueMatcher.group(1));
 				sb.append(StringPool.EQUAL);
-				sb.append(dataMatcher.group(2));
+				sb.append(nameValueMatcher.group(2));
 			}
 
 			sb.append(StringPool.CLOSE_CURLY_BRACE);
@@ -893,10 +889,10 @@ public class PortalLog4jTest {
 	private static final Log _log = LogFactoryUtil.getLog(
 		PortalLog4jTest.class);
 
-	private static final Pattern _dataPattern = Pattern.compile(
-		"name=\"([^\"]*)\" value=\"([^\"]*)\"");
 	private static final Pattern _datePattern = Pattern.compile(
 		"\\d\\d\\d\\d-\\d\\d-\\d\\d \\d\\d:\\d\\d:\\d\\d.\\d\\d\\d");
+	private static final Pattern _nameValuePattern = Pattern.compile(
+		"name=\"([^\"]*)\" value=\"([^\"]*)\"");
 	private static Path _tempLogFileDirPath;
 	private static TestOutputStream _testOutputStream;
 	private static Path _textLogFilePath;

--- a/modules/apps/portal/portal-log4j-test/src/testIntegration/java/com/liferay/portal/log4j/test/PortalLog4jTest.java
+++ b/modules/apps/portal/portal-log4j-test/src/testIntegration/java/com/liferay/portal/log4j/test/PortalLog4jTest.java
@@ -193,17 +193,34 @@ public class PortalLog4jTest {
 
 	@Test
 	public void testLogOutputWithHTMLSpecialChars() throws Exception {
+		String htmlSpecialChars = "<>&\"";
+		String escapedHtmlSpecialChars = "&lt;&gt;&amp;&quot;";
+
+		String key = "key:" + htmlSpecialChars;
+		String value = "value:" + htmlSpecialChars;
+
+		String logContextName = "HTMLSpecialCharsLogContext";
+
 		Thread currentThread = Thread.currentThread();
 
 		String originalThreadName = currentThread.getName();
 
 		try {
-			currentThread.setName("thread:<>&\"");
+			currentThread.setName("thread:" + htmlSpecialChars);
 
-			for (String level : _LEVELS) {
-				_testLogOutput(
-					level, "message", null, null, "thread:&lt;&gt;&amp;&quot;");
-			}
+			_testLogOutputWithLogContext(
+				HashMapBuilder.put(
+					key, value
+				).build(),
+				StringBundler.concat(
+					StringPool.OPEN_CURLY_BRACE, logContextName,
+					StringPool.PERIOD, key, StringPool.EQUAL, value,
+					StringPool.CLOSE_CURLY_BRACE),
+				StringBundler.concat(
+					StringPool.OPEN_CURLY_BRACE, logContextName, ".key:",
+					escapedHtmlSpecialChars, "=value:", escapedHtmlSpecialChars,
+					StringPool.CLOSE_CURLY_BRACE),
+				null, "thread:" + escapedHtmlSpecialChars, logContextName);
 		}
 		finally {
 			currentThread.setName(originalThreadName);

--- a/modules/apps/portal/portal-log4j-test/src/testIntegration/java/com/liferay/portal/log4j/test/PortalLog4jTest.java
+++ b/modules/apps/portal/portal-log4j-test/src/testIntegration/java/com/liferay/portal/log4j/test/PortalLog4jTest.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogContext;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -140,12 +141,9 @@ public class PortalLog4jTest {
 
 	@Test
 	public void testLogOutput() throws Exception {
-		_testLogOutput("DEBUG");
-		_testLogOutput("ERROR");
-		_testLogOutput("FATAL");
-		_testLogOutput("INFO");
-		_testLogOutput("TRACE");
-		_testLogOutput("WARN");
+		for (String level : _LEVELS) {
+			_testLogOutput(level);
+		}
 	}
 
 	@Test
@@ -356,9 +354,7 @@ public class PortalLog4jTest {
 
 		String[] outputLines = StringUtil.splitLines(actualOutput);
 
-		Assert.assertTrue(
-			"The log output should have at least 1 line",
-			outputLines.length > 0);
+		Assert.assertTrue(outputLines.length > 0);
 
 		String messageLine = outputLines[0];
 
@@ -367,9 +363,7 @@ public class PortalLog4jTest {
 		Matcher dateMatcher = _datePattern.matcher(
 			messageLine.substring(0, _DATE_FORMAT.length()));
 
-		Assert.assertTrue(
-			"Output date format should be yyyy-MM-dd HH:mm:ss.SSS",
-			dateMatcher.matches());
+		Assert.assertTrue(dateMatcher.matches());
 
 		// Level
 
@@ -445,8 +439,6 @@ public class PortalLog4jTest {
 				outputLines[outputLineIndex + 1].trim();
 
 			Assert.assertTrue(
-				"A throwable should be logged and the first stack should be " +
-					PortalLog4jTest.class.getName(),
 				actualFirstPrefixStackTraceElement.startsWith(
 					"at " + PortalLog4jTest.class.getName()));
 		}
@@ -460,9 +452,7 @@ public class PortalLog4jTest {
 
 		String[] outputLines = StringUtil.splitLines(actualOutput);
 
-		Assert.assertTrue(
-			"The log output should have at least 1 line",
-			outputLines.length > 0);
+		Assert.assertTrue(outputLines.length > 0);
 
 		// <log4j:event />
 
@@ -535,21 +525,7 @@ public class PortalLog4jTest {
 			String expectedNdcLine = StringBundler.concat(
 				"<log4j:NDC><![CDATA[", expectedXmlNdc, "]]></log4j:NDC>");
 
-			boolean found = false;
-
-			for (String outputLine : outputLines) {
-				if (Objects.equals(outputLine, expectedNdcLine)) {
-					found = true;
-
-					break;
-				}
-			}
-
-			Assert.assertTrue(
-				StringBundler.concat(
-					"<log4j:NDC><![CDATA[", expectedXmlNdc,
-					"]]></log4j:NDC> not found in XML output"),
-				found);
+			Assert.assertTrue(ArrayUtil.contains(outputLines, expectedNdcLine));
 		}
 
 		// <log4j:throwable>...</log4j:throwable>
@@ -565,8 +541,6 @@ public class PortalLog4jTest {
 			String actualFirstPrefixStackTraceElement = outputLines[3].trim();
 
 			Assert.assertTrue(
-				"A throwable should be logged and the first stack should be " +
-					PortalLog4jTest.class.getName(),
 				actualFirstPrefixStackTraceElement.startsWith(
 					"at " + PortalLog4jTest.class.getName()));
 		}
@@ -593,9 +567,7 @@ public class PortalLog4jTest {
 				}
 			}
 
-			Assert.assertTrue(
-				"<log4j:properties> should be present",
-				propertiesOpenLineIndex >= 0);
+			Assert.assertTrue(propertiesOpenLineIndex >= 0);
 
 			StringBundler sb = new StringBundler();
 
@@ -604,25 +576,17 @@ public class PortalLog4jTest {
 			for (int i = propertiesOpenLineIndex + 1;
 				 i < propertiesCloseLineIndex; i++) {
 
-				String dataLine = outputLines[i];
+				Matcher dataMatcher = _dataPattern.matcher(outputLines[i]);
 
-				int nameStart =
-					dataLine.indexOf("name=\"") + "name=\"".length();
-
-				int nameEnd = dataLine.indexOf(StringPool.QUOTE, nameStart);
-
-				int valueStart =
-					dataLine.indexOf("value=\"", nameEnd) + "value=\"".length();
-
-				int valueEnd = dataLine.indexOf(StringPool.QUOTE, valueStart);
+				Assert.assertTrue(dataMatcher.find());
 
 				if (i > (propertiesOpenLineIndex + 1)) {
 					sb.append(", ");
 				}
 
-				sb.append(dataLine.substring(nameStart, nameEnd));
+				sb.append(dataMatcher.group(1));
 				sb.append(StringPool.EQUAL);
-				sb.append(dataLine.substring(valueStart, valueEnd));
+				sb.append(dataMatcher.group(2));
 			}
 
 			sb.append(StringPool.CLOSE_CURLY_BRACE);
@@ -843,8 +807,9 @@ public class PortalLog4jTest {
 
 		Appender xmlFileAppender = rootAppenders.get("XML_FILE");
 
-		Class<?> liferayXmlLayoutClass = xmlFileAppender.getLayout(
-		).getClass();
+		Object xmlFileAppenderLayout = xmlFileAppender.getLayout();
+
+		Class<?> liferayXmlLayoutClass = xmlFileAppenderLayout.getClass();
 
 		Object liferayXmlLayoutBuilder = ReflectionTestUtil.invoke(
 			liferayXmlLayoutClass, "newBuilder", new Class<?>[0]);
@@ -871,30 +836,12 @@ public class PortalLog4jTest {
 		logger.addAppender(xmlLogContextWriterAppender);
 
 		try {
-			_testLogOutputWithLogContext(
-				"DEBUG", logContextMessage, expectedXmlLogContextMessage,
-				expectedXmlNdc, expectedXmlThread, textUnsyncStringWriter,
-				xmlUnsyncStringWriter);
-			_testLogOutputWithLogContext(
-				"ERROR", logContextMessage, expectedXmlLogContextMessage,
-				expectedXmlNdc, expectedXmlThread, textUnsyncStringWriter,
-				xmlUnsyncStringWriter);
-			_testLogOutputWithLogContext(
-				"FATAL", logContextMessage, expectedXmlLogContextMessage,
-				expectedXmlNdc, expectedXmlThread, textUnsyncStringWriter,
-				xmlUnsyncStringWriter);
-			_testLogOutputWithLogContext(
-				"INFO", logContextMessage, expectedXmlLogContextMessage,
-				expectedXmlNdc, expectedXmlThread, textUnsyncStringWriter,
-				xmlUnsyncStringWriter);
-			_testLogOutputWithLogContext(
-				"TRACE", logContextMessage, expectedXmlLogContextMessage,
-				expectedXmlNdc, expectedXmlThread, textUnsyncStringWriter,
-				xmlUnsyncStringWriter);
-			_testLogOutputWithLogContext(
-				"WARN", logContextMessage, expectedXmlLogContextMessage,
-				expectedXmlNdc, expectedXmlThread, textUnsyncStringWriter,
-				xmlUnsyncStringWriter);
+			for (String level : _LEVELS) {
+				_testLogOutputWithLogContext(
+					level, logContextMessage, expectedXmlLogContextMessage,
+					expectedXmlNdc, expectedXmlThread, textUnsyncStringWriter,
+					xmlUnsyncStringWriter);
+			}
 		}
 		finally {
 			serviceRegistration.unregister();
@@ -939,9 +886,15 @@ public class PortalLog4jTest {
 
 	private static final String _DATE_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";
 
+	private static final String[] _LEVELS = {
+		"DEBUG", "ERROR", "FATAL", "INFO", "TRACE", "WARN"
+	};
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		PortalLog4jTest.class);
 
+	private static final Pattern _dataPattern = Pattern.compile(
+		"name=\"([^\"]*)\" value=\"([^\"]*)\"");
 	private static final Pattern _datePattern = Pattern.compile(
 		"\\d\\d\\d\\d-\\d\\d-\\d\\d \\d\\d:\\d\\d:\\d\\d.\\d\\d\\d");
 	private static Path _tempLogFileDirPath;

--- a/modules/apps/portal/portal-log4j-test/src/testIntegration/java/com/liferay/portal/log4j/test/PortalLog4jTest.java
+++ b/modules/apps/portal/portal-log4j-test/src/testIntegration/java/com/liferay/portal/log4j/test/PortalLog4jTest.java
@@ -168,74 +168,16 @@ public class PortalLog4jTest {
 
 	@Test
 	public void testLogOutputWithForbiddenXML10Chars() throws Exception {
-		String forbiddenCharString = String.valueOf((char)1);
-
-		String key = "key:" + forbiddenCharString;
-		String value = "value:" + forbiddenCharString;
-
-		String logContextName = "ForbiddenCharsLogContext";
-
-		Thread currentThread = Thread.currentThread();
-
-		String originalThreadName = currentThread.getName();
-
-		try {
-			currentThread.setName("thread:" + forbiddenCharString);
-
-			ThreadContext.push("ndc:" + forbiddenCharString);
-
-			_testLogOutputWithLogContext(
-				HashMapBuilder.put(
-					key, value
-				).build(),
-				StringBundler.concat(
-					StringPool.OPEN_CURLY_BRACE, logContextName,
-					StringPool.PERIOD, key, StringPool.EQUAL, value,
-					StringPool.CLOSE_CURLY_BRACE),
-				"{ForbiddenCharsLogContext.key: =value: }", "ndc:", "thread: ",
-				logContextName);
-		}
-		finally {
-			currentThread.setName(originalThreadName);
-
-			ThreadContext.pop();
-		}
+		_testLogOutputWithSpecialChars(
+			String.valueOf((char)1), StringPool.SPACE, StringPool.BLANK,
+			"ForbiddenCharsLogContext");
 	}
 
 	@Test
 	public void testLogOutputWithHTMLSpecialChars() throws Exception {
-		String htmlSpecialChars = "<>&\"";
-		String escapedHtmlSpecialChars = "&lt;&gt;&amp;&quot;";
-
-		String key = "key:" + htmlSpecialChars;
-		String value = "value:" + htmlSpecialChars;
-
-		String logContextName = "HTMLSpecialCharsLogContext";
-
-		Thread currentThread = Thread.currentThread();
-
-		String originalThreadName = currentThread.getName();
-
-		try {
-			currentThread.setName("thread:" + htmlSpecialChars);
-
-			_testLogOutputWithLogContext(
-				HashMapBuilder.put(
-					key, value
-				).build(),
-				StringBundler.concat(
-					StringPool.OPEN_CURLY_BRACE, logContextName,
-					StringPool.PERIOD, key, StringPool.EQUAL, value,
-					StringPool.CLOSE_CURLY_BRACE),
-				StringBundler.concat(
-					StringPool.OPEN_CURLY_BRACE, logContextName, ".key:",
-					escapedHtmlSpecialChars, "=value:", escapedHtmlSpecialChars,
-					StringPool.CLOSE_CURLY_BRACE),
-				null, "thread:" + escapedHtmlSpecialChars, logContextName);
-		}
-		finally {
-			currentThread.setName(originalThreadName);
-		}
+		_testLogOutputWithSpecialChars(
+			"<>&\"", "&lt;&gt;&amp;&quot;", "<>&\"",
+			"HTMLSpecialCharsLogContext");
 	}
 
 	@Test
@@ -905,6 +847,45 @@ public class PortalLog4jTest {
 
 		textUnsyncStringWriter.reset();
 		xmlUnsyncStringWriter.reset();
+	}
+
+	private void _testLogOutputWithSpecialChars(
+			String rawChars, String expectedAttributeChars,
+			String expectedCdataChars, String logContextName)
+		throws Exception {
+
+		String key = "key:" + rawChars;
+		String value = "value:" + rawChars;
+
+		Thread currentThread = Thread.currentThread();
+
+		String originalThreadName = currentThread.getName();
+
+		try {
+			currentThread.setName("thread:" + rawChars);
+
+			ThreadContext.push("ndc:" + rawChars);
+
+			_testLogOutputWithLogContext(
+				HashMapBuilder.put(
+					key, value
+				).build(),
+				StringBundler.concat(
+					StringPool.OPEN_CURLY_BRACE, logContextName,
+					StringPool.PERIOD, key, StringPool.EQUAL, value,
+					StringPool.CLOSE_CURLY_BRACE),
+				StringBundler.concat(
+					StringPool.OPEN_CURLY_BRACE, logContextName, ".key:",
+					expectedAttributeChars, "=value:", expectedAttributeChars,
+					StringPool.CLOSE_CURLY_BRACE),
+				"ndc:" + expectedCdataChars, "thread:" + expectedAttributeChars,
+				logContextName);
+		}
+		finally {
+			currentThread.setName(originalThreadName);
+
+			ThreadContext.pop();
+		}
 	}
 
 	private static final int _BUFFER_SIZE = 8192;

--- a/modules/apps/portal/portal-log4j-test/src/testIntegration/java/com/liferay/portal/log4j/test/PortalLog4jTest.java
+++ b/modules/apps/portal/portal-log4j-test/src/testIntegration/java/com/liferay/portal/log4j/test/PortalLog4jTest.java
@@ -238,6 +238,75 @@ public class PortalLog4jTest {
 			"TestLogContext");
 	}
 
+	@Test
+	public void testXMLLogOutputWithCDATAClosingSequence() throws Exception {
+		_testLogOutput(
+			"INFO", "before]]>after", null, "before]]>]]&gt;<![CDATA[after",
+			null);
+	}
+
+	@Test
+	public void testXMLLogOutputWithForbiddenXML10Chars() throws Exception {
+		String forbiddenCharString = String.valueOf((char)1);
+
+		String originalThreadNameString = Thread.currentThread(
+		).getName();
+
+		Thread.currentThread(
+		).setName(
+			"thread:" + forbiddenCharString
+		);
+
+		ThreadContext.push("ndc:" + forbiddenCharString);
+
+		String key = "key:" + forbiddenCharString;
+		String logContextName = "ForbiddenCharsLogContext";
+		String value = "value:" + forbiddenCharString;
+
+		try {
+			_testLogOutputWithLogContext(
+				HashMapBuilder.put(
+					key, value
+				).build(),
+				StringBundler.concat(
+					StringPool.OPEN_CURLY_BRACE, logContextName,
+					StringPool.PERIOD, key, StringPool.EQUAL, value,
+					StringPool.CLOSE_CURLY_BRACE),
+				"{ForbiddenCharsLogContext.key: =value: }", "ndc:", "thread: ",
+				logContextName);
+		}
+		finally {
+			Thread.currentThread(
+			).setName(
+				originalThreadNameString
+			);
+
+			ThreadContext.pop();
+		}
+	}
+
+	@Test
+	public void testXMLLogOutputWithHTMLSpecialChars() throws Exception {
+		String originalThreadNameString = Thread.currentThread(
+		).getName();
+
+		Thread.currentThread(
+		).setName(
+			"thread:<>&\""
+		);
+
+		try {
+			_testLogOutput(
+				"INFO", "message", null, null, "thread:&lt;&gt;&amp;&quot;");
+		}
+		finally {
+			Thread.currentThread(
+			).setName(
+				originalThreadNameString
+			);
+		}
+	}
+
 	private static Path _initFileAppender(
 		Logger logger, Appender appender, String tempLogDir) {
 
@@ -476,7 +545,11 @@ public class PortalLog4jTest {
 				}
 			}
 
-			Assert.assertTrue(found);
+			Assert.assertTrue(
+				StringBundler.concat(
+					"<log4j:NDC><![CDATA[", expectedXmlNdc,
+					"]]></log4j:NDC> not found in XML output"),
+				found);
 		}
 
 		// <log4j:throwable>...</log4j:throwable>

--- a/modules/apps/portal/portal-log4j-test/src/testIntegration/java/com/liferay/portal/log4j/test/PortalLog4jTest.java
+++ b/modules/apps/portal/portal-log4j-test/src/testIntegration/java/com/liferay/portal/log4j/test/PortalLog4jTest.java
@@ -148,7 +148,7 @@ public class PortalLog4jTest {
 	}
 
 	@Test
-	public void testLogOutputWithLogContext() {
+	public void testLogOutputWithLogContext() throws Exception {
 		String key1 = "test.key.1";
 		String key2 = "test.key.2";
 		String value1 = "test.value.1";
@@ -171,7 +171,9 @@ public class PortalLog4jTest {
 	}
 
 	@Test
-	public void testLogOutputWithLogContextAndExternalContext() {
+	public void testLogOutputWithLogContextAndExternalContext()
+		throws Exception {
+
 		String key1 = "test.key.1";
 		String key2 = "test.key.2";
 		String value1 = "test.value.1";
@@ -204,7 +206,9 @@ public class PortalLog4jTest {
 	}
 
 	@Test
-	public void testLogOutputWithLogContextWithEmptyContextName() {
+	public void testLogOutputWithLogContextWithEmptyContextName()
+		throws Exception {
+
 		String key1 = "test.key.1";
 		String key2 = "test.key.2";
 		String value1 = "test.value.1";
@@ -224,7 +228,9 @@ public class PortalLog4jTest {
 	}
 
 	@Test
-	public void testLogOutputWithLogContextWithEmptyLogContext() {
+	public void testLogOutputWithLogContextWithEmptyLogContext()
+		throws Exception {
+
 		_testLogOutputWithLogContext(
 			Collections.emptyMap(),
 			StringPool.OPEN_CURLY_BRACE + StringPool.CLOSE_CURLY_BRACE,
@@ -679,8 +685,9 @@ public class PortalLog4jTest {
 	}
 
 	private void _testLogOutputWithLogContext(
-		Map<String, String> contexts, String logContextMessage,
-		String logContextName) {
+			Map<String, String> contexts, String logContextMessage,
+			String logContextName)
+		throws Exception {
 
 		Bundle bundle = FrameworkUtil.getBundle(PortalLog4jTest.class);
 
@@ -706,7 +713,8 @@ public class PortalLog4jTest {
 
 		PatternLayout.Builder builder = PatternLayout.newBuilder();
 
-		builder.withPattern("%level - %m%n %X");
+		builder.withPattern(
+			"%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p [%t][%c{1}:%L] %m%n %X");
 
 		UnsyncStringWriter unsyncStringWriter = new UnsyncStringWriter();
 
@@ -738,6 +746,15 @@ public class PortalLog4jTest {
 			serviceRegistration.unregister();
 
 			logger.removeAppender(logContextWriterAppender);
+
+			_unsyncStringWriter.reset();
+
+			Files.write(
+				_textLogFilePath, new byte[0],
+				StandardOpenOption.TRUNCATE_EXISTING);
+			Files.write(
+				_xmlLogFilePath, new byte[0],
+				StandardOpenOption.TRUNCATE_EXISTING);
 		}
 	}
 
@@ -745,20 +762,13 @@ public class PortalLog4jTest {
 		String level, String logContextMessage,
 		UnsyncStringWriter unsyncStringWriter) {
 
-		_outputLog(level, level + " message", null);
+		String message = level + " message";
 
-		String[] outputLines = StringUtil.splitLines(
+		_outputLog(level, message, null);
+
+		_assertTextLog(
+			level, message, null, logContextMessage,
 			unsyncStringWriter.toString());
-
-		Assert.assertTrue(
-			"The log output should have at least 1 line",
-			outputLines.length > 0);
-
-		Assert.assertEquals(
-			StringBundler.concat(level, " - ", level, " message"),
-			outputLines[0]);
-
-		Assert.assertEquals(logContextMessage, outputLines[1].trim());
 
 		unsyncStringWriter.reset();
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/LiferayXmlLayout.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/LiferayXmlLayout.java
@@ -7,6 +7,8 @@ package com.liferay.portal.kernel.internal.log4j;
 
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.xml.XMLUtil;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -95,14 +97,14 @@ public final class LiferayXmlLayout extends AbstractStringLayout {
 
 	private void _generateXMLLog(LogEvent logEvent, StringBuilder sb) {
 		sb.append("<log4j:event logger=\"");
-		sb.append(Transform.escapeHtmlTags(logEvent.getLoggerName()));
+		sb.append(HtmlUtil.escapeAttribute(logEvent.getLoggerName()));
 		sb.append("\" timestamp=\"");
 		sb.append(logEvent.getTimeMillis());
 		sb.append("\" level=\"");
 		sb.append(
-			Transform.escapeHtmlTags(String.valueOf(logEvent.getLevel())));
+			HtmlUtil.escapeAttribute(String.valueOf(logEvent.getLevel())));
 		sb.append("\" thread=\"");
-		sb.append(Transform.escapeHtmlTags(logEvent.getThreadName()));
+		sb.append(HtmlUtil.escapeAttribute(logEvent.getThreadName()));
 		sb.append("\">");
 		sb.append(StringPool.RETURN_NEW_LINE);
 		sb.append("<log4j:message>");
@@ -110,7 +112,8 @@ public final class LiferayXmlLayout extends AbstractStringLayout {
 
 		Message message = logEvent.getMessage();
 
-		Transform.appendEscapingCData(sb, message.getFormattedMessage());
+		Transform.appendEscapingCData(
+			sb, XMLUtil.stripInvalidChars(message.getFormattedMessage()));
 
 		sb.append(StringPool.CDATA_CLOSE);
 		sb.append("</log4j:message>");
@@ -125,7 +128,8 @@ public final class LiferayXmlLayout extends AbstractStringLayout {
 			sb.append(StringPool.CDATA_OPEN);
 
 			Transform.appendEscapingCData(
-				sb, Strings.join(ndc, CharPool.SPACE));
+				sb,
+				XMLUtil.stripInvalidChars(Strings.join(ndc, CharPool.SPACE)));
 
 			sb.append(StringPool.CDATA_CLOSE);
 			sb.append("</log4j:NDC>");
@@ -142,7 +146,8 @@ public final class LiferayXmlLayout extends AbstractStringLayout {
 
 			throwable.printStackTrace(new PrintWriter(stringWriter));
 
-			Transform.appendEscapingCData(sb, stringWriter.toString());
+			Transform.appendEscapingCData(
+				sb, XMLUtil.stripInvalidChars(stringWriter.toString()));
 
 			sb.append(StringPool.CDATA_CLOSE);
 			sb.append("</log4j:throwable>");
@@ -155,14 +160,14 @@ public final class LiferayXmlLayout extends AbstractStringLayout {
 			if (stackTraceElement != null) {
 				sb.append("<log4j:locationInfo class=\"");
 				sb.append(
-					Transform.escapeHtmlTags(stackTraceElement.getClassName()));
+					HtmlUtil.escapeAttribute(stackTraceElement.getClassName()));
 				sb.append("\" method=\"");
 				sb.append(
-					Transform.escapeHtmlTags(
+					HtmlUtil.escapeAttribute(
 						stackTraceElement.getMethodName()));
 				sb.append("\" file=\"");
 				sb.append(
-					Transform.escapeHtmlTags(stackTraceElement.getFileName()));
+					HtmlUtil.escapeAttribute(stackTraceElement.getFileName()));
 				sb.append("\" line=\"");
 				sb.append(stackTraceElement.getLineNumber());
 				sb.append("\"/>");
@@ -181,10 +186,10 @@ public final class LiferayXmlLayout extends AbstractStringLayout {
 					(key, value) -> {
 						if (value != null) {
 							sb.append("<log4j:data name=\"");
-							sb.append(Transform.escapeHtmlTags(key));
+							sb.append(HtmlUtil.escapeAttribute(key));
 							sb.append("\" value=\"");
 							sb.append(
-								Transform.escapeHtmlTags(
+								HtmlUtil.escapeAttribute(
 									String.valueOf(value)));
 							sb.append("\"/>");
 							sb.append(StringPool.RETURN_NEW_LINE);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88934

## What is being fixed

LiferayXmlLayout emits user-controlled values (log message, NDC, throwable text, thread name, log-context properties) into XML log output without sanitizing for XML 1.0 forbidden control characters. An attacker who lands arbitrary bytes in any of those fields can produce malformed XML, breaking log ingestion pipelines that parse the log4j XML output.

## How it is being fixed

XMLUtil.stripInvalidChars now wraps every CDATA emission (`<log4j:message>`, `<log4j:NDC>`, `<log4j:throwable>`), stripping forbidden XML 1.0 characters before they reach the output. Existing handlers still apply: Transform.appendEscapingCData neutralizes `]]>` in CDATA, and HtmlUtil.escapeAttribute entity-escapes attribute values.

Tests in PortalLog4jTest cover three attack classes:

- CDATA-closing sequence (`]]>`) planted in message and NDC, verifying Transform.appendEscapingCData on both CDATA emitters.
- HTML special chars (`<>&"`) planted in thread name and log-context key/value, verifying HtmlUtil.escapeAttribute on both user-controllable attributes.
- Forbidden XML 1.0 chars (``) planted in thread, NDC, and log context, verifying both attribute-escape and CDATA-strip paths remove the control character.

A shared `_testLogOutputWithSpecialChars` helper unifies the latter two tests so each test reads as a one-line declaration with the raw input and its expected attribute-escape / CDATA-escape forms.