### PR TITLE
LPD-85513 Map FragmentCollectionNameException

### DIFF
--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/vulcan/problem/FragmentCollectionNameExceptionProblemMapper.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/vulcan/problem/FragmentCollectionNameExceptionProblemMapper.java
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.fragment.internal.vulcan.problem;
+
+import com.liferay.fragment.exception.FragmentCollectionNameException;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.vulcan.problem.Problem;
+import com.liferay.portal.vulcan.problem.ProblemMapper;
+
+import java.util.Locale;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Rubén Pulido
+ */
+@Component(service = ProblemMapper.class)
+public class FragmentCollectionNameExceptionProblemMapper
+	implements ProblemMapper<FragmentCollectionNameException> {
+
+	@Override
+	public Problem getProblem(
+		FragmentCollectionNameException fragmentCollectionNameException) {
+
+		return new Problem() {
+
+			@Override
+			public String getDetail(Locale locale) {
+				return _language.get(locale, "name-is-invalid");
+			}
+
+			@Override
+			public Status getStatus() {
+				return Status.BAD_REQUEST;
+			}
+
+			@Override
+			public String getTitle(Locale locale) {
+				return _language.get(locale, "name-is-invalid");
+			}
+
+			@Override
+			public String getType() {
+				return FragmentCollectionNameException.class.getName();
+			}
+
+		};
+	}
+
+	@Reference
+	private Language _language;
+
+}

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
@@ -201,6 +202,7 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 
 		Boolean originalMarketplace = fragmentSet.getMarketplace();
 
+		fragmentSet.setDescription((String)null);
 		fragmentSet.setExternalReferenceCode(RandomTestUtil.randomString());
 		fragmentSet.setKey(RandomTestUtil.randomString());
 		fragmentSet.setMarketplace(!originalMarketplace);
@@ -209,6 +211,7 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 			testGroup.getExternalReferenceCode(), originalExternalReferenceCode,
 			fragmentSet);
 
+		Assert.assertTrue(Validator.isNull(putFragmentSet.getDescription()));
 		Assert.assertEquals(
 			originalExternalReferenceCode,
 			putFragmentSet.getExternalReferenceCode());
@@ -239,23 +242,6 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 				testGroup.getExternalReferenceCode(),
 				nullNameFragmentSet.getExternalReferenceCode(),
 				nullNameFragmentSet));
-
-		FragmentSet nullDescriptionFragmentSet =
-			testPutSiteFragmentSet_addFragmentSet();
-
-		nullDescriptionFragmentSet.setDescription((String)null);
-		nullDescriptionFragmentSet.setName(RandomTestUtil.randomString());
-
-		FragmentSet nullDescriptionPutFragmentSet =
-			fragmentSetResource.putSiteFragmentSet(
-				testGroup.getExternalReferenceCode(),
-				nullDescriptionFragmentSet.getExternalReferenceCode(),
-				nullDescriptionFragmentSet);
-
-		Assert.assertEquals("", nullDescriptionPutFragmentSet.getDescription());
-		Assert.assertEquals(
-			nullDescriptionFragmentSet.getName(),
-			nullDescriptionPutFragmentSet.getName());
 
 		_testPutSiteFragmentSetBatch();
 	}

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -147,6 +147,15 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 				testGroup.getExternalReferenceCode(), duplicateKeyFragmentSet),
 			duplicateKeyFragmentSet.getKey());
 
+		FragmentSet invalidNameFragmentSet = randomFragmentSet();
+
+		invalidNameFragmentSet.setName("bad.name");
+
+		_assertProblemException(
+			"BAD_REQUEST", "name-is-invalid",
+			() -> fragmentSetResource.postSiteFragmentSet(
+				testGroup.getExternalReferenceCode(), invalidNameFragmentSet));
+
 		_testPostSiteFragmentSetBatch();
 	}
 

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -231,6 +231,23 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 				nullNameFragmentSet.getExternalReferenceCode(),
 				nullNameFragmentSet));
 
+		FragmentSet nullDescriptionFragmentSet =
+			testPutSiteFragmentSet_addFragmentSet();
+
+		nullDescriptionFragmentSet.setDescription((String)null);
+		nullDescriptionFragmentSet.setName(RandomTestUtil.randomString());
+
+		FragmentSet nullDescriptionPutFragmentSet =
+			fragmentSetResource.putSiteFragmentSet(
+				testGroup.getExternalReferenceCode(),
+				nullDescriptionFragmentSet.getExternalReferenceCode(),
+				nullDescriptionFragmentSet);
+
+		Assert.assertEquals("", nullDescriptionPutFragmentSet.getDescription());
+		Assert.assertEquals(
+			nullDescriptionFragmentSet.getName(),
+			nullDescriptionPutFragmentSet.getName());
+
 		_testPutSiteFragmentSetBatch();
 	}
 

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -219,6 +219,18 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 				duplicateKeyFragmentSet),
 			duplicateKeyFragmentSet.getKey());
 
+		FragmentSet nullNameFragmentSet =
+			testPutSiteFragmentSet_addFragmentSet();
+
+		nullNameFragmentSet.setName((String)null);
+
+		_assertProblemException(
+			"BAD_REQUEST", "name-is-invalid",
+			() -> fragmentSetResource.putSiteFragmentSet(
+				testGroup.getExternalReferenceCode(),
+				nullNameFragmentSet.getExternalReferenceCode(),
+				nullNameFragmentSet));
+
 		_testPutSiteFragmentSetBatch();
 	}
 

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -14,6 +14,7 @@ import com.liferay.headless.admin.fragment.client.pagination.Page;
 import com.liferay.headless.admin.fragment.client.problem.Problem;
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
@@ -150,7 +151,9 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 
 		FragmentSet invalidNameFragmentSet = randomFragmentSet();
 
-		invalidNameFragmentSet.setName("bad.name");
+		invalidNameFragmentSet.setName(
+			RandomTestUtil.randomString() + StringPool.PERIOD +
+				RandomTestUtil.randomString());
 
 		_assertProblemException(
 			"BAD_REQUEST", "name-is-invalid",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85513

Previous PR: https://github.com/brianchandotcom/liferay-portal/pull/174767

Following review feedback on https://github.com/brianchandotcom/liferay-portal/pull/174767, this randomizes the hardcoded `bad.name` literal in `FragmentSetResourceTest.testPostSiteFragmentSet`.

cc @ruben-pulido
