### PR TITLE
LPD-88154 Convert pending email collaborator invites on user signup

### DIFF
--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
@@ -5,8 +5,6 @@
 
 package com.liferay.sharing.internal.model.listener;
 
-import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
-import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -14,19 +12,16 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.model.Ticket;
 import com.liferay.portal.kernel.model.TicketConstants;
-import com.liferay.portal.kernel.model.TicketTable;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.TicketLocalService;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.sharing.model.SharingEntry;
-import com.liferay.sharing.model.SharingEntryTable;
 import com.liferay.sharing.service.SharingEntryLocalService;
 
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -63,69 +58,55 @@ public class UserModelListener extends BaseModelListener<User> {
 		_sharingEntryLocalService.deleteToUserSharingEntries(user.getUserId());
 	}
 
-	private Predicate _getWherePredicate(User user) {
-		return TicketTable.INSTANCE.companyId.eq(
-			user.getCompanyId()
-		).and(
-			TicketTable.INSTANCE.type.eq(
-				TicketConstants.TYPE_INVITE_COLLABORATOR)
-		).and(
-			TicketTable.INSTANCE.expirationDate.gt(new Date())
-		);
-	}
-
 	private void _updateSharingEntries(User user) {
-		List<SharingEntry> sharingEntries =
-			(List<SharingEntry>)_sharingEntryLocalService.dslQuery(
-				DSLQueryFactoryUtil.selectDistinct(
-					SharingEntryTable.INSTANCE
-				).from(
-					SharingEntryTable.INSTANCE
-				).innerJoinON(
-					TicketTable.INSTANCE,
-					SharingEntryTable.INSTANCE.toTicketId.eq(
-						TicketTable.INSTANCE.ticketId)
-				).where(
-					_getWherePredicate(user)
-				),
-				false);
+		List<Ticket> tickets = _ticketLocalService.getTickets(
+			user.getCompanyId(), TicketConstants.TYPE_INVITE_COLLABORATOR,
+			user.getEmailAddress());
 
-		Set<Long> ticketIds = new HashSet<>();
+		Date now = new Date();
 
-		for (SharingEntry pendingSharingEntry : sharingEntries) {
-			ticketIds.add(pendingSharingEntry.getToTicketId());
+		for (Ticket ticket : tickets) {
+			Date expirationDate = ticket.getExpirationDate();
 
-			SharingEntry existingSharingEntry =
-				_sharingEntryLocalService.fetchSharingEntry(
-					0, pendingSharingEntry.getToUserGroupId(), user.getUserId(),
-					pendingSharingEntry.getClassNameId(),
-					pendingSharingEntry.getClassPK());
+			if ((expirationDate != null) && !expirationDate.after(now)) {
+				continue;
+			}
 
-			if (existingSharingEntry != null) {
-				if (_log.isInfoEnabled()) {
-					_log.info(
-						StringBundler.concat(
-							"A sharing entry already exists for user ",
-							user.getUserId(), " with classNameId ",
-							pendingSharingEntry.getClassNameId(),
-							" and classPK ", pendingSharingEntry.getClassPK()));
+			List<SharingEntry> pendingSharingEntries =
+				_sharingEntryLocalService.getToTicketSharingEntries(
+					ticket.getTicketId());
+
+			for (SharingEntry pendingSharingEntry : pendingSharingEntries) {
+				SharingEntry existingSharingEntry =
+					_sharingEntryLocalService.fetchSharingEntry(
+						0, pendingSharingEntry.getToUserGroupId(),
+						user.getUserId(), pendingSharingEntry.getClassNameId(),
+						pendingSharingEntry.getClassPK());
+
+				if (existingSharingEntry != null) {
+					if (_log.isInfoEnabled()) {
+						_log.info(
+							StringBundler.concat(
+								"A sharing entry already exists for user ",
+								user.getUserId(), " with classNameId ",
+								pendingSharingEntry.getClassNameId(),
+								" and classPK ", pendingSharingEntry.getClassPK()));
+					}
+
+					_sharingEntryLocalService.deleteSharingEntry(
+						pendingSharingEntry);
 				}
+				else {
+					pendingSharingEntry.setToTicketId(0);
+					pendingSharingEntry.setToUserId(user.getUserId());
 
-				_sharingEntryLocalService.deleteSharingEntry(
-					pendingSharingEntry);
+					_sharingEntryLocalService.updateSharingEntry(
+						pendingSharingEntry);
+				}
 			}
-			else {
-				pendingSharingEntry.setToTicketId(0);
-				pendingSharingEntry.setToUserId(user.getUserId());
 
-				_sharingEntryLocalService.updateSharingEntry(
-					pendingSharingEntry);
-			}
-		}
-
-		for (Long ticketId : ticketIds) {
 			try {
-				_ticketLocalService.deleteTicket(ticketId);
+				_ticketLocalService.deleteTicket(ticket.getTicketId());
 			}
 			catch (PortalException portalException) {
 				throw new ModelListenerException(portalException);

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.model.TicketTable;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.TicketLocalService;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.model.SharingEntryTable;
 import com.liferay.sharing.service.SharingEntryLocalService;
@@ -36,11 +37,22 @@ public class UserModelListener extends BaseModelListener<User> {
 
 	@Override
 	public void onAfterCreate(User user) {
+		if (user.getStatus() != WorkflowConstants.STATUS_APPROVED) {
+			return;
+		}
+
 		_updateSharingEntries(user);
 	}
 
 	@Override
 	public void onAfterUpdate(User originalUser, User user) {
+		if ((originalUser.getStatus() == user.getStatus()) ||
+			(originalUser.getStatus() == WorkflowConstants.STATUS_APPROVED) ||
+			(user.getStatus() != WorkflowConstants.STATUS_APPROVED)) {
+
+			return;
+		}
+
 		_updateSharingEntries(user);
 	}
 
@@ -60,6 +72,17 @@ public class UserModelListener extends BaseModelListener<User> {
 		);
 	}
 
+	private Predicate _getWherePredicate(User user) {
+		return TicketTable.INSTANCE.companyId.eq(
+			user.getCompanyId()
+		).and(
+			TicketTable.INSTANCE.type.eq(
+				TicketConstants.TYPE_INVITE_COLLABORATOR)
+		).and(
+			TicketTable.INSTANCE.expirationDate.gt(new Date())
+		);
+	}
+
 	private void _updateSharingEntries(User user) {
 		TransactionCommitCallbackUtil.registerCallback(
 			() -> {
@@ -72,7 +95,7 @@ public class UserModelListener extends BaseModelListener<User> {
 						).innerJoinON(
 							SharingEntryTable.INSTANCE, _getPredicate()
 						).where(
-							_wherePredicate(user)
+							_getWherePredicate(user)
 						));
 
 				for (Ticket ticket : tickets) {
@@ -115,17 +138,6 @@ public class UserModelListener extends BaseModelListener<User> {
 		sharingEntry.setToUserId(user.getUserId());
 
 		_sharingEntryLocalService.updateSharingEntry(sharingEntry);
-	}
-
-	private Predicate _wherePredicate(User user) {
-		return TicketTable.INSTANCE.companyId.eq(
-			user.getCompanyId()
-		).and(
-			TicketTable.INSTANCE.type.eq(
-				TicketConstants.TYPE_INVITE_COLLABORATOR)
-		).and(
-			TicketTable.INSTANCE.expirationDate.gt(new Date())
-		);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
@@ -5,10 +5,25 @@
 
 package com.liferay.sharing.internal.model.listener;
 
+import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
+import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.model.Ticket;
+import com.liferay.portal.kernel.model.TicketConstants;
+import com.liferay.portal.kernel.model.TicketTable;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.TicketLocalService;
+import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.sharing.model.SharingEntry;
+import com.liferay.sharing.model.SharingEntryTable;
 import com.liferay.sharing.service.SharingEntryLocalService;
+
+import java.util.Date;
+import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -20,11 +35,106 @@ import org.osgi.service.component.annotations.Reference;
 public class UserModelListener extends BaseModelListener<User> {
 
 	@Override
+	public void onAfterCreate(User user) {
+		_updateSharingEntries(user);
+	}
+
+	@Override
+	public void onAfterUpdate(User originalUser, User user) {
+		_updateSharingEntries(user);
+	}
+
+	@Override
 	public void onBeforeRemove(User user) {
 		_sharingEntryLocalService.deleteToUserSharingEntries(user.getUserId());
 	}
 
+	private Predicate _getPredicate() {
+		return SharingEntryTable.INSTANCE.classNameId.eq(
+			TicketTable.INSTANCE.classNameId
+		).and(
+			SharingEntryTable.INSTANCE.classPK.eq(TicketTable.INSTANCE.classPK)
+		).and(
+			SharingEntryTable.INSTANCE.toTicketId.eq(
+				TicketTable.INSTANCE.ticketId)
+		);
+	}
+
+	private void _updateSharingEntries(User user) {
+		TransactionCommitCallbackUtil.registerCallback(
+			() -> {
+				List<Ticket> tickets =
+					(List<Ticket>)_ticketLocalService.dslQuery(
+						DSLQueryFactoryUtil.selectDistinct(
+							TicketTable.INSTANCE
+						).from(
+							TicketTable.INSTANCE
+						).innerJoinON(
+							SharingEntryTable.INSTANCE, _getPredicate()
+						).where(
+							_wherePredicate(user)
+						));
+
+				for (Ticket ticket : tickets) {
+					for (SharingEntry sharingEntry :
+							_sharingEntryLocalService.getToTicketSharingEntries(
+								ticket.getTicketId())) {
+
+						_updateSharingEntry(sharingEntry, user);
+					}
+
+					_ticketLocalService.deleteTicket(ticket);
+				}
+
+				return null;
+			});
+	}
+
+	private void _updateSharingEntry(SharingEntry sharingEntry, User user) {
+		SharingEntry existingSharingEntry =
+			_sharingEntryLocalService.fetchSharingEntry(
+				0, sharingEntry.getToUserGroupId(), user.getUserId(),
+				sharingEntry.getClassNameId(), sharingEntry.getClassPK());
+
+		if (existingSharingEntry != null) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					StringBundler.concat(
+						"A sharing entry already exists for user ",
+						user.getUserId(), " with classNameId ",
+						sharingEntry.getClassNameId(), " and classPK ",
+						sharingEntry.getClassPK()));
+			}
+
+			_sharingEntryLocalService.deleteSharingEntry(sharingEntry);
+
+			return;
+		}
+
+		sharingEntry.setToTicketId(0);
+		sharingEntry.setToUserId(user.getUserId());
+
+		_sharingEntryLocalService.updateSharingEntry(sharingEntry);
+	}
+
+	private Predicate _wherePredicate(User user) {
+		return TicketTable.INSTANCE.companyId.eq(
+			user.getCompanyId()
+		).and(
+			TicketTable.INSTANCE.type.eq(
+				TicketConstants.TYPE_INVITE_COLLABORATOR)
+		).and(
+			TicketTable.INSTANCE.expirationDate.gt(new Date())
+		);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		UserModelListener.class);
+
 	@Reference
 	private SharingEntryLocalService _sharingEntryLocalService;
+
+	@Reference
+	private TicketLocalService _ticketLocalService;
 
 }

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
@@ -8,23 +8,25 @@ package com.liferay.sharing.internal.model.listener;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
-import com.liferay.portal.kernel.model.Ticket;
 import com.liferay.portal.kernel.model.TicketConstants;
 import com.liferay.portal.kernel.model.TicketTable;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.TicketLocalService;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.model.SharingEntryTable;
 import com.liferay.sharing.service.SharingEntryLocalService;
 
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -61,17 +63,6 @@ public class UserModelListener extends BaseModelListener<User> {
 		_sharingEntryLocalService.deleteToUserSharingEntries(user.getUserId());
 	}
 
-	private Predicate _getPredicate() {
-		return SharingEntryTable.INSTANCE.classNameId.eq(
-			TicketTable.INSTANCE.classNameId
-		).and(
-			SharingEntryTable.INSTANCE.classPK.eq(TicketTable.INSTANCE.classPK)
-		).and(
-			SharingEntryTable.INSTANCE.toTicketId.eq(
-				TicketTable.INSTANCE.ticketId)
-		);
-	}
-
 	private Predicate _getWherePredicate(User user) {
 		return TicketTable.INSTANCE.companyId.eq(
 			user.getCompanyId()
@@ -84,60 +75,62 @@ public class UserModelListener extends BaseModelListener<User> {
 	}
 
 	private void _updateSharingEntries(User user) {
-		TransactionCommitCallbackUtil.registerCallback(
-			() -> {
-				List<Ticket> tickets =
-					(List<Ticket>)_ticketLocalService.dslQuery(
-						DSLQueryFactoryUtil.selectDistinct(
-							TicketTable.INSTANCE
-						).from(
-							TicketTable.INSTANCE
-						).innerJoinON(
-							SharingEntryTable.INSTANCE, _getPredicate()
-						).where(
-							_getWherePredicate(user)
-						));
+		List<SharingEntry> sharingEntries =
+			(List<SharingEntry>)_sharingEntryLocalService.dslQuery(
+				DSLQueryFactoryUtil.selectDistinct(
+					SharingEntryTable.INSTANCE
+				).from(
+					SharingEntryTable.INSTANCE
+				).innerJoinON(
+					TicketTable.INSTANCE,
+					SharingEntryTable.INSTANCE.toTicketId.eq(
+						TicketTable.INSTANCE.ticketId)
+				).where(
+					_getWherePredicate(user)
+				),
+				false);
 
-				for (Ticket ticket : tickets) {
-					for (SharingEntry sharingEntry :
-							_sharingEntryLocalService.getToTicketSharingEntries(
-								ticket.getTicketId())) {
+		Set<Long> ticketIds = new HashSet<>();
 
-						_updateSharingEntry(sharingEntry, user);
-					}
+		for (SharingEntry pendingSharingEntry : sharingEntries) {
+			ticketIds.add(pendingSharingEntry.getToTicketId());
 
-					_ticketLocalService.deleteTicket(ticket);
+			SharingEntry existingSharingEntry =
+				_sharingEntryLocalService.fetchSharingEntry(
+					0, pendingSharingEntry.getToUserGroupId(), user.getUserId(),
+					pendingSharingEntry.getClassNameId(),
+					pendingSharingEntry.getClassPK());
+
+			if (existingSharingEntry != null) {
+				if (_log.isInfoEnabled()) {
+					_log.info(
+						StringBundler.concat(
+							"A sharing entry already exists for user ",
+							user.getUserId(), " with classNameId ",
+							pendingSharingEntry.getClassNameId(),
+							" and classPK ", pendingSharingEntry.getClassPK()));
 				}
 
-				return null;
-			});
-	}
-
-	private void _updateSharingEntry(SharingEntry sharingEntry, User user) {
-		SharingEntry existingSharingEntry =
-			_sharingEntryLocalService.fetchSharingEntry(
-				0, sharingEntry.getToUserGroupId(), user.getUserId(),
-				sharingEntry.getClassNameId(), sharingEntry.getClassPK());
-
-		if (existingSharingEntry != null) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(
-					StringBundler.concat(
-						"A sharing entry already exists for user ",
-						user.getUserId(), " with classNameId ",
-						sharingEntry.getClassNameId(), " and classPK ",
-						sharingEntry.getClassPK()));
+				_sharingEntryLocalService.deleteSharingEntry(
+					pendingSharingEntry);
 			}
+			else {
+				pendingSharingEntry.setToTicketId(0);
+				pendingSharingEntry.setToUserId(user.getUserId());
 
-			_sharingEntryLocalService.deleteSharingEntry(sharingEntry);
-
-			return;
+				_sharingEntryLocalService.updateSharingEntry(
+					pendingSharingEntry);
+			}
 		}
 
-		sharingEntry.setToTicketId(0);
-		sharingEntry.setToUserId(user.getUserId());
-
-		_sharingEntryLocalService.updateSharingEntry(sharingEntry);
+		for (Long ticketId : ticketIds) {
+			try {
+				_ticketLocalService.deleteTicket(ticketId);
+			}
+			catch (PortalException portalException) {
+				throw new ModelListenerException(portalException);
+			}
+		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/model/listener/UserModelListener.java
@@ -88,9 +88,10 @@ public class UserModelListener extends BaseModelListener<User> {
 						_log.info(
 							StringBundler.concat(
 								"A sharing entry already exists for user ",
-								user.getUserId(), " with classNameId ",
+								user.getUserId(), " with class name ID ",
 								pendingSharingEntry.getClassNameId(),
-								" and classPK ", pendingSharingEntry.getClassPK()));
+								" and class primary key ",
+								pendingSharingEntry.getClassPK()));
 					}
 
 					_sharingEntryLocalService.deleteSharingEntry(

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/TicketModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/TicketModelListenerTest.java
@@ -93,6 +93,16 @@ public class TicketModelListenerTest {
 				_group.getGroupId()));
 	}
 
+	private SharingEntry _addSharingEntry(long toTicketId) throws Exception {
+		return _sharingEntryLocalService.addSharingEntry(
+			null, TestPropsValues.getUserId(), toTicketId, 0, 0,
+			_classNameLocalService.getClassNameId(Group.class.getName()),
+			_group.getGroupId(), _group.getGroupId(), true,
+			Arrays.asList(SharingEntryAction.VIEW), null,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
 	private Ticket _addTicket() throws Exception {
 		return _ticketLocalService.addTicket(
 			TestPropsValues.getCompanyId(), Group.class.getName(),
@@ -102,18 +112,6 @@ public class TicketModelListenerTest {
 			).toString(),
 			new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(48)),
 			new ServiceContext());
-	}
-
-	private SharingEntry _addSharingEntry(long toTicketId)
-		throws Exception {
-
-		return _sharingEntryLocalService.addSharingEntry(
-			null, TestPropsValues.getUserId(), toTicketId, 0, 0,
-			_classNameLocalService.getClassNameId(Group.class.getName()),
-			_group.getGroupId(), _group.getGroupId(), true,
-			Arrays.asList(SharingEntryAction.VIEW), null,
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
 	}
 
 	@Inject

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
@@ -6,17 +6,30 @@
 package com.liferay.sharing.internal.model.listener.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Ticket;
+import com.liferay.portal.kernel.model.TicketConstants;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserConstants;
+import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.TicketLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -25,8 +38,12 @@ import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.security.permission.SharingEntryAction;
 import com.liferay.sharing.service.SharingEntryLocalService;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -51,25 +68,288 @@ public class UserModelListenerTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_group = GroupTestUtil.addGroup();
+		_group1 = GroupTestUtil.addGroup();
 
 		_groupUser1 = UserTestUtil.addGroupUser(
-			_group, RoleConstants.POWER_USER);
+			_group1, RoleConstants.POWER_USER);
 		_groupUser2 = UserTestUtil.addGroupUser(
-			_group, RoleConstants.POWER_USER);
+			_group1, RoleConstants.POWER_USER);
+	}
+
+	@Test
+	@TestInfo("LPD-48130")
+	public void testAddUser() throws Exception {
+		String emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
+		String emailAddress2 = RandomTestUtil.randomString() + "@liferay.com";
+
+		_group2 = GroupTestUtil.addGroup();
+
+		Ticket ticket1 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress1);
+		Ticket ticket2 = _addInviteCollaboratorTicket(
+			_group2.getGroupId(), emailAddress1);
+		Ticket ticket3 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress2);
+
+		SharingEntry sharingEntry1 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket1.getTicketId());
+		SharingEntry sharingEntry2 = _addTicketSharingEntry(
+			_group2.getGroupId(), ticket2.getTicketId());
+		SharingEntry sharingEntry3 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket3.getTicketId());
+
+		User user1 = _addUser(emailAddress1);
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
+
+		sharingEntry1 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry1.getSharingEntryId());
+
+		Assert.assertEquals(0, sharingEntry1.getToTicketId());
+		Assert.assertEquals(user1.getUserId(), sharingEntry1.getToUserId());
+
+		sharingEntry2 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry2.getSharingEntryId());
+
+		Assert.assertEquals(0, sharingEntry2.getToTicketId());
+		Assert.assertEquals(user1.getUserId(), sharingEntry2.getToUserId());
+
+		ticket3 = _ticketLocalService.fetchTicket(ticket3.getTicketId());
+
+		sharingEntry3 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry3.getSharingEntryId());
+
+		Assert.assertEquals(
+			ticket3.getTicketId(), sharingEntry3.getToTicketId());
+		Assert.assertEquals(0, sharingEntry3.getToUserId());
+
+		// With Duplicate Sharing Entry
+
+		emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
+
+		ticket1 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress1);
+		ticket2 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress1);
+
+		_addTicketSharingEntry(_group1.getGroupId(), ticket1.getTicketId());
+		_addTicketSharingEntry(_group1.getGroupId(), ticket2.getTicketId());
+
+		List<SharingEntry> toTicketSharingEntries =
+			_sharingEntryLocalService.getToTicketSharingEntries(
+				ticket1.getTicketId());
+
+		Assert.assertEquals(
+			toTicketSharingEntries.toString(), 1,
+			toTicketSharingEntries.size());
+
+		toTicketSharingEntries =
+			_sharingEntryLocalService.getToTicketSharingEntries(
+				ticket2.getTicketId());
+
+		Assert.assertEquals(
+			toTicketSharingEntries.toString(), 1,
+			toTicketSharingEntries.size());
+
+		User user2 = _addUser(emailAddress1);
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
+
+		List<SharingEntry> toUserSharingEntries =
+			_sharingEntryLocalService.getToUserSharingEntries(
+				user2.getUserId());
+
+		Assert.assertEquals(
+			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
+
+		SharingEntry toUserSharingEntry = toUserSharingEntries.get(0);
+
+		Assert.assertEquals(0, toUserSharingEntry.getToTicketId());
+
+		toTicketSharingEntries =
+			_sharingEntryLocalService.getToTicketSharingEntries(
+				ticket1.getTicketId());
+
+		Assert.assertEquals(
+			toTicketSharingEntries.toString(), 0,
+			toTicketSharingEntries.size());
+
+		toTicketSharingEntries =
+			_sharingEntryLocalService.getToTicketSharingEntries(
+				ticket2.getTicketId());
+
+		Assert.assertEquals(
+			toTicketSharingEntries.toString(), 0,
+			toTicketSharingEntries.size());
+
+		// With Existing User-Based Sharing Entry
+
+		emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
+
+		User user3 = _addUser(emailAddress1);
+
+		ticket1 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress1);
+
+		sharingEntry1 = _sharingEntryLocalService.addSharingEntry(
+			null, TestPropsValues.getUserId(), 0, 0, user3.getUserId(),
+			_classNameLocalService.getClassNameId(Group.class.getName()),
+			_group1.getGroupId(), _group1.getGroupId(), true,
+			Arrays.asList(SharingEntryAction.VIEW), null,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		_addTicketSharingEntry(_group1.getGroupId(), ticket1.getTicketId());
+
+		_userLocalService.updateStatus(
+			user3.getUserId(), WorkflowConstants.STATUS_INACTIVE,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		_userLocalService.updateStatus(
+			user3.getUserId(), WorkflowConstants.STATUS_APPROVED,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+
+		toTicketSharingEntries =
+			_sharingEntryLocalService.getToTicketSharingEntries(
+				ticket1.getTicketId());
+
+		Assert.assertEquals(
+			toTicketSharingEntries.toString(), 0,
+			toTicketSharingEntries.size());
+
+		toUserSharingEntries =
+			_sharingEntryLocalService.getToUserSharingEntries(
+				user3.getUserId());
+
+		Assert.assertEquals(
+			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
+
+		toUserSharingEntry = toUserSharingEntries.get(0);
+
+		Assert.assertEquals(
+			sharingEntry1.getSharingEntryId(),
+			toUserSharingEntry.getSharingEntryId());
+
+		// With Invalid Extra Info
+
+		emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
+
+		ticket1 = _addInviteCollaboratorTicket(_group1.getGroupId(), null);
+		ticket2 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), "not-an-email");
+		ticket3 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress1);
+
+		sharingEntry1 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket1.getTicketId());
+		sharingEntry2 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket2.getTicketId());
+		sharingEntry3 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket3.getTicketId());
+
+		User user4 = _addUser(emailAddress1);
+
+		Assert.assertNotNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+		Assert.assertNotNull(
+			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket3.getTicketId()));
+
+		sharingEntry1 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry1.getSharingEntryId());
+
+		Assert.assertEquals(
+			ticket1.getTicketId(), sharingEntry1.getToTicketId());
+		Assert.assertEquals(0, sharingEntry1.getToUserId());
+
+		sharingEntry2 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry2.getSharingEntryId());
+
+		Assert.assertEquals(
+			ticket2.getTicketId(), sharingEntry2.getToTicketId());
+		Assert.assertEquals(0, sharingEntry2.getToUserId());
+
+		sharingEntry3 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry3.getSharingEntryId());
+
+		Assert.assertEquals(0, sharingEntry3.getToTicketId());
+		Assert.assertEquals(user4.getUserId(), sharingEntry3.getToUserId());
+	}
+
+	@Test
+	@TestInfo("LPD-48130")
+	public void testAddUserWithWorkflow() throws Exception {
+		String emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
+		String emailAddress2 = RandomTestUtil.randomString() + "@liferay.com";
+
+		_group2 = GroupTestUtil.addGroup();
+
+		Ticket ticket1 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress1);
+		Ticket ticket2 = _addInviteCollaboratorTicket(
+			_group2.getGroupId(), emailAddress1);
+		Ticket ticket3 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress2);
+
+		SharingEntry sharingEntry1 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket1.getTicketId());
+		SharingEntry sharingEntry2 = _addTicketSharingEntry(
+			_group2.getGroupId(), ticket2.getTicketId());
+		SharingEntry sharingEntry3 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket3.getTicketId());
+
+		User user = _addUserWithWorkflow(emailAddress1);
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
+
+		sharingEntry1 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry1.getSharingEntryId());
+
+		Assert.assertEquals(0, sharingEntry1.getToTicketId());
+		Assert.assertEquals(user.getUserId(), sharingEntry1.getToUserId());
+
+		sharingEntry2 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry2.getSharingEntryId());
+
+		Assert.assertEquals(0, sharingEntry2.getToTicketId());
+		Assert.assertEquals(user.getUserId(), sharingEntry2.getToUserId());
+
+		ticket3 = _ticketLocalService.fetchTicket(ticket3.getTicketId());
+
+		sharingEntry3 = _sharingEntryLocalService.getSharingEntry(
+			sharingEntry3.getSharingEntryId());
+
+		Assert.assertEquals(
+			ticket3.getTicketId(), sharingEntry3.getToTicketId());
+		Assert.assertEquals(0, sharingEntry3.getToUserId());
 	}
 
 	@Test
 	public void testDeletingUserSharedDeletesSharingEntries() throws Exception {
-		long classPK = _group.getGroupId();
+		long classPK = _group1.getGroupId();
 
 		_sharingEntryLocalService.addSharingEntry(
 			null, TestPropsValues.getUserId(), 0, 0, _groupUser1.getUserId(),
 			_classNameLocalService.getClassNameId(Group.class.getName()),
-			classPK, _group.getGroupId(), true,
+			classPK, _group1.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null,
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
+				_group1.getGroupId(), TestPropsValues.getUserId()));
 
 		List<SharingEntry> toUserSharingEntries =
 			_sharingEntryLocalService.getToUserSharingEntries(
@@ -92,15 +372,15 @@ public class UserModelListenerTest {
 	public void testDeletingUserSharingDoesNotDeleteSharingEntries()
 		throws Exception {
 
-		long classPK = _group.getGroupId();
+		long classPK = _group1.getGroupId();
 
 		_sharingEntryLocalService.addSharingEntry(
 			null, TestPropsValues.getUserId(), 0, 0, _groupUser1.getUserId(),
 			_classNameLocalService.getClassNameId(Group.class.getName()),
-			classPK, _group.getGroupId(), true,
+			classPK, _group1.getGroupId(), true,
 			Arrays.asList(SharingEntryAction.VIEW), null,
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
+				_group1.getGroupId(), TestPropsValues.getUserId()));
 
 		List<SharingEntry> toUserSharingEntries =
 			_sharingEntryLocalService.getToUserSharingEntries(
@@ -119,11 +399,125 @@ public class UserModelListenerTest {
 			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
 	}
 
+	@Test
+	@TestInfo("LPD-48130")
+	public void testUpdateUserStatus() throws Exception {
+		WorkflowDefinitionLink workflowDefinitionLink =
+			_workflowDefinitionLinkLocalService.addWorkflowDefinitionLink(
+				null, TestPropsValues.getUserId(),
+				TestPropsValues.getCompanyId(),
+				WorkflowConstants.DEFAULT_GROUP_ID, User.class.getName(), 0, 0,
+				"Single Approver", 1);
+
+		try {
+			String emailAddress =
+				RandomTestUtil.randomString() + "@liferay.com";
+
+			Ticket ticket = _addInviteCollaboratorTicket(
+				_group1.getGroupId(), emailAddress);
+
+			SharingEntry sharingEntry = _addTicketSharingEntry(
+				_group1.getGroupId(), ticket.getTicketId());
+
+			User user = _addUserWithWorkflow(emailAddress);
+
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_PENDING, user.getStatus());
+
+			Assert.assertNotNull(
+				_ticketLocalService.fetchTicket(ticket.getTicketId()));
+
+			sharingEntry = _sharingEntryLocalService.getSharingEntry(
+				sharingEntry.getSharingEntryId());
+
+			Assert.assertEquals(
+				ticket.getTicketId(), sharingEntry.getToTicketId());
+			Assert.assertEquals(0, sharingEntry.getToUserId());
+
+			_userLocalService.updateStatus(
+				user.getUserId(), WorkflowConstants.STATUS_APPROVED,
+				ServiceContextTestUtil.getServiceContext(
+					_group1.getGroupId(), TestPropsValues.getUserId()));
+
+			Assert.assertNull(
+				_ticketLocalService.fetchTicket(ticket.getTicketId()));
+
+			sharingEntry = _sharingEntryLocalService.getSharingEntry(
+				sharingEntry.getSharingEntryId());
+
+			Assert.assertEquals(0, sharingEntry.getToTicketId());
+			Assert.assertEquals(user.getUserId(), sharingEntry.getToUserId());
+		}
+		finally {
+			_workflowDefinitionLinkLocalService.deleteWorkflowDefinitionLink(
+				workflowDefinitionLink);
+		}
+	}
+
+	private Ticket _addInviteCollaboratorTicket(
+			long classPK, String emailAddress)
+		throws Exception {
+
+		return _ticketLocalService.addTicket(
+			TestPropsValues.getCompanyId(), Group.class.getName(), classPK,
+			TicketConstants.TYPE_INVITE_COLLABORATOR,
+			_normalizeEmailAddress(emailAddress),
+			new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(48)),
+			new ServiceContext());
+	}
+
+	private SharingEntry _addTicketSharingEntry(long classPK, long toTicketId)
+		throws Exception {
+
+		return _sharingEntryLocalService.addSharingEntry(
+			null, TestPropsValues.getUserId(), toTicketId, 0, 0,
+			_classNameLocalService.getClassNameId(Group.class.getName()),
+			classPK, _group1.getGroupId(), true,
+			Arrays.asList(SharingEntryAction.VIEW), null,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private User _addUser(String emailAddress) throws Exception {
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			StringPool.BLANK, emailAddress, RandomTestUtil.randomString(),
+			LocaleUtil.getDefault(), "Test", "User", null,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		_users.add(user);
+
+		return user;
+	}
+
+	private User _addUserWithWorkflow(String emailAddress) throws Exception {
+		User user = _userLocalService.addUserWithWorkflow(
+			TestPropsValues.getUserId(), TestPropsValues.getCompanyId(), true,
+			null, null, false, RandomTestUtil.randomString(), emailAddress,
+			LocaleUtil.getDefault(), "Test", StringPool.BLANK, "User", 0, 0,
+			true, Calendar.JANUARY, 1, 1970, StringPool.BLANK,
+			UserConstants.TYPE_REGULAR, null, null, null, null, false,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		_users.add(user);
+
+		return user;
+	}
+
+	private String _normalizeEmailAddress(String emailAddress) {
+		return StringUtil.toLowerCase(StringUtil.trim(emailAddress));
+	}
+
 	@Inject
 	private ClassNameLocalService _classNameLocalService;
 
 	@DeleteAfterTestRun
-	private Group _group;
+	private Group _group1;
+
+	@DeleteAfterTestRun
+	private Group _group2;
 
 	private User _groupUser1;
 	private User _groupUser2;
@@ -132,6 +526,16 @@ public class UserModelListenerTest {
 	private SharingEntryLocalService _sharingEntryLocalService;
 
 	@Inject
+	private TicketLocalService _ticketLocalService;
+
+	@Inject
 	private UserLocalService _userLocalService;
+
+	@DeleteAfterTestRun
+	private final List<User> _users = new ArrayList<>();
+
+	@Inject
+	private WorkflowDefinitionLinkLocalService
+		_workflowDefinitionLinkLocalService;
 
 }

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
@@ -69,20 +69,15 @@ public class UserModelListenerTest {
 	@Before
 	public void setUp() throws Exception {
 		_group1 = GroupTestUtil.addGroup();
-
-		_groupUser1 = UserTestUtil.addGroupUser(
-			_group1, RoleConstants.POWER_USER);
-		_groupUser2 = UserTestUtil.addGroupUser(
-			_group1, RoleConstants.POWER_USER);
 	}
 
 	@Test
 	@TestInfo("LPD-48130")
 	public void testAddUser() throws Exception {
-		_testAddUserWithDuplicatePendingInvitations();
-		_testAddUserWithExpiredInvitationTicket();
+		_testAddUserWithDuplicateInviteCollaboratorTickets();
+		_testAddUserWithExpiredInviteCollaboratorTicket();
 		_testAddUserWithInvalidEmailAddress();
-		_testAddUserWithPendingInvitations();
+		_testAddUserWithInviteCollaboratorTickets();
 		_testAddUserWithUpperCaseEmail();
 	}
 
@@ -121,70 +116,17 @@ public class UserModelListenerTest {
 	}
 
 	@Test
-	public void testDeletingUserSharedDeletesSharingEntries() throws Exception {
-		long classPK = _group1.getGroupId();
-
-		_sharingEntryLocalService.addSharingEntry(
-			null, TestPropsValues.getUserId(), 0, 0, _groupUser1.getUserId(),
-			_classNameLocalService.getClassNameId(Group.class.getName()),
-			classPK, _group1.getGroupId(), true,
-			Arrays.asList(SharingEntryAction.VIEW), null,
-			ServiceContextTestUtil.getServiceContext(
-				_group1.getGroupId(), TestPropsValues.getUserId()));
-
-		List<SharingEntry> toUserSharingEntries =
-			_sharingEntryLocalService.getToUserSharingEntries(
-				_groupUser1.getUserId());
-
-		Assert.assertEquals(
-			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
-
-		_userLocalService.deleteUser(_groupUser1.getUserId());
-
-		toUserSharingEntries =
-			_sharingEntryLocalService.getToUserSharingEntries(
-				_groupUser1.getUserId());
-
-		Assert.assertEquals(
-			toUserSharingEntries.toString(), 0, toUserSharingEntries.size());
-	}
-
-	@Test
-	public void testDeletingUserSharingDoesNotDeleteSharingEntries()
-		throws Exception {
-
-		long classPK = _group1.getGroupId();
-
-		_sharingEntryLocalService.addSharingEntry(
-			null, TestPropsValues.getUserId(), 0, 0, _groupUser1.getUserId(),
-			_classNameLocalService.getClassNameId(Group.class.getName()),
-			classPK, _group1.getGroupId(), true,
-			Arrays.asList(SharingEntryAction.VIEW), null,
-			ServiceContextTestUtil.getServiceContext(
-				_group1.getGroupId(), TestPropsValues.getUserId()));
-
-		List<SharingEntry> toUserSharingEntries =
-			_sharingEntryLocalService.getToUserSharingEntries(
-				_groupUser1.getUserId());
-
-		Assert.assertEquals(
-			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
-
-		_userLocalService.deleteUser(_groupUser2.getUserId());
-
-		toUserSharingEntries =
-			_sharingEntryLocalService.getToUserSharingEntries(
-				_groupUser1.getUserId());
-
-		Assert.assertEquals(
-			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
+	@TestInfo("LPD-48130")
+	public void testDeleteUser() throws Exception {
+		_testDeleteUserWithToUserSharingEntries();
+		_testDeleteUserWithoutToUserSharingEntries();
 	}
 
 	@Test
 	@TestInfo("LPD-48130")
 	public void testUpdateUserStatus() throws Exception {
-		_testUpdateUserStatusWithExistingUserSharingEntry();
-		_testUpdateUserStatusWithPendingInvitations();
+		_testUpdateUserStatusWithExistingToUserSharingEntry();
+		_testUpdateUserStatusWithInviteCollaboratorTicket();
 	}
 
 	private Ticket _addInviteCollaboratorTicket(
@@ -286,7 +228,7 @@ public class UserModelListenerTest {
 		return StringUtil.toLowerCase(StringUtil.trim(emailAddress));
 	}
 
-	private void _testAddUserWithDuplicatePendingInvitations()
+	private void _testAddUserWithDuplicateInviteCollaboratorTickets()
 		throws Exception {
 
 		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
@@ -323,7 +265,9 @@ public class UserModelListenerTest {
 		_assertToTicketSharingEntriesCount(0, ticket2);
 	}
 
-	private void _testAddUserWithExpiredInvitationTicket() throws Exception {
+	private void _testAddUserWithExpiredInviteCollaboratorTicket()
+		throws Exception {
+
 		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
 
 		Ticket ticket = _addInviteCollaboratorTicket(
@@ -372,7 +316,7 @@ public class UserModelListenerTest {
 		_assertSharingEntryToUserId(sharingEntry3, user);
 	}
 
-	private void _testAddUserWithPendingInvitations() throws Exception {
+	private void _testAddUserWithInviteCollaboratorTickets() throws Exception {
 		String emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
 		String emailAddress2 = RandomTestUtil.randomString() + "@liferay.com";
 
@@ -422,7 +366,67 @@ public class UserModelListenerTest {
 		_assertSharingEntryToUserId(sharingEntry, user);
 	}
 
-	private void _testUpdateUserStatusWithExistingUserSharingEntry()
+	private void _testDeleteUserWithoutToUserSharingEntries() throws Exception {
+		User toUser = UserTestUtil.addGroupUser(
+			_group1, RoleConstants.POWER_USER);
+		User otherUser = UserTestUtil.addGroupUser(
+			_group1, RoleConstants.POWER_USER);
+
+		_sharingEntryLocalService.addSharingEntry(
+			null, TestPropsValues.getUserId(), 0, 0, toUser.getUserId(),
+			_classNameLocalService.getClassNameId(Group.class.getName()),
+			_group1.getGroupId(), _group1.getGroupId(), true,
+			Arrays.asList(SharingEntryAction.VIEW), null,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		List<SharingEntry> toUserSharingEntries =
+			_sharingEntryLocalService.getToUserSharingEntries(
+				toUser.getUserId());
+
+		Assert.assertEquals(
+			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
+
+		_userLocalService.deleteUser(otherUser.getUserId());
+
+		toUserSharingEntries =
+			_sharingEntryLocalService.getToUserSharingEntries(
+				toUser.getUserId());
+
+		Assert.assertEquals(
+			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
+	}
+
+	private void _testDeleteUserWithToUserSharingEntries() throws Exception {
+		User toUser = UserTestUtil.addGroupUser(
+			_group1, RoleConstants.POWER_USER);
+
+		_sharingEntryLocalService.addSharingEntry(
+			null, TestPropsValues.getUserId(), 0, 0, toUser.getUserId(),
+			_classNameLocalService.getClassNameId(Group.class.getName()),
+			_group1.getGroupId(), _group1.getGroupId(), true,
+			Arrays.asList(SharingEntryAction.VIEW), null,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		List<SharingEntry> toUserSharingEntries =
+			_sharingEntryLocalService.getToUserSharingEntries(
+				toUser.getUserId());
+
+		Assert.assertEquals(
+			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
+
+		_userLocalService.deleteUser(toUser.getUserId());
+
+		toUserSharingEntries =
+			_sharingEntryLocalService.getToUserSharingEntries(
+				toUser.getUserId());
+
+		Assert.assertEquals(
+			toUserSharingEntries.toString(), 0, toUserSharingEntries.size());
+	}
+
+	private void _testUpdateUserStatusWithExistingToUserSharingEntry()
 		throws Exception {
 
 		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
@@ -471,7 +475,7 @@ public class UserModelListenerTest {
 			toUserSharingEntry.getSharingEntryId());
 	}
 
-	private void _testUpdateUserStatusWithPendingInvitations()
+	private void _testUpdateUserStatusWithInviteCollaboratorTicket()
 		throws Exception {
 
 		WorkflowDefinitionLink workflowDefinitionLink =
@@ -520,9 +524,6 @@ public class UserModelListenerTest {
 
 	@DeleteAfterTestRun
 	private Group _group2;
-
-	private User _groupUser1;
-	private User _groupUser2;
 
 	@Inject
 	private SharingEntryLocalService _sharingEntryLocalService;

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
@@ -481,40 +481,35 @@ public class UserModelListenerTest {
 				WorkflowConstants.DEFAULT_GROUP_ID, User.class.getName(), 0, 0,
 				"Single Approver", 1);
 
-		try {
-			String emailAddress =
-				RandomTestUtil.randomString() + "@liferay.com";
+		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
 
-			Ticket ticket = _addInviteCollaboratorTicket(
-				_group1.getGroupId(), emailAddress);
+		Ticket ticket = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress);
 
-			SharingEntry sharingEntry = _addTicketSharingEntry(
-				_group1.getGroupId(), ticket.getTicketId());
+		SharingEntry sharingEntry = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket.getTicketId());
 
-			User user = _addUserWithWorkflow(emailAddress);
+		User user = _addUserWithWorkflow(emailAddress);
 
-			Assert.assertEquals(
-				WorkflowConstants.STATUS_PENDING, user.getStatus());
+		Assert.assertEquals(WorkflowConstants.STATUS_PENDING, user.getStatus());
 
-			Assert.assertNotNull(
-				_ticketLocalService.fetchTicket(ticket.getTicketId()));
+		Assert.assertNotNull(
+			_ticketLocalService.fetchTicket(ticket.getTicketId()));
 
-			_assertSharingEntryToTicketId(sharingEntry, ticket);
+		_assertSharingEntryToTicketId(sharingEntry, ticket);
 
-			_userLocalService.updateStatus(
-				user.getUserId(), WorkflowConstants.STATUS_APPROVED,
-				ServiceContextTestUtil.getServiceContext(
-					_group1.getGroupId(), TestPropsValues.getUserId()));
+		_userLocalService.updateStatus(
+			user.getUserId(), WorkflowConstants.STATUS_APPROVED,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
 
-			Assert.assertNull(
-				_ticketLocalService.fetchTicket(ticket.getTicketId()));
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket.getTicketId()));
 
-			_assertSharingEntryToUserId(sharingEntry, user);
-		}
-		finally {
-			_workflowDefinitionLinkLocalService.deleteWorkflowDefinitionLink(
-				workflowDefinitionLink);
-		}
+		_assertSharingEntryToUserId(sharingEntry, user);
+
+		_workflowDefinitionLinkLocalService.deleteWorkflowDefinitionLink(
+			workflowDefinitionLink);
 	}
 
 	@Inject

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
@@ -79,213 +79,11 @@ public class UserModelListenerTest {
 	@Test
 	@TestInfo("LPD-48130")
 	public void testAddUser() throws Exception {
-		String emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
-		String emailAddress2 = RandomTestUtil.randomString() + "@liferay.com";
-
-		_group2 = GroupTestUtil.addGroup();
-
-		Ticket ticket1 = _addInviteCollaboratorTicket(
-			_group1.getGroupId(), emailAddress1);
-		Ticket ticket2 = _addInviteCollaboratorTicket(
-			_group2.getGroupId(), emailAddress1);
-		Ticket ticket3 = _addInviteCollaboratorTicket(
-			_group1.getGroupId(), emailAddress2);
-
-		SharingEntry sharingEntry1 = _addTicketSharingEntry(
-			_group1.getGroupId(), ticket1.getTicketId());
-		SharingEntry sharingEntry2 = _addTicketSharingEntry(
-			_group2.getGroupId(), ticket2.getTicketId());
-		SharingEntry sharingEntry3 = _addTicketSharingEntry(
-			_group1.getGroupId(), ticket3.getTicketId());
-
-		User user1 = _addUser(emailAddress1);
-
-		Assert.assertNull(
-			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
-		Assert.assertNull(
-			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
-
-		sharingEntry1 = _sharingEntryLocalService.getSharingEntry(
-			sharingEntry1.getSharingEntryId());
-
-		Assert.assertEquals(0, sharingEntry1.getToTicketId());
-		Assert.assertEquals(user1.getUserId(), sharingEntry1.getToUserId());
-
-		sharingEntry2 = _sharingEntryLocalService.getSharingEntry(
-			sharingEntry2.getSharingEntryId());
-
-		Assert.assertEquals(0, sharingEntry2.getToTicketId());
-		Assert.assertEquals(user1.getUserId(), sharingEntry2.getToUserId());
-
-		ticket3 = _ticketLocalService.fetchTicket(ticket3.getTicketId());
-
-		sharingEntry3 = _sharingEntryLocalService.getSharingEntry(
-			sharingEntry3.getSharingEntryId());
-
-		Assert.assertEquals(
-			ticket3.getTicketId(), sharingEntry3.getToTicketId());
-		Assert.assertEquals(0, sharingEntry3.getToUserId());
-
-		// With Duplicate Sharing Entry
-
-		emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
-
-		ticket1 = _addInviteCollaboratorTicket(
-			_group1.getGroupId(), emailAddress1);
-		ticket2 = _addInviteCollaboratorTicket(
-			_group1.getGroupId(), emailAddress1);
-
-		_addTicketSharingEntry(_group1.getGroupId(), ticket1.getTicketId());
-		_addTicketSharingEntry(_group1.getGroupId(), ticket2.getTicketId());
-
-		List<SharingEntry> toTicketSharingEntries =
-			_sharingEntryLocalService.getToTicketSharingEntries(
-				ticket1.getTicketId());
-
-		Assert.assertEquals(
-			toTicketSharingEntries.toString(), 1,
-			toTicketSharingEntries.size());
-
-		toTicketSharingEntries =
-			_sharingEntryLocalService.getToTicketSharingEntries(
-				ticket2.getTicketId());
-
-		Assert.assertEquals(
-			toTicketSharingEntries.toString(), 1,
-			toTicketSharingEntries.size());
-
-		User user2 = _addUser(emailAddress1);
-
-		Assert.assertNull(
-			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
-		Assert.assertNull(
-			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
-
-		List<SharingEntry> toUserSharingEntries =
-			_sharingEntryLocalService.getToUserSharingEntries(
-				user2.getUserId());
-
-		Assert.assertEquals(
-			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
-
-		SharingEntry toUserSharingEntry = toUserSharingEntries.get(0);
-
-		Assert.assertEquals(0, toUserSharingEntry.getToTicketId());
-
-		toTicketSharingEntries =
-			_sharingEntryLocalService.getToTicketSharingEntries(
-				ticket1.getTicketId());
-
-		Assert.assertEquals(
-			toTicketSharingEntries.toString(), 0,
-			toTicketSharingEntries.size());
-
-		toTicketSharingEntries =
-			_sharingEntryLocalService.getToTicketSharingEntries(
-				ticket2.getTicketId());
-
-		Assert.assertEquals(
-			toTicketSharingEntries.toString(), 0,
-			toTicketSharingEntries.size());
-
-		// With Existing User-Based Sharing Entry
-
-		emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
-
-		User user3 = _addUser(emailAddress1);
-
-		ticket1 = _addInviteCollaboratorTicket(
-			_group1.getGroupId(), emailAddress1);
-
-		sharingEntry1 = _sharingEntryLocalService.addSharingEntry(
-			null, TestPropsValues.getUserId(), 0, 0, user3.getUserId(),
-			_classNameLocalService.getClassNameId(Group.class.getName()),
-			_group1.getGroupId(), _group1.getGroupId(), true,
-			Arrays.asList(SharingEntryAction.VIEW), null,
-			ServiceContextTestUtil.getServiceContext(
-				_group1.getGroupId(), TestPropsValues.getUserId()));
-
-		_addTicketSharingEntry(_group1.getGroupId(), ticket1.getTicketId());
-
-		_userLocalService.updateStatus(
-			user3.getUserId(), WorkflowConstants.STATUS_INACTIVE,
-			ServiceContextTestUtil.getServiceContext(
-				_group1.getGroupId(), TestPropsValues.getUserId()));
-
-		_userLocalService.updateStatus(
-			user3.getUserId(), WorkflowConstants.STATUS_APPROVED,
-			ServiceContextTestUtil.getServiceContext(
-				_group1.getGroupId(), TestPropsValues.getUserId()));
-
-		Assert.assertNull(
-			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
-
-		toTicketSharingEntries =
-			_sharingEntryLocalService.getToTicketSharingEntries(
-				ticket1.getTicketId());
-
-		Assert.assertEquals(
-			toTicketSharingEntries.toString(), 0,
-			toTicketSharingEntries.size());
-
-		toUserSharingEntries =
-			_sharingEntryLocalService.getToUserSharingEntries(
-				user3.getUserId());
-
-		Assert.assertEquals(
-			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
-
-		toUserSharingEntry = toUserSharingEntries.get(0);
-
-		Assert.assertEquals(
-			sharingEntry1.getSharingEntryId(),
-			toUserSharingEntry.getSharingEntryId());
-
-		// With Invalid Extra Info
-
-		emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
-
-		ticket1 = _addInviteCollaboratorTicket(_group1.getGroupId(), null);
-		ticket2 = _addInviteCollaboratorTicket(
-			_group1.getGroupId(), "not-an-email");
-		ticket3 = _addInviteCollaboratorTicket(
-			_group1.getGroupId(), emailAddress1);
-
-		sharingEntry1 = _addTicketSharingEntry(
-			_group1.getGroupId(), ticket1.getTicketId());
-		sharingEntry2 = _addTicketSharingEntry(
-			_group1.getGroupId(), ticket2.getTicketId());
-		sharingEntry3 = _addTicketSharingEntry(
-			_group1.getGroupId(), ticket3.getTicketId());
-
-		User user4 = _addUser(emailAddress1);
-
-		Assert.assertNotNull(
-			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
-		Assert.assertNotNull(
-			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
-		Assert.assertNull(
-			_ticketLocalService.fetchTicket(ticket3.getTicketId()));
-
-		sharingEntry1 = _sharingEntryLocalService.getSharingEntry(
-			sharingEntry1.getSharingEntryId());
-
-		Assert.assertEquals(
-			ticket1.getTicketId(), sharingEntry1.getToTicketId());
-		Assert.assertEquals(0, sharingEntry1.getToUserId());
-
-		sharingEntry2 = _sharingEntryLocalService.getSharingEntry(
-			sharingEntry2.getSharingEntryId());
-
-		Assert.assertEquals(
-			ticket2.getTicketId(), sharingEntry2.getToTicketId());
-		Assert.assertEquals(0, sharingEntry2.getToUserId());
-
-		sharingEntry3 = _sharingEntryLocalService.getSharingEntry(
-			sharingEntry3.getSharingEntryId());
-
-		Assert.assertEquals(0, sharingEntry3.getToTicketId());
-		Assert.assertEquals(user4.getUserId(), sharingEntry3.getToUserId());
+		_testAddUserWithDuplicatePendingInvitations();
+		_testAddUserWithExpiredInvitationTicket();
+		_testAddUserWithInvalidExtraInfo();
+		_testAddUserWithMixedCaseExtraInfo();
+		_testAddUserWithPendingInvitations();
 	}
 
 	@Test
@@ -317,26 +115,9 @@ public class UserModelListenerTest {
 		Assert.assertNull(
 			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
 
-		sharingEntry1 = _sharingEntryLocalService.getSharingEntry(
-			sharingEntry1.getSharingEntryId());
-
-		Assert.assertEquals(0, sharingEntry1.getToTicketId());
-		Assert.assertEquals(user.getUserId(), sharingEntry1.getToUserId());
-
-		sharingEntry2 = _sharingEntryLocalService.getSharingEntry(
-			sharingEntry2.getSharingEntryId());
-
-		Assert.assertEquals(0, sharingEntry2.getToTicketId());
-		Assert.assertEquals(user.getUserId(), sharingEntry2.getToUserId());
-
-		ticket3 = _ticketLocalService.fetchTicket(ticket3.getTicketId());
-
-		sharingEntry3 = _sharingEntryLocalService.getSharingEntry(
-			sharingEntry3.getSharingEntryId());
-
-		Assert.assertEquals(
-			ticket3.getTicketId(), sharingEntry3.getToTicketId());
-		Assert.assertEquals(0, sharingEntry3.getToUserId());
+		_assertSharingEntryToUserId(sharingEntry1, user);
+		_assertSharingEntryToUserId(sharingEntry2, user);
+		_assertSharingEntryToTicketId(sharingEntry3, ticket3);
 	}
 
 	@Test
@@ -402,68 +183,28 @@ public class UserModelListenerTest {
 	@Test
 	@TestInfo("LPD-48130")
 	public void testUpdateUserStatus() throws Exception {
-		WorkflowDefinitionLink workflowDefinitionLink =
-			_workflowDefinitionLinkLocalService.addWorkflowDefinitionLink(
-				null, TestPropsValues.getUserId(),
-				TestPropsValues.getCompanyId(),
-				WorkflowConstants.DEFAULT_GROUP_ID, User.class.getName(), 0, 0,
-				"Single Approver", 1);
+		_testUpdateUserStatusWithExistingUserSharingEntry();
+		_testUpdateUserStatusWithPendingInvitations();
+	}
 
-		try {
-			String emailAddress =
-				RandomTestUtil.randomString() + "@liferay.com";
+	private Ticket _addInviteCollaboratorTicket(
+			long classPK, Date expirationDate, String extraInfo)
+		throws Exception {
 
-			Ticket ticket = _addInviteCollaboratorTicket(
-				_group1.getGroupId(), emailAddress);
-
-			SharingEntry sharingEntry = _addTicketSharingEntry(
-				_group1.getGroupId(), ticket.getTicketId());
-
-			User user = _addUserWithWorkflow(emailAddress);
-
-			Assert.assertEquals(
-				WorkflowConstants.STATUS_PENDING, user.getStatus());
-
-			Assert.assertNotNull(
-				_ticketLocalService.fetchTicket(ticket.getTicketId()));
-
-			sharingEntry = _sharingEntryLocalService.getSharingEntry(
-				sharingEntry.getSharingEntryId());
-
-			Assert.assertEquals(
-				ticket.getTicketId(), sharingEntry.getToTicketId());
-			Assert.assertEquals(0, sharingEntry.getToUserId());
-
-			_userLocalService.updateStatus(
-				user.getUserId(), WorkflowConstants.STATUS_APPROVED,
-				ServiceContextTestUtil.getServiceContext(
-					_group1.getGroupId(), TestPropsValues.getUserId()));
-
-			Assert.assertNull(
-				_ticketLocalService.fetchTicket(ticket.getTicketId()));
-
-			sharingEntry = _sharingEntryLocalService.getSharingEntry(
-				sharingEntry.getSharingEntryId());
-
-			Assert.assertEquals(0, sharingEntry.getToTicketId());
-			Assert.assertEquals(user.getUserId(), sharingEntry.getToUserId());
-		}
-		finally {
-			_workflowDefinitionLinkLocalService.deleteWorkflowDefinitionLink(
-				workflowDefinitionLink);
-		}
+		return _ticketLocalService.addTicket(
+			TestPropsValues.getCompanyId(), Group.class.getName(), classPK,
+			TicketConstants.TYPE_INVITE_COLLABORATOR, extraInfo, expirationDate,
+			new ServiceContext());
 	}
 
 	private Ticket _addInviteCollaboratorTicket(
 			long classPK, String emailAddress)
 		throws Exception {
 
-		return _ticketLocalService.addTicket(
-			TestPropsValues.getCompanyId(), Group.class.getName(), classPK,
-			TicketConstants.TYPE_INVITE_COLLABORATOR,
-			_normalizeEmailAddress(emailAddress),
+		return _addInviteCollaboratorTicket(
+			classPK,
 			new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(48)),
-			new ServiceContext());
+			_normalizeEmailAddress(emailAddress));
 	}
 
 	private SharingEntry _addTicketSharingEntry(long classPK, long toTicketId)
@@ -506,8 +247,277 @@ public class UserModelListenerTest {
 		return user;
 	}
 
+	private void _assertSharingEntryToTicketId(
+			SharingEntry sharingEntry, Ticket ticket)
+		throws Exception {
+
+		SharingEntry persistedSharingEntry =
+			_sharingEntryLocalService.getSharingEntry(
+				sharingEntry.getSharingEntryId());
+
+		Assert.assertEquals(
+			ticket.getTicketId(), persistedSharingEntry.getToTicketId());
+		Assert.assertEquals(0, persistedSharingEntry.getToUserId());
+	}
+
+	private void _assertSharingEntryToUserId(
+			SharingEntry sharingEntry, User user)
+		throws Exception {
+
+		SharingEntry persistedSharingEntry =
+			_sharingEntryLocalService.getSharingEntry(
+				sharingEntry.getSharingEntryId());
+
+		Assert.assertEquals(0, persistedSharingEntry.getToTicketId());
+		Assert.assertEquals(
+			user.getUserId(), persistedSharingEntry.getToUserId());
+	}
+
+	private void _assertToTicketSharingEntriesCount(int count, Ticket ticket) {
+		List<SharingEntry> toTicketSharingEntries =
+			_sharingEntryLocalService.getToTicketSharingEntries(
+				ticket.getTicketId());
+
+		Assert.assertEquals(
+			toTicketSharingEntries.toString(), count,
+			toTicketSharingEntries.size());
+	}
+
 	private String _normalizeEmailAddress(String emailAddress) {
 		return StringUtil.toLowerCase(StringUtil.trim(emailAddress));
+	}
+
+	private void _testAddUserWithDuplicatePendingInvitations()
+		throws Exception {
+
+		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
+
+		Ticket ticket1 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress);
+		Ticket ticket2 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress);
+
+		_addTicketSharingEntry(_group1.getGroupId(), ticket1.getTicketId());
+		_addTicketSharingEntry(_group1.getGroupId(), ticket2.getTicketId());
+
+		_assertToTicketSharingEntriesCount(1, ticket1);
+		_assertToTicketSharingEntriesCount(1, ticket2);
+
+		User user = _addUser(emailAddress);
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
+
+		List<SharingEntry> toUserSharingEntries =
+			_sharingEntryLocalService.getToUserSharingEntries(user.getUserId());
+
+		Assert.assertEquals(
+			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
+
+		SharingEntry toUserSharingEntry = toUserSharingEntries.get(0);
+
+		Assert.assertEquals(0, toUserSharingEntry.getToTicketId());
+
+		_assertToTicketSharingEntriesCount(0, ticket1);
+		_assertToTicketSharingEntriesCount(0, ticket2);
+	}
+
+	private void _testAddUserWithExpiredInvitationTicket() throws Exception {
+		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
+
+		Ticket ticket = _addInviteCollaboratorTicket(
+			_group1.getGroupId(),
+			new Date(System.currentTimeMillis() - TimeUnit.HOURS.toMillis(1)),
+			_normalizeEmailAddress(emailAddress));
+
+		SharingEntry sharingEntry = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket.getTicketId());
+
+		_addUser(emailAddress);
+
+		Assert.assertNotNull(
+			_ticketLocalService.fetchTicket(ticket.getTicketId()));
+
+		_assertSharingEntryToTicketId(sharingEntry, ticket);
+	}
+
+	private void _testAddUserWithInvalidExtraInfo() throws Exception {
+		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
+
+		Ticket ticket1 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), null);
+		Ticket ticket2 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), "not-an-email");
+		Ticket ticket3 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress);
+
+		SharingEntry sharingEntry1 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket1.getTicketId());
+		SharingEntry sharingEntry2 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket2.getTicketId());
+		SharingEntry sharingEntry3 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket3.getTicketId());
+
+		User user = _addUser(emailAddress);
+
+		Assert.assertNotNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+		Assert.assertNotNull(
+			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket3.getTicketId()));
+
+		_assertSharingEntryToTicketId(sharingEntry1, ticket1);
+		_assertSharingEntryToTicketId(sharingEntry2, ticket2);
+		_assertSharingEntryToUserId(sharingEntry3, user);
+	}
+
+	private void _testAddUserWithMixedCaseExtraInfo() throws Exception {
+		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
+
+		Ticket ticket = _addInviteCollaboratorTicket(
+			_group1.getGroupId(),
+			new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(48)),
+			StringUtil.toUpperCase(emailAddress));
+
+		SharingEntry sharingEntry = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket.getTicketId());
+
+		User user = _addUser(emailAddress);
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket.getTicketId()));
+
+		_assertSharingEntryToUserId(sharingEntry, user);
+	}
+
+	private void _testAddUserWithPendingInvitations() throws Exception {
+		String emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
+		String emailAddress2 = RandomTestUtil.randomString() + "@liferay.com";
+
+		_group2 = GroupTestUtil.addGroup();
+
+		Ticket ticket1 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress1);
+		Ticket ticket2 = _addInviteCollaboratorTicket(
+			_group2.getGroupId(), emailAddress1);
+		Ticket ticket3 = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress2);
+
+		SharingEntry sharingEntry1 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket1.getTicketId());
+		SharingEntry sharingEntry2 = _addTicketSharingEntry(
+			_group2.getGroupId(), ticket2.getTicketId());
+		SharingEntry sharingEntry3 = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket3.getTicketId());
+
+		User user = _addUser(emailAddress1);
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket1.getTicketId()));
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket2.getTicketId()));
+
+		_assertSharingEntryToUserId(sharingEntry1, user);
+		_assertSharingEntryToUserId(sharingEntry2, user);
+		_assertSharingEntryToTicketId(sharingEntry3, ticket3);
+	}
+
+	private void _testUpdateUserStatusWithExistingUserSharingEntry()
+		throws Exception {
+
+		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
+
+		User user = _addUser(emailAddress);
+
+		Ticket ticket = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), emailAddress);
+
+		SharingEntry existingSharingEntry =
+			_sharingEntryLocalService.addSharingEntry(
+				null, TestPropsValues.getUserId(), 0, 0, user.getUserId(),
+				_classNameLocalService.getClassNameId(Group.class.getName()),
+				_group1.getGroupId(), _group1.getGroupId(), true,
+				Arrays.asList(SharingEntryAction.VIEW), null,
+				ServiceContextTestUtil.getServiceContext(
+					_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		_addTicketSharingEntry(_group1.getGroupId(), ticket.getTicketId());
+
+		_userLocalService.updateStatus(
+			user.getUserId(), WorkflowConstants.STATUS_INACTIVE,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		_userLocalService.updateStatus(
+			user.getUserId(), WorkflowConstants.STATUS_APPROVED,
+			ServiceContextTestUtil.getServiceContext(
+				_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket.getTicketId()));
+
+		_assertToTicketSharingEntriesCount(0, ticket);
+
+		List<SharingEntry> toUserSharingEntries =
+			_sharingEntryLocalService.getToUserSharingEntries(user.getUserId());
+
+		Assert.assertEquals(
+			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
+
+		SharingEntry toUserSharingEntry = toUserSharingEntries.get(0);
+
+		Assert.assertEquals(
+			existingSharingEntry.getSharingEntryId(),
+			toUserSharingEntry.getSharingEntryId());
+	}
+
+	private void _testUpdateUserStatusWithPendingInvitations()
+		throws Exception {
+
+		WorkflowDefinitionLink workflowDefinitionLink =
+			_workflowDefinitionLinkLocalService.addWorkflowDefinitionLink(
+				null, TestPropsValues.getUserId(),
+				TestPropsValues.getCompanyId(),
+				WorkflowConstants.DEFAULT_GROUP_ID, User.class.getName(), 0, 0,
+				"Single Approver", 1);
+
+		try {
+			String emailAddress =
+				RandomTestUtil.randomString() + "@liferay.com";
+
+			Ticket ticket = _addInviteCollaboratorTicket(
+				_group1.getGroupId(), emailAddress);
+
+			SharingEntry sharingEntry = _addTicketSharingEntry(
+				_group1.getGroupId(), ticket.getTicketId());
+
+			User user = _addUserWithWorkflow(emailAddress);
+
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_PENDING, user.getStatus());
+
+			Assert.assertNotNull(
+				_ticketLocalService.fetchTicket(ticket.getTicketId()));
+
+			_assertSharingEntryToTicketId(sharingEntry, ticket);
+
+			_userLocalService.updateStatus(
+				user.getUserId(), WorkflowConstants.STATUS_APPROVED,
+				ServiceContextTestUtil.getServiceContext(
+					_group1.getGroupId(), TestPropsValues.getUserId()));
+
+			Assert.assertNull(
+				_ticketLocalService.fetchTicket(ticket.getTicketId()));
+
+			_assertSharingEntryToUserId(sharingEntry, user);
+		}
+		finally {
+			_workflowDefinitionLinkLocalService.deleteWorkflowDefinitionLink(
+				workflowDefinitionLink);
+		}
 	}
 
 	@Inject

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
@@ -78,7 +78,7 @@ public class UserModelListenerTest {
 		_testAddUserWithExpiredInviteCollaboratorTicket();
 		_testAddUserWithInvalidEmailAddress();
 		_testAddUserWithInviteCollaboratorTickets();
-		_testAddUserWithUpperCaseEmail();
+		_testAddUserWithUpperCaseEmailAddress();
 	}
 
 	@Test
@@ -348,7 +348,7 @@ public class UserModelListenerTest {
 		_assertSharingEntryToTicketId(sharingEntry3, ticket3);
 	}
 
-	private void _testAddUserWithUpperCaseEmail() throws Exception {
+	private void _testAddUserWithUpperCaseEmailAddress() throws Exception {
 		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
 
 		Ticket ticket = _addInviteCollaboratorTicket(
@@ -369,7 +369,10 @@ public class UserModelListenerTest {
 	private void _testDeleteUserWithoutToUserSharingEntries() throws Exception {
 		User toUser = UserTestUtil.addGroupUser(
 			_group1, RoleConstants.POWER_USER);
-		User otherUser = UserTestUtil.addGroupUser(
+
+		_users.add(toUser);
+
+		User unrelatedUser = UserTestUtil.addGroupUser(
 			_group1, RoleConstants.POWER_USER);
 
 		_sharingEntryLocalService.addSharingEntry(
@@ -387,7 +390,7 @@ public class UserModelListenerTest {
 		Assert.assertEquals(
 			toUserSharingEntries.toString(), 1, toUserSharingEntries.size());
 
-		_userLocalService.deleteUser(otherUser.getUserId());
+		_userLocalService.deleteUser(unrelatedUser.getUserId());
 
 		toUserSharingEntries =
 			_sharingEntryLocalService.getToUserSharingEntries(

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
@@ -82,8 +82,8 @@ public class UserModelListenerTest {
 		_testAddUserWithDuplicatePendingInvitations();
 		_testAddUserWithExpiredInvitationTicket();
 		_testAddUserWithInvalidEmailAddress();
-		_testAddUserWithMixedCaseEmailAddress();
 		_testAddUserWithPendingInvitations();
+		_testAddUserWithUpperCaseEmail();
 	}
 
 	@Test
@@ -372,24 +372,6 @@ public class UserModelListenerTest {
 		_assertSharingEntryToUserId(sharingEntry3, user);
 	}
 
-	private void _testAddUserWithMixedCaseEmailAddress() throws Exception {
-		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
-
-		Ticket ticket = _addInviteCollaboratorTicket(
-			_group1.getGroupId(), StringUtil.toUpperCase(emailAddress),
-			new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(48)));
-
-		SharingEntry sharingEntry = _addTicketSharingEntry(
-			_group1.getGroupId(), ticket.getTicketId());
-
-		_addUser(emailAddress);
-
-		Assert.assertNotNull(
-			_ticketLocalService.fetchTicket(ticket.getTicketId()));
-
-		_assertSharingEntryToTicketId(sharingEntry, ticket);
-	}
-
 	private void _testAddUserWithPendingInvitations() throws Exception {
 		String emailAddress1 = RandomTestUtil.randomString() + "@liferay.com";
 		String emailAddress2 = RandomTestUtil.randomString() + "@liferay.com";
@@ -420,6 +402,24 @@ public class UserModelListenerTest {
 		_assertSharingEntryToUserId(sharingEntry1, user);
 		_assertSharingEntryToUserId(sharingEntry2, user);
 		_assertSharingEntryToTicketId(sharingEntry3, ticket3);
+	}
+
+	private void _testAddUserWithUpperCaseEmail() throws Exception {
+		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
+
+		Ticket ticket = _addInviteCollaboratorTicket(
+			_group1.getGroupId(), StringUtil.toUpperCase(emailAddress),
+			new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(48)));
+
+		SharingEntry sharingEntry = _addTicketSharingEntry(
+			_group1.getGroupId(), ticket.getTicketId());
+
+		User user = _addUser(emailAddress);
+
+		Assert.assertNull(
+			_ticketLocalService.fetchTicket(ticket.getTicketId()));
+
+		_assertSharingEntryToUserId(sharingEntry, user);
 	}
 
 	private void _testUpdateUserStatusWithExistingUserSharingEntry()

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/internal/model/listener/test/UserModelListenerTest.java
@@ -81,8 +81,8 @@ public class UserModelListenerTest {
 	public void testAddUser() throws Exception {
 		_testAddUserWithDuplicatePendingInvitations();
 		_testAddUserWithExpiredInvitationTicket();
-		_testAddUserWithInvalidExtraInfo();
-		_testAddUserWithMixedCaseExtraInfo();
+		_testAddUserWithInvalidEmailAddress();
+		_testAddUserWithMixedCaseEmailAddress();
 		_testAddUserWithPendingInvitations();
 	}
 
@@ -188,23 +188,22 @@ public class UserModelListenerTest {
 	}
 
 	private Ticket _addInviteCollaboratorTicket(
-			long classPK, Date expirationDate, String extraInfo)
-		throws Exception {
-
-		return _ticketLocalService.addTicket(
-			TestPropsValues.getCompanyId(), Group.class.getName(), classPK,
-			TicketConstants.TYPE_INVITE_COLLABORATOR, extraInfo, expirationDate,
-			new ServiceContext());
-	}
-
-	private Ticket _addInviteCollaboratorTicket(
 			long classPK, String emailAddress)
 		throws Exception {
 
 		return _addInviteCollaboratorTicket(
-			classPK,
-			new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(48)),
-			_normalizeEmailAddress(emailAddress));
+			classPK, _normalizeEmailAddress(emailAddress),
+			new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(48)));
+	}
+
+	private Ticket _addInviteCollaboratorTicket(
+			long classPK, String emailAddress, Date expirationDate)
+		throws Exception {
+
+		return _ticketLocalService.addTicket(
+			TestPropsValues.getCompanyId(), Group.class.getName(), classPK,
+			TicketConstants.TYPE_INVITE_COLLABORATOR, emailAddress, null,
+			expirationDate, new ServiceContext());
 	}
 
 	private SharingEntry _addTicketSharingEntry(long classPK, long toTicketId)
@@ -328,9 +327,8 @@ public class UserModelListenerTest {
 		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
 
 		Ticket ticket = _addInviteCollaboratorTicket(
-			_group1.getGroupId(),
-			new Date(System.currentTimeMillis() - TimeUnit.HOURS.toMillis(1)),
-			_normalizeEmailAddress(emailAddress));
+			_group1.getGroupId(), _normalizeEmailAddress(emailAddress),
+			new Date(System.currentTimeMillis() - TimeUnit.HOURS.toMillis(1)));
 
 		SharingEntry sharingEntry = _addTicketSharingEntry(
 			_group1.getGroupId(), ticket.getTicketId());
@@ -343,7 +341,7 @@ public class UserModelListenerTest {
 		_assertSharingEntryToTicketId(sharingEntry, ticket);
 	}
 
-	private void _testAddUserWithInvalidExtraInfo() throws Exception {
+	private void _testAddUserWithInvalidEmailAddress() throws Exception {
 		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
 
 		Ticket ticket1 = _addInviteCollaboratorTicket(
@@ -374,23 +372,22 @@ public class UserModelListenerTest {
 		_assertSharingEntryToUserId(sharingEntry3, user);
 	}
 
-	private void _testAddUserWithMixedCaseExtraInfo() throws Exception {
+	private void _testAddUserWithMixedCaseEmailAddress() throws Exception {
 		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
 
 		Ticket ticket = _addInviteCollaboratorTicket(
-			_group1.getGroupId(),
-			new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(48)),
-			StringUtil.toUpperCase(emailAddress));
+			_group1.getGroupId(), StringUtil.toUpperCase(emailAddress),
+			new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(48)));
 
 		SharingEntry sharingEntry = _addTicketSharingEntry(
 			_group1.getGroupId(), ticket.getTicketId());
 
-		User user = _addUser(emailAddress);
+		_addUser(emailAddress);
 
-		Assert.assertNull(
+		Assert.assertNotNull(
 			_ticketLocalService.fetchTicket(ticket.getTicketId()));
 
-		_assertSharingEntryToUserId(sharingEntry, user);
+		_assertSharingEntryToTicketId(sharingEntry, ticket);
 	}
 
 	private void _testAddUserWithPendingInvitations() throws Exception {

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/TicketPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/TicketPersistenceTest.java
@@ -128,6 +128,8 @@ public class TicketPersistenceTest {
 
 		newTicket.setType(RandomTestUtil.nextInt());
 
+		newTicket.setEmailAddress(RandomTestUtil.randomString());
+
 		newTicket.setExtraInfo(RandomTestUtil.randomString());
 
 		newTicket.setExpirationDate(RandomTestUtil.nextDate());
@@ -153,6 +155,8 @@ public class TicketPersistenceTest {
 		Assert.assertEquals(existingTicket.getKey(), newTicket.getKey());
 		Assert.assertEquals(existingTicket.getType(), newTicket.getType());
 		Assert.assertEquals(
+			existingTicket.getEmailAddress(), newTicket.getEmailAddress());
+		Assert.assertEquals(
 			existingTicket.getExtraInfo(), newTicket.getExtraInfo());
 		Assert.assertEquals(
 			Time.getShortTimestamp(existingTicket.getExpirationDate()),
@@ -175,6 +179,16 @@ public class TicketPersistenceTest {
 			RandomTestUtil.nextLong());
 
 		_persistence.countByC_C_C(0L, 0L, 0L);
+	}
+
+	@Test
+	public void testCountByC_T_EA() throws Exception {
+		_persistence.countByC_T_EA(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextInt(), "");
+
+		_persistence.countByC_T_EA(0L, 0, "null");
+
+		_persistence.countByC_T_EA(0L, 0, (String)null);
 	}
 
 	@Test
@@ -222,7 +236,7 @@ public class TicketPersistenceTest {
 		return OrderByComparatorFactoryUtil.create(
 			"Ticket", "mvccVersion", true, "ticketId", true, "companyId", true,
 			"createDate", true, "classNameId", true, "classPK", true, "key",
-			true, "type", true, "expirationDate", true);
+			true, "type", true, "emailAddress", true, "expirationDate", true);
 	}
 
 	@Test
@@ -500,6 +514,8 @@ public class TicketPersistenceTest {
 
 		ticket.setType(RandomTestUtil.nextInt());
 
+		ticket.setEmailAddress(RandomTestUtil.randomString());
+
 		ticket.setExtraInfo(RandomTestUtil.randomString());
 
 		ticket.setExpirationDate(RandomTestUtil.nextDate());
@@ -514,4 +530,4 @@ public class TicketPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:393071913
+// LIFERAY-SERVICE-BUILDER-HASH:852277907

--- a/portal-impl/src/META-INF/portal-hbm.xml
+++ b/portal-impl/src/META-INF/portal-hbm.xml
@@ -989,6 +989,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="classPK" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="key_" name="key" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="type_" name="type" type="com.liferay.portal.dao.orm.hibernate.IntegerType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="emailAddress" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="extraInfo" type="com.liferay.portal.dao.orm.hibernate.StringClobType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="expirationDate" type="org.hibernate.type.TimestampType" />
 	</class>

--- a/portal-impl/src/META-INF/portal-model-hints.xml
+++ b/portal-impl/src/META-INF/portal-model-hints.xml
@@ -1545,6 +1545,10 @@
 			<hint name="max-length">255</hint>
 		</field>
 		<field name="type" type="int" />
+		<field name="emailAddress" type="String">
+			<hint-collection name="EMAIL-ADDRESS" />
+			<validator name="email" />
+		</field>
 		<field name="extraInfo" type="String">
 			<hint-collection name="CLOB" />
 		</field>

--- a/portal-impl/src/com/liferay/portal/model/impl/TicketCacheModel.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/TicketCacheModel.java
@@ -67,7 +67,7 @@ public class TicketCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(21);
+		StringBundler sb = new StringBundler(23);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -85,6 +85,8 @@ public class TicketCacheModel
 		sb.append(key);
 		sb.append(", type=");
 		sb.append(type);
+		sb.append(", emailAddress=");
+		sb.append(emailAddress);
 		sb.append(", extraInfo=");
 		sb.append(extraInfo);
 		sb.append(", expirationDate=");
@@ -120,6 +122,13 @@ public class TicketCacheModel
 		}
 
 		ticketImpl.setType(type);
+
+		if (emailAddress == null) {
+			ticketImpl.setEmailAddress("");
+		}
+		else {
+			ticketImpl.setEmailAddress(emailAddress);
+		}
 
 		if (extraInfo == null) {
 			ticketImpl.setExtraInfo("");
@@ -157,6 +166,7 @@ public class TicketCacheModel
 		key = objectInput.readUTF();
 
 		type = objectInput.readInt();
+		emailAddress = objectInput.readUTF();
 		extraInfo = (String)objectInput.readObject();
 		expirationDate = objectInput.readLong();
 	}
@@ -183,6 +193,13 @@ public class TicketCacheModel
 
 		objectOutput.writeInt(type);
 
+		if (emailAddress == null) {
+			objectOutput.writeUTF("");
+		}
+		else {
+			objectOutput.writeUTF(emailAddress);
+		}
+
 		if (extraInfo == null) {
 			objectOutput.writeObject("");
 		}
@@ -201,8 +218,9 @@ public class TicketCacheModel
 	public long classPK;
 	public String key;
 	public int type;
+	public String emailAddress;
 	public String extraInfo;
 	public long expirationDate;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-878817001
+// LIFERAY-SERVICE-BUILDER-HASH:1332514131

--- a/portal-impl/src/com/liferay/portal/model/impl/TicketModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/TicketModelImpl.java
@@ -63,7 +63,8 @@ public class TicketModelImpl
 		{"companyId", Types.BIGINT}, {"createDate", Types.TIMESTAMP},
 		{"classNameId", Types.BIGINT}, {"classPK", Types.BIGINT},
 		{"key_", Types.VARCHAR}, {"type_", Types.INTEGER},
-		{"extraInfo", Types.CLOB}, {"expirationDate", Types.TIMESTAMP}
+		{"emailAddress", Types.VARCHAR}, {"extraInfo", Types.CLOB},
+		{"expirationDate", Types.TIMESTAMP}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -78,12 +79,13 @@ public class TicketModelImpl
 		TABLE_COLUMNS_MAP.put("classPK", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("key_", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("type_", Types.INTEGER);
+		TABLE_COLUMNS_MAP.put("emailAddress", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("extraInfo", Types.CLOB);
 		TABLE_COLUMNS_MAP.put("expirationDate", Types.TIMESTAMP);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table Ticket (mvccVersion LONG default 0 not null,ticketId LONG not null primary key,companyId LONG,createDate DATE null,classNameId LONG,classPK LONG,key_ VARCHAR(255) null,type_ INTEGER,extraInfo TEXT null,expirationDate DATE null)";
+		"create table Ticket (mvccVersion LONG default 0 not null,ticketId LONG not null primary key,companyId LONG,createDate DATE null,classNameId LONG,classPK LONG,key_ VARCHAR(255) null,type_ INTEGER,emailAddress VARCHAR(254) null,extraInfo TEXT null,expirationDate DATE null)";
 
 	public static final String TABLE_SQL_DROP = "drop table Ticket";
 
@@ -139,20 +141,26 @@ public class TicketModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long KEY_COLUMN_BITMASK = 8L;
+	public static final long EMAILADDRESS_COLUMN_BITMASK = 8L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long TYPE_COLUMN_BITMASK = 16L;
+	public static final long KEY_COLUMN_BITMASK = 16L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long TYPE_COLUMN_BITMASK = 32L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *		#getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long TICKETID_COLUMN_BITMASK = 32L;
+	public static final long TICKETID_COLUMN_BITMASK = 64L;
 
 	public static final long LOCK_EXPIRATION_TIME = GetterUtil.getLong(
 		com.liferay.portal.kernel.util.PropsUtil.get(
@@ -256,6 +264,8 @@ public class TicketModelImpl
 			attributeGetterFunctions.put("classPK", Ticket::getClassPK);
 			attributeGetterFunctions.put("key", Ticket::getKey);
 			attributeGetterFunctions.put("type", Ticket::getType);
+			attributeGetterFunctions.put(
+				"emailAddress", Ticket::getEmailAddress);
 			attributeGetterFunctions.put("extraInfo", Ticket::getExtraInfo);
 			attributeGetterFunctions.put(
 				"expirationDate", Ticket::getExpirationDate);
@@ -293,6 +303,9 @@ public class TicketModelImpl
 				"key", (BiConsumer<Ticket, String>)Ticket::setKey);
 			attributeSetterBiConsumers.put(
 				"type", (BiConsumer<Ticket, Integer>)Ticket::setType);
+			attributeSetterBiConsumers.put(
+				"emailAddress",
+				(BiConsumer<Ticket, String>)Ticket::setEmailAddress);
 			attributeSetterBiConsumers.put(
 				"extraInfo", (BiConsumer<Ticket, String>)Ticket::setExtraInfo);
 			attributeSetterBiConsumers.put(
@@ -491,6 +504,34 @@ public class TicketModelImpl
 	}
 
 	@Override
+	public String getEmailAddress() {
+		if (_emailAddress == null) {
+			return "";
+		}
+		else {
+			return _emailAddress;
+		}
+	}
+
+	@Override
+	public void setEmailAddress(String emailAddress) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_emailAddress = emailAddress;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public String getOriginalEmailAddress() {
+		return getColumnOriginalValue("emailAddress");
+	}
+
+	@Override
 	public String getExtraInfo() {
 		if (_extraInfo == null) {
 			return "";
@@ -587,6 +628,7 @@ public class TicketModelImpl
 		ticketImpl.setClassPK(getClassPK());
 		ticketImpl.setKey(getKey());
 		ticketImpl.setType(getType());
+		ticketImpl.setEmailAddress(getEmailAddress());
 		ticketImpl.setExtraInfo(getExtraInfo());
 		ticketImpl.setExpirationDate(getExpirationDate());
 
@@ -610,6 +652,8 @@ public class TicketModelImpl
 		ticketImpl.setClassPK(this.<Long>getColumnOriginalValue("classPK"));
 		ticketImpl.setKey(this.<String>getColumnOriginalValue("key_"));
 		ticketImpl.setType(this.<Integer>getColumnOriginalValue("type_"));
+		ticketImpl.setEmailAddress(
+			this.<String>getColumnOriginalValue("emailAddress"));
 		ticketImpl.setExtraInfo(
 			this.<String>getColumnOriginalValue("extraInfo"));
 		ticketImpl.setExpirationDate(
@@ -724,6 +768,14 @@ public class TicketModelImpl
 
 		ticketCacheModel.type = getType();
 
+		ticketCacheModel.emailAddress = getEmailAddress();
+
+		String emailAddress = ticketCacheModel.emailAddress;
+
+		if ((emailAddress != null) && (emailAddress.length() == 0)) {
+			ticketCacheModel.emailAddress = null;
+		}
+
 		ticketCacheModel.extraInfo = getExtraInfo();
 
 		String extraInfo = ticketCacheModel.extraInfo;
@@ -809,6 +861,7 @@ public class TicketModelImpl
 	private long _classPK;
 	private String _key;
 	private int _type;
+	private String _emailAddress;
 	private String _extraInfo;
 	private Date _expirationDate;
 
@@ -850,6 +903,7 @@ public class TicketModelImpl
 		_columnOriginalValues.put("classPK", _classPK);
 		_columnOriginalValues.put("key_", _key);
 		_columnOriginalValues.put("type_", _type);
+		_columnOriginalValues.put("emailAddress", _emailAddress);
 		_columnOriginalValues.put("extraInfo", _extraInfo);
 		_columnOriginalValues.put("expirationDate", _expirationDate);
 	}
@@ -892,9 +946,11 @@ public class TicketModelImpl
 
 		columnBitmasks.put("type_", 128L);
 
-		columnBitmasks.put("extraInfo", 256L);
+		columnBitmasks.put("emailAddress", 256L);
 
-		columnBitmasks.put("expirationDate", 512L);
+		columnBitmasks.put("extraInfo", 512L);
+
+		columnBitmasks.put("expirationDate", 1024L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}
@@ -903,4 +959,4 @@ public class TicketModelImpl
 	private Ticket _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2016124624
+// LIFERAY-SERVICE-BUILDER-HASH:1394219312

--- a/portal-impl/src/com/liferay/portal/service.xml
+++ b/portal-impl/src/com/liferay/portal/service.xml
@@ -2488,6 +2488,7 @@
 		<column name="classPK" type="long" />
 		<column name="key" type="String" />
 		<column name="type" type="int" />
+		<column name="emailAddress" type="String" />
 		<column name="extraInfo" type="String" />
 		<column name="expirationDate" type="Date" />
 
@@ -2506,6 +2507,11 @@
 			<finder-column name="companyId" />
 			<finder-column name="classNameId" />
 			<finder-column name="classPK" />
+		</finder>
+		<finder name="C_T_EA" return-type="Collection">
+			<finder-column name="companyId" />
+			<finder-column name="type" />
+			<finder-column name="emailAddress" />
 		</finder>
 		<finder name="C_C_T" return-type="Collection">
 			<finder-column name="classNameId" />

--- a/portal-impl/src/com/liferay/portal/service/impl/TicketLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/TicketLocalServiceImpl.java
@@ -10,6 +10,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Ticket;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import com.liferay.portal.service.base.TicketLocalServiceBaseImpl;
 
@@ -61,7 +62,8 @@ public class TicketLocalServiceImpl extends TicketLocalServiceBaseImpl {
 		ticket.setClassPK(classPK);
 		ticket.setKey(PortalUUIDUtil.generate());
 		ticket.setType(type);
-		ticket.setEmailAddress(emailAddress);
+		ticket.setEmailAddress(
+			StringUtil.toLowerCase(StringUtil.trim(emailAddress)));
 		ticket.setExtraInfo(extraInfo);
 		ticket.setExpirationDate(expirationDate);
 

--- a/portal-impl/src/com/liferay/portal/service/impl/TicketLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/TicketLocalServiceImpl.java
@@ -98,6 +98,15 @@ public class TicketLocalServiceImpl extends TicketLocalServiceBaseImpl {
 
 	@Override
 	public List<Ticket> getTickets(
+		long companyId, int type, String emailAddress) {
+
+		return ticketPersistence.findByC_T_EA(
+			companyId, type,
+			StringUtil.toLowerCase(StringUtil.trim(emailAddress)));
+	}
+
+	@Override
+	public List<Ticket> getTickets(
 		long companyId, String className, long classPK) {
 
 		return ticketPersistence.findByC_C_C(

--- a/portal-impl/src/com/liferay/portal/service/impl/TicketLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/TicketLocalServiceImpl.java
@@ -30,15 +30,26 @@ public class TicketLocalServiceImpl extends TicketLocalServiceBaseImpl {
 			companyId, _classNameLocalService.getClassNameId(className),
 			classPK, type);
 
-		return addTicket(
-			companyId, className, classPK, type, extraInfo, expirationDate,
-			serviceContext);
+		return ticketLocalService.addTicket(
+			companyId, className, classPK, type, null, extraInfo,
+			expirationDate, serviceContext);
 	}
 
 	@Override
 	public Ticket addTicket(
 		long companyId, String className, long classPK, int type,
 		String extraInfo, Date expirationDate, ServiceContext serviceContext) {
+
+		return ticketLocalService.addTicket(
+			companyId, className, classPK, type, null, extraInfo,
+			expirationDate, serviceContext);
+	}
+
+	@Override
+	public Ticket addTicket(
+		long companyId, String className, long classPK, int type,
+		String emailAddress, String extraInfo, Date expirationDate,
+		ServiceContext serviceContext) {
 
 		long ticketId = counterLocalService.increment();
 
@@ -50,6 +61,7 @@ public class TicketLocalServiceImpl extends TicketLocalServiceBaseImpl {
 		ticket.setClassPK(classPK);
 		ticket.setKey(PortalUUIDUtil.generate());
 		ticket.setType(type);
+		ticket.setEmailAddress(emailAddress);
 		ticket.setExtraInfo(extraInfo);
 		ticket.setExpirationDate(expirationDate);
 

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/TicketPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/TicketPersistenceImpl.java
@@ -244,6 +244,113 @@ public class TicketPersistenceImpl
 	}
 
 	private CollectionPersistenceFinder<Ticket>
+		_collectionPersistenceFinderByC_T_EA;
+
+	/**
+	 * Returns an ordered range of all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>TicketModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param start the lower bound of the range of tickets
+	 * @param end the upper bound of the range of tickets (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching tickets
+	 */
+	@Override
+	public List<Ticket> findByC_T_EA(
+		long companyId, int type, String emailAddress, int start, int end,
+		OrderByComparator<Ticket> orderByComparator, boolean useFinderCache) {
+
+		return _collectionPersistenceFinderByC_T_EA.find(
+			FinderCacheUtil.getFinderCache(),
+			new Object[] {companyId, type, emailAddress}, start, end,
+			orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first ticket in the ordered set where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ticket
+	 * @throws NoSuchTicketException if a matching ticket could not be found
+	 */
+	@Override
+	public Ticket findByC_T_EA_First(
+			long companyId, int type, String emailAddress,
+			OrderByComparator<Ticket> orderByComparator)
+		throws NoSuchTicketException {
+
+		Ticket ticket = fetchByC_T_EA_First(
+			companyId, type, emailAddress, orderByComparator);
+
+		if (ticket != null) {
+			return ticket;
+		}
+
+		throw new NoSuchTicketException(
+			_collectionPersistenceFinderByC_T_EA.buildNoSuchKeyMessage(
+				_NO_SUCH_ENTITY_WITH_KEY,
+				new Object[] {companyId, type, emailAddress}));
+	}
+
+	/**
+	 * Returns the first ticket in the ordered set where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ticket, or <code>null</code> if a matching ticket could not be found
+	 */
+	@Override
+	public Ticket fetchByC_T_EA_First(
+		long companyId, int type, String emailAddress,
+		OrderByComparator<Ticket> orderByComparator) {
+
+		return _collectionPersistenceFinderByC_T_EA.fetchFirst(
+			FinderCacheUtil.getFinderCache(),
+			new Object[] {companyId, type, emailAddress}, orderByComparator);
+	}
+
+	/**
+	 * Removes all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 */
+	@Override
+	public void removeByC_T_EA(long companyId, int type, String emailAddress) {
+		_collectionPersistenceFinderByC_T_EA.remove(
+			FinderCacheUtil.getFinderCache(),
+			new Object[] {companyId, type, emailAddress});
+	}
+
+	/**
+	 * Returns the number of tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @return the number of matching tickets
+	 */
+	@Override
+	public int countByC_T_EA(long companyId, int type, String emailAddress) {
+		return _collectionPersistenceFinderByC_T_EA.count(
+			FinderCacheUtil.getFinderCache(),
+			new Object[] {companyId, type, emailAddress});
+	}
+
+	private CollectionPersistenceFinder<Ticket>
 		_collectionPersistenceFinderByC_C_T;
 
 	/**
@@ -709,6 +816,46 @@ public class TicketPersistenceImpl
 				"ticket.", "classPK", FinderColumn.Type.LONG, "=", true, true,
 				Ticket::getClassPK));
 
+		_collectionPersistenceFinderByC_T_EA =
+			new CollectionPersistenceFinder<>(
+				this,
+				new FinderPath(
+					FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_T_EA",
+					new String[] {
+						Long.class.getName(), Integer.class.getName(),
+						String.class.getName(), Integer.class.getName(),
+						Integer.class.getName(),
+						OrderByComparator.class.getName()
+					},
+					new String[] {"companyId", "type_", "emailAddress"}, true),
+				new FinderPath(
+					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_T_EA",
+					new String[] {
+						Long.class.getName(), Integer.class.getName(),
+						String.class.getName()
+					},
+					new String[] {"companyId", "type_", "emailAddress"}, 0, 4,
+					true, null),
+				new FinderPath(
+					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_T_EA",
+					new String[] {
+						Long.class.getName(), Integer.class.getName(),
+						String.class.getName()
+					},
+					new String[] {"companyId", "type_", "emailAddress"}, 0, 4,
+					false, null),
+				_SQL_SELECT_TICKET_WHERE, _SQL_COUNT_TICKET_WHERE,
+				TicketModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+				new FinderColumn<>(
+					"ticket.", "companyId", FinderColumn.Type.LONG, "=", true,
+					true, Ticket::getCompanyId),
+				new FinderColumn<>(
+					"ticket.", "type", FinderColumn.Type.INTEGER, "=", true,
+					true, Ticket::getType),
+				new FinderColumn<>(
+					"ticket.", "emailAddress", FinderColumn.Type.STRING, "=",
+					true, true, Ticket::getEmailAddress));
+
 		_collectionPersistenceFinderByC_C_T = new CollectionPersistenceFinder<>(
 			this,
 			new FinderPath(
@@ -831,4 +978,4 @@ public class TicketPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1252553510
+// LIFERAY-SERVICE-BUILDER-HASH:-1448420254

--- a/portal-kernel/src/com/liferay/portal/kernel/model/TicketModel.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/TicketModel.java
@@ -178,6 +178,21 @@ public interface TicketModel
 	public void setType(int type);
 
 	/**
+	 * Returns the email address of this ticket.
+	 *
+	 * @return the email address of this ticket
+	 */
+	@AutoEscape
+	public String getEmailAddress();
+
+	/**
+	 * Sets the email address of this ticket.
+	 *
+	 * @param emailAddress the email address of this ticket
+	 */
+	public void setEmailAddress(String emailAddress);
+
+	/**
 	 * Returns the extra info of this ticket.
 	 *
 	 * @return the extra info of this ticket
@@ -214,4 +229,4 @@ public interface TicketModel
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1000540596
+// LIFERAY-SERVICE-BUILDER-HASH:1971965592

--- a/portal-kernel/src/com/liferay/portal/kernel/model/TicketTable.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/TicketTable.java
@@ -40,6 +40,8 @@ public class TicketTable extends BaseTable<TicketTable> {
 		"key_", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
 	public final Column<TicketTable, Integer> type = createColumn(
 		"type_", Integer.class, Types.INTEGER, Column.FLAG_DEFAULT);
+	public final Column<TicketTable, String> emailAddress = createColumn(
+		"emailAddress", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
 	public final Column<TicketTable, Clob> extraInfo = createColumn(
 		"extraInfo", Clob.class, Types.CLOB, Column.FLAG_DEFAULT);
 	public final Column<TicketTable, Date> expirationDate = createColumn(
@@ -50,4 +52,4 @@ public class TicketTable extends BaseTable<TicketTable> {
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1325508359
+// LIFERAY-SERVICE-BUILDER-HASH:-1420567643

--- a/portal-kernel/src/com/liferay/portal/kernel/model/TicketWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/TicketWrapper.java
@@ -39,6 +39,7 @@ public class TicketWrapper
 		attributes.put("classPK", getClassPK());
 		attributes.put("key", getKey());
 		attributes.put("type", getType());
+		attributes.put("emailAddress", getEmailAddress());
 		attributes.put("extraInfo", getExtraInfo());
 		attributes.put("expirationDate", getExpirationDate());
 
@@ -93,6 +94,12 @@ public class TicketWrapper
 
 		if (type != null) {
 			setType(type);
+		}
+
+		String emailAddress = (String)attributes.get("emailAddress");
+
+		if (emailAddress != null) {
+			setEmailAddress(emailAddress);
 		}
 
 		String extraInfo = (String)attributes.get("extraInfo");
@@ -161,6 +168,16 @@ public class TicketWrapper
 	@Override
 	public Date getCreateDate() {
 		return model.getCreateDate();
+	}
+
+	/**
+	 * Returns the email address of this ticket.
+	 *
+	 * @return the email address of this ticket
+	 */
+	@Override
+	public String getEmailAddress() {
+		return model.getEmailAddress();
 	}
 
 	/**
@@ -289,6 +306,16 @@ public class TicketWrapper
 	}
 
 	/**
+	 * Sets the email address of this ticket.
+	 *
+	 * @param emailAddress the email address of this ticket
+	 */
+	@Override
+	public void setEmailAddress(String emailAddress) {
+		model.setEmailAddress(emailAddress);
+	}
+
+	/**
 	 * Sets the expiration date of this ticket.
 	 *
 	 * @param expirationDate the expiration date of this ticket
@@ -369,4 +396,4 @@ public class TicketWrapper
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1378583455
+// LIFERAY-SERVICE-BUILDER-HASH:777544895

--- a/portal-kernel/src/com/liferay/portal/kernel/service/TicketLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/TicketLocalService.java
@@ -63,6 +63,11 @@ public interface TicketLocalService
 		long companyId, String className, long classPK, int type,
 		String extraInfo, Date expirationDate, ServiceContext serviceContext);
 
+	public Ticket addTicket(
+		long companyId, String className, long classPK, int type,
+		String emailAddress, String extraInfo, Date expirationDate,
+		ServiceContext serviceContext);
+
 	/**
 	 * Adds the ticket to the database. Also notifies the appropriate model listeners.
 	 *
@@ -258,6 +263,10 @@ public interface TicketLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<Ticket> getTickets(
+		long companyId, int type, String emailAddress);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<Ticket> getTickets(
 		long companyId, String className, long classPK);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -294,4 +303,4 @@ public interface TicketLocalService
 	public Ticket updateTicket(Ticket ticket);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:351293955
+// LIFERAY-SERVICE-BUILDER-HASH:-519894446

--- a/portal-kernel/src/com/liferay/portal/kernel/service/TicketLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/TicketLocalServiceUtil.java
@@ -55,6 +55,16 @@ public class TicketLocalServiceUtil {
 			serviceContext);
 	}
 
+	public static Ticket addTicket(
+		long companyId, String className, long classPK, int type,
+		String emailAddress, String extraInfo, java.util.Date expirationDate,
+		ServiceContext serviceContext) {
+
+		return getService().addTicket(
+			companyId, className, classPK, type, emailAddress, extraInfo,
+			expirationDate, serviceContext);
+	}
+
 	/**
 	 * Adds the ticket to the database. Also notifies the appropriate model listeners.
 	 *
@@ -295,6 +305,12 @@ public class TicketLocalServiceUtil {
 	}
 
 	public static List<Ticket> getTickets(
+		long companyId, int type, String emailAddress) {
+
+		return getService().getTickets(companyId, type, emailAddress);
+	}
+
+	public static List<Ticket> getTickets(
 		long companyId, String className, long classPK) {
 
 		return getService().getTickets(companyId, className, classPK);
@@ -355,4 +371,4 @@ public class TicketLocalServiceUtil {
 	private static volatile TicketLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2021983297
+// LIFERAY-SERVICE-BUILDER-HASH:815814338

--- a/portal-kernel/src/com/liferay/portal/kernel/service/TicketLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/TicketLocalServiceWrapper.java
@@ -47,6 +47,17 @@ public class TicketLocalServiceWrapper
 			serviceContext);
 	}
 
+	@Override
+	public com.liferay.portal.kernel.model.Ticket addTicket(
+		long companyId, String className, long classPK, int type,
+		String emailAddress, String extraInfo, java.util.Date expirationDate,
+		ServiceContext serviceContext) {
+
+		return _ticketLocalService.addTicket(
+			companyId, className, classPK, type, emailAddress, extraInfo,
+			expirationDate, serviceContext);
+	}
+
 	/**
 	 * Adds the ticket to the database. Also notifies the appropriate model listeners.
 	 *
@@ -331,6 +342,13 @@ public class TicketLocalServiceWrapper
 
 	@Override
 	public java.util.List<com.liferay.portal.kernel.model.Ticket> getTickets(
+		long companyId, int type, String emailAddress) {
+
+		return _ticketLocalService.getTickets(companyId, type, emailAddress);
+	}
+
+	@Override
+	public java.util.List<com.liferay.portal.kernel.model.Ticket> getTickets(
 		long companyId, String className, long classPK) {
 
 		return _ticketLocalService.getTickets(companyId, className, classPK);
@@ -406,4 +424,4 @@ public class TicketLocalServiceWrapper
 	private TicketLocalService _ticketLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-338077197
+// LIFERAY-SERVICE-BUILDER-HASH:-2109147802

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/TicketPersistence.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/TicketPersistence.java
@@ -136,6 +136,77 @@ public interface TicketPersistence extends BasePersistence<Ticket> {
 	public int countByC_C_C(long companyId, long classNameId, long classPK);
 
 	/**
+	 * Returns an ordered range of all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.portal.model.impl.TicketModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param start the lower bound of the range of tickets
+	 * @param end the upper bound of the range of tickets (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching tickets
+	 */
+	public java.util.List<Ticket> findByC_T_EA(
+		long companyId, int type, String emailAddress, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<Ticket>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first ticket in the ordered set where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ticket
+	 * @throws NoSuchTicketException if a matching ticket could not be found
+	 */
+	public Ticket findByC_T_EA_First(
+			long companyId, int type, String emailAddress,
+			com.liferay.portal.kernel.util.OrderByComparator<Ticket>
+				orderByComparator)
+		throws NoSuchTicketException;
+
+	/**
+	 * Returns the first ticket in the ordered set where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ticket, or <code>null</code> if a matching ticket could not be found
+	 */
+	public Ticket fetchByC_T_EA_First(
+		long companyId, int type, String emailAddress,
+		com.liferay.portal.kernel.util.OrderByComparator<Ticket>
+			orderByComparator);
+
+	/**
+	 * Removes all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 */
+	public void removeByC_T_EA(long companyId, int type, String emailAddress);
+
+	/**
+	 * Returns the number of tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @return the number of matching tickets
+	 */
+	public int countByC_T_EA(long companyId, int type, String emailAddress);
+
+	/**
 	 * Returns an ordered range of all the tickets where classNameId = &#63; and classPK = &#63; and type = &#63;.
 	 *
 	 * <p>
@@ -395,6 +466,68 @@ public interface TicketPersistence extends BasePersistence<Ticket> {
 	}
 
 	/**
+	 * Returns all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @return the matching tickets
+	 */
+	public default java.util.List<Ticket> findByC_T_EA(
+		long companyId, int type, String emailAddress) {
+
+		return findByC_T_EA(
+			companyId, type, emailAddress,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS, null, true);
+	}
+
+	/**
+	 * Returns a range of all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.portal.model.impl.TicketModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param start the lower bound of the range of tickets
+	 * @param end the upper bound of the range of tickets (not inclusive)
+	 * @return the range of matching tickets
+	 */
+	public default java.util.List<Ticket> findByC_T_EA(
+		long companyId, int type, String emailAddress, int start, int end) {
+
+		return findByC_T_EA(
+			companyId, type, emailAddress, start, end, null, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.portal.model.impl.TicketModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param start the lower bound of the range of tickets
+	 * @param end the upper bound of the range of tickets (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching tickets
+	 */
+	public default java.util.List<Ticket> findByC_T_EA(
+		long companyId, int type, String emailAddress, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<Ticket>
+			orderByComparator) {
+
+		return findByC_T_EA(
+			companyId, type, emailAddress, start, end, orderByComparator, true);
+	}
+
+	/**
 	 * Returns all the tickets where classNameId = &#63; and classPK = &#63; and type = &#63;.
 	 *
 	 * @param classNameId the class name ID
@@ -524,4 +657,4 @@ public interface TicketPersistence extends BasePersistence<Ticket> {
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-114569280
+// LIFERAY-SERVICE-BUILDER-HASH:688359375

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/TicketUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/TicketUtil.java
@@ -255,6 +255,94 @@ public class TicketUtil {
 	}
 
 	/**
+	 * Returns an ordered range of all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.portal.model.impl.TicketModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param start the lower bound of the range of tickets
+	 * @param end the upper bound of the range of tickets (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching tickets
+	 */
+	public static List<Ticket> findByC_T_EA(
+		long companyId, int type, String emailAddress, int start, int end,
+		OrderByComparator<Ticket> orderByComparator, boolean useFinderCache) {
+
+		return getPersistence().findByC_T_EA(
+			companyId, type, emailAddress, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first ticket in the ordered set where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ticket
+	 * @throws NoSuchTicketException if a matching ticket could not be found
+	 */
+	public static Ticket findByC_T_EA_First(
+			long companyId, int type, String emailAddress,
+			OrderByComparator<Ticket> orderByComparator)
+		throws com.liferay.portal.kernel.exception.NoSuchTicketException {
+
+		return getPersistence().findByC_T_EA_First(
+			companyId, type, emailAddress, orderByComparator);
+	}
+
+	/**
+	 * Returns the first ticket in the ordered set where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ticket, or <code>null</code> if a matching ticket could not be found
+	 */
+	public static Ticket fetchByC_T_EA_First(
+		long companyId, int type, String emailAddress,
+		OrderByComparator<Ticket> orderByComparator) {
+
+		return getPersistence().fetchByC_T_EA_First(
+			companyId, type, emailAddress, orderByComparator);
+	}
+
+	/**
+	 * Removes all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 */
+	public static void removeByC_T_EA(
+		long companyId, int type, String emailAddress) {
+
+		getPersistence().removeByC_T_EA(companyId, type, emailAddress);
+	}
+
+	/**
+	 * Returns the number of tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @return the number of matching tickets
+	 */
+	public static int countByC_T_EA(
+		long companyId, int type, String emailAddress) {
+
+		return getPersistence().countByC_T_EA(companyId, type, emailAddress);
+	}
+
+	/**
 	 * Returns an ordered range of all the tickets where classNameId = &#63; and classPK = &#63; and type = &#63;.
 	 *
 	 * <p>
@@ -552,6 +640,64 @@ public class TicketUtil {
 	}
 
 	/**
+	 * Returns all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @return the matching tickets
+	 */
+	public static List<Ticket> findByC_T_EA(
+		long companyId, int type, String emailAddress) {
+
+		return getPersistence().findByC_T_EA(companyId, type, emailAddress);
+	}
+
+	/**
+	 * Returns a range of all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.portal.model.impl.TicketModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param start the lower bound of the range of tickets
+	 * @param end the upper bound of the range of tickets (not inclusive)
+	 * @return the range of matching tickets
+	 */
+	public static List<Ticket> findByC_T_EA(
+		long companyId, int type, String emailAddress, int start, int end) {
+
+		return getPersistence().findByC_T_EA(
+			companyId, type, emailAddress, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the tickets where companyId = &#63; and type = &#63; and emailAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.portal.model.impl.TicketModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param type the type
+	 * @param emailAddress the email address
+	 * @param start the lower bound of the range of tickets
+	 * @param end the upper bound of the range of tickets (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching tickets
+	 */
+	public static List<Ticket> findByC_T_EA(
+		long companyId, int type, String emailAddress, int start, int end,
+		OrderByComparator<Ticket> orderByComparator) {
+
+		return getPersistence().findByC_T_EA(
+			companyId, type, emailAddress, start, end, orderByComparator);
+	}
+
+	/**
 	 * Returns all the tickets where classNameId = &#63; and classPK = &#63; and type = &#63;.
 	 *
 	 * @param classNameId the class name ID
@@ -684,4 +830,4 @@ public class TicketUtil {
 	private static volatile TicketPersistence _persistence;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1587241034
+// LIFERAY-SERVICE-BUILDER-HASH:-1323902993

--- a/sql/indexes.sql
+++ b/sql/indexes.sql
@@ -432,8 +432,9 @@ create index IX_93AB8545 on Team (companyId);
 create unique index IX_D424D1E4 on Team (groupId, name[$COLUMN_LENGTH:75$], ctCollectionId);
 create unique index IX_1AAF62D7 on Team (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId);
 
-create index IX_DAD135B4 on Ticket (classNameId, classPK, companyId, type_);
 create index IX_1E8DFB2E on Ticket (classNameId, classPK, type_);
+create index IX_8BACD0AA on Ticket (companyId, classNameId, classPK, type_);
+create index IX_3AFCAA8B on Ticket (companyId, type_, emailAddress[$COLUMN_LENGTH:254$]);
 create unique index IX_B2468446 on Ticket (key_[$COLUMN_LENGTH:255$]);
 
 create unique index IX_544FAE0D on UserGroup (companyId, externalReferenceCode[$COLUMN_LENGTH:75$], ctCollectionId);

--- a/sql/portal-tables.sql
+++ b/sql/portal-tables.sql
@@ -1473,6 +1473,7 @@ create table Ticket (
 	classPK LONG,
 	key_ VARCHAR(255) null,
 	type_ INTEGER,
+	emailAddress VARCHAR(254) null,
 	extraInfo TEXT null,
 	expirationDate DATE null
 );


### PR DESCRIPTION
Follow-up to https://github.com/brianchandotcom/liferay-portal/pull/174661.

Switches the pending-invitation conversion in `UserModelListener` from a DSL `JOIN` to the existing `C_T_EA` finder, now that the new `Ticket.emailAddress` column from LPD-90195 makes the email lookup trivial.

### Why finders instead of DSL

- `TicketLocalService.findByC_T_EA` (added in this branch as a wrapper) is backed by the Service Builder–generated `IX_3AFCAA8B (companyId, type_, emailAddress[254])` index. The index is guaranteed by construction.
- Both `Ticket.findByC_T_EA` and `SharingEntry.findByToTicketId` hit the entity cache. The prior DSL `JOIN` bypassed it entirely.
- The code reads as plain Liferay idiom.

### Trade-off

1 + N round trips instead of a single `JOIN`. N is the number of `(companyId, type, email)` matches, which should be at most a handful in practice, and this runs only on user approval (cold path). 

https://liferay.atlassian.net/browse/LPD-88154

cc @AliciaGarciaGarcia

_AI-assisted with Claude Code._
