### PR TITLE
LPD-90093 Prevent TOC TOU in QuotaUtil

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/quota/QuotaUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/quota/QuotaUtil.java
@@ -16,14 +16,17 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectEntryLocalServiceUtil;
+import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProviderUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.lock.Lock;
+import com.liferay.portal.kernel.lock.LockManagerUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -45,7 +48,96 @@ public class QuotaUtil {
 			return;
 		}
 
-		long tokensCount = 0L;
+		long tokensCount = _countTokens(companyId, text);
+
+		_updateUsage(
+			objectEntry.getObjectEntryId(),
+			() -> {
+				ObjectEntry currentObjectEntry =
+					ObjectEntryLocalServiceUtil.getObjectEntry(
+						objectEntry.getObjectEntryId());
+
+				Map<String, Serializable> values =
+					currentObjectEntry.getValues();
+
+				long currentUsage = GetterUtil.getLong(values.get("usage"));
+
+				long limit = GetterUtil.getLong(values.get("limit"));
+
+				if ((currentUsage + tokensCount) > limit) {
+					throw new UnsupportedOperationException(
+						"You have exceeded your token quota");
+				}
+
+				_persistUsage(
+					companyId, currentObjectEntry, currentUsage + tokensCount,
+					userId);
+			});
+	}
+
+	public static void updateUsage(
+			long companyId, long tokensCount, long userId)
+		throws PortalException {
+
+		ObjectEntry objectEntry = _fetchQuotaObjectEntry(companyId, userId);
+
+		if (objectEntry == null) {
+			return;
+		}
+
+		_updateUsage(
+			objectEntry.getObjectEntryId(),
+			() -> {
+				ObjectEntry currentObjectEntry =
+					ObjectEntryLocalServiceUtil.getObjectEntry(
+						objectEntry.getObjectEntryId());
+
+				long currentUsage = GetterUtil.getLong(
+					currentObjectEntry.getValues(
+					).get(
+						"usage"
+					));
+
+				_persistUsage(
+					companyId, currentObjectEntry, currentUsage + tokensCount,
+					userId);
+			});
+	}
+
+	private static void _acquireLock(String className, String key, String owner)
+		throws PortalException {
+
+		long deadline =
+			System.currentTimeMillis() + _LOCK_ACQUIRE_TIMEOUT_MILLIS;
+
+		while (true) {
+			Lock lock = LockManagerUtil.lock(className, key, null, owner);
+
+			if (Objects.equals(lock.getOwner(), owner)) {
+				return;
+			}
+
+			if (System.currentTimeMillis() >= deadline) {
+				throw new PortalException("Timed out acquiring quota lock");
+			}
+
+			try {
+				Thread.sleep(_LOCK_RETRY_INTERVAL_MILLIS);
+			}
+			catch (InterruptedException interruptedException) {
+				Thread currentThread = Thread.currentThread();
+
+				currentThread.interrupt();
+
+				throw new PortalException(
+					"Interrupted while waiting for quota lock",
+					interruptedException);
+			}
+		}
+	}
+
+	private static long _countTokens(long companyId, String text)
+		throws PortalException {
 
 		VertexAIConfiguration vertexAIConfiguration =
 			ConfigurationProviderUtil.getCompanyConfiguration(
@@ -68,51 +160,11 @@ public class QuotaUtil {
 			CountTokensResponse countTokensResponse =
 				generativeModel.countTokens(text);
 
-			tokensCount = countTokensResponse.getTotalTokens();
+			return countTokensResponse.getTotalTokens();
 		}
 		catch (IOException ioException) {
 			throw new PortalException(ioException);
 		}
-
-		Map<String, Serializable> values = objectEntry.getValues();
-
-		if ((GetterUtil.getLong(values.get("usage")) + tokensCount) >
-				GetterUtil.getLong(values.get("limit"))) {
-
-			throw new UnsupportedOperationException(
-				"You have exceeded your token quota");
-		}
-
-		updateUsage(companyId, tokensCount, userId);
-	}
-
-	public static void updateUsage(
-			long companyId, long tokensCount, long userId)
-		throws PortalException {
-
-		ObjectEntry objectEntry = _fetchQuotaObjectEntry(companyId, userId);
-
-		if (objectEntry == null) {
-			return;
-		}
-
-		ServiceContext serviceContext = new ServiceContext();
-
-		serviceContext.setCompanyId(companyId);
-		serviceContext.setUserId(userId);
-
-		ObjectEntryLocalServiceUtil.partialUpdateObjectEntry(
-			userId, objectEntry.getObjectEntryId(), 0,
-			HashMapBuilder.<String, Serializable>put(
-				"usage",
-				() -> {
-					long usage = MapUtil.getLong(
-						objectEntry.getValues(), "usage");
-
-					return usage + tokensCount;
-				}
-			).build(),
-			serviceContext);
 	}
 
 	private static ObjectEntry _fetchQuotaObjectEntry(
@@ -148,5 +200,48 @@ public class QuotaUtil {
 		return ObjectEntryLocalServiceUtil.fetchObjectEntry(
 			externalReferenceCode, 0, objectDefinition.getObjectDefinitionId());
 	}
+
+	private static String _getLockKey(long objectEntryId) {
+		return "ai-hub-quota-" + objectEntryId;
+	}
+
+	private static void _persistUsage(
+			long companyId, ObjectEntry objectEntry, long newUsage, long userId)
+		throws PortalException {
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setCompanyId(companyId);
+		serviceContext.setUserId(userId);
+
+		ObjectEntryLocalServiceUtil.partialUpdateObjectEntry(
+			userId, objectEntry.getObjectEntryId(), 0,
+			HashMapBuilder.<String, Serializable>put(
+				"usage", newUsage
+			).build(),
+			serviceContext);
+	}
+
+	private static void _updateUsage(
+			long objectEntryId, UnsafeRunnable<PortalException> unsafeRunnable)
+		throws PortalException {
+
+		String className = QuotaUtil.class.getName();
+		String key = _getLockKey(objectEntryId);
+		String owner = PortalUUIDUtil.generate();
+
+		_acquireLock(className, key, owner);
+
+		try {
+			unsafeRunnable.run();
+		}
+		finally {
+			LockManagerUtil.unlock(className, key, owner);
+		}
+	}
+
+	private static final long _LOCK_ACQUIRE_TIMEOUT_MILLIS = 10_000L;
+
+	private static final long _LOCK_RETRY_INTERVAL_MILLIS = 50L;
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/quota/QuotaUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/quota/QuotaUtil.java
@@ -16,7 +16,6 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectEntryLocalServiceUtil;
-import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProviderUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.lock.Lock;
@@ -24,15 +23,17 @@ import com.liferay.portal.kernel.lock.LockManagerUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.Serializable;
 
-import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeoutException;
 
 /**
  * @author Feliphe Marinho
@@ -50,29 +51,23 @@ public class QuotaUtil {
 
 		long tokensCount = _countTokens(companyId, text);
 
-		_updateUsage(
-			objectEntry.getObjectEntryId(),
-			() -> {
-				ObjectEntry currentObjectEntry =
-					ObjectEntryLocalServiceUtil.getObjectEntry(
-						objectEntry.getObjectEntryId());
+		try (Closeable closeable = _lock(objectEntry.getObjectEntryId())) {
+			objectEntry = ObjectEntryLocalServiceUtil.getObjectEntry(
+				objectEntry.getObjectEntryId());
 
-				Map<String, Serializable> values =
-					currentObjectEntry.getValues();
+			long usage =
+				MapUtil.getLong(objectEntry.getValues(), "usage") + tokensCount;
 
-				long currentUsage = GetterUtil.getLong(values.get("usage"));
+			if (usage > MapUtil.getLong(objectEntry.getValues(), "limit")) {
+				throw new UnsupportedOperationException(
+					"You have exceeded your token quota");
+			}
 
-				long limit = GetterUtil.getLong(values.get("limit"));
-
-				if ((currentUsage + tokensCount) > limit) {
-					throw new UnsupportedOperationException(
-						"You have exceeded your token quota");
-				}
-
-				_persistUsage(
-					companyId, currentObjectEntry, currentUsage + tokensCount,
-					userId);
-			});
+			_partialUpdateObjectEntry(companyId, objectEntry, usage, userId);
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
 	}
 
 	public static void updateUsage(
@@ -85,54 +80,17 @@ public class QuotaUtil {
 			return;
 		}
 
-		_updateUsage(
-			objectEntry.getObjectEntryId(),
-			() -> {
-				ObjectEntry currentObjectEntry =
-					ObjectEntryLocalServiceUtil.getObjectEntry(
-						objectEntry.getObjectEntryId());
+		try (Closeable closeable = _lock(objectEntry.getObjectEntryId())) {
+			objectEntry = ObjectEntryLocalServiceUtil.getObjectEntry(
+				objectEntry.getObjectEntryId());
 
-				long currentUsage = GetterUtil.getLong(
-					currentObjectEntry.getValues(
-					).get(
-						"usage"
-					));
-
-				_persistUsage(
-					companyId, currentObjectEntry, currentUsage + tokensCount,
-					userId);
-			});
-	}
-
-	private static void _acquireLock(String className, String key, String owner)
-		throws PortalException {
-
-		long deadline =
-			System.currentTimeMillis() + _LOCK_ACQUIRE_TIMEOUT_MILLIS;
-
-		while (true) {
-			Lock lock = LockManagerUtil.lock(className, key, null, owner);
-
-			if (Objects.equals(lock.getOwner(), owner)) {
-				return;
-			}
-
-			if (System.currentTimeMillis() >= deadline) {
-				throw new PortalException("Timed out acquiring quota lock");
-			}
-
-			try {
-				Thread.sleep(_LOCK_RETRY_INTERVAL_MILLIS);
-			}
-			catch (InterruptedException interruptedException) {
-				Thread currentThread = Thread.currentThread();
-
-				currentThread.interrupt();
-
-				throw new PortalException(
-					"Interrupted while waiting for quota lock",
-					interruptedException);
-			}
+			_partialUpdateObjectEntry(
+				companyId, objectEntry,
+				MapUtil.getLong(objectEntry.getValues(), "usage") + tokensCount,
+				userId);
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
 		}
 	}
 
@@ -201,12 +159,43 @@ public class QuotaUtil {
 			externalReferenceCode, 0, objectDefinition.getObjectDefinitionId());
 	}
 
-	private static String _getLockKey(long objectEntryId) {
-		return "ai-hub-quota-" + objectEntryId;
+	private static Closeable _lock(long objectEntryId) throws PortalException {
+		String updatedOwner = PortalUUIDUtil.generate();
+
+		long deadline = System.currentTimeMillis() + (10 * Time.SECOND);
+
+		while (true) {
+			Lock lock = LockManagerUtil.lock(
+				QuotaUtil.class.getName(), String.valueOf(objectEntryId), null,
+				updatedOwner);
+
+			if (Objects.equals(lock.getOwner(), updatedOwner)) {
+				break;
+			}
+
+			if (System.currentTimeMillis() >= deadline) {
+				throw new PortalException(new TimeoutException());
+			}
+
+			try {
+				Thread.sleep(50);
+			}
+			catch (InterruptedException interruptedException) {
+				Thread thread = Thread.currentThread();
+
+				thread.interrupt();
+
+				throw new PortalException(interruptedException);
+			}
+		}
+
+		return () -> LockManagerUtil.unlock(
+			QuotaUtil.class.getName(), String.valueOf(objectEntryId),
+			updatedOwner);
 	}
 
-	private static void _persistUsage(
-			long companyId, ObjectEntry objectEntry, long newUsage, long userId)
+	private static void _partialUpdateObjectEntry(
+			long companyId, ObjectEntry objectEntry, long usage, long userId)
 		throws PortalException {
 
 		ServiceContext serviceContext = new ServiceContext();
@@ -217,31 +206,9 @@ public class QuotaUtil {
 		ObjectEntryLocalServiceUtil.partialUpdateObjectEntry(
 			userId, objectEntry.getObjectEntryId(), 0,
 			HashMapBuilder.<String, Serializable>put(
-				"usage", newUsage
+				"usage", usage
 			).build(),
 			serviceContext);
 	}
-
-	private static void _updateUsage(
-			long objectEntryId, UnsafeRunnable<PortalException> unsafeRunnable)
-		throws PortalException {
-
-		String className = QuotaUtil.class.getName();
-		String key = _getLockKey(objectEntryId);
-		String owner = PortalUUIDUtil.generate();
-
-		_acquireLock(className, key, owner);
-
-		try {
-			unsafeRunnable.run();
-		}
-		finally {
-			LockManagerUtil.unlock(className, key, owner);
-		}
-	}
-
-	private static final long _LOCK_ACQUIRE_TIMEOUT_MILLIS = 10_000L;
-
-	private static final long _LOCK_RETRY_INTERVAL_MILLIS = 50L;
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
@@ -155,11 +155,15 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 		Map<String, Serializable> workflowContext =
 			executionContext.getWorkflowContext();
 
-		QuotaUtil.checkUsage(
+		boolean checkUsage = QuotaUtil.checkUsage(
 			serviceContext.getCompanyId(), currentKaleoNode.getName(),
 			prompt + "\n" + userMessage, workflowContext,
 			kaleoInstanceToken.getKaleoInstanceId(),
 			serviceContext.getUserId());
+
+		if (!checkUsage) {
+			return;
+		}
 
 		VertexAiGeminiStreamingChatModel vertexAiGeminiStreamingChatModel =
 			VertexAiGeminiUtil.createVertexAiGeminiStreamingChatModel(

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/LLMNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/LLMNodeExecutor.java
@@ -110,11 +110,15 @@ public class LLMNodeExecutor extends BaseNodeExecutor {
 		Map<String, Serializable> workflowContext =
 			executionContext.getWorkflowContext();
 
-		QuotaUtil.checkUsage(
+		boolean checkUsage = QuotaUtil.checkUsage(
 			serviceContext.getCompanyId(), currentKaleoNode.getName(),
 			prompt + "\n" + userMessage, workflowContext,
 			kaleoInstanceToken.getKaleoInstanceId(),
 			serviceContext.getUserId());
+
+		if (!checkUsage) {
+			return;
+		}
 
 		VertexAiGeminiStreamingChatModel vertexAiGeminiStreamingChatModel =
 			VertexAiGeminiUtil.createVertexAiGeminiStreamingChatModel(

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/QuotaUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/QuotaUtil.java
@@ -25,7 +25,7 @@ import java.util.Map;
  */
 public class QuotaUtil {
 
-	public static void checkUsage(
+	public static boolean checkUsage(
 			long companyId, String nodeName, String text,
 			Map<String, Serializable> workflowContext, long workflowInstanceId,
 			long userId)
@@ -34,6 +34,8 @@ public class QuotaUtil {
 		try {
 			com.liferay.ai.hub.internal.quota.QuotaUtil.checkUsage(
 				companyId, text, userId);
+
+			return true;
 		}
 		catch (UnsupportedOperationException unsupportedOperationException) {
 			Message message = new Message();
@@ -50,6 +52,8 @@ public class QuotaUtil {
 				nodeName,
 				GetterUtil.getString(workflowContext.get("sseEventSinkKey")));
 		}
+
+		return false;
 	}
 
 	public static void updateUsage(

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentInstanceResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentInstanceResourceTest.java
@@ -10,7 +10,6 @@ import com.liferay.account.model.AccountEntry;
 import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.account.service.AccountEntryUserRelLocalService;
 import com.liferay.ai.hub.cell.configuration.AIHubCellConfiguration;
-import com.liferay.ai.hub.rest.manager.v1_0.ContentRetrieverManager;
 import com.liferay.ai.hub.rest.resource.v1_0.test.util.SseEventSourceTestUtil;
 import com.liferay.ai.hub.rest.resource.v1_0.test.util.TokenTestUtil;
 import com.liferay.ai.hub.rest.resource.v1_0.util.SseUtil;
@@ -21,7 +20,6 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
-import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -67,14 +65,12 @@ import com.liferay.portal.kernel.workflow.WorkflowInstance;
 import com.liferay.portal.kernel.workflow.WorkflowInstanceManager;
 import com.liferay.portal.kernel.workflow.WorkflowLog;
 import com.liferay.portal.kernel.workflow.WorkflowNode;
-import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
 import com.liferay.portal.search.test.util.IdempotentRetryAssert;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
-import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.workflow.constants.WorkflowDefinitionConstants;
 import com.liferay.portal.workflow.kaleo.runtime.util.WorkflowContextUtil;
 import com.liferay.portal.workflow.manager.WorkflowDefinitionManager;
@@ -90,7 +86,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+
+import org.hibernate.engine.jdbc.spi.SqlExceptionHelper;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -185,11 +186,6 @@ public class AgentInstanceResourceTest
 			_objectDefinitionLocalService.
 				getObjectDefinitionByExternalReferenceCode(
 					"L_AI_HUB_AGENT_DEFINITION",
-					TestPropsValues.getCompanyId());
-		_contentRetrieverObjectDefinition =
-			_objectDefinitionLocalService.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_AI_HUB_CONTENT_RETRIEVER",
 					TestPropsValues.getCompanyId());
 		_instructionObjectDefinition =
 			_objectDefinitionLocalService.
@@ -297,7 +293,6 @@ public class AgentInstanceResourceTest
 	@Test
 	public void testPostAgentInstance() throws Exception {
 		_testPostAgentInstance();
-		_testPostAgentInstanceWithConcurrentQuotaUpdates();
 		_testPostAgentInstanceWithTypeAIDecisionNodeWithToolWorkflowDefinition();
 		_testPostAgentInstanceWithTypeAIDecisionNodeWorkflowDefinition();
 		_testPostAgentInstanceWithTypeFixSpellingAndGrammarWithInstruction();
@@ -380,6 +375,12 @@ public class AgentInstanceResourceTest
 				values
 			).build(),
 			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private void _assertContains(String line, String... texts) {
+		for (String text : texts) {
+			Assert.assertTrue(line, line.contains(text));
+		}
 	}
 
 	private String _getExpectedPromptInput(
@@ -514,126 +515,6 @@ public class AgentInstanceResourceTest
 			jsonObject.getLong("externalReferenceCode"));
 
 		Assert.assertEquals(2, workflowInstance.getWorkflowDefinitionVersion());
-	}
-
-	private void _testPostAgentInstanceWithConcurrentQuotaUpdates()
-		throws Exception {
-
-		ObjectDefinition objectDefinition =
-			_objectDefinitionLocalService.
-				getObjectDefinitionByExternalReferenceCode(
-					"L_AI_HUB_QUOTA", TestPropsValues.getCompanyId());
-
-		_objectEntryLocalService.addObjectEntry(
-			0, TestPropsValues.getUserId(),
-			objectDefinition.getObjectDefinitionId(), 0,
-			LocaleUtil.toLanguageId(LocaleUtil.getDefault()),
-			HashMapBuilder.<String, Serializable>put(
-				"externalReferenceCode",
-				"quota-" + _accountEntry.getAccountEntryId()
-			).put(
-				"limit", 0
-			).put(
-				"r_accountToAIHubQuotas_accountEntryId",
-				_accountEntry.getAccountEntryId()
-			).put(
-				"usage", 0
-			).build(),
-			ServiceContextTestUtil.getServiceContext());
-
-		int concurrentCalls = 4;
-
-		List<Map<String, String>> headersList = new ArrayList<>();
-
-		for (int i = 0; i < concurrentCalls; i++) {
-			JSONObject tokenJSONObject = TokenTestUtil.postToken();
-
-			headersList.add(
-				HashMapBuilder.put(
-					"Authorization",
-					"Bearer " + tokenJSONObject.getString("accessToken")
-				).put(
-					"Liferay-AI-Hub-Cell-On-Behalf-Of",
-					tokenJSONObject.getString("userToken")
-				).build());
-		}
-
-		CountDownLatch countDownLatch = new CountDownLatch(10);
-
-		List<String> lines = Collections.synchronizedList(new ArrayList<>());
-
-		String sseEventSinkKey = SseEventSourceTestUtil.open(
-			List.of(countDownLatch), lines, "agent-instances/subscribe");
-
-		CountDownLatch startCountDownLatch = new CountDownLatch(1);
-		CountDownLatch doneCountDownLatch = new CountDownLatch(concurrentCalls);
-
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"org.hibernate.engine.jdbc.spi.SqlExceptionHelper",
-				LoggerTestUtil.FATAL)) {
-
-			for (int i = 0; i < concurrentCalls; i++) {
-				Map<String, String> headers = headersList.get(i);
-
-				Thread thread = new Thread(
-					() -> {
-						try {
-							startCountDownLatch.await();
-
-							HTTPTestUtil.invokeToJSONObject(
-								JSONUtil.put(
-									"agentDefinitionExternalReferenceCode",
-									"L_MAKE_SHORTER"
-								).put(
-									"context",
-									JSONUtil.put("text", "This is a long text.")
-								).put(
-									"sseEventSinkKey", sseEventSinkKey
-								).toString(),
-								"ai-hub/v1.0/agent-instances", headers,
-								Http.Method.POST);
-						}
-						catch (Exception exception) {
-						}
-						finally {
-							doneCountDownLatch.countDown();
-						}
-					});
-
-				thread.start();
-			}
-
-			startCountDownLatch.countDown();
-
-			Assert.assertTrue(doneCountDownLatch.await(60, TimeUnit.SECONDS));
-			Assert.assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
-		}
-
-		String message = lines.get(3);
-
-		Assert.assertTrue(
-			lines.toString(),
-			message.contains("You have exceeded your token quota"));
-
-		message = lines.get(5);
-
-		Assert.assertTrue(
-			lines.toString(),
-			message.contains("You have exceeded your token quota"));
-
-		message = lines.get(7);
-
-		Assert.assertTrue(
-			lines.toString(),
-			message.contains("You have exceeded your token quota"));
-
-		message = lines.get(9);
-
-		Assert.assertTrue(
-			lines.toString(),
-			message.contains("You have exceeded your token quota"));
-
-		SseUtil.closeAll();
 	}
 
 	private void _testPostAgentInstanceWithTypeAIDecisionNodeWithToolWorkflowDefinition()
@@ -932,10 +813,9 @@ public class AgentInstanceResourceTest
 
 		Assert.assertEquals(lines.toString(), 6, lines.size());
 
-		response = StringUtil.toLowerCase(lines.get(5));
-
-		Assert.assertTrue(response, response.contains("brazilian barbecue"));
-		Assert.assertTrue(response, response.contains("\"nodename\":\"llm\""));
+		_assertContains(
+			StringUtil.toLowerCase(lines.get(5)), "brazilian barbecue",
+			"\"nodename\":\"llm\"");
 
 		SseUtil.closeAll();
 	}
@@ -1018,12 +898,9 @@ public class AgentInstanceResourceTest
 
 				Assert.assertEquals(lines.toString(), 6, lines.size());
 
-				response = StringUtil.toLowerCase(lines.get(5));
-
-				Assert.assertTrue(
-					response, response.contains("brazilian barbecue"));
-				Assert.assertTrue(
-					response, response.contains("\"nodename\":\"llm\""));
+				_assertContains(
+					StringUtil.toLowerCase(lines.get(5)), "brazilian barbecue",
+					"\"nodename\":\"llm\"");
 			}
 		);
 
@@ -1048,10 +925,9 @@ public class AgentInstanceResourceTest
 
 		Assert.assertEquals(lines.toString(), 4, lines.size());
 
-		String response = StringUtil.toLowerCase(lines.get(3));
-
-		Assert.assertTrue(response, response.contains("\"nodename\":\"llm\""));
-		Assert.assertTrue(response, response.contains("yes"));
+		_assertContains(
+			StringUtil.toLowerCase(lines.get(3)), "\"nodename\":\"llm\"",
+			"yes");
 
 		SseUtil.closeAll();
 	}
@@ -1136,7 +1012,7 @@ public class AgentInstanceResourceTest
 				"externalReferenceCode",
 				"quota-" + _accountEntry.getAccountEntryId()
 			).put(
-				"limit", 0
+				"limit", 100
 			).put(
 				"r_accountToAIHubQuotas_accountEntryId",
 				_accountEntry.getAccountEntryId()
@@ -1145,23 +1021,68 @@ public class AgentInstanceResourceTest
 			).build(),
 			ServiceContextTestUtil.getServiceContext());
 
-		CountDownLatch countDownLatch = new CountDownLatch(3);
-		List<String> lines = new ArrayList<>();
+		int threadsCount = 4;
+
+		List<JSONObject> jsonObjects = new ArrayList<>();
+
+		for (int i = 0; i < threadsCount; i++) {
+			jsonObjects.add(TokenTestUtil.postToken());
+		}
+
+		CountDownLatch countDownLatch1 = new CountDownLatch(10);
+
+		List<String> lines = Collections.synchronizedList(new ArrayList<>());
 
 		String sseEventSinkKey = SseEventSourceTestUtil.open(
-			List.of(countDownLatch), lines, "agent-instances/subscribe");
+			List.of(countDownLatch1), lines, "agent-instances/subscribe");
 
-		_postAgentInstance(
-			"L_MAKE_SHORTER", "This is a long text.", "text", sseEventSinkKey);
+		CountDownLatch countDownLatch2 = new CountDownLatch(1);
 
-		Assert.assertTrue(countDownLatch.await(20, TimeUnit.SECONDS));
+		ExecutorService executorService = Executors.newFixedThreadPool(
+			threadsCount);
 
-		Assert.assertEquals(lines.toString(), 4, lines.size());
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				SqlExceptionHelper.class.getName(), LoggerTestUtil.OFF)) {
 
-		String line = lines.get(3);
+			List<Future<?>> futures = new ArrayList<>();
 
-		Assert.assertTrue(
-			line, line.contains("You have exceeded your token quota"));
+			for (JSONObject jsonObject : jsonObjects) {
+				futures.add(
+					executorService.submit(
+						() -> {
+							countDownLatch2.await();
+
+							return _postAgentInstance(
+								"L_MAKE_SHORTER", "This is a long text.",
+								"text", null, jsonObject, sseEventSinkKey);
+						}));
+			}
+
+			countDownLatch2.countDown();
+
+			for (Future<?> future : futures) {
+				future.get(60, TimeUnit.SECONDS);
+			}
+
+			Assert.assertTrue(countDownLatch1.await(30, TimeUnit.SECONDS));
+		}
+
+		executorService.shutdown();
+
+		Assert.assertEquals(lines.toString(), 10, lines.size());
+
+		int count = 0;
+
+		for (String line :
+				List.of(
+					lines.get(3), lines.get(5), lines.get(7), lines.get(9))) {
+
+			if (line.contains("You have exceeded your token quota")) {
+				count++;
+			}
+		}
+
+		Assert.assertEquals(lines.toString(), 3, count);
 
 		SseUtil.closeAll();
 	}
@@ -1190,12 +1111,9 @@ public class AgentInstanceResourceTest
 		Assert.assertEquals(
 			"pageBuilder", outputJSONObject.getString("nodeName"));
 
-		String data = outputJSONObject.getString("data");
-
-		Assert.assertTrue(data, data.contains("BASIC_COMPONENT-heading"));
-		Assert.assertTrue(data, data.contains("ContentPage"));
-		Assert.assertTrue(data, data.contains("ContentPageSpecification"));
-		Assert.assertTrue(data, data.contains("Hello World"));
+		_assertContains(
+			outputJSONObject.getString("data"), "BASIC_COMPONENT-heading",
+			"ContentPage", "ContentPageSpecification", "Hello World");
 
 		SseUtil.closeAll();
 	}
@@ -1214,7 +1132,6 @@ public class AgentInstanceResourceTest
 	@Inject
 	private static ClassNameLocalService _classNameLocalService;
 
-	private static ObjectDefinition _contentRetrieverObjectDefinition;
 	private static ObjectDefinition _instructionObjectDefinition;
 	private static ObjectDefinition _mcpServerObjectDefinition;
 	private static ObjectDefinition _objectDefinition;
@@ -1235,22 +1152,10 @@ public class AgentInstanceResourceTest
 	private static WorkflowDefinitionManager _workflowDefinitionManager;
 
 	@Inject
-	private ContentRetrieverManager _contentRetrieverManager;
-
-	@Inject
-	private DTOConverterRegistry _dtoConverterRegistry;
-
-	@Inject
 	private JSONFactory _jsonFactory;
 
 	@Inject
-	private ObjectRelationshipLocalService _objectRelationshipLocalService;
-
-	@Inject
 	private ResourcePermissionLocalService _resourcePermissionLocalService;
-
-	@Inject
-	private SearchEngineAdapter _searchEngineAdapter;
 
 	@Inject
 	private UserLocalService _userLocalService;

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentInstanceResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentInstanceResourceTest.java
@@ -69,6 +69,8 @@ import com.liferay.portal.kernel.workflow.WorkflowLog;
 import com.liferay.portal.kernel.workflow.WorkflowNode;
 import com.liferay.portal.search.engine.adapter.SearchEngineAdapter;
 import com.liferay.portal.search.test.util.IdempotentRetryAssert;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
@@ -84,6 +86,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -254,6 +257,8 @@ public class AgentInstanceResourceTest
 		_addAgentDefinitionObjectEntry(
 			"L_WORKFLOW_DEFINITION", "text", "workflow-definition.json",
 			"Workflow Definition");
+
+		SseUtil.closeAll();
 	}
 
 	@AfterClass
@@ -292,6 +297,7 @@ public class AgentInstanceResourceTest
 	@Test
 	public void testPostAgentInstance() throws Exception {
 		_testPostAgentInstance();
+		_testPostAgentInstanceWithConcurrentQuotaUpdates();
 		_testPostAgentInstanceWithTypeAIDecisionNodeWithToolWorkflowDefinition();
 		_testPostAgentInstanceWithTypeAIDecisionNodeWorkflowDefinition();
 		_testPostAgentInstanceWithTypeFixSpellingAndGrammarWithInstruction();
@@ -508,6 +514,126 @@ public class AgentInstanceResourceTest
 			jsonObject.getLong("externalReferenceCode"));
 
 		Assert.assertEquals(2, workflowInstance.getWorkflowDefinitionVersion());
+	}
+
+	private void _testPostAgentInstanceWithConcurrentQuotaUpdates()
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_AI_HUB_QUOTA", TestPropsValues.getCompanyId());
+
+		_objectEntryLocalService.addObjectEntry(
+			0, TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId(), 0,
+			LocaleUtil.toLanguageId(LocaleUtil.getDefault()),
+			HashMapBuilder.<String, Serializable>put(
+				"externalReferenceCode",
+				"quota-" + _accountEntry.getAccountEntryId()
+			).put(
+				"limit", 0
+			).put(
+				"r_accountToAIHubQuotas_accountEntryId",
+				_accountEntry.getAccountEntryId()
+			).put(
+				"usage", 0
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		int concurrentCalls = 4;
+
+		List<Map<String, String>> headersList = new ArrayList<>();
+
+		for (int i = 0; i < concurrentCalls; i++) {
+			JSONObject tokenJSONObject = TokenTestUtil.postToken();
+
+			headersList.add(
+				HashMapBuilder.put(
+					"Authorization",
+					"Bearer " + tokenJSONObject.getString("accessToken")
+				).put(
+					"Liferay-AI-Hub-Cell-On-Behalf-Of",
+					tokenJSONObject.getString("userToken")
+				).build());
+		}
+
+		CountDownLatch countDownLatch = new CountDownLatch(10);
+
+		List<String> lines = Collections.synchronizedList(new ArrayList<>());
+
+		String sseEventSinkKey = SseEventSourceTestUtil.open(
+			List.of(countDownLatch), lines, "agent-instances/subscribe");
+
+		CountDownLatch startCountDownLatch = new CountDownLatch(1);
+		CountDownLatch doneCountDownLatch = new CountDownLatch(concurrentCalls);
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"org.hibernate.engine.jdbc.spi.SqlExceptionHelper",
+				LoggerTestUtil.FATAL)) {
+
+			for (int i = 0; i < concurrentCalls; i++) {
+				Map<String, String> headers = headersList.get(i);
+
+				Thread thread = new Thread(
+					() -> {
+						try {
+							startCountDownLatch.await();
+
+							HTTPTestUtil.invokeToJSONObject(
+								JSONUtil.put(
+									"agentDefinitionExternalReferenceCode",
+									"L_MAKE_SHORTER"
+								).put(
+									"context",
+									JSONUtil.put("text", "This is a long text.")
+								).put(
+									"sseEventSinkKey", sseEventSinkKey
+								).toString(),
+								"ai-hub/v1.0/agent-instances", headers,
+								Http.Method.POST);
+						}
+						catch (Exception exception) {
+						}
+						finally {
+							doneCountDownLatch.countDown();
+						}
+					});
+
+				thread.start();
+			}
+
+			startCountDownLatch.countDown();
+
+			Assert.assertTrue(doneCountDownLatch.await(60, TimeUnit.SECONDS));
+			Assert.assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
+		}
+
+		String message = lines.get(3);
+
+		Assert.assertTrue(
+			lines.toString(),
+			message.contains("You have exceeded your token quota"));
+
+		message = lines.get(5);
+
+		Assert.assertTrue(
+			lines.toString(),
+			message.contains("You have exceeded your token quota"));
+
+		message = lines.get(7);
+
+		Assert.assertTrue(
+			lines.toString(),
+			message.contains("You have exceeded your token quota"));
+
+		message = lines.get(9);
+
+		Assert.assertTrue(
+			lines.toString(),
+			message.contains("You have exceeded your token quota"));
+
+		SseUtil.closeAll();
 	}
 
 	private void _testPostAgentInstanceWithTypeAIDecisionNodeWithToolWorkflowDefinition()


### PR DESCRIPTION
## Without the lock — TOCTOU bug

````mermaid
  sequenceDiagram
      participant DB as Quota row<br/>(usage)
      participant A as Thread A
      participant B as Thread B
      participant C as Thread C
      participant D as Thread D

      par All four read concurrently
          A->>DB: read usage
          DB-->>A: 0
      and
          B->>DB: read usage
          DB-->>B: 0
      and
          C->>DB: read usage
          DB-->>C: 0
      and
          D->>DB: read usage
          DB-->>D: 0
      end

      Note over A,D: each computes 0 + 95 = 95 ≤ 100 ✅
  
      par All four write
          A->>DB: write usage = 95
      and
          B->>DB: write usage = 95
      and
          C->>DB: write usage = 95
      and
          D->>DB: write usage = 95
      end

      Note over DB: usage = 95<br/>but 4 × 95 = 380 tokens spent
````

## With the CAS lock — the fix

````mermaid
  sequenceDiagram
      participant L as Lock_<br/>row
      participant DB as Quota row<br/>(usage)
      participant A as Thread A
      participant B as Thread B
      participant C as Thread C
      participant D as Thread D
  
      par Four threads race the CAS
          A->>L: CAS(null → A)
          L-->>A: owner = A ✅
      and
          B->>L: CAS(null → B)
          L-->>B: owner = A ❌ retry
      and
          C->>L: CAS(null → C)
          L-->>C: owner = A ❌ retry
      and
          D->>L: CAS(null → D)
          L-->>D: owner = A ❌  retry
      end

      A->>DB: read usage
      DB-->>A: 0
      Note over A: 0 + 95 = 95 ≤ 100 ✅
      A->>DB: write usage = 95
      A->>L: unlock(A)

      B->>L: CAS(null → B) ✅
      B->>DB: read usage
      DB-->>B: 95
      Note over B: 95 + 95 = 190 > 100 ❌ throw
      B->>L: unlock(B)

      C->>L: CAS(null → C) ✅
      C->>DB: read usage
      DB-->>C: 95
      Note over C: 190 > 100 ❌  throw
      C->>L: unlock(C)
  
      D->>L: CAS(null → D) ✅
      D->>DB: read usage
      DB-->>D: 95
      Note over D: 190 > 100 ❌ throw
      D->>L: unlock(D)

      Note over DB: usage = 95 ✅<br/>reflects real consumption
````