### PR TITLE
LPD-89912 Fix export test to match server rejection of empty file names

### DIFF
--- a/modules/test/playwright/tests/export-import-web/main/site.export.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/site.export.spec.ts
@@ -59,14 +59,20 @@ test('can export at site level with custom export task name', async ({
 });
 
 test(
-	'Can successfully export without file name by falling back to default',
+	'cannot export at site level without file name',
 	{tag: '@LPD-76875'},
 	async ({exportImportPage}) => {
 		await exportImportPage.goToExport();
 
-		const exportFilePath = await exportImportPage.export({taskName: ''});
+		await exportImportPage.newExportButton.click();
 
-		expect(exportFilePath).toMatch(/\/Export\.lar$/);
+		await exportImportPage.exportButton.click();
+
+		await expect(
+			exportImportPage.page.getByRole('alert').filter({
+				hasText: 'Please enter a file with a valid file name.',
+			})
+		).toBeVisible();
 	}
 );
 


### PR DESCRIPTION
Commit fa28577 updated the test to expect an export with an empty file name to fall back to "Export.lar", but commit b2045ac had already intentionally removed that server-side fallback so that empty names are rejected with a validation error. Revert the test to assert the validation alert instead.