### PR TITLE
LPD-90042 Hide Home quick actions for inaccessible Spaces

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewHomeQuickActionsDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewHomeQuickActionsDisplayContextTest.java
@@ -1,0 +1,192 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.display.context.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.constants.DepotRolesConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.fragment.renderer.FragmentRenderer;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectDefinitionSettingConstants;
+import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.definition.setting.builder.ObjectDefinitionSettingBuilder;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectFolder;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Mikel Lorza
+ */
+@FeatureFlag("LPD-17564")
+@RunWith(Arquillian.class)
+public class ViewHomeQuickActionsDisplayContextTest
+	extends BaseDisplayContextTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	@TestInfo("LPD-90042")
+	public void testGetQuickActions() throws Exception {
+		DepotEntry depotEntry = _addDepotEntry();
+
+		ObjectFolder objectFolder =
+			objectFolderLocalService.getObjectFolderByExternalReferenceCode(
+				ObjectFolderConstants.
+					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES,
+				TestPropsValues.getCompanyId());
+
+		ObjectDefinition customObjectDefinition = addCustomObjectDefinition(
+			objectFolder.getObjectFolderId(), true, true,
+			Collections.singletonList(
+				new ObjectDefinitionSettingBuilder(
+				).name(
+					ObjectDefinitionSettingConstants.NAME_ACCEPTED_GROUP_IDS
+				).value(
+					String.valueOf(depotEntry.getGroupId())
+				).build()),
+			ObjectDefinitionConstants.SCOPE_DEPOT,
+			WorkflowConstants.STATUS_APPROVED);
+
+		User user = UserTestUtil.addUser();
+
+		UserTestUtil.setUser(user);
+
+		List<Map<String, Object>> quickActions = _getQuickActions(user);
+
+		Assert.assertFalse(
+			quickActions.toString(),
+			_hasQuickActionForObjectDefinition(
+				quickActions, customObjectDefinition));
+
+		_groupLocalService.addUserGroup(
+			user.getUserId(), depotEntry.getGroup());
+
+		quickActions = _getQuickActions(user);
+
+		Assert.assertFalse(
+			quickActions.toString(),
+			_hasQuickActionForObjectDefinition(
+				quickActions, customObjectDefinition));
+
+		Role role = _roleLocalService.getRole(
+			TestPropsValues.getCompanyId(),
+			DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR);
+
+		_userGroupRoleLocalService.addUserGroupRoles(
+			user.getUserId(), depotEntry.getGroupId(),
+			new long[] {role.getRoleId()});
+
+		quickActions = _getQuickActions(user);
+
+		Assert.assertTrue(
+			quickActions.toString(),
+			_hasQuickActionForObjectDefinition(
+				quickActions, customObjectDefinition));
+	}
+
+	private DepotEntry _addDepotEntry() throws Exception {
+		return _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+	}
+
+	private List<Map<String, Object>> _getQuickActions(User user)
+		throws Exception {
+
+		mockHttpServletRequest = getMockHttpServletRequest(user);
+
+		_fragmentRenderer.render(
+			null, mockHttpServletRequest, new MockHttpServletResponse());
+
+		Object displayContext = mockHttpServletRequest.getAttribute(
+			"com.liferay.site.cms.site.initializer.internal.display.context." +
+				"ViewHomeQuickActionsDisplayContext");
+
+		Assert.assertNotNull(displayContext);
+
+		Map<String, Object> props = ReflectionTestUtil.invoke(
+			displayContext, "getProps", new Class<?>[0]);
+
+		return (List<Map<String, Object>>)props.get("quickActions");
+	}
+
+	private boolean _hasQuickActionForObjectDefinition(
+		List<Map<String, Object>> quickActions,
+		ObjectDefinition objectDefinition) {
+
+		String title = objectDefinition.getLabel(LocaleUtil.getDefault());
+
+		for (Map<String, Object> quickAction : quickActions) {
+			if (Objects.equals(quickAction.get("title"), title)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject(
+		filter = "component.name=com.liferay.site.cms.site.initializer.internal.fragment.renderer.ViewHomeQuickActionsJSPSectionFragmentRenderer"
+	)
+	private FragmentRenderer _fragmentRenderer;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@Inject
+	private UserGroupRoleLocalService _userGroupRoleLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseContentsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseContentsSectionDisplayContext.java
@@ -10,11 +10,8 @@ import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
@@ -36,19 +33,13 @@ public abstract class BaseContentsSectionDisplayContext
 		DepotEntryLocalService depotEntryLocalService,
 		GroupLocalService groupLocalService,
 		HttpServletRequest httpServletRequest, Language language,
-		ObjectDefinitionService objectDefinitionService,
-		ObjectDefinitionSettingLocalService objectDefinitionSettingLocalService,
-		ModelResourcePermission<ObjectEntryFolder>
-			objectEntryFolderModelResourcePermission,
-		Portal portal,
+		ObjectDefinitionService objectDefinitionService, Portal portal,
 		TranslationInfoItemFieldValuesExporterRegistry
 			translationInfoItemFieldValuesExporterRegistry) {
 
 		super(
 			depotEntryLocalService, null, groupLocalService, httpServletRequest,
-			language, objectDefinitionService,
-			objectDefinitionSettingLocalService,
-			objectEntryFolderModelResourcePermission, portal,
+			language, objectDefinitionService, portal,
 			translationInfoItemFieldValuesExporterRegistry);
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseContentsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseContentsSectionDisplayContext.java
@@ -54,7 +54,7 @@ public abstract class BaseContentsSectionDisplayContext
 
 	@Override
 	public List<DropdownItem> getBulkActionDropdownItems() {
-		return sectionDisplayContextHelper.getContentsBulkActionDropdownItems(
+		return SectionDisplayContextUtil.getContentsBulkActionDropdownItems(
 			httpServletRequest);
 	}
 
@@ -78,7 +78,7 @@ public abstract class BaseContentsSectionDisplayContext
 
 	@Override
 	public List<FDSActionDropdownItem> getFDSActionDropdownItems() {
-		return sectionDisplayContextHelper.getContentsFDSActionDropdownItems(
+		return SectionDisplayContextUtil.getContentsFDSActionDropdownItems(
 			httpServletRequest);
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseFilesSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseFilesSectionDisplayContext.java
@@ -56,7 +56,7 @@ public abstract class BaseFilesSectionDisplayContext
 
 	@Override
 	public List<DropdownItem> getBulkActionDropdownItems() {
-		return sectionDisplayContextHelper.getFilesBulkActionDropdownItems(
+		return SectionDisplayContextUtil.getFilesBulkActionDropdownItems(
 			httpServletRequest);
 	}
 
@@ -80,7 +80,7 @@ public abstract class BaseFilesSectionDisplayContext
 
 	@Override
 	public List<FDSActionDropdownItem> getFDSActionDropdownItems() {
-		return sectionDisplayContextHelper.getFilesFDSActionDropdownItems(
+		return SectionDisplayContextUtil.getFilesFDSActionDropdownItems(
 			httpServletRequest);
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseFilesSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseFilesSectionDisplayContext.java
@@ -11,12 +11,9 @@ import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
@@ -38,19 +35,13 @@ public abstract class BaseFilesSectionDisplayContext
 		DepotEntryLocalService depotEntryLocalService,
 		DLConfiguration dlConfiguration, GroupLocalService groupLocalService,
 		HttpServletRequest httpServletRequest, Language language,
-		ObjectDefinitionService objectDefinitionService,
-		ObjectDefinitionSettingLocalService objectDefinitionSettingLocalService,
-		ModelResourcePermission<ObjectEntryFolder>
-			objectEntryFolderModelResourcePermission,
-		Portal portal,
+		ObjectDefinitionService objectDefinitionService, Portal portal,
 		TranslationInfoItemFieldValuesExporterRegistry
 			translationInfoItemFieldValuesExporterRegistry) {
 
 		super(
 			depotEntryLocalService, dlConfiguration, groupLocalService,
-			httpServletRequest, language, objectDefinitionService,
-			objectDefinitionSettingLocalService,
-			objectEntryFolderModelResourcePermission, portal,
+			httpServletRequest, language, objectDefinitionService, portal,
 			translationInfoItemFieldValuesExporterRegistry);
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseRelatedAssetsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseRelatedAssetsSectionDisplayContext.java
@@ -11,9 +11,7 @@ import com.liferay.document.library.configuration.DLConfiguration;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -21,7 +19,6 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -50,19 +47,13 @@ public abstract class BaseRelatedAssetsSectionDisplayContext
 		HttpServletRequest httpServletRequest, Language language,
 		ObjectDefinition objectDefinition,
 		ObjectDefinitionService objectDefinitionService,
-		ObjectDefinitionSettingLocalService objectDefinitionSettingLocalService,
-		ObjectEntry objectEntry,
-		ModelResourcePermission<ObjectEntryFolder>
-			objectEntryFolderModelResourcePermission,
-		Portal portal,
+		ObjectEntry objectEntry, Portal portal,
 		TranslationInfoItemFieldValuesExporterRegistry
 			translationInfoItemFieldValuesExporterRegistry) {
 
 		super(
 			depotEntryLocalService, dlConfiguration, groupLocalService,
-			httpServletRequest, language, objectDefinitionService,
-			objectDefinitionSettingLocalService,
-			objectEntryFolderModelResourcePermission, portal,
+			httpServletRequest, language, objectDefinitionService, portal,
 			translationInfoItemFieldValuesExporterRegistry);
 
 		this.assetTagLocalService = assetTagLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -101,15 +101,10 @@ public abstract class BaseSectionDisplayContext {
 		objectEntryFolder = _getObjectEntryFolder(
 			themeDisplay.getCompanyId(),
 			httpServletRequest.getAttribute(InfoDisplayWebKeys.INFO_ITEM));
-
-		sectionDisplayContextHelper = new SectionDisplayContextHelper(
-			depotEntryLocalService, groupLocalService, language,
-			objectDefinitionSettingLocalService,
-			objectEntryFolderModelResourcePermission, portal);
 	}
 
 	public String getAdditionalAPIURLParameters() {
-		return sectionDisplayContextHelper.getAdditionalAPIURLParameters(
+		return SectionDisplayContextUtil.getAdditionalAPIURLParameters(
 			getCMSSectionFilterString(), httpServletRequest,
 			getRootObjectEntryFolderExternalReferenceCode());
 	}
@@ -126,7 +121,7 @@ public abstract class BaseSectionDisplayContext {
 			}
 		).put(
 			"assetLibraries",
-			sectionDisplayContextHelper.getDepotEntriesJSONArray(
+			SectionDisplayContextUtil.getDepotEntriesJSONArray(
 				httpServletRequest)
 		).put(
 			"autocompleteURL",
@@ -156,7 +151,7 @@ public abstract class BaseSectionDisplayContext {
 				PropsUtil.get(PropsKeys.CMS_BROKEN_LINKS_CHECKER_ENABLED))
 		).put(
 			"candidateAssetLibraries",
-			sectionDisplayContextHelper.getDepotEntriesJSONArray(
+			SectionDisplayContextUtil.getDepotEntriesJSONArray(
 				httpServletRequest,
 				getRootObjectEntryFolderExternalReferenceCode())
 		).put(
@@ -305,7 +300,7 @@ public abstract class BaseSectionDisplayContext {
 	}
 
 	public CreationMenu getCreationMenu() {
-		return sectionDisplayContextHelper.getCreationMenu(
+		return SectionDisplayContextUtil.getCreationMenu(
 			getCreationMenuDropdownItems(), httpServletRequest,
 			getRootObjectEntryFolderExternalReferenceCode());
 	}
@@ -317,7 +312,7 @@ public abstract class BaseSectionDisplayContext {
 	public abstract Map<String, Object> getEmptyState();
 
 	public List<FDSActionDropdownItem> getFDSActionDropdownItems() {
-		return sectionDisplayContextHelper.getFDSActionDropdownItems(
+		return SectionDisplayContextUtil.getFDSActionDropdownItems(
 			httpServletRequest);
 	}
 
@@ -335,12 +330,12 @@ public abstract class BaseSectionDisplayContext {
 	}
 
 	protected String appendGroupIds(String filterString) {
-		return sectionDisplayContextHelper.appendGroupIds(
+		return SectionDisplayContextUtil.appendGroupIds(
 			filterString, httpServletRequest);
 	}
 
 	protected String appendStatus(String filterString) {
-		return sectionDisplayContextHelper.appendStatus(filterString);
+		return SectionDisplayContextUtil.appendStatus(filterString);
 	}
 
 	protected abstract String getCMSSectionFilterString();
@@ -366,7 +361,6 @@ public abstract class BaseSectionDisplayContext {
 	protected final Language language;
 	protected final ObjectEntryFolder objectEntryFolder;
 	protected final Portal portal;
-	protected final SectionDisplayContextHelper sectionDisplayContextHelper;
 	protected final ThemeDisplay themeDisplay;
 
 	private JSONObject _getExportFileFormatJSONObject(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -18,7 +18,6 @@ import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalServiceUtil;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
@@ -35,7 +34,6 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -73,11 +71,7 @@ public abstract class BaseSectionDisplayContext {
 		DepotEntryLocalService depotEntryLocalService,
 		DLConfiguration dlConfiguration, GroupLocalService groupLocalService,
 		HttpServletRequest httpServletRequest, Language language,
-		ObjectDefinitionService objectDefinitionService,
-		ObjectDefinitionSettingLocalService objectDefinitionSettingLocalService,
-		ModelResourcePermission<ObjectEntryFolder>
-			objectEntryFolderModelResourcePermission,
-		Portal portal,
+		ObjectDefinitionService objectDefinitionService, Portal portal,
 		TranslationInfoItemFieldValuesExporterRegistry
 			translationInfoItemFieldValuesExporterRegistry) {
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextHelper.java
@@ -318,15 +318,15 @@ public class SectionDisplayContextHelper {
 		}
 		else {
 			Map<Long, List<Long>> objectEntryFolderIdsMap =
-				_getObjectEntryFolderIdsMap(
+				getObjectEntryFolderIdsMap(
 					themeDisplay.getCompanyId(),
 					rootObjectEntryFolderExternalReferenceCode,
 					themeDisplay.getUserId());
 
-			objectEntryDepotEntryGroupIds = _getDepotEntryGroupIds(
+			objectEntryDepotEntryGroupIds = getDepotEntryGroupIds(
 				ActionKeys.ADD_ENTRY, objectEntryFolderIdsMap, themeDisplay);
 
-			objectEntryFolderDepotEntryGroupIds = _getDepotEntryGroupIds(
+			objectEntryFolderDepotEntryGroupIds = getDepotEntryGroupIds(
 				ObjectActionKeys.ADD_OBJECT_ENTRY_FOLDER,
 				objectEntryFolderIdsMap, themeDisplay);
 		}
@@ -406,6 +406,29 @@ public class SectionDisplayContextHelper {
 				themeDisplay.getCompanyId(), themeDisplay.getUserId(),
 				DepotConstants.TYPE_SPACE),
 			themeDisplay.getLocale());
+	}
+
+	public List<Long> getDepotEntryGroupIds(
+		String actionId, Map<Long, List<Long>> objectEntryFolderIdsMap,
+		ThemeDisplay themeDisplay) {
+
+		List<Long> depotEntryGroupIds = new ArrayList<>();
+
+		for (Map.Entry<Long, List<Long>> entry :
+				objectEntryFolderIdsMap.entrySet()) {
+
+			for (long objectEntryFolderId : entry.getValue()) {
+				if (_modelResourcePermissionContains(
+						actionId, objectEntryFolderId, themeDisplay)) {
+
+					depotEntryGroupIds.add(entry.getKey());
+
+					break;
+				}
+			}
+		}
+
+		return depotEntryGroupIds;
 	}
 
 	public List<FDSActionDropdownItem> getFDSActionDropdownItems(
@@ -706,6 +729,40 @@ public class SectionDisplayContextHelper {
 		return fdsActionDropdownItems;
 	}
 
+	public Map<Long, List<Long>> getObjectEntryFolderIdsMap(
+		long companyId, String rootObjectEntryFolderExternalReferenceCode,
+		long userId) {
+
+		Map<Long, List<Long>> objectEntryFolderIdsMap = new HashMap<>();
+
+		for (long depotEntryGroupId :
+				DepotEntryServiceUtil.getDepotEntryGroupIds(
+					companyId, userId, DepotConstants.TYPE_SPACE)) {
+
+			for (String objectEntryFolderExternalReferenceCode :
+					_getRootObjectEntryFolderExternalReferenceCodes(
+						rootObjectEntryFolderExternalReferenceCode)) {
+
+				ObjectEntryFolder objectEntryFolder =
+					ObjectEntryFolderLocalServiceUtil.
+						fetchObjectEntryFolderByExternalReferenceCode(
+							objectEntryFolderExternalReferenceCode,
+							depotEntryGroupId, companyId);
+
+				if (objectEntryFolder != null) {
+					List<Long> objectEntryFolderIds =
+						objectEntryFolderIdsMap.computeIfAbsent(
+							depotEntryGroupId, key -> new ArrayList<>());
+
+					objectEntryFolderIds.add(
+						objectEntryFolder.getObjectEntryFolderId());
+				}
+			}
+		}
+
+		return objectEntryFolderIdsMap;
+	}
+
 	private void _addEditCategoriesAndTagsBulkActions(
 		List<DropdownItem> bulkActionDropdownItems,
 		HttpServletRequest httpServletRequest) {
@@ -927,29 +984,6 @@ public class SectionDisplayContextHelper {
 		return jsonArray;
 	}
 
-	private List<Long> _getDepotEntryGroupIds(
-		String actionId, Map<Long, List<Long>> objectEntryFolderIdsMap,
-		ThemeDisplay themeDisplay) {
-
-		List<Long> depotEntryGroupIds = new ArrayList<>();
-
-		for (Map.Entry<Long, List<Long>> entry :
-				objectEntryFolderIdsMap.entrySet()) {
-
-			for (long objectEntryFolderId : entry.getValue()) {
-				if (_modelResourcePermissionContains(
-						actionId, objectEntryFolderId, themeDisplay)) {
-
-					depotEntryGroupIds.add(entry.getKey());
-
-					break;
-				}
-			}
-		}
-
-		return depotEntryGroupIds;
-	}
-
 	private JSONObject _getJSONObject(long groupId, Locale locale) {
 		Group group = _groupLocalService.fetchGroup(groupId);
 
@@ -983,40 +1017,6 @@ public class SectionDisplayContextHelper {
 		}
 
 		return null;
-	}
-
-	private Map<Long, List<Long>> _getObjectEntryFolderIdsMap(
-		long companyId, String rootObjectEntryFolderExternalReferenceCode,
-		long userId) {
-
-		Map<Long, List<Long>> objectEntryFolderIdsMap = new HashMap<>();
-
-		for (long depotEntryGroupId :
-				DepotEntryServiceUtil.getDepotEntryGroupIds(
-					companyId, userId, DepotConstants.TYPE_SPACE)) {
-
-			for (String objectEntryFolderExternalReferenceCode :
-					_getRootObjectEntryFolderExternalReferenceCodes(
-						rootObjectEntryFolderExternalReferenceCode)) {
-
-				ObjectEntryFolder objectEntryFolder =
-					ObjectEntryFolderLocalServiceUtil.
-						fetchObjectEntryFolderByExternalReferenceCode(
-							objectEntryFolderExternalReferenceCode,
-							depotEntryGroupId, companyId);
-
-				if (objectEntryFolder != null) {
-					List<Long> objectEntryFolderIds =
-						objectEntryFolderIdsMap.computeIfAbsent(
-							depotEntryGroupId, key -> new ArrayList<>());
-
-					objectEntryFolderIds.add(
-						objectEntryFolder.getObjectEntryFolderId());
-				}
-			}
-		}
-
-		return objectEntryFolderIdsMap;
 	}
 
 	private FDSActionDropdownItem _getPermissionsFDSActionDropdownItem(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextUtil.java
@@ -7,7 +7,7 @@ package com.liferay.site.cms.site.initializer.internal.display.context;
 
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
-import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.depot.service.DepotEntryServiceUtil;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItemBuilder;
@@ -18,7 +18,6 @@ import com.liferay.info.constants.InfoDisplayWebKeys;
 import com.liferay.object.constants.ObjectActionKeys;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectEntryFolder;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalServiceUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -28,7 +27,6 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
-import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -39,13 +37,14 @@ import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
-import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionRegistryUtil;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
-import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.site.cms.site.initializer.constants.CMSWorkflowConstants;
@@ -66,27 +65,9 @@ import java.util.Objects;
 /**
  * @author Daniel Sanz
  */
-public class SectionDisplayContextHelper {
+public class SectionDisplayContextUtil {
 
-	public SectionDisplayContextHelper(
-		DepotEntryLocalService depotEntryLocalService,
-		GroupLocalService groupLocalService, Language language,
-		ObjectDefinitionSettingLocalService objectDefinitionSettingLocalService,
-		ModelResourcePermission<ObjectEntryFolder>
-			objectEntryFolderModelResourcePermission,
-		Portal portal) {
-
-		_depotEntryLocalService = depotEntryLocalService;
-		_groupLocalService = groupLocalService;
-		_language = language;
-		_objectDefinitionSettingLocalService =
-			objectDefinitionSettingLocalService;
-		_objectEntryFolderModelResourcePermission =
-			objectEntryFolderModelResourcePermission;
-		_portal = portal;
-	}
-
-	public String appendGroupIds(
+	public static String appendGroupIds(
 		String filterString, HttpServletRequest httpServletRequest) {
 
 		ThemeDisplay themeDisplay =
@@ -110,20 +91,20 @@ public class SectionDisplayContextHelper {
 		return StringBundler.concat(
 			filterString, " and groupIds/any(g:g in (",
 			StringUtil.merge(
-				_depotEntryLocalService.getDepotEntryGroupIds(
+				DepotEntryLocalServiceUtil.getDepotEntryGroupIds(
 					themeDisplay.getCompanyId(), themeDisplay.getUserId(),
 					DepotConstants.TYPE_SPACE),
 				StringPool.COMMA),
 			"))");
 	}
 
-	public String appendStatus(String filterString) {
+	public static String appendStatus(String filterString) {
 		return StringBundler.concat(
 			filterString, " and status in (", _CMS_WORKFLOW_STATUSES_STRING,
 			")");
 	}
 
-	public String getAdditionalAPIURLParameters(
+	public static String getAdditionalAPIURLParameters(
 		String filterString, HttpServletRequest httpServletRequest,
 		String rootObjectEntryFolderExternalReferenceCode) {
 
@@ -170,7 +151,7 @@ public class SectionDisplayContextHelper {
 		return sb.toString();
 	}
 
-	public List<DropdownItem> getAllSectionBulkActionDropdownItems(
+	public static List<DropdownItem> getAllSectionBulkActionDropdownItems(
 		HttpServletRequest httpServletRequest) {
 
 		List<DropdownItem> bulkActionDropdownItems =
@@ -220,8 +201,9 @@ public class SectionDisplayContextHelper {
 		return bulkActionDropdownItems;
 	}
 
-	public List<FDSActionDropdownItem> getAllSectionFDSActionDropdownItems(
-		HttpServletRequest httpServletRequest) {
+	public static List<FDSActionDropdownItem>
+		getAllSectionFDSActionDropdownItems(
+			HttpServletRequest httpServletRequest) {
 
 		List<FDSActionDropdownItem> fdsActionDropdownItems =
 			getFDSActionDropdownItems(httpServletRequest);
@@ -245,7 +227,7 @@ public class SectionDisplayContextHelper {
 		return fdsActionDropdownItems;
 	}
 
-	public List<DropdownItem> getContentsBulkActionDropdownItems(
+	public static List<DropdownItem> getContentsBulkActionDropdownItems(
 		HttpServletRequest httpServletRequest) {
 
 		List<DropdownItem> bulkActionDropdownItems =
@@ -271,13 +253,13 @@ public class SectionDisplayContextHelper {
 		return bulkActionDropdownItems;
 	}
 
-	public List<FDSActionDropdownItem> getContentsFDSActionDropdownItems(
+	public static List<FDSActionDropdownItem> getContentsFDSActionDropdownItems(
 		HttpServletRequest httpServletRequest) {
 
 		return getFDSActionDropdownItems(httpServletRequest);
 	}
 
-	public CreationMenu getCreationMenu(
+	public static CreationMenu getCreationMenu(
 		List<DropdownItem> dropdownItems, HttpServletRequest httpServletRequest,
 		String rootObjectEntryFolderExternalReferenceCode) {
 
@@ -300,7 +282,7 @@ public class SectionDisplayContextHelper {
 			rootObjectEntryFolderExternalReferenceCode);
 
 		if (objectEntryFolder != null) {
-			if (_modelResourcePermissionContains(
+			if (_contains(
 					ActionKeys.ADD_ENTRY,
 					objectEntryFolder.getObjectEntryFolderId(), themeDisplay)) {
 
@@ -308,7 +290,7 @@ public class SectionDisplayContextHelper {
 					objectEntryFolder.getGroupId());
 			}
 
-			if (_modelResourcePermissionContains(
+			if (_contains(
 					ObjectActionKeys.ADD_OBJECT_ENTRY_FOLDER,
 					objectEntryFolder.getObjectEntryFolderId(), themeDisplay)) {
 
@@ -368,7 +350,7 @@ public class SectionDisplayContextHelper {
 		return creationMenu;
 	}
 
-	public JSONArray getDepotEntriesJSONArray(
+	public static JSONArray getDepotEntriesJSONArray(
 		HttpServletRequest httpServletRequest) {
 
 		ThemeDisplay themeDisplay =
@@ -382,7 +364,7 @@ public class SectionDisplayContextHelper {
 			themeDisplay.getLocale());
 	}
 
-	public JSONArray getDepotEntriesJSONArray(
+	public static JSONArray getDepotEntriesJSONArray(
 		HttpServletRequest httpServletRequest,
 		String rootObjectEntryFolderExternalReferenceCode) {
 
@@ -408,7 +390,7 @@ public class SectionDisplayContextHelper {
 			themeDisplay.getLocale());
 	}
 
-	public List<Long> getDepotEntryGroupIds(
+	public static List<Long> getDepotEntryGroupIds(
 		String actionId, Map<Long, List<Long>> objectEntryFolderIdsMap,
 		ThemeDisplay themeDisplay) {
 
@@ -418,7 +400,7 @@ public class SectionDisplayContextHelper {
 				objectEntryFolderIdsMap.entrySet()) {
 
 			for (long objectEntryFolderId : entry.getValue()) {
-				if (_modelResourcePermissionContains(
+				if (_contains(
 						actionId, objectEntryFolderId, themeDisplay)) {
 
 					depotEntryGroupIds.add(entry.getKey());
@@ -431,7 +413,7 @@ public class SectionDisplayContextHelper {
 		return depotEntryGroupIds;
 	}
 
-	public List<FDSActionDropdownItem> getFDSActionDropdownItems(
+	public static List<FDSActionDropdownItem> getFDSActionDropdownItems(
 		HttpServletRequest httpServletRequest) {
 
 		ThemeDisplay themeDisplay =
@@ -460,7 +442,7 @@ public class SectionDisplayContextHelper {
 				StringBundler.concat(
 					themeDisplay.getPathFriendlyURLPublic(),
 					GroupConstants.CMS_FRIENDLY_URL, "/e/edit-folder/",
-					_portal.getClassNameId(ObjectEntryFolder.class),
+					PortalUtil.getClassNameId(ObjectEntryFolder.class),
 					"/{embedded.id}?redirect=", themeDisplay.getURLCurrent())
 			).setIcon(
 				"pencil"
@@ -598,7 +580,7 @@ public class SectionDisplayContextHelper {
 			FDSActionDropdownItemBuilder.setIcon(
 				"move-folder"
 			).setLabel(
-				_language.get(httpServletRequest, "move")
+				LanguageUtil.get(httpServletRequest, "move")
 			).setPermissionKey(
 				"update"
 			).build(
@@ -607,7 +589,7 @@ public class SectionDisplayContextHelper {
 			_getCopyFDSActionDropdownItem(httpServletRequest),
 			FDSActionDropdownItemBuilder.setHref(
 				PortletURLBuilder.create(
-					_portal.getControlPanelPortletURL(
+					PortalUtil.getControlPanelPortletURL(
 						httpServletRequest, TranslationPortletKeys.TRANSLATION,
 						ActionRequest.RENDER_PHASE)
 				).setMVCRenderCommandName(
@@ -650,7 +632,7 @@ public class SectionDisplayContextHelper {
 			FDSActionDropdownItemBuilder.setIcon(
 				"trash"
 			).setLabel(
-				_language.get(httpServletRequest, "delete")
+				LanguageUtil.get(httpServletRequest, "delete")
 			).setPermissionKey(
 				"delete"
 			).build(
@@ -658,7 +640,7 @@ public class SectionDisplayContextHelper {
 			));
 	}
 
-	public List<DropdownItem> getFilesBulkActionDropdownItems(
+	public static List<DropdownItem> getFilesBulkActionDropdownItems(
 		HttpServletRequest httpServletRequest) {
 
 		List<DropdownItem> bulkActionDropdownItems =
@@ -682,7 +664,7 @@ public class SectionDisplayContextHelper {
 		return bulkActionDropdownItems;
 	}
 
-	public List<FDSActionDropdownItem> getFilesFDSActionDropdownItems(
+	public static List<FDSActionDropdownItem> getFilesFDSActionDropdownItems(
 		HttpServletRequest httpServletRequest) {
 
 		List<FDSActionDropdownItem> fdsActionDropdownItems =
@@ -708,7 +690,7 @@ public class SectionDisplayContextHelper {
 			FDSActionDropdownItemBuilder.setHref(
 				StringBundler.concat(
 					"/o", GroupConstants.CMS_FRIENDLY_URL, "/download-folder/",
-					_portal.getClassNameId(ObjectEntryFolder.class),
+					PortalUtil.getClassNameId(ObjectEntryFolder.class),
 					"/{embedded.id}")
 			).setIcon(
 				"download"
@@ -729,7 +711,7 @@ public class SectionDisplayContextHelper {
 		return fdsActionDropdownItems;
 	}
 
-	public Map<Long, List<Long>> getObjectEntryFolderIdsMap(
+	public static Map<Long, List<Long>> getObjectEntryFolderIdsMap(
 		long companyId, String rootObjectEntryFolderExternalReferenceCode,
 		long userId) {
 
@@ -763,7 +745,7 @@ public class SectionDisplayContextHelper {
 		return objectEntryFolderIdsMap;
 	}
 
-	private void _addEditCategoriesAndTagsBulkActions(
+	private static void _addEditCategoriesAndTagsBulkActions(
 		List<DropdownItem> bulkActionDropdownItems,
 		HttpServletRequest httpServletRequest) {
 
@@ -793,7 +775,7 @@ public class SectionDisplayContextHelper {
 			));
 	}
 
-	private void _addPermissionsBulkActions(
+	private static void _addPermissionsBulkActions(
 		List<DropdownItem> bulkActionDropdownItems,
 		HttpServletRequest httpServletRequest) {
 
@@ -851,7 +833,7 @@ public class SectionDisplayContextHelper {
 			));
 	}
 
-	private List<DropdownItem> _getBulkActionDropdownItems(
+	private static List<DropdownItem> _getBulkActionDropdownItems(
 		HttpServletRequest httpServletRequest) {
 
 		return ListUtil.fromArray(
@@ -908,7 +890,7 @@ public class SectionDisplayContextHelper {
 			));
 	}
 
-	private FDSActionDropdownItem _getCopyFDSActionDropdownItem(
+	private static FDSActionDropdownItem _getCopyFDSActionDropdownItem(
 		HttpServletRequest httpServletRequest) {
 
 		return FDSActionDropdownItemBuilder.setFDSActionDropdownItems(
@@ -918,7 +900,7 @@ public class SectionDisplayContextHelper {
 				).setIcon(
 					"copy"
 				).setLabel(
-					_language.get(httpServletRequest, "copy-to")
+					LanguageUtil.get(httpServletRequest, "copy-to")
 				).setPermissionKey(
 					"update"
 				).build(
@@ -929,7 +911,7 @@ public class SectionDisplayContextHelper {
 				).setIcon(
 					"copy"
 				).setLabel(
-					_language.get(httpServletRequest, "duplicate")
+					LanguageUtil.get(httpServletRequest, "duplicate")
 				).setPermissionKey(
 					"update"
 				).build(
@@ -938,7 +920,7 @@ public class SectionDisplayContextHelper {
 		).setIcon(
 			"copy"
 		).setLabel(
-			_language.get(httpServletRequest, "copy")
+			LanguageUtil.get(httpServletRequest, "copy")
 		).setPermissionKey(
 			"update"
 		).setType(
@@ -948,7 +930,7 @@ public class SectionDisplayContextHelper {
 		);
 	}
 
-	private JSONArray _getDepotEntriesJSONArray(
+	private static JSONArray _getDepotEntriesJSONArray(
 		List<Long> depotEntryGroupIds, DropdownItem dropdownItem,
 		Locale locale) {
 
@@ -968,7 +950,7 @@ public class SectionDisplayContextHelper {
 		return _getDepotEntriesJSONArray(depotEntryGroupIds, locale);
 	}
 
-	private JSONArray _getDepotEntriesJSONArray(
+	private static JSONArray _getDepotEntriesJSONArray(
 		List<Long> groupIds, Locale locale) {
 
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
@@ -984,8 +966,8 @@ public class SectionDisplayContextHelper {
 		return jsonArray;
 	}
 
-	private JSONObject _getJSONObject(long groupId, Locale locale) {
-		Group group = _groupLocalService.fetchGroup(groupId);
+	private static JSONObject _getJSONObject(long groupId, Locale locale) {
+		Group group = GroupLocalServiceUtil.fetchGroup(groupId);
 
 		if (group == null) {
 			return null;
@@ -1000,7 +982,7 @@ public class SectionDisplayContextHelper {
 		);
 	}
 
-	private ObjectEntryFolder _getObjectEntryFolder(
+	private static ObjectEntryFolder _getObjectEntryFolder(
 		long companyId, Object object,
 		String rootObjectEntryFolderExternalReferenceCode) {
 
@@ -1019,14 +1001,14 @@ public class SectionDisplayContextHelper {
 		return null;
 	}
 
-	private FDSActionDropdownItem _getPermissionsFDSActionDropdownItem(
+	private static FDSActionDropdownItem _getPermissionsFDSActionDropdownItem(
 		HttpServletRequest httpServletRequest, ThemeDisplay themeDisplay) {
 
 		return FDSActionDropdownItemBuilder.setFDSActionDropdownItems(
 			FDSActionDropdownItemList.of(
 				FDSActionDropdownItemBuilder.setHref(
 					PortletURLBuilder.create(
-						_portal.getControlPanelPortletURL(
+						PortalUtil.getControlPanelPortletURL(
 							httpServletRequest,
 							"com_liferay_portlet_configuration_web_portlet_" +
 								"PortletConfigurationPortlet",
@@ -1049,7 +1031,7 @@ public class SectionDisplayContextHelper {
 				).setIcon(
 					"password-policies"
 				).setLabel(
-					_language.get(httpServletRequest, "permissions")
+					LanguageUtil.get(httpServletRequest, "permissions")
 				).setMethod(
 					"get"
 				).setPermissionKey(
@@ -1106,7 +1088,7 @@ public class SectionDisplayContextHelper {
 		).setIcon(
 			"password-policies"
 		).setLabel(
-			_language.get(httpServletRequest, "permissions")
+			LanguageUtil.get(httpServletRequest, "permissions")
 		).setPermissionKey(
 			"permissions"
 		).setType(
@@ -1116,7 +1098,7 @@ public class SectionDisplayContextHelper {
 		);
 	}
 
-	private String[] _getRootObjectEntryFolderExternalReferenceCodes(
+	private static String[] _getRootObjectEntryFolderExternalReferenceCodes(
 		String rootObjectEntryFolderExternalReferenceCode) {
 
 		if (rootObjectEntryFolderExternalReferenceCode == null) {
@@ -1129,11 +1111,19 @@ public class SectionDisplayContextHelper {
 		return new String[] {rootObjectEntryFolderExternalReferenceCode};
 	}
 
-	private boolean _modelResourcePermissionContains(
+	private static boolean _contains(
 		String actionId, long objectEntryFolderId, ThemeDisplay themeDisplay) {
 
 		try {
-			return _objectEntryFolderModelResourcePermission.contains(
+			ModelResourcePermission<ObjectEntryFolder> modelResourcePermission =
+				ModelResourcePermissionRegistryUtil.getModelResourcePermission(
+					ObjectEntryFolder.class.getName());
+
+			if (modelResourcePermission == null) {
+				return false;
+			}
+
+			return modelResourcePermission.contains(
 				themeDisplay.getPermissionChecker(), objectEntryFolderId,
 				actionId);
 		}
@@ -1150,15 +1140,6 @@ public class SectionDisplayContextHelper {
 		StringUtil.merge(CMSWorkflowConstants.STATUSES, ", ");
 
 	private static final Log _log = LogFactoryUtil.getLog(
-		SectionDisplayContextHelper.class);
-
-	private final DepotEntryLocalService _depotEntryLocalService;
-	private final GroupLocalService _groupLocalService;
-	private final Language _language;
-	private final ObjectDefinitionSettingLocalService
-		_objectDefinitionSettingLocalService;
-	private final ModelResourcePermission<ObjectEntryFolder>
-		_objectEntryFolderModelResourcePermission;
-	private final Portal _portal;
+		SectionDisplayContextUtil.class);
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextUtil.java
@@ -400,9 +400,7 @@ public class SectionDisplayContextUtil {
 				objectEntryFolderIdsMap.entrySet()) {
 
 			for (long objectEntryFolderId : entry.getValue()) {
-				if (_contains(
-						actionId, objectEntryFolderId, themeDisplay)) {
-
+				if (_contains(actionId, objectEntryFolderId, themeDisplay)) {
 					depotEntryGroupIds.add(entry.getKey());
 
 					break;
@@ -833,6 +831,31 @@ public class SectionDisplayContextUtil {
 			));
 	}
 
+	private static boolean _contains(
+		String actionId, long objectEntryFolderId, ThemeDisplay themeDisplay) {
+
+		try {
+			ModelResourcePermission<ObjectEntryFolder> modelResourcePermission =
+				ModelResourcePermissionRegistryUtil.getModelResourcePermission(
+					ObjectEntryFolder.class.getName());
+
+			if (modelResourcePermission == null) {
+				return false;
+			}
+
+			return modelResourcePermission.contains(
+				themeDisplay.getPermissionChecker(), objectEntryFolderId,
+				actionId);
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+
+		return false;
+	}
+
 	private static List<DropdownItem> _getBulkActionDropdownItems(
 		HttpServletRequest httpServletRequest) {
 
@@ -1109,31 +1132,6 @@ public class SectionDisplayContextUtil {
 		}
 
 		return new String[] {rootObjectEntryFolderExternalReferenceCode};
-	}
-
-	private static boolean _contains(
-		String actionId, long objectEntryFolderId, ThemeDisplay themeDisplay) {
-
-		try {
-			ModelResourcePermission<ObjectEntryFolder> modelResourcePermission =
-				ModelResourcePermissionRegistryUtil.getModelResourcePermission(
-					ObjectEntryFolder.class.getName());
-
-			if (modelResourcePermission == null) {
-				return false;
-			}
-
-			return modelResourcePermission.contains(
-				themeDisplay.getPermissionChecker(), objectEntryFolderId,
-				actionId);
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-		}
-
-		return false;
 	}
 
 	private static final String _CMS_WORKFLOW_STATUSES_STRING =

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllRelatedAssetsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllRelatedAssetsSectionDisplayContext.java
@@ -11,11 +11,9 @@ import com.liferay.document.library.configuration.DLConfiguration;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -24,7 +22,6 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.translation.exporter.TranslationInfoItemFieldValuesExporterRegistry;
@@ -49,10 +46,7 @@ public class ViewAllRelatedAssetsSectionDisplayContext
 		ObjectDefinition objectDefinition,
 		ObjectDefinitionLocalService objectDefinitionLocalService,
 		ObjectDefinitionService objectDefinitionService,
-		ObjectDefinitionSettingLocalService objectDefinitionSettingLocalService,
 		ObjectEntry objectEntry,
-		ModelResourcePermission<ObjectEntryFolder>
-			objectEntryFolderModelResourcePermission,
 		ObjectEntryLocalService objectEntryLocalService,
 		ObjectRelationship objectRelationship, Portal portal,
 		TranslationInfoItemFieldValuesExporterRegistry
@@ -61,8 +55,7 @@ public class ViewAllRelatedAssetsSectionDisplayContext
 		super(
 			assetTagLocalService, depotEntryLocalService, dlConfiguration,
 			groupLocalService, httpServletRequest, language, objectDefinition,
-			objectDefinitionService, objectDefinitionSettingLocalService,
-			objectEntry, objectEntryFolderModelResourcePermission, portal,
+			objectDefinitionService, objectEntry, portal,
 			translationInfoItemFieldValuesExporterRegistry);
 
 		_objectDefinitionLocalService = objectDefinitionLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllSectionDisplayContext.java
@@ -13,15 +13,12 @@ import com.liferay.frontend.data.set.action.FDSItemsActions;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
@@ -41,11 +38,8 @@ public class ViewAllSectionDisplayContext extends BaseSectionDisplayContext {
 		DepotEntryLocalService depotEntryLocalService,
 		DLConfiguration dlConfiguration, GroupLocalService groupLocalService,
 		HttpServletRequest httpServletRequest, Language language,
-		ObjectDefinitionService objectDefinitionService,
-		ObjectDefinitionSettingLocalService objectDefinitionSettingLocalService,
-		ModelResourcePermission<ObjectEntryFolder>
-			objectEntryFolderModelResourcePermission,
-		Portal portal, FDSCreationMenu viewAllSectionFDSCreationMenu,
+		ObjectDefinitionService objectDefinitionService, Portal portal,
+		FDSCreationMenu viewAllSectionFDSCreationMenu,
 		FDSItemsActions viewAllSectionFDSItemsActions,
 		SystemFDSEntry viewAllSectionSystemFDSEntry,
 		TranslationInfoItemFieldValuesExporterRegistry
@@ -53,9 +47,7 @@ public class ViewAllSectionDisplayContext extends BaseSectionDisplayContext {
 
 		super(
 			depotEntryLocalService, dlConfiguration, groupLocalService,
-			httpServletRequest, language, objectDefinitionService,
-			objectDefinitionSettingLocalService,
-			objectEntryFolderModelResourcePermission, portal,
+			httpServletRequest, language, objectDefinitionService, portal,
 			translationInfoItemFieldValuesExporterRegistry);
 
 		_httpServletRequest = httpServletRequest;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllSectionDisplayContext.java
@@ -89,7 +89,7 @@ public class ViewAllSectionDisplayContext extends BaseSectionDisplayContext {
 
 	@Override
 	public List<DropdownItem> getBulkActionDropdownItems() {
-		return sectionDisplayContextHelper.getAllSectionBulkActionDropdownItems(
+		return SectionDisplayContextUtil.getAllSectionBulkActionDropdownItems(
 			httpServletRequest);
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewContentsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewContentsSectionDisplayContext.java
@@ -6,14 +6,11 @@
 package com.liferay.site.cms.site.initializer.internal.display.context;
 
 import com.liferay.depot.service.DepotEntryLocalService;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
@@ -34,19 +31,13 @@ public class ViewContentsSectionDisplayContext
 		DepotEntryLocalService depotEntryLocalService,
 		GroupLocalService groupLocalService,
 		HttpServletRequest httpServletRequest, Language language,
-		ObjectDefinitionService objectDefinitionService,
-		ObjectDefinitionSettingLocalService objectDefinitionSettingLocalService,
-		ModelResourcePermission<ObjectEntryFolder>
-			objectEntryFolderModelResourcePermission,
-		Portal portal,
+		ObjectDefinitionService objectDefinitionService, Portal portal,
 		TranslationInfoItemFieldValuesExporterRegistry
 			translationInfoItemFieldValuesExporterRegistry) {
 
 		super(
 			depotEntryLocalService, groupLocalService, httpServletRequest,
-			language, objectDefinitionService,
-			objectDefinitionSettingLocalService,
-			objectEntryFolderModelResourcePermission, portal,
+			language, objectDefinitionService, portal,
 			translationInfoItemFieldValuesExporterRegistry);
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFilesSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFilesSectionDisplayContext.java
@@ -7,15 +7,12 @@ package com.liferay.site.cms.site.initializer.internal.display.context;
 
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.configuration.DLConfiguration;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
@@ -36,19 +33,13 @@ public class ViewFilesSectionDisplayContext
 		DepotEntryLocalService depotEntryLocalService,
 		DLConfiguration dlConfiguration, GroupLocalService groupLocalService,
 		HttpServletRequest httpServletRequest, Language language,
-		ObjectDefinitionService objectDefinitionService,
-		ObjectDefinitionSettingLocalService objectDefinitionSettingLocalService,
-		ModelResourcePermission<ObjectEntryFolder>
-			objectEntryFolderModelResourcePermission,
-		Portal portal,
+		ObjectDefinitionService objectDefinitionService, Portal portal,
 		TranslationInfoItemFieldValuesExporterRegistry
 			translationInfoItemFieldValuesExporterRegistry) {
 
 		super(
 			depotEntryLocalService, dlConfiguration, groupLocalService,
-			httpServletRequest, language, objectDefinitionService,
-			objectDefinitionSettingLocalService,
-			objectEntryFolderModelResourcePermission, portal,
+			httpServletRequest, language, objectDefinitionService, portal,
 			translationInfoItemFieldValuesExporterRegistry);
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderSectionDisplayContext.java
@@ -170,11 +170,11 @@ public class ViewFolderSectionDisplayContext extends BaseSectionDisplayContext {
 	@Override
 	public List<DropdownItem> getBulkActionDropdownItems() {
 		if (_isContentsFolder()) {
-			return sectionDisplayContextHelper.
-				getContentsBulkActionDropdownItems(httpServletRequest);
+			return SectionDisplayContextUtil.getContentsBulkActionDropdownItems(
+				httpServletRequest);
 		}
 
-		return sectionDisplayContextHelper.getFilesBulkActionDropdownItems(
+		return SectionDisplayContextUtil.getFilesBulkActionDropdownItems(
 			httpServletRequest);
 	}
 
@@ -241,11 +241,11 @@ public class ViewFolderSectionDisplayContext extends BaseSectionDisplayContext {
 	@Override
 	public List<FDSActionDropdownItem> getFDSActionDropdownItems() {
 		if (_isContentsFolder()) {
-			return sectionDisplayContextHelper.
-				getContentsFDSActionDropdownItems(httpServletRequest);
+			return SectionDisplayContextUtil.getContentsFDSActionDropdownItems(
+				httpServletRequest);
 		}
 
-		return sectionDisplayContextHelper.getFilesFDSActionDropdownItems(
+		return SectionDisplayContextUtil.getFilesFDSActionDropdownItems(
 			httpServletRequest);
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderSectionDisplayContext.java
@@ -13,7 +13,6 @@ import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.json.JSONArray;
@@ -21,7 +20,6 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -50,10 +48,7 @@ public class ViewFolderSectionDisplayContext extends BaseSectionDisplayContext {
 		DLConfiguration dlConfiguration, GroupLocalService groupLocalService,
 		HttpServletRequest httpServletRequest, Language language,
 		ObjectDefinitionService objectDefinitionService,
-		ObjectDefinitionSettingLocalService objectDefinitionSettingLocalService,
 		ObjectEntryFolderLocalService objectEntryFolderLocalService,
-		ModelResourcePermission<ObjectEntryFolder>
-			objectEntryFolderModelResourcePermission,
 		Portal portal,
 		TranslationInfoItemFieldValuesExporterRegistry
 			translationInfoItemFieldValuesExporterRegistry,
@@ -61,9 +56,7 @@ public class ViewFolderSectionDisplayContext extends BaseSectionDisplayContext {
 
 		super(
 			depotEntryLocalService, dlConfiguration, groupLocalService,
-			httpServletRequest, language, objectDefinitionService,
-			objectDefinitionSettingLocalService,
-			objectEntryFolderModelResourcePermission, portal,
+			httpServletRequest, language, objectDefinitionService, portal,
 			translationInfoItemFieldValuesExporterRegistry);
 
 		_objectEntryFolderLocalService = objectEntryFolderLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeQuickActionsDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeQuickActionsDisplayContext.java
@@ -6,7 +6,6 @@
 package com.liferay.site.cms.site.initializer.internal.display.context;
 
 import com.liferay.depot.constants.DepotConstants;
-import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
@@ -14,7 +13,6 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
-import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
@@ -53,6 +51,7 @@ public class ViewHomeQuickActionsDisplayContext {
 		ObjectEntryFolderLocalService objectEntryFolderLocalService,
 		ModelResourcePermission<ObjectEntryFolder>
 			objectEntryFolderModelResourcePermission,
+		SectionDisplayContextHelper sectionDisplayContextHelper,
 		ThemeDisplay themeDisplay) {
 
 		_depotEntryLocalService = depotEntryLocalService;
@@ -61,6 +60,7 @@ public class ViewHomeQuickActionsDisplayContext {
 		_objectEntryFolderLocalService = objectEntryFolderLocalService;
 		_objectEntryFolderModelResourcePermission =
 			objectEntryFolderModelResourcePermission;
+		_sectionDisplayContextHelper = sectionDisplayContextHelper;
 		_themeDisplay = themeDisplay;
 	}
 
@@ -178,11 +178,6 @@ public class ViewHomeQuickActionsDisplayContext {
 	private List<Map<String, Object>> _getQuickActions() throws Exception {
 		List<Map<String, Object>> quickActions = new ArrayList<>();
 
-		List<Long> depotEntryGroupIds = TransformUtil.transform(
-			_depotEntryLocalService.getDepotEntries(
-				_themeDisplay.getCompanyId(), DepotConstants.TYPE_SPACE),
-			DepotEntry::getGroupId);
-
 		List<ObjectDefinition> objectDefinitions =
 			_objectDefinitionService.getCMSObjectDefinitions(
 				_themeDisplay.getCompanyId(),
@@ -195,7 +190,12 @@ public class ViewHomeQuickActionsDisplayContext {
 		for (ObjectDefinition objectDefinition : objectDefinitions) {
 			JSONArray depotEntriesJSONArray = _getDepotEntriesJSONArray(
 				ActionUtil.getAcceptedDepotEntryGroupIds(
-					depotEntryGroupIds,
+					_sectionDisplayContextHelper.getDepotEntryGroupIds(
+						ActionKeys.ADD_ENTRY,
+						_sectionDisplayContextHelper.getObjectEntryFolderIdsMap(
+							_themeDisplay.getCompanyId(), null,
+							_themeDisplay.getUserId()),
+						_themeDisplay),
 					objectDefinition.getObjectDefinitionId()));
 
 			if (depotEntriesJSONArray.length() == 0) {
@@ -270,6 +270,7 @@ public class ViewHomeQuickActionsDisplayContext {
 	private final ObjectEntryFolderLocalService _objectEntryFolderLocalService;
 	private final ModelResourcePermission<ObjectEntryFolder>
 		_objectEntryFolderModelResourcePermission;
+	private final SectionDisplayContextHelper _sectionDisplayContextHelper;
 	private final ThemeDisplay _themeDisplay;
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeQuickActionsDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeQuickActionsDisplayContext.java
@@ -5,13 +5,10 @@
 
 package com.liferay.site.cms.site.initializer.internal.display.context;
 
-import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -21,7 +18,6 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -42,21 +38,13 @@ import java.util.Objects;
 public class ViewHomeQuickActionsDisplayContext {
 
 	public ViewHomeQuickActionsDisplayContext(
-		DepotEntryLocalService depotEntryLocalService,
 		GroupLocalService groupLocalService,
 		ObjectDefinitionService objectDefinitionService,
-		ObjectEntryFolderLocalService objectEntryFolderLocalService,
-		ModelResourcePermission<ObjectEntryFolder>
-			objectEntryFolderModelResourcePermission,
 		SectionDisplayContextHelper sectionDisplayContextHelper,
 		ThemeDisplay themeDisplay) {
 
-		_depotEntryLocalService = depotEntryLocalService;
 		_groupLocalService = groupLocalService;
 		_objectDefinitionService = objectDefinitionService;
-		_objectEntryFolderLocalService = objectEntryFolderLocalService;
-		_objectEntryFolderModelResourcePermission =
-			objectEntryFolderModelResourcePermission;
 		_sectionDisplayContextHelper = sectionDisplayContextHelper;
 		_themeDisplay = themeDisplay;
 	}
@@ -242,12 +230,8 @@ public class ViewHomeQuickActionsDisplayContext {
 		"L_FILES", "document-default"
 	).build();
 
-	private final DepotEntryLocalService _depotEntryLocalService;
 	private final GroupLocalService _groupLocalService;
 	private final ObjectDefinitionService _objectDefinitionService;
-	private final ObjectEntryFolderLocalService _objectEntryFolderLocalService;
-	private final ModelResourcePermission<ObjectEntryFolder>
-		_objectEntryFolderModelResourcePermission;
 	private List<Map<String, Object>> _quickActions;
 	private final SectionDisplayContextHelper _sectionDisplayContextHelper;
 	private final ThemeDisplay _themeDisplay;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeQuickActionsDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeQuickActionsDisplayContext.java
@@ -153,44 +153,50 @@ public class ViewHomeQuickActionsDisplayContext {
 
 		_quickActions = new ArrayList<>();
 
-		List<ObjectDefinition> objectDefinitions =
-			_objectDefinitionService.getCMSObjectDefinitions(
-				_themeDisplay.getCompanyId(),
-				new String[] {
-					ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES,
-					ObjectFolderConstants.
-						EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES
-				});
+		List<Long> depotEntryGroupIds =
+			_sectionDisplayContextHelper.getDepotEntryGroupIds(
+				ActionKeys.ADD_ENTRY,
+				_sectionDisplayContextHelper.getObjectEntryFolderIdsMap(
+					_themeDisplay.getCompanyId(), null,
+					_themeDisplay.getUserId()),
+				_themeDisplay);
 
-		for (ObjectDefinition objectDefinition : objectDefinitions) {
-			JSONArray depotEntriesJSONArray = _getDepotEntriesJSONArray(
-				ActionUtil.getAcceptedDepotEntryGroupIds(
-					_sectionDisplayContextHelper.getDepotEntryGroupIds(
-						ActionKeys.ADD_ENTRY,
-						_sectionDisplayContextHelper.getObjectEntryFolderIdsMap(
-							_themeDisplay.getCompanyId(), null,
-							_themeDisplay.getUserId()),
-						_themeDisplay),
-					objectDefinition.getObjectDefinitionId()));
+		if (ListUtil.isNotEmpty(depotEntryGroupIds)) {
+			List<ObjectDefinition> objectDefinitions =
+				_objectDefinitionService.getCMSObjectDefinitions(
+					_themeDisplay.getCompanyId(),
+					new String[] {
+						ObjectFolderConstants.
+							EXTERNAL_REFERENCE_CODE_FILE_TYPES,
+						ObjectFolderConstants.
+							EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES
+					});
 
-			if (depotEntriesJSONArray.length() == 0) {
-				continue;
+			for (ObjectDefinition objectDefinition : objectDefinitions) {
+				JSONArray depotEntriesJSONArray = _getDepotEntriesJSONArray(
+					ActionUtil.getAcceptedDepotEntryGroupIds(
+						depotEntryGroupIds,
+						objectDefinition.getObjectDefinitionId()));
+
+				if (depotEntriesJSONArray.length() == 0) {
+					continue;
+				}
+
+				String actionIcon = _icons.get(
+					objectDefinition.getExternalReferenceCode());
+
+				if (actionIcon == null) {
+					String entryFolderERC =
+						_getObjectEntryFolderExternalReferenceCode(
+							objectDefinition);
+
+					actionIcon = _icons.getOrDefault(entryFolderERC, "forms");
+				}
+
+				_quickActions.add(
+					_createQuickAction(
+						depotEntriesJSONArray, actionIcon, objectDefinition));
 			}
-
-			String actionIcon = _icons.get(
-				objectDefinition.getExternalReferenceCode());
-
-			if (actionIcon == null) {
-				String entryFolderERC =
-					_getObjectEntryFolderExternalReferenceCode(
-						objectDefinition);
-
-				actionIcon = _icons.getOrDefault(entryFolderERC, "forms");
-			}
-
-			_quickActions.add(
-				_createQuickAction(
-					depotEntriesJSONArray, actionIcon, objectDefinition));
 		}
 
 		if (AssetCategoriesPermission.contains(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeQuickActionsDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeQuickActionsDisplayContext.java
@@ -40,12 +40,10 @@ public class ViewHomeQuickActionsDisplayContext {
 	public ViewHomeQuickActionsDisplayContext(
 		GroupLocalService groupLocalService,
 		ObjectDefinitionService objectDefinitionService,
-		SectionDisplayContextHelper sectionDisplayContextHelper,
 		ThemeDisplay themeDisplay) {
 
 		_groupLocalService = groupLocalService;
 		_objectDefinitionService = objectDefinitionService;
-		_sectionDisplayContextHelper = sectionDisplayContextHelper;
 		_themeDisplay = themeDisplay;
 	}
 
@@ -142,9 +140,9 @@ public class ViewHomeQuickActionsDisplayContext {
 		_quickActions = new ArrayList<>();
 
 		List<Long> depotEntryGroupIds =
-			_sectionDisplayContextHelper.getDepotEntryGroupIds(
+			SectionDisplayContextUtil.getDepotEntryGroupIds(
 				ActionKeys.ADD_ENTRY,
-				_sectionDisplayContextHelper.getObjectEntryFolderIdsMap(
+				SectionDisplayContextUtil.getObjectEntryFolderIdsMap(
 					_themeDisplay.getCompanyId(), null,
 					_themeDisplay.getUserId()),
 				_themeDisplay);
@@ -233,7 +231,6 @@ public class ViewHomeQuickActionsDisplayContext {
 	private final GroupLocalService _groupLocalService;
 	private final ObjectDefinitionService _objectDefinitionService;
 	private List<Map<String, Object>> _quickActions;
-	private final SectionDisplayContextHelper _sectionDisplayContextHelper;
 	private final ThemeDisplay _themeDisplay;
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeQuickActionsDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeQuickActionsDisplayContext.java
@@ -67,7 +67,7 @@ public class ViewHomeQuickActionsDisplayContext {
 		).build();
 	}
 
-	public boolean hasAddEntryPermission() throws Exception {
+	public boolean hasQuickActions() throws Exception {
 		return ListUtil.isNotEmpty(_getQuickActions());
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeQuickActionsDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeQuickActionsDisplayContext.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portlet.asset.service.permission.AssetCategoriesPermission;
 import com.liferay.site.cms.site.initializer.internal.util.ActionUtil;
 
 import java.util.ArrayList;
@@ -217,24 +218,29 @@ public class ViewHomeQuickActionsDisplayContext {
 					depotEntriesJSONArray, actionIcon, objectDefinition));
 		}
 
-		quickActions.add(
-			HashMapBuilder.<String, Object>put(
-				"action", "createVocabulary"
-			).put(
-				"icon", _icons.get("L_CMS_VOCABULARY")
-			).put(
-				"redirect",
-				StringBundler.concat(
-					PortalUtil.getLayoutFullURL(
-						LayoutLocalServiceUtil.getLayoutByFriendlyURL(
-							_themeDisplay.getScopeGroupId(), false,
-							"/categorization/new-vocabulary"),
-						_themeDisplay),
-					"?backURL=", _themeDisplay.getURLCurrent())
-			).put(
-				"title",
-				LanguageUtil.get(_themeDisplay.getLocale(), "vocabulary")
-			).build());
+		if (AssetCategoriesPermission.contains(
+				_themeDisplay.getPermissionChecker(),
+				_themeDisplay.getScopeGroupId(), ActionKeys.ADD_VOCABULARY)) {
+
+			quickActions.add(
+				HashMapBuilder.<String, Object>put(
+					"action", "createVocabulary"
+				).put(
+					"icon", _icons.get("L_CMS_VOCABULARY")
+				).put(
+					"redirect",
+					StringBundler.concat(
+						PortalUtil.getLayoutFullURL(
+							LayoutLocalServiceUtil.getLayoutByFriendlyURL(
+								_themeDisplay.getScopeGroupId(), false,
+								"/categorization/new-vocabulary"),
+							_themeDisplay),
+						"?backURL=", _themeDisplay.getURLCurrent())
+				).put(
+					"title",
+					LanguageUtil.get(_themeDisplay.getLocale(), "vocabulary")
+				).build());
+		}
 
 		return quickActions;
 	}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeQuickActionsDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeQuickActionsDisplayContext.java
@@ -5,7 +5,6 @@
 
 package com.liferay.site.cms.site.initializer.internal.display.context;
 
-import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
@@ -14,14 +13,11 @@ import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
@@ -30,6 +26,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portlet.asset.service.permission.AssetCategoriesPermission;
 import com.liferay.site.cms.site.initializer.internal.util.ActionUtil;
@@ -70,34 +67,8 @@ public class ViewHomeQuickActionsDisplayContext {
 		).build();
 	}
 
-	public boolean hasAddEntryPermission() {
-		List<ObjectEntryFolder> objectEntryFolders =
-			_objectEntryFolderLocalService.
-				getObjectEntryFoldersByExternalReferenceCode(
-					ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS,
-					_depotEntryLocalService.getDepotEntryGroupIds(
-						_themeDisplay.getCompanyId(),
-						DepotConstants.TYPE_SPACE),
-					_themeDisplay.getCompanyId());
-
-		for (ObjectEntryFolder objectEntryFolder : objectEntryFolders) {
-			try {
-				if (_objectEntryFolderModelResourcePermission.contains(
-						_themeDisplay.getPermissionChecker(),
-						objectEntryFolder.getObjectEntryFolderId(),
-						ActionKeys.ADD_ENTRY)) {
-
-					return true;
-				}
-			}
-			catch (PortalException portalException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(portalException);
-				}
-			}
-		}
-
-		return false;
+	public boolean hasAddEntryPermission() throws Exception {
+		return ListUtil.isNotEmpty(_getQuickActions());
 	}
 
 	private Map<String, Object> _createQuickAction(
@@ -176,7 +147,11 @@ public class ViewHomeQuickActionsDisplayContext {
 	}
 
 	private List<Map<String, Object>> _getQuickActions() throws Exception {
-		List<Map<String, Object>> quickActions = new ArrayList<>();
+		if (_quickActions != null) {
+			return _quickActions;
+		}
+
+		_quickActions = new ArrayList<>();
 
 		List<ObjectDefinition> objectDefinitions =
 			_objectDefinitionService.getCMSObjectDefinitions(
@@ -213,7 +188,7 @@ public class ViewHomeQuickActionsDisplayContext {
 				actionIcon = _icons.getOrDefault(entryFolderERC, "forms");
 			}
 
-			quickActions.add(
+			_quickActions.add(
 				_createQuickAction(
 					depotEntriesJSONArray, actionIcon, objectDefinition));
 		}
@@ -222,7 +197,7 @@ public class ViewHomeQuickActionsDisplayContext {
 				_themeDisplay.getPermissionChecker(),
 				_themeDisplay.getScopeGroupId(), ActionKeys.ADD_VOCABULARY)) {
 
-			quickActions.add(
+			_quickActions.add(
 				HashMapBuilder.<String, Object>put(
 					"action", "createVocabulary"
 				).put(
@@ -242,11 +217,8 @@ public class ViewHomeQuickActionsDisplayContext {
 				).build());
 		}
 
-		return quickActions;
+		return _quickActions;
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		ViewHomeQuickActionsDisplayContext.class);
 
 	private static final Map<String, String> _icons = HashMapBuilder.put(
 		"L_CMS_BASIC_DOCUMENT", "documents-and-media"
@@ -270,6 +242,7 @@ public class ViewHomeQuickActionsDisplayContext {
 	private final ObjectEntryFolderLocalService _objectEntryFolderLocalService;
 	private final ModelResourcePermission<ObjectEntryFolder>
 		_objectEntryFolderModelResourcePermission;
+	private List<Map<String, Object>> _quickActions;
 	private final SectionDisplayContextHelper _sectionDisplayContextHelper;
 	private final ThemeDisplay _themeDisplay;
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeRecentAssetsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewHomeRecentAssetsSectionDisplayContext.java
@@ -8,13 +8,10 @@ package com.liferay.site.cms.site.initializer.internal.display.context;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.configuration.DLConfiguration;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -37,19 +34,13 @@ public class ViewHomeRecentAssetsSectionDisplayContext
 		DepotEntryLocalService depotEntryLocalService,
 		DLConfiguration dlConfiguration, GroupLocalService groupLocalService,
 		HttpServletRequest httpServletRequest, Language language,
-		ObjectDefinitionService objectDefinitionService,
-		ObjectDefinitionSettingLocalService objectDefinitionSettingLocalService,
-		ModelResourcePermission<ObjectEntryFolder>
-			objectEntryFolderModelResourcePermission,
-		Portal portal,
+		ObjectDefinitionService objectDefinitionService, Portal portal,
 		TranslationInfoItemFieldValuesExporterRegistry
 			translationInfoItemFieldValuesExporterRegistry) {
 
 		super(
 			depotEntryLocalService, dlConfiguration, groupLocalService,
-			httpServletRequest, language, objectDefinitionService,
-			objectDefinitionSettingLocalService,
-			objectEntryFolderModelResourcePermission, portal,
+			httpServletRequest, language, objectDefinitionService, portal,
 			translationInfoItemFieldValuesExporterRegistry);
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewRecycleBinSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewRecycleBinSectionDisplayContext.java
@@ -13,7 +13,6 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.headless.asset.library.resource.v1_0.AssetLibraryResource;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
@@ -25,7 +24,6 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -60,10 +58,7 @@ public class ViewRecycleBinSectionDisplayContext
 		GroupLocalService groupLocalService,
 		HttpServletRequest httpServletRequest, Language language,
 		ObjectDefinitionService objectDefinitionService,
-		ObjectDefinitionSettingLocalService objectDefinitionSettingLocalService,
 		ObjectEntryFolderLocalService objectEntryFolderLocalService,
-		ModelResourcePermission<ObjectEntryFolder>
-			objectEntryFolderModelResourcePermission,
 		Portal portal, SearchResultResource.Factory searchResultResourceFactory,
 		TranslationInfoItemFieldValuesExporterRegistry
 			translationInfoItemFieldValuesExporterRegistry,
@@ -71,9 +66,7 @@ public class ViewRecycleBinSectionDisplayContext
 
 		super(
 			depotEntryLocalService, null, groupLocalService, httpServletRequest,
-			language, objectDefinitionService,
-			objectDefinitionSettingLocalService,
-			objectEntryFolderModelResourcePermission, portal,
+			language, objectDefinitionService, portal,
 			translationInfoItemFieldValuesExporterRegistry);
 
 		_assetLibraryResourceFactory = assetLibraryResourceFactory;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewRelatedAssetsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewRelatedAssetsSectionDisplayContext.java
@@ -97,10 +97,9 @@ public class ViewRelatedAssetsSectionDisplayContext
 						SectionDisplayContextUtil.getAdditionalAPIURLParameters(
 							appendStatus(
 								StringBundler.concat(
-									"(cmsSection eq 'contents' or ",
-									"cmsSection eq 'files') and not ",
-									"(keywords/any(k:k in (",
-									getKeywordsFilterString(),
+									"(cmsSection eq 'contents' or cmsSection ",
+									"eq 'files') and not (keywords/any(k:k in ",
+									"(", getKeywordsFilterString(),
 									"))) and objectDefinitionId gt 0")),
 							httpServletRequest, null);
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewRelatedAssetsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewRelatedAssetsSectionDisplayContext.java
@@ -13,14 +13,11 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemBuilder;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -48,19 +45,14 @@ public class ViewRelatedAssetsSectionDisplayContext
 		HttpServletRequest httpServletRequest, Language language,
 		ObjectDefinition objectDefinition,
 		ObjectDefinitionService objectDefinitionService,
-		ObjectDefinitionSettingLocalService objectDefinitionSettingLocalService,
-		ObjectEntry objectEntry,
-		ModelResourcePermission<ObjectEntryFolder>
-			objectEntryFolderModelResourcePermission,
-		Portal portal,
+		ObjectEntry objectEntry, Portal portal,
 		TranslationInfoItemFieldValuesExporterRegistry
 			translationInfoItemFieldValuesExporterRegistry) {
 
 		super(
 			assetTagLocalService, depotEntryLocalService, dlConfiguration,
 			groupLocalService, httpServletRequest, language, objectDefinition,
-			objectDefinitionService, objectDefinitionSettingLocalService,
-			objectEntry, objectEntryFolderModelResourcePermission, portal,
+			objectDefinitionService, objectEntry, portal,
 			translationInfoItemFieldValuesExporterRegistry);
 
 		Set<String> tagNames = getTagNames(objectDefinition, objectEntry);

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewRelatedAssetsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewRelatedAssetsSectionDisplayContext.java
@@ -102,16 +102,15 @@ public class ViewRelatedAssetsSectionDisplayContext
 				"searchAPIURL",
 				() -> {
 					String additionalAPIURLParameters =
-						sectionDisplayContextHelper.
-							getAdditionalAPIURLParameters(
-								appendStatus(
-									StringBundler.concat(
-										"(cmsSection eq 'contents' or ",
-										"cmsSection eq 'files') and not ",
-										"(keywords/any(k:k in (",
-										getKeywordsFilterString(),
-										"))) and objectDefinitionId gt 0")),
-								httpServletRequest, null);
+						SectionDisplayContextUtil.getAdditionalAPIURLParameters(
+							appendStatus(
+								StringBundler.concat(
+									"(cmsSection eq 'contents' or ",
+									"cmsSection eq 'files') and not ",
+									"(keywords/any(k:k in (",
+									getKeywordsFilterString(),
+									"))) and objectDefinitionId gt 0")),
+							httpServletRequest, null);
 
 					return "/o/search/v1.0/search?" +
 						additionalAPIURLParameters;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceContentsSummarySectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceContentsSummarySectionDisplayContext.java
@@ -8,7 +8,6 @@ package com.liferay.site.cms.site.initializer.internal.display.context;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -16,7 +15,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.site.cms.site.initializer.internal.constants.CMSSpaceConstants;
@@ -40,19 +38,14 @@ public class ViewSpaceContentsSummarySectionDisplayContext
 		GroupLocalService groupLocalService,
 		HttpServletRequest httpServletRequest, Language language,
 		ObjectDefinitionService objectDefinitionService,
-		ObjectDefinitionSettingLocalService objectDefinitionSettingLocalService,
 		ObjectEntryFolderLocalService objectEntryFolderLocalService,
-		ModelResourcePermission<ObjectEntryFolder>
-			objectEntryFolderModelResourcePermission,
 		Portal portal,
 		TranslationInfoItemFieldValuesExporterRegistry
 			translationInfoItemFieldValuesExporterRegistry) {
 
 		super(
 			depotEntryLocalService, groupLocalService, httpServletRequest,
-			language, objectDefinitionService,
-			objectDefinitionSettingLocalService,
-			objectEntryFolderModelResourcePermission, portal,
+			language, objectDefinitionService, portal,
 			translationInfoItemFieldValuesExporterRegistry);
 
 		_groupId = groupId;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceFilesSummarySectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceFilesSummarySectionDisplayContext.java
@@ -9,7 +9,6 @@ import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.configuration.DLConfiguration;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -17,7 +16,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.site.cms.site.initializer.internal.constants.CMSSpaceConstants;
@@ -42,19 +40,14 @@ public class ViewSpaceFilesSummarySectionDisplayContext
 		GroupLocalService groupLocalService,
 		HttpServletRequest httpServletRequest, Language language,
 		ObjectDefinitionService objectDefinitionService,
-		ObjectDefinitionSettingLocalService objectDefinitionSettingLocalService,
 		ObjectEntryFolderLocalService objectEntryFolderLocalService,
-		ModelResourcePermission<ObjectEntryFolder>
-			objectEntryFolderModelResourcePermission,
 		Portal portal,
 		TranslationInfoItemFieldValuesExporterRegistry
 			translationInfoItemFieldValuesExporterRegistry) {
 
 		super(
 			depotEntryLocalService, dlConfiguration, groupLocalService,
-			httpServletRequest, language, objectDefinitionService,
-			objectDefinitionSettingLocalService,
-			objectEntryFolderModelResourcePermission, portal,
+			httpServletRequest, language, objectDefinitionService, portal,
 			translationInfoItemFieldValuesExporterRegistry);
 
 		_groupId = groupId;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewAllJSPSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewAllJSPSectionFragmentRenderer.java
@@ -11,11 +11,8 @@ import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.frontend.data.set.SystemFDSEntry;
 import com.liferay.frontend.data.set.action.FDSCreationMenu;
 import com.liferay.frontend.data.set.action.FDSItemsActions;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializerFDSNames;
 import com.liferay.site.cms.site.initializer.internal.display.context.ViewAllSectionDisplayContext;
@@ -62,9 +59,7 @@ public class ViewAllJSPSectionFragmentRenderer
 
 		return new ViewAllSectionDisplayContext(
 			_depotEntryLocalService, _dlConfiguration, groupLocalService,
-			httpServletRequest, language, _objectDefinitionService,
-			_objectDefinitionSettingLocalService,
-			_objectEntryFolderModelResourcePermission, _portal,
+			httpServletRequest, language, _objectDefinitionService, _portal,
 			_viewAllSectionFDSCreationMenu, _viewAllSectionFDSItemsActions,
 			_viewAllSectionSystemFDSEntry,
 			translationInfoItemFieldValuesExporterRegistry);
@@ -82,16 +77,6 @@ public class ViewAllJSPSectionFragmentRenderer
 
 	@Reference
 	private ObjectDefinitionService _objectDefinitionService;
-
-	@Reference
-	private ObjectDefinitionSettingLocalService
-		_objectDefinitionSettingLocalService;
-
-	@Reference(
-		target = "(model.class.name=com.liferay.object.model.ObjectEntryFolder)"
-	)
-	private ModelResourcePermission<ObjectEntryFolder>
-		_objectEntryFolderModelResourcePermission;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewAllRelatedAssetsJSPSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewAllRelatedAssetsJSPSectionFragmentRenderer.java
@@ -11,13 +11,10 @@ import com.liferay.document.library.configuration.DLConfiguration;
 import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.info.constants.InfoDisplayWebKeys;
 import com.liferay.object.model.ObjectEntry;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.site.cms.site.initializer.internal.display.context.ViewAllRelatedAssetsSectionDisplayContext;
 
@@ -63,8 +60,7 @@ public class ViewAllRelatedAssetsJSPSectionFragmentRenderer
 			_objectDefinitionLocalService.fetchObjectDefinition(
 				objectEntry.getObjectDefinitionId()),
 			_objectDefinitionLocalService, _objectDefinitionService,
-			_objectDefinitionSettingLocalService, objectEntry,
-			_objectEntryFolderModelResourcePermission, _objectEntryLocalService,
+			objectEntry, _objectEntryLocalService,
 			(ObjectRelationship)httpServletRequest.getAttribute(
 				"OBJECT_RELATIONSHIP"),
 			_portal, translationInfoItemFieldValuesExporterRegistry);
@@ -88,16 +84,6 @@ public class ViewAllRelatedAssetsJSPSectionFragmentRenderer
 
 	@Reference
 	private ObjectDefinitionService _objectDefinitionService;
-
-	@Reference
-	private ObjectDefinitionSettingLocalService
-		_objectDefinitionSettingLocalService;
-
-	@Reference(
-		target = "(model.class.name=com.liferay.object.model.ObjectEntryFolder)"
-	)
-	private ModelResourcePermission<ObjectEntryFolder>
-		_objectEntryFolderModelResourcePermission;
 
 	@Reference
 	private ObjectEntryLocalService _objectEntryLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewContentsJSPSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewContentsJSPSectionFragmentRenderer.java
@@ -7,10 +7,7 @@ package com.liferay.site.cms.site.initializer.internal.fragment.renderer;
 
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.fragment.renderer.FragmentRenderer;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.site.cms.site.initializer.internal.display.context.ViewContentsSectionDisplayContext;
 
@@ -42,9 +39,7 @@ public class ViewContentsJSPSectionFragmentRenderer
 
 		return new ViewContentsSectionDisplayContext(
 			_depotEntryLocalService, groupLocalService, httpServletRequest,
-			language, _objectDefinitionService,
-			_objectDefinitionSettingLocalService,
-			_objectEntryFolderModelResourcePermission, _portal,
+			language, _objectDefinitionService, _portal,
 			translationInfoItemFieldValuesExporterRegistry);
 	}
 
@@ -58,16 +53,6 @@ public class ViewContentsJSPSectionFragmentRenderer
 
 	@Reference
 	private ObjectDefinitionService _objectDefinitionService;
-
-	@Reference
-	private ObjectDefinitionSettingLocalService
-		_objectDefinitionSettingLocalService;
-
-	@Reference(
-		target = "(model.class.name=com.liferay.object.model.ObjectEntryFolder)"
-	)
-	private ModelResourcePermission<ObjectEntryFolder>
-		_objectEntryFolderModelResourcePermission;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewFilesJSPSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewFilesJSPSectionFragmentRenderer.java
@@ -8,11 +8,8 @@ package com.liferay.site.cms.site.initializer.internal.fragment.renderer;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.configuration.DLConfiguration;
 import com.liferay.fragment.renderer.FragmentRenderer;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.site.cms.site.initializer.internal.display.context.ViewFilesSectionDisplayContext;
 
@@ -58,9 +55,7 @@ public class ViewFilesJSPSectionFragmentRenderer
 
 		return new ViewFilesSectionDisplayContext(
 			_depotEntryLocalService, _dlConfiguration, groupLocalService,
-			httpServletRequest, language, _objectDefinitionService,
-			_objectDefinitionSettingLocalService,
-			_objectEntryFolderModelResourcePermission, _portal,
+			httpServletRequest, language, _objectDefinitionService, _portal,
 			translationInfoItemFieldValuesExporterRegistry);
 	}
 
@@ -76,16 +71,6 @@ public class ViewFilesJSPSectionFragmentRenderer
 
 	@Reference
 	private ObjectDefinitionService _objectDefinitionService;
-
-	@Reference
-	private ObjectDefinitionSettingLocalService
-		_objectDefinitionSettingLocalService;
-
-	@Reference(
-		target = "(model.class.name=com.liferay.object.model.ObjectEntryFolder)"
-	)
-	private ModelResourcePermission<ObjectEntryFolder>
-		_objectEntryFolderModelResourcePermission;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewFolderJSPSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewFolderJSPSectionFragmentRenderer.java
@@ -8,12 +8,9 @@ package com.liferay.site.cms.site.initializer.internal.fragment.renderer;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.configuration.DLConfiguration;
 import com.liferay.fragment.renderer.FragmentRenderer;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.site.cms.site.initializer.internal.display.context.ViewFolderSectionDisplayContext;
@@ -57,9 +54,7 @@ public class ViewFolderJSPSectionFragmentRenderer
 		return new ViewFolderSectionDisplayContext(
 			_depotEntryLocalService, _dlConfiguration, _groupLocalService,
 			httpServletRequest, language, _objectDefinitionService,
-			_objectDefinitionSettingLocalService,
-			_objectEntryFolderLocalService,
-			_objectEntryFolderModelResourcePermission, _portal,
+			_objectEntryFolderLocalService, _portal,
 			translationInfoItemFieldValuesExporterRegistry, _trashHelper);
 	}
 
@@ -80,17 +75,7 @@ public class ViewFolderJSPSectionFragmentRenderer
 	private ObjectDefinitionService _objectDefinitionService;
 
 	@Reference
-	private ObjectDefinitionSettingLocalService
-		_objectDefinitionSettingLocalService;
-
-	@Reference
 	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
-
-	@Reference(
-		target = "(model.class.name=com.liferay.object.model.ObjectEntryFolder)"
-	)
-	private ModelResourcePermission<ObjectEntryFolder>
-		_objectEntryFolderModelResourcePermission;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewHomeQuickActionsJSPSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewHomeQuickActionsJSPSectionFragmentRenderer.java
@@ -10,7 +10,6 @@ import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
-import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -41,9 +40,7 @@ public class ViewHomeQuickActionsJSPSectionFragmentRenderer
 		HttpServletRequest httpServletRequest) {
 
 		return new ViewHomeQuickActionsDisplayContext(
-			_depotEntryLocalService, groupLocalService,
-			_objectDefinitionService, _objectEntryFolderLocalService,
-			_objectEntryFolderModelResourcePermission,
+			groupLocalService, _objectDefinitionService,
 			new SectionDisplayContextHelper(
 				_depotEntryLocalService, groupLocalService, _language,
 				_objectDefinitionSettingLocalService,
@@ -69,9 +66,6 @@ public class ViewHomeQuickActionsJSPSectionFragmentRenderer
 	@Reference
 	private ObjectDefinitionSettingLocalService
 		_objectDefinitionSettingLocalService;
-
-	@Reference
-	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
 
 	@Reference(
 		target = "(model.class.name=com.liferay.object.model.ObjectEntryFolder)"

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewHomeQuickActionsJSPSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewHomeQuickActionsJSPSectionFragmentRenderer.java
@@ -9,10 +9,14 @@ import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
+import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.site.cms.site.initializer.internal.display.context.SectionDisplayContextHelper;
 import com.liferay.site.cms.site.initializer.internal.display.context.ViewHomeQuickActionsDisplayContext;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -40,6 +44,10 @@ public class ViewHomeQuickActionsJSPSectionFragmentRenderer
 			_depotEntryLocalService, groupLocalService,
 			_objectDefinitionService, _objectEntryFolderLocalService,
 			_objectEntryFolderModelResourcePermission,
+			new SectionDisplayContextHelper(
+				_depotEntryLocalService, groupLocalService, _language,
+				_objectDefinitionSettingLocalService,
+				_objectEntryFolderModelResourcePermission, _portal),
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY));
 	}
@@ -53,7 +61,14 @@ public class ViewHomeQuickActionsJSPSectionFragmentRenderer
 	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Reference
+	private Language _language;
+
+	@Reference
 	private ObjectDefinitionService _objectDefinitionService;
+
+	@Reference
+	private ObjectDefinitionSettingLocalService
+		_objectDefinitionSettingLocalService;
 
 	@Reference
 	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
@@ -63,5 +78,8 @@ public class ViewHomeQuickActionsJSPSectionFragmentRenderer
 	)
 	private ModelResourcePermission<ObjectEntryFolder>
 		_objectEntryFolderModelResourcePermission;
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewHomeQuickActionsJSPSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewHomeQuickActionsJSPSectionFragmentRenderer.java
@@ -5,17 +5,10 @@
 
 package com.liferay.site.cms.site.initializer.internal.fragment.renderer;
 
-import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.fragment.renderer.FragmentRenderer;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
-import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.site.cms.site.initializer.internal.display.context.SectionDisplayContextHelper;
 import com.liferay.site.cms.site.initializer.internal.display.context.ViewHomeQuickActionsDisplayContext;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -41,10 +34,6 @@ public class ViewHomeQuickActionsJSPSectionFragmentRenderer
 
 		return new ViewHomeQuickActionsDisplayContext(
 			groupLocalService, _objectDefinitionService,
-			new SectionDisplayContextHelper(
-				_depotEntryLocalService, groupLocalService, _language,
-				_objectDefinitionSettingLocalService,
-				_objectEntryFolderModelResourcePermission, _portal),
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY));
 	}
@@ -55,25 +44,6 @@ public class ViewHomeQuickActionsJSPSectionFragmentRenderer
 	}
 
 	@Reference
-	private DepotEntryLocalService _depotEntryLocalService;
-
-	@Reference
-	private Language _language;
-
-	@Reference
 	private ObjectDefinitionService _objectDefinitionService;
-
-	@Reference
-	private ObjectDefinitionSettingLocalService
-		_objectDefinitionSettingLocalService;
-
-	@Reference(
-		target = "(model.class.name=com.liferay.object.model.ObjectEntryFolder)"
-	)
-	private ModelResourcePermission<ObjectEntryFolder>
-		_objectEntryFolderModelResourcePermission;
-
-	@Reference
-	private Portal _portal;
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewHomeRecentAssetsJSPSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewHomeRecentAssetsJSPSectionFragmentRenderer.java
@@ -8,11 +8,8 @@ package com.liferay.site.cms.site.initializer.internal.fragment.renderer;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.configuration.DLConfiguration;
 import com.liferay.fragment.renderer.FragmentRenderer;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.site.cms.site.initializer.internal.display.context.ViewHomeRecentAssetsSectionDisplayContext;
 
@@ -54,9 +51,7 @@ public class ViewHomeRecentAssetsJSPSectionFragmentRenderer
 
 		return new ViewHomeRecentAssetsSectionDisplayContext(
 			_depotEntryLocalService, _dlConfiguration, groupLocalService,
-			httpServletRequest, language, _objectDefinitionService,
-			_objectDefinitionSettingLocalService,
-			_objectEntryFolderModelResourcePermission, _portal,
+			httpServletRequest, language, _objectDefinitionService, _portal,
 			translationInfoItemFieldValuesExporterRegistry);
 	}
 
@@ -72,16 +67,6 @@ public class ViewHomeRecentAssetsJSPSectionFragmentRenderer
 
 	@Reference
 	private ObjectDefinitionService _objectDefinitionService;
-
-	@Reference
-	private ObjectDefinitionSettingLocalService
-		_objectDefinitionSettingLocalService;
-
-	@Reference(
-		target = "(model.class.name=com.liferay.object.model.ObjectEntryFolder)"
-	)
-	private ModelResourcePermission<ObjectEntryFolder>
-		_objectEntryFolderModelResourcePermission;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewRecycleBinJSPSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewRecycleBinJSPSectionFragmentRenderer.java
@@ -8,12 +8,9 @@ package com.liferay.site.cms.site.initializer.internal.fragment.renderer;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.headless.asset.library.resource.v1_0.AssetLibraryResource;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -52,9 +49,7 @@ public class ViewRecycleBinJSPSectionFragmentRenderer
 			_assetLibraryResourceFactory, _depotEntryLocalService,
 			themeDisplay.getScopeGroupId(), groupLocalService,
 			httpServletRequest, language, _objectDefinitionService,
-			_objectDefinitionSettingLocalService,
-			_objectEntryFolderLocalService,
-			_objectEntryFolderModelResourcePermission, _portal,
+			_objectEntryFolderLocalService, _portal,
 			_searchResultResourceFactory,
 			translationInfoItemFieldValuesExporterRegistry, _trashHelper);
 	}
@@ -74,17 +69,7 @@ public class ViewRecycleBinJSPSectionFragmentRenderer
 	private ObjectDefinitionService _objectDefinitionService;
 
 	@Reference
-	private ObjectDefinitionSettingLocalService
-		_objectDefinitionSettingLocalService;
-
-	@Reference
 	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
-
-	@Reference(
-		target = "(model.class.name=com.liferay.object.model.ObjectEntryFolder)"
-	)
-	private ModelResourcePermission<ObjectEntryFolder>
-		_objectEntryFolderModelResourcePermission;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewRelatedAssetsJSPSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewRelatedAssetsJSPSectionFragmentRenderer.java
@@ -11,11 +11,8 @@ import com.liferay.document.library.configuration.DLConfiguration;
 import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.info.constants.InfoDisplayWebKeys;
 import com.liferay.object.model.ObjectEntry;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.site.cms.site.initializer.internal.display.context.ViewRelatedAssetsSectionDisplayContext;
 
@@ -60,8 +57,7 @@ public class ViewRelatedAssetsJSPSectionFragmentRenderer
 			groupLocalService, httpServletRequest, language,
 			_objectDefinitionLocalService.fetchObjectDefinition(
 				objectEntry.getObjectDefinitionId()),
-			_objectDefinitionService, _objectDefinitionSettingLocalService,
-			objectEntry, _objectEntryFolderModelResourcePermission, _portal,
+			_objectDefinitionService, objectEntry, _portal,
 			translationInfoItemFieldValuesExporterRegistry);
 	}
 
@@ -83,16 +79,6 @@ public class ViewRelatedAssetsJSPSectionFragmentRenderer
 
 	@Reference
 	private ObjectDefinitionService _objectDefinitionService;
-
-	@Reference
-	private ObjectDefinitionSettingLocalService
-		_objectDefinitionSettingLocalService;
-
-	@Reference(
-		target = "(model.class.name=com.liferay.object.model.ObjectEntryFolder)"
-	)
-	private ModelResourcePermission<ObjectEntryFolder>
-		_objectEntryFolderModelResourcePermission;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewSpaceContentsSummaryJSPSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewSpaceContentsSummaryJSPSectionFragmentRenderer.java
@@ -7,12 +7,9 @@ package com.liferay.site.cms.site.initializer.internal.fragment.renderer;
 
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.fragment.renderer.FragmentRenderer;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.site.cms.site.initializer.internal.display.context.ViewSpaceContentsSummarySectionDisplayContext;
@@ -48,9 +45,7 @@ public class ViewSpaceContentsSummaryJSPSectionFragmentRenderer
 			_depotEntryLocalService,
 			InfoItemUtil.getGroupId(httpServletRequest), _groupLocalService,
 			httpServletRequest, _language, _objectDefinitionService,
-			_objectDefinitionSettingLocalService,
-			_objectEntryFolderLocalService,
-			_objectEntryFolderModelResourcePermission, _portal,
+			_objectEntryFolderLocalService, _portal,
 			translationInfoItemFieldValuesExporterRegistry);
 	}
 
@@ -72,17 +67,7 @@ public class ViewSpaceContentsSummaryJSPSectionFragmentRenderer
 	private ObjectDefinitionService _objectDefinitionService;
 
 	@Reference
-	private ObjectDefinitionSettingLocalService
-		_objectDefinitionSettingLocalService;
-
-	@Reference
 	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
-
-	@Reference(
-		target = "(model.class.name=com.liferay.object.model.ObjectEntryFolder)"
-	)
-	private ModelResourcePermission<ObjectEntryFolder>
-		_objectEntryFolderModelResourcePermission;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewSpaceFilesSummaryJSPSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewSpaceFilesSummaryJSPSectionFragmentRenderer.java
@@ -8,13 +8,10 @@ package com.liferay.site.cms.site.initializer.internal.fragment.renderer;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.configuration.DLConfiguration;
 import com.liferay.fragment.renderer.FragmentRenderer;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.site.cms.site.initializer.internal.display.context.ViewSpaceFilesSummarySectionDisplayContext;
@@ -64,9 +61,7 @@ public class ViewSpaceFilesSummaryJSPSectionFragmentRenderer
 			_depotEntryLocalService, _dlConfiguration,
 			InfoItemUtil.getGroupId(httpServletRequest), _groupLocalService,
 			httpServletRequest, _language, _objectDefinitionService,
-			_objectDefinitionSettingLocalService,
-			_objectEntryFolderLocalService,
-			_objectEntryFolderModelResourcePermission, _portal,
+			_objectEntryFolderLocalService, _portal,
 			translationInfoItemFieldValuesExporterRegistry);
 	}
 
@@ -90,17 +85,7 @@ public class ViewSpaceFilesSummaryJSPSectionFragmentRenderer
 	private ObjectDefinitionService _objectDefinitionService;
 
 	@Reference
-	private ObjectDefinitionSettingLocalService
-		_objectDefinitionSettingLocalService;
-
-	@Reference
 	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
-
-	@Reference(
-		target = "(model.class.name=com.liferay.object.model.ObjectEntryFolder)"
-	)
-	private ModelResourcePermission<ObjectEntryFolder>
-		_objectEntryFolderModelResourcePermission;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/ViewAllSectionSystemFDSEntry.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/ViewAllSectionSystemFDSEntry.java
@@ -5,25 +5,15 @@
 
 package com.liferay.site.cms.site.initializer.internal.frontend.data.set;
 
-import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.frontend.data.set.SystemFDSEntry;
-import com.liferay.object.model.ObjectEntryFolder;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
-import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializerFDSNames;
-import com.liferay.site.cms.site.initializer.internal.display.context.SectionDisplayContextHelper;
+import com.liferay.site.cms.site.initializer.internal.display.context.SectionDisplayContextUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import org.osgi.framework.BundleContext;
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Daniel Sanz
@@ -38,14 +28,14 @@ public class ViewAllSectionSystemFDSEntry implements SystemFDSEntry {
 	public String getAdditionalAPIURLParameters(
 		HttpServletRequest httpServletRequest) {
 
-		String filterString = _sectionDisplayContextHelper.appendStatus(
-			_sectionDisplayContextHelper.appendGroupIds(
+		String filterString = SectionDisplayContextUtil.appendStatus(
+			SectionDisplayContextUtil.appendGroupIds(
 				"cmsKind eq 'object' and (cmsSection eq 'contents' or " +
 					"cmsSection eq 'files')",
 				httpServletRequest));
 
 		String additionalAPIURLParameters =
-			_sectionDisplayContextHelper.getAdditionalAPIURLParameters(
+			SectionDisplayContextUtil.getAdditionalAPIURLParameters(
 				filterString, httpServletRequest, null);
 
 		String searchQuery = httpServletRequest.getParameter("q");
@@ -114,37 +104,5 @@ public class ViewAllSectionSystemFDSEntry implements SystemFDSEntry {
 	public String getTitle() {
 		return "All Section";
 	}
-
-	@Activate
-	protected void activate(BundleContext bundleContext) {
-		_sectionDisplayContextHelper = new SectionDisplayContextHelper(
-			_depotEntryLocalService, _groupLocalService, _language,
-			_objectDefinitionSettingLocalService,
-			_objectEntryFolderModelResourcePermission, _portal);
-	}
-
-	@Reference
-	private DepotEntryLocalService _depotEntryLocalService;
-
-	@Reference
-	private GroupLocalService _groupLocalService;
-
-	@Reference
-	private Language _language;
-
-	@Reference
-	private ObjectDefinitionSettingLocalService
-		_objectDefinitionSettingLocalService;
-
-	@Reference(
-		target = "(model.class.name=com.liferay.object.model.ObjectEntryFolder)"
-	)
-	private ModelResourcePermission<ObjectEntryFolder>
-		_objectEntryFolderModelResourcePermission;
-
-	@Reference
-	private Portal _portal;
-
-	private SectionDisplayContextHelper _sectionDisplayContextHelper;
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/action/ViewAllSectionFDSCreationMenu.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/action/ViewAllSectionFDSCreationMenu.java
@@ -5,26 +5,16 @@
 
 package com.liferay.site.cms.site.initializer.internal.frontend.data.set.action;
 
-import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.frontend.data.set.FDSEntryItemImportPolicy;
 import com.liferay.frontend.data.set.action.FDSCreationMenu;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
-import com.liferay.object.model.ObjectEntryFolder;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
-import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
-import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.util.Portal;
 import com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializerFDSNames;
-import com.liferay.site.cms.site.initializer.internal.display.context.SectionDisplayContextHelper;
+import com.liferay.site.cms.site.initializer.internal.display.context.SectionDisplayContextUtil;
 import com.liferay.site.cms.site.initializer.internal.util.ActionUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import org.osgi.framework.BundleContext;
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Daniel Sanz
@@ -37,7 +27,7 @@ public class ViewAllSectionFDSCreationMenu implements FDSCreationMenu {
 
 	@Override
 	public CreationMenu getCreationMenu(HttpServletRequest httpServletRequest) {
-		return _sectionDisplayContextHelper.getCreationMenu(
+		return SectionDisplayContextUtil.getCreationMenu(
 			ActionUtil.getAllSectionCreationMenuDropdownItems(
 				httpServletRequest),
 			httpServletRequest, null);
@@ -47,37 +37,5 @@ public class ViewAllSectionFDSCreationMenu implements FDSCreationMenu {
 	public FDSEntryItemImportPolicy getFDSEntryItemImportPolicy() {
 		return FDSEntryItemImportPolicy.GROUP_PROXY;
 	}
-
-	@Activate
-	protected void activate(BundleContext bundleContext) {
-		_sectionDisplayContextHelper = new SectionDisplayContextHelper(
-			_depotEntryLocalService, _groupLocalService, _language,
-			_objectDefinitionSettingLocalService,
-			_objectEntryFolderModelResourcePermission, _portal);
-	}
-
-	@Reference
-	private DepotEntryLocalService _depotEntryLocalService;
-
-	@Reference
-	private GroupLocalService _groupLocalService;
-
-	@Reference
-	private Language _language;
-
-	@Reference
-	private ObjectDefinitionSettingLocalService
-		_objectDefinitionSettingLocalService;
-
-	@Reference(
-		target = "(model.class.name=com.liferay.object.model.ObjectEntryFolder)"
-	)
-	private ModelResourcePermission<ObjectEntryFolder>
-		_objectEntryFolderModelResourcePermission;
-
-	@Reference
-	private Portal _portal;
-
-	private SectionDisplayContextHelper _sectionDisplayContextHelper;
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/action/ViewAllSectionFDSItemsActions.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/action/ViewAllSectionFDSItemsActions.java
@@ -5,26 +5,16 @@
 
 package com.liferay.site.cms.site.initializer.internal.frontend.data.set.action;
 
-import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.frontend.data.set.action.FDSItemsActions;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
-import com.liferay.object.model.ObjectEntryFolder;
-import com.liferay.object.service.ObjectDefinitionSettingLocalService;
-import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
-import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.util.Portal;
 import com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializerFDSNames;
-import com.liferay.site.cms.site.initializer.internal.display.context.SectionDisplayContextHelper;
+import com.liferay.site.cms.site.initializer.internal.display.context.SectionDisplayContextUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.List;
 
-import org.osgi.framework.BundleContext;
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Daniel Sanz
@@ -39,40 +29,8 @@ public class ViewAllSectionFDSItemsActions implements FDSItemsActions {
 	public List<FDSActionDropdownItem> getFDSActionDropdownItems(
 		HttpServletRequest httpServletRequest) {
 
-		return _sectionDisplayContextHelper.getAllSectionFDSActionDropdownItems(
+		return SectionDisplayContextUtil.getAllSectionFDSActionDropdownItems(
 			httpServletRequest);
 	}
-
-	@Activate
-	protected void activate(BundleContext bundleContext) {
-		_sectionDisplayContextHelper = new SectionDisplayContextHelper(
-			_depotEntryLocalService, _groupLocalService, _language,
-			_objectDefinitionSettingLocalService,
-			_objectEntryFolderModelResourcePermission, _portal);
-	}
-
-	@Reference
-	private DepotEntryLocalService _depotEntryLocalService;
-
-	@Reference
-	private GroupLocalService _groupLocalService;
-
-	@Reference
-	private Language _language;
-
-	@Reference
-	private ObjectDefinitionSettingLocalService
-		_objectDefinitionSettingLocalService;
-
-	@Reference(
-		target = "(model.class.name=com.liferay.object.model.ObjectEntryFolder)"
-	)
-	private ModelResourcePermission<ObjectEntryFolder>
-		_objectEntryFolderModelResourcePermission;
-
-	@Reference
-	private Portal _portal;
-
-	private SectionDisplayContextHelper _sectionDisplayContextHelper;
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_home_quick_actions.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_home_quick_actions.jsp
@@ -11,7 +11,7 @@
 ViewHomeQuickActionsDisplayContext viewHomeQuickActionsDisplayContext = (ViewHomeQuickActionsDisplayContext)request.getAttribute(ViewHomeQuickActionsDisplayContext.class.getName());
 %>
 
-<c:if test="<%= viewHomeQuickActionsDisplayContext.hasAddEntryPermission() %>">
+<c:if test="<%= viewHomeQuickActionsDisplayContext.hasQuickActions() %>">
 	<div class="cms-section">
 		<react:component
 			module="{QuickActions} from site-cms-site-initializer"

--- a/modules/test/playwright/tests/site-cms-site-initializer/permissions/fixtures/cmsPagesTest.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/permissions/fixtures/cmsPagesTest.ts
@@ -8,6 +8,7 @@ import {test} from '@playwright/test';
 import {AssetsPage} from '../../main/pages/AssetsPage';
 import {ContentsPage} from '../../main/pages/ContentsPage';
 import {FolderPage} from '../../main/pages/FolderPage';
+import {HomePage} from '../../main/pages/HomePage';
 import {SpaceSummaryPage} from '../../main/pages/SpaceSummaryPage';
 import {CopyFolderModalPage} from '../pages/CopyFolderModalPage';
 import {DefaultPermissionsPage} from '../pages/DefaultPermissionsPage';
@@ -21,6 +22,7 @@ const cmsPagesTest = test.extend<{
 	defaultPermissionsPage: DefaultPermissionsPage;
 	filesPage: FilesPage;
 	folderPage: FolderPage;
+	homePage: HomePage;
 	permissionsPage: PermissionsPage;
 	spaceSummaryPage: SpaceSummaryPage;
 }>({
@@ -41,6 +43,9 @@ const cmsPagesTest = test.extend<{
 	},
 	folderPage: async ({page}, use) => {
 		await use(new FolderPage(page));
+	},
+	homePage: async ({page}, use) => {
+		await use(new HomePage(page));
 	},
 	permissionsPage: async ({page}, use) => {
 		await use(new PermissionsPage(page));

--- a/modules/test/playwright/tests/site-cms-site-initializer/permissions/vocabularies.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/permissions/vocabularies.spec.ts
@@ -9,6 +9,7 @@ import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import getRandomString from '../../../utils/getRandomString';
+import {performUserSwitch, userData} from '../../../utils/performLogin';
 import {PORTLET_URLS} from '../../../utils/portletUrls';
 import {addRoleMemberAndSwitch} from '../main/spaces/helpers/roleMembership';
 import {cmsPagesTest} from './fixtures/cmsPagesTest';
@@ -48,5 +49,81 @@ test(
 		await expect(
 			page.getByRole('heading', {name: 'Categorization'})
 		).toBeHidden();
+	}
+);
+
+test(
+	'A Space Content Reviewer does not see the Vocabulary Quick Action on the CMS Home Page',
+	{tag: '@LPD-90072'},
+	async ({apiHelpers, homePage, page, spaceSummaryPage}) => {
+		const spaceName = getRandomString();
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {},
+			type: 'Space',
+		});
+
+		await addRoleMemberAndSwitch({
+			apiHelpers,
+			page,
+			role: 'Space Content Reviewer',
+			spaceName,
+			spaceSummaryPage,
+		});
+
+		await homePage.goto();
+
+		await expect(
+			page.getByRole('heading', {name: 'Quick Actions'})
+		).toBeVisible();
+
+		await expect(homePage.vocabularyButton).toBeHidden();
+	}
+);
+
+test(
+	'A CMS Administrator sees the Vocabulary Quick Action on the CMS Home Page',
+	{tag: '@LPD-90072'},
+	async ({apiHelpers, homePage, page, spaceSummaryPage}) => {
+		const spaceName = getRandomString();
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {},
+			type: 'Space',
+		});
+
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		userData[user.alternateName] = {
+			name: user.givenName,
+			password: 'test',
+			surname: user.familyName,
+		};
+
+		const cmsAdministratorRole =
+			await apiHelpers.headlessAdminUser.getRoleByName(
+				'CMS Administrator'
+			);
+
+		await apiHelpers.headlessAdminUser.postRoleUserAccountAssociation(
+			cmsAdministratorRole.id,
+			Number(user.id)
+		);
+
+		await spaceSummaryPage.goto(spaceName);
+
+		await spaceSummaryPage.addUserOrUserGroup(user.name, 'users');
+
+		await performUserSwitch(page, user.alternateName);
+
+		await homePage.goto();
+
+		await expect(
+			page.getByRole('heading', {name: 'Quick Actions'})
+		).toBeVisible();
+
+		await expect(homePage.vocabularyButton).toBeVisible();
 	}
 );


### PR DESCRIPTION
I have included the commits from https://github.com/liferay-content-management/liferay-portal/pull/8282 because we are changing the same quick filters actions.

https://liferay.atlassian.net/browse/LPD-90042

## What is being fixed

Custom Content Structures were appearing in the Home Quick Actions widget for users who had no access to the Space where those structures lived. A user not a member of a private Space could still see the structure name and metadata on their dashboard, exposing information they should not be aware of.

## How it is being fixed

The depot entry group IDs feeding the quick actions list are now sourced through `SectionDisplayContextHelper`, the same helper the All section already uses to filter its creation menu. The list is restricted to Spaces the user can access and on which the user has `ADD_ENTRY` on the relevant `ObjectEntryFolder`, then intersected with each `ObjectDefinition`'s accepted group IDs; structures whose intersection is empty are dropped. `hasAddEntryPermission` is reduced to a non-emptiness check on the filtered list and renamed to `hasQuickActions` so the JSP guard reads literally. The integration test under `site-cms-site-initializer-test` covers the three boundaries (non-member, member, Space Administrator) to lock the regression.