### PR TITLE
LPD-90275 Honor the caller's virtualHostnames map in getCanonicalDomain

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -509,23 +509,23 @@ public class LayoutReferencesExportImportContentProcessor
 					company.getVirtualHostname(), serverPort, false);
 			}
 
-			NavigableMap<String, String> privateVirtualHostnames =
-				privateLayoutSet.getVirtualHostnames();
+			String privateDefaultVirtualHostname =
+				_portal.getDefaultVirtualHostname(false, privateLayoutSet);
 
-			if (!privateVirtualHostnames.isEmpty()) {
+			if (Validator.isNotNull(privateDefaultVirtualHostname)) {
 				privateLayoutSetPortalURL = _portal.getPortalURL(
-					privateVirtualHostnames.firstKey(), serverPort, false);
+					privateDefaultVirtualHostname, serverPort, false);
 			}
 			else {
 				privateLayoutSetPortalURL = companyPortalURL;
 			}
 
-			NavigableMap<String, String> publicVirtualHostnames =
-				publicLayoutSet.getVirtualHostnames();
+			String publicDefaultVirtualHostname =
+				_portal.getDefaultVirtualHostname(false, publicLayoutSet);
 
-			if (!publicVirtualHostnames.isEmpty()) {
+			if (Validator.isNotNull(publicDefaultVirtualHostname)) {
 				publicLayoutSetPortalURL = _portal.getPortalURL(
-					publicVirtualHostnames.firstKey(), serverPort, false);
+					publicDefaultVirtualHostname, serverPort, false);
 			}
 			else {
 				publicLayoutSetPortalURL = companyPortalURL;
@@ -552,20 +552,20 @@ public class LayoutReferencesExportImportContentProcessor
 					company.getVirtualHostname(), secureSecurePort, true);
 			}
 
-			NavigableMap<String, String> privateVirtualHostnames =
-				privateLayoutSet.getVirtualHostnames();
+			String privateDefaultVirtualHostname =
+				_portal.getDefaultVirtualHostname(false, privateLayoutSet);
 
-			if (!privateVirtualHostnames.isEmpty()) {
+			if (Validator.isNotNull(privateDefaultVirtualHostname)) {
 				privateLayoutSetSecurePortalURL = _portal.getPortalURL(
-					privateVirtualHostnames.firstKey(), secureSecurePort, true);
+					privateDefaultVirtualHostname, secureSecurePort, true);
 			}
 
-			NavigableMap<String, String> publicVirtualHostnames =
-				publicLayoutSet.getVirtualHostnames();
+			String publicDefaultVirtualHostname =
+				_portal.getDefaultVirtualHostname(false, publicLayoutSet);
 
-			if (!publicVirtualHostnames.isEmpty()) {
+			if (Validator.isNotNull(publicDefaultVirtualHostname)) {
 				publicLayoutSetSecurePortalURL = _portal.getPortalURL(
-					publicVirtualHostnames.firstKey(), secureSecurePort, true);
+					publicDefaultVirtualHostname, secureSecurePort, true);
 			}
 
 			if (_isDefaultGroup(group)) {
@@ -794,16 +794,15 @@ public class LayoutReferencesExportImportContentProcessor
 			return url;
 		}
 
-		LayoutSet publicLayoutSet = group.getPublicLayoutSet();
-
-		NavigableMap<String, String> publicLayoutSetVirtualHostnames =
-			publicLayoutSet.getVirtualHostnames();
+		String publicLayoutSetDefaultVirtualHostname =
+			_portal.getDefaultVirtualHostname(
+				false, group.getPublicLayoutSet());
 
 		String portalURL = StringPool.BLANK;
 
-		if (!publicLayoutSetVirtualHostnames.isEmpty()) {
+		if (Validator.isNotNull(publicLayoutSetDefaultVirtualHostname)) {
 			portalURL = _portal.getPortalURL(
-				publicLayoutSetVirtualHostnames.firstKey(), serverPort, secure);
+				publicLayoutSetDefaultVirtualHostname, serverPort, secure);
 
 			if (url.startsWith(portalURL)) {
 				if (secure) {
@@ -817,15 +816,13 @@ public class LayoutReferencesExportImportContentProcessor
 			}
 		}
 
-		LayoutSet privateLayoutSet = group.getPrivateLayoutSet();
+		String privateLayoutSetDefaultVirtualHostname =
+			_portal.getDefaultVirtualHostname(
+				false, group.getPrivateLayoutSet());
 
-		NavigableMap<String, String> privateLayoutSetVirtualHostnames =
-			privateLayoutSet.getVirtualHostnames();
-
-		if (!privateLayoutSetVirtualHostnames.isEmpty()) {
+		if (Validator.isNotNull(privateLayoutSetDefaultVirtualHostname)) {
 			portalURL = _portal.getPortalURL(
-				privateLayoutSetVirtualHostnames.firstKey(), serverPort,
-				secure);
+				privateLayoutSetDefaultVirtualHostname, serverPort, secure);
 
 			if (url.startsWith(portalURL)) {
 				if (secure) {

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/LayoutReferencesExportImportContentProcessorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/LayoutReferencesExportImportContentProcessorTest.java
@@ -60,7 +60,6 @@ import com.liferay.segments.service.SegmentsExperienceLocalService;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
-import java.util.NavigableMap;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -1044,12 +1043,9 @@ public class LayoutReferencesExportImportContentProcessorTest {
 			layoutSet = group.getPublicLayoutSet();
 		}
 
-		NavigableMap<String, String> virtualHostnames =
-			layoutSet.getVirtualHostnames();
-
 		return _portal.getPortalURL(
-			virtualHostnames.firstKey(), _portal.getPortalServerPort(false),
-			false);
+			_portal.getDefaultVirtualHostname(false, layoutSet),
+			_portal.getPortalServerPort(false), false);
 	}
 
 	private static final String _CONTENT_POSTFIX = "\">link</a>";

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/util/ExportImportContentProcessorTestUtil.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/util/ExportImportContentProcessorTestUtil.java
@@ -35,7 +35,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.NavigableMap;
 import java.util.Scanner;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -145,14 +144,7 @@ public class ExportImportContentProcessorTestUtil {
 		}
 
 		LayoutSet sourcePrivateLayoutSet = sourceGroup.getPrivateLayoutSet();
-
-		NavigableMap<String, String> sourcePrivateVirtualHostnames =
-			sourcePrivateLayoutSet.getVirtualHostnames();
-
 		LayoutSet sourcePublicLayoutSet = sourceGroup.getPublicLayoutSet();
-
-		NavigableMap<String, String> sourcePublicVirtualHostnames =
-			sourcePublicLayoutSet.getVirtualHostnames();
 
 		String targetPublicLayoutFriendlyURL = "";
 		String targetPublicLayoutLocaleFriendlyURL = "";
@@ -214,8 +206,10 @@ public class ExportImportContentProcessorTestUtil {
 				String.valueOf(fileEntry.getGroupId()),
 				StringUtil.removeFirst(
 					sourceGroup.getFriendlyURL(), StringPool.SLASH),
-				sourcePrivateVirtualHostnames.firstKey(),
-				sourcePublicVirtualHostnames.firstKey(),
+				PortalUtil.getDefaultVirtualHostname(
+					false, sourcePrivateLayoutSet),
+				PortalUtil.getDefaultVirtualHostname(
+					false, sourcePublicLayoutSet),
 				String.valueOf(fileEntry.getFileEntryId()),
 				targetGroup.getFriendlyURL(),
 				String.valueOf(targetGroup.getGroupId()),

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
@@ -1680,14 +1680,8 @@ public class LayoutsAdminDisplayContext {
 			return StringPool.BLANK;
 		}
 
-		String virtualHostname = null;
-
-		NavigableMap<String, String> virtualHostnames =
-			PortalUtil.getVirtualHostnames(layoutSet);
-
-		if (!virtualHostnames.isEmpty()) {
-			virtualHostname = virtualHostnames.firstKey();
-		}
+		String virtualHostname = PortalUtil.getDefaultVirtualHostname(
+			true, layoutSet);
 
 		Group scopeGroup = themeDisplay.getScopeGroup();
 
@@ -1700,14 +1694,8 @@ public class LayoutsAdminDisplayContext {
 				liveGroupLayoutSet = liveGroup.getPrivateLayoutSet();
 			}
 
-			virtualHostname = null;
-
-			virtualHostnames = PortalUtil.getVirtualHostnames(
-				liveGroupLayoutSet);
-
-			if (!virtualHostnames.isEmpty()) {
-				virtualHostname = virtualHostnames.firstKey();
-			}
+			virtualHostname = PortalUtil.getDefaultVirtualHostname(
+				true, liveGroupLayoutSet);
 		}
 
 		return virtualHostname;

--- a/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/internal/util/AlternateURLMapperProvider.java
+++ b/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/internal/util/AlternateURLMapperProvider.java
@@ -25,7 +25,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.NavigableMap;
 import java.util.Set;
 
 /**
@@ -159,14 +158,8 @@ public class AlternateURLMapperProvider {
 		}
 
 		private String _getPortalURL(ThemeDisplay themeDisplay) {
-			NavigableMap<String, String> virtualHostnames =
-				_portal.getVirtualHostnames(themeDisplay.getLayoutSet());
-
-			String virtualHostname = null;
-
-			if (!virtualHostnames.isEmpty()) {
-				virtualHostname = virtualHostnames.firstKey();
-			}
+			String virtualHostname = _portal.getDefaultVirtualHostname(
+				true, themeDisplay.getLayoutSet());
 
 			if (Validator.isNull(virtualHostname)) {
 				virtualHostname = "localhost";

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplAlternateURLTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplAlternateURLTest.java
@@ -65,7 +65,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.NavigableMap;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -511,17 +510,17 @@ public class PortalImplAlternateURLTest {
 
 		LayoutSet layoutSet = group.getPublicLayoutSet();
 
-		NavigableMap<String, String> virtualHostnames =
-			layoutSet.getVirtualHostnames();
+		String defaultVirtualHostname = _portal.getDefaultVirtualHostname(
+			false, layoutSet);
 
-		if (virtualHostnames.isEmpty()) {
+		if (Validator.isNull(defaultVirtualHostname)) {
 			return _generateLayoutURL(
 				defaultLocale, friendlyURL, _group.getFriendlyURL(), locale,
 				portalURL, portletPreferences);
 		}
 
 		return StringBundler.concat(
-			"http://", virtualHostnames.firstKey(), ":8080",
+			"http://", defaultVirtualHostname, ":8080",
 			_getI18nPath(defaultLocale, locale, portletPreferences),
 			friendlyURL);
 	}

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplGetDefaultVirtualHostnameTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplGetDefaultVirtualHostnameTest.java
@@ -1,0 +1,122 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.util.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.service.LayoutSetLocalService;
+import com.liferay.portal.kernel.service.VirtualHostLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.TreeMapBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.TreeMap;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+@RunWith(Arquillian.class)
+public class PortalImplGetDefaultVirtualHostnameTest
+	extends BasePortalImplURLTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	@TestInfo("LPD-90275")
+	public void testGetDefaultVirtualHostname() throws Exception {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"VIRTUAL_HOSTS_DEFAULT_SITE_NAME", group.getName())) {
+
+			_testGetDefaultVirtualHostname(false, StringPool.BLANK);
+
+			LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
+				group.getGroupId(), false);
+
+			String companyFallbackVirtualHostname =
+				layoutSet.getCompanyFallbackVirtualHostname();
+
+			Assert.assertNotNull(companyFallbackVirtualHostname);
+
+			_testGetDefaultVirtualHostname(
+				true, companyFallbackVirtualHostname);
+		}
+	}
+
+	private void _testGetDefaultVirtualHostname(
+			boolean companyFallback, String expectedDefaultVirtualHostname)
+		throws Exception {
+
+		LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
+			group.getGroupId(), false);
+
+		_virtualHostLocalService.updateVirtualHosts(
+			company.getCompanyId(), layoutSet.getLayoutSetId(),
+			new TreeMap<>());
+
+		Assert.assertEquals(
+			expectedDefaultVirtualHostname,
+			portal.getDefaultVirtualHostname(
+				companyFallback,
+				_layoutSetLocalService.getLayoutSet(
+					layoutSet.getLayoutSetId())));
+
+		String defaultVirtualHostname = "z-" + RandomTestUtil.randomString();
+
+		_virtualHostLocalService.updateVirtualHosts(
+			company.getCompanyId(), layoutSet.getLayoutSetId(),
+			TreeMapBuilder.put(
+				"a-" + RandomTestUtil.randomString(),
+				LocaleUtil.toLanguageId(LocaleUtil.US)
+			).put(
+				defaultVirtualHostname, StringPool.BLANK
+			).build());
+
+		Assert.assertEquals(
+			defaultVirtualHostname,
+			portal.getDefaultVirtualHostname(
+				false,
+				_layoutSetLocalService.getLayoutSet(
+					layoutSet.getLayoutSetId())));
+
+		_virtualHostLocalService.updateVirtualHosts(
+			company.getCompanyId(), layoutSet.getLayoutSetId(),
+			TreeMapBuilder.put(
+				RandomTestUtil.randomString(),
+				LocaleUtil.toLanguageId(LocaleUtil.US)
+			).build());
+
+		Assert.assertEquals(
+			expectedDefaultVirtualHostname,
+			portal.getDefaultVirtualHostname(
+				companyFallback,
+				_layoutSetLocalService.getLayoutSet(
+					layoutSet.getLayoutSetId())));
+	}
+
+	@Inject
+	private LayoutSetLocalService _layoutSetLocalService;
+
+	@Inject
+	private VirtualHostLocalService _virtualHostLocalService;
+
+}

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/client/model/util/ExperimentUtil.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/client/model/util/ExperimentUtil.java
@@ -10,7 +10,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
@@ -39,7 +38,6 @@ import com.liferay.segments.service.SegmentsExperienceLocalService;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.NavigableMap;
 
 /**
  * @author Sarai Díaz
@@ -195,17 +193,10 @@ public class ExperimentUtil {
 			}
 		}
 
-		String virtualHostname = null;
+		String virtualHostname = portal.getDefaultVirtualHostname(
+			false, layout.getLayoutSet());
 
-		LayoutSet layoutSet = layout.getLayoutSet();
-
-		NavigableMap<String, String> virtualHostnames =
-			layoutSet.getVirtualHostnames();
-
-		if (!virtualHostnames.isEmpty()) {
-			virtualHostname = virtualHostnames.firstKey();
-		}
-		else {
+		if (Validator.isNull(virtualHostname)) {
 			Company company = companyLocalService.getCompany(
 				layout.getCompanyId());
 

--- a/portal-impl/src/com/liferay/portal/model/impl/CompanyImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/CompanyImpl.java
@@ -15,7 +15,6 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.CompanyInfo;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.VirtualHost;
 import com.liferay.portal.kernel.model.cache.CacheField;
@@ -34,7 +33,6 @@ import com.liferay.portal.kernel.util.Validator;
 import java.security.Key;
 
 import java.util.Locale;
-import java.util.NavigableMap;
 import java.util.TimeZone;
 
 /**
@@ -190,27 +188,25 @@ public class CompanyImpl extends CompanyBaseImpl {
 		Group group = GroupLocalServiceUtil.getGroup(groupId);
 
 		if (group.hasPublicLayouts()) {
-			LayoutSet layoutSet = LayoutSetLocalServiceUtil.getLayoutSet(
-				groupId, false);
+			String defaultVirtualHostname =
+				PortalUtil.getDefaultVirtualHostname(
+					false,
+					LayoutSetLocalServiceUtil.getLayoutSet(groupId, false));
 
-			NavigableMap<String, String> virtualHostnames =
-				layoutSet.getVirtualHostnames();
-
-			if (!virtualHostnames.isEmpty()) {
+			if (Validator.isNotNull(defaultVirtualHostname)) {
 				portalURL = PortalUtil.getPortalURL(
-					virtualHostnames.firstKey(), portalServerPort, false);
+					defaultVirtualHostname, portalServerPort, false);
 			}
 		}
 		else if (group.hasPrivateLayouts()) {
-			LayoutSet layoutSet = LayoutSetLocalServiceUtil.getLayoutSet(
-				groupId, true);
+			String defaultVirtualHostname =
+				PortalUtil.getDefaultVirtualHostname(
+					false,
+					LayoutSetLocalServiceUtil.getLayoutSet(groupId, true));
 
-			NavigableMap<String, String> virtualHostnames =
-				layoutSet.getVirtualHostnames();
-
-			if (!virtualHostnames.isEmpty()) {
+			if (Validator.isNotNull(defaultVirtualHostname)) {
 				portalURL = PortalUtil.getPortalURL(
-					virtualHostnames.firstKey(), portalServerPort, false);
+					defaultVirtualHostname, portalServerPort, false);
 			}
 		}
 
@@ -230,15 +226,13 @@ public class CompanyImpl extends CompanyBaseImpl {
 			return portalURL;
 		}
 
-		LayoutSet layoutSet = LayoutSetLocalServiceUtil.getLayoutSet(
-			groupId, privateLayout);
+		String defaultVirtualHostname = PortalUtil.getDefaultVirtualHostname(
+			false,
+			LayoutSetLocalServiceUtil.getLayoutSet(groupId, privateLayout));
 
-		NavigableMap<String, String> virtualHostnames =
-			layoutSet.getVirtualHostnames();
-
-		if (!virtualHostnames.isEmpty()) {
+		if (Validator.isNotNull(defaultVirtualHostname)) {
 			portalURL = PortalUtil.getPortalURL(
-				virtualHostnames.firstKey(), portalServerPort, false);
+				defaultVirtualHostname, portalServerPort, false);
 		}
 
 		return portalURL;

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -2920,8 +2920,8 @@ public class PortalImpl implements Portal {
 			String portalDomain = portalURL.substring(index + 3);
 
 			String virtualHostname = getCanonicalDomain(
-				virtualHostnames, portalDomain, defaultVirtualHostname,
-				layoutSet);
+				defaultVirtualHostname, layoutSet, portalDomain,
+				virtualHostnames);
 
 			virtualHostname = getPortalURL(
 				virtualHostname, portalPort, secureConnection);
@@ -6804,8 +6804,8 @@ public class PortalImpl implements Portal {
 	}
 
 	protected String getCanonicalDomain(
-		NavigableMap<String, String> virtualHostnames, String portalDomain,
-		String defaultVirtualHostname, LayoutSet layoutSet) {
+		String defaultVirtualHostname, LayoutSet layoutSet, String portalDomain,
+		NavigableMap<String, String> virtualHostnames) {
 
 		if (Validator.isBlank(portalDomain) ||
 			StringUtil.equalsIgnoreCase(portalDomain, defaultVirtualHostname) ||
@@ -7672,8 +7672,8 @@ public class PortalImpl implements Portal {
 						!virtualHostnames.containsKey(defaultVirtualHostname)) {
 
 						String virtualHostname = getCanonicalDomain(
-							virtualHostnames, portalDomain,
-							defaultVirtualHostname, layoutSet);
+							defaultVirtualHostname, layoutSet, portalDomain,
+							virtualHostnames);
 
 						portalURL = getPortalURL(
 							virtualHostname, themeDisplay.getServerPort(),

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1222,8 +1222,7 @@ public class PortalImpl implements Portal {
 		NavigableMap<String, String> virtualHostnames = getVirtualHostnames(
 			themeDisplay.getLayoutSet());
 
-		String virtualHostname = _getVirtualHostname(
-			virtualHostnames, themeDisplay);
+		String virtualHostname = _getVirtualHostname(themeDisplay);
 
 		if ((!Validator.isBlank(portalDomain) &&
 			 !StringUtil.equalsIgnoreCase(
@@ -2832,17 +2831,10 @@ public class PortalImpl implements Portal {
 			}
 		}
 
-		String virtualHostname = null;
+		String virtualHostname = getDefaultVirtualHostname(
+			false, layout.getLayoutSet());
 
-		LayoutSet layoutSet = layout.getLayoutSet();
-
-		NavigableMap<String, String> virtualHostnames =
-			layoutSet.getVirtualHostnames();
-
-		if (!virtualHostnames.isEmpty()) {
-			virtualHostname = virtualHostnames.firstKey();
-		}
-		else {
+		if (Validator.isNull(virtualHostname)) {
 			Company company = CompanyLocalServiceUtil.getCompany(
 				layout.getCompanyId());
 
@@ -2928,7 +2920,8 @@ public class PortalImpl implements Portal {
 			String portalDomain = portalURL.substring(index + 3);
 
 			String virtualHostname = getCanonicalDomain(
-				virtualHostnames, portalDomain, defaultVirtualHostname);
+				virtualHostnames, portalDomain, defaultVirtualHostname,
+				layoutSet);
 
 			virtualHostname = getPortalURL(
 				virtualHostname, portalPort, secureConnection);
@@ -2972,14 +2965,7 @@ public class PortalImpl implements Portal {
 		String defaultVirtualHostname = _getDefaultVirtualHostname(
 			themeDisplay.getCompany());
 
-		String virtualHostname = null;
-
-		NavigableMap<String, String> virtualHostnames = getVirtualHostnames(
-			layoutSet);
-
-		if (!virtualHostnames.isEmpty()) {
-			virtualHostname = virtualHostnames.firstKey();
-		}
+		String virtualHostname = getDefaultVirtualHostname(true, layoutSet);
 
 		if (Validator.isNotNull(virtualHostname) &&
 			!StringUtil.equalsIgnoreCase(
@@ -6819,13 +6805,20 @@ public class PortalImpl implements Portal {
 
 	protected String getCanonicalDomain(
 		NavigableMap<String, String> virtualHostnames, String portalDomain,
-		String defaultVirtualHostname) {
+		String defaultVirtualHostname, LayoutSet layoutSet) {
 
 		if (Validator.isBlank(portalDomain) ||
 			StringUtil.equalsIgnoreCase(portalDomain, defaultVirtualHostname) ||
 			!virtualHostnames.containsKey(defaultVirtualHostname)) {
 
-			return virtualHostnames.firstKey();
+			String virtualHostname = getDefaultVirtualHostname(
+				false, layoutSet);
+
+			if (Validator.isNotNull(virtualHostname)) {
+				return virtualHostname;
+			}
+
+			return defaultVirtualHostname;
 		}
 
 		int pos = portalDomain.indexOf(CharPool.COLON);
@@ -7615,7 +7608,7 @@ public class PortalImpl implements Portal {
 								virtualHostnames, portalDomain)) {
 
 							portalURL = getPortalURL(
-								virtualHostnames.firstKey(),
+								getDefaultVirtualHostname(true, layoutSet),
 								themeDisplay.getServerPort(),
 								themeDisplay.isSecure());
 						}
@@ -7680,7 +7673,7 @@ public class PortalImpl implements Portal {
 
 						String virtualHostname = getCanonicalDomain(
 							virtualHostnames, portalDomain,
-							defaultVirtualHostname);
+							defaultVirtualHostname, layoutSet);
 
 						portalURL = getPortalURL(
 							virtualHostname, themeDisplay.getServerPort(),
@@ -8072,17 +8065,17 @@ public class PortalImpl implements Portal {
 		).build();
 	}
 
-	private String _getVirtualHostname(
-		NavigableMap<String, String> virtualHostnames,
-		ThemeDisplay themeDisplay) {
+	private String _getVirtualHostname(ThemeDisplay themeDisplay) {
+		String virtualHostname = getDefaultVirtualHostname(
+			true, themeDisplay.getLayoutSet());
 
-		if (virtualHostnames.isEmpty()) {
-			Company company = themeDisplay.getCompany();
-
-			return company.getVirtualHostname();
+		if (Validator.isNotNull(virtualHostname)) {
+			return virtualHostname;
 		}
 
-		return virtualHostnames.firstKey();
+		Company company = themeDisplay.getCompany();
+
+		return company.getVirtualHostname();
 	}
 
 	private boolean _isSignedIn(HttpServletRequest httpServletRequest) {

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -6811,6 +6811,14 @@ public class PortalImpl implements Portal {
 			StringUtil.equalsIgnoreCase(portalDomain, defaultVirtualHostname) ||
 			!virtualHostnames.containsKey(defaultVirtualHostname)) {
 
+			for (Map.Entry<String, String> entry :
+					virtualHostnames.entrySet()) {
+
+				if (Validator.isNull(entry.getValue())) {
+					return entry.getKey();
+				}
+			}
+
 			String virtualHostname = getDefaultVirtualHostname(
 				false, layoutSet);
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -2271,6 +2271,26 @@ public class PortalImpl implements Portal {
 	}
 
 	@Override
+	public String getDefaultVirtualHostname(
+		boolean companyFallback, LayoutSet layoutSet) {
+
+		NavigableMap<String, String> virtualHostnames =
+			layoutSet.getVirtualHostnames();
+
+		for (Map.Entry<String, String> entry : virtualHostnames.entrySet()) {
+			if (Validator.isNull(entry.getValue())) {
+				return entry.getKey();
+			}
+		}
+
+		if (companyFallback) {
+			return layoutSet.getCompanyFallbackVirtualHostname();
+		}
+
+		return StringPool.BLANK;
+	}
+
+	@Override
 	public String getEmailFromAddress(
 		PortletPreferences portletPreferences, long companyId,
 		String defaultValue) {

--- a/portal-impl/src/com/liferay/portal/util/RobotsUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/RobotsUtil.java
@@ -5,7 +5,6 @@
 
 package com.liferay.portal.util;
 
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -17,8 +16,6 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.io.IOException;
-
-import java.util.NavigableMap;
 
 /**
  * @author David Truong
@@ -45,14 +42,8 @@ public class RobotsUtil {
 
 		int portalServerPort = PortalUtil.getPortalServerPort(secure);
 
-		NavigableMap<String, String> virtualHostnames =
-			PortalUtil.getVirtualHostnames(layoutSet);
-
-		String virtualHostname = StringPool.BLANK;
-
-		if (!virtualHostnames.isEmpty()) {
-			virtualHostname = virtualHostnames.firstKey();
-		}
+		String virtualHostname = GetterUtil.getString(
+			PortalUtil.getDefaultVirtualHostname(true, layoutSet));
 
 		String robotsTxt = null;
 

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 78.0.0
+version 79.0.0

--- a/portal-impl/test/unit/com/liferay/portal/util/PortalImplUnitTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/util/PortalImplUnitTest.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.upgrade.MockPortletPreferences;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LayoutTypePortletFactoryUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.ProxyFactory;
@@ -150,6 +151,56 @@ public class PortalImplUnitTest {
 		portalUtilMockedStatic.close();
 
 		_assertActionResponse(actionResponse, params);
+	}
+
+	@Test
+	@TestInfo("LPD-90275")
+	public void testGetCanonicalDomain() {
+		String defaultVirtualHostname = "localhost";
+
+		String hostname = "z-" + RandomTestUtil.randomString();
+
+		String portalDomain = hostname + ":8080";
+
+		LayoutSet layoutSet = new LayoutSetImpl();
+
+		layoutSet.setVirtualHostnames(Collections.emptyNavigableMap());
+
+		Assert.assertEquals(
+			defaultVirtualHostname,
+			_portalImpl.getCanonicalDomain(
+				defaultVirtualHostname, layoutSet, portalDomain,
+				Collections.emptyNavigableMap()));
+
+		Assert.assertEquals(
+			hostname,
+			_portalImpl.getCanonicalDomain(
+				defaultVirtualHostname, layoutSet, portalDomain,
+				TreeMapBuilder.put(
+					hostname, StringPool.BLANK
+				).build()));
+
+		String languageSpecificHostname = "a-" + RandomTestUtil.randomString();
+
+		Assert.assertEquals(
+			hostname,
+			_portalImpl.getCanonicalDomain(
+				defaultVirtualHostname, layoutSet, portalDomain,
+				TreeMapBuilder.put(
+					hostname, StringPool.BLANK
+				).put(
+					languageSpecificHostname,
+					LocaleUtil.toLanguageId(LocaleUtil.US)
+				).build()));
+
+		Assert.assertEquals(
+			defaultVirtualHostname,
+			_portalImpl.getCanonicalDomain(
+				defaultVirtualHostname, layoutSet, portalDomain,
+				TreeMapBuilder.put(
+					languageSpecificHostname,
+					LocaleUtil.toLanguageId(LocaleUtil.US)
+				).build()));
 	}
 
 	@Test

--- a/portal-impl/test/unit/com/liferay/portal/util/PortalImplUnitTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/util/PortalImplUnitTest.java
@@ -325,7 +325,7 @@ public class PortalImplUnitTest {
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest();
 
-		int portalServerPort = PortalUtil.getPortalServerPort(false);
+		int portalServerPort = _portalImpl.getPortalServerPort(false);
 
 		mockHttpServletRequest.setServerPort(portalServerPort);
 
@@ -353,10 +353,11 @@ public class PortalImplUnitTest {
 
 			mockHttpServletRequest.addHeader("X-Forwarded-Custom-Port", 8081);
 			mockHttpServletRequest.setServerPort(
-				PortalUtil.getPortalServerPort(false));
+				_portalImpl.getPortalServerPort(false));
 
 			Assert.assertEquals(
-				8080, _portalImpl.getForwardedPort(mockHttpServletRequest));
+				_portalImpl.getPortalServerPort(false),
+				_portalImpl.getForwardedPort(mockHttpServletRequest));
 		}
 		finally {
 			setPropsValuesValue(
@@ -383,10 +384,11 @@ public class PortalImplUnitTest {
 
 			mockHttpServletRequest.addHeader("X-Forwarded-Port", 8081);
 			mockHttpServletRequest.setServerPort(
-				PortalUtil.getPortalServerPort(false));
+				_portalImpl.getPortalServerPort(false));
 
 			Assert.assertEquals(
-				8080, _portalImpl.getForwardedPort(mockHttpServletRequest));
+				_portalImpl.getPortalServerPort(false),
+				_portalImpl.getForwardedPort(mockHttpServletRequest));
 		}
 		finally {
 			setPropsValuesValue(
@@ -410,7 +412,7 @@ public class PortalImplUnitTest {
 
 			mockHttpServletRequest.addHeader("X-Forwarded-Port", "8081");
 			mockHttpServletRequest.setServerPort(
-				PortalUtil.getPortalServerPort(false));
+				_portalImpl.getPortalServerPort(false));
 
 			Assert.assertEquals(
 				8081, _portalImpl.getForwardedPort(mockHttpServletRequest));
@@ -442,7 +444,7 @@ public class PortalImplUnitTest {
 
 		_assertGetLayoutSetFriendlyURL(
 			"/web/test-group",
-			"http://liferay.com:" + PortalUtil.getPortalServerPort(false),
+			"http://liferay.com:" + _portalImpl.getPortalServerPort(false),
 			false, new TreeMap<>());
 	}
 
@@ -454,8 +456,8 @@ public class PortalImplUnitTest {
 
 		_assertGetLayoutSetFriendlyURL(
 			"/group/test-group",
-			"http://liferay.com:" + PortalUtil.getPortalServerPort(false), true,
-			new TreeMap<>());
+			"http://liferay.com:" + _portalImpl.getPortalServerPort(false),
+			true, new TreeMap<>());
 	}
 
 	@Test
@@ -466,8 +468,8 @@ public class PortalImplUnitTest {
 
 		_assertGetLayoutSetFriendlyURL(
 			"/user/test-group",
-			"http://liferay.com:" + PortalUtil.getPortalServerPort(false), true,
-			new TreeMap<>());
+			"http://liferay.com:" + _portalImpl.getPortalServerPort(false),
+			true, new TreeMap<>());
 	}
 
 	@Test
@@ -478,7 +480,7 @@ public class PortalImplUnitTest {
 
 		_assertGetLayoutSetFriendlyURL(
 			"/web/test-group",
-			"http://liferay.com:" + PortalUtil.getPortalServerPort(false),
+			"http://liferay.com:" + _portalImpl.getPortalServerPort(false),
 			false,
 			TreeMapBuilder.put(
 				"test.com", StringPool.BLANK
@@ -491,8 +493,8 @@ public class PortalImplUnitTest {
 
 		_setUpPortalImpl(StringPool.BLANK);
 
-		String portalURL =
-			"http://test.com:" + PortalUtil.getPortalServerPort(false);
+		String portalURL = _portalImpl.getPortalURL(
+			"test.com", _portalImpl.getPortalServerPort(false), false);
 
 		_assertGetLayoutSetFriendlyURL(
 			portalURL, portalURL, false,
@@ -509,7 +511,7 @@ public class PortalImplUnitTest {
 
 		_assertGetLayoutSetFriendlyURL(
 			"/context-path/web/test-group",
-			"http://liferay.com:" + PortalUtil.getPortalServerPort(false) +
+			"http://liferay.com:" + _portalImpl.getPortalServerPort(false) +
 				"/context-path",
 			false,
 			TreeMapBuilder.put(
@@ -523,12 +525,13 @@ public class PortalImplUnitTest {
 
 		_setUpPortalImpl("context-path");
 
-		String portalURL =
-			"http://test.com:" + PortalUtil.getPortalServerPort(false) +
-				"/context-path";
+		String portalURL = _portalImpl.getPortalURL(
+			"test.com", _portalImpl.getPortalServerPort(false), false);
+
+		String portalURLWithContextPath = portalURL + "/context-path";
 
 		_assertGetLayoutSetFriendlyURL(
-			portalURL, portalURL, false,
+			portalURLWithContextPath, portalURLWithContextPath, false,
 			TreeMapBuilder.put(
 				"test.com", StringPool.BLANK
 			).build());
@@ -549,7 +552,7 @@ public class PortalImplUnitTest {
 
 			_assertGetLayoutSetFriendlyURL(
 				"/test-group",
-				"http://liferay.com:" + PortalUtil.getPortalServerPort(false) +
+				"http://liferay.com:" + _portalImpl.getPortalServerPort(false) +
 					"",
 				false, new TreeMap<>());
 		}
@@ -575,7 +578,7 @@ public class PortalImplUnitTest {
 
 			_assertGetLayoutSetFriendlyURL(
 				"/context-path/test-group",
-				"http://liferay.com:" + PortalUtil.getPortalServerPort(false) +
+				"http://liferay.com:" + _portalImpl.getPortalServerPort(false) +
 					"/context-path",
 				false, new TreeMap<>());
 		}
@@ -601,7 +604,7 @@ public class PortalImplUnitTest {
 
 			_assertGetLayoutSetFriendlyURL(
 				"/group/test-group",
-				"http://liferay.com:" + PortalUtil.getPortalServerPort(false),
+				"http://liferay.com:" + _portalImpl.getPortalServerPort(false),
 				true, new TreeMap<>());
 		}
 		finally {
@@ -626,7 +629,7 @@ public class PortalImplUnitTest {
 
 			_assertGetLayoutSetFriendlyURL(
 				"/user/test-group",
-				"http://liferay.com:" + PortalUtil.getPortalServerPort(false),
+				"http://liferay.com:" + _portalImpl.getPortalServerPort(false),
 				true, new TreeMap<>());
 		}
 		finally {
@@ -651,7 +654,7 @@ public class PortalImplUnitTest {
 
 			_assertGetLayoutSetFriendlyURL(
 				"/test-group",
-				"http://liferay.com:" + PortalUtil.getPortalServerPort(false),
+				"http://liferay.com:" + _portalImpl.getPortalServerPort(false),
 				false,
 				TreeMapBuilder.put(
 					"test.com", StringPool.BLANK
@@ -679,7 +682,7 @@ public class PortalImplUnitTest {
 
 			_assertGetLayoutSetFriendlyURL(
 				"/web/test-group",
-				"http://liferay.com:" + PortalUtil.getPortalServerPort(false),
+				"http://liferay.com:" + _portalImpl.getPortalServerPort(false),
 				false, new TreeMap<>());
 		}
 		finally {
@@ -1020,7 +1023,7 @@ public class PortalImplUnitTest {
 		themeDisplay.setRefererGroupId(0);
 		themeDisplay.setRefererPlid(0);
 		themeDisplay.setSecure(false);
-		themeDisplay.setServerPort(PortalUtil.getPortalServerPort(false));
+		themeDisplay.setServerPort(_portalImpl.getPortalServerPort(false));
 		themeDisplay.setURLPortal(portalURL);
 
 		Assert.assertEquals(

--- a/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
@@ -571,6 +571,9 @@ public interface Portal {
 
 	public long getDefaultCompanyId();
 
+	public String getDefaultVirtualHostname(
+		boolean companyFallback, LayoutSet layoutSet);
+
 	public String getEmailFromAddress(
 		PortletPreferences portletPreferences, long companyId,
 		String defaultValue);

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
@@ -773,6 +773,12 @@ public class PortalUtil {
 		return _portal.getDefaultCompanyId();
 	}
 
+	public static String getDefaultVirtualHostname(
+		boolean companyFallback, LayoutSet layoutSet) {
+
+		return _portal.getDefaultVirtualHostname(companyFallback, layoutSet);
+	}
+
 	public static String getEmailFromAddress(
 		PortletPreferences portletPreferences, long companyId,
 		String defaultValue) {


### PR DESCRIPTION

Re-submits [LPD-90275](https://liferay.atlassian.net/browse/LPD-90275) after the previous merge was reverted. The six original commits are re-applied unchanged; three new commits on top address the regression that triggered the revert and the side-effect it surfaced.

Previously:

- Original merge: <https://github.com/brianchandotcom/liferay-portal/pull/174880>
- Revert: <https://github.com/brianchandotcom/liferay-portal/pull/174986>

The original change introduced `Portal#getDefaultVirtualHostname(boolean companyFallback, LayoutSet layoutSet)` and migrated the `NavigableMap#firstKey()` callsites in `PortalImpl` so that the default-language entry wins over the alphabetically-first hostname.

After the merge, the playwright smoke test `portalSmoke.spec.ts` started failing on CI slaves that serve the portal on `i-<instance>:8080` (a host different from the company default `localhost`). The trace showed every entry in the applications menu pointing at `http://localhost:8080/...` while the user was browsing `http://i-<instance>:8080/...`.

## Root cause

`_getGroupFriendlyURL`, when building a cross-site URL to a Control Panel layout served on a host other than the company default, constructs a synthetic `{serverName -> ""}` map and hands it to `getCanonicalDomain`. After the refactor, `getCanonicalDomain` falls back to `getDefaultVirtualHostname(false, layoutSet)`, which reads the layout set's model map directly. For the Control Panel that map is empty, so the canonical host collapses to `Company#virtualHostname` (`localhost`). The synthetic information the caller had just constructed gets dropped on the floor. Before the refactor, `virtualHostnames.firstKey()` returned the synthetic entry directly, masking the issue.

## What's new in this reland

| Commit | What it does |
| --- | --- |
| `LPD-90275 Honor the caller's virtualHostnames map in getCanonicalDomain` | Iterates the provided map first and returns the default-language entry when present, preserving the synthetic hostname before falling back to the layout set lookup. |
| `LPD-90275 Cover getCanonicalDomain with a synthetic virtualHostnames map` | Unit test in `PortalImplUnitTest` covering empty map, single synthetic entry, mixed synthetic + language-specific, and language-specific only. |
| `LPD-90275 Fix PortalImplUnitTest test failures, making the tests port-agnostic` | Pre-existing breakage I noticed along the way: `PortalImplUnitTest` has never run cleanly in isolation. 17 tests route every port lookup through the `PortalUtil` static facade, which expects `PortalUtil._portal` to be primed by a sibling test in the suite, and 4 assertions hard-code `8080` or `:port` segments that only match when `WEB_SERVER_HTTP_PORT` happened to be configured. Under `ant test-unit` both are primed incidentally; under `ant test-class -Dtest.class=PortalImplUnitTest` (and IDE invocations) the class fails with 17 `NullPointerException`s plus 4 assertion mismatches. The new `testGetCanonicalDomain` does not depend on either — but running the class in isolation to validate it surfaced the latent failures, so this commit drops the facade indirection and derives expected URLs from `_portalImpl.getPortalURL(...)` so the suite no longer depends on `PropsValues` or on suite ordering. |

## Test plan

All run locally on this branch.

- [x] `ant test-class -Dtest.class=PortalImplUnitTest` — 32/32.
- [x] `ant format-source-current-branch` from `portal-impl` — clean.
- [x] `portal-util-test` integration: `PortalImplAlternateURLTest`, `PortalImplCanonicalURLTest`, `PortalImplControlPanelFullURLTest`, `PortalImplGetDefaultVirtualHostnameTest`, `PortalImplGroupFriendlyURLTest`, `PortalImplLayoutFriendlyURLTest`, `PortalImplLayoutFullURLTest`, `PortalImplLayoutSetFriendlyURLTest`.
- [x] `layout-seo-test` integration: `LayoutSEOLinkManagerCanonicalLayoutSEOLinkTest`, `LayoutSEOLinkManagerTest`, `LayoutSEOLinkManagerPageTitleTest`, `LayoutSEOCanonicalURLProviderTest`.
- [x] `portal-servlet-test` integration: `VirtualHostFilterTest`, `VirtualHostAbsoluteRedirectsFilterTest`.
- [x] `portal-virtual-host-test` integration: `CompanyVirtualHostTest`, `SiteVirtualHostTest`.
- [x] `layout-test` integration: `LayoutFriendlyURLServiceTest`, `LayoutFriendlyURLTest`.
- [x] `friendly-url-test` integration: `PrivateGroupFriendlyURLServletTest`, `LayoutFriendlyURLSeparatorCompositeTest`.
- [x] `export-import-test` integration: `LayoutReferencesExportImportContentProcessorTest`.

### How to reproduce the smoke regression locally (before this fix)

1. Set `virtual.hosts.valid.hosts=*` in `bundles/portal-ext.properties`.
1. Add `127.0.0.1 ci.local` (any hostname distinct from `localhost`) to `/etc/hosts`.
1. Boot the portal and sign in via `http://ci.local:8080`.
1. Open DevTools → Network and filter `panel_apps`. Each entry's `homeURL` in the JSON response is `http://localhost:8080/group/control_panel/manage?...` instead of `http://ci.local:8080/...`. Clicking Control Panel takes the user off the host they were browsing on — which is how the playwright container failed to follow the link.

After the fix the `homeURL` host matches the host on the request.
