### PR TITLE
LPD-88001 Mock useBrowserTabVisibility in React 16 Jest tests

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ModelBuilder/RightSidebar/RightSidebarObjectDefinitionDetails.spec.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ModelBuilder/RightSidebar/RightSidebarObjectDefinitionDetails.spec.tsx
@@ -30,6 +30,10 @@ jest.mock('frontend-js-web', () => ({
 	sub: jest.fn((langKey, arg) => langKey.replace('x', arg)),
 }));
 
+jest.mock('@liferay/frontend-js-react-web', () => ({
+	useBrowserTabVisibility: () => true,
+}));
+
 jest.mock(
 	'../../../components/ModelBuilder/ModelBuilderContext/objectFolderContext',
 	() => ({

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectDetails/EditObjectDetails.spec.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectDetails/EditObjectDetails.spec.tsx
@@ -45,6 +45,10 @@ jest.mock('frontend-js-web', () => ({
 	),
 }));
 
+jest.mock('@liferay/frontend-js-react-web', () => ({
+	useBrowserTabVisibility: () => true,
+}));
+
 afterAll(() => {
 	jest.restoreAllMocks();
 });


### PR DESCRIPTION
PR to unblock master sync as stated in [#portal-failures](https://liferay.slack.com/archives/CLCD3DQLF/p1779347009836889)

The new useBrowserTabVisibility hook in EditObjectDetails and RightSidebarObjectDefinitionDetails calls React 18's useSyncExternalStore, which does not exist in React 16, causing the error. This PR fixes the issue.