### PR TITLE
LPD-91677 Refines CSP nonce caching follow-up

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalContentImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalContentImpl.java
@@ -43,6 +43,8 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import jakarta.portlet.RenderRequest;
 
+import jakarta.servlet.http.HttpServletRequest;
+
 import java.io.Serializable;
 
 import java.util.Date;
@@ -245,9 +247,15 @@ public class JournalContentImpl implements JournalContent {
 			articleDisplay = _portalCache.get(journalContentKey);
 		}
 
+		HttpServletRequest httpServletRequest = null;
+
+		if (themeDisplay != null) {
+			httpServletRequest = themeDisplay.getRequest();
+		}
+
 		String nonceAttribute =
 			ContentSecurityPolicyNonceProviderUtil.getNonceAttribute(
-				(themeDisplay != null) ? themeDisplay.getRequest() : null);
+				httpServletRequest);
 
 		if ((articleDisplay == null) || !lifecycleRender) {
 			articleDisplay = getArticleDisplay(

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/example/test/JournalContentTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/example/test/JournalContentTest.java
@@ -215,9 +215,7 @@ public class JournalContentTest {
 		ServiceContextThreadLocal.popServiceContext();
 	}
 
-	private JournalArticle _addJournalArticleWithTemplate(String script)
-		throws Exception {
-
+	private JournalArticle _addJournalArticle(String script) throws Exception {
 		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
 			_group.getGroupId(), JournalArticle.class.getName());
 
@@ -247,6 +245,52 @@ public class JournalContentTest {
 			LocaleUtil.getSiteDefault());
 	}
 
+	private JournalArticleDisplay _getArticleDisplay(
+			JournalArticle journalArticle)
+		throws Exception {
+
+		return _getArticleDisplay(journalArticle, new MockHttpServletRequest());
+	}
+
+	private JournalArticleDisplay _getArticleDisplay(
+			JournalArticle journalArticle,
+			HttpServletRequest httpServletRequest)
+		throws Exception {
+
+		ThemeDisplay themeDisplay = getThemeDisplay(httpServletRequest);
+
+		MockRenderRequest mockRenderRequest = new MockRenderRequest();
+
+		mockRenderRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
+
+		httpServletRequest.setAttribute(
+			JavaConstants.JAKARTA_PORTLET_REQUEST, mockRenderRequest);
+
+		PortletRequestModel portletRequestModel = new PortletRequestModel(
+			mockRenderRequest, new MockPortletResponse());
+
+		return _journalContent.getDisplay(
+			journalArticle.getGroupId(), journalArticle.getArticleId(),
+			journalArticle.getDDMTemplateKey(), Constants.VIEW,
+			journalArticle.getDefaultLanguageId(), 1, portletRequestModel,
+			themeDisplay);
+	}
+
+	private JournalArticleDisplay _getArticleDisplay(
+			JournalArticle journalArticle, String nonce)
+		throws Exception {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			"com.liferay.portal.security.content.security.policy.internal." +
+				"ContentSecurityPolicyNonceManager#NONCE",
+			nonce);
+
+		return _getArticleDisplay(journalArticle, mockHttpServletRequest);
+	}
+
 	private CompanyConfigurationTemporarySwapper
 			_getCompanyConfigurationTemporarySwapper()
 		throws Exception {
@@ -264,39 +308,6 @@ public class JournalContentTest {
 			).put(
 				"reportOnly", false
 			).build());
-	}
-
-	private JournalArticleDisplay _getDisplay(
-			JournalArticle journalArticle, String nonce)
-		throws Exception {
-
-		MockHttpServletRequest mockHttpServletRequest =
-			new MockHttpServletRequest();
-
-		if (nonce != null) {
-			mockHttpServletRequest.setAttribute(
-				"com.liferay.portal.security.content.security.policy." +
-					"internal.ContentSecurityPolicyNonceManager#NONCE",
-				nonce);
-		}
-
-		ThemeDisplay themeDisplay = getThemeDisplay(mockHttpServletRequest);
-
-		MockRenderRequest mockRenderRequest = new MockRenderRequest();
-
-		mockRenderRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
-
-		mockHttpServletRequest.setAttribute(
-			JavaConstants.JAKARTA_PORTLET_REQUEST, mockRenderRequest);
-
-		PortletRequestModel portletRequestModel = new PortletRequestModel(
-			mockRenderRequest, new MockPortletResponse());
-
-		return _journalContent.getDisplay(
-			journalArticle.getGroupId(), journalArticle.getArticleId(),
-			journalArticle.getDDMTemplateKey(), Constants.VIEW,
-			journalArticle.getDefaultLanguageId(), 1, portletRequestModel,
-			themeDisplay);
 	}
 
 	private Map<Locale, String> _getLocalizedMap(Locale[] locales) {
@@ -389,24 +400,18 @@ public class JournalContentTest {
 				companyConfigurationTemporarySwapper =
 					_getCompanyConfigurationTemporarySwapper()) {
 
-			JournalArticle journalArticle = _addJournalArticleWithTemplate(
-				"<script ${nonceAttribute}>console.log(\"LPD-91677\");" +
-					"</script>");
+			JournalArticle journalArticle = _addJournalArticle(_SCRIPT);
 
 			String oldNonce = RandomTestUtil.randomString();
 
-			JournalArticleDisplay journalArticleDisplay = _getDisplay(
-				journalArticle, oldNonce);
-
-			String content = journalArticleDisplay.getContent();
-
-			Assert.assertTrue(content.contains(" nonce=\"" + oldNonce + "\""));
+			_getArticleDisplay(journalArticle, oldNonce);
 
 			String newNonce = RandomTestUtil.randomString();
 
-			journalArticleDisplay = _getDisplay(journalArticle, newNonce);
+			JournalArticleDisplay articleDisplay = _getArticleDisplay(
+				journalArticle, newNonce);
 
-			content = journalArticleDisplay.getContent();
+			String content = articleDisplay.getContent();
 
 			Assert.assertTrue(content.contains(" nonce=\"" + newNonce + "\""));
 			Assert.assertFalse(content.contains(" nonce=\"" + oldNonce + "\""));
@@ -420,16 +425,14 @@ public class JournalContentTest {
 				companyConfigurationTemporarySwapper =
 					_getCompanyConfigurationTemporarySwapper()) {
 
-			JournalArticle journalArticle = _addJournalArticleWithTemplate(
-				"<script ${nonceAttribute}>console.log(\"LPD-91677\");" +
-					"</script>");
+			JournalArticle journalArticle = _addJournalArticle(_SCRIPT);
 
-			_getDisplay(journalArticle, RandomTestUtil.randomString());
+			_getArticleDisplay(journalArticle, RandomTestUtil.randomString());
 
-			JournalArticleDisplay journalArticleDisplay = _getDisplay(
-				journalArticle, null);
+			JournalArticleDisplay articleDisplay = _getArticleDisplay(
+				journalArticle);
 
-			String content = journalArticleDisplay.getContent();
+			String content = articleDisplay.getContent();
 
 			Assert.assertTrue(content.contains("data-lfr-nonce-journal"));
 		}
@@ -440,20 +443,23 @@ public class JournalContentTest {
 				companyConfigurationTemporarySwapper =
 					_getCompanyConfigurationTemporarySwapper()) {
 
-			JournalArticle journalArticle = _addJournalArticleWithTemplate(
-				"<script>console.log(\"LPD-91677\");</script>");
+			JournalArticle journalArticle = _addJournalArticle(
+				"<script>console.log(\"test\");</script>");
 
-			_getDisplay(journalArticle, RandomTestUtil.randomString());
+			_getArticleDisplay(journalArticle, RandomTestUtil.randomString());
 
-			JournalArticleDisplay journalArticleDisplay = _getDisplay(
+			JournalArticleDisplay articleDisplay = _getArticleDisplay(
 				journalArticle, RandomTestUtil.randomString());
 
-			String content = journalArticleDisplay.getContent();
+			String content = articleDisplay.getContent();
 
 			Assert.assertFalse(content.contains("data-lfr-nonce-journal"));
 			Assert.assertFalse(content.contains(" nonce=\""));
 		}
 	}
+
+	private static final String _SCRIPT =
+		"<script ${nonceAttribute}>console.log(\"test\");</script>";
 
 	@Inject
 	private CompanyLocalService _companyLocalService;


### PR DESCRIPTION
Follow-up to https://github.com/brianchandotcom/liferay-portal/pull/175073 with post-merge refinements.

https://liferay.atlassian.net/browse/LPD-91677

## What changes

`JournalContentImpl.java` — replaces the `themeDisplay != null ? themeDisplay.getRequest() : null` ternary with an `if`/`else` assignment (codeowner preference).

`JournalContentTest.java` — bundle of test cleanups:

- Renames `_getDisplay` to `_getArticleDisplay` to disambiguate from `_journalContent.getDisplay(...)` calls and align with the local variable name.
- Splits the helper into three overloads — `_getArticleDisplay(JournalArticle)`, `_getArticleDisplay(JournalArticle, HttpServletRequest)`, `_getArticleDisplay(JournalArticle, String nonce)` — dropping the `pass null + branch inside` pattern.
- Widens the workhorse parameter to `HttpServletRequest` (only `MockHttpServletRequest` was used at the new-site, the helper has no need for the concrete type).
- Extracts the duplicated script literal to a `_SCRIPT` constant.
- Replaces `console.log("LPD-91677")` with `console.log("test")` so the constant is reusable.
- Drops the redundant call-#1 assertion in `_testGetDisplayWithCSPNonceTemplate` so all three CSP scenarios share a warm-then-assert shape.
- Renames `journalArticleDisplay` to `articleDisplay` to match the file's existing convention.

## Test plan

- [ ] `gradlew -p modules/apps/journal/journal-test testIntegration --tests JournalContentTest` passes against a bundle deployed with the impl change.