### PR TITLE
LPD-90484 | follow-up

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
@@ -847,14 +847,22 @@ public class ObjectActionLocalServiceTest {
 			Assert.assertEquals(
 				"2023-06-01 06:42:08.0", MapUtil.getString(values, "time"));
 
+			_assertWebhookObjectAction(
+				"2000-12-25T00:00:00.000Z", "Peter", "White",
+				ObjectActionTriggerConstants.KEY_ON_AFTER_UPDATE,
+				_objectDefinition, "João", "o Discípulo Amado",
+				WorkflowConstants.STATUS_APPROVED);
+
 			// Execute standalone system action to update the current object
 			// entry
+
+			String firstName = RandomTestUtil.randomString();
 
 			objectEntry = _objectEntryLocalService.partialUpdateObjectEntry(
 				TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
 				objectEntry.getObjectEntryFolderId(),
 				HashMapBuilder.<String, Serializable>put(
-					"firstName", RandomTestUtil.randomString()
+					"firstName", firstName
 				).build(),
 				ServiceContextTestUtil.getServiceContext());
 
@@ -871,6 +879,12 @@ public class ObjectActionLocalServiceTest {
 				objectEntry.getObjectEntryId());
 
 			Assert.assertEquals("Jack", MapUtil.getString(values, "firstName"));
+
+			_assertWebhookObjectAction(
+				"2000-12-25T00:00:00.000Z", "Jack", "White",
+				ObjectActionTriggerConstants.KEY_ON_AFTER_UPDATE,
+				_objectDefinition, firstName, "White",
+				WorkflowConstants.STATUS_APPROVED);
 
 			// Delete object entry
 


### PR DESCRIPTION
follow-up of https://liferay.atlassian.net/browse/LPD-90484 / https://github.com/liferay-bpm/liferay-portal/pull/6107

after the fix in ObjectActionEngineImpl.executeObjectAction, standalone
action calls via the REST endpoint now start with a fresh dedup window
(clearObjectEntryIdsMap). When a standalone action modifies an object
entry, the resulting onAfterUpdate event is no longer suppressed by a
stale dedup entry from a prior top-level operation.

testAddObjectAction was relying on that implicit suppression and missing
two webhook assertions: one for objectAction5 updating the entry to
Peter/White, and one for systemObjectAction updating it to Jack.