### PR TITLE
LPD-91940 Improve worktree-create script robustness

### DIFF
--- a/.claude/hooks/_common.sh
+++ b/.claude/hooks/_common.sh
@@ -53,10 +53,10 @@ function _drop_database {
 	local user=root
 	local password=""
 
-	if [[ -n ${bundles_dir} && -f ${bundles_dir}/portal-ext.properties ]]
+	if [[ -n ${bundles_dir} ]]
 	then
-		user="$(_get_property "${bundles_dir}/portal-ext.properties" "jdbc\.default\.username" root)"
-		password="$(_get_property "${bundles_dir}/portal-ext.properties" "jdbc\.default\.password")"
+		user="$(_get_property_from_files "jdbc\.default\.username" root "${bundles_dir}/portal-ext.properties" "${bundles_dir}/portal-setup-wizard.properties")"
+		password="$(_get_property_from_files "jdbc\.default\.password" "" "${bundles_dir}/portal-ext.properties" "${bundles_dir}/portal-setup-wizard.properties")"
 	fi
 
 	local mysql_args=(--user "${user}")
@@ -127,4 +127,25 @@ function _get_property {
 	fi
 
 	echo "${value}"
+}
+
+function _get_property_from_files {
+	local key="${1}"
+	local default="${2}"
+
+	shift 2
+
+	local file
+
+	for file in "${@}"
+	do
+		if [[ -f ${file} ]] && grep --extended-regexp --quiet "^[[:space:]]*${key}=" "${file}"
+		then
+			grep --extended-regexp "^[[:space:]]*${key}=" "${file}" | tail --lines=1 | sed --regexp-extended "s/^[[:space:]]*${key}=[[:space:]]*//; s/[[:space:]]+\$//"
+
+			return
+		fi
+	done
+
+	echo "${default}"
 }

--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -185,11 +185,12 @@ function _set_database {
 	db_name="$(_derive_db_name "$(basename "${WORKTREE_DIR}")")"
 
 	local file="${BUNDLES_DIR}/portal-ext.properties"
+	local wizard_file="${BUNDLES_DIR}/portal-setup-wizard.properties"
 
 	local existing_user existing_password
 
-	existing_user="$(_get_property "${file}" "jdbc\.default\.username" root)"
-	existing_password="$(_get_property "${file}" "jdbc\.default\.password")"
+	existing_user="$(_get_property_from_files "jdbc\.default\.username" root "${file}" "${wizard_file}")"
+	existing_password="$(_get_property_from_files "jdbc\.default\.password" "" "${file}" "${wizard_file}")"
 
 	_set_property "${file}" jdbc.default.driverClassName com.mysql.cj.jdbc.Driver
 	_set_property "${file}" jdbc.default.url "jdbc:mysql://localhost/${db_name}?characterEncoding=UTF-8&dontTrackOpenResources=true&holdResultsOpenOverStatementClose=true&serverTimezone=GMT&useFastDateParsing=false&useUnicode=true"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,7 @@
 				"hooks": [
 					{
 						"command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/worktree-create.sh",
+						"timeout": 1800,
 						"type": "command"
 					}
 				]


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91940

## What is being fixed

The worktree-create hook fails when JDBC credentials are only stored in portal-setup-wizard.properties instead of portal-ext.properties, so the new bundle ends up with the wrong database user. The hook also aborts mid-bootstrap on slower setups because the 5-minute default timeout is not enough to provision a fresh database.

## How it is being fixed

A new _get_property_from_files helper walks an ordered list of property files and returns the first match, falling back to a default. The hook now reads jdbc.default.username and jdbc.default.password from portal-ext.properties and then portal-setup-wizard.properties. The worktree-create hook timeout is raised to 30 minutes so the bootstrap can finish on a fresh database.

## Why are there no tests?

These are shell-script changes to local .claude/hooks tooling. The repository has no harness for exercising hook scripts, so the change is validated by running the hook locally.