### PR TITLE
LRDOCS-17027 Derive worktree path prefix from main worktree basename

### DIFF
--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -67,9 +67,11 @@ function _create_worktree {
 	cwd="$(jq --exit-status --raw-output ".cwd" <<< "${input}")" || _die "The cwd field is missing from the hook input ${input}."
 	name="$(jq --exit-status --raw-output ".name" <<< "${input}")" || _die "The name field is missing from the hook input ${input}."
 
-	local target_path
+	local main_worktree target_path
 
-	target_path="$(dirname "$(git -C "${cwd}" rev-parse --show-toplevel)")/liferay-portal-${name}"
+	main_worktree="$(git -C "${cwd}" worktree list --porcelain | grep --extended-regexp "^worktree " | head --lines=1 | sed "s/^worktree //")"
+
+	target_path="$(dirname "${main_worktree}")/$(basename "${main_worktree}")-${name}"
 
 	if ! git -C "${cwd}" worktree list --porcelain | grep --fixed-strings --line-regexp --quiet "worktree ${target_path}"
 	then


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRDOCS-17027

## What is being fixed

The worktree-create hook hardcodes the `liferay-portal-` prefix when computing the new worktree path, so other Liferay repos that want to reuse the same hook (for example `liferay-learn` with LIFERAY_PROVISION=none) would land their worktrees at `~/projects/liferay-portal-<branch>` instead of `~/projects/liferay-learn-<branch>`.

## How it is being fixed

The hook now derives the prefix from the basename of the main worktree, resolved via `git worktree list --porcelain | head`. Portal invocations continue to produce `~/projects/liferay-portal-<branch>` because the main worktree is listed first regardless of which checkout the script is invoked from. `_resolve_main_worktree_dir` still uses a literal `liferay-portal` regex, but it only runs inside the provisioning path that a `liferay-learn` invocation skips via LIFERAY_PROVISION=none.

## Why are there no tests?

These are shell-script changes to local .claude/hooks tooling. The repository has no harness for exercising hook scripts, so the change is validated by running the hook locally across the seven cwd scenarios documented on the original PR.