### PR TITLE
LPD-91133 Add format-source rule for Chicago Title Case in language properties

### DIFF
--- a/.claude/skills/format-source/SKILL.md
+++ b/.claude/skills/format-source/SKILL.md
@@ -1000,3 +1000,14 @@ The same applies when renaming a method or its parameter to match the vocabulary
 ```
 
 When you rename a local, propagate the new name to every call site, every parameter that passes it on, and every private helper that receives it.
+
+### Rule 48: Chicago Title Case for Titles in Language Properties
+
+**Why:** Titles in `Language.properties` — labels, headings, button text, dropdown options, filter values — follow the Chicago Manual of Style: capitalize the first word, the last word, and every major word (nouns, verbs, adjectives, adverbs, pronouns), and keep articles, coordinating conjunctions, and prepositions lowercase. Sentences and inline phrases stay in sentence case; full sentences fall under Rule 18.
+
+**Examples:**
+
+```diff
+-some-key=Alpha of the bravo
++some-key=Alpha of the Bravo
+```


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91133

## What is being fixed

The format-source skill did not codify Liferay's convention for capitalizing titles in Language.properties, so reviewers had to call out the Chicago Manual of Style title-case convention by hand on every PR touching label, heading, button, dropdown, or filter copy.

## How it is being fixed

A new Rule 48 in `.claude/skills/format-source/SKILL.md` documents Chicago Manual of Style title case for titles in Language.properties: capitalize the first word, the last word, and every major word; keep articles, coordinating conjunctions, and prepositions lowercase. Sentences and inline phrases stay in sentence case and continue to fall under Rule 18.