### PR TITLE
⚠️ DO NOT MERGE — LRCI-7460 auto-close webhook test

### DIFF
--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -1,5 +1,5 @@
 %-of-assets=% of Assets (Automatic Copy)
-+-add-address-line=+ Add Address Line
++-add-address-line=DO NOT MERGE - LRCI-7460 auto-close webhook test
 0-analytics-cloud-connection=Analytics Cloud Connection
 1-account-was-added-to-x=1 account was added to {0}.
 1-day=1 Day


### PR DESCRIPTION
# ⚠️ DO NOT MERGE — TEST PR ⚠️

This is a sandbox test PR for [LRCI-7460](https://liferay.atlassian.net/browse/LRCI-7460), to verify the now-live `auto-close-merge-conflict-pullrequest` webhook automation against BChan's queue.

**Expected behavior**: the receiver dispatches the auto-close job → the job sees `mergeable_state: dirty` → posts the standard "merge conflicts and has been closed" comment → closes this PR automatically.

If you are reading this and the PR is still open, the automation did not fire as expected — please leave the PR alone so I can diagnose, or just close it manually.

The only change is a single line in `Language_km.properties` (set to `DO NOT MERGE - LRCI-7460 auto-close webhook test`) chosen to deliberately conflict with the latest Khmer translation update on master.

Parent: [LRCI-6965](https://liferay.atlassian.net/browse/LRCI-6965).
