### PR TITLE
⚠️ DO NOT MERGE — LRCI-7460 auto-close webhook test (retry)

### DIFF
--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -1,5 +1,5 @@
 %-of-assets=% of Assets (Automatic Copy)
-+-add-address-line=+ Add Address Line
++-add-address-line=DO NOT MERGE - LRCI-7460 auto-close webhook test
 0-analytics-cloud-connection=Analytics Cloud Connection
 1-account-was-added-to-x=1 account was added to {0}.
 1-day=1 Day


### PR DESCRIPTION
# ⚠️ DO NOT MERGE — TEST PR (retry) ⚠️

Second sandbox attempt for [LRCI-7460](https://liferay.atlassian.net/browse/LRCI-7460) after the first attempt didn't trigger the auto-close webhook (deployment issue, now fixed).

**Expected behavior**: the receiver dispatches the `auto-close-merge-conflict-pullrequest` Jenkins job → the job sees `mergeable_state: dirty` → posts the standard "merge conflicts and has been closed" comment → closes this PR automatically.

If this PR is still open after a few minutes, the automation still isn't working — please leave it alone so I can diagnose, or close it manually if it lingers.

The only change is a single line in `Language_km.properties` set to `DO NOT MERGE - LRCI-7460 auto-close webhook test`, deliberately conflicting with the latest Khmer translation update on master.

Parent: [LRCI-6965](https://liferay.atlassian.net/browse/LRCI-6965).
