### PR TITLE
LPD-92213 Match inverse Clay label CSS class in structure builder tests

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/referencedStructures.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/referencedStructures.spec.ts
@@ -73,7 +73,7 @@ test(
 		// Assert correct label style
 
 		await expect(
-			page.locator('.label-warning', {
+			page.locator('.label-inverse-warning', {
 				hasText: 'Referenced Content Structure',
 			})
 		).toBeVisible();

--- a/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/repeatableGroups.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/repeatableGroups.spec.ts
@@ -78,7 +78,9 @@ test(
 		// Assert correct label style
 
 		await expect(
-			page.locator('.label-success', {hasText: 'Repeatable Group'})
+			page.locator('.label-inverse-success', {
+				hasText: 'Repeatable Group',
+			})
 		).toBeVisible();
 
 		// Check groups are persisted

--- a/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/structureBuilder.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/structureBuilder.spec.ts
@@ -215,7 +215,7 @@ test(
 		// Assert correct label style
 
 		await expect(
-			page.locator('.label-info', {hasText: 'Text'})
+			page.locator('.label-inverse-info', {hasText: 'Text'})
 		).toBeVisible();
 
 		// Configure the field


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92213

## Failing Test

`site-cms-site-initializer/structure-builder/repeatableGroups.spec.ts > Groups can be created, persisted and ungrouped`

`modules/test/playwright/tests/site-cms-site-initializer/structure-builder/repeatableGroups.spec.ts`

```
Error: Timed out 15000ms waiting for expect(locator).toBeVisible()
Locator: locator('.label-success').filter({ hasText: 'Repeatable Group' })
Expected: visible
Received: <element(s) not found>
```

## Root Cause

Commit `9576a8338ad3` ("LPD-88103 Use inverse Clay label variant in CMS site initializer") wrapped the structure builder field-type `ClayLabel` components in the `inverse` variant. The Clay label component (`dc876ae88674`) renders `label-inverse-<displayType>` when `inverse` is set, so `RepeatableGroupSettings`, `StructureFieldSettings`, and `ReferencedStructureSettings` now emit `label-inverse-success`, `label-inverse-info`, and `label-inverse-warning`. The Playwright assertions still targeted the pre-inverse class names and timed out.

The change is a deliberate restyling — the label is still semantically a success/info/warning — so the regression lives in the test assertions, not in the product code.

## Fix

Update the three structure builder Playwright assertions to target the new inverse class names. The two sibling assertions (`structureBuilder.spec.ts` / `referencedStructures.spec.ts`) share the same root cause and break for the same reason, so they are fixed in the same commit.

- `modules/test/playwright/tests/site-cms-site-initializer/structure-builder/repeatableGroups.spec.ts`
- `modules/test/playwright/tests/site-cms-site-initializer/structure-builder/referencedStructures.spec.ts`
- `modules/test/playwright/tests/site-cms-site-initializer/structure-builder/structureBuilder.spec.ts`
