### PR TITLE
LPD-91601 Refresh DateTimeInput snapshots for new aria-live region

### DIFF
--- a/modules/apps/segments/segments-web/test/js/components/inputs/__snapshots__/DateTimeInput.test.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/inputs/__snapshots__/DateTimeInput.test.js.snap
@@ -9,6 +9,11 @@ exports[`DateTimeInput renders date with no change in the input 1`] = `
       class="date-picker"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="sr-only"
+      />
+      <div
         class="input-group"
       >
         <div
@@ -63,6 +68,11 @@ exports[`DateTimeInput renders date-time with no change in the input 1`] = `
     <div
       class="date-picker"
     >
+      <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="sr-only"
+      />
       <div
         class="input-group"
       >
@@ -119,6 +129,11 @@ exports[`DateTimeInput renders previous date with wrong date 1`] = `
       class="date-picker"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="sr-only"
+      />
+      <div
         class="input-group"
       >
         <div
@@ -173,6 +188,11 @@ exports[`DateTimeInput renders previous date with wrong date-time 1`] = `
     <div
       class="date-picker"
     >
+      <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="sr-only"
+      />
       <div
         class="input-group"
       >
@@ -229,6 +249,11 @@ exports[`DateTimeInput renders type date 1`] = `
       class="date-picker"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="sr-only"
+      />
+      <div
         class="input-group"
       >
         <div
@@ -283,6 +308,11 @@ exports[`DateTimeInput renders type date-time 1`] = `
     <div
       class="date-picker"
     >
+      <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="sr-only"
+      />
       <div
         class="input-group"
       >


### PR DESCRIPTION
The ClayDatePicker change to announce out-of-range rejections inserts a polite aria-live container inside the picker, which propagates into the segments-web DateTimeInput rendering. Regenerate the affected snapshots so the Jest suite passes again.