### PR TITLE
LPD-90966 Clarify that test modules should not be deployed

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -58,6 +58,8 @@ Logs are available at `<bundles>/logs/liferay.<yyyy-MM-dd>.log`. Check them when
 
 	Then copy the resulting `com.liferay.<name>.test.util.jar` from `<bundles>/osgi/test` to `<bundles>/osgi/modules`.
 
+- **`*-test` modules** — Do not deploy. The `testIntegration` task wires the test bundle into the runtime itself, so a manual deploy is redundant and slows the cycle.
+
 - **Gradle plugin modules** (under `modules/sdk/gradle-plugins*`):
 
 	```bash


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90966

## What Is Being Fixed

The deploy instructions in CLAUDE.md did not mention `*-test` modules, leaving it unclear whether they need a manual deploy like other module types.

## How It Is Being Fixed

Adds a note clarifying that `*-test` modules should not be deployed, since the `testIntegration` task wires the test bundle into the runtime itself, making a manual deploy redundant and slower.

## Why Are There No Tests?

Documentation-only change to `.claude/CLAUDE.md`; there is no code to test.