### PR TITLE
LPD-92283 Make the test-fix skill more reliable and portable

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -58,6 +58,8 @@ Logs are available at `<bundles>/logs/liferay.<yyyy-MM-dd>.log`. Check them when
 
 	Then copy the resulting `com.liferay.<name>.test.util.jar` from `<bundles>/osgi/test` to `<bundles>/osgi/modules`.
 
+- **`*-test` modules** — Do not deploy. The `testIntegration` task wires the test bundle into the runtime itself, so a manual deploy is redundant and slows the cycle.
+
 - **Gradle plugin modules** (under `modules/sdk/gradle-plugins*`):
 
 	```bash

--- a/.claude/skills/jira-bug/SKILL.md
+++ b/.claude/skills/jira-bug/SKILL.md
@@ -43,4 +43,4 @@ Create the issue in the LPD project with the gathered summary, description, and 
 
 ## Output
 
-Return the ticket key and the browse URL: `https://liferay.atlassian.net/browse/<KEY>`.
+The ticket key and the browse URL: `https://liferay.atlassian.net/browse/<KEY>`.

--- a/.claude/skills/jira-task/SKILL.md
+++ b/.claude/skills/jira-task/SKILL.md
@@ -42,4 +42,4 @@ Create the issue in the LPD project with the gathered summary, description, and 
 
 ## Output
 
-Return the ticket key and the browse URL: `https://liferay.atlassian.net/browse/<KEY>`.
+The ticket key and the browse URL: `https://liferay.atlassian.net/browse/<KEY>`.

--- a/.claude/skills/test-fix/SKILL.md
+++ b/.claude/skills/test-fix/SKILL.md
@@ -31,7 +31,7 @@ When `${ARGUMENTS}` is anything else, resolve it to a case result ID by followin
 
 ### Failure Data
 
-Fetched at the start of the run by following [`references/testray.md`](references/testray.md), which covers authentication, name-to-ID resolution, and how to derive each field. When a test name was passed and the resolution aborts, surface the reason and ask the user to retry with the case result ID directly. When the case result is already `PASSED`, skip the workflow and exit with `Verdict: No fix needed`. Otherwise, the procedure returns these fields:
+Fetched at the start of the run by following [`references/testray.md`](references/testray.md), which covers authentication, name-to-ID resolution, and how to derive each field. When a test name was passed and the resolution aborts, surface the reason and ask the user to retry with the case result ID directly. When the case result is already `PASSED`, skip the workflow and exit with `Verdict: No fix needed`. When it is `BLOCKED` — a tester deliberately flagged it, so it must not be auto-fixed — skip the workflow and exit reporting that the case is blocked. Otherwise, the procedure returns these fields:
 
 - **errorTrace** — error trace produced by the test framework.
 - **failureDate** — timestamp when the case result was recorded, used to scope the duplicate-ticket check in **Claim the Failure**.

--- a/.claude/skills/test-fix/SKILL.md
+++ b/.claude/skills/test-fix/SKILL.md
@@ -13,7 +13,7 @@ Resolve a single test failure end-to-end.
 
 ## Preconditions
 
-- The Liferay portal is running (required for `Java Integration`, `Playwright`, and `Poshi`). Start it if it is not.
+- Tomcat is running (required for `Java Integration`, `Playwright`, and `Poshi`). Start it if it is not.
 
 ## Input
 

--- a/.claude/skills/test-fix/SKILL.md
+++ b/.claude/skills/test-fix/SKILL.md
@@ -33,6 +33,7 @@ When `${ARGUMENTS}` is anything else, resolve it to a case result ID by followin
 
 Fetched at the start of the run by following [`references/testray.md`](references/testray.md), which covers authentication, name-to-ID resolution, and how to derive each field. When a test name was passed and the resolution aborts, surface the reason and ask the user to retry with the case result ID directly. When the case result is already `PASSED`, skip the workflow and exit with `Verdict: No fix needed`. When it is `BLOCKED` — a tester deliberately flagged it, so it must not be auto-fixed — skip the workflow and exit reporting that the case is blocked. Otherwise, the procedure returns these fields:
 
+- **buildSha** — commit the failing build was tested against.
 - **errorTrace** — error trace produced by the test framework.
 - **failureDate** — timestamp when the case result was recorded, used to scope the duplicate-ticket check in **Claim the Failure**.
 - **firstFailSha** — first commit where the test failed (may be `null` when the case has no recorded failure history).
@@ -123,8 +124,10 @@ Commit `<short-sha>` ("<subject>") <one or two sentences>.
 1. Check Jira for an LPD ticket whose summary contains `<test-name>` and is labeled `claude-test-fix`. Decide whether it already covers this failure by its state:
 
 	- **Unresolved** (Open, In Progress, or any non-resolved state) → claimed, skip. Someone is already working it.
-	- **Resolved on or after `<failureDate>`** → fix already shipped for this occurrence, skip.
-	- **Resolved before `<failureDate>`** → stale fix, a new occurrence is not covered, proceed.
+	- **Resolved** → find the ticket's PR by following the `pr` skill's rules for where it is recorded, derive its fix commit, and test whether it already reached the build that failed, judging by `git merge-base --is-ancestor <fixSha> <buildSha>`:
+		- **Fix commit is an ancestor of `<buildSha>`** → the fix was already present when this build ran, yet the test still failed, so it does not cover this occurrence → proceed.
+		- **Fix commit is not yet in `<buildSha>`** → Testray has not retested since the fix merged, so the failure is already addressed → skip.
+		- **No fix commit found** (test-only ticket, unmerged commit, or a non-fixing resolution) → fall back to the resolution date: resolved before `<failureDate>` proceeds, resolved on or after skips.
 
 	When skipping and other candidates remain, retry with the next one.
 

--- a/.claude/skills/test-fix/SKILL.md
+++ b/.claude/skills/test-fix/SKILL.md
@@ -76,7 +76,7 @@ The elapsed time of the run, formatted as `<minutes>m <seconds>s`.
 
 The Task created in **Claim the Failure** is the persistent ticket of record for every verdict. Update it at the end of the run based on the verdict:
 
-- **Bug in portal** — invoke the `jira-bug` skill to create a separate Bug describing the regression. The title summarizes the regression. The description carries the failing test name, the trace, and the reproduction steps derived from the test scenario. Link the Bug to the Task with the **Fix** issue link type so the Task surfaces it as **is fixed by**. Return the Bug URL alongside the Task URL.
+- **Bug in portal** — invoke the `jira-bug` skill to create a separate Bug describing the regression. The title summarizes the regression. The description carries the failing test name, the trace, and the reproduction steps derived from the test scenario. Do **not** add the `claude-test-fix` label to the Bug — that label belongs to the Task alone, so the duplicate-ticket check in **Claim the Failure** matches one ticket per failure. Link the Bug to the Task with the **Fix** issue link type so the Task surfaces it as **is fixed by**. Return the Bug URL alongside the Task URL.
 
 - **Outdated test** — return the Task URL.
 

--- a/.claude/skills/test-fix/SKILL.md
+++ b/.claude/skills/test-fix/SKILL.md
@@ -13,12 +13,7 @@ Resolve a single test failure end-to-end.
 
 ## Preconditions
 
-Verify all of these once at the start of the run. Fail fast with a clear message when any is missing.
-
-- The current working directory is a Git checkout of `liferay-portal`.
-- The working tree is clean (`git status --porcelain` is empty).
-- The checkout is on `master`.
-- The Liferay portal is running (required for `Java Integration`, `Playwright`, and `Poshi`). Start it when it is not.
+- The Liferay portal is running (required for `Java Integration`, `Playwright`, and `Poshi`). Start it if it is not.
 
 ## Input
 

--- a/.claude/skills/test-fix/SKILL.md
+++ b/.claude/skills/test-fix/SKILL.md
@@ -120,7 +120,13 @@ Commit `<short-sha>` ("<subject>") <one or two sentences>.
 
 ### Claim the Failure
 
-1. Check Jira for an LPD ticket whose summary contains `<test-name>`, is labeled `claude-test-fix`, and was **created on or after `<failureDate>`**. A ticket matching those criteria already covers this failure (in progress when still open, already shipped when resolved), so skip it; when there are other candidates, retry with the next one.
+1. Check Jira for an LPD ticket whose summary contains `<test-name>` and is labeled `claude-test-fix`. Decide whether it already covers this failure by its state:
+
+	- **Unresolved** (Open, In Progress, or any non-resolved state) → claimed, skip. Someone is already working it.
+	- **Resolved on or after `<failureDate>`** → fix already shipped for this occurrence, skip.
+	- **Resolved before `<failureDate>`** → stale fix, a new occurrence is not covered, proceed.
+
+	When skipping and other candidates remain, retry with the next one.
 
 1. Invoke the `jira-task` skill with summary `<test-name>` and a description that names the case result ID, the source build, and the failure trace excerpt. Add the `claude-test-fix` label.
 

--- a/.claude/skills/test-fix/references/testray.md
+++ b/.claude/skills/test-fix/references/testray.md
@@ -103,7 +103,7 @@ curl \
 	--url "https://testray.liferay.com/o/c/caseresults/<caseResultId>"
 ```
 
-When `dueStatus.key` is `PASSED`, return only **Name** below; the rest are skipped. Otherwise, return all five fields.
+When `dueStatus.key` is `PASSED` or `BLOCKED`, return only **Name** and that `dueStatus`; the rest are skipped. Otherwise, return all five fields.
 
 ### Name
 

--- a/.claude/skills/test-fix/references/testray.md
+++ b/.claude/skills/test-fix/references/testray.md
@@ -103,7 +103,7 @@ curl \
 	--url "https://testray.liferay.com/o/c/caseresults/<caseResultId>"
 ```
 
-When `dueStatus.key` is `PASSED` or `BLOCKED`, return only **Name** and that `dueStatus`; the rest are skipped. Otherwise, return all five fields.
+When `dueStatus.key` is `PASSED` or `BLOCKED`, return only **Name** and that `dueStatus`; the rest are skipped. Otherwise, return all fields.
 
 ### Name
 
@@ -177,3 +177,7 @@ Filter to entries where `testrayRoutineId` equals `<routineId>` and walk newest-
 - `lastPassSha` is the `gitHash` of the first entry whose `status` is `PASSED`, or `null` if none.
 
 - `firstFailSha` is the `gitHash` of the oldest entry whose `status` is `FAILED` before that `PASSED`, or `null` if none.
+
+### Build SHA
+
+The `gitHash` of the build the case result belongs to — the commit the failing build was actually tested against, distinct from `firstFailSha` because later failing builds run against newer commits. Read it from the same `/o/c/builds/<buildId>` fetch used to resolve `<routineId>` above.

--- a/.claude/skills/test-fix/references/testray.md
+++ b/.claude/skills/test-fix/references/testray.md
@@ -8,18 +8,7 @@ Pull a single Testray case result through the REST API at `https://testray.lifer
 
 ## Authentication
 
-Fetch a bearer token once per run via the OAuth2 client credentials grant and reuse it for every call:
-
-```bash
-export ACCESS_TOKEN=$(curl \
-	--data "grant_type=client_credentials" \
-	--header "Authorization: Basic $(printf "%s:%s" "${TESTRAY_CLIENT_ID}" "${TESTRAY_CLIENT_SECRET}" | base64 --wrap 0)" \
-	--header "Content-Type: application/x-www-form-urlencoded" \
-	--request POST \
-	--silent \
-	--url "https://testray.liferay.com/o/oauth2/token" \
-	| jq --raw-output .access_token)
-```
+Obtain a bearer token once per run through the OAuth2 client credentials grant at `https://testray.liferay.com/o/oauth2/token`, authenticating with `${TESTRAY_CLIENT_ID}` and `${TESTRAY_CLIENT_SECRET}` as HTTP Basic credentials. Read the `access_token` from the JSON response, store it in `${ACCESS_TOKEN}`, and present it as a `Bearer` token on every subsequent request.
 
 ## Resolve a Test Name to a Case Result ID
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92283

## What Is Being Fixed

The test-fix skill and its companion Jira skills had several rough edges that made automated test-failure handling unreliable. The run paused partway through whenever it created a Jira ticket. It refused to start unless the working tree was clean and checked out on master. It picked up failures that a tester had deliberately marked BLOCKED in Testray. Its already-claimed detection could not reliably tell whether an existing ticket covered a failure. And the Testray token fetch was pinned to a specific command-line tool.

## How It Is Being Fixed

The Jira skills' output wording no longer reads as an end-of-work handoff, so the skill keeps running after creating a ticket. The rigid preconditions are relaxed. BLOCKED case results are skipped rather than auto-fixed. The claim check now treats any unresolved ticket as an active claim and, for resolved ones, judges whether the fix commit actually reached the build that failed instead of comparing dates. The token fetch is described by its intended outcome rather than a fixed command, so it no longer depends on any single utility being installed.

## Why Are There No Tests?

These are documentation-only changes to the `.claude` skill definitions; there is no code to test.