### PR TITLE
LPD-92314 Resolve Poshi test URLs to the worktree's portal port

### DIFF
--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -368,6 +368,16 @@ function _set_portal_http_address {
 	_set_property "${BUNDLES_DIR}/portal-ext.properties" portal.instance.inet.socket.address "localhost:${http_port}"
 }
 
+function _set_poshi_url {
+	local http_port=$((8080 + OFFSET))
+
+	local file="${WORKTREE_DIR}/test.${USER}.properties"
+
+	_set_property "${file}" default.portal.url "http://localhost:${http_port}"
+	_set_property "${file}" instance.url "http://localhost:${http_port}"
+	_set_property "${file}" test.url "http://localhost:${http_port}"
+}
+
 function _set_property {
 	local file="${1}"
 	local key="${2}"
@@ -475,6 +485,7 @@ function main {
 	_set_playwright_port
 	_set_portal_home
 	_set_portal_http_address
+	_set_poshi_url
 	_set_test_integration_port
 	_set_tomcat_ports
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92314

## What is being fixed

The worktree provisioning hook already rewrites the bundle's Tomcat ports and writes per-tool port overrides for the app server, Playwright, and the integration test runner, but Poshi had none. A Poshi run in a non-8080 worktree therefore resolved its companyId from whichever bundle owned 8080, and the setUp aborted with NoSuchUserException.

## How it is being fixed

The Poshi runner reads portal.url from the bundled poshi.properties, which hardcodes localhost:8080, and Ant regenerates portal-web/poshi-ext.properties at prepare time from the test.url, instance.url, and default.portal.url Ant properties. Those default to 8080 unless overridden in test.${USER}.properties, which build-test.xml loads before test.properties under first-write-wins precedence. The hook now writes the worktree's port into those three properties in test.${USER}.properties, so every Poshi run targets the right bundle without manual -D overrides.

## Why are there no tests?

The change is to a Claude Code worktree provisioning hook under .claude; the repository has no automated test harness for these shell hooks, and the behavior is verified empirically by provisioning a worktree and running a Poshi test against its non-default port.
