### PR TITLE
LPD-91322 LPD-91059 Use country setting in phone number info field type

### DIFF
--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/phone-number-input/index.css
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/phone-number-input/index.css
@@ -1,26 +1,26 @@
-.phone-number-input-country-code-picker {
+.phone-number-input-prefix-picker {
 	position: relative;
 }
 
-.phone-number-input-country-code-picker > .form-control-select-secondary {
+.phone-number-input-prefix-picker > .form-control-select-secondary {
 	position: relative;
 	z-index: 2;
 }
 
-.phone-number-input-country-code-flag:empty {
+.phone-number-input-prefix-flag:empty {
 	display: none;
 }
 
-.phone-number-input-country-code-menu {
+.phone-number-input-prefix-menu {
 	max-height: 18rem;
 	min-width: 16rem;
 	overflow-y: auto;
 }
 
-.phone-number-input-country-code-menu.show {
+.phone-number-input-prefix-menu.show {
 	display: block;
 }
 
-.phone-number-input-country-code-menu-item-code {
+.phone-number-input-prefix-menu-item-code {
 	min-width: 45px;
 }

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/phone-number-input/index.css
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/phone-number-input/index.css
@@ -1,26 +1,26 @@
-.phone-number-input-prefix-picker {
+.phone-number-input-country-code-picker {
 	position: relative;
 }
 
-.phone-number-input-prefix-picker > .form-control-select-secondary {
+.phone-number-input-country-code-picker > .form-control-select-secondary {
 	position: relative;
 	z-index: 2;
 }
 
-.phone-number-input-prefix-flag:empty {
+.phone-number-input-country-code-flag:empty {
 	display: none;
 }
 
-.phone-number-input-prefix-menu {
+.phone-number-input-country-code-menu {
 	max-height: 18rem;
 	min-width: 16rem;
 	overflow-y: auto;
 }
 
-.phone-number-input-prefix-menu.show {
+.phone-number-input-country-code-menu.show {
 	display: block;
 }
 
-.phone-number-input-prefix-menu-item-code {
+.phone-number-input-country-code-menu-item-code {
 	min-width: 45px;
 }

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/phone-number-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/phone-number-input/index.html
@@ -64,23 +64,23 @@
 [#assign countries = (input.attributes.countries)![] /]
 [#assign defaultLanguageId = (input.attributes.defaultLanguageId)!"" /]
 [#assign disabled = (input.attributes.disabled)?? && input.attributes.disabled /]
-[#assign prefix = (input.attributes.prefix)!"" /]
-[#assign prefixType = (input.attributes.prefixType)!"definedByUser" /]
-[#assign fixed = prefixType == "fixed" /]
+[#assign countryA2 = (input.attributes.country)!"" /]
+[#assign countrySource = (input.attributes.countrySource)!"definedByUser" /]
+[#assign fixed = countrySource == "fixed" /]
 [#assign showFlag = configuration.showCountryFlag /]
-[#assign showPrefixPicker = configuration.showPrefix /]
+[#assign showCountryCodePicker = configuration.showPrefix /]
 [#assign selectedCountry = {} /]
 
-[#if fixed && prefix?has_content]
+[#if fixed && countryA2?has_content]
 	[#list countries as country]
-		[#if "+" + country.prefix == prefix]
+		[#if country.a2 == countryA2]
 			[#assign selectedCountry = country /]
 			[#break]
 		[/#if]
 	[/#list]
 [#elseif input.value??]
 	[#list countries as country]
-		[#if input.value?starts_with("+" + country.prefix)]
+		[#if input.value?starts_with("+" + country.idd)]
 			[#assign selectedCountry = country /]
 			[#break]
 		[/#if]
@@ -104,10 +104,8 @@
 
 [#assign displayValue = (input.value)!"" /]
 
-[#if fixed && prefix?has_content && displayValue?starts_with(prefix)]
-	[#assign displayValue = displayValue?remove_beginning(prefix) /]
-[#elseif !fixed && selectedCountry.prefix?? && displayValue?starts_with("+" + selectedCountry.prefix)]
-	[#assign displayValue = displayValue?remove_beginning("+" + selectedCountry.prefix) /]
+[#if selectedCountry.idd?? && displayValue?starts_with("+" + selectedCountry.idd)]
+	[#assign displayValue = displayValue?remove_beginning("+" + selectedCountry.idd) /]
 [/#if]
 
 <div class="phone-number-input">
@@ -123,7 +121,7 @@
 		</label>
 
 		<div class="input-group">
-			[#if showPrefixPicker]
+			[#if showCountryCodePicker]
 				[#if fixed]
 					<div class="input-group-item input-group-item-shrink input-group-prepend">
 						<div class="input-group-text p-3">
@@ -136,36 +134,36 @@
 							[/#if]
 
 							<span>
-								[#if selectedCountry.prefix??]+${selectedCountry.prefix}[#else]${prefix}[/#if]
+								[#if selectedCountry.idd??]+${selectedCountry.idd}[/#if]
 							</span>
 						</div>
 					</div>
 				[#else]
-				<div class="dropdown input-group-item input-group-item-shrink input-group-prepend phone-number-input-prefix-picker" id="${fragmentElementId}-prefix-picker">
-					<button aria-expanded="false" aria-haspopup="listbox" aria-label="${languageUtil.get(locale, "country-code")}" class="form-control form-control-select form-control-select-secondary" [#if disabled || input.readOnly]disabled[/#if] id="${fragmentElementId}-prefix-trigger" type="button">
+				<div class="dropdown input-group-item input-group-item-shrink input-group-prepend phone-number-input-country-code-picker" id="${fragmentElementId}-country-code-picker">
+					<button aria-expanded="false" aria-haspopup="listbox" aria-label="${languageUtil.get(locale, "country-code")}" class="form-control form-control-select form-control-select-secondary" [#if disabled || input.readOnly]disabled[/#if] id="${fragmentElementId}-country-code-trigger" type="button">
 						[#assign selectedFlagSymbol = (FLAG_ICON_MAP[selectedCountry.a2!""])!"" /]
 
 						[#if showFlag]
-							<span class="inline-item inline-item-before phone-number-input-prefix-flag" id="${fragmentElementId}-prefix-flag">
+							<span class="inline-item inline-item-before phone-number-input-country-code-flag" id="${fragmentElementId}-country-code-flag">
 								[#if selectedFlagSymbol?has_content][@clay["icon"] symbol="${selectedFlagSymbol}" /][/#if]
 							</span>
 						[/#if]
 
-						<span class="mr-2" id="${fragmentElementId}-prefix-code">
-							[#if selectedCountry.prefix??]+${selectedCountry.prefix}[/#if]
+						<span class="mr-2" id="${fragmentElementId}-country-code">
+							[#if selectedCountry.idd??]+${selectedCountry.idd}[/#if]
 						</span>
 					</button>
 
-					<input id="${fragmentElementId}-prefix-value" type="hidden" value="${(selectedCountry.a2)!""}" />
+					<input id="${fragmentElementId}-country-code-value" type="hidden" value="${(selectedCountry.a2)!""}" />
 
 					[#if !input.readOnly]
-						<div class="dropdown-menu dropdown-menu-indicator-start dropdown-menu-select phone-number-input-prefix-menu" id="${fragmentElementId}-prefix-menu">
-							<ul aria-labelledby="${fragmentElementId}-prefix-trigger" class="inline-scroller list-unstyled" role="listbox">
+						<div class="dropdown-menu dropdown-menu-indicator-start dropdown-menu-select phone-number-input-country-code-menu" id="${fragmentElementId}-country-code-menu">
+							<ul aria-labelledby="${fragmentElementId}-country-code-trigger" class="inline-scroller list-unstyled" role="listbox">
 								[#list countries as country]
 									[#assign isSelected = selectedCountry.a2?? && country.a2 == selectedCountry.a2 /]
 
 									<li role="presentation">
-										<button aria-selected="${isSelected?string}" class="dropdown-item phone-number-input-prefix-menu-item[#if isSelected] active[/#if]" data-a2="${country.a2}" data-prefix="${country.prefix}" role="option" tabindex="-1" type="button">
+										<button aria-selected="${isSelected?string}" class="dropdown-item phone-number-input-country-code-menu-item[#if isSelected] active[/#if]" data-a2="${country.a2}" data-idd="${country.idd}" role="option" tabindex="-1" type="button">
 											<span class="dropdown-item-indicator-start">
 												[#if isSelected][@clay["icon"] symbol="check-small" /][/#if]
 											</span>
@@ -179,7 +177,7 @@
 													</div>
 												[/#if]
 
-												<div class="autofit-col phone-number-input-prefix-menu-item-code">+${country.prefix}</div>
+												<div class="autofit-col phone-number-input-country-code-menu-item-code">+${country.idd}</div>
 
 												<div class="autofit-col autofit-col-expand">${country.name}</div>
 											</div>

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/phone-number-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/phone-number-input/index.html
@@ -68,7 +68,7 @@
 [#assign countrySource = (input.attributes.countrySource)!"definedByUser" /]
 [#assign fixed = countrySource == "fixed" /]
 [#assign showFlag = configuration.showCountryFlag /]
-[#assign showCountryCodePicker = configuration.showPrefix /]
+[#assign showPrefixPicker = configuration.showPrefix /]
 [#assign selectedCountry = {} /]
 
 [#if fixed && countryA2?has_content]
@@ -80,7 +80,7 @@
 	[/#list]
 [#elseif input.value??]
 	[#list countries as country]
-		[#if input.value?starts_with("+" + country.idd)]
+		[#if input.value?starts_with("+" + country.prefix)]
 			[#assign selectedCountry = country /]
 			[#break]
 		[/#if]
@@ -102,10 +102,16 @@
 	[#assign selectedCountry = countries?first /]
 [/#if]
 
+[#assign prefix = "" /]
+
+[#if selectedCountry.prefix??]
+	[#assign prefix = "+" + selectedCountry.prefix /]
+[/#if]
+
 [#assign displayValue = (input.value)!"" /]
 
-[#if selectedCountry.idd?? && displayValue?starts_with("+" + selectedCountry.idd)]
-	[#assign displayValue = displayValue?remove_beginning("+" + selectedCountry.idd) /]
+[#if prefix?has_content && displayValue?starts_with(prefix)]
+	[#assign displayValue = displayValue?remove_beginning(prefix) /]
 [/#if]
 
 <div class="phone-number-input">
@@ -121,7 +127,7 @@
 		</label>
 
 		<div class="input-group">
-			[#if showCountryCodePicker]
+			[#if showPrefixPicker]
 				[#if fixed]
 					<div class="input-group-item input-group-item-shrink input-group-prepend">
 						<div class="input-group-text p-3">
@@ -134,36 +140,36 @@
 							[/#if]
 
 							<span>
-								[#if selectedCountry.idd??]+${selectedCountry.idd}[/#if]
+								[#if selectedCountry.prefix??]+${selectedCountry.prefix}[#else]${prefix}[/#if]
 							</span>
 						</div>
 					</div>
 				[#else]
-				<div class="dropdown input-group-item input-group-item-shrink input-group-prepend phone-number-input-country-code-picker" id="${fragmentElementId}-country-code-picker">
-					<button aria-expanded="false" aria-haspopup="listbox" aria-label="${languageUtil.get(locale, "country-code")}" class="form-control form-control-select form-control-select-secondary" [#if disabled || input.readOnly]disabled[/#if] id="${fragmentElementId}-country-code-trigger" type="button">
+				<div class="dropdown input-group-item input-group-item-shrink input-group-prepend phone-number-input-prefix-picker" id="${fragmentElementId}-prefix-picker">
+					<button aria-expanded="false" aria-haspopup="listbox" aria-label="${languageUtil.get(locale, "country-code")}" class="form-control form-control-select form-control-select-secondary" [#if disabled || input.readOnly]disabled[/#if] id="${fragmentElementId}-prefix-trigger" type="button">
 						[#assign selectedFlagSymbol = (FLAG_ICON_MAP[selectedCountry.a2!""])!"" /]
 
 						[#if showFlag]
-							<span class="inline-item inline-item-before phone-number-input-country-code-flag" id="${fragmentElementId}-country-code-flag">
+							<span class="inline-item inline-item-before phone-number-input-prefix-flag" id="${fragmentElementId}-prefix-flag">
 								[#if selectedFlagSymbol?has_content][@clay["icon"] symbol="${selectedFlagSymbol}" /][/#if]
 							</span>
 						[/#if]
 
-						<span class="mr-2" id="${fragmentElementId}-country-code">
-							[#if selectedCountry.idd??]+${selectedCountry.idd}[/#if]
+						<span class="mr-2" id="${fragmentElementId}-prefix-code">
+							[#if selectedCountry.prefix??]+${selectedCountry.prefix}[/#if]
 						</span>
 					</button>
 
-					<input id="${fragmentElementId}-country-code-value" type="hidden" value="${(selectedCountry.a2)!""}" />
+					<input id="${fragmentElementId}-prefix-value" type="hidden" value="${(selectedCountry.a2)!""}" />
 
 					[#if !input.readOnly]
-						<div class="dropdown-menu dropdown-menu-indicator-start dropdown-menu-select phone-number-input-country-code-menu" id="${fragmentElementId}-country-code-menu">
-							<ul aria-labelledby="${fragmentElementId}-country-code-trigger" class="inline-scroller list-unstyled" role="listbox">
+						<div class="dropdown-menu dropdown-menu-indicator-start dropdown-menu-select phone-number-input-prefix-menu" id="${fragmentElementId}-prefix-menu">
+							<ul aria-labelledby="${fragmentElementId}-prefix-trigger" class="inline-scroller list-unstyled" role="listbox">
 								[#list countries as country]
 									[#assign isSelected = selectedCountry.a2?? && country.a2 == selectedCountry.a2 /]
 
 									<li role="presentation">
-										<button aria-selected="${isSelected?string}" class="dropdown-item phone-number-input-country-code-menu-item[#if isSelected] active[/#if]" data-a2="${country.a2}" data-idd="${country.idd}" role="option" tabindex="-1" type="button">
+										<button aria-selected="${isSelected?string}" class="dropdown-item phone-number-input-prefix-menu-item[#if isSelected] active[/#if]" data-a2="${country.a2}" data-prefix="${country.prefix}" role="option" tabindex="-1" type="button">
 											<span class="dropdown-item-indicator-start">
 												[#if isSelected][@clay["icon"] symbol="check-small" /][/#if]
 											</span>
@@ -177,7 +183,7 @@
 													</div>
 												[/#if]
 
-												<div class="autofit-col phone-number-input-country-code-menu-item-code">+${country.idd}</div>
+												<div class="autofit-col phone-number-input-prefix-menu-item-code">+${country.prefix}</div>
 
 												<div class="autofit-col autofit-col-expand">${country.name}</div>
 											</div>

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/phone-number-input/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/phone-number-input/index.js
@@ -12,29 +12,20 @@ const SPRITEMAP =
 // DOM elements
 
 const inputElement = document.getElementById(`${fragmentElementId}-input`);
+const prefixCode = document.getElementById(`${fragmentElementId}-prefix-code`);
+const prefixFlag = document.getElementById(`${fragmentElementId}-prefix-flag`);
+const prefixMenu = document.getElementById(`${fragmentElementId}-prefix-menu`);
 
-const countryCode = document.getElementById(
-	`${fragmentElementId}-country-code`
+const prefixPicker = document.getElementById(
+	`${fragmentElementId}-prefix-picker`
 );
 
-const countryCodeFlag = document.getElementById(
-	`${fragmentElementId}-country-code-flag`
+const prefixTrigger = document.getElementById(
+	`${fragmentElementId}-prefix-trigger`
 );
 
-const countryCodeMenu = document.getElementById(
-	`${fragmentElementId}-country-code-menu`
-);
-
-const countryCodePicker = document.getElementById(
-	`${fragmentElementId}-country-code-picker`
-);
-
-const countryCodeTrigger = document.getElementById(
-	`${fragmentElementId}-country-code-trigger`
-);
-
-const countryCodeValueInput = document.getElementById(
-	`${fragmentElementId}-country-code-value`
+const prefixValueInput = document.getElementById(
+	`${fragmentElementId}-prefix-value`
 );
 
 const hiddenInputContainer = document.getElementById(
@@ -55,25 +46,25 @@ async function main() {
 	const COUNTRIES = (input.attributes.countries || []).map((country) => ({
 		a2: country.a2,
 		flagSymbol: getFlagSymbol(country.a2),
-		idd: country.idd,
+		idd: country.prefix,
 		name: country.name,
 	}));
 
-	const fixedCountry = COUNTRIES.find(
-		(country) => country.a2 === FIXED_COUNTRY_A2
-	);
+	const FIXED_COUNTRY = IS_FIXED
+		? COUNTRIES.find((country) => country.a2 === FIXED_COUNTRY_A2)
+		: null;
 
-	const fixedPrefix = fixedCountry ? `+${fixedCountry.idd}` : '';
+	const FIXED_PREFIX = FIXED_COUNTRY ? `+${FIXED_COUNTRY.idd}` : '';
 
 	// Utils
 
 	function getSelectedCountry() {
-		if (!countryCodeValueInput?.value) {
+		if (!prefixValueInput?.value) {
 			return null;
 		}
 
 		return COUNTRIES.find(
-			(country) => country.a2 === countryCodeValueInput.value
+			(country) => country.a2 === prefixValueInput.value
 		);
 	}
 
@@ -85,7 +76,7 @@ async function main() {
 		}
 
 		if (IS_FIXED) {
-			return `${fixedPrefix}${digits}`;
+			return `${FIXED_PREFIX}${digits}`;
 		}
 
 		const country = getSelectedCountry();
@@ -108,15 +99,15 @@ async function main() {
 			return;
 		}
 
-		countryCodeValueInput.value = country.a2;
-		countryCode.textContent = `+${country.idd}`;
+		prefixValueInput.value = country.a2;
+		prefixCode.textContent = `+${country.idd}`;
 
-		if (SHOW_FLAG && countryCodeFlag) {
-			countryCodeFlag.innerHTML = renderClayIcon(country.flagSymbol);
+		if (SHOW_FLAG && prefixFlag) {
+			prefixFlag.innerHTML = renderClayIcon(country.flagSymbol);
 		}
 
-		for (const item of countryCodeMenu.querySelectorAll(
-			'.phone-number-input-country-code-menu-item'
+		for (const item of prefixMenu.querySelectorAll(
+			'.phone-number-input-prefix-menu-item'
 		)) {
 			const selected = item.dataset.a2 === country.a2;
 
@@ -135,20 +126,20 @@ async function main() {
 		}
 	}
 
-	function toggleCountryCodeMenu(open) {
+	function togglePrefixMenu(open) {
 		const next =
 			typeof open === 'boolean'
 				? open
-				: !countryCodeMenu.classList.contains('show');
+				: !prefixMenu.classList.contains('show');
 
-		countryCodeMenu.classList.toggle('show', next);
-		countryCodeTrigger.setAttribute('aria-expanded', next);
+		prefixMenu.classList.toggle('show', next);
+		prefixTrigger.setAttribute('aria-expanded', next);
 	}
 
 	function syncFromValue(value) {
 		if (IS_FIXED) {
-			if (value && value.startsWith(fixedPrefix)) {
-				inputElement.value = value.slice(fixedPrefix.length);
+			if (value && value.startsWith(FIXED_PREFIX)) {
+				inputElement.value = value.slice(FIXED_PREFIX.length);
 			}
 
 			return;
@@ -169,32 +160,32 @@ async function main() {
 	// Event handlers
 
 	function handleTriggerClick() {
-		toggleCountryCodeMenu();
+		togglePrefixMenu();
 	}
 
 	function handleTriggerKeydown(event) {
 		if (event.key === 'ArrowDown' || event.key === 'Enter') {
 			event.preventDefault();
-			toggleCountryCodeMenu(true);
+			togglePrefixMenu(true);
 
 			const activeItem =
-				countryCodeMenu.querySelector(
-					'.phone-number-input-country-code-menu-item.active'
+				prefixMenu.querySelector(
+					'.phone-number-input-prefix-menu-item.active'
 				) ||
-				countryCodeMenu.querySelector(
-					'.phone-number-input-country-code-menu-item'
+				prefixMenu.querySelector(
+					'.phone-number-input-prefix-menu-item'
 				);
 
 			activeItem?.focus();
 		}
 		else if (event.key === 'Escape') {
-			toggleCountryCodeMenu(false);
+			togglePrefixMenu(false);
 		}
 	}
 
 	function handleMenuClick(event) {
 		const item = event.target.closest(
-			'.phone-number-input-country-code-menu-item'
+			'.phone-number-input-prefix-menu-item'
 		);
 
 		if (!item) {
@@ -202,14 +193,14 @@ async function main() {
 		}
 
 		selectCountry(item.dataset.a2);
-		toggleCountryCodeMenu(false);
+		togglePrefixMenu(false);
 
-		countryCodeTrigger.dispatchEvent(new Event('change', {bubbles: true}));
+		prefixTrigger.dispatchEvent(new Event('change', {bubbles: true}));
 	}
 
 	function handleDocumentClick(event) {
-		if (!countryCodePicker.contains(event.target)) {
-			toggleCountryCodeMenu(false);
+		if (!prefixPicker.contains(event.target)) {
+			togglePrefixMenu(false);
 		}
 	}
 
@@ -223,13 +214,13 @@ async function main() {
 		focusInput(inputElement);
 	}
 
-	// Add country code picker listeners
+	// Add prefix picker listeners
 
-	if (!IS_FIXED && countryCodeTrigger && countryCodeMenu) {
-		countryCodeTrigger.addEventListener('click', handleTriggerClick);
-		countryCodeTrigger.addEventListener('keydown', handleTriggerKeydown);
+	if (!IS_FIXED && prefixTrigger && prefixMenu) {
+		prefixTrigger.addEventListener('click', handleTriggerClick);
+		prefixTrigger.addEventListener('keydown', handleTriggerKeydown);
 
-		countryCodeMenu.addEventListener('click', handleMenuClick);
+		prefixMenu.addEventListener('click', handleMenuClick);
 
 		document.addEventListener('click', handleDocumentClick);
 	}
@@ -252,7 +243,7 @@ async function main() {
 		const handleChange = () => onChange(getCombinedValue());
 
 		inputElement.addEventListener('input', handleChange);
-		countryCodeTrigger?.addEventListener('change', handleChange);
+		prefixTrigger?.addEventListener('change', handleChange);
 
 		Liferay.on('localizationSelect:localeChanged', () => {
 			requestAnimationFrame(() => {
@@ -288,7 +279,7 @@ async function main() {
 if (layoutMode === 'edit') {
 	inputElement.setAttribute('disabled', true);
 
-	countryCodeTrigger?.setAttribute('disabled', true);
+	prefixTrigger?.setAttribute('disabled', true);
 }
 
 // Otherwise, execute main logic

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/phone-number-input/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/phone-number-input/index.js
@@ -1,7 +1,7 @@
 // Constants
 
-const FIXED_PREFIX = input.attributes.prefix || '';
-const IS_FIXED = input.attributes.prefixType === 'fixed';
+const FIXED_COUNTRY_A2 = input.attributes.country || '';
+const IS_FIXED = input.attributes.countrySource === 'fixed';
 const SHOW_FLAG = configuration.showCountryFlag;
 
 const SPRITEMAP =
@@ -12,20 +12,29 @@ const SPRITEMAP =
 // DOM elements
 
 const inputElement = document.getElementById(`${fragmentElementId}-input`);
-const prefixCode = document.getElementById(`${fragmentElementId}-prefix-code`);
-const prefixFlag = document.getElementById(`${fragmentElementId}-prefix-flag`);
-const prefixMenu = document.getElementById(`${fragmentElementId}-prefix-menu`);
 
-const prefixPicker = document.getElementById(
-	`${fragmentElementId}-prefix-picker`
+const countryCode = document.getElementById(
+	`${fragmentElementId}-country-code`
 );
 
-const prefixTrigger = document.getElementById(
-	`${fragmentElementId}-prefix-trigger`
+const countryCodeFlag = document.getElementById(
+	`${fragmentElementId}-country-code-flag`
 );
 
-const prefixValueInput = document.getElementById(
-	`${fragmentElementId}-prefix-value`
+const countryCodeMenu = document.getElementById(
+	`${fragmentElementId}-country-code-menu`
+);
+
+const countryCodePicker = document.getElementById(
+	`${fragmentElementId}-country-code-picker`
+);
+
+const countryCodeTrigger = document.getElementById(
+	`${fragmentElementId}-country-code-trigger`
+);
+
+const countryCodeValueInput = document.getElementById(
+	`${fragmentElementId}-country-code-value`
 );
 
 const hiddenInputContainer = document.getElementById(
@@ -46,19 +55,25 @@ async function main() {
 	const COUNTRIES = (input.attributes.countries || []).map((country) => ({
 		a2: country.a2,
 		flagSymbol: getFlagSymbol(country.a2),
-		idd: country.prefix,
+		idd: country.idd,
 		name: country.name,
 	}));
+
+	const fixedCountry = COUNTRIES.find(
+		(country) => country.a2 === FIXED_COUNTRY_A2
+	);
+
+	const fixedPrefix = fixedCountry ? `+${fixedCountry.idd}` : '';
 
 	// Utils
 
 	function getSelectedCountry() {
-		if (!prefixValueInput?.value) {
+		if (!countryCodeValueInput?.value) {
 			return null;
 		}
 
 		return COUNTRIES.find(
-			(country) => country.a2 === prefixValueInput.value
+			(country) => country.a2 === countryCodeValueInput.value
 		);
 	}
 
@@ -70,7 +85,7 @@ async function main() {
 		}
 
 		if (IS_FIXED) {
-			return `${FIXED_PREFIX}${digits}`;
+			return `${fixedPrefix}${digits}`;
 		}
 
 		const country = getSelectedCountry();
@@ -93,15 +108,15 @@ async function main() {
 			return;
 		}
 
-		prefixValueInput.value = country.a2;
-		prefixCode.textContent = `+${country.idd}`;
+		countryCodeValueInput.value = country.a2;
+		countryCode.textContent = `+${country.idd}`;
 
-		if (SHOW_FLAG && prefixFlag) {
-			prefixFlag.innerHTML = renderClayIcon(country.flagSymbol);
+		if (SHOW_FLAG && countryCodeFlag) {
+			countryCodeFlag.innerHTML = renderClayIcon(country.flagSymbol);
 		}
 
-		for (const item of prefixMenu.querySelectorAll(
-			'.phone-number-input-prefix-menu-item'
+		for (const item of countryCodeMenu.querySelectorAll(
+			'.phone-number-input-country-code-menu-item'
 		)) {
 			const selected = item.dataset.a2 === country.a2;
 
@@ -120,20 +135,20 @@ async function main() {
 		}
 	}
 
-	function togglePrefixMenu(open) {
+	function toggleCountryCodeMenu(open) {
 		const next =
 			typeof open === 'boolean'
 				? open
-				: !prefixMenu.classList.contains('show');
+				: !countryCodeMenu.classList.contains('show');
 
-		prefixMenu.classList.toggle('show', next);
-		prefixTrigger.setAttribute('aria-expanded', next);
+		countryCodeMenu.classList.toggle('show', next);
+		countryCodeTrigger.setAttribute('aria-expanded', next);
 	}
 
 	function syncFromValue(value) {
 		if (IS_FIXED) {
-			if (value && value.startsWith(FIXED_PREFIX)) {
-				inputElement.value = value.slice(FIXED_PREFIX.length);
+			if (value && value.startsWith(fixedPrefix)) {
+				inputElement.value = value.slice(fixedPrefix.length);
 			}
 
 			return;
@@ -154,32 +169,32 @@ async function main() {
 	// Event handlers
 
 	function handleTriggerClick() {
-		togglePrefixMenu();
+		toggleCountryCodeMenu();
 	}
 
 	function handleTriggerKeydown(event) {
 		if (event.key === 'ArrowDown' || event.key === 'Enter') {
 			event.preventDefault();
-			togglePrefixMenu(true);
+			toggleCountryCodeMenu(true);
 
 			const activeItem =
-				prefixMenu.querySelector(
-					'.phone-number-input-prefix-menu-item.active'
+				countryCodeMenu.querySelector(
+					'.phone-number-input-country-code-menu-item.active'
 				) ||
-				prefixMenu.querySelector(
-					'.phone-number-input-prefix-menu-item'
+				countryCodeMenu.querySelector(
+					'.phone-number-input-country-code-menu-item'
 				);
 
 			activeItem?.focus();
 		}
 		else if (event.key === 'Escape') {
-			togglePrefixMenu(false);
+			toggleCountryCodeMenu(false);
 		}
 	}
 
 	function handleMenuClick(event) {
 		const item = event.target.closest(
-			'.phone-number-input-prefix-menu-item'
+			'.phone-number-input-country-code-menu-item'
 		);
 
 		if (!item) {
@@ -187,14 +202,14 @@ async function main() {
 		}
 
 		selectCountry(item.dataset.a2);
-		togglePrefixMenu(false);
+		toggleCountryCodeMenu(false);
 
-		prefixTrigger.dispatchEvent(new Event('change', {bubbles: true}));
+		countryCodeTrigger.dispatchEvent(new Event('change', {bubbles: true}));
 	}
 
 	function handleDocumentClick(event) {
-		if (!prefixPicker.contains(event.target)) {
-			togglePrefixMenu(false);
+		if (!countryCodePicker.contains(event.target)) {
+			toggleCountryCodeMenu(false);
 		}
 	}
 
@@ -208,13 +223,13 @@ async function main() {
 		focusInput(inputElement);
 	}
 
-	// Add prefix picker listeners
+	// Add country code picker listeners
 
-	if (!IS_FIXED && prefixTrigger && prefixMenu) {
-		prefixTrigger.addEventListener('click', handleTriggerClick);
-		prefixTrigger.addEventListener('keydown', handleTriggerKeydown);
+	if (!IS_FIXED && countryCodeTrigger && countryCodeMenu) {
+		countryCodeTrigger.addEventListener('click', handleTriggerClick);
+		countryCodeTrigger.addEventListener('keydown', handleTriggerKeydown);
 
-		prefixMenu.addEventListener('click', handleMenuClick);
+		countryCodeMenu.addEventListener('click', handleMenuClick);
 
 		document.addEventListener('click', handleDocumentClick);
 	}
@@ -237,7 +252,7 @@ async function main() {
 		const handleChange = () => onChange(getCombinedValue());
 
 		inputElement.addEventListener('input', handleChange);
-		prefixTrigger?.addEventListener('change', handleChange);
+		countryCodeTrigger?.addEventListener('change', handleChange);
 
 		Liferay.on('localizationSelect:localeChanged', () => {
 			requestAnimationFrame(() => {
@@ -273,7 +288,7 @@ async function main() {
 if (layoutMode === 'edit') {
 	inputElement.setAttribute('disabled', true);
 
-	prefixTrigger?.setAttribute('disabled', true);
+	countryCodeTrigger?.setAttribute('disabled', true);
 }
 
 // Otherwise, execute main logic

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/input/template/parser/FragmentEntryInputTemplateNodeContextHelperImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/input/template/parser/FragmentEntryInputTemplateNodeContextHelperImpl.java
@@ -740,10 +740,11 @@ public class FragmentEntryInputTemplateNodeContextHelperImpl
 		inputTemplateNode.addAttribute(
 			"countries", _getCountriesJSONObjects(locale));
 		inputTemplateNode.addAttribute(
-			"prefix", infoField.getAttribute(PhoneNumberInfoFieldType.PREFIX));
+			"country",
+			infoField.getAttribute(PhoneNumberInfoFieldType.COUNTRY));
 		inputTemplateNode.addAttribute(
-			"prefixType",
-			infoField.getAttribute(PhoneNumberInfoFieldType.PREFIX_TYPE));
+			"countrySource",
+			infoField.getAttribute(PhoneNumberInfoFieldType.COUNTRY_SOURCE));
 	}
 
 	private void _addRelationshipInfoFieldTypeInputTemplateNodeAttributes(
@@ -899,9 +900,9 @@ public class FragmentEntryInputTemplateNodeContextHelperImpl
 				JSONUtil.put(
 					"a2", a2
 				).put(
-					"name", country.getTitle(languageId)
+					"idd", idd
 				).put(
-					"prefix", idd
+					"name", country.getTitle(languageId)
 				));
 		}
 

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/input/template/parser/FragmentEntryInputTemplateNodeContextHelperImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/input/template/parser/FragmentEntryInputTemplateNodeContextHelperImpl.java
@@ -900,9 +900,9 @@ public class FragmentEntryInputTemplateNodeContextHelperImpl
 				JSONUtil.put(
 					"a2", a2
 				).put(
-					"idd", idd
-				).put(
 					"name", country.getTitle(languageId)
+				).put(
+					"prefix", idd
 				));
 		}
 

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/field/type/PhoneNumberInfoFieldType.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/field/type/PhoneNumberInfoFieldType.java
@@ -10,14 +10,14 @@ package com.liferay.info.field.type;
  */
 public class PhoneNumberInfoFieldType implements InfoFieldType {
 
-	public static final PhoneNumberInfoFieldType INSTANCE =
-		new PhoneNumberInfoFieldType();
-
-	public static final Attribute<PhoneNumberInfoFieldType, String> PREFIX =
+	public static final Attribute<PhoneNumberInfoFieldType, String> COUNTRY =
 		new Attribute<>();
 
 	public static final Attribute<PhoneNumberInfoFieldType, String>
-		PREFIX_TYPE = new Attribute<>();
+		COUNTRY_SOURCE = new Attribute<>();
+
+	public static final PhoneNumberInfoFieldType INSTANCE =
+		new PhoneNumberInfoFieldType();
 
 	@Override
 	public String getName() {

--- a/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/field/converter/ObjectFieldInfoFieldConverter.java
+++ b/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/field/converter/ObjectFieldInfoFieldConverter.java
@@ -247,13 +247,14 @@ public class ObjectFieldInfoFieldConverter {
 					ObjectFieldConstants.BUSINESS_TYPE_PHONE_NUMBER)) {
 
 			finalStep.attribute(
-				PhoneNumberInfoFieldType.PREFIX,
+				PhoneNumberInfoFieldType.COUNTRY,
 				ObjectFieldSettingUtil.getValue(
-					ObjectFieldSettingConstants.NAME_PREFIX, objectField)
+					ObjectFieldSettingConstants.NAME_COUNTRY, objectField)
 			).attribute(
-				PhoneNumberInfoFieldType.PREFIX_TYPE,
+				PhoneNumberInfoFieldType.COUNTRY_SOURCE,
 				ObjectFieldSettingUtil.getValue(
-					ObjectFieldSettingConstants.NAME_PREFIX_TYPE, objectField)
+					ObjectFieldSettingConstants.NAME_COUNTRY_SOURCE,
+					objectField)
 			);
 		}
 		else if (Objects.equals(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/info/field/converter/test/ObjectFieldInfoFieldConverterTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/info/field/converter/test/ObjectFieldInfoFieldConverterTest.java
@@ -265,7 +265,7 @@ public class ObjectFieldInfoFieldConverterTest {
 				Collections.singletonList(
 					new ObjectFieldSettingBuilder(
 					).name(
-						ObjectFieldSettingConstants.NAME_PREFIX_TYPE
+						ObjectFieldSettingConstants.NAME_COUNTRY_SOURCE
 					).value(
 						ObjectFieldSettingConstants.VALUE_DEFINED_BY_USER
 					).build())
@@ -287,10 +287,10 @@ public class ObjectFieldInfoFieldConverterTest {
 		Assert.assertSame(
 			PhoneNumberInfoFieldType.INSTANCE, infoField.getInfoFieldType());
 		Assert.assertNull(
-			infoField.getAttribute(PhoneNumberInfoFieldType.PREFIX));
+			infoField.getAttribute(PhoneNumberInfoFieldType.COUNTRY));
 		Assert.assertEquals(
 			ObjectFieldSettingConstants.VALUE_DEFINED_BY_USER,
-			infoField.getAttribute(PhoneNumberInfoFieldType.PREFIX_TYPE));
+			infoField.getAttribute(PhoneNumberInfoFieldType.COUNTRY_SOURCE));
 
 		objectField = ObjectFieldUtil.addCustomObjectField(
 			new PhoneNumberObjectFieldBuilder(
@@ -304,13 +304,13 @@ public class ObjectFieldInfoFieldConverterTest {
 				Arrays.asList(
 					new ObjectFieldSettingBuilder(
 					).name(
-						ObjectFieldSettingConstants.NAME_PREFIX
+						ObjectFieldSettingConstants.NAME_COUNTRY
 					).value(
-						"+1"
+						"US"
 					).build(),
 					new ObjectFieldSettingBuilder(
 					).name(
-						ObjectFieldSettingConstants.NAME_PREFIX_TYPE
+						ObjectFieldSettingConstants.NAME_COUNTRY_SOURCE
 					).value(
 						ObjectFieldSettingConstants.VALUE_FIXED
 					).build())
@@ -326,10 +326,10 @@ public class ObjectFieldInfoFieldConverterTest {
 		Assert.assertSame(
 			PhoneNumberInfoFieldType.INSTANCE, infoField.getInfoFieldType());
 		Assert.assertEquals(
-			"+1", infoField.getAttribute(PhoneNumberInfoFieldType.PREFIX));
+			"US", infoField.getAttribute(PhoneNumberInfoFieldType.COUNTRY));
 		Assert.assertEquals(
 			ObjectFieldSettingConstants.VALUE_FIXED,
-			infoField.getAttribute(PhoneNumberInfoFieldType.PREFIX_TYPE));
+			infoField.getAttribute(PhoneNumberInfoFieldType.COUNTRY_SOURCE));
 	}
 
 	private String _getRelationshipURL(

--- a/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/phoneNumberField.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/phoneNumberField.spec.ts
@@ -93,7 +93,7 @@ test(
 		await clickAndExpectToBeVisible({
 			autoClick: true,
 			target: page.getByRole('option', {name: 'Fixed'}),
-			trigger: page.getByLabel('Prefix Type'),
+			trigger: page.getByLabel('Country Source'),
 		});
 
 		await clickAndExpectToBeVisible({


### PR DESCRIPTION
## Summary

Aligns the phone number info field type and the phone number input fragment with the country / countrySource model introduced by LPD-91322 in the phone number object field. The info field type added in LPD-91059 still read the removed `prefix` / `prefixType` settings, which broke the `object-info-api` compile after the mainline rollup.

The PR layers two commits:

1. **`LPD-91322 LPD-91059 Use country setting in phone number info field type`** (Marcela Cunha — original commit from liferay-page-management#18509) — renames `PhoneNumberInfoFieldType.PREFIX` / `PREFIX_TYPE` to `COUNTRY` / `COUNTRY_SOURCE`, updates the converter and the fragment helper, and rewrites the phone-number-input fragment template to read the new attributes and derive the calling code from the selected country.

2. **`LPD-91322 LPD-91059 Keep prefix notation inside the phone number fragment`** — keeps the country / countrySource model at the boundary (input template node attributes), but reverts the DOM id / CSS class / countries JSON key renames inside the fragment so existing markup contracts and selectors stay intact.

## Test plan

- [x] `gw testIntegration --tests ObjectFieldInfoFieldConverterTest.testGetPhoneNumberInfoField` passes.
- [ ] Playwright `phoneNumberField.spec.ts` fails on `page.getByLabel('Prefix Type')`. The UI label was renamed to "Country Source" by LPD-91322 (PhoneNumberFieldComponents.tsx reads `Liferay.Language.get('country-source')`); the spec was not updated in that change. The failure is not introduced by this PR.