### PR TITLE
LPD-39987 Fix KeyboardArrowsIndicator test failures

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/icon-selector/__tests__/IconSelector.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/icon-selector/__tests__/IconSelector.tsx
@@ -11,20 +11,23 @@ import '@testing-library/jest-dom';
 
 import {IconSelector} from '../';
 
-// `IconSelector` fetches the spritemap on mount to extract the available icon
-// names. The indicator does not depend on that fetch, so a no-op stub keeps
-// jsdom happy without affecting what these tests assert.
-
-beforeAll(() => {
-	(global as any).fetch = jest.fn(() =>
-		Promise.resolve({
-			text: () => Promise.resolve('<svg></svg>'),
-		})
-	);
-});
-
 describe('IconSelector keyboard arrows indicator', () => {
 	afterEach(cleanup);
+
+	// `IconSelector` fetches the spritemap on mount to extract the
+	// available icon names. The shared Jest setup replaces `global.fetch`
+	// with a throw-stub in its own `beforeEach`, so the override has to
+	// happen per-test (after that setup runs) rather than once in
+	// `beforeAll`. A no-op SVG keeps `DOMParser` and the icon list path
+	// happy without affecting what these tests assert.
+
+	beforeEach(() => {
+		(global.fetch as jest.Mock).mockImplementation(() =>
+			Promise.resolve({
+				text: () => Promise.resolve('<svg></svg>'),
+			})
+		);
+	});
 
 	it('does not render the indicator by default', async () => {
 		const {getByRole} = render(<IconSelector spritemap="/foo/bar.svg" />);

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/__tests__/BasicRendering.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/__tests__/BasicRendering.tsx
@@ -316,7 +316,7 @@ describe('Picker basic rendering', () => {
 	});
 
 	it('does not render the keyboard arrows indicator by default', async () => {
-		const {getByRole, queryByRole} = render(
+		const {getByRole} = render(
 			<Picker>
 				<Option key="apple">Apple</Option>
 
@@ -326,9 +326,9 @@ describe('Picker basic rendering', () => {
 
 		await userEvent.click(getByRole('combobox'));
 
-		expect(queryByRole('img')).not.toHaveClass(
-			'clay-keyboard-arrows-indicator'
-		);
+		expect(
+			document.querySelector('.clay-keyboard-arrows-indicator')
+		).not.toBeInTheDocument();
 	});
 
 	it('renders the keyboard arrows indicator alongside the menu when enabled', async () => {

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/vertical-nav/__tests__/BasicRendering.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/vertical-nav/__tests__/BasicRendering.tsx
@@ -117,19 +117,19 @@ describe('VerticalNav basic rendering', () => {
 
 	describe('keyboard arrows indicator', () => {
 		it('does not render the indicator by default', () => {
-			const {container} = renderStaticWithProps();
+			renderStaticWithProps();
 
 			expect(
-				container.querySelector('.clay-keyboard-arrows-indicator')
+				document.body.querySelector('.clay-keyboard-arrows-indicator')
 			).not.toBeInTheDocument();
 		});
 
 		it('renders the floating indicator with direction "all" when enabled', () => {
-			const {container} = renderStaticWithProps({
+			renderStaticWithProps({
 				displayKeyboardArrowsIndicator: true,
 			});
 
-			const indicator = container.querySelector(
+			const indicator = document.body.querySelector(
 				'.clay-keyboard-arrows-indicator'
 			);
 


### PR DESCRIPTION
This PR attempts to fix current stable build. Three CI failures from the previous run of the `KeyboardArrowsIndicator` wiring tests: the `IconSelector` suite crashed the Jest worker, `Picker`'s "no indicator by default" assertion blew up on a null element, and `VerticalNav` queried the portaled indicator from the wrong root.