### PR TITLE
LRDOCS-17032 Add modules/util/semantic-search-cli/

### DIFF
--- a/modules/util/semantic-search-cli/README.md
+++ b/modules/util/semantic-search-cli/README.md
@@ -1,0 +1,142 @@
+# modules/util/semantic-search-cli
+
+A jar-based CLI for semantic search over a project's text corpus.
+Talks HTTP to Hugging Face's text-embeddings-inference (TEI) for
+embeddings, and uses the Qdrant Java client for vector ops. The
+bundled `docker-compose.yml` brings up both containers; the jar
+itself stays small and dependency-light.
+
+Skills and other agents invoke this jar by shell command — the
+subcommands, flags, and JSON output schema are the stable interface.
+
+## What gets indexed
+
+Files are selected by extension. The default is `.md`; set the
+`SEARCH_FILE_EXTS` env var to a comma-separated list to widen the
+walk:
+
+| Setting | Effect |
+| :--- | :--- |
+| (default) | Markdown only (`.md`). |
+| `SEARCH_FILE_EXTS=.java` | Java source only. |
+| `SEARCH_FILE_EXTS=.md,.java` | Markdown plus Java. |
+
+A language-appropriate chunker handles each extension. Markdown is
+split by `##` sections (heading-path becomes `[H1, H2]`); Java is
+split at top-level method signatures (heading-path becomes
+`[ClassName, methodName]`), after stripping the license header,
+`package` line, and the entire `import` block.
+
+## CLI contract
+
+```
+search ingest <dir> [--force]
+search query "<text>" [--top N] [--format text|json]
+search similar <path> [--top N] [--format text|json]
+search status
+```
+
+Exit codes:
+
+| Code | Meaning |
+| ---: | :--- |
+| 0 | Success. |
+| 1 | Bad input. |
+| 2 | Bad CLI usage. |
+| 3 | Index does not exist. |
+| 4 | Target file for `similar` has no extractable content. |
+| 5 | Qdrant unreachable. |
+| 6 | Internal error. |
+
+JSON output schema for `query` and `similar`:
+
+```json
+{
+	"chunk_id": "...",
+	"heading_path": [
+		"H1",
+		"H2"
+	],
+	"path": "...",
+	"score": 0.0,
+	"snippet": "..."
+}
+```
+
+## Runtime data location
+
+Persistent state — the Qdrant index and the downloaded embedding
+model — lives outside the calling project's checkout, as a sibling.
+Default layout, computed by `DataHome.compute()` from the project
+root:
+
+```
+<parent-of-project>/<project-basename>-tools[-<worktree-suffix>]/search/
+├── qdrant-data/   (vector index)
+└── model-cache/   (TEI's model cache)
+```
+
+Override the whole path with `SEARCH_DATA_HOME`. Use different
+override values to keep separate indices for different corpora.
+
+## Use cases
+
+### Technical writer in `liferay-learn`
+
+Index the English docs corpus, then surface related articles when
+writing or reviewing.
+
+```bash
+cd ~/projects/liferay-learn
+search ingest docs/dxp/latest/en/                            # ~14 min first run, seconds incremental
+search query "client extension deployment"                   # natural-language → article
+search similar docs/dxp/latest/en/some-article.md            # related-article surface
+```
+
+Default extension (`.md`) is the right setting; no env var needed.
+
+### Developer working in `liferay-portal`
+
+Index the Java source of one or more modules, then find code by
+intent or by example.
+
+```bash
+cd ~/projects/liferay-portal
+SEARCH_FILE_EXTS=.java search ingest modules/apps/headless/headless-delivery/
+
+search query "REST endpoint that lists comments for a blog posting"
+search similar modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/CommentResourceImpl.java
+```
+
+`search query` returns method-level hits with a `Class > method`
+heading path. `search similar <path>` finds peer implementations
+across the indexed subtree.
+
+Scope each ingest to what you actually need (a module or two);
+indexing the entire `modules/apps/` tree is possible but takes
+hours and is rarely what you want.
+
+### Content engineer cross-referencing docs against portal source
+
+Maintain two indices side by side — one per repo, one per corpus.
+Because `SEARCH_DATA_HOME` defaults to a per-checkout sibling
+directory, the two indices stay isolated automatically.
+
+```bash
+# Index 1: liferay-learn docs (default extension)
+cd ~/projects/liferay-learn
+search ingest docs/dxp/latest/en/
+
+# Index 2: liferay-portal Java for the same feature area
+cd ~/projects/liferay-portal
+SEARCH_FILE_EXTS=.java search ingest modules/apps/headless/headless-delivery/
+
+# Query each in its own checkout
+( cd ~/projects/liferay-learn   && search query "client extension manifest" )
+( cd ~/projects/liferay-portal  && search query "client extension manifest" )
+```
+
+The pattern generalizes to any number of repos: cd into the
+checkout that contains the corpus you want to search, run the same
+CLI. The data-home resolution handles separation; you don't need to
+juggle collection names.

--- a/modules/util/semantic-search-cli/bnd.bnd
+++ b/modules/util/semantic-search-cli/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Semantic Search CLI
+Bundle-SymbolicName: com.liferay.semantic.search.cli
+Bundle-Version: 1.0.0
+Main-Class: com.liferay.semantic.search.cli.SemanticSearchCLI

--- a/modules/util/semantic-search-cli/build.gradle
+++ b/modules/util/semantic-search-cli/build.gradle
@@ -1,0 +1,23 @@
+sourceCompatibility = "11"
+targetCompatibility = "11"
+
+dependencies {
+	api group: "com.google.protobuf", name: "protobuf-java", version: "3.25.5"
+	api group: "io.grpc", name: "grpc-netty-shaded", version: "1.75.0"
+	api group: "io.grpc", name: "grpc-protobuf", version: "1.75.0"
+	api group: "io.grpc", name: "grpc-stub", version: "1.75.0"
+	api group: "io.qdrant", name: "client", version: "1.13.0"
+	api group: "org.json", name: "json", version: "20231013"
+	compileInclude group: "com.liferay", name: "com.liferay.petra.lang", version: "6.0.0"
+	compileInclude group: "com.liferay", name: "com.liferay.petra.string", version: "5.3.7"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testImplementation group: "junit", name: "junit", version: "4.13.1"
+}
+
+liferay {
+	deployDir = "../../../tools/sdk/dependencies/com.liferay.semantic.search.cli/lib"
+}
+
+test {
+	jvmArgs "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
+}

--- a/modules/util/semantic-search-cli/docker-compose.yml
+++ b/modules/util/semantic-search-cli/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+    qdrant:
+        container_name: search-qdrant
+        image: qdrant/qdrant:v1.12.4
+        ports:
+            -   "127.0.0.1:6333:6333"
+            -   "127.0.0.1:6334:6334"
+        restart: unless-stopped
+        volumes:
+            -   ${SEARCH_DATA_HOME:?must be set; see modules/util/semantic-search-cli/README.md}/qdrant-data:/qdrant/storage
+    tei:
+        container_name: search-tei
+        environment:
+            AUTO_TRUNCATE: "true"
+            MAX_CLIENT_BATCH_SIZE: "64"
+            MODEL_ID: BAAI/bge-small-en-v1.5
+        image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.6
+        ports:
+            -   "127.0.0.1:8080:80"
+        restart: unless-stopped
+        volumes:
+            -   ${SEARCH_DATA_HOME:?must be set; see modules/util/semantic-search-cli/README.md}/model-cache:/data

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/SemanticSearchCLI.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/SemanticSearchCLI.java
@@ -1,0 +1,93 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
+import com.liferay.semantic.search.cli.command.Command;
+import com.liferay.semantic.search.cli.command.IngestCommand;
+import com.liferay.semantic.search.cli.command.QueryCommand;
+import com.liferay.semantic.search.cli.command.SimilarCommand;
+import com.liferay.semantic.search.cli.command.StatusCommand;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Entry point for the semantic-search CLI. Subcommands, flags, and the
+ * JSON output schema are the stable interface; skills and agents shell
+ * out to this jar by command.
+ *
+ * @author JR Houn
+ */
+public class SemanticSearchCLI {
+
+	public static void main(String[] args) {
+		Map<String, Command> commands =
+			LinkedHashMapBuilder.<String, Command>put(
+				"ingest", new IngestCommand()
+			).put(
+				"query", new QueryCommand()
+			).put(
+				"similar", new SimilarCommand()
+			).put(
+				"status", new StatusCommand()
+			).build();
+
+		if ((args.length == 0) || Objects.equals(args[0], "--help") ||
+			Objects.equals(args[0], "-h")) {
+
+			_printUsage(commands);
+
+			System.exit((args.length == 0) ? 2 : 0);
+		}
+
+		String commandName = args[0];
+
+		Command command = commands.get(commandName);
+
+		if (command == null) {
+			System.err.println("search: unknown command: " + commandName);
+			System.err.println();
+
+			_printUsage(commands);
+
+			System.exit(2);
+		}
+
+		String[] commandArgs = Arrays.copyOfRange(args, 1, args.length);
+
+		try {
+			int exitCode = command.run(commandArgs);
+
+			System.exit(exitCode);
+		}
+		catch (Exception exception) {
+			System.err.println(
+				"search: internal error: " + exception.getMessage());
+
+			exception.printStackTrace(System.err);
+
+			System.exit(6);
+		}
+	}
+
+	private static void _printUsage(Map<String, Command> commands) {
+		System.err.println("Usage: search <command> [args...]");
+		System.err.println();
+		System.err.println("Commands:");
+
+		for (Map.Entry<String, Command> entry : commands.entrySet()) {
+			Command command = entry.getValue();
+
+			System.err.println(
+				StringBundler.concat(
+					"  ", entry.getKey(), "  ", command.description()));
+		}
+	}
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/chunker/Chunkers.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/chunker/Chunkers.java
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.chunker;
+
+import com.liferay.semantic.search.cli.util.Chunk;
+
+import java.util.List;
+
+/**
+ * Dispatches to a language-specific chunker by file extension.
+ *
+ * @author JR Houn
+ */
+public class Chunkers {
+
+	public static List<Chunk> parse(String text, String relPath) {
+		if (relPath.endsWith(".java")) {
+			return _JAVA_CHUNKER.parse(text, relPath);
+		}
+
+		return _MARKDOWN_CHUNKER.parse(text, relPath);
+	}
+
+	private static final JavaChunker _JAVA_CHUNKER = new JavaChunker();
+
+	private static final MarkdownChunker _MARKDOWN_CHUNKER =
+		new MarkdownChunker();
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/chunker/JavaChunker.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/chunker/JavaChunker.java
@@ -1,0 +1,189 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.chunker;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.semantic.search.cli.util.Chunk;
+
+import java.nio.file.Paths;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Splits a Java source file into method-scoped chunks.
+ *
+ *   1. Strip the license header (everything before the {@code package}
+ *      line).
+ *   2. Strip the {@code package} declaration and the entire
+ *      {@code import} block — both are pure boilerplate that
+ *      otherwise produces near-identical first chunks across every
+ *      file in the same package and ruins code-to-code similarity.
+ *   3. Capture the top-level class/interface name as the H1 analog.
+ *   4. Each top-level method signature begins a chunk; the chunk runs
+ *      to just before the next method signature.
+ *   5. The class-level content before the first method (class javadoc,
+ *      fields, constants) is the intro chunk with heading
+ *      {@code [className]}.
+ *   6. Methods longer than CHUNK_WINDOW_WORDS get a sliding-window
+ *      split sharing the same heading_path.
+ *
+ * @author JR Houn
+ */
+public class JavaChunker {
+
+	public List<Chunk> parse(String text, String relPath) {
+		String className = _classNameFromFile(relPath);
+
+		Matcher classMatcher = _classPattern.matcher(text);
+
+		if (classMatcher.find()) {
+			className = classMatcher.group(2);
+		}
+
+		Matcher packageMatcher = _packagePattern.matcher(text);
+
+		String body = text;
+
+		if (packageMatcher.find()) {
+			body = text.substring(packageMatcher.end());
+		}
+
+		Matcher importsMatcher = _importsPattern.matcher(body);
+
+		if (importsMatcher.find() && (importsMatcher.start() < 100)) {
+			body = body.substring(importsMatcher.end());
+		}
+
+		body = body.replaceFirst("\\A\\s+", "");
+
+		List<int[]> methodSigs = new ArrayList<>();
+
+		Matcher sigMatcher = _methodSigPattern.matcher(body);
+
+		while (sigMatcher.find()) {
+			methodSigs.add(new int[] {sigMatcher.start(), sigMatcher.end()});
+		}
+
+		List<Chunk> chunks = new ArrayList<>();
+
+		if (methodSigs.isEmpty()) {
+			_emit(chunks, relPath, Arrays.asList(className), body);
+
+			return chunks;
+		}
+
+		String intro = body.substring(0, methodSigs.get(0)[0]);
+
+		_emit(chunks, relPath, Arrays.asList(className), intro);
+
+		for (int i = 0; i < methodSigs.size(); i++) {
+			int[] sig = methodSigs.get(i);
+
+			int end = body.length();
+
+			if ((i + 1) < methodSigs.size()) {
+				end = methodSigs.get(i + 1)[0];
+			}
+
+			String signatureLine = body.substring(sig[0], sig[1]);
+
+			Matcher nameMatcher = _methodNamePattern.matcher(signatureLine);
+
+			String methodName = "method";
+
+			if (nameMatcher.find()) {
+				methodName = nameMatcher.group(1);
+			}
+
+			String methodBlock = body.substring(sig[0], end);
+
+			_emit(
+				chunks, relPath, Arrays.asList(className, methodName),
+				methodBlock);
+		}
+
+		return chunks;
+	}
+
+	private String _classNameFromFile(String relPath) {
+		String name = String.valueOf(
+			Paths.get(
+				relPath
+			).getFileName());
+
+		return name.replaceFirst("\\.java$", "");
+	}
+
+	private void _emit(
+		List<Chunk> chunks, String relPath, List<String> headingPath,
+		String sectionText) {
+
+		String stripped = sectionText.strip();
+
+		if (stripped.isEmpty()) {
+			return;
+		}
+
+		List<String> parts = _splitByWords(
+			stripped, MarkdownChunker.CHUNK_WINDOW_WORDS,
+			MarkdownChunker.CHUNK_OVERLAP_WORDS);
+
+		String headingSlug = String.join(" > ", headingPath);
+
+		for (int idx = 0; idx < parts.size(); idx++) {
+			String chunkId = StringBundler.concat(
+				relPath, "#", headingSlug, "#", idx);
+
+			chunks.add(
+				new Chunk(chunkId, relPath, headingPath, parts.get(idx)));
+		}
+	}
+
+	private List<String> _splitByWords(String text, int window, int overlap) {
+		String[] words = text.split("\\s+");
+
+		List<String> result = new ArrayList<>();
+
+		if (words.length <= window) {
+			result.add(text);
+
+			return result;
+		}
+
+		int step = Math.max(window - overlap, 1);
+
+		List<String> wordList = Arrays.asList(words);
+
+		for (int start = 0; start < words.length; start += step) {
+			int end = Math.min(start + window, words.length);
+
+			result.add(String.join(" ", wordList.subList(start, end)));
+
+			if ((start + window) >= words.length) {
+				break;
+			}
+		}
+
+		return result;
+	}
+
+	private static final Pattern _classPattern = Pattern.compile(
+		"\\b(class|interface|enum|@interface)\\s+(\\w+)");
+	private static final Pattern _importsPattern = Pattern.compile(
+		"(?m)(^import\\s+[^\\n]+;\\s*\\n)" +
+			"(?:\\s*(?:import\\s+[^\\n]+;\\s*\\n)?\\n?)*");
+	private static final Pattern _methodNamePattern = Pattern.compile(
+		"\\s(\\w+)\\s*\\(");
+	private static final Pattern _methodSigPattern = Pattern.compile(
+		"(?m)^\\t(?:public|protected|private)\\b[^=\\n]*\\([^)]*\\)[^\\n]*$");
+	private static final Pattern _packagePattern = Pattern.compile(
+		"(?m)^package\\s+[\\w.]+;\\s*\\n");
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/chunker/MarkdownChunker.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/chunker/MarkdownChunker.java
@@ -1,0 +1,214 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.chunker;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.semantic.search.cli.util.Chunk;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Splits a Markdown document into chunks for embedding:
+ *
+ *   1. Strip YAML front matter (`---` block at the start).
+ *   2. Capture the H1 as the document title. If absent, use the file
+ *      path as the title.
+ *   3. The intro between H1 and the first H2 is one chunk with
+ *      heading_path = [h1].
+ *   4. Each ## section is one chunk with heading_path = [h1, h2].
+ *   5. Sections longer than CHUNK_WINDOW_WORDS are split with a
+ *      sliding window of CHUNK_WINDOW_WORDS / CHUNK_OVERLAP_WORDS,
+ *      sharing the same heading_path.
+ *   6. H3+ headings stay inside the chunk body.
+ *
+ * @author JR Houn
+ */
+public class MarkdownChunker {
+
+	public static final int CHUNK_OVERLAP_WORDS = 60;
+
+	public static final int CHUNK_WINDOW_WORDS = 350;
+
+	public List<Chunk> parse(String text, String relPath) {
+		String body = _stripFrontMatter(text);
+
+		Matcher h1Matcher = _h1Pattern.matcher(body);
+
+		String h1 = relPath;
+
+		int introStart = 0;
+
+		if (h1Matcher.find()) {
+			String h1Group = h1Matcher.group(1);
+
+			h1 = h1Group.trim();
+
+			introStart = h1Matcher.end();
+		}
+
+		List<int[]> h2Matches = new ArrayList<>();
+
+		Matcher h2Matcher = _h2Pattern.matcher(body);
+
+		while (h2Matcher.find()) {
+			h2Matches.add(
+				new int[] {
+					h2Matcher.start(), h2Matcher.end(),
+					_findEndOfLine(body, h2Matcher.end())
+				});
+		}
+
+		List<RawSection> rawSections = new ArrayList<>();
+
+		if (h2Matches.isEmpty()) {
+			String content = body.substring(introStart);
+
+			content = content.trim();
+
+			if (!content.isEmpty()) {
+				rawSections.add(new RawSection(Arrays.asList(h1), content));
+			}
+		}
+		else {
+			int firstH2Start = h2Matches.get(0)[0];
+
+			String intro = body.substring(introStart, firstH2Start);
+
+			intro = intro.trim();
+
+			if (!intro.isEmpty()) {
+				rawSections.add(new RawSection(Arrays.asList(h1), intro));
+			}
+
+			for (int i = 0; i < h2Matches.size(); i++) {
+				int[] match = h2Matches.get(i);
+
+				String h2Heading = _h2Text(body, match);
+
+				int sectionStart = match[1];
+
+				int sectionEnd =
+					((i + 1) < h2Matches.size()) ? h2Matches.get(i + 1)[0] :
+						body.length();
+
+				String sectionBody = body.substring(sectionStart, sectionEnd);
+
+				sectionBody = sectionBody.trim();
+
+				if (!sectionBody.isEmpty()) {
+					rawSections.add(
+						new RawSection(
+							Arrays.asList(h1, h2Heading), sectionBody));
+				}
+			}
+		}
+
+		List<Chunk> chunks = new ArrayList<>();
+
+		for (RawSection rawSection : rawSections) {
+			List<String> parts = _splitByWords(
+				rawSection._text, CHUNK_WINDOW_WORDS, CHUNK_OVERLAP_WORDS);
+
+			String headingSlug = String.join(" > ", rawSection._headingPath);
+
+			for (int idx = 0; idx < parts.size(); idx++) {
+				String chunkId = StringBundler.concat(
+					relPath, "#", headingSlug, "#", idx);
+
+				chunks.add(
+					new Chunk(
+						chunkId, relPath, rawSection._headingPath,
+						parts.get(idx)));
+			}
+		}
+
+		return chunks;
+	}
+
+	private int _findEndOfLine(String body, int from) {
+		int newline = body.indexOf('\n', from);
+
+		if (newline < 0) {
+			return body.length();
+		}
+
+		return newline;
+	}
+
+	private String _h2Text(String body, int[] match) {
+		String fullMatch = body.substring(match[0], match[1]);
+
+		String head = fullMatch.substring(3);
+
+		return head.trim();
+	}
+
+	private List<String> _splitByWords(String text, int window, int overlap) {
+		String[] words = text.split("\\s+");
+
+		List<String> result = new ArrayList<>();
+
+		if (words.length <= window) {
+			result.add(text);
+
+			return result;
+		}
+
+		int step = Math.max(window - overlap, 1);
+
+		for (int start = 0; start < words.length; start += step) {
+			int end = Math.min(start + window, words.length);
+
+			List<String> sub = Arrays.asList(words);
+
+			result.add(String.join(" ", sub.subList(start, end)));
+
+			if ((start + window) >= words.length) {
+				break;
+			}
+		}
+
+		return result;
+	}
+
+	private String _stripFrontMatter(String text) {
+		if (!text.startsWith("---\n") && !text.startsWith("---\r\n")) {
+			return text;
+		}
+
+		Matcher matcher = _frontMatterEndPattern.matcher(text);
+
+		if (matcher.find()) {
+			return text.substring(matcher.end());
+		}
+
+		return text;
+	}
+
+	private static final Pattern _frontMatterEndPattern = Pattern.compile(
+		"\\n---\\s*\\n");
+	private static final Pattern _h1Pattern = Pattern.compile(
+		"^#\\s+(.+?)\\s*$", Pattern.MULTILINE);
+	private static final Pattern _h2Pattern = Pattern.compile(
+		"^##\\s+.+?\\s*$", Pattern.MULTILINE);
+
+	private static class RawSection {
+
+		private RawSection(List<String> headingPath, String text) {
+			_headingPath = headingPath;
+			_text = text;
+		}
+
+		private final List<String> _headingPath;
+		private final String _text;
+
+	}
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/client/QdrantClientWrapper.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/client/QdrantClientWrapper.java
@@ -1,0 +1,602 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.client;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.semantic.search.cli.util.Chunk;
+
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Collections;
+import io.qdrant.client.grpc.JsonWithInt;
+import io.qdrant.client.grpc.Points;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Thin wrapper around io.qdrant:client for this tool's vector ops.
+ * Stays lazy — the gRPC channel opens on first call so the `status`
+ * subcommand can fail fast with a clear unreachable message before
+ * incurring connection cost.
+ *
+ * @author JR Houn
+ */
+public class QdrantClientWrapper {
+
+	public static final String COLLECTION = "liferay_learn_docs";
+
+	public static final String META_COLLECTION = "liferay_learn_meta";
+
+	public boolean collectionExists(String name) throws Exception {
+		QdrantClient qdrantClient = _client();
+
+		List<String> names = qdrantClient.listCollectionsAsync(
+		).get();
+
+		return names.contains(name);
+	}
+
+	public void deleteByRelPaths(List<String> relPaths) throws Exception {
+		if (relPaths.isEmpty()) {
+			return;
+		}
+
+		QdrantClient qdrantClient = _client();
+
+		for (String relPath : relPaths) {
+			Points.Filter filter = Points.Filter.newBuilder(
+			).addMust(
+				Points.Condition.newBuilder(
+				).setField(
+					Points.FieldCondition.newBuilder(
+					).setKey(
+						"rel_path"
+					).setMatch(
+						Points.Match.newBuilder(
+						).setKeyword(
+							relPath
+						).build()
+					).build()
+				).build()
+			).build();
+
+			qdrantClient.deleteAsync(
+				COLLECTION, filter
+			).get();
+		}
+	}
+
+	public void deleteMetaFiles(List<String> relPaths) throws Exception {
+		if (relPaths.isEmpty()) {
+			return;
+		}
+
+		QdrantClient qdrantClient = _client();
+
+		List<Points.PointId> ids = new ArrayList<>();
+
+		for (String relPath : relPaths) {
+			UUID uuid = _metaFileRecordId(relPath);
+
+			ids.add(
+				Points.PointId.newBuilder(
+				).setUuid(
+					uuid.toString()
+				).build());
+		}
+
+		qdrantClient.deleteAsync(
+			META_COLLECTION, ids
+		).get();
+	}
+
+	public void ensureCollection(String name, int vectorSize) throws Exception {
+		QdrantClient qdrantClient = _client();
+
+		List<String> existing = qdrantClient.listCollectionsAsync(
+		).get();
+
+		if (!existing.contains(name)) {
+			qdrantClient.createCollectionAsync(
+				name,
+				Collections.VectorParams.newBuilder(
+				).setSize(
+					vectorSize
+				).setDistance(
+					Collections.Distance.Cosine
+				).build()
+			).get();
+
+			if (name.equals(COLLECTION)) {
+				qdrantClient.createPayloadIndexAsync(
+					COLLECTION, "rel_path",
+					Collections.PayloadSchemaType.Keyword, null, null, null,
+					null
+				).get();
+			}
+		}
+	}
+
+	public int getChunkCount() throws Exception {
+		QdrantClient qdrantClient = _client();
+
+		Collections.CollectionInfo info = qdrantClient.getCollectionInfoAsync(
+			COLLECTION
+		).get();
+
+		return (int)info.getPointsCount();
+	}
+
+	public String getQdrantUrl() {
+		return StringBundler.concat("http://", _host(), ":", _port());
+	}
+
+	public boolean isReachable() {
+		try {
+			QdrantClient qdrantClient = _client();
+
+			qdrantClient.listCollectionsAsync(
+			).get();
+
+			return true;
+		}
+		catch (Exception exception) {
+			return false;
+		}
+	}
+
+	public Map<String, String> loadFileHashes() throws Exception {
+		QdrantClient qdrantClient = _client();
+
+		Points.Filter filter = Points.Filter.newBuilder(
+		).addMust(
+			Points.Condition.newBuilder(
+			).setField(
+				Points.FieldCondition.newBuilder(
+				).setKey(
+					"kind"
+				).setMatch(
+					Points.Match.newBuilder(
+					).setKeyword(
+						"file"
+					).build()
+				).build()
+			).build()
+		).build();
+
+		Map<String, String> hashes = new HashMap<>();
+
+		Points.PointId offset = null;
+
+		while (true) {
+			Points.ScrollPoints.Builder builder =
+				Points.ScrollPoints.newBuilder(
+				).setCollectionName(
+					META_COLLECTION
+				).setFilter(
+					filter
+				).setLimit(
+					512
+				).setWithPayload(
+					Points.WithPayloadSelector.newBuilder(
+					).setEnable(
+						true
+					).build()
+				);
+
+			if (offset != null) {
+				builder.setOffset(offset);
+			}
+
+			Points.ScrollResponse response = qdrantClient.scrollAsync(
+				builder.build()
+			).get();
+
+			for (Points.RetrievedPoint point : response.getResultList()) {
+				Map<String, JsonWithInt.Value> payload = point.getPayloadMap();
+
+				JsonWithInt.Value relPathValue = payload.get("rel_path");
+
+				JsonWithInt.Value sha256Value = payload.get("sha256");
+
+				if ((relPathValue != null) && (sha256Value != null)) {
+					hashes.put(
+						relPathValue.getStringValue(),
+						sha256Value.getStringValue());
+				}
+			}
+
+			if (!response.hasNextPageOffset()) {
+				break;
+			}
+
+			offset = response.getNextPageOffset();
+		}
+
+		return hashes;
+	}
+
+	public MetaState readMetaState() throws Exception {
+		QdrantClient qdrantClient = _client();
+
+		Points.ScrollResponse response = qdrantClient.scrollAsync(
+			Points.ScrollPoints.newBuilder(
+			).setCollectionName(
+				META_COLLECTION
+			).setFilter(
+				Points.Filter.newBuilder(
+				).addMust(
+					Points.Condition.newBuilder(
+					).setField(
+						Points.FieldCondition.newBuilder(
+						).setKey(
+							"kind"
+						).setMatch(
+							Points.Match.newBuilder(
+							).setKeyword(
+								"state"
+							).build()
+						).build()
+					).build()
+				).build()
+			).setLimit(
+				1
+			).setWithPayload(
+				Points.WithPayloadSelector.newBuilder(
+				).setEnable(
+					true
+				).build()
+			).build()
+		).get();
+
+		List<Points.RetrievedPoint> points = response.getResultList();
+
+		if (points.isEmpty()) {
+			return null;
+		}
+
+		Points.RetrievedPoint point = points.get(0);
+
+		Map<String, JsonWithInt.Value> payload = point.getPayloadMap();
+
+		JsonWithInt.Value lastIngest = payload.get("last_ingest");
+
+		JsonWithInt.Value docCount = payload.get("doc_count");
+
+		return new MetaState(
+			(lastIngest != null) ? lastIngest.getStringValue() : null,
+			(docCount != null) ? (int)docCount.getIntegerValue() : 0);
+	}
+
+	public List<Hit> search(float[] vector, int limit) throws Exception {
+		QdrantClient qdrantClient = _client();
+
+		List<Float> vectorList = new ArrayList<>(vector.length);
+
+		for (float f : vector) {
+			vectorList.add(f);
+		}
+
+		List<Points.ScoredPoint> scoredPoints = qdrantClient.searchAsync(
+			Points.SearchPoints.newBuilder(
+			).setCollectionName(
+				COLLECTION
+			).addAllVector(
+				vectorList
+			).setLimit(
+				limit
+			).setWithPayload(
+				Points.WithPayloadSelector.newBuilder(
+				).setEnable(
+					true
+				).build()
+			).build()
+		).get();
+
+		List<Hit> hits = new ArrayList<>();
+
+		for (Points.ScoredPoint scored : scoredPoints) {
+			Map<String, JsonWithInt.Value> payload = scored.getPayloadMap();
+
+			List<String> headingPath = new ArrayList<>();
+
+			JsonWithInt.Value hp = payload.get("heading_path");
+
+			if ((hp != null) && hp.hasListValue()) {
+				JsonWithInt.ListValue listValue = hp.getListValue();
+
+				for (JsonWithInt.Value entry : listValue.getValuesList()) {
+					headingPath.add(entry.getStringValue());
+				}
+			}
+
+			JsonWithInt.Value relPathValue = payload.get("rel_path");
+			JsonWithInt.Value chunkIdValue = payload.get("chunk_id");
+			JsonWithInt.Value textValue = payload.get("text");
+
+			hits.add(
+				new Hit(
+					relPathValue.getStringValue(), scored.getScore(),
+					chunkIdValue.getStringValue(), textValue.getStringValue(),
+					headingPath));
+		}
+
+		return hits;
+	}
+
+	public void upsertChunks(List<Chunk> chunks, float[][] vectors)
+		throws Exception {
+
+		if (chunks.isEmpty()) {
+			return;
+		}
+
+		QdrantClient qdrantClient = _client();
+
+		List<Points.PointStruct> points = new ArrayList<>();
+
+		for (int i = 0; i < chunks.size(); i++) {
+			Chunk chunk = chunks.get(i);
+
+			List<Float> vector = new ArrayList<>(vectors[i].length);
+
+			for (float f : vectors[i]) {
+				vector.add(f);
+			}
+
+			JsonWithInt.ListValue.Builder listBuilder =
+				JsonWithInt.ListValue.newBuilder();
+
+			for (String heading : chunk.headingPath()) {
+				listBuilder.addValues(_stringValue(heading));
+			}
+
+			Map<String, JsonWithInt.Value> payload =
+				HashMapBuilder.<String, JsonWithInt.Value>put(
+					"chunk_id", _stringValue(chunk.chunkId())
+				).put(
+					"heading_path",
+					JsonWithInt.Value.newBuilder(
+					).setListValue(
+						listBuilder.build()
+					).build()
+				).put(
+					"rel_path", _stringValue(chunk.relPath())
+				).put(
+					"text", _stringValue(chunk.text())
+				).build();
+
+			UUID pointId = chunk.pointId();
+
+			points.add(
+				Points.PointStruct.newBuilder(
+				).setId(
+					Points.PointId.newBuilder(
+					).setUuid(
+						pointId.toString()
+					).build()
+				).setVectors(
+					Points.Vectors.newBuilder(
+					).setVector(
+						Points.Vector.newBuilder(
+						).addAllData(
+							vector
+						).build()
+					).build()
+				).putAllPayload(
+					payload
+				).build());
+		}
+
+		qdrantClient.upsertAsync(
+			COLLECTION, points
+		).get();
+	}
+
+	public void writeMetaFile(String relPath, String sha256) throws Exception {
+		QdrantClient qdrantClient = _client();
+
+		Map<String, JsonWithInt.Value> payload =
+			HashMapBuilder.<String, JsonWithInt.Value>put(
+				"kind", _stringValue("file")
+			).put(
+				"rel_path", _stringValue(relPath)
+			).put(
+				"sha256", _stringValue(sha256)
+			).build();
+
+		UUID pointId = _metaFileRecordId(relPath);
+
+		qdrantClient.upsertAsync(
+			META_COLLECTION,
+			Arrays.asList(
+				Points.PointStruct.newBuilder(
+				).setId(
+					Points.PointId.newBuilder(
+					).setUuid(
+						pointId.toString()
+					).build()
+				).setVectors(
+					Points.Vectors.newBuilder(
+					).setVector(
+						Points.Vector.newBuilder(
+						).addData(
+							0.0F
+						).build()
+					).build()
+				).putAllPayload(
+					payload
+				).build())
+		).get();
+	}
+
+	public void writeMetaState(String rootPath, int docCount) throws Exception {
+		QdrantClient qdrantClient = _client();
+
+		qdrantClient.upsertAsync(
+			META_COLLECTION,
+			Arrays.asList(
+				Points.PointStruct.newBuilder(
+				).setId(
+					Points.PointId.newBuilder(
+					).setUuid(
+						_metaStateRecordId().toString()
+					).build()
+				).setVectors(
+					Points.Vectors.newBuilder(
+					).setVector(
+						Points.Vector.newBuilder(
+						).addData(
+							0.0F
+						).build()
+					).build()
+				).putAllPayload(
+					HashMapBuilder.<String, JsonWithInt.Value>put(
+						"doc_count",
+						JsonWithInt.Value.newBuilder(
+						).setIntegerValue(
+							docCount
+						).build()
+					).put(
+						"ingest_root", _stringValue(rootPath)
+					).put(
+						"kind", _stringValue("state")
+					).put(
+						"last_ingest",
+						() -> _stringValue(
+							OffsetDateTime.now(
+								ZoneOffset.UTC
+							).format(
+								DateTimeFormatter.ISO_OFFSET_DATE_TIME
+							))
+					).build()
+				).build())
+		).get();
+	}
+
+	public static class Hit {
+
+		public Hit(
+			String relPath, double score, String chunkId, String text,
+			List<String> headingPath) {
+
+			_relPath = relPath;
+			_score = score;
+			_chunkId = chunkId;
+			_text = text;
+			_headingPath = headingPath;
+		}
+
+		public String chunkId() {
+			return _chunkId;
+		}
+
+		public List<String> headingPath() {
+			return _headingPath;
+		}
+
+		public String relPath() {
+			return _relPath;
+		}
+
+		public double score() {
+			return _score;
+		}
+
+		public String text() {
+			return _text;
+		}
+
+		private final String _chunkId;
+		private final List<String> _headingPath;
+		private final String _relPath;
+		private final double _score;
+		private final String _text;
+
+	}
+
+	public static class MetaState {
+
+		public MetaState(String lastIngest, int docCount) {
+			_lastIngest = lastIngest;
+			_docCount = docCount;
+		}
+
+		public int docCount() {
+			return _docCount;
+		}
+
+		public String lastIngest() {
+			return _lastIngest;
+		}
+
+		private final int _docCount;
+		private final String _lastIngest;
+
+	}
+
+	private synchronized QdrantClient _client() {
+		if (_qdrantClient == null) {
+			_qdrantClient = new QdrantClient(
+				QdrantGrpcClient.newBuilder(
+					_host(), 6334, false
+				).build());
+		}
+
+		return _qdrantClient;
+	}
+
+	private String _host() {
+		String host = System.getenv("QDRANT_HOST");
+
+		if ((host == null) || host.isEmpty()) {
+			return "localhost";
+		}
+
+		return host;
+	}
+
+	private UUID _metaFileRecordId(String relPath) {
+		String name = "semsearch:meta:file:" + relPath;
+
+		return UUID.nameUUIDFromBytes(name.getBytes());
+	}
+
+	private UUID _metaStateRecordId() {
+		return UUID.nameUUIDFromBytes("semsearch:meta:state".getBytes());
+	}
+
+	private int _port() {
+		String port = System.getenv("QDRANT_PORT");
+
+		if ((port == null) || port.isEmpty()) {
+			return 6333;
+		}
+
+		return GetterUtil.getInteger(port, 6333);
+	}
+
+	private JsonWithInt.Value _stringValue(String string) {
+		return JsonWithInt.Value.newBuilder(
+		).setStringValue(
+			string
+		).build();
+	}
+
+	private QdrantClient _qdrantClient;
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/client/TextEmbeddingsClient.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/client/TextEmbeddingsClient.java
@@ -1,0 +1,175 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.client;
+
+import com.liferay.petra.string.StringBundler;
+
+import java.io.IOException;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import java.time.Duration;
+
+import java.util.List;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * HTTP client for Hugging Face's text-embeddings-inference (TEI)
+ * server. TEI exposes /embed (batch) and /info (model metadata).
+ *
+ * Configuration via env vars:
+ *   TEI_URL    default "http://localhost:8080"
+ *
+ * No retry, no auth — TEI runs on localhost behind the docker-compose
+ * network. If we ever move it to a remote host, add a connect-timeout
+ * retry loop here.
+ *
+ * @author JR Houn
+ */
+public class TextEmbeddingsClient {
+
+	public TextEmbeddingsClient() {
+		String url = System.getenv("TEI_URL");
+
+		if ((url == null) || url.isEmpty()) {
+			url = "http://localhost:8080";
+		}
+
+		_baseUrl = url;
+
+		_httpClient = HttpClient.newBuilder(
+		).connectTimeout(
+			Duration.ofSeconds(5)
+		).build();
+	}
+
+	public float[][] embedDocuments(List<String> texts) throws IOException {
+		return _embedBatch(texts);
+	}
+
+	public float[] embedQuery(String text) throws IOException {
+		float[][] all = _embedBatch(List.of(text));
+
+		return all[0];
+	}
+
+	public int getDimension() throws IOException {
+		HttpRequest httpRequest = HttpRequest.newBuilder(
+			URI.create(_baseUrl + "/info")
+		).GET(
+		).timeout(
+			Duration.ofSeconds(5)
+		).build();
+
+		try {
+			HttpResponse<String> httpResponse = _httpClient.send(
+				httpRequest, HttpResponse.BodyHandlers.ofString());
+
+			if (httpResponse.statusCode() != 200) {
+				throw new IOException(
+					"TEI /info returned " + httpResponse.statusCode());
+			}
+
+			JSONObject responseJSONObject = new JSONObject(httpResponse.body());
+
+			return responseJSONObject.getInt("max_input_length");
+		}
+		catch (InterruptedException interruptedException) {
+			Thread currentThread = Thread.currentThread();
+
+			currentThread.interrupt();
+
+			throw new IOException("interrupted", interruptedException);
+		}
+	}
+
+	public boolean isReachable() {
+		try {
+			HttpRequest httpRequest = HttpRequest.newBuilder(
+				URI.create(_baseUrl + "/health")
+			).GET(
+			).timeout(
+				Duration.ofSeconds(2)
+			).build();
+
+			HttpResponse<Void> httpResponse = _httpClient.send(
+				httpRequest, HttpResponse.BodyHandlers.discarding());
+
+			if (httpResponse.statusCode() == 200) {
+				return true;
+			}
+
+			return false;
+		}
+		catch (Exception exception) {
+			return false;
+		}
+	}
+
+	private float[][] _embedBatch(List<String> texts) throws IOException {
+		JSONObject bodyJSONObject = new JSONObject();
+
+		bodyJSONObject.put(
+			"inputs", new JSONArray(texts)
+		).put(
+			"normalize", true
+		);
+
+		HttpRequest httpRequest = HttpRequest.newBuilder(
+			URI.create(_baseUrl + "/embed")
+		).header(
+			"Content-Type", "application/json"
+		).POST(
+			HttpRequest.BodyPublishers.ofString(bodyJSONObject.toString())
+		).timeout(
+			Duration.ofMinutes(2)
+		).build();
+
+		try {
+			HttpResponse<String> httpResponse = _httpClient.send(
+				httpRequest, HttpResponse.BodyHandlers.ofString());
+
+			if (httpResponse.statusCode() != 200) {
+				throw new IOException(
+					StringBundler.concat(
+						"TEI /embed returned ", httpResponse.statusCode(), ": ",
+						httpResponse.body()));
+			}
+
+			JSONArray responseJSONArray = new JSONArray(httpResponse.body());
+
+			float[][] vectors = new float[responseJSONArray.length()][];
+
+			for (int i = 0; i < responseJSONArray.length(); i++) {
+				JSONArray vectorJSONArray = responseJSONArray.getJSONArray(i);
+
+				vectors[i] = new float[vectorJSONArray.length()];
+
+				for (int j = 0; j < vectorJSONArray.length(); j++) {
+					vectors[i][j] = (float)vectorJSONArray.getDouble(j);
+				}
+			}
+
+			return vectors;
+		}
+		catch (InterruptedException interruptedException) {
+			Thread currentThread = Thread.currentThread();
+
+			currentThread.interrupt();
+
+			throw new IOException("interrupted", interruptedException);
+		}
+	}
+
+	private final String _baseUrl;
+	private final HttpClient _httpClient;
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/Command.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/Command.java
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.command;
+
+/**
+ * Contract for every CLI subcommand.
+ *
+ * Exit codes:
+ *   0  success
+ *   1  bad input (no .md files under target, etc.)
+ *   2  bad CLI usage
+ *   3  index does not exist
+ *   4  target file has no extractable content
+ *   5  Qdrant unreachable
+ *   6  internal error reading the index
+ *
+ * @author JR Houn
+ */
+public interface Command {
+
+	public String description();
+
+	public int run(String[] args) throws Exception;
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/IngestCommand.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/IngestCommand.java
@@ -1,0 +1,320 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.command;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.semantic.search.cli.chunker.Chunkers;
+import com.liferay.semantic.search.cli.client.QdrantClientWrapper;
+import com.liferay.semantic.search.cli.client.TextEmbeddingsClient;
+import com.liferay.semantic.search.cli.util.Args;
+import com.liferay.semantic.search.cli.util.Chunk;
+
+import java.io.IOException;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+import java.security.MessageDigest;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * @author JR Houn
+ */
+public class IngestCommand implements Command {
+
+	@Override
+	public String description() {
+		return "Index every .md file under <dir> [--force]";
+	}
+
+	@Override
+	public int run(String[] args) throws Exception {
+		Args parsed = new Args(args);
+
+		List<String> positional = parsed.positional();
+
+		if (positional.isEmpty()) {
+			System.err.println("search: ingest requires a <dir> argument");
+
+			return 2;
+		}
+
+		Path root = Paths.get(
+			positional.get(0)
+		).toAbsolutePath();
+
+		if (!Files.exists(root)) {
+			System.err.println("search: ingest target does not exist: " + root);
+
+			return 1;
+		}
+
+		List<Path> files = _indexableFiles(root);
+
+		if (files.isEmpty()) {
+			System.err.println("search: no .md files found under " + root);
+
+			return 1;
+		}
+
+		QdrantClientWrapper qdrantClient = new QdrantClientWrapper();
+
+		if (!qdrantClient.isReachable()) {
+			System.err.println(
+				"search: cannot reach Qdrant at " +
+					qdrantClient.getQdrantUrl());
+
+			return 5;
+		}
+
+		Path base = Files.isDirectory(root) ? root : root.getParent();
+
+		TextEmbeddingsClient teiClient = new TextEmbeddingsClient();
+
+		int vectorDim = teiClient.embedQuery("warmup").length;
+
+		qdrantClient.ensureCollection(
+			QdrantClientWrapper.COLLECTION, vectorDim);
+
+		qdrantClient.ensureCollection(QdrantClientWrapper.META_COLLECTION, 1);
+
+		Map<String, String> existingHashes = qdrantClient.loadFileHashes();
+
+		Set<String> seenRelPaths = new HashSet<>();
+
+		List<Chunk> pendingChunks = new ArrayList<>();
+
+		List<String[]> pendingFiles = new ArrayList<>();
+
+		int skipped = 0;
+
+		System.err.println(
+			StringBundler.concat(
+				"Scanning ", files.size(), " file(s) under ", root));
+
+		for (Path file : files) {
+			String text = new String(
+				Files.readAllBytes(file), StandardCharsets.UTF_8);
+
+			String sha = _sha256(text);
+
+			String relPath = base.relativize(
+				file
+			).toString();
+
+			seenRelPaths.add(relPath);
+
+			if (!parsed.force() && sha.equals(existingHashes.get(relPath))) {
+				skipped++;
+
+				continue;
+			}
+
+			List<Chunk> chunks = Chunkers.parse(text, relPath);
+
+			pendingFiles.add(new String[] {relPath, sha});
+
+			pendingChunks.addAll(chunks);
+		}
+
+		int indexed = pendingFiles.size();
+
+		if (!pendingChunks.isEmpty()) {
+			Set<String> changedRelPaths = new TreeSet<>();
+
+			for (Chunk chunk : pendingChunks) {
+				changedRelPaths.add(chunk.relPath());
+			}
+
+			qdrantClient.deleteByRelPaths(new ArrayList<>(changedRelPaths));
+
+			int batchSize = 64;
+
+			int upserted = 0;
+
+			for (int from = 0; from < pendingChunks.size(); from += batchSize) {
+				int to = Math.min(from + batchSize, pendingChunks.size());
+
+				List<Chunk> batch = pendingChunks.subList(from, to);
+
+				List<String> texts = new ArrayList<>();
+
+				for (Chunk chunk : batch) {
+					texts.add(chunk.text());
+				}
+
+				float[][] vectors = teiClient.embedDocuments(texts);
+
+				qdrantClient.upsertChunks(batch, vectors);
+
+				upserted += batch.size();
+
+				System.err.println(
+					StringBundler.concat(
+						"  embedded ", upserted, "/", pendingChunks.size(),
+						" chunks"));
+			}
+		}
+
+		for (String[] fileEntry : pendingFiles) {
+			qdrantClient.writeMetaFile(fileEntry[0], fileEntry[1]);
+		}
+
+		List<String> removed = new ArrayList<>();
+
+		if (Files.isDirectory(root)) {
+			Set<String> stale = new HashSet<>(existingHashes.keySet());
+
+			stale.removeAll(seenRelPaths);
+
+			for (String relPath : stale) {
+				removed.add(relPath);
+			}
+
+			if (!removed.isEmpty()) {
+				qdrantClient.deleteByRelPaths(removed);
+
+				qdrantClient.deleteMetaFiles(removed);
+			}
+		}
+
+		qdrantClient.writeMetaState(base.toString(), seenRelPaths.size());
+
+		System.err.println(
+			StringBundler.concat(
+				"Done. indexed=", indexed, " skipped=", skipped, " removed=",
+				removed.size(), " total_files=", seenRelPaths.size()));
+
+		return 0;
+	}
+
+	private String[] _fileExtensions() {
+		String env = System.getenv("SEARCH_FILE_EXTS");
+
+		if ((env == null) || env.isEmpty()) {
+			return new String[] {".md"};
+		}
+
+		String[] split = env.split(",");
+
+		List<String> exts = new ArrayList<>();
+
+		for (String ext : split) {
+			String trimmed = ext.trim();
+
+			if (!trimmed.isEmpty()) {
+				exts.add(trimmed);
+			}
+		}
+
+		return exts.toArray(new String[0]);
+	}
+
+	private List<Path> _indexableFiles(Path root) throws Exception {
+		String[] exts = _fileExtensions();
+
+		List<Path> files = new ArrayList<>();
+
+		if (Files.isRegularFile(root)) {
+			String name = String.valueOf(root.getFileName());
+
+			if (_matchesExtension(name, exts) && !name.startsWith(".")) {
+				files.add(root);
+			}
+
+			return files;
+		}
+
+		Files.walkFileTree(
+			root,
+			new SimpleFileVisitor<Path>() {
+
+				@Override
+				public FileVisitResult preVisitDirectory(
+						Path dir, BasicFileAttributes basicFileAttributes)
+					throws IOException {
+
+					Path dirFileName = dir.getFileName();
+
+					if (dirFileName == null) {
+						return FileVisitResult.CONTINUE;
+					}
+
+					String dirName = dirFileName.toString();
+
+					if (dirName.startsWith(".")) {
+						return FileVisitResult.SKIP_SUBTREE;
+					}
+
+					return FileVisitResult.CONTINUE;
+				}
+
+				@Override
+				public FileVisitResult visitFile(
+						Path file, BasicFileAttributes basicFileAttributes)
+					throws IOException {
+
+					Path fileNamePath = file.getFileName();
+
+					if (fileNamePath == null) {
+						return FileVisitResult.CONTINUE;
+					}
+
+					String fileName = fileNamePath.toString();
+
+					if (_matchesExtension(fileName, exts) &&
+						!fileName.startsWith(".")) {
+
+						files.add(file);
+					}
+
+					return FileVisitResult.CONTINUE;
+				}
+
+			});
+
+		Collections.sort(files);
+
+		return files;
+	}
+
+	private boolean _matchesExtension(String name, String[] exts) {
+		for (String ext : exts) {
+			if (name.endsWith(ext)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private String _sha256(String text) throws Exception {
+		MessageDigest digest = MessageDigest.getInstance("SHA-256");
+
+		byte[] bytes = digest.digest(text.getBytes(StandardCharsets.UTF_8));
+
+		StringBuilder stringBuilder = new StringBuilder();
+
+		for (byte b : bytes) {
+			stringBuilder.append(String.format("%02x", b));
+		}
+
+		return stringBuilder.toString();
+	}
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/QueryCommand.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/QueryCommand.java
@@ -1,0 +1,80 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.command;
+
+import com.liferay.semantic.search.cli.client.QdrantClientWrapper;
+import com.liferay.semantic.search.cli.client.TextEmbeddingsClient;
+import com.liferay.semantic.search.cli.util.Args;
+import com.liferay.semantic.search.cli.util.Hit;
+import com.liferay.semantic.search.cli.util.Output;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author JR Houn
+ */
+public class QueryCommand implements Command {
+
+	@Override
+	public String description() {
+		return "Search by string: query \"<text>\" [--top N] [--format " +
+			"text|json]";
+	}
+
+	@Override
+	public int run(String[] args) throws Exception {
+		Args parsed = new Args(args);
+
+		List<String> positional = parsed.positional();
+
+		if (positional.isEmpty()) {
+			System.err.println("search: query requires a \"<text>\" argument");
+
+			return 2;
+		}
+
+		QdrantClientWrapper qdrantClient = new QdrantClientWrapper();
+
+		if (!qdrantClient.isReachable()) {
+			System.err.println(
+				"search: cannot reach Qdrant at " +
+					qdrantClient.getQdrantUrl());
+
+			return 5;
+		}
+
+		if (!qdrantClient.collectionExists(QdrantClientWrapper.COLLECTION)) {
+			System.err.println(
+				"search: index does not exist. Run ingest first.");
+
+			return 3;
+		}
+
+		String text = positional.get(0);
+
+		TextEmbeddingsClient teiClient = new TextEmbeddingsClient();
+
+		float[] vector = teiClient.embedQuery(text);
+
+		List<QdrantClientWrapper.Hit> rawHits = qdrantClient.search(
+			vector, parsed.top());
+
+		List<Hit> hits = new ArrayList<>();
+
+		for (QdrantClientWrapper.Hit rawHit : rawHits) {
+			hits.add(
+				new Hit(
+					rawHit.relPath(), rawHit.score(), rawHit.chunkId(),
+					Output.snippet(rawHit.text()), rawHit.headingPath()));
+		}
+
+		System.out.println(Output.formatHits(hits, parsed.format()));
+
+		return 0;
+	}
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/SimilarCommand.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/SimilarCommand.java
@@ -1,0 +1,123 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.command;
+
+import com.liferay.semantic.search.cli.chunker.Chunkers;
+import com.liferay.semantic.search.cli.client.QdrantClientWrapper;
+import com.liferay.semantic.search.cli.client.TextEmbeddingsClient;
+import com.liferay.semantic.search.cli.util.Args;
+import com.liferay.semantic.search.cli.util.Chunk;
+import com.liferay.semantic.search.cli.util.Hit;
+import com.liferay.semantic.search.cli.util.Output;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author JR Houn
+ */
+public class SimilarCommand implements Command {
+
+	@Override
+	public String description() {
+		return "Search by file: similar <path> [--top N] [--format text|json]";
+	}
+
+	@Override
+	public int run(String[] args) throws Exception {
+		Args parsed = new Args(args);
+
+		List<String> positional = parsed.positional();
+
+		if (positional.isEmpty()) {
+			System.err.println("search: similar requires a <path> argument");
+
+			return 2;
+		}
+
+		Path targetPath = Paths.get(positional.get(0));
+
+		if (!Files.exists(targetPath)) {
+			System.err.println("search: file not found: " + targetPath);
+
+			return 1;
+		}
+
+		String text = new String(
+			Files.readAllBytes(targetPath), StandardCharsets.UTF_8);
+
+		String targetBaseName = String.valueOf(targetPath.getFileName());
+
+		List<Chunk> chunks = Chunkers.parse(text, targetBaseName);
+
+		if (chunks.isEmpty()) {
+			System.err.println(
+				"search: target file has no extractable content.");
+
+			return 4;
+		}
+
+		QdrantClientWrapper qdrantClient = new QdrantClientWrapper();
+
+		if (!qdrantClient.isReachable()) {
+			System.err.println(
+				"search: cannot reach Qdrant at " +
+					qdrantClient.getQdrantUrl());
+
+			return 5;
+		}
+
+		if (!qdrantClient.collectionExists(QdrantClientWrapper.COLLECTION)) {
+			System.err.println(
+				"search: index does not exist. Run ingest first.");
+
+			return 3;
+		}
+
+		Chunk seed = chunks.get(0);
+
+		String queryText =
+			String.join(" > ", seed.headingPath()) + "\n\n" + seed.text();
+
+		TextEmbeddingsClient teiClient = new TextEmbeddingsClient();
+
+		float[] vector = teiClient.embedQuery(queryText);
+
+		List<QdrantClientWrapper.Hit> rawHits = qdrantClient.search(
+			vector, (parsed.top() * 3) + 10);
+
+		List<Hit> hits = new ArrayList<>();
+
+		for (QdrantClientWrapper.Hit rawHit : rawHits) {
+			String relPath = rawHit.relPath();
+
+			if (relPath.equals(targetBaseName) ||
+				relPath.endsWith("/" + targetBaseName)) {
+
+				continue;
+			}
+
+			hits.add(
+				new Hit(
+					relPath, rawHit.score(), rawHit.chunkId(),
+					Output.snippet(rawHit.text()), rawHit.headingPath()));
+
+			if (hits.size() >= parsed.top()) {
+				break;
+			}
+		}
+
+		System.out.println(Output.formatHits(hits, parsed.format()));
+
+		return 0;
+	}
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/StatusCommand.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/StatusCommand.java
@@ -1,0 +1,106 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.command;
+
+import com.liferay.semantic.search.cli.client.QdrantClientWrapper;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+
+import org.json.JSONObject;
+
+/**
+ * @author JR Houn
+ */
+public class StatusCommand implements Command {
+
+	@Override
+	public String description() {
+		return "Print index status as JSON (always JSON; ignores --format)";
+	}
+
+	@Override
+	public int run(String[] args) throws Exception {
+		QdrantClientWrapper qdrantClient = new QdrantClientWrapper();
+
+		JSONObject statusJSONObject = new JSONObject();
+
+		statusJSONObject.put(
+			"doc_count", 0
+		).put(
+			"index_exists", false
+		).put(
+			"last_ingest", JSONObject.NULL
+		).put(
+			"qdrant_reachable", false
+		).put(
+			"qdrant_url", qdrantClient.getQdrantUrl()
+		).put(
+			"stale_days", JSONObject.NULL
+		);
+
+		if (!qdrantClient.isReachable()) {
+			System.out.println(statusJSONObject.toString(2));
+
+			System.err.println(
+				"search: cannot reach Qdrant at " +
+					qdrantClient.getQdrantUrl() +
+						". Start it: docker compose up -d qdrant");
+
+			return 5;
+		}
+
+		statusJSONObject.put("qdrant_reachable", true);
+
+		boolean indexExists = qdrantClient.collectionExists(
+			QdrantClientWrapper.COLLECTION);
+
+		statusJSONObject.put("index_exists", indexExists);
+
+		boolean metaExists = qdrantClient.collectionExists(
+			QdrantClientWrapper.META_COLLECTION);
+
+		QdrantClientWrapper.MetaState metaState =
+			metaExists ? qdrantClient.readMetaState() : null;
+
+		if (metaState != null) {
+			statusJSONObject.put(
+				"doc_count", metaState.docCount()
+			).put(
+				"last_ingest", metaState.lastIngest()
+			);
+
+			String lastIngest = metaState.lastIngest();
+
+			if (lastIngest != null) {
+				OffsetDateTime when = OffsetDateTime.parse(lastIngest);
+
+				Duration elapsed = Duration.between(when, OffsetDateTime.now());
+
+				double elapsedSeconds = elapsed.toSeconds();
+
+				double days = elapsedSeconds / 86400.0;
+
+				statusJSONObject.put("stale_days", _round(days, 2));
+			}
+		}
+
+		if (indexExists && (metaState == null)) {
+			statusJSONObject.put("chunk_count", qdrantClient.getChunkCount());
+		}
+
+		System.out.println(statusJSONObject.toString(2));
+
+		return 0;
+	}
+
+	private double _round(double value, int decimals) {
+		double scale = Math.pow(10, decimals);
+
+		return Math.round(value * scale) / scale;
+	}
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/util/Args.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/util/Args.java
@@ -1,0 +1,79 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.util;
+
+import com.liferay.portal.kernel.util.GetterUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tiny argument parser. Recognizes long flags only:
+ *   --top N
+ *   --format text|json
+ *   --force
+ *
+ * Anything else is a positional argument, accumulated in order.
+ *
+ * Intentionally limited. Subcommands validate their own positional
+ * counts and unknown-flag handling; this class is just the split.
+ *
+ * @author JR Houn
+ */
+public class Args {
+
+	public Args(String[] args) {
+		List<String> positional = new ArrayList<>();
+
+		boolean force = false;
+
+		int i = 0;
+
+		while (i < args.length) {
+			String arg = args[i];
+
+			if (arg.equals("--top")) {
+				_top = GetterUtil.getInteger(args[++i], _top);
+			}
+			else if (arg.equals("--format")) {
+				_format = args[++i];
+			}
+			else if (arg.equals("--force")) {
+				force = true;
+			}
+			else {
+				positional.add(arg);
+			}
+
+			i++;
+		}
+
+		_force = force;
+		_positional = positional;
+	}
+
+	public boolean force() {
+		return _force;
+	}
+
+	public String format() {
+		return _format;
+	}
+
+	public List<String> positional() {
+		return _positional;
+	}
+
+	public int top() {
+		return _top;
+	}
+
+	private final boolean _force;
+	private String _format = "text";
+	private final List<String> _positional;
+	private int _top = 5;
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/util/Chunk.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/util/Chunk.java
@@ -1,0 +1,114 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.util;
+
+import java.nio.charset.StandardCharsets;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * One unit of indexable content — a section (or sliding-window slice
+ * of a section) of a Markdown document. The chunk_id field is the
+ * stable opaque identifier used as the Qdrant point ID after a
+ * UUID5 transform.
+ *
+ * @author JR Houn
+ */
+public class Chunk {
+
+	public static final UUID NAMESPACE = UUID.fromString(
+		"6f1f0d6c-1c4a-4f6e-9b1a-7c0b8d9e0f11");
+
+	public Chunk(
+		String chunkId, String relPath, List<String> headingPath, String text) {
+
+		_chunkId = chunkId;
+		_relPath = relPath;
+		_headingPath = headingPath;
+		_text = text;
+	}
+
+	public String chunkId() {
+		return _chunkId;
+	}
+
+	public List<String> headingPath() {
+		return _headingPath;
+	}
+
+	public UUID pointId() {
+		return _uuid5(NAMESPACE, _chunkId);
+	}
+
+	public String relPath() {
+		return _relPath;
+	}
+
+	public String text() {
+		return _text;
+	}
+
+	private byte[] _toBytes(UUID uuid) {
+		byte[] bytes = new byte[16];
+
+		long msb = uuid.getMostSignificantBits();
+
+		long lsb = uuid.getLeastSignificantBits();
+
+		for (int i = 0; i < 8; i++) {
+			bytes[i] = (byte)(msb >>> (8 * (7 - i)));
+		}
+
+		for (int i = 0; i < 8; i++) {
+			bytes[8 + i] = (byte)(lsb >>> (8 * (7 - i)));
+		}
+
+		return bytes;
+	}
+
+	private UUID _uuid5(UUID namespace, String name) {
+		try {
+			MessageDigest messageDigest = MessageDigest.getInstance("SHA-1");
+
+			messageDigest.update(_toBytes(namespace));
+			messageDigest.update(name.getBytes(StandardCharsets.UTF_8));
+
+			byte[] hash = messageDigest.digest();
+
+			hash[6] &= 0x0f;
+			hash[6] |= 0x50;
+			hash[8] &= 0x3f;
+			hash[8] |= 0x80;
+
+			long msb = 0;
+
+			long lsb = 0;
+
+			for (int i = 0; i < 8; i++) {
+				msb = (msb << 8) | (hash[i] & 0xff);
+			}
+
+			for (int i = 8; i < 16; i++) {
+				lsb = (lsb << 8) | (hash[i] & 0xff);
+			}
+
+			return new UUID(msb, lsb);
+		}
+		catch (NoSuchAlgorithmException noSuchAlgorithmException) {
+			throw new RuntimeException(noSuchAlgorithmException);
+		}
+	}
+
+	private final String _chunkId;
+	private final List<String> _headingPath;
+	private final String _relPath;
+	private final String _text;
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/util/DataHome.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/util/DataHome.java
@@ -1,0 +1,61 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.util;
+
+import com.liferay.petra.string.StringBundler;
+
+import java.io.File;
+
+/**
+ * Computes the runtime-data directory for this tool — outside the
+ * project checkout, as a sibling. The layout is
+ * {@code <parent>/<basename>-tools[-<worktree-suffix>]/search/}.
+ *
+ * Override with the SEARCH_DATA_HOME env var.
+ *
+ * @author JR Houn
+ */
+public class DataHome {
+
+	public static File compute(File projectRoot) {
+		String override = System.getenv("SEARCH_DATA_HOME");
+
+		if ((override != null) && !override.isEmpty()) {
+			File overrideFile = new File(override);
+
+			return overrideFile.getAbsoluteFile();
+		}
+
+		File parent = projectRoot.getParentFile();
+
+		String baseName = projectRoot.getName();
+
+		String toolsDir;
+
+		if (baseName.equals(_REPO_BASE_NAME)) {
+			toolsDir = _REPO_BASE_NAME + _TOOLS_DIR_SUFFIX;
+		}
+		else if (baseName.startsWith(_REPO_BASE_NAME + "-")) {
+			String worktreeSuffix = baseName.substring(
+				_REPO_BASE_NAME.length() + 1);
+
+			toolsDir = StringBundler.concat(
+				_REPO_BASE_NAME, _TOOLS_DIR_SUFFIX, "-", worktreeSuffix);
+		}
+		else {
+			toolsDir = baseName + _TOOLS_DIR_SUFFIX;
+		}
+
+		return new File(parent, toolsDir + "/" + _TOOL_NAME);
+	}
+
+	private static final String _REPO_BASE_NAME = "liferay-learn";
+
+	private static final String _TOOL_NAME = "search";
+
+	private static final String _TOOLS_DIR_SUFFIX = "-tools";
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/util/Hit.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/util/Hit.java
@@ -1,0 +1,55 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.util;
+
+import java.util.List;
+
+/**
+ * One element of the JSON output array emitted by `query` and
+ * `similar`. Field names are part of the stable contract.
+ *
+ * @author JR Houn
+ */
+public class Hit {
+
+	public Hit(
+		String path, double score, String chunkId, String snippet,
+		List<String> headingPath) {
+
+		_path = path;
+		_score = score;
+		_chunkId = chunkId;
+		_snippet = snippet;
+		_headingPath = headingPath;
+	}
+
+	public String chunkId() {
+		return _chunkId;
+	}
+
+	public List<String> headingPath() {
+		return _headingPath;
+	}
+
+	public String path() {
+		return _path;
+	}
+
+	public double score() {
+		return _score;
+	}
+
+	public String snippet() {
+		return _snippet;
+	}
+
+	private final String _chunkId;
+	private final List<String> _headingPath;
+	private final String _path;
+	private final double _score;
+	private final String _snippet;
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/util/Output.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/util/Output.java
@@ -1,0 +1,116 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.util;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * Formats result lists as the two output styles `query` and `similar`
+ * accept. The JSON shape is the stable contract — field names and
+ * types must not change without bumping the contract version.
+ *
+ * @author JR Houn
+ */
+public class Output {
+
+	public static String formatHits(List<Hit> hits, String format) {
+		if (Objects.equals(format, "json")) {
+			return _formatHitsJSON(hits);
+		}
+
+		return _formatHitsText(hits);
+	}
+
+	public static String snippet(String text) {
+		String collapsed = text.replaceAll("\\s+", " ");
+
+		collapsed = collapsed.trim();
+
+		if (collapsed.length() <= _SNIPPET_MAX_CHARS) {
+			return collapsed;
+		}
+
+		String cut = collapsed.substring(0, _SNIPPET_MAX_CHARS);
+
+		int lastSpace = cut.lastIndexOf(' ');
+
+		if (lastSpace > (_SNIPPET_MAX_CHARS * 0.6)) {
+			cut = cut.substring(0, lastSpace);
+		}
+
+		return cut + "...";
+	}
+
+	private static String _formatHitsJSON(List<Hit> hits) {
+		JSONArray hitsJSONArray = new JSONArray();
+
+		for (Hit hit : hits) {
+			JSONObject hitJSONObject = new JSONObject();
+
+			hitJSONObject.put(
+				"chunk_id", hit.chunkId()
+			).put(
+				"heading_path", new JSONArray(hit.headingPath())
+			).put(
+				"path", hit.path()
+			).put(
+				"score", _round(hit.score(), 4)
+			).put(
+				"snippet", hit.snippet()
+			);
+
+			hitsJSONArray.put(hitJSONObject);
+		}
+
+		return hitsJSONArray.toString(2);
+	}
+
+	private static String _formatHitsText(List<Hit> hits) {
+		if (hits.isEmpty()) {
+			return "(no results)";
+		}
+
+		StringBuilder stringBuilder = new StringBuilder();
+
+		int i = 1;
+
+		for (Hit hit : hits) {
+			String head = String.join(" > ", hit.headingPath());
+
+			if (head.isEmpty()) {
+				head = "(no heading)";
+			}
+
+			stringBuilder.append(i++);
+			stringBuilder.append(". ");
+			stringBuilder.append(hit.path());
+			stringBuilder.append("  [");
+			stringBuilder.append(String.format("%.3f", hit.score()));
+			stringBuilder.append("]\n   ");
+			stringBuilder.append(head);
+			stringBuilder.append("\n   ");
+			stringBuilder.append(hit.snippet());
+			stringBuilder.append('\n');
+		}
+
+		stringBuilder.setLength(stringBuilder.length() - 1);
+
+		return stringBuilder.toString();
+	}
+
+	private static double _round(double value, int decimals) {
+		double scale = Math.pow(10, decimals);
+
+		return Math.round(value * scale) / scale;
+	}
+
+	private static final int _SNIPPET_MAX_CHARS = 300;
+
+}

--- a/modules/util/semantic-search-cli/src/test/java/com/liferay/semantic/search/cli/chunker/JavaChunkerTest.java
+++ b/modules/util/semantic-search-cli/src/test/java/com/liferay/semantic/search/cli/chunker/JavaChunkerTest.java
@@ -1,0 +1,134 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.chunker;
+
+import com.liferay.semantic.search.cli.util.Chunk;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author JR Houn
+ */
+public class JavaChunkerTest {
+
+	@Test
+	public void testClassNameDrivesHeadingPath() {
+		String text = _read("SampleResourceImpl.java.txt");
+
+		JavaChunker javaChunker = new JavaChunker();
+
+		List<Chunk> chunks = javaChunker.parse(text, "SampleResourceImpl.java");
+
+		for (Chunk chunk : chunks) {
+			List<String> headingPath = chunk.headingPath();
+
+			Assert.assertEquals("SampleResourceImpl", headingPath.get(0));
+		}
+	}
+
+	@Test
+	public void testImportBlockIsStripped() {
+		String text = _read("SampleResourceImpl.java.txt");
+
+		JavaChunker javaChunker = new JavaChunker();
+
+		List<Chunk> chunks = javaChunker.parse(text, "SampleResourceImpl.java");
+
+		for (Chunk chunk : chunks) {
+			Assert.assertFalse(
+				"chunks must not contain raw import lines",
+				chunk.text(
+				).contains(
+					"import com.example.other.SampleService"
+				));
+		}
+	}
+
+	@Test
+	public void testLicenseHeaderIsStripped() {
+		String text = _read("SampleResourceImpl.java.txt");
+
+		JavaChunker javaChunker = new JavaChunker();
+
+		List<Chunk> chunks = javaChunker.parse(text, "SampleResourceImpl.java");
+
+		for (Chunk chunk : chunks) {
+			Assert.assertFalse(
+				"chunks must not contain license-header text",
+				chunk.text(
+				).contains(
+					"SPDX-FileCopyrightText"
+				));
+		}
+	}
+
+	@Test
+	public void testMethodNamesBecomeSecondHeadingElement() {
+		String text = _read("SampleResourceImpl.java.txt");
+
+		JavaChunker javaChunker = new JavaChunker();
+
+		List<Chunk> chunks = javaChunker.parse(text, "SampleResourceImpl.java");
+
+		List<String> methodNames = new ArrayList<>();
+
+		for (Chunk chunk : chunks) {
+			List<String> headingPath = chunk.headingPath();
+
+			if (headingPath.size() == 2) {
+				methodNames.add(headingPath.get(1));
+			}
+		}
+
+		Assert.assertEquals(
+			"three top-level methods",
+			Arrays.asList("getItems", "postItem", "_validate"), methodNames);
+	}
+
+	@Test
+	public void testOneChunkPerMethodPlusIntro() {
+		String text = _read("SampleResourceImpl.java.txt");
+
+		JavaChunker javaChunker = new JavaChunker();
+
+		List<Chunk> chunks = javaChunker.parse(text, "SampleResourceImpl.java");
+
+		Assert.assertEquals("intro + 3 methods", 4, chunks.size());
+	}
+
+	private String _read(String fixtureName) {
+		String resourcePath =
+			"com/liferay/semantic/search/cli/chunker/dependencies/" +
+				fixtureName;
+
+		ClassLoader classLoader = JavaChunkerTest.class.getClassLoader();
+
+		try (InputStream inputStream = classLoader.getResourceAsStream(
+				resourcePath)) {
+
+			if (inputStream == null) {
+				throw new RuntimeException("missing fixture: " + resourcePath);
+			}
+
+			return new String(
+				inputStream.readAllBytes(), StandardCharsets.UTF_8);
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
+	}
+
+}

--- a/modules/util/semantic-search-cli/src/test/java/com/liferay/semantic/search/cli/chunker/MarkdownChunkerTest.java
+++ b/modules/util/semantic-search-cli/src/test/java/com/liferay/semantic/search/cli/chunker/MarkdownChunkerTest.java
@@ -1,0 +1,156 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.chunker;
+
+import com.liferay.semantic.search.cli.util.Chunk;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author JR Houn
+ */
+public class MarkdownChunkerTest {
+
+	@Test
+	public void testFrontMatterIsStripped() {
+		String text = _read("simple.md");
+
+		MarkdownChunker chunker = new MarkdownChunker();
+
+		List<Chunk> chunks = chunker.parse(text, "simple.md");
+
+		Chunk firstChunk = chunks.get(0);
+
+		String firstChunkText = firstChunk.text();
+
+		Assert.assertFalse(
+			"chunk text should not contain front matter",
+			firstChunkText.contains("uuid:"));
+	}
+
+	@Test
+	public void testH2SectionsGetH1H2HeadingPath() {
+		String text = _read("simple.md");
+
+		MarkdownChunker chunker = new MarkdownChunker();
+
+		List<Chunk> chunks = chunker.parse(text, "simple.md");
+
+		List<List<String>> headingPaths = new ArrayList<>();
+
+		for (Chunk chunk : chunks) {
+			headingPaths.add(chunk.headingPath());
+		}
+
+		Assert.assertEquals(List.of("Simple Document"), headingPaths.get(0));
+
+		Assert.assertEquals(
+			List.of("Simple Document", "First Section"), headingPaths.get(1));
+
+		Assert.assertEquals(
+			List.of("Simple Document", "Second Section"), headingPaths.get(2));
+	}
+
+	@Test
+	public void testIntroBecomesH1Chunk() {
+		String text = _read("simple.md");
+
+		MarkdownChunker chunker = new MarkdownChunker();
+
+		List<Chunk> chunks = chunker.parse(text, "simple.md");
+
+		Chunk intro = chunks.get(0);
+
+		List<String> headingPath = intro.headingPath();
+
+		Assert.assertEquals(headingPath.toString(), 1, headingPath.size());
+
+		Assert.assertEquals(
+			headingPath.toString(), "Simple Document", headingPath.get(0));
+
+		String introText = intro.text();
+
+		Assert.assertTrue(introText.startsWith("This is the intro"));
+	}
+
+	@Test
+	public void testNoH2_singleChunkUnderH1() {
+		String text = _read("no-h2.md");
+
+		MarkdownChunker chunker = new MarkdownChunker();
+
+		List<Chunk> chunks = chunker.parse(text, "no-h2.md");
+
+		Assert.assertEquals(chunks.toString(), 1, chunks.size());
+
+		Chunk only = chunks.get(0);
+
+		Assert.assertEquals(List.of("Just an H1"), only.headingPath());
+	}
+
+	@Test
+	public void testSimpleDocumentChunkCount() {
+		String text = _read("simple.md");
+
+		MarkdownChunker chunker = new MarkdownChunker();
+
+		List<Chunk> chunks = chunker.parse(text, "simple.md");
+
+		Assert.assertEquals(chunks.toString(), 3, chunks.size());
+	}
+
+	@Test
+	public void testSlidingWindowSplitsLongSections() {
+		StringBuilder stringBuilder = new StringBuilder("# Long Doc\n\n");
+
+		for (int i = 0; i < 500; i++) {
+			stringBuilder.append("word ");
+		}
+
+		MarkdownChunker chunker = new MarkdownChunker();
+
+		List<Chunk> chunks = chunker.parse(stringBuilder.toString(), "long.md");
+
+		Assert.assertTrue(
+			"long intro should produce more than one chunk", chunks.size() > 1);
+
+		for (Chunk chunk : chunks) {
+			Assert.assertEquals(List.of("Long Doc"), chunk.headingPath());
+		}
+	}
+
+	private String _read(String fixtureName) {
+		String resourcePath =
+			"com/liferay/semantic/search/cli/chunker/dependencies/" +
+				fixtureName;
+
+		ClassLoader classLoader = MarkdownChunkerTest.class.getClassLoader();
+
+		try (InputStream inputStream = classLoader.getResourceAsStream(
+				resourcePath)) {
+
+			if (inputStream == null) {
+				throw new RuntimeException("missing fixture: " + resourcePath);
+			}
+
+			return new String(
+				inputStream.readAllBytes(), StandardCharsets.UTF_8);
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
+	}
+
+}

--- a/modules/util/semantic-search-cli/src/test/resources/com/liferay/semantic/search/cli/chunker/dependencies/SampleResourceImpl.java.txt
+++ b/modules/util/semantic-search-cli/src/test/resources/com/liferay/semantic/search/cli/chunker/dependencies/SampleResourceImpl.java.txt
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.example.sample;
+
+import com.example.other.SampleService;
+import com.example.other.SampleUtil;
+
+import java.util.List;
+
+/**
+ * @author JR Houn
+ */
+public class SampleResourceImpl {
+
+	public List<String> getItems() {
+		return _sampleService.getItems();
+	}
+
+	public void postItem(String item) {
+		_sampleService.add(item);
+	}
+
+	private void _validate(String item) {
+		if (item == null) {
+			throw new IllegalArgumentException();
+		}
+	}
+
+	private static final SampleService _sampleService = SampleUtil.getService();
+
+}

--- a/modules/util/semantic-search-cli/src/test/resources/com/liferay/semantic/search/cli/chunker/dependencies/no-h2.md
+++ b/modules/util/semantic-search-cli/src/test/resources/com/liferay/semantic/search/cli/chunker/dependencies/no-h2.md
@@ -1,0 +1,4 @@
+# Just an H1
+
+The whole body sits under the H1, no H2 sections exist. It should
+become a single chunk with heading_path = [h1].

--- a/modules/util/semantic-search-cli/src/test/resources/com/liferay/semantic/search/cli/chunker/dependencies/simple.md
+++ b/modules/util/semantic-search-cli/src/test/resources/com/liferay/semantic/search/cli/chunker/dependencies/simple.md
@@ -1,0 +1,20 @@
+---
+
+uuid: abc-123
+
+---
+
+# Simple Document
+
+This is the intro under the H1, before any H2.
+
+## First Section
+
+Body of the first section.
+
+## Second Section
+
+Body of the second section, with a list:
+
+- item one
+- item two


### PR DESCRIPTION
# Semantic Search CLI — `modules/util/semantic-search-cli/`

## TL;DR

Publishes a small jar from `liferay-portal/modules/util/semantic-search-cli/` that any Liferay repo (or an external dev's working copy) can use for semantic search over its Markdown content and Java source. The jar talks HTTP to a Hugging Face text-embeddings-inference (TEI) container for embeddings and gRPC to a Qdrant container for vector ops; both come up via the bundled `docker-compose.yml`. Subcommands, flags, and JSON output schema are the stable contract that skills and agents call by shell command.

This is the production successor to the Python prototype published from `liferay-learn` in [brianchandotcom/liferay-learn#254](https://github.com/brianchandotcom/liferay-learn/pull/254). Same CLI surface (validated end-to-end against the same corpus), bigger scope (Java source in addition to Markdown), one canonical place to maintain it.

## What this PR adds

One module at `modules/util/semantic-search-cli/`:

- **Java CLI** with four subcommands — `ingest`, `query`, `similar`, `status` — and a stable JSON output schema for `query`/`similar`.
- **`docker-compose.yml`** that brings up Qdrant + TEI (image: `text-embeddings-inference:cpu-1.6`, model: `BAAI/bge-small-en-v1.5`, 384-dim, Apache-2.0).
- **Pluggable chunkers** dispatched by file extension:
  - `MarkdownChunker` splits at `##` sections; heading-path is `[H1, H2]`.
  - `JavaChunker` strips the license header, `package` line, and entire `import` block, then splits at top-level method signatures; heading-path is `[ClassName, methodName]`.
- **`SEARCH_FILE_EXTS` env var** controls the file walker (default `.md`; set to `.java` or `.md,.java` to widen).
- **`SEARCH_DATA_HOME` runtime data convention** — Qdrant index and TEI model cache live outside the calling project's checkout as a sibling directory (`<parent>/<basename>-tools[-<worktree-suffix>]/search/`). Mirrors `liferay-portal`'s `bundles/` placement so the repo stays clean and concurrent worktrees don't corrupt each other.
- **`tools/sdk/dependencies/...` deploy hook** in `build.gradle` (consistent with `copyright-formatter`, `javadoc-formatter`, etc.).
- **Unit tests** for both chunkers (11 tests; JUnit 4; fixtures under `src/test/resources/`).

Stable interface for callers:

```
search ingest <dir> [--force]
search query "<text>" [--top N] [--format text|json]
search similar <path> [--top N] [--format text|json]
search status
```

Exit codes: `0` success, `1` bad input, `2` bad CLI usage, `3` index missing, `4` target file has no content, `5` Qdrant unreachable, `6` internal error. JSON shape: `{path, score, chunk_id, snippet, heading_path}`.

## Why this matters

Three concrete personas the same jar serves:

1. **Technical writer in `liferay-learn`.** Indexes the docs corpus, finds related articles by intent, surfaces near-duplicate or parallel-update candidates that grep can't catch. Already wired into the doc-writing skills via the prototype; this module is the canonical implementation.

2. **Developer working in `liferay-portal`.** Indexes one or more modules' Java source, then queries by description (`"REST endpoint that lists comments for a blog posting"`) or by example (`similar CommentResourceImpl.java`). Returns method-level hits with a `Class > method` heading-path that points the dev directly at the relevant code.

3. **Content engineer cross-referencing docs against portal source.** Maintains two indices — one per checkout, isolated by the `SEARCH_DATA_HOME` per-checkout default — and queries each independently when validating that a doc claim matches the implementation.

The README walks through each persona with copy-pasteable commands.

## Validation

### Markdown parity with the Python prototype

Same corpus (`docs/dxp/latest/en/`, ~1945 files), same embedding model, two implementations:

- Python prototype indexed 9533 chunks; this Java module indexed 9533 chunks. **Chunker output is byte-equivalent.**
- `similar` against the recently-merged `cne-gcp-bootstrap-config-reference.md` returns the **same five articles in the same order** in both implementations:

| Rank | Path | Python | Java |
| :--- | :--- | ---: | ---: |
| 1 | `cne-aws-ready-bootstrap-config-reference.md` | 0.901 | **0.903** |
| 2 | `cne-gcp-ready/getting-started/prerequisites.md` | 0.888 | 0.895 |
| 3 | `cne-gcp-ready/configuring-the-cne.md` | 0.853 | 0.861 |
| 4 | `cne-gcp-ready/security-recommendations.md` | 0.841 | 0.843 |
| 5 | `cne-reference.md` | 0.835 | 0.842 |

Score deltas are inference-runtime noise (TEI uses ONNX; the Python prototype uses PyTorch through `sentence-transformers`). Same model weights, same result ordering.

### Java source — empirical evaluation against `headless-delivery-impl`

Indexed 183 `.java` files (4194 chunks; ~5 min wall-clock on CPU). Four representative queries:

| Query | Result |
| :--- | :--- |
| **NL → code:** "REST endpoint that lists comments for a blog posting" | Top hits are `Query > blogPostingComments`, `CommentResourceImpl > getBlogPostingCommentsPage`, `Mutation > createBlogPostingCommentBatch` — method-level pinpoints. |
| **Code → code:** `similar CommentResourceImpl.java` | Top hits are `BlogPostingResourceImpl`, `WikiPageResourceImpl`, `KnowledgeBaseArticleResourceImpl` — peer REST resources. Scores 0.83–0.91. |
| **NL → code:** "permission check that prevents anonymous users from creating content" | Top hit is `MessageBoardThreadResourceImpl > _checkPermission` with the actual `PermissionThreadLocal.getPermissionChecker()` call in the chunk snippet. |
| **NL → code:** "asynchronous batch import or export of content" | Top hits are `Mutation > createSiteContentElementsPageExportBatch`, `Mutation > createSiteStructuredContentsPageExportBatch` — direct hits on the `*ExportBatch` mutations. |

The key finding from the experiment: **the chunker matters more than the embedding model for code search.** An earlier round with a naive sliding-window chunker produced false-positive code-to-code similarities because every Java file's opening 350 words are dominated by identical SPDX header + `package` + `import` blocks. Stripping that header and splitting at method signatures flipped `similar` from noise to useful while keeping the same general-purpose BGE model.

A code-tuned model (`BAAI/bge-code-v1`, `nomic-embed-code`, etc.) is a future option but isn't a prerequisite. Worth revisiting if specific failure modes show up; not for v1.

## Design choices (anticipating questions)

**Why TEI over in-process embeddings (DJL / ONNX)?**

| Option | Java footprint | Container count |
| :--- | :--- | :--- |
| TEI HTTP (chosen) | ~30 MB jar | qdrant + tei |
| DJL + ONNX in-process | ~300 MB jar | qdrant only |
| Ollama embeddings | ~30 MB jar | qdrant + ollama |

TEI keeps the Java jar small and dependency-light. The embedding model is a `docker-compose` configuration concern, not a Java compile-time constant — swapping models means changing `MODEL_ID`, not rebuilding the jar. TEI is Apache-2.0, first-party Hugging Face, ghcr.io-hosted.

**Why `BAAI/bge-small-en-v1.5` (384 dims)?** Speed/quality sweet spot for CPU-only inference. `nomic-embed-text-v1` is ~1 MTEB point better but ~15× slower on CPU. `all-MiniLM-L6-v2` is faster but ~10 MTEB points worse. BGE-small clears the bar for both Markdown retrieval and the Java-code experiment with room to spare.

**Why method-level chunking for Java instead of file-level or AST-based?** The naive file-level approach produced false positives (every file's first chunk is its SPDX header + imports). JavaParser would do better but adds a dependency. The regex-based "strip-header → strip-imports → split-at-method-signatures" approach is ~150 lines, no extra dependency, and produced usable results across all four test queries. JavaParser is a credible future upgrade if specific edge cases surface.

**Why does data live outside the repo?** Vector indices are hundreds of MB of binary data — not git-friendly. The sibling-to-checkout placement mirrors `bundles/`. Each worktree gets its own data home so concurrent worktrees don't corrupt each other's index.

**Why not just `grep`?** Grep finds strings; semantic search finds concepts even when wording differs. The CNE GCP validation makes the point: `similar(cne-gcp-bootstrap-config-reference)` returns the AWS twin at 0.901, which grep wouldn't find without knowing to also search for "AWS." For code: `query "REST endpoint that lists comments for a blog posting"` directly hits `getBlogPostingCommentsPage` without needing to know the method name.

**Maintenance burden?** Ingest is idempotent (file-hash skip; deleted files pruned). Typical re-ingest after editing a few files is seconds. A full corpus re-ingest is needed only after a model swap.

**Rollback path?** Delete the module. The CLI is the contract; no other module in `modules/util/` depends on this jar.

## Structure

One signed commit (`LRDOCS-17032 Add modules/util/semantic-search-cli/`), 25 files, +2926 over master:

- `bnd.bnd`, `build.gradle`, `docker-compose.yml`, `README.md`
- `src/main/java/com/liferay/semantic/search/cli/` — `SemanticSearchCLI`, `Command` interface and four subcommand classes, `Chunkers` dispatcher, `MarkdownChunker`, `JavaChunker`, `QdrantClientWrapper`, `TextEmbeddingsClient`, `Args`/`Chunk`/`Hit`/`Output`/`DataHome` support classes.
- `src/test/java/.../chunker/` — `MarkdownChunkerTest` (6), `JavaChunkerTest` (5); 11 tests passing.
- `src/test/resources/.../dependencies/` — `simple.md`, `no-h2.md`, `SampleResourceImpl.java.txt`.

`./gradlew formatSource` clean. `./gradlew test` green.

## Known follow-ups (not in this PR)

- `--add-opens=java.base/java.lang.invoke=ALL-UNNAMED` is needed for petra.string 5.3.7's `StringBundler.<clinit>` reflection on JDK 17+. The test JVM is configured with the flag; the CLI launcher (however the jar is invoked in production) needs the same flag at runtime. Resolved by pinning a JDK-21-clean petra.string when one ships, or by baking the flag into a launcher script.
- Indexing the entire `modules/apps/` tree is hours; designed for module-scoped ingest in practice. A future enhancement could add `.searchignore` for pruning build artifacts.
- A code-tuned model option (`BAAI/bge-code-v1` etc.) is a one-line change to `docker-compose.yml`. Worth evaluating if specific failure modes show up against deeper code corpora.
