### PR TITLE
LPD-89991 Update object-definition allowlist for MCP REST bundle

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
@@ -137,7 +137,7 @@ public class ObjectDefinitionUtil {
 		"com.liferay.frontend.data.set.admin.web",
 		"com.liferay.frontend.data.set.impl",
 		"com.liferay.headless.builder.impl", "com.liferay.list.type.service",
-		"com.liferay.mcp.server", "com.liferay.notification.service",
+		"com.liferay.mcp.server.rest.impl", "com.liferay.notification.service",
 		"com.liferay.object.service", "com.liferay.seo.studio.site.initializer",
 		"com.liferay.site.initializer.cmp", "com.liferay.site.initializer.cms",
 		"com.liferay.site.initializer.dsr"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89991

**What is being fixed:** The object-definition allowlist still references `com.liferay.mcp.server`, the symbolic name of the bundle that previously seeded MCP-related object definitions. That bundle was removed when the MCP server moved to a REST Builder module, so the seed bundle now reports the wrong symbolic name and would be rejected at runtime.

**How it is being fixed:** Update the allowlist entry to `com.liferay.mcp.server.rest.impl`, the symbolic name of the new bundle that now performs the seeding.