### PR TITLE
LPD-92325 Pass sequential to form-level validateSegmentEditor

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/index.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/index.tsx
@@ -254,7 +254,8 @@ class SegmentEditor extends React.Component<ISegmentEditorProps> {
 						onSubmit={this.handleSubmit}
 						validate={(values: FormValues) => {
 							const error = validateSegmentEditor(
-								values.criteria
+								values.criteria,
+								values.sequential
 							);
 
 							return error ? {criteria: error} : {};


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92325

## What is being fixed

The Save Segment button stays enabled when the criteria exceed the sequential limits (either the 5-criteria root cap or the 3-condition nested OR cap). The form-level `validate` was already wired, but the call was missing the `sequential` argument:

```ts
validate={(values: FormValues) => {
    const error = validateSegmentEditor(values.criteria);  // ← missing values.sequential
    ...
}}
```

`validateSegmentEditor(criteria, sequential)` requires the second argument to reach its `else if (sequential)` branch, where the `hasRootAndExceeded` and `hasNestedOrExceeded` guards live. Without it the validator short-circuits to "no error" for any non-empty, syntactically valid criteria — so editing the segment title (or any other field change) re-runs the validator, returns no error, and Save Segment lights up even when the limits are violated.

## How it is being fixed

Pass `values.sequential` as the second argument to `validateSegmentEditor` inside the form-level `validate` callback. The sequential branch now fires on every form value change, including title edits, and the Save button correctly reflects the limit-exceeded state.

## Why are there no tests?

`validateSegmentEditor` is a pure function and is already covered by the existing unit tests in `__tests__/SegmentEditor.jsx` (including the sequential-exceeded and nested-OR-exceeded paths). The bug was a missed argument at a single call site; a faithful regression test would require mounting the full SegmentEditor with Formik, react-dnd, and Redux, then asserting `isValid` after each value change — out of scope for this one-line fix.