### PR TITLE
⚠️ DO NOT MERGE — LRCI-7460 auto-close webhook test (4th)

### DIFF
--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -1,5 +1,5 @@
 %-of-assets=% of Assets (Automatic Copy)
-+-add-address-line=+ Add Address Line
++-add-address-line=DO NOT MERGE - LRCI-7460 auto-close webhook test
 0-analytics-cloud-connection=Analytics Cloud Connection
 1-account-was-added-to-x=1 account was added to {0}.
 1-day=1 Day


### PR DESCRIPTION
# ⚠️ DO NOT MERGE — TEST PR (4th attempt) ⚠️

Fourth sandbox attempt for [LRCI-7460](https://liferay.atlassian.net/browse/LRCI-7460) — receiver redeploy with the LRCI-7458 dispatch should now be live.

**Expected behavior**: receiver dispatches the `auto-close-merge-conflict-pullrequest` Jenkins job → job sees `mergeable_state: dirty` → posts the standard "merge conflicts and has been closed" comment → closes this PR automatically.

If still open after a few minutes, the deploy didn't take or there's another issue — leave it alone for diagnosis.

Single-line change in `Language_km.properties` deliberately conflicting with the Khmer translation update on master.

Parent: [LRCI-6965](https://liferay.atlassian.net/browse/LRCI-6965).
