### PR TITLE
LPD-88843 Connect Google Search Console per instance (OAuth)

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
@@ -275,6 +275,8 @@ public class ObjectDefinitionUtil {
 		).put(
 			"SEOStudioDomain", "/seo-studio/domains"
 		).put(
+			"SEOStudioGSCCredentialEntry", "/seo-studio/gsc-credential-entries"
+		).put(
 			"SEOStudioInstance", "/seo-studio/instances"
 		).put(
 			"SEOStudioScan", "/seo-studio/scans"

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/05-seo-studio-gsc-credential-entry-object-definition.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-definitions/05-seo-studio-gsc-credential-entry-object-definition.json
@@ -1,0 +1,133 @@
+{
+	"accountEntryRestricted": false,
+	"className": "com.liferay.object.model.ObjectDefinition#SG05",
+	"enableFormContainer": false,
+	"enableIndexSearch": false,
+	"externalReferenceCode": "L_SEO_STUDIO_GSC_CREDENTIAL_ENTRY",
+	"friendlyURLSeparator": "l",
+	"label": {
+		"en_US": "SEO Studio GSC Credential Entry"
+	},
+	"modifiable": true,
+	"name": "SEOStudioGSCCredentialEntry",
+	"objectFields": [
+		{
+			"DBType": "Clob",
+			"businessType": "Encrypted",
+			"externalReferenceCode": "ACCESS_TOKEN",
+			"indexed": false,
+			"label": {
+				"en_US": "Access Token"
+			},
+			"name": "accessToken",
+			"system": true,
+			"type": "Clob"
+		},
+		{
+			"DBType": "DateTime",
+			"businessType": "DateTime",
+			"externalReferenceCode": "ACCESS_TOKEN_EXPIRATION_TIME",
+			"indexed": false,
+			"label": {
+				"en_US": "Access Token Expiration Time"
+			},
+			"name": "accessTokenExpirationTime",
+			"objectFieldSettings": [
+				{
+					"name": "timeStorage",
+					"value": "convertToUTC"
+				}
+			],
+			"system": true,
+			"type": "DateTime"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "CLIENT_ID",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"label": {
+				"en_US": "Client ID"
+			},
+			"name": "clientId",
+			"required": true,
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "Clob",
+			"businessType": "Encrypted",
+			"externalReferenceCode": "CLIENT_SECRET",
+			"indexed": false,
+			"label": {
+				"en_US": "Client Secret"
+			},
+			"name": "clientSecret",
+			"required": true,
+			"system": true,
+			"type": "Clob"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "EMAIL_ADDRESS",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"label": {
+				"en_US": "Email Address"
+			},
+			"name": "emailAddress",
+			"system": true,
+			"type": "String"
+		},
+		{
+			"DBType": "Long",
+			"businessType": "Relationship",
+			"externalReferenceCode": "SEO_STUDIO_INSTANCE_TO_SEO_STUDIO_GSC_CREDENTIAL_ENTRIES",
+			"indexed": true,
+			"label": {
+				"en_US": "SEO Studio Instance to SEO Studio GSC Credential Entries"
+			},
+			"name": "r_seoStudioInstanceToGSCCredentialEntries_seoStudioInstanceId",
+			"objectDefinitionExternalReferenceCode1": "L_SEO_STUDIO_INSTANCE",
+			"objectFieldSettings": [
+				{
+					"name": "objectDefinition1ShortName",
+					"value": "SEOStudioInstance"
+				},
+				{
+					"name": "objectRelationshipERCObjectFieldName",
+					"value": "r_seoStudioInstanceToGSCCredentialEntries_seoStudioInstanceERC"
+				}
+			],
+			"objectRelationshipExternalReferenceCode": "L_SEO_STUDIO_INSTANCE_TO_L_SEO_STUDIO_GSC_CREDENTIAL_ENTRIES",
+			"readOnly": "false",
+			"relationshipType": "oneToMany",
+			"required": true,
+			"system": true,
+			"type": "Long"
+		},
+		{
+			"DBType": "Clob",
+			"businessType": "Encrypted",
+			"externalReferenceCode": "REFRESH_TOKEN",
+			"indexed": false,
+			"label": {
+				"en_US": "Refresh Token"
+			},
+			"name": "refreshToken",
+			"system": true,
+			"type": "Clob"
+		}
+	],
+	"objectFolderExternalReferenceCode": "default",
+	"panelCategoryKey": "control_panel.object",
+	"pluralLabel": {
+		"en_US": "SEO Studio GSC Credential Entries"
+	},
+	"portlet": false,
+	"scope": "company",
+	"system": true,
+	"titleObjectFieldName": "clientId"
+}

--- a/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-relationships/05-seo-studio-gsc-credential-entry-object-relationship.json
+++ b/modules/dxp/apps/seo-studio/seo-studio-site-initializer/src/main/resources/site-initializer/object-relationships/05-seo-studio-gsc-credential-entry-object-relationship.json
@@ -1,0 +1,13 @@
+{
+	"deletionType": "cascade",
+	"externalReferenceCode": "L_SEO_STUDIO_INSTANCE_TO_L_SEO_STUDIO_GSC_CREDENTIAL_ENTRIES",
+	"label": {
+		"en_US": "SEO Studio Instance to SEO Studio GSC Credential Entries"
+	},
+	"name": "seoStudioInstanceToGSCCredentialEntries",
+	"objectDefinitionId1": "[$OBJECT_DEFINITION_ID:SEOStudioInstance$]",
+	"objectDefinitionId2": "[$OBJECT_DEFINITION_ID:SEOStudioGSCCredentialEntry$]",
+	"objectDefinitionName2": "SEOStudioGSCCredentialEntry",
+	"system": true,
+	"type": "oneToMany"
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/Dockerfile
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/Dockerfile
@@ -1,0 +1,3 @@
+FROM liferay/jar-runner:latest
+
+COPY --chown=liferay:liferay *.jar /opt/liferay/jar-runner.jar

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/LCP.json
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/LCP.json
@@ -1,0 +1,31 @@
+{
+	"cpu": 1,
+	"env": {
+		"LIFERAY_ROUTES_CLIENT_EXTENSION": "/etc/liferay/lxc/ext-init-metadata",
+		"LIFERAY_ROUTES_DXP": "/etc/liferay/lxc/dxp-metadata"
+	},
+	"environments": {
+		"infra": {
+			"deploy": false
+		}
+	},
+	"id": "__PROJECT_ID__",
+	"kind": "Deployment",
+	"livenessProbe": {
+		"httpGet": {
+			"path": "/ready",
+			"port": 58081
+		}
+	},
+	"loadBalancer": {
+		"targetPort": 58081
+	},
+	"memory": 512,
+	"readinessProbe": {
+		"httpGet": {
+			"path": "/ready",
+			"port": 58081
+		}
+	},
+	"scale": 1
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/build.gradle
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/build.gradle
@@ -1,0 +1,39 @@
+buildscript {
+	dependencies {
+		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.defaults", version: "latest.release"
+		classpath group: "org.springframework.boot", name: "spring-boot-gradle-plugin", version: "2.7.18"
+	}
+
+	repositories {
+		maven {
+			url new File(rootProject.projectDir, "../../.m2-tmp")
+		}
+
+		maven {
+			url "https://repository-cdn.liferay.com/nexus/content/groups/public"
+		}
+	}
+}
+
+apply plugin: "com.liferay.source.formatter"
+apply plugin: "java-library"
+apply plugin: "org.springframework.boot"
+
+dependencies {
+	implementation group: "com.google.api-client", name: "google-api-client", version: "2.7.2"
+	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot3", version: "latest.release"
+	implementation group: "io.jsonwebtoken", name: "jjwt-api", version: "0.12.6"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.18"
+	runtimeOnly group: "io.jsonwebtoken", name: "jjwt-impl", version: "0.12.6"
+	runtimeOnly group: "io.jsonwebtoken", name: "jjwt-jackson", version: "0.12.6"
+}
+
+repositories {
+	maven {
+		url new File(rootProject.projectDir, "../../.m2-tmp")
+	}
+
+	maven {
+		url "https://repository-cdn.liferay.com/nexus/content/groups/public"
+	}
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/build.gradle
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/build.gradle
@@ -22,6 +22,7 @@ apply plugin: "org.springframework.boot"
 dependencies {
 	implementation group: "com.google.api-client", name: "google-api-client", version: "2.7.2"
 	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot3", version: "latest.release"
+	implementation group: "com.liferay", name: "com.liferay.petra.string", version: "latest.release"
 	implementation group: "io.jsonwebtoken", name: "jjwt-api", version: "0.12.6"
 	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.18"
 	runtimeOnly group: "io.jsonwebtoken", name: "jjwt-impl", version: "0.12.6"

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/build.gradle
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/build.gradle
@@ -20,10 +20,12 @@ apply plugin: "java-library"
 apply plugin: "org.springframework.boot"
 
 dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "latest.release"
 	implementation group: "com.google.api-client", name: "google-api-client", version: "2.7.2"
 	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot3", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.petra.string", version: "latest.release"
 	implementation group: "io.jsonwebtoken", name: "jjwt-api", version: "0.12.6"
+	implementation group: "org.json", name: "json", version: "20231013"
 	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.18"
 	runtimeOnly group: "io.jsonwebtoken", name: "jjwt-impl", version: "0.12.6"
 	runtimeOnly group: "io.jsonwebtoken", name: "jjwt-jackson", version: "0.12.6"

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/client-extension.yaml
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/client-extension.yaml
@@ -1,0 +1,14 @@
+assemble:
+    -   fromTask: bootJar
+liferay-seostudio-google-search-console-oahs:
+    .serviceAddress: localhost:58081
+    .serviceScheme: http
+    name: Liferay SEO Studio Google Search Console OAuth Application Headless Server
+    scopes:
+        -   c_seostudiogsccredentialentry.everything
+    type: oAuthApplicationHeadlessServer
+liferay-seostudio-google-search-console-oaua:
+    .serviceAddress: localhost:58081
+    .serviceScheme: http
+    name: Liferay SEO Studio Google Search Console OAuth Application User Agent
+    type: oAuthApplicationUserAgent

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/src/main/java/com/liferay/seo/studio/google/search/console/SEOStudioGoogleSearchConsoleApplication.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/src/main/java/com/liferay/seo/studio/google/search/console/SEOStudioGoogleSearchConsoleApplication.java
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.google.search.console;
+
+import com.liferay.client.extension.util.spring.boot3.ClientExtensionUtilSpringBootComponentScan;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Import;
+
+/**
+ * @author Pei-Jung Lan
+ */
+@Import(ClientExtensionUtilSpringBootComponentScan.class)
+@SpringBootApplication
+public class SEOStudioGoogleSearchConsoleApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(
+			SEOStudioGoogleSearchConsoleApplication.class, args);
+	}
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/src/main/java/com/liferay/seo/studio/google/search/console/controller/AuthorizeRestController.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/src/main/java/com/liferay/seo/studio/google/search/console/controller/AuthorizeRestController.java
@@ -1,0 +1,95 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.google.search.console.controller;
+
+import com.liferay.client.extension.util.spring.boot3.BaseRestController;
+import com.liferay.seo.studio.google.search.console.service.GoogleOAuth2Service;
+import com.liferay.seo.studio.google.search.console.service.LiferayObjectService;
+import com.liferay.seo.studio.google.search.console.service.StateTokenService;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.io.IOException;
+
+import java.net.URI;
+
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+/**
+ * @author Pei-Jung Lan
+ */
+@RequestMapping("/authorize")
+@RestController
+public class AuthorizeRestController extends BaseRestController {
+
+	@PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<String> post(
+			HttpServletRequest httpServletRequest,
+			@RequestParam String redirectURL,
+			@RequestParam long seoStudioInstanceId)
+		throws InterruptedException, IOException {
+
+		URI redirectURI = URI.create(redirectURL);
+
+		if (!_mainDomain.equals(redirectURI.getHost()) ||
+			!_protocol.equals(redirectURI.getScheme())) {
+
+			return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+		}
+
+		LiferayObjectService.CredentialEntry credentialEntry =
+			_liferayObjectService.fetchCredentialEntry(seoStudioInstanceId);
+
+		if (credentialEntry == null) {
+			return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+		}
+
+		String stateString = _stateTokenService.generateState(
+			seoStudioInstanceId, redirectURL);
+
+		String callbackURL = ServletUriComponentsBuilder.fromContextPath(
+			httpServletRequest
+		).path(
+			"/callback"
+		).toUriString();
+
+		String authorizationURL = _googleOAuth2Service.buildAuthorizationURL(
+			credentialEntry.getClientId(), callbackURL, stateString);
+
+		return ResponseEntity.ok(
+			new JSONObject(
+			).put(
+				"authorizationUrl", authorizationURL
+			).toString());
+	}
+
+	@Autowired
+	private GoogleOAuth2Service _googleOAuth2Service;
+
+	@Autowired
+	private LiferayObjectService _liferayObjectService;
+
+	@Value("${com.liferay.lxc.dxp.mainDomain}")
+	private String _mainDomain;
+
+	@Value("${com.liferay.lxc.dxp.server.protocol}")
+	private String _protocol;
+
+	@Autowired
+	private StateTokenService _stateTokenService;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/src/main/java/com/liferay/seo/studio/google/search/console/controller/CallbackRestController.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/src/main/java/com/liferay/seo/studio/google/search/console/controller/CallbackRestController.java
@@ -1,0 +1,147 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.google.search.console.controller;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleTokenResponse;
+
+import com.liferay.client.extension.util.spring.boot3.BaseRestController;
+import com.liferay.seo.studio.google.search.console.service.GoogleOAuth2Service;
+import com.liferay.seo.studio.google.search.console.service.LiferayObjectService;
+import com.liferay.seo.studio.google.search.console.service.StateTokenService;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.net.URI;
+
+import java.time.Instant;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+/**
+ * @author Pei-Jung Lan
+ */
+@RequestMapping("/callback")
+@RestController
+public class CallbackRestController extends BaseRestController {
+
+	@GetMapping
+	public ResponseEntity<Void> get(
+		HttpServletRequest httpServletRequest,
+		@RequestParam(required = false) String code,
+		@RequestParam(required = false) String error,
+		@RequestParam(required = false) String state) {
+
+		if (state == null) {
+			return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+		}
+
+		Claims claims;
+		String redirectURL;
+		long seoStudioInstanceId;
+
+		try {
+			claims = _stateTokenService.verifyState(state);
+
+			redirectURL = claims.get("redirectURL", String.class);
+
+			Number seoStudioInstanceIdNumber = (Number)claims.get(
+				"seoStudioInstanceId");
+
+			seoStudioInstanceId = seoStudioInstanceIdNumber.longValue();
+		}
+		catch (JwtException jwtException) {
+			_log.error("Unable to verify state JWT", jwtException);
+
+			return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+		}
+
+		if (error != null) {
+			return _redirect(redirectURL + "?gsc_error=" + error);
+		}
+
+		try {
+			LiferayObjectService.CredentialEntry credentialEntry =
+				_liferayObjectService.fetchCredentialEntry(seoStudioInstanceId);
+
+			if (credentialEntry == null) {
+				return _redirect(
+					redirectURL + "?gsc_error=credential_not_found");
+			}
+
+			String callbackURL = ServletUriComponentsBuilder.fromContextPath(
+				httpServletRequest
+			).path(
+				"/callback"
+			).toUriString();
+
+			GoogleTokenResponse googleTokenResponse =
+				_googleOAuth2Service.exchangeCode(
+					credentialEntry.getClientId(),
+					credentialEntry.getClientSecret(), code, callbackURL);
+
+			String emailString = _googleOAuth2Service.fetchUserEmail(
+				googleTokenResponse.getAccessToken());
+
+			Long expiresInSeconds = googleTokenResponse.getExpiresInSeconds();
+
+			Instant accessTokenExpirationTime = null;
+
+			if (expiresInSeconds != null) {
+				accessTokenExpirationTime = Instant.now(
+				).plusSeconds(
+					expiresInSeconds
+				);
+			}
+
+			_liferayObjectService.updateTokens(
+				googleTokenResponse.getAccessToken(), accessTokenExpirationTime,
+				emailString, credentialEntry.getId(),
+				googleTokenResponse.getRefreshToken());
+
+			return _redirect(redirectURL + "?gsc_success=true");
+		}
+		catch (Exception exception) {
+			_log.error("Unable to process OAuth callback", exception);
+
+			return _redirect(redirectURL + "?gsc_error=server_error");
+		}
+	}
+
+	private ResponseEntity<Void> _redirect(String urlString) {
+		HttpHeaders httpHeaders = new HttpHeaders();
+
+		httpHeaders.setLocation(URI.create(urlString));
+
+		return new ResponseEntity<>(httpHeaders, HttpStatus.FOUND);
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		CallbackRestController.class);
+
+	@Autowired
+	private GoogleOAuth2Service _googleOAuth2Service;
+
+	@Autowired
+	private LiferayObjectService _liferayObjectService;
+
+	@Autowired
+	private StateTokenService _stateTokenService;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/src/main/java/com/liferay/seo/studio/google/search/console/controller/InfoRestController.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/src/main/java/com/liferay/seo/studio/google/search/console/controller/InfoRestController.java
@@ -1,0 +1,44 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.google.search.console.controller;
+
+import com.liferay.client.extension.util.spring.boot3.BaseRestController;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.json.JSONObject;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+/**
+ * @author Pei-Jung Lan
+ */
+@CrossOrigin("*")
+@RequestMapping("/info")
+@RestController
+public class InfoRestController extends BaseRestController {
+
+	@GetMapping
+	public ResponseEntity<String> get(HttpServletRequest httpServletRequest) {
+		String callbackURL = ServletUriComponentsBuilder.fromContextPath(
+			httpServletRequest
+		).path(
+			"/callback"
+		).toUriString();
+
+		return ResponseEntity.ok(
+			new JSONObject(
+			).put(
+				"callbackUrl", callbackURL
+			).toString());
+	}
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/src/main/java/com/liferay/seo/studio/google/search/console/controller/RevokeRestController.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/src/main/java/com/liferay/seo/studio/google/search/console/controller/RevokeRestController.java
@@ -1,0 +1,88 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.google.search.console.controller;
+
+import com.liferay.client.extension.util.spring.boot3.BaseRestController;
+import com.liferay.seo.studio.google.search.console.service.GoogleOAuth2Service;
+import com.liferay.seo.studio.google.search.console.service.LiferayObjectService;
+
+import java.io.IOException;
+
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Pei-Jung Lan
+ */
+@CrossOrigin("*")
+@RequestMapping("/revoke")
+@RestController
+public class RevokeRestController extends BaseRestController {
+
+	@PostMapping
+	public ResponseEntity<Void> post(@RequestBody Map<String, Object> body)
+		throws InterruptedException, IOException {
+
+		Object seoStudioInstanceIdObject = body.get("seoStudioInstanceId");
+
+		if (seoStudioInstanceIdObject == null) {
+			return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+		}
+
+		Number seoStudioInstanceIdNumber = (Number)seoStudioInstanceIdObject;
+
+		long seoStudioInstanceId = seoStudioInstanceIdNumber.longValue();
+
+		LiferayObjectService.CredentialEntry credentialEntry =
+			_liferayObjectService.fetchCredentialEntry(seoStudioInstanceId);
+
+		if (credentialEntry == null) {
+			return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+		}
+
+		String tokenString = credentialEntry.getRefreshToken();
+
+		if (tokenString == null) {
+			tokenString = credentialEntry.getAccessToken();
+		}
+
+		if (tokenString != null) {
+			try {
+				_googleOAuth2Service.revokeToken(tokenString);
+			}
+			catch (Exception exception) {
+				if (_log.isWarnEnabled()) {
+					_log.warn("Unable to revoke Google token", exception);
+				}
+			}
+		}
+
+		_liferayObjectService.deleteCredentialEntry(credentialEntry.getId());
+
+		return new ResponseEntity<>(HttpStatus.OK);
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		RevokeRestController.class);
+
+	@Autowired
+	private GoogleOAuth2Service _googleOAuth2Service;
+
+	@Autowired
+	private LiferayObjectService _liferayObjectService;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/src/main/java/com/liferay/seo/studio/google/search/console/controller/StatusRestController.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/src/main/java/com/liferay/seo/studio/google/search/console/controller/StatusRestController.java
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.google.search.console.controller;
+
+import com.liferay.client.extension.util.spring.boot3.BaseRestController;
+import com.liferay.seo.studio.google.search.console.service.LiferayObjectService;
+
+import java.io.IOException;
+
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Pei-Jung Lan
+ */
+@CrossOrigin("*")
+@RequestMapping("/status")
+@RestController
+public class StatusRestController extends BaseRestController {
+
+	@GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<String> get(@RequestParam long seoStudioInstanceId)
+		throws InterruptedException, IOException {
+
+		LiferayObjectService.CredentialEntry credentialEntry =
+			_liferayObjectService.fetchCredentialEntry(seoStudioInstanceId);
+
+		if ((credentialEntry != null) &&
+			StringUtils.hasText(credentialEntry.getEmailAddress())) {
+
+			return ResponseEntity.ok(
+				new JSONObject(
+				).put(
+					"connected", true
+				).put(
+					"emailAddress", credentialEntry.getEmailAddress()
+				).toString());
+		}
+
+		return ResponseEntity.ok(
+			new JSONObject(
+			).put(
+				"connected", false
+			).toString());
+	}
+
+	@Autowired
+	private LiferayObjectService _liferayObjectService;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/src/main/java/com/liferay/seo/studio/google/search/console/service/GoogleOAuth2Service.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/src/main/java/com/liferay/seo/studio/google/search/console/service/GoogleOAuth2Service.java
@@ -1,0 +1,125 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.google.search.console.service;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeRequestUrl;
+import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeTokenRequest;
+import com.google.api.client.googleapis.auth.oauth2.GoogleTokenResponse;
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+
+import java.io.IOException;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.List;
+
+import org.json.JSONObject;
+
+import org.springframework.stereotype.Service;
+
+/**
+ * @author Pei-Jung Lan
+ */
+@Service
+public class GoogleOAuth2Service {
+
+	public String buildAuthorizationURL(
+		String clientId, String callbackURI, String state) {
+
+		GoogleAuthorizationCodeRequestUrl googleAuthorizationCodeRequestUrl =
+			new GoogleAuthorizationCodeRequestUrl(
+				clientId, callbackURI, _scopes);
+
+		googleAuthorizationCodeRequestUrl.set("prompt", "consent");
+		googleAuthorizationCodeRequestUrl.setAccessType("offline");
+		googleAuthorizationCodeRequestUrl.setState(state);
+
+		return googleAuthorizationCodeRequestUrl.build();
+	}
+
+	public GoogleTokenResponse exchangeCode(
+			String clientId, String clientSecret, String code,
+			String callbackURI)
+		throws IOException {
+
+		return new GoogleAuthorizationCodeTokenRequest(
+			_netHttpTransport, GsonFactory.getDefaultInstance(), clientId,
+			clientSecret, code, callbackURI
+		).execute();
+	}
+
+	public String fetchUserEmail(String accessToken)
+		throws InterruptedException, IOException {
+
+		HttpRequest httpRequest = HttpRequest.newBuilder(
+		).header(
+			"Authorization", "Bearer " + accessToken
+		).uri(
+			URI.create(_USERINFO_URL)
+		).build();
+
+		HttpResponse<String> httpResponse = _httpClient.send(
+			httpRequest, HttpResponse.BodyHandlers.ofString());
+
+		if (httpResponse.statusCode() != HttpStatusCodes.STATUS_CODE_OK) {
+			throw new IOException(
+				"Unable to fetch user email, HTTP " +
+					httpResponse.statusCode());
+		}
+
+		JSONObject jsonObject = new JSONObject(httpResponse.body());
+
+		return jsonObject.getString("email");
+	}
+
+	public void revokeToken(String token)
+		throws InterruptedException, IOException {
+
+		HttpRequest httpRequest = HttpRequest.newBuilder(
+		).header(
+			"Content-Type", "application/x-www-form-urlencoded"
+		).method(
+			"POST",
+			HttpRequest.BodyPublishers.ofString(
+				"token=" + URLEncoder.encode(token, StandardCharsets.UTF_8))
+		).uri(
+			URI.create(_REVOKE_URL)
+		).build();
+
+		HttpResponse<Void> httpResponse = _httpClient.send(
+			httpRequest, HttpResponse.BodyHandlers.discarding());
+
+		int statusCode = httpResponse.statusCode();
+
+		if ((statusCode != HttpStatusCodes.STATUS_CODE_OK) &&
+			(statusCode != HttpStatusCodes.STATUS_CODE_BAD_REQUEST)) {
+
+			throw new IOException("Unable to revoke token, HTTP " + statusCode);
+		}
+	}
+
+	private static final String _REVOKE_URL =
+		"https://oauth2.googleapis.com/revoke";
+
+	private static final String _USERINFO_URL =
+		"https://www.googleapis.com/oauth2/v1/userinfo?alt=json";
+
+	private static final List<String> _scopes = List.of(
+		"email", "https://www.googleapis.com/auth/webmasters.readonly",
+		"openid");
+
+	private final HttpClient _httpClient = HttpClient.newHttpClient();
+	private final NetHttpTransport _netHttpTransport = new NetHttpTransport();
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/src/main/java/com/liferay/seo/studio/google/search/console/service/LiferayObjectService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/src/main/java/com/liferay/seo/studio/google/search/console/service/LiferayObjectService.java
@@ -1,0 +1,282 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.google.search.console.service;
+
+import com.google.api.client.http.HttpStatusCodes;
+
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
+import com.liferay.petra.string.StringBundler;
+
+import java.io.IOException;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * @author Pei-Jung Lan
+ */
+@Service
+public class LiferayObjectService {
+
+	public LiferayObjectService(
+		LiferayOAuth2AccessTokenManager liferayOAuth2AccessTokenManager,
+		@Value("${com.liferay.lxc.dxp.mainDomain}") String mainDomain,
+		@Value("${com.liferay.lxc.dxp.server.protocol}") String protocol) {
+
+		_liferayOAuth2AccessTokenManager = liferayOAuth2AccessTokenManager;
+
+		_httpClient = HttpClient.newHttpClient();
+		_liferayBaseURL = protocol + "://" + mainDomain;
+	}
+
+	public void deleteCredentialEntry(long id)
+		throws InterruptedException, IOException {
+
+		HttpRequest httpRequest = HttpRequest.newBuilder(
+		).header(
+			"Authorization", _getAuthorization()
+		).method(
+			"DELETE", HttpRequest.BodyPublishers.noBody()
+		).uri(
+			URI.create(
+				StringBundler.concat(
+					_liferayBaseURL, _CREDENTIAL_ENTRIES_PATH, "/", id))
+		).build();
+
+		HttpResponse<Void> httpResponse = _httpClient.send(
+			httpRequest, HttpResponse.BodyHandlers.discarding());
+
+		if (httpResponse.statusCode() !=
+				HttpStatusCodes.STATUS_CODE_NO_CONTENT) {
+
+			throw new IOException(
+				"Unable to delete credential entry, HTTP " +
+					httpResponse.statusCode());
+		}
+	}
+
+	public CredentialEntry fetchCredentialEntry(long seoStudioInstanceId)
+		throws InterruptedException, IOException {
+
+		HttpRequest httpRequest = HttpRequest.newBuilder(
+		).header(
+			"Authorization", _getAuthorization()
+		).uri(
+			UriComponentsBuilder.fromUriString(
+				_liferayBaseURL + _CREDENTIAL_ENTRIES_PATH
+			).queryParam(
+				"filter",
+				StringBundler.concat(
+					"r_seoStudioInstanceToGSCCredentialEntries_",
+					"seoStudioInstanceId eq '", seoStudioInstanceId, "'")
+			).build(
+			).toUri()
+		).build();
+
+		HttpResponse<String> httpResponse = _httpClient.send(
+			httpRequest, HttpResponse.BodyHandlers.ofString());
+
+		if (httpResponse.statusCode() ==
+				HttpStatusCodes.STATUS_CODE_NOT_FOUND) {
+
+			return null;
+		}
+
+		_checkStatus("fetch credential entry", httpResponse.statusCode());
+
+		JSONArray jsonArray = new JSONObject(
+			httpResponse.body()
+		).getJSONArray(
+			"items"
+		);
+
+		if (jsonArray.isEmpty()) {
+			return null;
+		}
+
+		return _toCredentialEntry(jsonArray.getJSONObject(0));
+	}
+
+	public void updateTokens(
+			String accessToken, Instant accessTokenExpirationTime,
+			String emailAddress, long id, String refreshToken)
+		throws InterruptedException, IOException {
+
+		JSONObject jsonObject = new JSONObject(
+		).put(
+			"accessToken", accessToken
+		).put(
+			"emailAddress", emailAddress
+		).put(
+			"refreshToken", refreshToken
+		);
+
+		if (accessTokenExpirationTime != null) {
+			jsonObject.put(
+				"accessTokenExpirationTime",
+				accessTokenExpirationTime.truncatedTo(
+					ChronoUnit.SECONDS
+				).toString());
+		}
+
+		_patchById(jsonObject.toString(), id);
+	}
+
+	public static class CredentialEntry {
+
+		public CredentialEntry(
+			String accessToken, Instant accessTokenExpirationTime,
+			String clientId, String clientSecret, String emailAddress, long id,
+			String refreshToken) {
+
+			_accessToken = accessToken;
+			_accessTokenExpirationTime = accessTokenExpirationTime;
+			_clientId = clientId;
+			_clientSecret = clientSecret;
+			_emailAddress = emailAddress;
+			_id = id;
+			_refreshToken = refreshToken;
+		}
+
+		public String getAccessToken() {
+			return _accessToken;
+		}
+
+		public Instant getAccessTokenExpirationTime() {
+			return _accessTokenExpirationTime;
+		}
+
+		public String getClientId() {
+			return _clientId;
+		}
+
+		public String getClientSecret() {
+			return _clientSecret;
+		}
+
+		public String getEmailAddress() {
+			return _emailAddress;
+		}
+
+		public long getId() {
+			return _id;
+		}
+
+		public String getRefreshToken() {
+			return _refreshToken;
+		}
+
+		private final String _accessToken;
+		private final Instant _accessTokenExpirationTime;
+		private final String _clientId;
+		private final String _clientSecret;
+		private final String _emailAddress;
+		private final long _id;
+		private final String _refreshToken;
+
+	}
+
+	private void _checkStatus(String operation, int statusCode)
+		throws IOException {
+
+		if (statusCode != HttpStatusCodes.STATUS_CODE_OK) {
+			throw new IOException(
+				StringBundler.concat(
+					"Unable to ", operation, ", HTTP ", statusCode));
+		}
+	}
+
+	private String _getAuthorization() {
+		return _liferayOAuth2AccessTokenManager.getAuthorization(
+			"liferay-seostudio-google-search-console-oahs");
+	}
+
+	private void _patchById(String body, long id)
+		throws InterruptedException, IOException {
+
+		HttpRequest httpRequest = HttpRequest.newBuilder(
+		).header(
+			"Authorization", _getAuthorization()
+		).header(
+			"Content-Type", "application/json"
+		).method(
+			"PATCH", HttpRequest.BodyPublishers.ofString(body)
+		).uri(
+			URI.create(
+				StringBundler.concat(
+					_liferayBaseURL, _CREDENTIAL_ENTRIES_PATH, "/", id))
+		).build();
+
+		HttpResponse<Void> httpResponse = _httpClient.send(
+			httpRequest, HttpResponse.BodyHandlers.discarding());
+
+		_checkStatus("update credential entry", httpResponse.statusCode());
+	}
+
+	private CredentialEntry _toCredentialEntry(JSONObject jsonObject) {
+		String accessToken = null;
+
+		if (!jsonObject.isNull("accessToken")) {
+			accessToken = jsonObject.getString("accessToken");
+		}
+
+		Instant accessTokenExpirationTime = null;
+
+		if (!jsonObject.isNull("accessTokenExpirationTime")) {
+			accessTokenExpirationTime = Instant.parse(
+				jsonObject.getString("accessTokenExpirationTime"));
+		}
+
+		String clientId = null;
+
+		if (!jsonObject.isNull("clientId")) {
+			clientId = jsonObject.getString("clientId");
+		}
+
+		String clientSecret = null;
+
+		if (!jsonObject.isNull("clientSecret")) {
+			clientSecret = jsonObject.getString("clientSecret");
+		}
+
+		String emailAddress = null;
+
+		if (!jsonObject.isNull("emailAddress")) {
+			emailAddress = jsonObject.getString("emailAddress");
+		}
+
+		String refreshToken = null;
+
+		if (!jsonObject.isNull("refreshToken")) {
+			refreshToken = jsonObject.getString("refreshToken");
+		}
+
+		return new CredentialEntry(
+			accessToken, accessTokenExpirationTime, clientId, clientSecret,
+			emailAddress, jsonObject.getLong("id"), refreshToken);
+	}
+
+	private static final String _CREDENTIAL_ENTRIES_PATH =
+		"/o/seo-studio/gsc-credential-entries";
+
+	private final HttpClient _httpClient;
+	private final String _liferayBaseURL;
+	private final LiferayOAuth2AccessTokenManager
+		_liferayOAuth2AccessTokenManager;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/src/main/java/com/liferay/seo/studio/google/search/console/service/StateTokenService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/src/main/java/com/liferay/seo/studio/google/search/console/service/StateTokenService.java
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.seo.studio.google.search.console.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.stereotype.Service;
+
+/**
+ * @author Pei-Jung Lan
+ */
+@Service
+public class StateTokenService {
+
+	public StateTokenService() {
+		_secretKey = Jwts.SIG.HS256.key(
+		).build();
+	}
+
+	public String generateState(long seoStudioInstanceId, String redirectURL) {
+		Date nowDate = new Date();
+
+		return Jwts.builder(
+		).claim(
+			"redirectURL", redirectURL
+		).claim(
+			"seoStudioInstanceId", seoStudioInstanceId
+		).expiration(
+			new Date(nowDate.getTime() + _ONE_HOUR_MS)
+		).issuedAt(
+			nowDate
+		).signWith(
+			_secretKey
+		).compact();
+	}
+
+	public Claims verifyState(String state) {
+		return Jwts.parser(
+		).verifyWith(
+			_secretKey
+		).build(
+		).parseSignedClaims(
+			state
+		).getPayload();
+	}
+
+	private static final long _ONE_HOUR_MS = 3600000;
+
+	private final SecretKey _secretKey;
+
+}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/src/main/java/com/liferay/seo/studio/google/search/console/service/StateTokenService.java
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/src/main/java/com/liferay/seo/studio/google/search/console/service/StateTokenService.java
@@ -7,11 +7,15 @@ package com.liferay.seo.studio.google.search.console.service;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+import java.nio.charset.StandardCharsets;
 
 import java.util.Date;
 
 import javax.crypto.SecretKey;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /**
@@ -20,9 +24,17 @@ import org.springframework.stereotype.Service;
 @Service
 public class StateTokenService {
 
-	public StateTokenService() {
-		_secretKey = Jwts.SIG.HS256.key(
-		).build();
+	public StateTokenService(
+		@Value("${liferay.seostudio.gsc.state.secret}") String stateSecret) {
+
+		if (stateSecret.length() < 32) {
+			throw new IllegalArgumentException(
+				"\"liferay.seostudio.gsc.state.secret\" must be at least 32 " +
+					"characters");
+		}
+
+		_secretKey = Keys.hmacShaKeyFor(
+			stateSecret.getBytes(StandardCharsets.UTF_8));
 	}
 
 	public String generateState(long seoStudioInstanceId, String redirectURL) {

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/src/main/resources/application-default.properties
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/src/main/resources/application-default.properties
@@ -1,0 +1,22 @@
+#
+# LXC
+#
+
+com.liferay.lxc.dxp.domains=localhost:8080
+com.liferay.lxc.dxp.mainDomain=localhost:8080
+com.liferay.lxc.dxp.server.protocol=http
+
+#
+# OAuth
+#
+
+liferay-seostudio-google-search-console-oahs.oauth2.headless.server.client.secret=myfancypassword
+liferay.oauth.application.external.reference.codes=liferay-seostudio-google-search-console-oahs,liferay-seostudio-google-search-console-oaua
+liferay.oauth.urls.excludes=/callback,/info,/ready
+
+#
+# Spring Boot
+#
+
+server.forward-headers-strategy=FRAMEWORK
+server.port=${PORT:58081}

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/src/main/resources/application-default.properties
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/src/main/resources/application-default.properties
@@ -1,4 +1,10 @@
 #
+# Application
+#
+
+liferay.seostudio.gsc.state.secret=${LIFERAY_SEOSTUDIO_GSC_STATE_SECRET}
+
+#
 # LXC
 #
 

--- a/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/src/main/resources/application.properties
+++ b/workspaces/liferay-seostudio-workspace/client-extensions/liferay-seostudio-google-search-console/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+spring.config.import=\
+    classpath:/application-default.properties,\
+    optional:configtree:${LIFERAY_ROUTES_CLIENT_EXTENSION}/,\
+    optional:configtree:${LIFERAY_ROUTES_DXP}/


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88843

What is being fixed: There was no mechanism to connect Google Search Console per SEO Studio instance using OAuth. Credentials need to be persisted durably and the OAuth redirect URI must be publicly reachable, which rules out an OSGi servlet running inside the portal.

How it is being fixed: A new SEOStudioGSCCredentialEntry site-scoped Liferay object definition stores each instance's credentials. A new Gradle workspace (liferay-seostudio-workspace) hosts the liferay-seostudio-google-search-console Spring Boot MVC client extension, which exposes five endpoints: POST /authorize initiates the flow via a signed JWT state token and redirects to Google; GET /callback validates the state, exchanges the authorization code, and persists tokens; POST /revoke calls Google's revocation API and clears local tokens; GET /status reports connection state and the connected email; GET /info returns the callback URL users must register in Google Cloud Console. The CX authenticates with Liferay via an M2M OAuth headless server application to read and write credentials.

Resent from https://github.com/brianchandotcom/liferay-portal/pull/175316