### PR TITLE
LPD-90443 buildRest

### DIFF
--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseImportProcessResourceTestCase.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseImportProcessResourceTestCase.java
@@ -797,8 +797,8 @@ public abstract class BaseImportProcessResourceTestCase {
 	protected ImportProcess testGetImportProcess_addImportProcess()
 		throws Exception {
 
-		return importProcessResource.postSiteImportProcess(
-			testGroup.getExternalReferenceCode(), randomImportProcess());
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -2299,4 +2299,4 @@ public abstract class BaseImportProcessResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1386081426
+// LIFERAY-REST-BUILDER-HASH:-1862664561


### PR DESCRIPTION
hi @brianchandotcom, the reason I am sending this again is because your [commit](https://github.com/brianchandotcom/liferay-portal/commit/9b77344cee92d6a6701c249c128af928a0950f92) reverted the fix. After some talk with Jeff from the Core team, we deduced the reason why ant build-rests generates different results is due to an outdated jar locally. Here is an explanation from Claude:
<img width="2526" height="639" alt="image" src="https://github.com/user-attachments/assets/9248958a-6f40-4e15-8bc4-34609ed900e4" />

Basically, there is a mismatch with jar versions on CI vs locally and I believe there needs to be a prep next commit to update the jar version. If you plan to run ant build-rests locally, it is recommended to run gradlew deploy jar in modules/util/portal-tools-rest-builder before running ant build-rests. 