### PR TITLE
LPD-88225 Add SitemapStorageHelper

### DIFF
--- a/modules/apps/site/site-api/src/main/java/com/liferay/site/storage/helper/SitemapStorageHelper.java
+++ b/modules/apps/site/site-api/src/main/java/com/liferay/site/storage/helper/SitemapStorageHelper.java
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.storage.helper;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+import java.io.InputStream;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * @author Cheryl Tang
+ */
+@ProviderType
+public interface SitemapStorageHelper {
+
+	public void deleteSitemaps(long companyId, long groupId)
+		throws PortalException;
+
+	public void deleteSitemaps(
+			long companyId, long groupId, String assetTypeKey)
+		throws PortalException;
+
+	public InputStream getSitemapInputStream(long companyId, long groupId)
+		throws PortalException;
+
+	public InputStream getSitemapInputStream(
+			long companyId, long groupId, String assetTypeKey, int page)
+		throws PortalException;
+
+	public boolean hasSitemapFile(long companyId, long groupId)
+		throws PortalException;
+
+	public boolean hasSitemapFile(
+			long companyId, long groupId, String assetTypeKey, int page)
+		throws PortalException;
+
+	public void storeSitemapFile(long companyId, long groupId, String xml)
+		throws PortalException;
+
+	public void storeSitemapFile(
+			long companyId, long groupId, String assetTypeKey, int page,
+			String xml)
+		throws PortalException;
+
+}

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/storage/helper/SitemapStorageHelperImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/storage/helper/SitemapStorageHelperImpl.java
@@ -1,0 +1,150 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.internal.storage.helper;
+
+import com.liferay.document.library.kernel.store.DLStore;
+import com.liferay.document.library.kernel.store.DLStoreRequest;
+import com.liferay.document.library.kernel.store.Store;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.site.storage.helper.SitemapStorageHelper;
+
+import java.io.InputStream;
+
+import java.nio.charset.StandardCharsets;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Cheryl Tang
+ */
+@Component(service = SitemapStorageHelper.class)
+public class SitemapStorageHelperImpl implements SitemapStorageHelper {
+
+	@Override
+	public void deleteSitemaps(long companyId, long groupId)
+		throws PortalException {
+
+		_dlStore.deleteDirectory(
+			companyId, CompanyConstants.SYSTEM, _getDirName(groupId));
+	}
+
+	@Override
+	public void deleteSitemaps(
+			long companyId, long groupId, String assetTypeKey)
+		throws PortalException {
+
+		_dlStore.deleteDirectory(
+			companyId, CompanyConstants.SYSTEM,
+			_getDirName(groupId, assetTypeKey));
+	}
+
+	@Override
+	public InputStream getSitemapInputStream(long companyId, long groupId)
+		throws PortalException {
+
+		return _dlStore.getFileAsStream(
+			companyId, CompanyConstants.SYSTEM, _getSitemapFileName(groupId),
+			Store.VERSION_DEFAULT);
+	}
+
+	@Override
+	public InputStream getSitemapInputStream(
+			long companyId, long groupId, String assetTypeKey, int page)
+		throws PortalException {
+
+		return _dlStore.getFileAsStream(
+			companyId, CompanyConstants.SYSTEM,
+			_getSitemapFileName(groupId, assetTypeKey, page),
+			Store.VERSION_DEFAULT);
+	}
+
+	@Override
+	public boolean hasSitemapFile(long companyId, long groupId)
+		throws PortalException {
+
+		return _dlStore.hasFile(
+			companyId, CompanyConstants.SYSTEM, _getSitemapFileName(groupId),
+			Store.VERSION_DEFAULT);
+	}
+
+	@Override
+	public boolean hasSitemapFile(
+			long companyId, long groupId, String assetTypeKey, int page)
+		throws PortalException {
+
+		return _dlStore.hasFile(
+			companyId, CompanyConstants.SYSTEM,
+			_getSitemapFileName(groupId, assetTypeKey, page),
+			Store.VERSION_DEFAULT);
+	}
+
+	@Override
+	public void storeSitemapFile(long companyId, long groupId, String xml)
+		throws PortalException {
+
+		_storeSitemapFile(companyId, _getSitemapFileName(groupId), xml);
+	}
+
+	@Override
+	public void storeSitemapFile(
+			long companyId, long groupId, String assetTypeKey, int page,
+			String xml)
+		throws PortalException {
+
+		_storeSitemapFile(
+			companyId, _getSitemapFileName(groupId, assetTypeKey, page), xml);
+	}
+
+	private String _getDirName(long groupId) {
+		return StringBundler.concat(
+			_DIR_NAME_PREFIX, StringPool.SLASH, groupId);
+	}
+
+	private String _getDirName(long groupId, String assetTypeKey) {
+		return StringBundler.concat(
+			_DIR_NAME_PREFIX, StringPool.SLASH, groupId, StringPool.SLASH,
+			assetTypeKey);
+	}
+
+	private String _getSitemapFileName(long groupId) {
+		return StringBundler.concat(
+			_DIR_NAME_PREFIX, StringPool.SLASH, groupId, "/sitemap-index.xml");
+	}
+
+	private String _getSitemapFileName(
+		long groupId, String assetTypeKey, int page) {
+
+		return StringBundler.concat(
+			_DIR_NAME_PREFIX, StringPool.SLASH, groupId, StringPool.SLASH,
+			assetTypeKey, StringPool.SLASH, page, ".xml");
+	}
+
+	private void _storeSitemapFile(long companyId, String fileName, String xml)
+		throws PortalException {
+
+		byte[] bytes = xml.getBytes(StandardCharsets.UTF_8);
+
+		DLStoreRequest dlStoreRequest = DLStoreRequest.builder(
+			companyId, CompanyConstants.SYSTEM, fileName
+		).size(
+			bytes.length
+		).versionLabel(
+			Store.VERSION_DEFAULT
+		).build();
+
+		_dlStore.addFile(dlStoreRequest, bytes);
+	}
+
+	private static final String _DIR_NAME_PREFIX = "sitemaps";
+
+	@Reference
+	private DLStore _dlStore;
+
+}


### PR DESCRIPTION
Continued from https://github.com/brianchandotcom/liferay-portal/pull/175387

Resending because I started working on a ticket that depends on this. As I worked through that ticket, it made more sense and fit requirements better if this helper class is in the API module instead. 

_______________________

In response to the [#bchan-bot-pr-review in the previous PR](https://github.com/brianchandotcom/liferay-portal/pull/175387#issuecomment-4578606635):

These issues the AI models found are all false flags/incorrect.

> Inconsistent path separator

What I have is what SF wants - Not combining has SF throw Combine the literal string "sitemap-index.xml" with "StringPool.SLASH"

> Class fields are declared after methods instead of before them per Liferay layout convention [001]

Wrong. Class fields after methods is our convention.

> Missing newline at end of file

This is how SF formats it, even after attempting to manually add the newline.