### PR TITLE
LPD-92391 Use POST on create so an existing ERC no longer overwrites

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/manager/v1_0/ModelArmorTemplateManager.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/manager/v1_0/ModelArmorTemplateManager.java
@@ -18,6 +18,11 @@ public interface ModelArmorTemplateManager {
 			String externalReferenceCode)
 		throws Exception;
 
+	public ModelArmorTemplate postModelArmorTemplate(
+			long companyId, DTOConverterContext dtoConverterContext,
+			ModelArmorTemplate modelArmorTemplate)
+		throws Exception;
+
 	public ModelArmorTemplate putModelArmorTemplate(
 			long companyId, DTOConverterContext dtoConverterContext,
 			String externalReferenceCode, ModelArmorTemplate modelArmorTemplate)

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/resource/v1_0/ModelArmorTemplateResource.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-api/src/main/java/com/liferay/ai/hub/rest/resource/v1_0/ModelArmorTemplateResource.java
@@ -14,12 +14,15 @@ import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import jakarta.annotation.Generated;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
 import java.util.Collections;
@@ -43,6 +46,14 @@ public interface ModelArmorTemplateResource {
 
 	public void deleteModelArmorTemplateByExternalReferenceCode(
 			String externalReferenceCode)
+		throws Exception;
+
+	public ModelArmorTemplate postModelArmorTemplate(
+			ModelArmorTemplate modelArmorTemplate)
+		throws Exception;
+
+	public Response postModelArmorTemplateBatch(
+			String callbackURL, Object object)
 		throws Exception;
 
 	public ModelArmorTemplate putModelArmorTemplateByExternalReferenceCode(
@@ -88,6 +99,14 @@ public interface ModelArmorTemplateResource {
 	public void setRoleLocalService(RoleLocalService roleLocalService);
 
 	public void setSortParserProvider(SortParserProvider sortParserProvider);
+
+	public void setVulcanBatchEngineExportTaskResource(
+		VulcanBatchEngineExportTaskResource
+			vulcanBatchEngineExportTaskResource);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
 		String filterString) {
@@ -137,4 +156,4 @@ public interface ModelArmorTemplateResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1769429809
+// LIFERAY-REST-BUILDER-HASH:456182443

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-client/src/main/java/com/liferay/ai/hub/rest/client/resource/v1_0/ModelArmorTemplateResource.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-client/src/main/java/com/liferay/ai/hub/rest/client/resource/v1_0/ModelArmorTemplateResource.java
@@ -41,6 +41,21 @@ public interface ModelArmorTemplateResource {
 				String externalReferenceCode)
 		throws Exception;
 
+	public ModelArmorTemplate postModelArmorTemplate(
+			ModelArmorTemplate modelArmorTemplate)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postModelArmorTemplateHttpResponse(
+			ModelArmorTemplate modelArmorTemplate)
+		throws Exception;
+
+	public void postModelArmorTemplateBatch(String callbackURL, Object object)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postModelArmorTemplateBatchHttpResponse(
+			String callbackURL, Object object)
+		throws Exception;
+
 	public ModelArmorTemplate putModelArmorTemplateByExternalReferenceCode(
 			String externalReferenceCode, ModelArmorTemplate modelArmorTemplate)
 		throws Exception;
@@ -268,6 +283,212 @@ public interface ModelArmorTemplateResource {
 			return httpInvoker.invoke();
 		}
 
+		public ModelArmorTemplate postModelArmorTemplate(
+				ModelArmorTemplate modelArmorTemplate)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postModelArmorTemplateHttpResponse(modelArmorTemplate);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return ModelArmorTemplateSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse postModelArmorTemplateHttpResponse(
+				ModelArmorTemplate modelArmorTemplate)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(modelArmorTemplate.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/ai-hub/v1.0/model-armor-templates");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void postModelArmorTemplateBatch(
+				String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postModelArmorTemplateBatchHttpResponse(callbackURL, object);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse postModelArmorTemplateBatchHttpResponse(
+				String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(object.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/ai-hub/v1.0/model-armor-templates/batch");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
 		public ModelArmorTemplate putModelArmorTemplateByExternalReferenceCode(
 				String externalReferenceCode,
 				ModelArmorTemplate modelArmorTemplate)
@@ -392,4 +613,4 @@ public interface ModelArmorTemplateResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-135134432
+// LIFERAY-REST-BUILDER-HASH:685772972

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/rest-openapi.yaml
@@ -458,6 +458,27 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/ContentRetriever"
             tags: ["ContentRetriever"]
+    "/model-armor-templates":
+        post:
+            operationId: postModelArmorTemplate
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ModelArmorTemplate"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/ModelArmorTemplate"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ModelArmorTemplate"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/ModelArmorTemplate"
+            tags: ["ModelArmorTemplate"]
     "/model-armor-templates/by-external-reference-code/{externalReferenceCode}":
         delete:
             operationId: deleteModelArmorTemplateByExternalReferenceCode

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/ModelArmorTemplateManagerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/ModelArmorTemplateManagerImpl.java
@@ -52,6 +52,28 @@ public class ModelArmorTemplateManagerImpl
 	}
 
 	@Override
+	public ModelArmorTemplate postModelArmorTemplate(
+			long companyId, DTOConverterContext dtoConverterContext,
+			ModelArmorTemplate modelArmorTemplate)
+		throws Exception {
+
+		AccountEntry accountEntry = AccountEntryUtil.getUserAccountEntry(
+			dtoConverterContext.getUserId());
+
+		ObjectEntry objectEntry = _objectEntryManager.addObjectEntry(
+			dtoConverterContext, _getObjectDefinition(companyId),
+			_toObjectEntry(
+				accountEntry.getAccountEntryId(), modelArmorTemplate),
+			null);
+
+		_modelArmorHandler.createModelArmorTemplate(
+			companyId, objectEntry.getExternalReferenceCode(),
+			objectEntry.getProperties());
+
+		return _toModelArmorTemplate(objectEntry);
+	}
+
+	@Override
 	public ModelArmorTemplate putModelArmorTemplate(
 			long companyId, DTOConverterContext dtoConverterContext,
 			String externalReferenceCode, ModelArmorTemplate modelArmorTemplate)
@@ -69,9 +91,12 @@ public class ModelArmorTemplateManagerImpl
 				dtoConverterContext, externalReferenceCode, objectDefinition,
 				null);
 
-		ObjectEntry objectEntry = _updateObjectEntry(
-			accountEntry.getAccountEntryId(), companyId, dtoConverterContext,
-			externalReferenceCode, modelArmorTemplate, objectDefinition);
+		ObjectEntry objectEntry = _objectEntryManager.updateObjectEntry(
+			companyId, dtoConverterContext, externalReferenceCode,
+			objectDefinition,
+			_toObjectEntry(
+				accountEntry.getAccountEntryId(), modelArmorTemplate),
+			null);
 
 		if (existingObjectEntry == null) {
 			_modelArmorHandler.createModelArmorTemplate(
@@ -82,6 +107,18 @@ public class ModelArmorTemplateManagerImpl
 				companyId, externalReferenceCode, objectEntry.getProperties());
 		}
 
+		return _toModelArmorTemplate(objectEntry);
+	}
+
+	private ObjectDefinition _getObjectDefinition(long companyId)
+		throws Exception {
+
+		return _objectDefinitionLocalService.
+			getObjectDefinitionByExternalReferenceCode(
+				"L_AI_HUB_MODEL_ARMOR_TEMPLATE", companyId);
+	}
+
+	private ModelArmorTemplate _toModelArmorTemplate(ObjectEntry objectEntry) {
 		return new ModelArmorTemplate() {
 			{
 				setActive(
@@ -149,100 +186,76 @@ public class ModelArmorTemplateManagerImpl
 		};
 	}
 
-	private ObjectDefinition _getObjectDefinition(long companyId)
-		throws Exception {
+	private ObjectEntry _toObjectEntry(
+		long accountEntryId, ModelArmorTemplate modelArmorTemplate) {
 
-		return _objectDefinitionLocalService.
-			getObjectDefinitionByExternalReferenceCode(
-				"L_AI_HUB_MODEL_ARMOR_TEMPLATE", companyId);
-	}
-
-	private ObjectEntry _updateObjectEntry(
-			long accountEntryId, long companyId,
-			DTOConverterContext dtoConverterContext,
-			String externalReferenceCode, ModelArmorTemplate modelArmorTemplate,
-			ObjectDefinition objectDefinition)
-		throws Exception {
-
-		return _objectEntryManager.updateObjectEntry(
-			companyId, dtoConverterContext, externalReferenceCode,
-			objectDefinition,
-			new ObjectEntry() {
-				{
-					setExternalReferenceCode(
-						modelArmorTemplate::getExternalReferenceCode);
-					setProperties(
-						() -> HashMapBuilder.<String, Object>put(
-							"active",
-							GetterUtil.getBoolean(
-								modelArmorTemplate.getActive(), true)
-						).put(
-							"description",
-							GetterUtil.getString(
-								modelArmorTemplate.getDescription())
-						).put(
-							"guardrailType",
-							String.valueOf(
-								modelArmorTemplate.getGuardrailType())
-						).put(
-							"location",
-							GetterUtil.getString(
-								modelArmorTemplate.getLocation())
-						).put(
-							"maliciousUriFilterEnabled",
-							GetterUtil.getBoolean(
-								modelArmorTemplate.
-									getMaliciousUriFilterEnabled())
-						).put(
-							"multilanguageDetectionEnabled",
-							GetterUtil.getBoolean(
-								modelArmorTemplate.
-									getMultilanguageDetectionEnabled())
-						).put(
-							"piAndJailbreakConfidenceLevel",
-							Objects.toString(
-								modelArmorTemplate.
-									getPiAndJailbreakConfidenceLevel(),
-								null)
-						).put(
-							"piAndJailbreakFilterEnabled",
-							GetterUtil.getBoolean(
-								modelArmorTemplate.
-									getPiAndJailbreakFilterEnabled())
-						).put(
-							"r_accountToAIHubModelArmorTemplates_" +
-								"accountEntryId",
-							String.valueOf(accountEntryId)
-						).put(
-							"raiDangerousLevel",
-							Objects.toString(
-								modelArmorTemplate.getRaiDangerousLevel(), null)
-						).put(
-							"raiHarassmentLevel",
-							Objects.toString(
-								modelArmorTemplate.getRaiHarassmentLevel(),
-								null)
-						).put(
-							"raiHateSpeechLevel",
-							Objects.toString(
-								modelArmorTemplate.getRaiHateSpeechLevel(),
-								null)
-						).put(
-							"raiSexuallyExplicitLevel",
-							Objects.toString(
-								modelArmorTemplate.
-									getRaiSexuallyExplicitLevel(),
-								null)
-						).put(
-							"sdpFilterEnabled",
-							GetterUtil.getBoolean(
-								modelArmorTemplate.getSdpFilterEnabled())
-						).put(
-							"title_i18n", modelArmorTemplate.getTitle_i18n()
-						).build());
-				}
-			},
-			null);
+		return new ObjectEntry() {
+			{
+				setExternalReferenceCode(
+					modelArmorTemplate::getExternalReferenceCode);
+				setProperties(
+					() -> HashMapBuilder.<String, Object>put(
+						"active",
+						GetterUtil.getBoolean(
+							modelArmorTemplate.getActive(), true)
+					).put(
+						"description",
+						GetterUtil.getString(
+							modelArmorTemplate.getDescription())
+					).put(
+						"guardrailType",
+						String.valueOf(modelArmorTemplate.getGuardrailType())
+					).put(
+						"location",
+						GetterUtil.getString(modelArmorTemplate.getLocation())
+					).put(
+						"maliciousUriFilterEnabled",
+						GetterUtil.getBoolean(
+							modelArmorTemplate.getMaliciousUriFilterEnabled())
+					).put(
+						"multiLanguageDetectionEnabled",
+						GetterUtil.getBoolean(
+							modelArmorTemplate.
+								getMultilanguageDetectionEnabled())
+					).put(
+						"piAndJailbreakConfidenceLevel",
+						Objects.toString(
+							modelArmorTemplate.
+								getPiAndJailbreakConfidenceLevel(),
+							null)
+					).put(
+						"piAndJailbreakFilterEnabled",
+						GetterUtil.getBoolean(
+							modelArmorTemplate.getPiAndJailbreakFilterEnabled())
+					).put(
+						"r_accountToAIHubModelArmorTemplates_accountEntryId",
+						String.valueOf(accountEntryId)
+					).put(
+						"raiDangerousLevel",
+						Objects.toString(
+							modelArmorTemplate.getRaiDangerousLevel(), null)
+					).put(
+						"raiHarassmentLevel",
+						Objects.toString(
+							modelArmorTemplate.getRaiHarassmentLevel(), null)
+					).put(
+						"raiHateSpeechLevel",
+						Objects.toString(
+							modelArmorTemplate.getRaiHateSpeechLevel(), null)
+					).put(
+						"raiSexuallyExplicitLevel",
+						Objects.toString(
+							modelArmorTemplate.getRaiSexuallyExplicitLevel(),
+							null)
+					).put(
+						"sdpFilterEnabled",
+						GetterUtil.getBoolean(
+							modelArmorTemplate.getSdpFilterEnabled())
+					).put(
+						"title_i18n", modelArmorTemplate.getTitle_i18n()
+					).build());
+			}
+		};
 	}
 
 	@Reference

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/BaseModelArmorTemplateResourceImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/BaseModelArmorTemplateResourceImpl.java
@@ -7,6 +7,9 @@ package com.liferay.ai.hub.rest.internal.resource.v1_0;
 
 import com.liferay.ai.hub.rest.dto.v1_0.ModelArmorTemplate;
 import com.liferay.ai.hub.rest.resource.v1_0.ModelArmorTemplateResource;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
+import com.liferay.petra.function.UnsafeBiConsumer;
+import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -15,10 +18,24 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParser;
 import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortField;
+import com.liferay.portal.odata.sort.SortParser;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.UriInfoUtil;
 
@@ -27,11 +44,20 @@ import jakarta.annotation.Generated;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import jakarta.ws.rs.NotSupportedException;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
+import java.io.Serializable;
+
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Feliphe Marinho
@@ -40,7 +66,8 @@ import java.util.Map;
 @Generated("")
 @jakarta.ws.rs.Path("/v1.0")
 public abstract class BaseModelArmorTemplateResourceImpl
-	implements ModelArmorTemplateResource {
+	implements EntityModelResource, ModelArmorTemplateResource,
+			   VulcanBatchEngineTaskItemDelegate<ModelArmorTemplate> {
 
 	/**
 	 * Invoke this method with the command line:
@@ -72,6 +99,74 @@ public abstract class BaseModelArmorTemplateResourceImpl
 			@jakarta.ws.rs.PathParam("externalReferenceCode")
 			String externalReferenceCode)
 		throws Exception {
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/ai-hub/v1.0/model-armor-templates' -d $'{"active": ___, "description": ___, "externalReferenceCode": ___, "guardrailType": ___, "location": ___, "maliciousUriFilterEnabled": ___, "multilanguageDetectionEnabled": ___, "piAndJailbreakConfidenceLevel": ___, "piAndJailbreakFilterEnabled": ___, "raiDangerousLevel": ___, "raiHarassmentLevel": ___, "raiHateSpeechLevel": ___, "raiSexuallyExplicitLevel": ___, "sdpFilterEnabled": ___, "title_i18n": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "ModelArmorTemplate")
+		}
+	)
+	@jakarta.ws.rs.Consumes({"application/json", "application/xml"})
+	@jakarta.ws.rs.Path("/model-armor-templates")
+	@jakarta.ws.rs.POST
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public ModelArmorTemplate postModelArmorTemplate(
+			ModelArmorTemplate modelArmorTemplate)
+		throws Exception {
+
+		return new ModelArmorTemplate();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/ai-hub/v1.0/model-armor-templates/batch'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "callbackURL"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "ModelArmorTemplate")
+		}
+	)
+	@jakarta.ws.rs.Consumes("application/json")
+	@jakarta.ws.rs.Path("/model-armor-templates/batch")
+	@jakarta.ws.rs.POST
+	@jakarta.ws.rs.Produces("application/json")
+	@Override
+	public Response postModelArmorTemplateBatch(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("callbackURL")
+			String callbackURL,
+			Object object)
+		throws Exception {
+
+		vulcanBatchEngineImportTaskResource.setContextAcceptLanguage(
+			contextAcceptLanguage);
+		vulcanBatchEngineImportTaskResource.setContextCompany(contextCompany);
+		vulcanBatchEngineImportTaskResource.setContextHttpServletRequest(
+			contextHttpServletRequest);
+		vulcanBatchEngineImportTaskResource.setContextUriInfo(contextUriInfo);
+		vulcanBatchEngineImportTaskResource.setContextUser(contextUser);
+
+		Response.ResponseBuilder responseBuilder = Response.accepted();
+
+		return responseBuilder.entity(
+			vulcanBatchEngineImportTaskResource.postImportTask(
+				ModelArmorTemplate.class.getName(), callbackURL, null, object)
+		).build();
 	}
 
 	/**
@@ -110,8 +205,202 @@ public abstract class BaseModelArmorTemplateResourceImpl
 		return new ModelArmorTemplate();
 	}
 
+	@Override
+	@SuppressWarnings("PMD.UnusedLocalVariable")
+	public void create(
+			Collection<ModelArmorTemplate> modelArmorTemplates,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		UnsafeFunction<ModelArmorTemplate, ModelArmorTemplate, Exception>
+			modelArmorTemplateUnsafeFunction = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if (StringUtil.equalsIgnoreCase(createStrategy, "INSERT")) {
+			modelArmorTemplateUnsafeFunction =
+				modelArmorTemplate -> postModelArmorTemplate(
+					modelArmorTemplate);
+		}
+
+		if (StringUtil.equalsIgnoreCase(createStrategy, "UPSERT")) {
+			String updateStrategy = (String)parameters.getOrDefault(
+				"updateStrategy", "UPDATE");
+
+			if (StringUtil.equalsIgnoreCase(updateStrategy, "UPDATE")) {
+				modelArmorTemplateUnsafeFunction = modelArmorTemplate -> {
+					ModelArmorTemplate persistedModelArmorTemplate = null;
+
+					persistedModelArmorTemplate =
+						putModelArmorTemplateByExternalReferenceCode(
+							modelArmorTemplate.getExternalReferenceCode(),
+							modelArmorTemplate);
+
+					return persistedModelArmorTemplate;
+				};
+			}
+		}
+
+		if (modelArmorTemplateUnsafeFunction == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" is not supported for ModelArmorTemplate");
+		}
+
+		if (contextBatchUnsafeBiConsumer != null) {
+			contextBatchUnsafeBiConsumer.accept(
+				modelArmorTemplates, modelArmorTemplateUnsafeFunction);
+		}
+		else if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				modelArmorTemplates, modelArmorTemplateUnsafeFunction::apply);
+		}
+		else {
+			for (ModelArmorTemplate modelArmorTemplate : modelArmorTemplates) {
+				modelArmorTemplateUnsafeFunction.apply(modelArmorTemplate);
+			}
+		}
+	}
+
+	@Override
+	public void delete(
+			Collection<ModelArmorTemplate> modelArmorTemplates,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		UnsafeFunction<ModelArmorTemplate, ModelArmorTemplate, Exception>
+			modelArmorTemplateUnsafeFunction = modelArmorTemplate -> {
+				if (modelArmorTemplate.getExternalReferenceCode() != null) {
+					deleteModelArmorTemplateByExternalReferenceCode(
+						modelArmorTemplate.getExternalReferenceCode());
+
+					return modelArmorTemplate;
+				}
+
+				throw new UnsupportedOperationException(
+					"Unable to delete by external reference code or ID");
+			};
+
+		if (contextBatchUnsafeBiConsumer != null) {
+			contextBatchUnsafeBiConsumer.accept(
+				modelArmorTemplates, modelArmorTemplateUnsafeFunction);
+		}
+		else if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				modelArmorTemplates, modelArmorTemplateUnsafeFunction::apply);
+		}
+		else {
+			for (ModelArmorTemplate modelArmorTemplate : modelArmorTemplates) {
+				modelArmorTemplateUnsafeFunction.apply(modelArmorTemplate);
+			}
+		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT", "UPSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	@Override
+	public EntityModel getEntityModel(Map<String, List<String>> multivaluedMap)
+		throws Exception {
+
+		return getEntityModel(
+			new MultivaluedHashMap<String, Object>(multivaluedMap));
+	}
+
+	public String getResourceName() {
+		return "ModelArmorTemplate";
+	}
+
+	public String getVersion() {
+		return "v1.0";
+	}
+
+	@Override
+	public Page<ModelArmorTemplate> read(
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts,
+			Map<String, Serializable> parameters, String search)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Override
+	public void setLanguageId(String languageId) {
+		this.contextAcceptLanguage = new AcceptLanguage() {
+
+			@Override
+			public List<Locale> getLocales() {
+				return null;
+			}
+
+			@Override
+			public String getPreferredLanguageId() {
+				return languageId;
+			}
+
+			@Override
+			public Locale getPreferredLocale() {
+				return LocaleUtil.fromLanguageId(languageId);
+			}
+
+			@Override
+			public boolean isAcceptAllLanguages() {
+				if (ExportImportThreadLocal.isExportInProcess()) {
+					return true;
+				}
+
+				return AcceptLanguage.super.isAcceptAllLanguages();
+			}
+
+		};
+	}
+
+	@Override
+	public void update(
+			Collection<ModelArmorTemplate> modelArmorTemplates,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap)
+		throws Exception {
+
+		return null;
+	}
+
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
 		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextBatchUnsafeBiConsumer(
+		UnsafeBiConsumer
+			<Collection<ModelArmorTemplate>,
+			 UnsafeFunction<ModelArmorTemplate, ModelArmorTemplate, Exception>,
+			 Exception> contextBatchUnsafeBiConsumer) {
+
+		this.contextBatchUnsafeBiConsumer = contextBatchUnsafeBiConsumer;
+	}
+
+	public void setContextBatchUnsafeConsumer(
+		UnsafeBiConsumer
+			<Collection<ModelArmorTemplate>,
+			 UnsafeConsumer<ModelArmorTemplate, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
+
+		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
 
 	public void setContextCompany(
@@ -182,6 +471,87 @@ public abstract class BaseModelArmorTemplateResourceImpl
 
 	protected String getApplicationPath() {
 		return "ai-hub";
+	}
+
+	public void setVulcanBatchEngineExportTaskResource(
+		VulcanBatchEngineExportTaskResource
+			vulcanBatchEngineExportTaskResource) {
+
+		this.vulcanBatchEngineExportTaskResource =
+			vulcanBatchEngineExportTaskResource;
+	}
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		try {
+			EntityModel entityModel = getEntityModel(multivaluedMap);
+
+			FilterParser filterParser = filterParserProvider.provide(
+				entityModel);
+
+			com.liferay.portal.odata.filter.Filter oDataFilter =
+				new com.liferay.portal.odata.filter.Filter(
+					filterParser.parse(filterString));
+
+			return expressionConvert.convert(
+				oDataFilter.getExpression(),
+				contextAcceptLanguage.getPreferredLocale(), entityModel);
+		}
+		catch (Exception exception) {
+			_log.error("Invalid filter " + filterString, exception);
+
+			return null;
+		}
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.Sort[] toSorts(String sortString) {
+		if (Validator.isNull(sortString)) {
+			return null;
+		}
+
+		try {
+			SortParser sortParser = sortParserProvider.provide(
+				getEntityModel(Collections.emptyMap()));
+
+			if (sortParser == null) {
+				return null;
+			}
+
+			com.liferay.portal.odata.sort.Sort oDataSort =
+				new com.liferay.portal.odata.sort.Sort(
+					sortParser.parse(sortString));
+
+			List<SortField> sortFields = oDataSort.getSortFields();
+			com.liferay.portal.kernel.search.Sort[] sorts =
+				new com.liferay.portal.kernel.search.Sort[sortFields.size()];
+
+			for (int i = 0; i < sortFields.size(); i++) {
+				SortField sortField = sortFields.get(i);
+
+				sorts[i] = new com.liferay.portal.kernel.search.Sort(
+					sortField.getSortableFieldName(
+						contextAcceptLanguage.getPreferredLocale()),
+					!sortField.isAscending());
+			}
+
+			return sorts;
+		}
+		catch (Exception exception) {
+			_log.error("Invalid sort " + sortString, exception);
+
+			return new com.liferay.portal.kernel.search.Sort[0];
+		}
 	}
 
 	protected Map<String, String> addAction(
@@ -536,6 +906,14 @@ public abstract class BaseModelArmorTemplateResourceImpl
 	}
 
 	protected AcceptLanguage contextAcceptLanguage;
+	protected UnsafeBiConsumer
+		<Collection<ModelArmorTemplate>,
+		 UnsafeFunction<ModelArmorTemplate, ModelArmorTemplate, Exception>,
+		 Exception> contextBatchUnsafeBiConsumer;
+	protected UnsafeBiConsumer
+		<Collection<ModelArmorTemplate>,
+		 UnsafeConsumer<ModelArmorTemplate, Exception>, Exception>
+			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -550,9 +928,13 @@ public abstract class BaseModelArmorTemplateResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
+	protected VulcanBatchEngineExportTaskResource
+		vulcanBatchEngineExportTaskResource;
+	protected VulcanBatchEngineImportTaskResource
+		vulcanBatchEngineImportTaskResource;
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseModelArmorTemplateResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1708761931
+// LIFERAY-REST-BUILDER-HASH:-1791803584

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/ModelArmorTemplateResourceImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/resource/v1_0/ModelArmorTemplateResourceImpl.java
@@ -48,6 +48,27 @@ public class ModelArmorTemplateResourceImpl
 	}
 
 	@Override
+	public ModelArmorTemplate postModelArmorTemplate(
+			ModelArmorTemplate modelArmorTemplate)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-62272")) {
+
+			throw new UnsupportedOperationException();
+		}
+
+		return _modelArmorTemplateManager.postModelArmorTemplate(
+			contextCompany.getCompanyId(),
+			new DefaultDTOConverterContext(
+				contextAcceptLanguage.isAcceptAllLanguages(), null,
+				_dtoConverterRegistry, contextHttpServletRequest, null,
+				contextAcceptLanguage.getPreferredLocale(), contextUriInfo,
+				contextUser),
+			modelArmorTemplate);
+	}
+
+	@Override
 	public ModelArmorTemplate putModelArmorTemplateByExternalReferenceCode(
 			String externalReferenceCode, ModelArmorTemplate modelArmorTemplate)
 		throws Exception {

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/model-armor-template.properties
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/model-armor-template.properties
@@ -3,6 +3,10 @@
 #
 
 api.version=v1.0
+batch.engine.entity.class.name=com.liferay.ai.hub.rest.dto.v1_0.ModelArmorTemplate
+batch.engine.task.item.delegate=true
+batch.planner.export.enabled=false
+batch.planner.import.enabled=true
 entity.class.name=com.liferay.ai.hub.rest.dto.v1_0.ModelArmorTemplate
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.AI.Hub.REST)
 osgi.jaxrs.resource=true

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/BaseModelArmorTemplateResourceTestCase.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/BaseModelArmorTemplateResourceTestCase.java
@@ -18,6 +18,9 @@ import com.liferay.ai.hub.rest.client.http.HttpInvoker;
 import com.liferay.ai.hub.rest.client.pagination.Page;
 import com.liferay.ai.hub.rest.client.resource.v1_0.ModelArmorTemplateResource;
 import com.liferay.ai.hub.rest.client.serdes.v1_0.ModelArmorTemplateSerDes;
+import com.liferay.headless.batch.engine.client.dto.v1_0.ImportTask;
+import com.liferay.headless.batch.engine.client.http.HttpInvoker.HttpResponse;
+import com.liferay.headless.batch.engine.client.resource.v1_0.ImportTaskResource;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -100,6 +103,17 @@ public abstract class BaseModelArmorTemplateResourceTestCase {
 			testCompany.getCompanyId());
 
 		modelArmorTemplateResource = ModelArmorTemplateResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+
+		importTaskResource = ImportTaskResource.builder(
 		).authentication(
 			_testCompanyAdminUser.getEmailAddress(),
 			PropsValues.DEFAULT_ADMIN_PASSWORD
@@ -210,6 +224,28 @@ public abstract class BaseModelArmorTemplateResourceTestCase {
 	}
 
 	@Test
+	public void testPostModelArmorTemplate() throws Exception {
+		ModelArmorTemplate randomModelArmorTemplate =
+			randomModelArmorTemplate();
+
+		ModelArmorTemplate postModelArmorTemplate =
+			testPostModelArmorTemplate_addModelArmorTemplate(
+				randomModelArmorTemplate);
+
+		assertEquals(randomModelArmorTemplate, postModelArmorTemplate);
+		assertValid(postModelArmorTemplate);
+	}
+
+	protected ModelArmorTemplate
+			testPostModelArmorTemplate_addModelArmorTemplate(
+				ModelArmorTemplate modelArmorTemplate)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
 	public void testPutModelArmorTemplateByExternalReferenceCode()
 		throws Exception {
 
@@ -279,6 +315,56 @@ public abstract class BaseModelArmorTemplateResourceTestCase {
 		throws Exception {
 
 		return randomModelArmorTemplate();
+	}
+
+	@Test
+	public void testBatchEngineDeleteImportTask() throws Exception {
+		ModelArmorTemplate modelArmorTemplate1 =
+			testBatchEngineDeleteImportTask_addModelArmorTemplate();
+
+		testBatchEngineDeleteImportTask_deleteModelArmorTemplate(
+			200, modelArmorTemplate1.getExternalReferenceCode());
+	}
+
+	protected ModelArmorTemplate
+			testBatchEngineDeleteImportTask_addModelArmorTemplate()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected void testBatchEngineDeleteImportTask_deleteModelArmorTemplate(
+			int expectedStatusCode, String externalReferenceCode,
+			String... parameters)
+		throws Exception {
+
+		ImportTaskResource importTaskResource = ImportTaskResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).parameters(
+			parameters
+		).build();
+
+		HttpResponse httpResponse =
+			importTaskResource.deleteImportTaskHttpResponse(
+				"com.liferay.ai.hub.rest.dto.v1_0.ModelArmorTemplate", null,
+				null, null, null,
+				JSONUtil.putAll(
+					JSONUtil.put(
+						"externalReferenceCode", () -> externalReferenceCode)));
+
+		Assert.assertEquals(expectedStatusCode, httpResponse.getStatusCode());
+
+		if (expectedStatusCode == 200) {
+			waitForFinish(
+				"COMPLETED",
+				JSONFactoryUtil.createJSONObject(httpResponse.getContent()));
+		}
 	}
 
 	protected void assertContains(
@@ -1274,7 +1360,30 @@ public abstract class BaseModelArmorTemplateResourceTestCase {
 		return randomModelArmorTemplate();
 	}
 
+	protected final JSONObject waitForFinish(
+			String expectedExecuteStatus, JSONObject jsonObject)
+		throws Exception {
+
+		while (true) {
+			ImportTask importTask = importTaskResource.getImportTask(
+				jsonObject.getLong("id"));
+
+			ImportTask.ExecuteStatus executeStatus =
+				importTask.getExecuteStatus();
+
+			if (StringUtil.equals(executeStatus.getValue(), "COMPLETED") ||
+				StringUtil.equals(executeStatus.getValue(), "FAILED")) {
+
+				Assert.assertEquals(
+					expectedExecuteStatus, executeStatus.getValue());
+
+				return jsonObject;
+			}
+		}
+	}
+
 	protected ModelArmorTemplateResource modelArmorTemplateResource;
+	protected ImportTaskResource importTaskResource;
 	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
 	protected com.liferay.portal.kernel.model.Company testCompany;
 	protected com.liferay.portal.kernel.model.Group testGroup;
@@ -1484,4 +1593,4 @@ public abstract class BaseModelArmorTemplateResourceTestCase {
 		_modelArmorTemplateResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1191882568
+// LIFERAY-REST-BUILDER-HASH:1091802144

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/ModelArmorTemplateResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/ModelArmorTemplateResourceTest.java
@@ -10,7 +10,9 @@ import com.liferay.account.model.AccountEntry;
 import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.account.service.AccountEntryUserRelLocalService;
 import com.liferay.ai.hub.rest.client.dto.v1_0.ModelArmorTemplate;
+import com.liferay.ai.hub.rest.client.problem.Problem;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManager;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.service.ObjectDefinitionLocalService;
@@ -19,6 +21,7 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -128,13 +131,27 @@ public class ModelArmorTemplateResourceTest
 			defaultObjectEntryManager.fetchObjectEntry(
 				_dtoConverterContext,
 				_modelArmorTemplate.getExternalReferenceCode(),
-				_objectDefinitionLocalService.
-					getObjectDefinitionByExternalReferenceCode(
-						"L_AI_HUB_MODEL_ARMOR_TEMPLATE",
-						TestPropsValues.getCompanyId()),
-				null));
+				_getObjectDefinition(), null));
 
 		_modelArmorTemplate = null;
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testPostModelArmorTemplate() throws Exception {
+		super.testPostModelArmorTemplate();
+
+		ModelArmorTemplate modelArmorTemplate = randomModelArmorTemplate();
+
+		modelArmorTemplate.setExternalReferenceCode(
+			_modelArmorTemplate.getExternalReferenceCode());
+
+		AssertUtils.assertFailure(
+			Problem.ProblemException.class,
+			"This external reference code is already in use.",
+			() -> testPostModelArmorTemplate_addModelArmorTemplate(
+				modelArmorTemplate));
 	}
 
 	@Ignore
@@ -155,11 +172,7 @@ public class ModelArmorTemplateResourceTest
 			_objectEntryManager.getObjectEntry(
 				TestPropsValues.getCompanyId(), _dtoConverterContext,
 				_modelArmorTemplate.getExternalReferenceCode(),
-				_objectDefinitionLocalService.
-					getObjectDefinitionByExternalReferenceCode(
-						"L_AI_HUB_MODEL_ARMOR_TEMPLATE",
-						TestPropsValues.getCompanyId()),
-				null));
+				_getObjectDefinition(), null));
 	}
 
 	@Override
@@ -190,6 +203,25 @@ public class ModelArmorTemplateResourceTest
 					modelArmorTemplate);
 
 		return _modelArmorTemplate;
+	}
+
+	@Override
+	protected ModelArmorTemplate
+			testPostModelArmorTemplate_addModelArmorTemplate(
+				ModelArmorTemplate modelArmorTemplate)
+		throws Exception {
+
+		_modelArmorTemplate = modelArmorTemplateResource.postModelArmorTemplate(
+			modelArmorTemplate);
+
+		return _modelArmorTemplate;
+	}
+
+	private ObjectDefinition _getObjectDefinition() throws Exception {
+		return _objectDefinitionLocalService.
+			getObjectDefinitionByExternalReferenceCode(
+				"L_AI_HUB_MODEL_ARMOR_TEMPLATE",
+				TestPropsValues.getCompanyId());
 	}
 
 	@Inject

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/agent_definition_form/hooks/useAgentDefinitionForm.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/agent_definition_form/hooks/useAgentDefinitionForm.ts
@@ -14,6 +14,7 @@ import {
 	deleteAgentDefinitionToContentRetrievers,
 	deleteAgentDefinitionToModelArmorTemplates,
 	getAgentDefinition,
+	postAgentDefinition,
 	putAgentDefinition,
 	putAgentDefinitionToContentRetrievers,
 	putAgentDefinitionToModelArmorTemplates,
@@ -70,7 +71,9 @@ export function useAgentDefinitionForm({
 		},
 		onSubmit: async (formValues) => {
 			try {
-				const response = await putAgentDefinition(formValues);
+				const response = externalReferenceCode
+					? await putAgentDefinition(formValues)
+					: await postAgentDefinition(formValues);
 
 				if (formValues.externalReferenceCode) {
 					await Promise.all([
@@ -102,9 +105,12 @@ export function useAgentDefinitionForm({
 				console.error(error);
 
 				openToast({
-					message: Liferay.Language.get(
-						'an-unexpected-error-occurred'
-					),
+					message:
+						error instanceof Error && error.message
+							? error.message
+							: Liferay.Language.get(
+									'an-unexpected-error-occurred'
+								),
 					type: 'danger',
 				});
 			}
@@ -165,7 +171,8 @@ export function useAgentDefinitionForm({
 					agentDefinition.agentDefinitionsToContentRetrievers || []
 				);
 				resetModelArmorTemplates(
-					agentDefinition.aiHubAgentDefinitionsToAIHubMATemplates || []
+					agentDefinition.aiHubAgentDefinitionsToAIHubMATemplates ||
+						[]
 				);
 			}
 			catch (error) {

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/agent_definition_form/services/AgentDefinitionService.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/agent_definition_form/services/AgentDefinitionService.ts
@@ -53,6 +53,24 @@ async function getAgentDefinitions() {
 	return response.json();
 }
 
+async function postAgentDefinition(agentDefinition: AgentDefinition) {
+	const response = await fetch(AGENT_DEFINITION_BASE_URI, {
+		body: JSON.stringify(agentDefinition),
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		method: 'POST',
+	});
+
+	if (!response.ok) {
+		const errorBody = await response.json().catch(() => ({}));
+
+		throw new Error(errorBody?.detail || errorBody?.title || '');
+	}
+
+	return response.json();
+}
+
 async function putAgentDefinition(agentDefinition: AgentDefinition) {
 	const response = await fetch(
 		`${AGENT_DEFINITION_BY_ERC_URI}${agentDefinition.externalReferenceCode}`,
@@ -95,6 +113,7 @@ export {
 	deleteAgentDefinitionToModelArmorTemplates,
 	getAgentDefinition,
 	getAgentDefinitions,
+	postAgentDefinition,
 	putAgentDefinition,
 	putAgentDefinitionToContentRetrievers,
 	putAgentDefinitionToModelArmorTemplates,

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/instruction_definition_form/InstructionDefinitionForm.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/instruction_definition_form/InstructionDefinitionForm.tsx
@@ -24,6 +24,7 @@ import {
 } from '../utils/externalReferenceCode';
 import {
 	getInstructionDefinition,
+	postInstructionDefinition,
 	putInstructionDefinition,
 } from './services/InstructionDefinitionService';
 import {
@@ -74,7 +75,9 @@ export default function InstructionDefinitionForm({
 
 	const handleSubmit = async () => {
 		try {
-			const response = await putInstructionDefinition(formData);
+			const response = externalReferenceCode
+				? await putInstructionDefinition(formData)
+				: await postInstructionDefinition(formData);
 
 			if (response?.externalReferenceCode) {
 				openToast({
@@ -95,7 +98,10 @@ export default function InstructionDefinitionForm({
 			console.error(error);
 
 			openToast({
-				message: Liferay.Language.get('an-unexpected-error-occurred'),
+				message:
+					error instanceof Error && error.message
+						? error.message
+						: Liferay.Language.get('an-unexpected-error-occurred'),
 				type: 'danger',
 			});
 		}

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/instruction_definition_form/services/InstructionDefinitionService.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/instruction_definition_form/services/InstructionDefinitionService.ts
@@ -7,12 +7,13 @@ import {fetch} from 'frontend-js-web';
 
 import {InstructionDefinition} from '../types/InstructionDefinition';
 
-const INSTRUCTION_DEFINITION_BASE_URI =
-	'/o/ai-hub/instruction-definitions/by-external-reference-code/';
+const INSTRUCTION_DEFINITION_BASE_URI = '/o/ai-hub/instruction-definitions';
+
+const INSTRUCTION_DEFINITION_BY_ERC_URI = `${INSTRUCTION_DEFINITION_BASE_URI}/by-external-reference-code/`;
 
 async function getInstructionDefinition(externalReferenceCode: string) {
 	const response = await fetch(
-		`${INSTRUCTION_DEFINITION_BASE_URI}${externalReferenceCode}`,
+		`${INSTRUCTION_DEFINITION_BY_ERC_URI}${externalReferenceCode}`,
 		{
 			method: 'GET',
 		}
@@ -25,11 +26,31 @@ async function getInstructionDefinition(externalReferenceCode: string) {
 	return response.json();
 }
 
+async function postInstructionDefinition(
+	instructionDefinition: InstructionDefinition
+) {
+	const response = await fetch(INSTRUCTION_DEFINITION_BASE_URI, {
+		body: JSON.stringify(instructionDefinition),
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		method: 'POST',
+	});
+
+	if (!response.ok) {
+		const errorBody = await response.json().catch(() => ({}));
+
+		throw new Error(errorBody?.detail || errorBody?.title || '');
+	}
+
+	return response.json();
+}
+
 async function putInstructionDefinition(
 	instructionDefinition: InstructionDefinition
 ) {
 	const response = await fetch(
-		`${INSTRUCTION_DEFINITION_BASE_URI}${instructionDefinition.externalReferenceCode}`,
+		`${INSTRUCTION_DEFINITION_BY_ERC_URI}${instructionDefinition.externalReferenceCode}`,
 		{
 			body: JSON.stringify(instructionDefinition),
 			headers: {
@@ -42,4 +63,8 @@ async function putInstructionDefinition(
 	return response.json();
 }
 
-export {getInstructionDefinition, putInstructionDefinition};
+export {
+	getInstructionDefinition,
+	postInstructionDefinition,
+	putInstructionDefinition,
+};

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/model_armor_template_form/hooks/useModelArmorTemplateForm.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/model_armor_template_form/hooks/useModelArmorTemplateForm.ts
@@ -11,6 +11,7 @@ import {generateExternalReferenceCode} from '../../utils/externalReferenceCode';
 import {DEFAULT_MODEL_ARMOR_TEMPLATE} from '../constants';
 import {
 	getModelArmorTemplate,
+	postModelArmorTemplate,
 	putModelArmorTemplate,
 } from '../services/ModelArmorTemplateService';
 import {ModelArmorTemplate} from '../types/ModelArmorTemplate';
@@ -44,7 +45,12 @@ export function useModelArmorTemplateForm({
 		},
 		onSubmit: async (formValues) => {
 			try {
-				await putModelArmorTemplate(formValues);
+				if (externalReferenceCode) {
+					await putModelArmorTemplate(formValues);
+				}
+				else {
+					await postModelArmorTemplate(formValues);
+				}
 
 				openToast({
 					message: Liferay.Language.get(

--- a/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/model_armor_template_form/services/ModelArmorTemplateService.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/src/main/resources/META-INF/resources/js/model_armor_template_form/services/ModelArmorTemplateService.ts
@@ -38,6 +38,26 @@ async function getModelArmorTemplate(
 	};
 }
 
+async function postModelArmorTemplate(
+	modelArmorTemplate: ModelArmorTemplate
+): Promise<ModelArmorTemplate> {
+	const response = await fetch('/o/ai-hub/v1.0/model-armor-templates', {
+		body: JSON.stringify(modelArmorTemplate),
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		method: 'POST',
+	});
+
+	if (!response.ok) {
+		const errorBody = await response.json().catch(() => ({}));
+
+		throw new Error(errorBody?.detail || errorBody?.title || '');
+	}
+
+	return response.json();
+}
+
 async function putModelArmorTemplate(
 	modelArmorTemplate: ModelArmorTemplate
 ): Promise<ModelArmorTemplate> {
@@ -61,4 +81,4 @@ async function putModelArmorTemplate(
 	return response.json();
 }
 
-export {getModelArmorTemplate, putModelArmorTemplate};
+export {getModelArmorTemplate, postModelArmorTemplate, putModelArmorTemplate};

--- a/modules/dxp/apps/ai-hub/ai-hub-web/test/js/agent_definition_form/hooks/useAgentDefinitionForm.test.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/test/js/agent_definition_form/hooks/useAgentDefinitionForm.test.tsx
@@ -13,6 +13,7 @@ const mockGetAgentDefinition = jest.fn();
 const mockGetContentRetrievers = jest.fn();
 const mockGetModelArmorTemplates = jest.fn();
 const mockOpenToast = jest.fn();
+const mockPostAgentDefinition = jest.fn();
 const mockPutAgentDefinition = jest.fn();
 const mockPutAgentDefinitionToContentRetrievers = jest.fn();
 const mockPutAgentDefinitionToModelArmorTemplates = jest.fn();
@@ -25,6 +26,8 @@ jest.mock(
 		deleteAgentDefinitionToModelArmorTemplates: (...args: any[]) =>
 			mockDeleteAgentDefinitionToModelArmorTemplates(...args),
 		getAgentDefinition: (...args: any[]) => mockGetAgentDefinition(...args),
+		postAgentDefinition: (...args: any[]) =>
+			mockPostAgentDefinition(...args),
 		putAgentDefinition: (...args: any[]) => mockPutAgentDefinition(...args),
 		putAgentDefinitionToContentRetrievers: (...args: any[]) =>
 			mockPutAgentDefinitionToContentRetrievers(...args),
@@ -98,6 +101,7 @@ describe('useAgentDefinitionForm', () => {
 		mockGetContentRetrievers.mockReset();
 		mockGetModelArmorTemplates.mockReset();
 		mockOpenToast.mockReset();
+		mockPostAgentDefinition.mockReset();
 		mockPutAgentDefinition.mockReset();
 		mockPutAgentDefinitionToContentRetrievers.mockReset();
 		mockPutAgentDefinitionToModelArmorTemplates.mockReset();
@@ -398,7 +402,7 @@ describe('useAgentDefinitionForm', () => {
 		});
 
 		it('shows a danger toast when the response status is not approved', async () => {
-			mockPutAgentDefinition.mockResolvedValueOnce({
+			mockPostAgentDefinition.mockResolvedValueOnce({
 				externalReferenceCode: 'AGENT_X',
 				status: {label: 'rejected'},
 			});
@@ -422,7 +426,7 @@ describe('useAgentDefinitionForm', () => {
 		});
 
 		it('shows the success toast when the API echoes back an approved status', async () => {
-			mockPutAgentDefinition.mockResolvedValueOnce({
+			mockPostAgentDefinition.mockResolvedValueOnce({
 				externalReferenceCode: 'AGENT_X',
 				status: {label: 'approved'},
 			});
@@ -445,8 +449,29 @@ describe('useAgentDefinitionForm', () => {
 			});
 		});
 
-		it('shows the unexpected-error toast when the API call rejects', async () => {
-			mockPutAgentDefinition.mockRejectedValueOnce(new Error('Boom'));
+		it('shows the error message in a danger toast when the API call rejects', async () => {
+			mockPostAgentDefinition.mockRejectedValueOnce(new Error('Boom'));
+
+			const {result} = renderAgentHook();
+
+			await fillRequiredFields(result);
+
+			await act(async () => {
+				result.current.handleSubmit();
+			});
+
+			await waitFor(() => {
+				expect(mockOpenToast).toHaveBeenCalledWith(
+					expect.objectContaining({
+						message: 'Boom',
+						type: 'danger',
+					})
+				);
+			});
+		});
+
+		it('shows the unexpected-error toast when the API call rejects without a message', async () => {
+			mockPostAgentDefinition.mockRejectedValueOnce({});
 
 			const {result} = renderAgentHook();
 
@@ -467,7 +492,7 @@ describe('useAgentDefinitionForm', () => {
 		});
 
 		it('skips relationship PUTs and DELETEs when neither picker has changed', async () => {
-			mockPutAgentDefinition.mockResolvedValueOnce({
+			mockPostAgentDefinition.mockResolvedValueOnce({
 				externalReferenceCode: 'AGENT_X',
 				status: {label: 'approved'},
 			});
@@ -481,7 +506,7 @@ describe('useAgentDefinitionForm', () => {
 			});
 
 			await waitFor(() => {
-				expect(mockPutAgentDefinition).toHaveBeenCalled();
+				expect(mockPostAgentDefinition).toHaveBeenCalled();
 			});
 
 			expect(
@@ -501,7 +526,7 @@ describe('useAgentDefinitionForm', () => {
 
 	describe('validate', () => {
 		it('clears errors once required fields are filled', async () => {
-			mockPutAgentDefinition.mockResolvedValueOnce({
+			mockPostAgentDefinition.mockResolvedValueOnce({
 				externalReferenceCode: 'AGENT_X',
 				status: {label: 'approved'},
 			});
@@ -552,7 +577,7 @@ describe('useAgentDefinitionForm', () => {
 			expect(result.current.errors.workflowDefinitionName).toBe(
 				'required'
 			);
-			expect(mockPutAgentDefinition).not.toHaveBeenCalled();
+			expect(mockPostAgentDefinition).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/modules/dxp/apps/ai-hub/ai-hub-web/test/js/model_armor_template_form/ModelArmorTemplateForm.test.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/test/js/model_armor_template_form/ModelArmorTemplateForm.test.tsx
@@ -16,6 +16,7 @@ import React from 'react';
 import ModelArmorTemplateForm from '../../../src/main/resources/META-INF/resources/js/model_armor_template_form/ModelArmorTemplateForm';
 
 const mockGetModelArmorTemplate = jest.fn();
+const mockPostModelArmorTemplate = jest.fn();
 const mockPutModelArmorTemplate = jest.fn();
 const mockOpenToast = jest.fn();
 
@@ -24,6 +25,8 @@ jest.mock(
 	() => ({
 		getModelArmorTemplate: (...args: any[]) =>
 			mockGetModelArmorTemplate(...args),
+		postModelArmorTemplate: (...args: any[]) =>
+			mockPostModelArmorTemplate(...args),
 		putModelArmorTemplate: (...args: any[]) =>
 			mockPutModelArmorTemplate(...args),
 	})
@@ -124,6 +127,7 @@ const defaultProps = {
 describe('ModelArmorTemplateForm', () => {
 	beforeEach(() => {
 		mockGetModelArmorTemplate.mockReset();
+		mockPostModelArmorTemplate.mockReset();
 		mockPutModelArmorTemplate.mockReset();
 		mockOpenToast.mockReset();
 	});
@@ -233,11 +237,12 @@ describe('ModelArmorTemplateForm', () => {
 				);
 			});
 
+			expect(mockPostModelArmorTemplate).not.toHaveBeenCalled();
 			expect(mockPutModelArmorTemplate).not.toHaveBeenCalled();
 		});
 
 		it('submits filled values and shows the success toast', async () => {
-			mockPutModelArmorTemplate.mockResolvedValueOnce({
+			mockPostModelArmorTemplate.mockResolvedValueOnce({
 				externalReferenceCode: 'TEMPLATE_X',
 			});
 
@@ -257,7 +262,7 @@ describe('ModelArmorTemplateForm', () => {
 			fireEvent.click(screen.getByRole('button', {name: 'save'}));
 
 			await waitFor(() => {
-				expect(mockPutModelArmorTemplate).toHaveBeenCalledWith(
+				expect(mockPostModelArmorTemplate).toHaveBeenCalledWith(
 					expect.objectContaining({
 						externalReferenceCode: 'TEMPLATE-X',
 						location: 'us-central1',

--- a/modules/dxp/apps/ai-hub/ai-hub-web/test/js/model_armor_template_form/hooks/useModelArmorTemplateForm.test.tsx
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/test/js/model_armor_template_form/hooks/useModelArmorTemplateForm.test.tsx
@@ -8,6 +8,7 @@ import {act, renderHook, waitFor} from '@testing-library/react';
 import {useModelArmorTemplateForm} from '../../../../src/main/resources/META-INF/resources/js/model_armor_template_form/hooks/useModelArmorTemplateForm';
 
 const mockGetModelArmorTemplate = jest.fn();
+const mockPostModelArmorTemplate = jest.fn();
 const mockPutModelArmorTemplate = jest.fn();
 const mockOpenToast = jest.fn();
 
@@ -16,6 +17,8 @@ jest.mock(
 	() => ({
 		getModelArmorTemplate: (...args: any[]) =>
 			mockGetModelArmorTemplate(...args),
+		postModelArmorTemplate: (...args: any[]) =>
+			mockPostModelArmorTemplate(...args),
 		putModelArmorTemplate: (...args: any[]) =>
 			mockPutModelArmorTemplate(...args),
 	})
@@ -111,6 +114,7 @@ describe('fetch lifecycle', () => {
 describe('useModelArmorTemplateForm', () => {
 	beforeEach(() => {
 		mockGetModelArmorTemplate.mockReset();
+		mockPostModelArmorTemplate.mockReset();
 		mockPutModelArmorTemplate.mockReset();
 		mockOpenToast.mockReset();
 	});
@@ -159,7 +163,7 @@ describe('useModelArmorTemplateForm', () => {
 
 	describe('submit', () => {
 		it("surfaces the thrown error's message in a danger toast", async () => {
-			mockPutModelArmorTemplate.mockRejectedValueOnce(
+			mockPostModelArmorTemplate.mockRejectedValueOnce(
 				new Error('External reference code already in use')
 			);
 
@@ -188,7 +192,7 @@ describe('useModelArmorTemplateForm', () => {
 		});
 
 		it('falls back to the localized error when the thrown error has no message', async () => {
-			mockPutModelArmorTemplate.mockRejectedValueOnce(new Error());
+			mockPostModelArmorTemplate.mockRejectedValueOnce(new Error());
 
 			const {result} = renderModelArmorHook();
 
@@ -214,8 +218,8 @@ describe('useModelArmorTemplateForm', () => {
 			});
 		});
 
-		it('shows a success toast when the API echoes back the ERC', async () => {
-			mockPutModelArmorTemplate.mockResolvedValueOnce({
+		it('calls postModelArmorTemplate in create mode', async () => {
+			mockPostModelArmorTemplate.mockResolvedValueOnce({
 				externalReferenceCode: 'TEMPLATE_X',
 			});
 
@@ -234,13 +238,65 @@ describe('useModelArmorTemplateForm', () => {
 			});
 
 			await waitFor(() => {
-				expect(mockOpenToast).toHaveBeenCalledWith(
-					expect.objectContaining({
-						message: 'guardrail-saved-successfully',
-						type: 'success',
-					})
+				expect(mockPostModelArmorTemplate).toHaveBeenCalled();
+			});
+
+			expect(mockPutModelArmorTemplate).not.toHaveBeenCalled();
+			expect(mockOpenToast).toHaveBeenCalledWith(
+				expect.objectContaining({
+					message: 'guardrail-saved-successfully',
+					type: 'success',
+				})
+			);
+		});
+
+		it('calls putModelArmorTemplate in edit mode', async () => {
+			mockGetModelArmorTemplate.mockResolvedValueOnce({
+				active: true,
+				description: '',
+				externalReferenceCode: 'TEMPLATE_X',
+				guardrailType: 'input',
+				location: 'us-central1',
+				maliciousUriFilterEnabled: false,
+				multiLanguageDetectionEnabled: false,
+				piAndJailbreakConfidenceLevel: 'mediumAndAbove',
+				piAndJailbreakFilterEnabled: false,
+				raiDangerousLevel: 'none',
+				raiHarassmentLevel: 'none',
+				raiHateSpeechLevel: 'none',
+				raiSexuallyExplicitLevel: 'none',
+				sdpFilterEnabled: false,
+				title_i18n: {en_US: 'My Template'},
+			});
+			mockPutModelArmorTemplate.mockResolvedValueOnce({
+				externalReferenceCode: 'TEMPLATE_X',
+			});
+
+			const {result} = renderModelArmorHook({
+				externalReferenceCode: 'TEMPLATE_X',
+			});
+
+			await waitFor(() => {
+				expect(result.current.values.externalReferenceCode).toBe(
+					'TEMPLATE_X'
 				);
 			});
+
+			await act(async () => {
+				result.current.handleSubmit();
+			});
+
+			await waitFor(() => {
+				expect(mockPutModelArmorTemplate).toHaveBeenCalled();
+			});
+
+			expect(mockPostModelArmorTemplate).not.toHaveBeenCalled();
+			expect(mockOpenToast).toHaveBeenCalledWith(
+				expect.objectContaining({
+					message: 'guardrail-saved-successfully',
+					type: 'success',
+				})
+			);
 		});
 	});
 
@@ -256,7 +312,7 @@ describe('useModelArmorTemplateForm', () => {
 				expect(result.current.errors.title_i18n).toBe('required');
 			});
 
-			mockPutModelArmorTemplate.mockResolvedValueOnce({
+			mockPostModelArmorTemplate.mockResolvedValueOnce({
 				externalReferenceCode: 'TEMPLATE_X',
 			});
 
@@ -293,6 +349,7 @@ describe('useModelArmorTemplateForm', () => {
 				expect(result.current.errors.location).toBe('required');
 			});
 
+			expect(mockPostModelArmorTemplate).not.toHaveBeenCalled();
 			expect(mockPutModelArmorTemplate).not.toHaveBeenCalled();
 		});
 	});

--- a/modules/dxp/apps/ai-hub/ai-hub-web/test/js/model_armor_template_form/services/ModelArmorTemplateService.test.ts
+++ b/modules/dxp/apps/ai-hub/ai-hub-web/test/js/model_armor_template_form/services/ModelArmorTemplateService.test.ts
@@ -5,6 +5,7 @@
 
 import {
 	getModelArmorTemplate,
+	postModelArmorTemplate,
 	putModelArmorTemplate,
 } from '../../../../src/main/resources/META-INF/resources/js/model_armor_template_form/services/ModelArmorTemplateService';
 
@@ -14,7 +15,8 @@ jest.mock('frontend-js-web', () => ({
 	fetch: (...args: any[]) => mockFetch(...args),
 }));
 
-const BASE_URI = '/o/ai-hub/model-armor-templates';
+const GET_BASE_URI = '/o/ai-hub/model-armor-templates';
+const POST_PUT_BASE_URI = '/o/ai-hub/v1.0/model-armor-templates';
 
 describe('ModelArmorTemplateService', () => {
 	beforeEach(() => {
@@ -43,7 +45,7 @@ describe('ModelArmorTemplateService', () => {
 			await getModelArmorTemplate('TEMPLATE_X');
 
 			expect(mockFetch).toHaveBeenCalledWith(
-				`${BASE_URI}/by-external-reference-code/TEMPLATE_X`,
+				`${GET_BASE_URI}/by-external-reference-code/TEMPLATE_X`,
 				expect.objectContaining({method: 'GET'})
 			);
 		});
@@ -88,6 +90,66 @@ describe('ModelArmorTemplateService', () => {
 		});
 	});
 
+	describe('postModelArmorTemplate', () => {
+		it('returns the parsed response body', async () => {
+			mockFetch.mockResolvedValueOnce({
+				json: () =>
+					Promise.resolve({
+						externalReferenceCode: 'TEMPLATE_X',
+						title_i18n: {en_US: 'Saved'},
+					}),
+				ok: true,
+			});
+
+			const result = await postModelArmorTemplate({
+				externalReferenceCode: 'TEMPLATE_X',
+			} as any);
+
+			expect(result.title_i18n.en_US).toBe('Saved');
+		});
+
+		it('sends a POST with the template serialized as JSON', async () => {
+			mockFetch.mockResolvedValueOnce({
+				json: () =>
+					Promise.resolve({externalReferenceCode: 'TEMPLATE_X'}),
+				ok: true,
+			});
+
+			const template = {
+				active: true,
+				externalReferenceCode: 'TEMPLATE_X',
+				title_i18n: {en_US: 'My Template'},
+			} as any;
+
+			await postModelArmorTemplate(template);
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				POST_PUT_BASE_URI,
+				expect.objectContaining({
+					body: JSON.stringify(template),
+					headers: {'Content-Type': 'application/json'},
+					method: 'POST',
+				})
+			);
+		});
+
+		it("throws with the server's detail when the response is not ok", async () => {
+			mockFetch.mockResolvedValueOnce({
+				json: () =>
+					Promise.resolve({
+						detail: 'External reference code already in use',
+					}),
+				ok: false,
+			});
+
+			await expect(
+				postModelArmorTemplate({
+					externalReferenceCode: 'TEMPLATE_X',
+				} as any)
+			).rejects.toThrow('External reference code already in use');
+		});
+	});
+
 	describe('putModelArmorTemplate', () => {
 		it('returns the parsed response body', async () => {
 			mockFetch.mockResolvedValueOnce({
@@ -122,7 +184,7 @@ describe('ModelArmorTemplateService', () => {
 			await putModelArmorTemplate(template);
 
 			expect(mockFetch).toHaveBeenCalledWith(
-				'/o/ai-hub/v1.0/model-armor-templates/by-external-reference-code/TEMPLATE_X',
+				`${POST_PUT_BASE_URI}/by-external-reference-code/TEMPLATE_X`,
 				expect.objectContaining({
 					body: JSON.stringify(template),
 					headers: {'Content-Type': 'application/json'},


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92391

Resending https://github.com/liferay-ai-hub/liferay-portal/pull/462.

## What Is Being Fixed

Creating an Agent, Guardrail, or Instruction with an external reference code
(ERC) that already existed overwrote the existing entity instead of creating a
new one, because the forms always issued a PUT (upsert) request.

## How It Is Being Fixed

The agent definition, instruction, and guardrail forms now issue a POST on
create and reserve PUT for updates, so an existing ERC no longer silently
overwrites another entity. The submit error toast also surfaces the actual
error message when one is available.

## Notes

The Source Format failures from the activity dashboard (a missing `MetricCard`
import) are unrelated to this change and were fixed in
https://github.com/brianchandotcom/liferay-portal/pull/175663.