### PR TITLE
LPD-89874 Truncate input to 200 character and does not persist the output in the logs

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/guardrail/InputGuardrailImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/guardrail/InputGuardrailImpl.java
@@ -54,17 +54,17 @@ public class InputGuardrailImpl implements InputGuardrail {
 	@Override
 	public InputGuardrailResult validate(UserMessage userMessage) {
 		try {
-			String violations = _modelArmorHandler.sanitizeUserPrompt(
+			String violationMessage = _modelArmorHandler.sanitizeUserPrompt(
 				_companyId, _externalReferenceCode, _location,
 				userMessage.singleText());
 
-			if (Validator.isNotNull(violations)) {
+			if (Validator.isNotNull(violationMessage)) {
 				return fatal(
 					JSONUtil.put(
 						"modelArmorTemplateExternalReferenceCode",
 						_externalReferenceCode
 					).put(
-						"violations", violations
+						"violationMessage", violationMessage
 					).toString());
 			}
 

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/guardrail/listener/BaseGuardrailExecutedListener.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/guardrail/listener/BaseGuardrailExecutedListener.java
@@ -19,6 +19,8 @@ import dev.langchain4j.guardrail.GuardrailResult;
 
 import java.time.Duration;
 
+import java.util.List;
+
 /**
  * @author Pedro Leite
  */
@@ -50,17 +52,17 @@ public abstract class BaseGuardrailExecutedListener {
 				).put(
 					"duration", duration.toMillis()
 				).put(
-					"errors",
-					JSONUtil.toJSONArray(
-						guardrailResult.failures(),
-						GuardrailResult.Failure::message)
-				).put(
 					"guardrailType", guardrailType
 				).put(
-					"sseEventSinkKey",
-					MapUtil.getString(
-						_executionContext.getWorkflowContext(),
-						"sseEventSinkKey")
+					"violation",
+					() -> {
+						List<GuardrailResult.Failure> failures =
+							guardrailResult.failures();
+
+						GuardrailResult.Failure failure = failures.get(0);
+
+						return failure.message();
+					}
 				).put(
 					"workflowInstanceId",
 					kaleoInstanceToken.getKaleoInstanceId()

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/guardrail/listener/BaseGuardrailExecutedListener.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/guardrail/listener/BaseGuardrailExecutedListener.java
@@ -10,10 +10,13 @@ import com.liferay.ai.hub.internal.audit.constants.AIHubEventTypes;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageBusUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.workflow.WorkflowInstance;
 import com.liferay.portal.workflow.kaleo.model.KaleoInstanceToken;
 import com.liferay.portal.workflow.kaleo.runtime.ExecutionContext;
+import com.liferay.portal.workflow.kaleo.runtime.constants.WorkflowInstanceDestinationNames;
 
 import dev.langchain4j.guardrail.GuardrailResult;
 
@@ -28,6 +31,21 @@ public abstract class BaseGuardrailExecutedListener {
 
 	public BaseGuardrailExecutedListener(ExecutionContext executionContext) {
 		_executionContext = executionContext;
+	}
+
+	protected void completeExceptionally() {
+		Message message = new Message();
+
+		message.put("exception", new IllegalArgumentException());
+
+		KaleoInstanceToken kaleoInstanceToken =
+			_executionContext.getKaleoInstanceToken();
+
+		message.put(
+			"workflowInstanceId", kaleoInstanceToken.getKaleoInstanceId());
+
+		MessageBusUtil.sendMessage(
+			WorkflowInstanceDestinationNames.WORKFLOW_INSTANCE, message);
 	}
 
 	protected void route(

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/guardrail/listener/InputGuardrailExecutedListenerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/guardrail/listener/InputGuardrailExecutedListenerImpl.java
@@ -37,6 +37,8 @@ public class InputGuardrailExecutedListenerImpl
 			return;
 		}
 
+		completeExceptionally();
+
 		InputGuardrailRequest inputGuardrailRequest =
 			inputGuardrailExecutedEvent.request();
 

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/guardrail/listener/InputGuardrailExecutedListenerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/guardrail/listener/InputGuardrailExecutedListenerImpl.java
@@ -42,8 +42,14 @@ public class InputGuardrailExecutedListenerImpl
 
 		UserMessage userMessage = inputGuardrailRequest.userMessage();
 
+		String content = userMessage.singleText();
+
+		if (content.length() > 200) {
+			content = content.substring(0, 200);
+		}
+
 		route(
-			userMessage.singleText(), inputGuardrailExecutedEvent.duration(),
+			content, inputGuardrailExecutedEvent.duration(),
 			inputGuardrailResult, "input");
 	}
 

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/guardrail/listener/OutputGuardrailExecutedListenerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/guardrail/listener/OutputGuardrailExecutedListenerImpl.java
@@ -35,6 +35,8 @@ public class OutputGuardrailExecutedListenerImpl
 			return;
 		}
 
+		completeExceptionally();
+
 		route(
 			null, outputGuardrailExecutedEvent.duration(),
 			outputGuardrailResult, "output");

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/guardrail/listener/OutputGuardrailExecutedListenerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/guardrail/listener/OutputGuardrailExecutedListenerImpl.java
@@ -7,10 +7,7 @@ package com.liferay.ai.hub.internal.guardrail.listener;
 
 import com.liferay.portal.workflow.kaleo.runtime.ExecutionContext;
 
-import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.guardrail.OutputGuardrailRequest;
 import dev.langchain4j.guardrail.OutputGuardrailResult;
-import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.observability.api.event.OutputGuardrailExecutedEvent;
 import dev.langchain4j.observability.api.listener.OutputGuardrailExecutedListener;
 
@@ -38,15 +35,8 @@ public class OutputGuardrailExecutedListenerImpl
 			return;
 		}
 
-		OutputGuardrailRequest outputGuardrailRequest =
-			outputGuardrailExecutedEvent.request();
-
-		ChatResponse chatResponse = outputGuardrailRequest.responseFromLLM();
-
-		AiMessage aiMessage = chatResponse.aiMessage();
-
 		route(
-			aiMessage.text(), outputGuardrailExecutedEvent.duration(),
+			null, outputGuardrailExecutedEvent.duration(),
 			outputGuardrailResult, "output");
 	}
 

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/KaleoLogUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/KaleoLogUtil.java
@@ -46,8 +46,6 @@ public class KaleoLogUtil {
 				HashMapBuilder.<String, Serializable>put(
 					"inputTokenCount", String.valueOf(inputTokenCount)
 				).put(
-					"output", output
-				).put(
 					"outputTokenCount", String.valueOf(outputTokenCount)
 				).put(
 					"promptInput", prompt


### PR DESCRIPTION
- **LPD-89874 refactor: rename**
- **LPD-89874 refactor: get the first and unique failure message**
- **LPD-89874 fix: truncate the user message to 200 character**
- **LPD-89874 fix: output should not be persisted**
- **LPD-89874 fix: complete exceptionally when guardrail response is different than success**
