### PR TITLE
LPD-68626 Add sort, filter, and search to import report entries

### DIFF
--- a/modules/apps/export-import/export-import-report-api/src/main/java/com/liferay/exportimport/report/constants/ExportImportReportEntryConstants.java
+++ b/modules/apps/export-import/export-import-report-api/src/main/java/com/liferay/exportimport/report/constants/ExportImportReportEntryConstants.java
@@ -26,4 +26,20 @@ public class ExportImportReportEntryConstants {
 
 	public static final int TYPE_MISSING_REFERENCE = 3;
 
+	public static String getTypeLabel(int type) {
+		if (type == TYPE_EMPTY) {
+			return "empty";
+		}
+
+		if (type == TYPE_ERROR) {
+			return "error";
+		}
+
+		if (type == TYPE_MISSING_REFERENCE) {
+			return "missing-reference";
+		}
+
+		return null;
+	}
+
 }

--- a/modules/apps/export-import/export-import-report-api/src/main/java/com/liferay/exportimport/report/constants/ExportImportReportEntryConstants.java
+++ b/modules/apps/export-import/export-import-report-api/src/main/java/com/liferay/exportimport/report/constants/ExportImportReportEntryConstants.java
@@ -30,12 +30,10 @@ public class ExportImportReportEntryConstants {
 		if (type == TYPE_EMPTY) {
 			return "empty";
 		}
-
-		if (type == TYPE_ERROR) {
+		else if (type == TYPE_ERROR) {
 			return "error";
 		}
-
-		if (type == TYPE_MISSING_REFERENCE) {
+		else if (type == TYPE_MISSING_REFERENCE) {
 			return "missing-reference";
 		}
 

--- a/modules/apps/export-import/export-import-report-service/build.gradle
+++ b/modules/apps/export-import/export-import-report-service/build.gradle
@@ -4,6 +4,7 @@ buildService {
 }
 
 dependencies {
+	compileOnly group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"

--- a/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/internal/search/spi/model/index/contributor/ExportImportReportEntryModelDocumentContributor.java
+++ b/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/internal/search/spi/model/index/contributor/ExportImportReportEntryModelDocumentContributor.java
@@ -5,15 +5,17 @@
 
 package com.liferay.exportimport.report.internal.search.spi.model.index.contributor;
 
+import com.liferay.exportimport.report.constants.ExportImportReportEntryConstants;
 import com.liferay.exportimport.report.model.ExportImportReportEntry;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Localization;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
-
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -32,12 +34,20 @@ public class ExportImportReportEntryModelDocumentContributor
 	public void contribute(
 		Document document, ExportImportReportEntry exportImportReportEntry) {
 
+		document.setSortableTextFields(
+			ArrayUtil.append(
+				PropsUtil.getArray(PropsKeys.INDEX_SORTABLE_TEXT_FIELDS),
+				new String[] {"classExternalReferenceCode"}));
+
 		document.addKeyword(
 			Field.COMPANY_ID, exportImportReportEntry.getCompanyId());
 		document.addDate(
 			Field.CREATE_DATE, exportImportReportEntry.getCreateDate());
 		document.addDate(
 			Field.MODIFIED_DATE, exportImportReportEntry.getModifiedDate());
+		document.addKeyword(
+			"classExternalReferenceCode",
+			exportImportReportEntry.getClassExternalReferenceCode(), true);
 		document.addText(
 			"errorMessage", exportImportReportEntry.getErrorMessage());
 		document.addText(
@@ -46,29 +56,29 @@ public class ExportImportReportEntryModelDocumentContributor
 			"exportImportConfigurationId_long",
 			exportImportReportEntry.getExportImportConfigurationId());
 		document.addLocalizedText(
-			"modelName", _getModelNameMap(exportImportReportEntry), true);
+			"modelName",
+			_localization.getLocalizationMap(
+				_language.getAvailableLocales(), LocaleUtil.getDefault(),
+				exportImportReportEntry.getModelNameLanguageKey()),
+			true);
 		document.addNumber(
 			"origin_integer", exportImportReportEntry.getOrigin());
 		document.addNumber("status", exportImportReportEntry.getStatus());
 		document.addNumber("type_integer", exportImportReportEntry.getType());
-	}
 
-	private Map<Locale, String> _getModelNameMap(
-		ExportImportReportEntry exportImportReportEntry) {
-
-		Map<Locale, String> map = new HashMap<>();
-
-		for (Locale locale : _language.getAvailableLocales()) {
-			map.put(
-				locale,
-				_language.get(
-					locale, exportImportReportEntry.getModelNameLanguageKey()));
-		}
-
-		return map;
+		document.addLocalizedText(
+			"type_label",
+			_localization.getLocalizationMap(
+				_language.getAvailableLocales(), LocaleUtil.getDefault(),
+				ExportImportReportEntryConstants.getTypeLabel(
+					exportImportReportEntry.getType())),
+			true);
 	}
 
 	@Reference
 	private Language _language;
+
+	@Reference
+	private Localization _localization;
 
 }

--- a/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/internal/search/spi/model/query/contributor/ExportImportReportEntryKeywordQueryContributor.java
+++ b/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/internal/search/spi/model/query/contributor/ExportImportReportEntryKeywordQueryContributor.java
@@ -33,6 +33,8 @@ public class ExportImportReportEntryKeywordQueryContributor
 			keywordQueryContributorHelper.getSearchContext();
 
 		queryHelper.addSearchTerm(
+			booleanQuery, searchContext, "classExternalReferenceCode", false);
+		queryHelper.addSearchTerm(
 			booleanQuery, searchContext, "errorMessage", false);
 		queryHelper.addSearchTerm(
 			booleanQuery, searchContext, "errorStacktrace", false);

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/odata/entity/v1_0/ReportEntryEntityModel.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/odata/entity/v1_0/ReportEntryEntityModel.java
@@ -13,6 +13,7 @@ import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.entity.IntegerEntityField;
 import com.liferay.portal.odata.entity.StringEntityField;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
@@ -34,8 +35,23 @@ public class ReportEntryEntityModel implements EntityModel {
 					new IntegerEntityField("code", locale -> Field.STATUS))),
 			new ComplexEntityField(
 				"type",
-				Collections.singletonList(
-					new IntegerEntityField("code", locale -> "type_integer"))),
+				Arrays.asList(
+					new IntegerEntityField(
+						"code",
+						locale -> Field.getSortableFieldName("type_integer")),
+					new StringEntityField(
+						"label",
+						locale -> Field.getSortableFieldName(
+							Field.getLocalizedName(locale, "type_label")),
+						locale -> {
+							String sortableFieldName =
+								Field.getSortableFieldName(
+									Field.getLocalizedName(
+										locale, "type_label"));
+
+							return sortableFieldName.concat(
+								".keyword_lowercase");
+						}))),
 			new DateTimeEntityField(
 				"dateCreated",
 				locale -> Field.getSortableFieldName(Field.CREATE_DATE),
@@ -45,7 +61,21 @@ public class ReportEntryEntityModel implements EntityModel {
 				locale -> Field.getSortableFieldName(Field.MODIFIED_DATE),
 				locale -> Field.MODIFIED_DATE),
 			new IntegerEntityField("id", locale -> Field.ENTRY_CLASS_PK),
-			new StringEntityField("modelName", locale -> "modelName"));
+			new StringEntityField(
+				"classExternalReferenceCode",
+				locale -> Field.getSortableFieldName(
+					"classExternalReferenceCode"),
+				locale -> "classExternalReferenceCode"),
+			new StringEntityField(
+				"modelName",
+				locale -> Field.getSortableFieldName(
+					Field.getLocalizedName(locale, "modelName")),
+				locale -> {
+					String sortableFieldName = Field.getSortableFieldName(
+						Field.getLocalizedName(locale, "modelName"));
+
+					return sortableFieldName.concat(".keyword_lowercase");
+				}));
 	}
 
 	@Override

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ReportEntryResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ReportEntryResourceImpl.java
@@ -145,26 +145,6 @@ public class ReportEntryResourceImpl extends BaseReportEntryResourceImpl {
 		return null;
 	}
 
-	private String _getTypeLabel(int type) {
-		if (type == ExportImportReportEntryConstants.TYPE_EMPTY) {
-			return _language.get(
-				contextAcceptLanguage.getPreferredLocale(), "empty");
-		}
-		else if (type == ExportImportReportEntryConstants.TYPE_ERROR) {
-			return _language.get(
-				contextAcceptLanguage.getPreferredLocale(), "error");
-		}
-		else if (type ==
-					ExportImportReportEntryConstants.TYPE_MISSING_REFERENCE) {
-
-			return _language.get(
-				contextAcceptLanguage.getPreferredLocale(),
-				"missing-reference");
-		}
-
-		return null;
-	}
-
 	private Origin _toOrigin(int origin) {
 		return new Origin() {
 			{
@@ -237,7 +217,7 @@ public class ReportEntryResourceImpl extends BaseReportEntryResourceImpl {
 				setLabel(
 					() -> _language.get(
 						contextAcceptLanguage.getPreferredLocale(),
-						_getTypeLabel(type)));
+						ExportImportReportEntryConstants.getTypeLabel(type)));
 			}
 		};
 	}

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ReportEntryResourceTest.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ReportEntryResourceTest.java
@@ -165,22 +165,20 @@ public class ReportEntryResourceTest extends BaseReportEntryResourceTestCase {
 			Long... expectedReportEntryIds)
 		throws Exception {
 
-		List<ReportEntry> items =
-			(List<ReportEntry>)
-				reportEntryResource.getImportProcessReportEntriesPage(
-					_backgroundTask.getBackgroundTaskId(), null, filterString,
-					Pagination.of(1, 10), sortString
-				).getItems();
+		Page<ReportEntry> page =
+			reportEntryResource.getImportProcessReportEntriesPage(
+				_backgroundTask.getBackgroundTaskId(), null, filterString,
+				Pagination.of(1, 10), sortString);
+
+		List<ReportEntry> items = (List<ReportEntry>)page.getItems();
 
 		Assert.assertEquals(
 			items.toString(), expectedReportEntryIds.length, items.size());
 
 		for (int i = 0; i < expectedReportEntryIds.length; i++) {
-			Assert.assertEquals(
-				expectedReportEntryIds[i],
-				items.get(
-					i
-				).getId());
+			ReportEntry reportEntry = items.get(i);
+
+			Assert.assertEquals(expectedReportEntryIds[i], reportEntry.getId());
 		}
 	}
 

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ReportEntryResourceTest.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ReportEntryResourceTest.java
@@ -167,8 +167,8 @@ public class ReportEntryResourceTest extends BaseReportEntryResourceTestCase {
 
 		Page<ReportEntry> page =
 			reportEntryResource.getImportProcessReportEntriesPage(
-				_backgroundTask.getBackgroundTaskId(), null, filterString,
-				Pagination.of(1, 10), sortString);
+				testGetImportProcessReportEntriesPage_getImportProcessId(),
+				null, filterString, Pagination.of(1, 10), sortString);
 
 		List<ReportEntry> items = (List<ReportEntry>)page.getItems();
 

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ReportEntryResourceTest.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ReportEntryResourceTest.java
@@ -160,27 +160,6 @@ public class ReportEntryResourceTest extends BaseReportEntryResourceTestCase {
 		};
 	}
 
-	private ReportEntry _addReportEntry(
-			String classExternalReferenceCode, String modelName,
-			boolean typeEmpty)
-		throws Exception {
-
-		ReportEntry reportEntry = randomReportEntry();
-
-		reportEntry.setClassExternalReferenceCode(classExternalReferenceCode);
-		reportEntry.setModelName(modelName);
-
-		if (typeEmpty) {
-			Type type = new Type();
-
-			type.setCode(ExportImportReportEntryConstants.TYPE_EMPTY);
-
-			reportEntry.setType(type);
-		}
-
-		return _addReportEntry(reportEntry);
-	}
-
 	private void _assertReportEntries(
 			String filterString, String sortString,
 			Long... expectedReportEntryIds)
@@ -205,6 +184,21 @@ public class ReportEntryResourceTest extends BaseReportEntryResourceTestCase {
 		}
 	}
 
+	private ReportEntry _randomReportEntry(int typeCode) throws Exception {
+		ReportEntry reportEntry = randomReportEntry();
+
+		reportEntry.setType(
+			() -> {
+				Type type = new Type();
+
+				type.setCode(typeCode);
+
+				return type;
+			});
+
+		return reportEntry;
+	}
+
 	private void _testGetImportProcessReportEntriesPageWithEmptyExportImportReportEntry()
 		throws Exception {
 
@@ -216,7 +210,7 @@ public class ReportEntryResourceTest extends BaseReportEntryResourceTestCase {
 		long totalCount = page.getTotalCount();
 
 		_addReportEntry(
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(), true);
+			_randomReportEntry(ExportImportReportEntryConstants.TYPE_EMPTY));
 
 		page = reportEntryResource.getImportProcessReportEntriesPage(
 			testGetImportProcessReportEntriesPage_getImportProcessId(), null,
@@ -229,8 +223,7 @@ public class ReportEntryResourceTest extends BaseReportEntryResourceTestCase {
 		throws Exception {
 
 		ReportEntry reportEntry1 = _addReportEntry(
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			false);
+			_randomReportEntry(ExportImportReportEntryConstants.TYPE_ERROR));
 
 		_assertReportEntries(
 			"contains(classExternalReferenceCode, '" +
@@ -250,7 +243,7 @@ public class ReportEntryResourceTest extends BaseReportEntryResourceTestCase {
 			null);
 
 		ReportEntry reportEntry2 = _addReportEntry(
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(), true);
+			_randomReportEntry(ExportImportReportEntryConstants.TYPE_EMPTY));
 
 		_assertReportEntries(
 			StringBundler.concat(
@@ -323,12 +316,23 @@ public class ReportEntryResourceTest extends BaseReportEntryResourceTestCase {
 	private void _testGetImportProcessReportEntriesPageWithSort()
 		throws Exception {
 
-		ReportEntry reportEntry1 = _addReportEntry(
-			"a" + RandomTestUtil.randomString(),
-			"z" + RandomTestUtil.randomString(), false);
-		ReportEntry reportEntry2 = _addReportEntry(
-			"z" + RandomTestUtil.randomString(),
-			"a" + RandomTestUtil.randomString(), true);
+		ReportEntry reportEntry1 = _randomReportEntry(
+			ExportImportReportEntryConstants.TYPE_EMPTY);
+
+		reportEntry1.setClassExternalReferenceCode(
+			"a" + RandomTestUtil.randomString());
+		reportEntry1.setModelName("z" + RandomTestUtil.randomString());
+
+		reportEntry1 = _addReportEntry(reportEntry1);
+
+		ReportEntry reportEntry2 = _randomReportEntry(
+			ExportImportReportEntryConstants.TYPE_ERROR);
+
+		reportEntry2.setClassExternalReferenceCode(
+			"z" + RandomTestUtil.randomString());
+		reportEntry2.setModelName("a" + RandomTestUtil.randomString());
+
+		reportEntry2 = _addReportEntry(reportEntry2);
 
 		String filterString = StringBundler.concat(
 			"id eq ", reportEntry1.getId(), " or id eq ", reportEntry2.getId());
@@ -346,17 +350,17 @@ public class ReportEntryResourceTest extends BaseReportEntryResourceTestCase {
 			filterString, "modelName:desc", reportEntry1.getId(),
 			reportEntry2.getId());
 		_assertReportEntries(
-			filterString, "type/code:asc", reportEntry1.getId(),
-			reportEntry2.getId());
-		_assertReportEntries(
-			filterString, "type/code:desc", reportEntry2.getId(),
+			filterString, "type/code:asc", reportEntry2.getId(),
 			reportEntry1.getId());
 		_assertReportEntries(
-			filterString, "type/label:asc", reportEntry2.getId(),
-			reportEntry1.getId());
-		_assertReportEntries(
-			filterString, "type/label:desc", reportEntry1.getId(),
+			filterString, "type/code:desc", reportEntry1.getId(),
 			reportEntry2.getId());
+		_assertReportEntries(
+			filterString, "type/label:asc", reportEntry1.getId(),
+			reportEntry2.getId());
+		_assertReportEntries(
+			filterString, "type/label:desc", reportEntry2.getId(),
+			reportEntry1.getId());
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ReportEntryResourceTest.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ReportEntryResourceTest.java
@@ -18,8 +18,10 @@ import com.liferay.exportimport.rest.client.dto.v1_0.Type;
 import com.liferay.exportimport.rest.client.pagination.Page;
 import com.liferay.exportimport.rest.client.pagination.Pagination;
 import com.liferay.exportimport.rest.client.resource.v1_0.ReportEntryResource;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.background.task.model.BackgroundTask;
 import com.liferay.portal.background.task.service.BackgroundTaskLocalService;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -77,7 +79,9 @@ public class ReportEntryResourceTest extends BaseReportEntryResourceTestCase {
 		super.testGetImportProcessReportEntriesPage();
 
 		_testGetImportProcessReportEntriesPageWithEmptyExportImportReportEntry();
+		_testGetImportProcessReportEntriesPageWithFilter();
 		_testGetImportProcessReportEntriesPageWithLocalizedSearchTerm();
+		_testGetImportProcessReportEntriesPageWithSort();
 	}
 
 	@Override
@@ -156,6 +160,51 @@ public class ReportEntryResourceTest extends BaseReportEntryResourceTestCase {
 		};
 	}
 
+	private ReportEntry _addReportEntry(
+			String classExternalReferenceCode, String modelName,
+			boolean typeEmpty)
+		throws Exception {
+
+		ReportEntry reportEntry = randomReportEntry();
+
+		reportEntry.setClassExternalReferenceCode(classExternalReferenceCode);
+		reportEntry.setModelName(modelName);
+
+		if (typeEmpty) {
+			Type type = new Type();
+
+			type.setCode(ExportImportReportEntryConstants.TYPE_EMPTY);
+
+			reportEntry.setType(type);
+		}
+
+		return _addReportEntry(reportEntry);
+	}
+
+	private void _assertReportEntries(
+			String filterString, String sortString,
+			Long... expectedReportEntryIds)
+		throws Exception {
+
+		List<ReportEntry> items =
+			(List<ReportEntry>)
+				reportEntryResource.getImportProcessReportEntriesPage(
+					_backgroundTask.getBackgroundTaskId(), null, filterString,
+					Pagination.of(1, 10), sortString
+				).getItems();
+
+		Assert.assertEquals(
+			items.toString(), expectedReportEntryIds.length, items.size());
+
+		for (int i = 0; i < expectedReportEntryIds.length; i++) {
+			Assert.assertEquals(
+				expectedReportEntryIds[i],
+				items.get(
+					i
+				).getId());
+		}
+	}
+
 	private void _testGetImportProcessReportEntriesPageWithEmptyExportImportReportEntry()
 		throws Exception {
 
@@ -166,15 +215,8 @@ public class ReportEntryResourceTest extends BaseReportEntryResourceTestCase {
 
 		long totalCount = page.getTotalCount();
 
-		ReportEntry reportEntry = randomReportEntry();
-
-		Type type = new Type();
-
-		type.setCode(ExportImportReportEntryConstants.TYPE_EMPTY);
-
-		reportEntry.setType(type);
-
-		_addReportEntry(reportEntry);
+		_addReportEntry(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), true);
 
 		page = reportEntryResource.getImportProcessReportEntriesPage(
 			testGetImportProcessReportEntriesPage_getImportProcessId(), null,
@@ -183,12 +225,70 @@ public class ReportEntryResourceTest extends BaseReportEntryResourceTestCase {
 		Assert.assertEquals(totalCount + 1, page.getTotalCount());
 	}
 
+	private void _testGetImportProcessReportEntriesPageWithFilter()
+		throws Exception {
+
+		ReportEntry reportEntry1 = _addReportEntry(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			false);
+
+		_assertReportEntries(
+			"contains(classExternalReferenceCode, '" +
+				reportEntry1.getClassExternalReferenceCode() + "')",
+			null, reportEntry1.getId());
+
+		_assertReportEntries(
+			"contains(classExternalReferenceCode, '" +
+				RandomTestUtil.randomString() + "')",
+			null);
+
+		_assertReportEntries(
+			"startswith(modelName, '" + reportEntry1.getModelName() + "')",
+			null, reportEntry1.getId());
+		_assertReportEntries(
+			"startswith(modelName, '" + RandomTestUtil.randomString() + "')",
+			null);
+
+		ReportEntry reportEntry2 = _addReportEntry(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), true);
+
+		_assertReportEntries(
+			StringBundler.concat(
+				"id eq ", reportEntry2.getId(), " and type/code eq ",
+				ExportImportReportEntryConstants.TYPE_EMPTY),
+			null, reportEntry2.getId());
+		_assertReportEntries(
+			StringBundler.concat(
+				"id eq ", reportEntry2.getId(), " and type/code eq ",
+				ExportImportReportEntryConstants.TYPE_ERROR),
+			null);
+
+		_assertReportEntries(
+			StringBundler.concat(
+				"id eq ", reportEntry2.getId(), " and type/label eq '",
+				LanguageUtil.get(
+					LocaleUtil.getDefault(),
+					ExportImportReportEntryConstants.getTypeLabel(
+						ExportImportReportEntryConstants.TYPE_EMPTY)),
+				"'"),
+			null, reportEntry2.getId());
+		_assertReportEntries(
+			StringBundler.concat(
+				"id eq ", reportEntry2.getId(), " and type/label eq '",
+				LanguageUtil.get(
+					LocaleUtil.getDefault(),
+					ExportImportReportEntryConstants.getTypeLabel(
+						ExportImportReportEntryConstants.TYPE_ERROR)),
+				"'"),
+			null);
+	}
+
 	private void _testGetImportProcessReportEntriesPageWithLocalizedSearchTerm()
 		throws Exception {
 
 		User user = UserTestUtil.getAdminUser(testCompany.getCompanyId());
 
-		reportEntryResource = ReportEntryResource.builder(
+		ReportEntryResource reportEntryResource = ReportEntryResource.builder(
 		).authentication(
 			user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD
 		).endpoint(
@@ -200,13 +300,15 @@ public class ReportEntryResourceTest extends BaseReportEntryResourceTestCase {
 
 		ReportEntry reportEntry = randomReportEntry();
 
-		_exportImportReportEntryLocalService.addErrorExportImportReportEntry(
-			testGroup.getGroupId(), testCompany.getCompanyId(),
-			reportEntry.getClassExternalReferenceCode(),
-			reportEntry.getClassNameId(), reportEntry.getClassPK(),
-			_exportImportConfiguration.getExportImportConfigurationId(),
-			reportEntry.getErrorMessage(), reportEntry.getErrorStacktrace(),
-			"example-text");
+		_exportImportReportEntries.add(
+			_exportImportReportEntryLocalService.
+				addErrorExportImportReportEntry(
+					testGroup.getGroupId(), testCompany.getCompanyId(),
+					reportEntry.getClassExternalReferenceCode(),
+					reportEntry.getClassNameId(), reportEntry.getClassPK(),
+					_exportImportConfiguration.getExportImportConfigurationId(),
+					reportEntry.getErrorMessage(),
+					reportEntry.getErrorStacktrace(), "example-text"));
 
 		Page<ReportEntry> page =
 			reportEntryResource.getImportProcessReportEntriesPage(
@@ -216,6 +318,45 @@ public class ReportEntryResourceTest extends BaseReportEntryResourceTestCase {
 		Assert.assertEquals(1, page.getTotalCount());
 
 		assertContains(reportEntry, (List<ReportEntry>)page.getItems());
+	}
+
+	private void _testGetImportProcessReportEntriesPageWithSort()
+		throws Exception {
+
+		ReportEntry reportEntry1 = _addReportEntry(
+			"a" + RandomTestUtil.randomString(),
+			"z" + RandomTestUtil.randomString(), false);
+		ReportEntry reportEntry2 = _addReportEntry(
+			"z" + RandomTestUtil.randomString(),
+			"a" + RandomTestUtil.randomString(), true);
+
+		String filterString = StringBundler.concat(
+			"id eq ", reportEntry1.getId(), " or id eq ", reportEntry2.getId());
+
+		_assertReportEntries(
+			filterString, "classExternalReferenceCode:asc",
+			reportEntry1.getId(), reportEntry2.getId());
+		_assertReportEntries(
+			filterString, "classExternalReferenceCode:desc",
+			reportEntry2.getId(), reportEntry1.getId());
+		_assertReportEntries(
+			filterString, "modelName:asc", reportEntry2.getId(),
+			reportEntry1.getId());
+		_assertReportEntries(
+			filterString, "modelName:desc", reportEntry1.getId(),
+			reportEntry2.getId());
+		_assertReportEntries(
+			filterString, "type/code:asc", reportEntry1.getId(),
+			reportEntry2.getId());
+		_assertReportEntries(
+			filterString, "type/code:desc", reportEntry2.getId(),
+			reportEntry1.getId());
+		_assertReportEntries(
+			filterString, "type/label:asc", reportEntry2.getId(),
+			reportEntry1.getId());
+		_assertReportEntries(
+			filterString, "type/label:desc", reportEntry1.getId(),
+			reportEntry2.getId());
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/export-import/export-import-web/build.gradle
+++ b/modules/apps/export-import/export-import-web/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:export-import:export-import-changeset-api")
+	compileOnly project(":apps:export-import:export-import-report-api")
 	compileOnly project(":apps:frontend-data-set:frontend-data-set-api")
 	compileOnly project(":apps:frontend-data-set:frontend-data-set-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/BaseImportReportEntrySelectionFDSFilter.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/BaseImportReportEntrySelectionFDSFilter.java
@@ -7,6 +7,7 @@ package com.liferay.exportimport.web.internal.frontend.data.set.filter;
 
 import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.frontend.data.set.filter.BaseSelectionFDSFilter;
+import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskManager;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
@@ -20,6 +21,9 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import java.io.Serializable;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Reference;
@@ -35,7 +39,28 @@ public abstract class BaseImportReportEntrySelectionFDSFilter
 		return FDSEntityFieldTypes.STRING;
 	}
 
-	protected long getExportImportConfigurationId() {
+	@Override
+	public List<SelectionFDSFilterItem> getSelectionFDSFilterItems(
+		Locale locale) {
+
+		long exportImportConfigurationId = _getExportImportConfigurationId();
+
+		if (exportImportConfigurationId == 0) {
+			return Collections.emptyList();
+		}
+
+		return doGetSelectionFDSFilterItems(
+			exportImportConfigurationId, locale);
+	}
+
+	protected abstract List<SelectionFDSFilterItem>
+		doGetSelectionFDSFilterItems(
+			long exportImportConfigurationId, Locale locale);
+
+	@Reference
+	protected BackgroundTaskManager backgroundTaskManager;
+
+	private long _getExportImportConfigurationId() {
 		ServiceContext serviceContext =
 			ServiceContextThreadLocal.getServiceContext();
 
@@ -92,8 +117,5 @@ public abstract class BaseImportReportEntrySelectionFDSFilter
 		return GetterUtil.getLong(
 			taskContextMap.get("exportImportConfigurationId"));
 	}
-
-	@Reference
-	protected BackgroundTaskManager backgroundTaskManager;
 
 }

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/BaseImportReportEntrySelectionFDSFilter.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/BaseImportReportEntrySelectionFDSFilter.java
@@ -18,6 +18,10 @@ import com.liferay.portal.kernel.util.PortalUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.io.Serializable;
+
+import java.util.Map;
+
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -82,11 +86,11 @@ public abstract class BaseImportReportEntrySelectionFDSFilter
 			return 0;
 		}
 
+		Map<String, Serializable> taskContextMap =
+			backgroundTask.getTaskContextMap();
+
 		return GetterUtil.getLong(
-			backgroundTask.getTaskContextMap(
-			).get(
-				"exportImportConfigurationId"
-			));
+			taskContextMap.get("exportImportConfigurationId"));
 	}
 
 	@Reference

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/BaseImportReportEntrySelectionFDSFilter.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/BaseImportReportEntrySelectionFDSFilter.java
@@ -1,0 +1,95 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.exportimport.web.internal.frontend.data.set.filter;
+
+import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
+import com.liferay.frontend.data.set.filter.BaseSelectionFDSFilter;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskManager;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Magdalena Jedraszak
+ */
+public abstract class BaseImportReportEntrySelectionFDSFilter
+	extends BaseSelectionFDSFilter {
+
+	@Override
+	public String getEntityFieldType() {
+		return FDSEntityFieldTypes.STRING;
+	}
+
+	protected long getExportImportConfigurationId() {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext == null) {
+			return 0;
+		}
+
+		long backgroundTaskId = 0;
+
+		LiferayPortletRequest liferayPortletRequest =
+			serviceContext.getLiferayPortletRequest();
+
+		if (liferayPortletRequest != null) {
+			backgroundTaskId = ParamUtil.getLong(
+				liferayPortletRequest, "backgroundTaskId");
+
+			if (backgroundTaskId == 0) {
+				backgroundTaskId = ParamUtil.getLong(
+					liferayPortletRequest, "importProcessId");
+			}
+		}
+
+		if (backgroundTaskId == 0) {
+			HttpServletRequest httpServletRequest = serviceContext.getRequest();
+
+			if (httpServletRequest != null) {
+				HttpServletRequest originalHttpServletRequest =
+					PortalUtil.getOriginalServletRequest(httpServletRequest);
+
+				backgroundTaskId = ParamUtil.getLong(
+					originalHttpServletRequest, "backgroundTaskId");
+
+				if (backgroundTaskId == 0) {
+					backgroundTaskId = ParamUtil.getLong(
+						originalHttpServletRequest, "importProcessId");
+				}
+			}
+		}
+
+		if (backgroundTaskId == 0) {
+			return 0;
+		}
+
+		BackgroundTask backgroundTask =
+			backgroundTaskManager.fetchBackgroundTask(backgroundTaskId);
+
+		if (backgroundTask == null) {
+			return 0;
+		}
+
+		return GetterUtil.getLong(
+			backgroundTask.getTaskContextMap(
+			).get(
+				"exportImportConfigurationId"
+			));
+	}
+
+	@Reference
+	protected BackgroundTaskManager backgroundTaskManager;
+
+}

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/ClassExternalReferenceCodeSelectionFDSFilter.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/ClassExternalReferenceCodeSelectionFDSFilter.java
@@ -12,9 +12,9 @@ import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.ProjectionFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
+import com.liferay.portal.kernel.util.TransformUtil;
 import com.liferay.portal.kernel.util.Validator;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -73,19 +73,16 @@ public class ClassExternalReferenceCodeSelectionFDSFilter
 			return Collections.emptyList();
 		}
 
-		List<SelectionFDSFilterItem> selectionFDSFilterItems =
-			new ArrayList<>();
+		return TransformUtil.transform(
+			classExternalReferenceCodes,
+			classExternalReferenceCode -> {
+				if (Validator.isBlank(classExternalReferenceCode)) {
+					return null;
+				}
 
-		for (String classExternalReferenceCode : classExternalReferenceCodes) {
-			if (!Validator.isBlank(classExternalReferenceCode)) {
-				selectionFDSFilterItems.add(
-					new SelectionFDSFilterItem(
-						classExternalReferenceCode,
-						classExternalReferenceCode));
-			}
-		}
-
-		return selectionFDSFilterItems;
+				return new SelectionFDSFilterItem(
+					classExternalReferenceCode, classExternalReferenceCode);
+			});
 	}
 
 	@Override

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/ClassExternalReferenceCodeSelectionFDSFilter.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/ClassExternalReferenceCodeSelectionFDSFilter.java
@@ -1,0 +1,100 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.exportimport.web.internal.frontend.data.set.filter;
+
+import com.liferay.exportimport.report.service.ExportImportReportEntryLocalService;
+import com.liferay.exportimport.web.internal.constants.ExportImportFDSNames;
+import com.liferay.frontend.data.set.filter.FDSFilter;
+import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
+import com.liferay.portal.kernel.dao.orm.DynamicQuery;
+import com.liferay.portal.kernel.dao.orm.ProjectionFactoryUtil;
+import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Magdalena Jedraszak
+ */
+@Component(
+	property = {
+		"frontend.data.set.name=" + ExportImportFDSNames.COMPANY_IMPORT_REPORT_ENTRIES,
+		"frontend.data.set.name=" + ExportImportFDSNames.IMPORT_REPORT_ENTRIES
+	},
+	service = FDSFilter.class
+)
+public class ClassExternalReferenceCodeSelectionFDSFilter
+	extends BaseImportReportEntrySelectionFDSFilter {
+
+	@Override
+	public String getId() {
+		return "classExternalReferenceCode";
+	}
+
+	@Override
+	public String getLabel() {
+		return "external-reference-code";
+	}
+
+	@Override
+	public List<SelectionFDSFilterItem> getSelectionFDSFilterItems(
+		Locale locale) {
+
+		long exportImportConfigurationId = getExportImportConfigurationId();
+
+		if (exportImportConfigurationId == 0) {
+			return Collections.emptyList();
+		}
+
+		DynamicQuery dynamicQuery =
+			_exportImportReportEntryLocalService.dynamicQuery();
+
+		dynamicQuery.add(
+			RestrictionsFactoryUtil.eq(
+				"exportImportConfigurationId", exportImportConfigurationId));
+
+		dynamicQuery.setProjection(
+			ProjectionFactoryUtil.distinct(
+				ProjectionFactoryUtil.property("classExternalReferenceCode")));
+
+		List<String> classExternalReferenceCodes =
+			_exportImportReportEntryLocalService.dynamicQuery(dynamicQuery);
+
+		if (classExternalReferenceCodes == null) {
+			return Collections.emptyList();
+		}
+
+		List<SelectionFDSFilterItem> selectionFDSFilterItems =
+			new ArrayList<>();
+
+		for (String classExternalReferenceCode : classExternalReferenceCodes) {
+			if (!Validator.isBlank(classExternalReferenceCode)) {
+				selectionFDSFilterItems.add(
+					new SelectionFDSFilterItem(
+						classExternalReferenceCode,
+						classExternalReferenceCode));
+			}
+		}
+
+		return selectionFDSFilterItems;
+	}
+
+	@Override
+	public boolean isAutocompleteEnabled() {
+		return true;
+	}
+
+	@Reference
+	private ExportImportReportEntryLocalService
+		_exportImportReportEntryLocalService;
+
+}

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/ClassExternalReferenceCodeSelectionFDSFilter.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/ClassExternalReferenceCodeSelectionFDSFilter.java
@@ -9,10 +9,10 @@ import com.liferay.exportimport.report.service.ExportImportReportEntryLocalServi
 import com.liferay.exportimport.web.internal.constants.ExportImportFDSNames;
 import com.liferay.frontend.data.set.filter.FDSFilter;
 import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.ProjectionFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
-import com.liferay.portal.kernel.util.TransformUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Collections;
@@ -46,14 +46,13 @@ public class ClassExternalReferenceCodeSelectionFDSFilter
 	}
 
 	@Override
-	public List<SelectionFDSFilterItem> getSelectionFDSFilterItems(
-		Locale locale) {
+	public boolean isAutocompleteEnabled() {
+		return true;
+	}
 
-		long exportImportConfigurationId = getExportImportConfigurationId();
-
-		if (exportImportConfigurationId == 0) {
-			return Collections.emptyList();
-		}
+	@Override
+	protected List<SelectionFDSFilterItem> doGetSelectionFDSFilterItems(
+		long exportImportConfigurationId, Locale locale) {
 
 		DynamicQuery dynamicQuery =
 			_exportImportReportEntryLocalService.dynamicQuery();
@@ -83,11 +82,6 @@ public class ClassExternalReferenceCodeSelectionFDSFilter
 				return new SelectionFDSFilterItem(
 					classExternalReferenceCode, classExternalReferenceCode);
 			});
-	}
-
-	@Override
-	public boolean isAutocompleteEnabled() {
-		return true;
 	}
 
 	@Reference

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/ImportErrorsGroupedFDSFilters.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/ImportErrorsGroupedFDSFilters.java
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.exportimport.web.internal.frontend.data.set.filter;
+
+import com.liferay.exportimport.web.internal.constants.ExportImportFDSNames;
+import com.liferay.frontend.data.set.filter.GroupedFDSFilters;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.language.LanguageUtil;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Magdalena Jedraszak
+ */
+@Component(
+	property = {
+		"frontend.data.set.name=" + ExportImportFDSNames.COMPANY_IMPORT_REPORT_ENTRIES,
+		"frontend.data.set.name=" + ExportImportFDSNames.IMPORT_REPORT_ENTRIES
+	},
+	service = GroupedFDSFilters.class
+)
+public class ImportErrorsGroupedFDSFilters implements GroupedFDSFilters {
+
+	@Override
+	public JSONArray getGroupedFDSFiltersJSONArray(
+		HttpServletRequest httpServletRequest) {
+
+		return JSONUtil.putAll(
+			JSONUtil.put(
+				LanguageUtil.get(httpServletRequest, "filters"),
+				JSONUtil.putAll(
+					"modelName", "classExternalReferenceCode", "type/code")));
+	}
+
+}

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/ImportErrorsGroupedFDSFilters.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/ImportErrorsGroupedFDSFilters.java
@@ -35,7 +35,7 @@ public class ImportErrorsGroupedFDSFilters implements GroupedFDSFilters {
 			JSONUtil.put(
 				LanguageUtil.get(httpServletRequest, "filters"),
 				JSONUtil.putAll(
-					"modelName", "classExternalReferenceCode", "type/code")));
+					"classExternalReferenceCode", "modelName", "type/code")));
 	}
 
 }

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/ModelNameSelectionFDSFilter.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/ModelNameSelectionFDSFilter.java
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.exportimport.web.internal.frontend.data.set.filter;
+
+import com.liferay.exportimport.report.service.ExportImportReportEntryLocalService;
+import com.liferay.exportimport.web.internal.constants.ExportImportFDSNames;
+import com.liferay.frontend.data.set.filter.FDSFilter;
+import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
+import com.liferay.portal.kernel.dao.orm.DynamicQuery;
+import com.liferay.portal.kernel.dao.orm.ProjectionFactoryUtil;
+import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Magdalena Jedraszak
+ */
+@Component(
+	property = {
+		"frontend.data.set.name=" + ExportImportFDSNames.COMPANY_IMPORT_REPORT_ENTRIES,
+		"frontend.data.set.name=" + ExportImportFDSNames.IMPORT_REPORT_ENTRIES
+	},
+	service = FDSFilter.class
+)
+public class ModelNameSelectionFDSFilter
+	extends BaseImportReportEntrySelectionFDSFilter {
+
+	@Override
+	public String getId() {
+		return "modelName";
+	}
+
+	@Override
+	public String getLabel() {
+		return "entity-type";
+	}
+
+	@Override
+	public List<SelectionFDSFilterItem> getSelectionFDSFilterItems(
+		Locale locale) {
+
+		long exportImportConfigurationId = getExportImportConfigurationId();
+
+		if (exportImportConfigurationId == 0) {
+			return Collections.emptyList();
+		}
+
+		DynamicQuery dynamicQuery =
+			_exportImportReportEntryLocalService.dynamicQuery();
+
+		dynamicQuery.add(
+			RestrictionsFactoryUtil.eq(
+				"exportImportConfigurationId", exportImportConfigurationId));
+		dynamicQuery.setProjection(
+			ProjectionFactoryUtil.distinct(
+				ProjectionFactoryUtil.property("modelNameLanguageKey")));
+
+		List<Object> modelNameLanguageKeys =
+			(List<Object>)_exportImportReportEntryLocalService.dynamicQuery(
+				dynamicQuery);
+
+		if (modelNameLanguageKeys == null) {
+			return Collections.emptyList();
+		}
+
+		List<SelectionFDSFilterItem> selectionFDSFilterItems =
+			new ArrayList<>();
+
+		for (Object key : modelNameLanguageKeys) {
+			if (Validator.isNotNull(key) && !Validator.isBlank((String)key)) {
+				String translatedModelName = _language.get(locale, (String)key);
+
+				selectionFDSFilterItems.add(
+					new SelectionFDSFilterItem(
+						translatedModelName, translatedModelName));
+			}
+		}
+
+		return selectionFDSFilterItems;
+	}
+
+	@Override
+	public boolean isAutocompleteEnabled() {
+		return true;
+	}
+
+	@Reference
+	private ExportImportReportEntryLocalService
+		_exportImportReportEntryLocalService;
+
+	@Reference
+	private Language _language;
+
+}

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/ModelNameSelectionFDSFilter.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/ModelNameSelectionFDSFilter.java
@@ -13,9 +13,9 @@ import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.ProjectionFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.util.TransformUtil;
 import com.liferay.portal.kernel.util.Validator;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -74,20 +74,18 @@ public class ModelNameSelectionFDSFilter
 			return Collections.emptyList();
 		}
 
-		List<SelectionFDSFilterItem> selectionFDSFilterItems =
-			new ArrayList<>();
+		return TransformUtil.transform(
+			modelNameLanguageKeys,
+			key -> {
+				if (Validator.isBlank((String)key)) {
+					return null;
+				}
 
-		for (Object key : modelNameLanguageKeys) {
-			if (Validator.isNotNull(key) && !Validator.isBlank((String)key)) {
 				String translatedModelName = _language.get(locale, (String)key);
 
-				selectionFDSFilterItems.add(
-					new SelectionFDSFilterItem(
-						translatedModelName, translatedModelName));
-			}
-		}
-
-		return selectionFDSFilterItems;
+				return new SelectionFDSFilterItem(
+					translatedModelName, translatedModelName);
+			});
 	}
 
 	@Override

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/ModelNameSelectionFDSFilter.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/ModelNameSelectionFDSFilter.java
@@ -9,11 +9,11 @@ import com.liferay.exportimport.report.service.ExportImportReportEntryLocalServi
 import com.liferay.exportimport.web.internal.constants.ExportImportFDSNames;
 import com.liferay.frontend.data.set.filter.FDSFilter;
 import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.ProjectionFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.util.TransformUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Collections;
@@ -47,14 +47,13 @@ public class ModelNameSelectionFDSFilter
 	}
 
 	@Override
-	public List<SelectionFDSFilterItem> getSelectionFDSFilterItems(
-		Locale locale) {
+	public boolean isAutocompleteEnabled() {
+		return true;
+	}
 
-		long exportImportConfigurationId = getExportImportConfigurationId();
-
-		if (exportImportConfigurationId == 0) {
-			return Collections.emptyList();
-		}
+	@Override
+	protected List<SelectionFDSFilterItem> doGetSelectionFDSFilterItems(
+		long exportImportConfigurationId, Locale locale) {
 
 		DynamicQuery dynamicQuery =
 			_exportImportReportEntryLocalService.dynamicQuery();
@@ -86,11 +85,6 @@ public class ModelNameSelectionFDSFilter
 				return new SelectionFDSFilterItem(
 					translatedModelName, translatedModelName);
 			});
-	}
-
-	@Override
-	public boolean isAutocompleteEnabled() {
-		return true;
 	}
 
 	@Reference

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/ModelNameSelectionFDSFilter.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/ModelNameSelectionFDSFilter.java
@@ -65,9 +65,8 @@ public class ModelNameSelectionFDSFilter
 			ProjectionFactoryUtil.distinct(
 				ProjectionFactoryUtil.property("modelNameLanguageKey")));
 
-		List<Object> modelNameLanguageKeys =
-			(List<Object>)_exportImportReportEntryLocalService.dynamicQuery(
-				dynamicQuery);
+		List<String> modelNameLanguageKeys =
+			_exportImportReportEntryLocalService.dynamicQuery(dynamicQuery);
 
 		if (modelNameLanguageKeys == null) {
 			return Collections.emptyList();
@@ -75,12 +74,13 @@ public class ModelNameSelectionFDSFilter
 
 		return TransformUtil.transform(
 			modelNameLanguageKeys,
-			key -> {
-				if (Validator.isBlank((String)key)) {
+			modelNameLanguageKey -> {
+				if (Validator.isBlank(modelNameLanguageKey)) {
 					return null;
 				}
 
-				String translatedModelName = _language.get(locale, (String)key);
+				String translatedModelName = _language.get(
+					locale, modelNameLanguageKey);
 
 				return new SelectionFDSFilterItem(
 					translatedModelName, translatedModelName);

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/TypeSelectionFDSFilter.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/TypeSelectionFDSFilter.java
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.exportimport.web.internal.frontend.data.set.filter;
+
+import com.liferay.exportimport.report.constants.ExportImportReportEntryConstants;
+import com.liferay.exportimport.web.internal.constants.ExportImportFDSNames;
+import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
+import com.liferay.frontend.data.set.filter.BaseSelectionFDSFilter;
+import com.liferay.frontend.data.set.filter.FDSFilter;
+import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Magdalena Jedraszak
+ */
+@Component(
+	property = {
+		"frontend.data.set.name=" + ExportImportFDSNames.COMPANY_IMPORT_REPORT_ENTRIES,
+		"frontend.data.set.name=" + ExportImportFDSNames.IMPORT_REPORT_ENTRIES
+	},
+	service = FDSFilter.class
+)
+public class TypeSelectionFDSFilter extends BaseSelectionFDSFilter {
+
+	@Override
+	public String getEntityFieldType() {
+		return FDSEntityFieldTypes.INTEGER;
+	}
+
+	@Override
+	public String getId() {
+		return "type/code";
+	}
+
+	@Override
+	public String getLabel() {
+		return "type";
+	}
+
+	@Override
+	public List<SelectionFDSFilterItem> getSelectionFDSFilterItems(
+		Locale locale) {
+
+		return ListUtil.fromArray(
+			new SelectionFDSFilterItem(
+				LanguageUtil.get(locale, "error"),
+				ExportImportReportEntryConstants.TYPE_ERROR),
+			new SelectionFDSFilterItem(
+				LanguageUtil.get(locale, "empty"),
+				ExportImportReportEntryConstants.TYPE_EMPTY));
+	}
+
+}

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/TypeSelectionFDSFilter.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/TypeSelectionFDSFilter.java
@@ -52,11 +52,11 @@ public class TypeSelectionFDSFilter extends BaseSelectionFDSFilter {
 
 		return ListUtil.fromArray(
 			new SelectionFDSFilterItem(
-				LanguageUtil.get(locale, "error"),
-				ExportImportReportEntryConstants.TYPE_ERROR),
-			new SelectionFDSFilterItem(
 				LanguageUtil.get(locale, "empty"),
-				ExportImportReportEntryConstants.TYPE_EMPTY));
+				ExportImportReportEntryConstants.TYPE_EMPTY),
+			new SelectionFDSFilterItem(
+				LanguageUtil.get(locale, "error"),
+				ExportImportReportEntryConstants.TYPE_ERROR));
 	}
 
 }

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/TypeSelectionFDSFilter.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/filter/TypeSelectionFDSFilter.java
@@ -56,7 +56,10 @@ public class TypeSelectionFDSFilter extends BaseSelectionFDSFilter {
 				ExportImportReportEntryConstants.TYPE_EMPTY),
 			new SelectionFDSFilterItem(
 				LanguageUtil.get(locale, "error"),
-				ExportImportReportEntryConstants.TYPE_ERROR));
+				ExportImportReportEntryConstants.TYPE_ERROR),
+			new SelectionFDSFilterItem(
+				LanguageUtil.get(locale, "missing-reference"),
+				ExportImportReportEntryConstants.TYPE_MISSING_REFERENCE));
 	}
 
 }

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/view/table/ImportErrorsTableFDSView.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/view/table/ImportErrorsTableFDSView.java
@@ -35,11 +35,13 @@ public class ImportErrorsTableFDSView extends BaseTableFDSView {
 			_fdsTableSchemaBuilderFactory.create();
 
 		return fdsTableSchemaBuilder.add(
-			"modelName", "entity-type"
+			"modelName", "entity-type",
+			fdsTableSchemaField -> fdsTableSchemaField.setSortable(true)
 		).add(
-			"classExternalReferenceCode", "external-reference-code"
+			"classExternalReferenceCode", "external-reference-code",
+			fdsTableSchemaField -> fdsTableSchemaField.setSortable(true)
 		).add(
-			"type", "type"
+			"type.label", "type"
 		).add(
 			"errorMessage", "description"
 		).add(

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/css/main.scss
@@ -346,6 +346,12 @@
 	}
 }
 
+.selected-elements-wrapper {
+	.label {
+		text-transform: none;
+	}
+}
+
 .export-import-options {
 	.alert-dismissible {
 		z-index: 100000;

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/fds/ImportReportFDSPropsTransformer.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/fds/ImportReportFDSPropsTransformer.ts
@@ -3,13 +3,17 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {IInternalRenderer} from '@liferay/frontend-data-set-web';
+import {
+	EConfigInURLBehavior,
+	IInternalRenderer,
+} from '@liferay/frontend-data-set-web';
 
 import ImportReportStatusRenderer from './cell_renderers/ImportReportStatusRenderer';
 
 export default function ImportReportFDSPropsTransformer({...otherProps}) {
 	return {
 		...otherProps,
+		configInURLBehavior: EConfigInURLBehavior.OFF,
 		customRenderers: {
 			tableCell: [
 				{

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/resources/META-INF/mappings/index-mappings.json
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/resources/META-INF/mappings/index-mappings.json
@@ -1448,6 +1448,9 @@
 		"assetVocabularyIds": {
 			"type": "keyword"
 		},
+		"classExternalReferenceCode": {
+			"type": "keyword"
+		},
 		"classTypeId": {
 			"type": "keyword"
 		},

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/LocalizationImplTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/LocalizationImplTest.java
@@ -152,7 +152,6 @@ public class LocalizationImplTest {
 		method.setAccessible(true);
 
 		Object object1 = method.invoke(null, LocaleUtil.BRAZIL);
-		Object object2 = method.invoke(null, new Locale("es"));
 
 		Class<?> class1 = object1.getClass();
 
@@ -162,6 +161,8 @@ public class LocalizationImplTest {
 
 		@SuppressWarnings("unchecked")
 		Map<String, String> fieldMap1 = (Map<String, String>)field.get(object1);
+
+		Object object2 = method.invoke(null, new Locale("es"));
 
 		@SuppressWarnings("unchecked")
 		Map<String, String> fieldMap2 = (Map<String, String>)field.get(object2);

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/LocalizationImplTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/LocalizationImplTest.java
@@ -11,7 +11,9 @@ import com.liferay.petra.memory.FinalizeManager;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.settings.LocalizedValuesMap;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.portlet.MockPortletRequest;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -20,6 +22,7 @@ import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.xml.DocumentException;
 import com.liferay.portal.kernel.xml.SAXReader;
+import com.liferay.portal.language.LanguageResources;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.LocalizationImpl;
@@ -28,6 +31,7 @@ import com.liferay.portlet.PortletPreferencesImpl;
 import jakarta.portlet.PortletPreferences;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -137,6 +141,56 @@ public class LocalizationImplTest {
 			"The default language ids from Document and XML do not match",
 			LocalizationUtil.getDefaultLanguageId(_saxReader.read(_xml)),
 			LocalizationUtil.getDefaultLanguageId(_xml));
+	}
+
+	@Test
+	@TestInfo("LPD-90780")
+	public void testGetLocalizationMap() throws Exception {
+		Method method = LanguageResources.class.getDeclaredMethod(
+			"_getMapHolder", Locale.class);
+
+		method.setAccessible(true);
+
+		Object object1 = method.invoke(null, LocaleUtil.BRAZIL);
+		Object object2 = method.invoke(null, new Locale("es"));
+
+		Class<?> class1 = object1.getClass();
+
+		Field field = class1.getDeclaredField("_map");
+
+		field.setAccessible(true);
+
+		@SuppressWarnings("unchecked")
+		Map<String, String> fieldMap1 = (Map<String, String>)field.get(object1);
+
+		@SuppressWarnings("unchecked")
+		Map<String, String> fieldMap2 = (Map<String, String>)field.get(object2);
+
+		String key = RandomTestUtil.randomString();
+		String value = RandomTestUtil.randomString();
+
+		fieldMap1.put(key, key);
+		fieldMap2.put(key, value);
+
+		try {
+			Map<Locale, String> localizationMap =
+				_localization.getLocalizationMap(
+					Arrays.asList(
+						LocaleUtil.BRAZIL, LocaleUtil.GERMANY, LocaleUtil.SPAIN,
+						_defaultLocale),
+					_defaultLocale, key);
+
+			Assert.assertEquals(key, localizationMap.get(LocaleUtil.BRAZIL));
+			Assert.assertFalse(localizationMap.containsKey(LocaleUtil.GERMANY));
+			Assert.assertEquals(
+				localizationMap.get(_defaultLocale),
+				LanguageUtil.get(LocaleUtil.GERMANY, key));
+			Assert.assertEquals(value, localizationMap.get(LocaleUtil.SPAIN));
+		}
+		finally {
+			fieldMap1.remove(key);
+			fieldMap2.remove(key);
+		}
 	}
 
 	@Test

--- a/modules/test/playwright/tests/export-import-web/main/instance.importReport.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/instance.importReport.spec.ts
@@ -118,6 +118,7 @@ test(
 		await exportImportPage.goToExport();
 
 		const exportFilePath = await exportImportPage.export({
+			includePageSettings: false,
 			portletLabels: [
 				`${objectDefinition1.name} 1 Items`,
 				`${objectDefinition2.name} 1 Items`,

--- a/modules/test/playwright/tests/export-import-web/main/instance.importReport.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/instance.importReport.spec.ts
@@ -28,125 +28,220 @@ export const test = mergeTests(
 );
 
 async function setupImportReportScenario(apiHelpers: DataApiHelpers) {
-	const objectDefinitionA = await _createObjectDefinition(
-		apiHelpers,
-		'A',
-		'site'
-	);
-	const objectDefinitionB = await _createObjectDefinition(
-		apiHelpers,
-		'B',
-		'site'
-	);
-	const objectDefinitionC = await _createObjectDefinition(
-		apiHelpers,
-		'C',
-		'company'
-	);
-	const objectDefinitionD = await _createObjectDefinition(
-		apiHelpers,
-		'D',
-		'site'
-	);
-	const objectDefinitionZ = await _createObjectDefinition(
-		apiHelpers,
-		'Z',
-		'site'
-	);
+	const [objectDefinition1, objectDefinition2] = await Promise.all([
+		apiHelpers.objectAdmin.postRandomObjectDefinition({
+			scope: 'site',
+			status: {code: 0},
+		}),
+		apiHelpers.objectAdmin.postRandomObjectDefinition({
+			scope: 'site',
+			status: {code: 0},
+		}),
+	]);
 
-	const relationshipName = 'rel' + getRandomInt();
-
-	await _createOneToManyRelationship(
-		apiHelpers,
-		objectDefinitionC,
-		objectDefinitionD,
-		relationshipName
-	);
-
-	await apiHelpers.objectEntry.postObjectEntry(
-		{},
-		`${normalizeRestPath(objectDefinitionA.restContextPath)}/scopes/Guest`
-	);
-
-	await apiHelpers.objectEntry.postObjectEntry(
-		{},
-		`${normalizeRestPath(objectDefinitionB.restContextPath)}/scopes/Guest`
-	);
-
-	await apiHelpers.objectEntry.postObjectEntry(
-		{},
-		`${normalizeRestPath(objectDefinitionZ.restContextPath)}/scopes/Guest`
-	);
-
-	const objectEntryC = await apiHelpers.objectEntry.postObjectEntry(
-		{},
-		normalizeRestPath(objectDefinitionC.restContextPath)
-	);
-
-	await apiHelpers.objectEntry.postObjectEntry(
-		{
-			externalReferenceCode: `ERC-D-${getRandomInt()}`,
-			[`r_${relationshipName}_c_${objectDefinitionC.name[0].toLowerCase() + objectDefinitionC.name.substring(1)}Id`]:
-				objectEntryC.id,
-		},
-		`${normalizeRestPath(objectDefinitionD.restContextPath)}/scopes/Guest`
-	);
-
-	return {
-		objectDefinitionA,
-		objectDefinitionB,
-		objectDefinitionC,
-		objectDefinitionD,
-		objectDefinitionZ,
-		objectEntryC,
-	};
-}
-
-async function _createObjectDefinition(
-	apiHelpers: DataApiHelpers,
-	prefix: string,
-	scope: 'site' | 'company'
-) {
-	const objectDefinition =
+	const objectDefinition3 =
 		await apiHelpers.objectAdmin.postRandomObjectDefinition({
-			objectDefinitionExternalReferenceCode:
-				`${prefix}ObjectDefinition` + getRandomInt(),
-			scope: scope === 'site' ? 'site' : undefined,
 			status: {code: 0},
 		});
 
-	apiHelpers.data.push({id: objectDefinition.id, type: 'objectDefinition'});
+	for (const objectDefinition of [
+		objectDefinition1,
+		objectDefinition2,
+		objectDefinition3,
+	]) {
+		apiHelpers.data.push({
+			id: objectDefinition.id,
+			type: 'objectDefinition',
+		});
+	}
 
-	return objectDefinition;
-}
-
-async function _createOneToManyRelationship(
-	apiHelpers: DataApiHelpers,
-	objectDefinition1: any,
-	objectDefinition2: any,
-	name: string
-) {
 	const objectRelationshipAPIClient = await apiHelpers.buildRestClient(
 		ObjectRelationshipAPI
 	);
 
+	const relationshipName = 'relationship';
+
 	await objectRelationshipAPIClient.postObjectDefinitionByExternalReferenceCodeObjectRelationship(
-		objectDefinition1.externalReferenceCode,
+		objectDefinition3.externalReferenceCode,
 		{
 			deletionType: 'disassociate',
 			label: {en_US: 'Relationship'},
-			name,
+			name: relationshipName,
 			objectDefinitionExternalReferenceCode1:
-				objectDefinition1.externalReferenceCode,
+				objectDefinition3.externalReferenceCode,
 			objectDefinitionExternalReferenceCode2:
 				objectDefinition2.externalReferenceCode,
-			objectDefinitionId1: objectDefinition1.id,
+			objectDefinitionId1: objectDefinition3.id,
 			objectDefinitionId2: objectDefinition2.id,
 			objectDefinitionName2: objectDefinition2.name,
 			type: 'oneToMany',
 		}
 	);
+
+	await apiHelpers.objectEntry.postObjectEntry(
+		{},
+		`${normalizeRestPath(objectDefinition1.restContextPath)}/scopes/Guest`
+	);
+
+	const objectEntry = await apiHelpers.objectEntry.postObjectEntry(
+		{},
+		normalizeRestPath(objectDefinition3.restContextPath)
+	);
+
+	await apiHelpers.objectEntry.postObjectEntry(
+		{
+			[`r_${relationshipName}_c_${objectDefinition3.name[0].toLowerCase() + objectDefinition3.name.substring(1)}Id`]:
+				objectEntry.id,
+		},
+		`${normalizeRestPath(objectDefinition2.restContextPath)}/scopes/Guest`
+	);
+
+	return {
+		objectDefinition1,
+		objectDefinition2,
+		objectDefinition3,
+		objectEntry,
+	};
 }
+
+test(
+	'Can filter, search and sort errors report entries',
+	{tag: '@LPD-68461'},
+	async ({apiHelpers, exportImportPage}) => {
+		const {
+			objectDefinition1,
+			objectDefinition2,
+			objectDefinition3,
+			objectEntry,
+		} = await setupImportReportScenario(apiHelpers);
+
+		await exportImportPage.goToExport();
+
+		const exportFilePath = await exportImportPage.export({
+			portletLabels: [
+				`${objectDefinition1.name} 1 Items`,
+				`${objectDefinition2.name} 1 Items`,
+			],
+		});
+
+		const objectFieldAPIClient =
+			await apiHelpers.buildRestClient(ObjectFieldAPI);
+
+		await objectFieldAPIClient.postObjectDefinitionObjectField(
+			objectDefinition1.id,
+			{
+				DBType: 'String',
+				businessType: 'Text',
+				label: {en_US: 'mandatoryField'},
+				name: 'mandatoryField',
+				required: true,
+			}
+		);
+
+		await apiHelpers.objectEntry.deleteObjectEntry(
+			normalizeRestPath(objectDefinition3.restContextPath),
+			String(objectEntry.id)
+		);
+
+		const site = await apiHelpers.headlessAdminSite.postSite({
+			name: 'TestSite' + getRandomInt(),
+		});
+
+		await exportImportPage.goToImport(site.friendlyUrlPath);
+
+		await exportImportPage.import({
+			filePath: exportFilePath,
+			taskStatus: 'completedWithErrors',
+		});
+
+		const exportName = exportFilePath.slice(
+			exportFilePath.lastIndexOf('/') + 1
+		);
+
+		await exportImportPage.goToImportDetails(exportName);
+
+		// Sort by Entity Type
+
+		await exportImportPage.sortReportBy('Entity Type');
+		let values =
+			await exportImportPage.getReportColumnValues('Entity Type');
+		expect(values).toEqual([...values].sort((a, b) => a.localeCompare(b)));
+
+		await exportImportPage.sortReportBy('Entity Type');
+		values = await exportImportPage.getReportColumnValues('Entity Type');
+		expect(values).toEqual([...values].sort((a, b) => b.localeCompare(a)));
+
+		// Sort by External Reference Code
+
+		await exportImportPage.sortReportBy('External Reference Code');
+		values = await exportImportPage.getReportColumnValues(
+			'External Reference Code'
+		);
+		expect(values).toEqual([...values].sort((a, b) => a.localeCompare(b)));
+
+		await exportImportPage.sortReportBy('External Reference Code');
+		values = await exportImportPage.getReportColumnValues(
+			'External Reference Code'
+		);
+		expect(values).toEqual([...values].sort((a, b) => b.localeCompare(a)));
+
+		// Search by Entity Type name
+
+		await exportImportPage.searchReportEntries(objectDefinition1.name);
+		values = await exportImportPage.getReportColumnValues('Entity Type');
+		expect(values).toEqual([objectDefinition1.name]);
+
+		await exportImportPage.clearReportSearch();
+
+		// Search by External Reference Code
+
+		await exportImportPage.searchReportEntries(
+			objectEntry.externalReferenceCode
+		);
+		values = await exportImportPage.getReportColumnValues(
+			'External Reference Code'
+		);
+		expect(values).toEqual([objectEntry.externalReferenceCode]);
+
+		await exportImportPage.clearReportSearch();
+
+		// Filter by Entity Type
+
+		await exportImportPage.filterReportBy(
+			'Entity Type',
+			objectDefinition1.name
+		);
+		values = await exportImportPage.getReportColumnValues('Entity Type');
+		expect(values).toEqual([objectDefinition1.name]);
+
+		await exportImportPage.removeReportFilter();
+
+		// Filter by External Reference Code
+
+		await exportImportPage.filterReportBy(
+			'External Reference Code',
+			objectEntry.externalReferenceCode
+		);
+		values = await exportImportPage.getReportColumnValues(
+			'External Reference Code'
+		);
+		expect(values).toEqual([objectEntry.externalReferenceCode]);
+
+		await exportImportPage.removeReportFilter();
+
+		// Filter by Type
+
+		await exportImportPage.filterReportBy('Type', 'Empty');
+		values = await exportImportPage.getReportColumnValues('Type');
+		expect(values).toEqual(['Empty']);
+
+		await exportImportPage.excludeReportFilter();
+		values = await exportImportPage.getReportColumnValues('Type');
+		expect(values).toEqual(['Error']);
+
+		await exportImportPage.removeReportFilter();
+	}
+);
 
 test('Can see error report and details', async ({
 	apiHelpers,
@@ -154,29 +249,20 @@ test('Can see error report and details', async ({
 	exportImportPage,
 	globalMenuPage,
 }) => {
-	const objectDefinition =
-		await apiHelpers.objectAdmin.postRandomObjectDefinition({
-			status: {code: 0},
-		});
-
-	apiHelpers.data.push({id: objectDefinition.id, type: 'objectDefinition'});
-
-	const objectEntry = await apiHelpers.objectEntry.postObjectEntry(
-		{externalReferenceCode: '', name: objectDefinition.name},
-		normalizeRestPath(`${objectDefinition.restContextPath}`)
-	);
+	const {objectDefinition3, objectEntry} =
+		await setupImportReportScenario(apiHelpers);
 
 	await globalMenuPage.goToApplications('Export');
 
 	const exportFilePath = await exportImportPage.export({
-		portletLabels: [`${objectDefinition.name} 1 Items`],
+		portletLabels: [`${objectDefinition3.name} 1 Items`],
 	});
 
 	const objectFieldAPIClient =
 		await apiHelpers.buildRestClient(ObjectFieldAPI);
 
 	await objectFieldAPIClient.postObjectDefinitionObjectField(
-		objectDefinition.id,
+		objectDefinition3.id,
 		{
 			DBType: 'String',
 			businessType: 'Text',
@@ -234,185 +320,22 @@ test('Can see error report and details', async ({
 	).toBeVisible();
 });
 
-test(
-	'Can filter, search and sort errors report entries',
-	{tag: '@LPD-68461'},
-	async ({apiHelpers, exportImportPage}) => {
-		const {
-			objectDefinitionA,
-			objectDefinitionB,
-			objectDefinitionC,
-			objectDefinitionD,
-			objectDefinitionZ,
-			objectEntryC,
-		} = await setupImportReportScenario(apiHelpers);
-
-		await exportImportPage.goToExport();
-
-		const exportFilePath = await exportImportPage.export({
-			portletLabels: [
-				`${objectDefinitionA.name} 1 Items`,
-				`${objectDefinitionB.name} 1 Items`,
-				`${objectDefinitionZ.name} 1 Items`,
-				`${objectDefinitionD.name} 1 Items`,
-			],
-		});
-
-		const objectFieldAPIClient =
-			await apiHelpers.buildRestClient(ObjectFieldAPI);
-
-		for (const objectDefinition of [
-			objectDefinitionA,
-			objectDefinitionB,
-			objectDefinitionZ,
-		]) {
-			await objectFieldAPIClient.postObjectDefinitionObjectField(
-				objectDefinition.id,
-				{
-					DBType: 'String',
-					businessType: 'Text',
-					label: {en_US: 'mandatoryField'},
-					name: 'mandatoryField',
-					required: true,
-				}
-			);
-		}
-
-		await apiHelpers.objectEntry.deleteObjectEntry(
-			normalizeRestPath(objectDefinitionC.restContextPath),
-			String(objectEntryC.id)
-		);
-
-		const newSite = await apiHelpers.headlessAdminSite.postSite({
-			name: 'TestSite' + getRandomInt(),
-		});
-
-		await exportImportPage.goToImport(newSite.friendlyUrlPath);
-
-		await exportImportPage.import({
-			filePath: exportFilePath,
-			taskStatus: 'completedWithErrors',
-		});
-
-		const exportName = exportFilePath.slice(
-			exportFilePath.lastIndexOf('/') + 1
-		);
-
-		await exportImportPage.goToImportDetails(exportName);
-
-		// Sort by Entity Type
-
-		await exportImportPage.sortReportBy('Entity Type');
-		let values =
-			await exportImportPage.getReportColumnValues('Entity Type');
-		expect(values).toEqual([...values].sort((a, b) => a.localeCompare(b)));
-
-		await exportImportPage.sortReportBy('Entity Type');
-		values = await exportImportPage.getReportColumnValues('Entity Type');
-		expect(values).toEqual([...values].sort((a, b) => b.localeCompare(a)));
-
-		// Sort by External Reference Code
-
-		await exportImportPage.sortReportBy('External Reference Code');
-		values = await exportImportPage.getReportColumnValues(
-			'External Reference Code'
-		);
-		expect(values).toEqual([...values].sort((a, b) => a.localeCompare(b)));
-
-		await exportImportPage.sortReportBy('External Reference Code');
-		values = await exportImportPage.getReportColumnValues(
-			'External Reference Code'
-		);
-		expect(values).toEqual([...values].sort((a, b) => b.localeCompare(a)));
-
-		// Search by Entity Type name
-
-		await exportImportPage.searchReportEntries(objectDefinitionA.name);
-		values = await exportImportPage.getReportColumnValues('Entity Type');
-		expect(values).toEqual([objectDefinitionA.name]);
-
-		await exportImportPage.clearReportSearch();
-
-		// Search by External Reference Code
-
-		const ercValues = await exportImportPage.getReportColumnValues(
-			'External Reference Code'
-		);
-		const searchERC = ercValues[0];
-
-		await exportImportPage.searchReportEntries(searchERC);
-		values = await exportImportPage.getReportColumnValues(
-			'External Reference Code'
-		);
-		expect(values).toEqual([searchERC]);
-
-		await exportImportPage.clearReportSearch();
-
-		// Filter by Entity Type
-
-		await exportImportPage.filterReportBy(
-			'Entity Type',
-			objectDefinitionA.name
-		);
-		values = await exportImportPage.getReportColumnValues('Entity Type');
-		expect(values).toEqual([objectDefinitionA.name]);
-
-		await exportImportPage.removeReportFilter();
-
-		// Filter by External Reference Code
-
-		await exportImportPage.filterReportBy(
-			'External Reference Code',
-			searchERC
-		);
-		values = await exportImportPage.getReportColumnValues(
-			'External Reference Code'
-		);
-		expect(values).toEqual([searchERC]);
-
-		await exportImportPage.removeReportFilter();
-
-		// Filter by Type
-
-		await exportImportPage.filterReportBy('Type', 'Empty');
-		values = await exportImportPage.getReportColumnValues('Type');
-		expect(values).toEqual(['Empty']);
-
-		await exportImportPage.excludeReportFilter();
-		values = await exportImportPage.getReportColumnValues('Type');
-		expect(values).toEqual(['Error', 'Error', 'Error']);
-
-		await exportImportPage.removeReportFilter();
-	}
-);
-
 test('Report entries actions are not visible for a successful import', async ({
 	apiHelpers,
-	companyExportImportPage,
 	exportImportPage,
-	globalMenuPage,
 }) => {
-	const objectDefinition =
-		await apiHelpers.objectAdmin.postRandomObjectDefinition({
-			status: {code: 0},
-		});
+	const {objectDefinition1} = await setupImportReportScenario(apiHelpers);
 
-	apiHelpers.data.push({id: objectDefinition.id, type: 'objectDefinition'});
-
-	await apiHelpers.objectEntry.postObjectEntry(
-		{externalReferenceCode: '', name: objectDefinition.name},
-		normalizeRestPath(`${objectDefinition.restContextPath}`)
-	);
-
-	await globalMenuPage.goToApplications('Export');
+	await exportImportPage.goToExport();
 
 	const exportFilePath = await exportImportPage.export({
-		portletLabels: [`${objectDefinition.name} 1 Items`],
+		portletLabels: [`${objectDefinition1.name} 1 Items`],
 	});
 
-	await companyExportImportPage.import({
+	await exportImportPage.goToImport();
+
+	await exportImportPage.import({
 		filePath: exportFilePath,
-		includePermissions: true,
 	});
 
 	const exportName = exportFilePath.slice(

--- a/modules/test/playwright/tests/export-import-web/main/instance.importReport.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/instance.importReport.spec.ts
@@ -3,13 +3,18 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {ObjectFieldAPI} from '@liferay/object-admin-rest-client-js';
+import {
+	ObjectFieldAPI,
+	ObjectRelationshipAPI,
+} from '@liferay/object-admin-rest-client-js';
 import {expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {globalMenuPagesTest} from '../../../fixtures/globalMenuPagesTest';
 import {loginTest} from '../../../fixtures/loginTest';
+import {DataApiHelpers} from '../../../helpers/ApiHelpers';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
+import {getRandomInt} from '../../../utils/getRandomInt';
 import {normalizeRestPath} from '../../../utils/normalizeRestPath';
 import {companyExportImportPageTest} from './fixtures/companyExportImportPagesTest';
 import {exportImportPagesTest} from './fixtures/exportImportPagesTest';
@@ -21,6 +26,127 @@ export const test = mergeTests(
 	globalMenuPagesTest,
 	loginTest()
 );
+
+async function setupImportReportScenario(apiHelpers: DataApiHelpers) {
+	const objectDefinitionA = await _createObjectDefinition(
+		apiHelpers,
+		'A',
+		'site'
+	);
+	const objectDefinitionB = await _createObjectDefinition(
+		apiHelpers,
+		'B',
+		'site'
+	);
+	const objectDefinitionC = await _createObjectDefinition(
+		apiHelpers,
+		'C',
+		'company'
+	);
+	const objectDefinitionD = await _createObjectDefinition(
+		apiHelpers,
+		'D',
+		'site'
+	);
+	const objectDefinitionZ = await _createObjectDefinition(
+		apiHelpers,
+		'Z',
+		'site'
+	);
+
+	const relationshipName = 'rel' + getRandomInt();
+
+	await _createOneToManyRelationship(
+		apiHelpers,
+		objectDefinitionC,
+		objectDefinitionD,
+		relationshipName
+	);
+
+	await apiHelpers.objectEntry.postObjectEntry(
+		{},
+		`${normalizeRestPath(objectDefinitionA.restContextPath)}/scopes/Guest`
+	);
+
+	await apiHelpers.objectEntry.postObjectEntry(
+		{},
+		`${normalizeRestPath(objectDefinitionB.restContextPath)}/scopes/Guest`
+	);
+
+	await apiHelpers.objectEntry.postObjectEntry(
+		{},
+		`${normalizeRestPath(objectDefinitionZ.restContextPath)}/scopes/Guest`
+	);
+
+	const objectEntryC = await apiHelpers.objectEntry.postObjectEntry(
+		{},
+		normalizeRestPath(objectDefinitionC.restContextPath)
+	);
+
+	await apiHelpers.objectEntry.postObjectEntry(
+		{
+			externalReferenceCode: `ERC-D-${getRandomInt()}`,
+			[`r_${relationshipName}_c_${objectDefinitionC.name[0].toLowerCase() + objectDefinitionC.name.substring(1)}Id`]:
+				objectEntryC.id,
+		},
+		`${normalizeRestPath(objectDefinitionD.restContextPath)}/scopes/Guest`
+	);
+
+	return {
+		objectDefinitionA,
+		objectDefinitionB,
+		objectDefinitionC,
+		objectDefinitionD,
+		objectDefinitionZ,
+		objectEntryC,
+	};
+}
+
+async function _createObjectDefinition(
+	apiHelpers: DataApiHelpers,
+	prefix: string,
+	scope: 'site' | 'company'
+) {
+	const objectDefinition =
+		await apiHelpers.objectAdmin.postRandomObjectDefinition({
+			objectDefinitionExternalReferenceCode:
+				`${prefix}ObjectDefinition` + getRandomInt(),
+			scope: scope === 'site' ? 'site' : undefined,
+			status: {code: 0},
+		});
+
+	apiHelpers.data.push({id: objectDefinition.id, type: 'objectDefinition'});
+
+	return objectDefinition;
+}
+
+async function _createOneToManyRelationship(
+	apiHelpers: DataApiHelpers,
+	objectDefinition1: any,
+	objectDefinition2: any,
+	name: string
+) {
+	const objectRelationshipAPIClient = await apiHelpers.buildRestClient(
+		ObjectRelationshipAPI
+	);
+
+	await objectRelationshipAPIClient.postObjectDefinitionByExternalReferenceCodeObjectRelationship(
+		objectDefinition1.externalReferenceCode,
+		{
+			deletionType: 'disassociate',
+			label: {en_US: 'Relationship'},
+			name,
+			objectDefinitionExternalReferenceCode1:
+				objectDefinition1.externalReferenceCode,
+			objectDefinitionExternalReferenceCode2:
+				objectDefinition2.externalReferenceCode,
+			objectDefinitionId1: objectDefinition1.id,
+			objectDefinitionId2: objectDefinition2.id,
+			objectDefinitionName2: objectDefinition2.name,
+			type: 'oneToMany',
+		}
+	);
+}
 
 test('Can see error report and details', async ({
 	apiHelpers,
@@ -107,6 +233,158 @@ test('Can see error report and details', async ({
 		exportImportPage.page.getByText(objectEntry.externalReferenceCode)
 	).toBeVisible();
 });
+
+test(
+	'Can filter, search and sort errors report entries',
+	{tag: '@LPD-68461'},
+	async ({apiHelpers, exportImportPage}) => {
+		const {
+			objectDefinitionA,
+			objectDefinitionB,
+			objectDefinitionC,
+			objectDefinitionD,
+			objectDefinitionZ,
+			objectEntryC,
+		} = await setupImportReportScenario(apiHelpers);
+
+		await exportImportPage.goToExport();
+
+		const exportFilePath = await exportImportPage.export({
+			portletLabels: [
+				`${objectDefinitionA.name} 1 Items`,
+				`${objectDefinitionB.name} 1 Items`,
+				`${objectDefinitionZ.name} 1 Items`,
+				`${objectDefinitionD.name} 1 Items`,
+			],
+		});
+
+		const objectFieldAPIClient =
+			await apiHelpers.buildRestClient(ObjectFieldAPI);
+
+		for (const objectDefinition of [
+			objectDefinitionA,
+			objectDefinitionB,
+			objectDefinitionZ,
+		]) {
+			await objectFieldAPIClient.postObjectDefinitionObjectField(
+				objectDefinition.id,
+				{
+					DBType: 'String',
+					businessType: 'Text',
+					label: {en_US: 'mandatoryField'},
+					name: 'mandatoryField',
+					required: true,
+				}
+			);
+		}
+
+		await apiHelpers.objectEntry.deleteObjectEntry(
+			normalizeRestPath(objectDefinitionC.restContextPath),
+			String(objectEntryC.id)
+		);
+
+		const newSite = await apiHelpers.headlessAdminSite.postSite({
+			name: 'TestSite' + getRandomInt(),
+		});
+
+		await exportImportPage.goToImport(newSite.friendlyUrlPath);
+
+		await exportImportPage.import({
+			filePath: exportFilePath,
+			taskStatus: 'completedWithErrors',
+		});
+
+		const exportName = exportFilePath.slice(
+			exportFilePath.lastIndexOf('/') + 1
+		);
+
+		await exportImportPage.goToImportDetails(exportName);
+
+		// Sort by Entity Type
+
+		await exportImportPage.sortReportBy('Entity Type');
+		let values =
+			await exportImportPage.getReportColumnValues('Entity Type');
+		expect(values).toEqual([...values].sort((a, b) => a.localeCompare(b)));
+
+		await exportImportPage.sortReportBy('Entity Type');
+		values = await exportImportPage.getReportColumnValues('Entity Type');
+		expect(values).toEqual([...values].sort((a, b) => b.localeCompare(a)));
+
+		// Sort by External Reference Code
+
+		await exportImportPage.sortReportBy('External Reference Code');
+		values = await exportImportPage.getReportColumnValues(
+			'External Reference Code'
+		);
+		expect(values).toEqual([...values].sort((a, b) => a.localeCompare(b)));
+
+		await exportImportPage.sortReportBy('External Reference Code');
+		values = await exportImportPage.getReportColumnValues(
+			'External Reference Code'
+		);
+		expect(values).toEqual([...values].sort((a, b) => b.localeCompare(a)));
+
+		// Search by Entity Type name
+
+		await exportImportPage.searchReportEntries(objectDefinitionA.name);
+		values = await exportImportPage.getReportColumnValues('Entity Type');
+		expect(values).toEqual([objectDefinitionA.name]);
+
+		await exportImportPage.clearReportSearch();
+
+		// Search by External Reference Code
+
+		const ercValues = await exportImportPage.getReportColumnValues(
+			'External Reference Code'
+		);
+		const searchERC = ercValues[0];
+
+		await exportImportPage.searchReportEntries(searchERC);
+		values = await exportImportPage.getReportColumnValues(
+			'External Reference Code'
+		);
+		expect(values).toEqual([searchERC]);
+
+		await exportImportPage.clearReportSearch();
+
+		// Filter by Entity Type
+
+		await exportImportPage.filterReportBy(
+			'Entity Type',
+			objectDefinitionA.name
+		);
+		values = await exportImportPage.getReportColumnValues('Entity Type');
+		expect(values).toEqual([objectDefinitionA.name]);
+
+		await exportImportPage.removeReportFilter();
+
+		// Filter by External Reference Code
+
+		await exportImportPage.filterReportBy(
+			'External Reference Code',
+			searchERC
+		);
+		values = await exportImportPage.getReportColumnValues(
+			'External Reference Code'
+		);
+		expect(values).toEqual([searchERC]);
+
+		await exportImportPage.removeReportFilter();
+
+		// Filter by Type
+
+		await exportImportPage.filterReportBy('Type', 'Empty');
+		values = await exportImportPage.getReportColumnValues('Type');
+		expect(values).toEqual(['Empty']);
+
+		await exportImportPage.excludeReportFilter();
+		values = await exportImportPage.getReportColumnValues('Type');
+		expect(values).toEqual(['Error', 'Error', 'Error']);
+
+		await exportImportPage.removeReportFilter();
+	}
+);
 
 test('Report entries actions are not visible for a successful import', async ({
 	apiHelpers,

--- a/modules/test/playwright/tests/export-import-web/main/pages/ExportImportPage.ts
+++ b/modules/test/playwright/tests/export-import-web/main/pages/ExportImportPage.ts
@@ -24,9 +24,11 @@ type DateFilter = {
 export type taskStatus = 'success' | 'completedWithErrors';
 
 export class ExportImportPage {
+	readonly addFilterButton: Locator;
 	readonly allRadioButton: Locator;
 	readonly cancelButton: Locator;
 	readonly clearMenuItem: Locator;
+	readonly clearSearchButton: Locator;
 	readonly continueButton: Locator;
 	readonly copyAsNewRadioButton: Locator;
 	readonly deleteApplicationDataAlert: Locator;
@@ -35,12 +37,15 @@ export class ExportImportPage {
 	readonly deletionsLabel: Locator;
 	readonly downloadButton: Locator;
 	readonly exportButton: Locator;
+	readonly excludeSwitch: Locator;
 	readonly exportPermissionsButton: Locator;
 	readonly exportReportEntriesMenuItem: Locator;
 	readonly exportReportEntriesModal: Locator;
 	readonly exportReportEntriesModalDownloadButton: Locator;
 	readonly exportReportEntriesModalProgressbar: Locator;
 	readonly fileSelector: Locator;
+	readonly filterBackButton: Locator;
+	readonly filterButton: Locator;
 	readonly importButton: Locator;
 	readonly importModalButton: Locator;
 	readonly importPermissionsCheckbox: Locator;
@@ -58,6 +63,9 @@ export class ExportImportPage {
 	readonly rangeLast: Locator;
 	readonly rangeLastRadioButton: Locator;
 	readonly refreshCountsLink: Locator;
+	readonly removeFilterButton: Locator;
+	readonly searchButton: Locator;
+	readonly searchInput: Locator;
 	readonly taskActionsMenu: (taskName: string) => Locator;
 	readonly taskRow: (taskName: string) => Locator;
 	readonly taskStatusLabel: (
@@ -72,9 +80,14 @@ export class ExportImportPage {
 	readonly warningHeader: Locator;
 
 	constructor(page: Page) {
+		this.addFilterButton = page.getByRole('button', {name: 'Add Filter'});
 		this.allRadioButton = page.getByTestId('range_rangeAll');
 		this.cancelButton = page.getByRole('button', {name: 'Cancel'});
 		this.clearMenuItem = page.getByRole('link', {name: 'Clear'});
+		this.clearSearchButton = page.getByRole('button', {
+			exact: true,
+			name: 'Clear',
+		});
 		this.continueButton = page.getByRole('button', {name: 'Continue'});
 		this.copyAsNewRadioButton = page.getByLabel('Copy as new');
 		this.deleteApplicationDataAlert = page.locator('[role="alert"]', {
@@ -96,6 +109,7 @@ export class ExportImportPage {
 		this.exportReportEntriesMenuItem = page.getByRole('menuitem', {
 			name: 'Export Report Entries',
 		});
+		this.excludeSwitch = page.getByRole('switch', {name: 'Exclude'});
 		this.exportPermissionsButton = page.getByLabel('Export Permissions');
 		this.exportReportEntriesModal = page.getByRole('dialog', {
 			name: 'Export Report Entries',
@@ -107,6 +121,10 @@ export class ExportImportPage {
 		this.exportReportEntriesModalProgressbar =
 			this.exportReportEntriesModal.getByRole('progressbar');
 		this.fileSelector = page.getByRole('button', {name: 'Select File'});
+		this.filterBackButton = page.getByRole('button', {name: 'Back'});
+		this.filterButton = page
+			.getByTestId('managementToolbar')
+			.getByRole('button', {name: 'Filter'});
 		this.importButton = page.getByRole('button', {name: 'Import'});
 		this.importModalButton = page
 			.getByLabel('Important Info About Your Import')
@@ -174,6 +192,9 @@ export class ExportImportPage {
 		this.refreshCountsLink = page.getByRole('link', {
 			name: 'Refresh Counts',
 		});
+		this.removeFilterButton = page.getByLabel('Remove Filter');
+		this.searchButton = page.getByRole('button', {name: 'Search'});
+		this.searchInput = page.getByRole('searchbox', {name: 'Search'});
 		this.taskActionsMenu = (taskName) =>
 			this.taskRow(taskName).getByRole('button');
 		this.taskRow = (taskName) =>
@@ -614,10 +635,81 @@ export class ExportImportPage {
 		).toBeVisible();
 	}
 
+	async clearReportSearch() {
+		await this.clearSearchButton.click();
+		await this.page.waitForLoadState('networkidle');
+	}
+
+	async excludeReportFilter() {
+		await this.filterButton.click();
+		await this.excludeSwitch.check();
+		const responsePromise = this.page.waitForResponse(
+			(response) =>
+				response.url().includes('report-entries') &&
+				response.status() === 200
+		);
+		await this.addFilterButton.click();
+		await responsePromise;
+	}
+
+	async filterReportBy(category: string, value: string) {
+		await this.filterButton.click();
+		if (await this.filterBackButton.isVisible()) {
+			await this.filterBackButton.click();
+		}
+		await this.page
+			.getByRole('menuitem', {exact: true, name: category})
+			.click();
+		await this.page.getByRole('checkbox', {name: value}).check();
+		await this.addFilterButton.click();
+		await this.page.waitForLoadState('networkidle');
+	}
+
+	async getReportColumnValues(headerName: string): Promise<string[]> {
+		const header = this.page.getByRole('columnheader', {
+			exact: true,
+			name: headerName,
+		});
+		const index = await header.evaluate((node) => {
+			return (
+				Array.from(
+					(node as HTMLElement).parentElement!.children
+				).indexOf(node as HTMLElement) + 1
+			);
+		});
+
+		return this.page
+			.locator(`tbody tr td:nth-child(${index})`)
+			.allTextContents();
+	}
+
 	async openExportReportEntriesModal(exportName) {
 		await this.clickTaskAction(exportName, 'Export Report Entries');
 
 		await this.exportReportEntriesModal.waitFor();
+	}
+
+	async removeReportFilter() {
+		await this.removeFilterButton.click();
+		await this.page.waitForLoadState('networkidle');
+	}
+
+	async searchReportEntries(searchTerm: string) {
+		await this.searchInput.fill(searchTerm);
+		await this.searchButton.click();
+		await expect(
+			this.page.getByRole('button', {name: 'Clear Search'})
+		).toBeVisible({timeout: 2000});
+
+		await this.page.waitForLoadState('networkidle');
+	}
+
+	async sortReportBy(headerName: string) {
+		await this.page
+			.getByRole('columnheader', {exact: true, name: headerName})
+			.getByRole('button')
+			.click();
+		await this.page.waitForLoadState('networkidle');
 	}
 
 	async selectImportFile({

--- a/modules/test/playwright/tests/export-import-web/main/pages/ExportImportPage.ts
+++ b/modules/test/playwright/tests/export-import-web/main/pages/ExportImportPage.ts
@@ -53,6 +53,7 @@ export class ExportImportPage {
 	readonly newExportButton: Locator;
 	readonly newImportButton: Locator;
 	readonly page: Page;
+	readonly pagesFieldset: Locator;
 	readonly portletListContainer: Locator;
 	readonly productMenuPage: ProductMenuPage;
 	readonly rangeDateRangeEndDate: Locator;
@@ -137,6 +138,7 @@ export class ExportImportPage {
 		this.newExportButton = page.getByRole('link', {name: 'Custom Export'});
 		this.newImportButton = page.getByRole('link', {name: 'Import'});
 		this.page = page;
+		this.pagesFieldset = page.locator('#pages-fieldset');
 		this.portletListContainer = page
 			.locator(
 				'#_com_liferay_exportimport_web_portlet_ExportPortlet_selectContents .portlet-list'
@@ -358,6 +360,18 @@ export class ExportImportPage {
 		}
 	}
 
+	async uncheckPageSettings() {
+		await this.pagesFieldset.waitFor({state: 'attached'});
+
+		await this.pagesFieldset.evaluate((fieldset) => {
+			fieldset
+				.querySelectorAll<HTMLInputElement>(
+					'input[type="checkbox"]:checked'
+				)
+				.forEach((input) => input.click());
+		});
+	}
+
 	async uncheckPortlets() {
 		const portletListContainer = this.portletListContainer;
 
@@ -375,12 +389,14 @@ export class ExportImportPage {
 	async export({
 		dateFilter,
 		exportAllPortlets = false,
+		includePageSettings = true,
 		includePermissions = false,
 		portletLabels,
 		taskName = `Export-${getRandomString()}`,
 	}: {
 		dateFilter?: DateFilter;
 		exportAllPortlets?: boolean;
+		includePageSettings?: boolean;
 		includePermissions?: boolean;
 		portletLabels?: string[];
 		taskName?: string;
@@ -388,6 +404,10 @@ export class ExportImportPage {
 		await this.newExportButton.click();
 
 		await this.title.fill(taskName);
+
+		if (!includePageSettings) {
+			await this.uncheckPageSettings();
+		}
 
 		if (exportAllPortlets) {
 			await this.checkAllPortlets();

--- a/modules/test/playwright/tests/export-import-web/main/pages/ExportImportPage.ts
+++ b/modules/test/playwright/tests/export-import-web/main/pages/ExportImportPage.ts
@@ -66,6 +66,7 @@ export class ExportImportPage {
 	readonly removeFilterButton: Locator;
 	readonly searchButton: Locator;
 	readonly searchInput: Locator;
+	readonly showResultsButton: Locator;
 	readonly taskActionsMenu: (taskName: string) => Locator;
 	readonly taskRow: (taskName: string) => Locator;
 	readonly taskStatusLabel: (
@@ -195,6 +196,9 @@ export class ExportImportPage {
 		this.removeFilterButton = page.getByLabel('Remove Filter');
 		this.searchButton = page.getByRole('button', {name: 'Search'});
 		this.searchInput = page.getByRole('searchbox', {name: 'Search'});
+		this.showResultsButton = page.getByRole('button', {
+			name: 'Show Results',
+		});
 		this.taskActionsMenu = (taskName) =>
 			this.taskRow(taskName).getByRole('button');
 		this.taskRow = (taskName) =>
@@ -643,12 +647,12 @@ export class ExportImportPage {
 	async excludeReportFilter() {
 		await this.filterButton.click();
 		await this.excludeSwitch.check();
+		await this.showResultsButton.click();
 		const responsePromise = this.page.waitForResponse(
 			(response) =>
 				response.url().includes('report-entries') &&
 				response.status() === 200
 		);
-		await this.addFilterButton.click();
 		await responsePromise;
 	}
 

--- a/portal-impl/src/com/liferay/portal/util/LocalizationImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/LocalizationImpl.java
@@ -379,13 +379,15 @@ public class LocalizationImpl implements Localization {
 
 		Map<Locale, String> map = new HashMap<>();
 
-		String defaultValue = LanguageUtil.get(defaultLocale, key);
-
 		for (Locale locale : locales) {
-			String value = LanguageUtil.get(locale, key);
+			String value = LanguageUtil.get(locale, key, null);
 
-			if (!locale.equals(defaultLocale) && value.equals(defaultValue)) {
-				continue;
+			if (value == null) {
+				if (!locale.equals(defaultLocale)) {
+					continue;
+				}
+
+				value = key;
 			}
 
 			map.put(locale, value);


### PR DESCRIPTION



> @magjed4289
> 
> There is a 28% chance that Brian will reject this PR.
> 
> sonnet-4.6 (28% chance of rejection):
> 
> * Rule 203 (LocalizationImplTest.java, testGetLocalizationMap): `object2` is declared on the line immediately after `object1`, but its first use is at `Map<String, String> fieldMap2 = (Map<String, String>)field.get(object2)`, several local variables later (`class1`, `field`, `fieldMap1` are all declared and used in between). Per rule 203, `object2` should be declared immediately before `fieldMap2`.
> * Potential locale inconsistency (LocalizationImplTest.java, testGetLocalizationMap): setup calls `method.invoke(null, new Locale("es"))` (Spanish, no country code) but the assertion uses `localizationMap.get(LocaleUtil.SPAIN)` where `LocaleUtil.SPAIN = new Locale("es", "ES")` — a different Locale object. This appears intentional to test that `getLocalizationMap` falls back from `es_ES` to the `es` map holder, but the asymmetry is non-obvious; verify against implementation intent.
> * Potentially unused dependency (export-import-report-service/build.gradle): `com.liferay.jakarta.portlet-api` is added but no file changed in the diff for this module imports any `jakarta.portlet.*` class; verify against other non-diff files in the module to confirm the dependency is needed.
> 
> #bchan-bot-pr-review

1. `com.liferay.jakarta.portlet-api` is needed in export-import-report-service:

```
Task :apps:export-import:export-import-report-service:compileJava FAILED
/home/me/dev/projects/liferay-portal/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/internal/search/spi/model/index/contributor/ExportImportReportEntryModelDocumentContributor.java:60: error: cannot access PortletRequest
			_localization.getLocalizationMap(
			             ^
  class file for jakarta.portlet.PortletRequest not found
/home/me/dev/projects/liferay-portal/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/internal/search/spi/model/index/contributor/ExportImportReportEntryModelDocumentContributor.java:71: error: cannot access PortletPreferences
			_localization.getLocalizationMap(
			             ^
  class file for jakarta.portlet.PortletPreferences not found
Note: /home/me/dev/projects/liferay-portal/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/service/persistence/impl/ExportImportReportEntryPersistenceImpl.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: /home/me/dev/projects/liferay-portal/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/model/impl/ExportImportReportEntryModelImpl.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
2 errors

> Task :apps:object:object-api:autoUpdateXml SKIPPED
> Task :apps:portal:portal-aop-api:autoUpdateXml SKIPPED
> Task :apps:portal-search:portal-search-api:autoUpdateXml SKIPPED
> Task :apps:portal-search:portal-search-spi:autoUpdateXml SKIPPED
> Task :apps:portal-vulcan:portal-vulcan-api:autoUpdateXml SKIPPED
> Task :apps:staging:staging-api:autoUpdateXml SKIPPED
> Task :core:petra:petra-function:autoUpdateXml SKIPPED
> Task :core:petra:petra-lang:autoUpdateXml SKIPPED
> Task :core:petra:petra-sql-dsl-api:autoUpdateXml SKIPPED
> Task :core:petra:petra-string:autoUpdateXml SKIPPED
> Task :apps:static:portal:portal-upgrade-api:autoUpdateXml SKIPPED


FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':apps:export-import:export-import-report-service:compileJava'.
> Compilation failed; see the compiler error output for details.

* Try:
> Run with --info option to get more log output.
> Run with --scan to get full insights.

BUILD FAILED in 20s
225 actionable tasks: 9 executed, 216 up-to-date
```
2. The setup with `method.invoke(null, new Locale("es"))` (no country code) and the assertion with `localizationMap.get(LocaleUtil.SPAIN)` is intentional to verify es_ES correctly falls back to the `es`.