### PR TITLE
LPD-93262 Add DevCon 2026 promotional banner to root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Liferay DXP
 
+> 🚀 **See what's next and meet the team behind it at** &nbsp; [![Devcon London, November 2026 — event details and registration](https://img.shields.io/badge/Devcon%20London%20%C2%B7%20November%202026-E500BD)](https://events.liferay.com/2zo4M1?utm_source=github&utm_campaign=Github&utm_medium=organic&RefId=Github)
+
 This `liferay-portal` repository contains the source code for [Liferay DXP](https://www.liferay.com/products/dxp), Liferay's Java-based digital experience platform. Liferay Portal and Liferay DXP are now a single product. Building this repository produces a Liferay DXP bundle. The platform is maintained by Liferay engineering and a global community of contributors.
 
 ## Getting Liferay DXP


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93262

## What Is Being Fixed

The root README has no pointer to DevCon London 2026. Developers landing on the repository miss a timely invitation to the event where the roadmap is presented and the team behind the product is present.

## How It Is Being Fixed

Adds a small, time-boxed promotional banner directly below the title in the root README. The banner links to the DevCon 2026 event page (with campaign tracking parameters) and uses the event's brand color via a shields.io badge. It is scoped to the root README only and is meant to be removed after the event.

## Why Are There No Tests?

This change only touches Markdown (the root README); there is no code to test.
