### PR TITLE
LPD-82451 Consolidate friendly URL group resolution into a util

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -127,12 +127,12 @@ public class FriendlyURLServlet extends HttpServlet {
 			return new Redirect();
 		}
 
-		long companyId = PortalInstances.getCompanyId(httpServletRequest);
-
 		Group group = (Group)httpServletRequest.getAttribute(
 			WebKeys.FRIENDLY_URL_GROUP);
 		String groupFriendlyURL = (String)httpServletRequest.getAttribute(
 			WebKeys.GROUP_FRIENDLY_URL);
+
+		long companyId = PortalInstances.getCompanyId(httpServletRequest);
 
 		if (group == null) {
 			groupFriendlyURL = FriendlyURLUtil.parseGroupFriendlyURL(path);

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -81,9 +81,9 @@ import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.util.FriendlyURLUtil;
 import com.liferay.portal.util.PortalInstances;
 import com.liferay.portlet.AsyncPortletServletRequest;
-import com.liferay.portlet.documentlibrary.constants.DLFriendlyURLConstants;
 import com.liferay.redirect.provider.RedirectProvider;
 import com.liferay.redirect.tracker.RedirectNotFoundTracker;
 import com.liferay.site.model.SiteFriendlyURL;
@@ -127,30 +127,33 @@ public class FriendlyURLServlet extends HttpServlet {
 			return new Redirect();
 		}
 
-		String groupFriendlyURL = path;
-
-		int pos = path.indexOf(CharPool.SLASH, 1);
-
-		if (pos != -1) {
-			String friendlyURL = path.substring(pos);
-
-			if (friendlyURL.startsWith(
-					DLFriendlyURLConstants.PATH_PREFIX_DOCUMENT)) {
-
-				String fileEntryFriendlyURL = friendlyURL.substring(
-					DLFriendlyURLConstants.PATH_PREFIX_DOCUMENT.length() - 1);
-
-				groupFriendlyURL = fileEntryFriendlyURL.substring(
-					0, fileEntryFriendlyURL.indexOf(CharPool.SLASH, 1));
-			}
-			else {
-				groupFriendlyURL = path.substring(0, pos);
-			}
-		}
-
 		long companyId = PortalInstances.getCompanyId(httpServletRequest);
 
-		Group group = _getGroup(path, groupFriendlyURL, companyId);
+		Group group = (Group)httpServletRequest.getAttribute(
+			WebKeys.FRIENDLY_URL_GROUP);
+		String groupFriendlyURL = (String)httpServletRequest.getAttribute(
+			WebKeys.GROUP_FRIENDLY_URL);
+
+		if (group == null) {
+			groupFriendlyURL = FriendlyURLUtil.parseGroupFriendlyURL(path);
+
+			group = FriendlyURLUtil.fetchFriendlyURLGroup(
+				companyId, groupFriendlyURL);
+		}
+
+		if ((group == null) ||
+			(!group.isActive() && !groupLocalService.isMaintenanceMode(group) &&
+			 !inactiveRequestHandler.isShowInactiveRequestMessage() &&
+			 !path.startsWith(GroupConstants.CONTROL_PANEL_FRIENDLY_URL) &&
+			 !path.startsWith(
+				 groupFriendlyURL +
+					 VirtualLayoutConstants.CANONICAL_URL_SEPARATOR))) {
+
+			throw new NoSuchGroupException(
+				StringBundler.concat(
+					"{companyId=", companyId, ", friendlyURL=",
+					groupFriendlyURL, "}"));
+		}
 
 		if (!group.isActive() && groupLocalService.isMaintenanceMode(group)) {
 			User user = _getUser(httpServletRequest);
@@ -175,6 +178,8 @@ public class FriendlyURLServlet extends HttpServlet {
 
 		String layoutFriendlyURL = null;
 		Redirect redirectProviderRedirect = null;
+
+		int pos = path.indexOf(CharPool.SLASH, 1);
 
 		if ((pos != -1) && ((pos + 1) != path.length())) {
 			layoutFriendlyURL = path.substring(pos);
@@ -967,43 +972,6 @@ public class FriendlyURLServlet extends HttpServlet {
 					getCompanyFriendlyURLRedirectionConfiguration(companyId);
 
 		return friendlyURLRedirectionConfiguration.redirectionType();
-	}
-
-	private Group _getGroup(String path, String friendlyURL, long companyId)
-		throws NoSuchGroupException {
-
-		Group group = groupLocalService.fetchFriendlyURLGroup(
-			companyId, friendlyURL);
-
-		if (group == null) {
-			String screenName = friendlyURL.substring(1);
-
-			User user = userLocalService.fetchUserByScreenName(
-				companyId, screenName);
-
-			if (user != null) {
-				group = user.getGroup();
-			}
-			else if (_log.isWarnEnabled()) {
-				_log.warn("No user exists with friendly URL " + screenName);
-			}
-		}
-
-		if ((group == null) ||
-			(!group.isActive() && !groupLocalService.isMaintenanceMode(group) &&
-			 !inactiveRequestHandler.isShowInactiveRequestMessage() &&
-			 !path.startsWith(GroupConstants.CONTROL_PANEL_FRIENDLY_URL) &&
-			 !path.startsWith(
-				 friendlyURL +
-					 VirtualLayoutConstants.CANONICAL_URL_SEPARATOR))) {
-
-			throw new NoSuchGroupException(
-				StringBundler.concat(
-					"{companyId=", companyId, ", friendlyURL=", friendlyURL,
-					"}"));
-		}
-
-		return group;
 	}
 
 	private LastPath _getLastPath(

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/servlet/test/FriendlyURLServletTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/servlet/test/FriendlyURLServletTest.java
@@ -503,6 +503,23 @@ public class FriendlyURLServletTest {
 	}
 
 	@Test
+	public void testGetRedirectWithGroupInRequestAttributes() throws Throwable {
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(WebKeys.FRIENDLY_URL_GROUP, _group);
+		mockHttpServletRequest.setAttribute(
+			WebKeys.GROUP_FRIENDLY_URL, _group.getFriendlyURL());
+		mockHttpServletRequest.setPathInfo(StringPool.SLASH);
+
+		testGetRedirect(
+			mockHttpServletRequest,
+			StringPool.SLASH + RandomTestUtil.randomString() +
+				_layout.getFriendlyURL(),
+			_redirectConstructor1.newInstance(getURL(_layout)));
+	}
+
+	@Test
 	public void testGetRedirectWithI18nPath() throws Throwable {
 		testGetI18nRedirect("/fr");
 		testGetI18nRedirect("/hu");

--- a/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/virtualhost/test/VirtualHostFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/virtualhost/test/VirtualHostFilterTest.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.struts.LastPath;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -86,6 +87,25 @@ public class VirtualHostFilterTest {
 		_portalUtil.setPortal(_portal);
 
 		_virtualHostFilter.destroy();
+	}
+
+	@Test
+	public void testProcessFilterDoesNotSetGroupOnRequestForUnknownPath() {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED",
+					false)) {
+
+			MockHttpServletRequest mockHttpServletRequest = _processFilter(
+				null, StringPool.SLASH + RandomTestUtil.randomString());
+
+			Assert.assertNull(
+				mockHttpServletRequest.getAttribute(
+					WebKeys.FRIENDLY_URL_GROUP));
+			Assert.assertNull(
+				mockHttpServletRequest.getAttribute(
+					WebKeys.GROUP_FRIENDLY_URL));
+		}
 	}
 
 	@Test
@@ -216,6 +236,56 @@ public class VirtualHostFilterTest {
 		}
 	}
 
+	@Test
+	public void testProcessFilterSetsGroupOnRequestWhenLayoutSetMatches()
+		throws Exception {
+
+		String groupFriendlyURL = _getGroupFriendlyURL(_publicLayoutSet);
+
+		MockHttpServletRequest mockHttpServletRequest = _processFilter(
+			_publicLayoutSet,
+			groupFriendlyURL + StringPool.SLASH +
+				RandomTestUtil.randomString());
+
+		Group group = (Group)mockHttpServletRequest.getAttribute(
+			WebKeys.FRIENDLY_URL_GROUP);
+
+		Assert.assertEquals(_publicLayoutSet.getGroupId(), group.getGroupId());
+
+		Assert.assertEquals(
+			groupFriendlyURL,
+			mockHttpServletRequest.getAttribute(WebKeys.GROUP_FRIENDLY_URL));
+	}
+
+	@Test
+	public void testProcessFilterSetsGroupOnRequestWhenPathForwards()
+		throws Exception {
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED",
+					false)) {
+
+			String groupFriendlyURL = _getGroupFriendlyURL(_publicLayoutSet);
+
+			MockHttpServletRequest mockHttpServletRequest = _processFilter(
+				null,
+				groupFriendlyURL + StringPool.SLASH +
+					RandomTestUtil.randomString());
+
+			Group group = (Group)mockHttpServletRequest.getAttribute(
+				WebKeys.FRIENDLY_URL_GROUP);
+
+			Assert.assertEquals(
+				_publicLayoutSet.getGroupId(), group.getGroupId());
+
+			Assert.assertEquals(
+				groupFriendlyURL,
+				mockHttpServletRequest.getAttribute(
+					WebKeys.GROUP_FRIENDLY_URL));
+		}
+	}
+
 	private String _getForwardedURL(LayoutSet layoutSet, String requestURI) {
 		MockHttpServletRequest mockHttpServletRequest =
 			_getMockHttpServletRequest(layoutSet, requestURI);
@@ -308,6 +378,26 @@ public class VirtualHostFilterTest {
 		String requestURI) {
 
 		return _getMockHttpServletRequest(_publicLayoutSet, requestURI);
+	}
+
+	private MockHttpServletRequest _processFilter(
+		LayoutSet layoutSet, String requestURI) {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			_getMockHttpServletRequest(layoutSet, requestURI);
+
+		_virtualHostFilter.init(new MockFilterConfig());
+
+		ReflectionTestUtil.invoke(
+			_virtualHostFilter, "processFilter",
+			new Class<?>[] {
+				HttpServletRequest.class, HttpServletResponse.class,
+				FilterChain.class
+			},
+			mockHttpServletRequest, new MockHttpServletResponse(),
+			new MockFilterChain());
+
+		return mockHttpServletRequest;
 	}
 
 	private void _testProcessFilterLastPath(

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/FriendlyURLUtilTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/FriendlyURLUtilTest.java
@@ -1,0 +1,93 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.util.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.FriendlyURLUtil;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Dante Wang
+ */
+@RunWith(Arquillian.class)
+public class FriendlyURLUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testFetchFriendlyURLGroupWithGroupFriendlyURL()
+		throws Exception {
+
+		_group = GroupTestUtil.addGroup();
+
+		Group group = FriendlyURLUtil.fetchFriendlyURLGroup(
+			TestPropsValues.getCompanyId(), _group.getFriendlyURL());
+
+		Assert.assertEquals(_group.getGroupId(), group.getGroupId());
+	}
+
+	@Test
+	public void testFetchFriendlyURLGroupWithNullFriendlyURL()
+		throws Exception {
+
+		Assert.assertNull(
+			FriendlyURLUtil.fetchFriendlyURLGroup(
+				TestPropsValues.getCompanyId(), null));
+	}
+
+	@Test
+	public void testFetchFriendlyURLGroupWithoutMatchingGroupOrUser()
+		throws Exception {
+
+		Assert.assertNull(
+			FriendlyURLUtil.fetchFriendlyURLGroup(
+				TestPropsValues.getCompanyId(),
+				StringPool.SLASH + RandomTestUtil.randomString()));
+	}
+
+	@Test
+	public void testFetchFriendlyURLGroupWithUserScreenName() throws Exception {
+		User user = UserTestUtil.addUser();
+
+		Group userGroup = user.getGroup();
+
+		_groupLocalService.updateFriendlyURL(
+			userGroup.getGroupId(),
+			StringPool.SLASH + RandomTestUtil.randomString());
+
+		Group group = FriendlyURLUtil.fetchFriendlyURLGroup(
+			TestPropsValues.getCompanyId(),
+			StringPool.SLASH + user.getScreenName());
+
+		Assert.assertEquals(userGroup.getGroupId(), group.getGroupId());
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+}

--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 127.0.2
+Bundle-Version: 127.1.0
 CPE-Name: ${cpe.name}
 Export-Package:\
 	com.liferay.portal.bean,\

--- a/portal-impl/src/com/liferay/portal/servlet/filters/virtualhost/VirtualHostFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/virtualhost/VirtualHostFilter.java
@@ -15,7 +15,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.struts.LastPath;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
@@ -28,6 +27,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.model.impl.LayoutImpl;
 import com.liferay.portal.servlet.I18nServlet;
 import com.liferay.portal.servlet.filters.BasePortalFilter;
+import com.liferay.portal.util.FriendlyURLUtil;
 import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.webserver.WebServerServlet;
 
@@ -261,8 +261,11 @@ public class VirtualHostFilter extends BasePortalFilter {
 		}
 
 		if (layoutSet == null) {
-			Group group = _fetchGroupByFriendlyURLPrefix(
-				CompanyThreadLocal.getCompanyId(), friendlyURL);
+			String groupFriendlyURL = FriendlyURLUtil.parseGroupFriendlyURL(
+				friendlyURL);
+
+			Group group = FriendlyURLUtil.fetchFriendlyURLGroup(
+				CompanyThreadLocal.getCompanyId(), groupFriendlyURL);
 
 			if (!PropsValues.
 					LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED &&
@@ -280,6 +283,11 @@ public class VirtualHostFilter extends BasePortalFilter {
 				if (_log.isDebugEnabled()) {
 					_log.debug("Forward to " + sb.toString());
 				}
+
+				httpServletRequest.setAttribute(
+					WebKeys.FRIENDLY_URL_GROUP, group);
+				httpServletRequest.setAttribute(
+					WebKeys.GROUP_FRIENDLY_URL, groupFriendlyURL);
 
 				RequestDispatcher requestDispatcher =
 					_servletContext.getRequestDispatcher(sb.toString());
@@ -346,8 +354,18 @@ public class VirtualHostFilter extends BasePortalFilter {
 					StringPool.BLANK);
 			}
 
-			Group group = _fetchGroupByFriendlyURLPrefix(
-				companyId, friendlyURL);
+			String groupFriendlyURL = FriendlyURLUtil.parseGroupFriendlyURL(
+				friendlyURL);
+
+			Group group = FriendlyURLUtil.fetchFriendlyURLGroup(
+				companyId, groupFriendlyURL);
+
+			if (group != null) {
+				httpServletRequest.setAttribute(
+					WebKeys.FRIENDLY_URL_GROUP, group);
+				httpServletRequest.setAttribute(
+					WebKeys.GROUP_FRIENDLY_URL, groupFriendlyURL);
+			}
 
 			if (!PropsValues.
 					LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED &&
@@ -445,28 +463,6 @@ public class VirtualHostFilter extends BasePortalFilter {
 				VirtualHostFilter.class.getName(), httpServletRequest,
 				httpServletResponse, filterChain);
 		}
-	}
-
-	private Group _fetchGroupByFriendlyURLPrefix(
-		long companyId, String friendlyURL) {
-
-		if (friendlyURL.equals(StringPool.SLASH)) {
-			return null;
-		}
-
-		int index = friendlyURL.indexOf(CharPool.SLASH, 1);
-
-		String groupFriendlyURL;
-
-		if (index != -1) {
-			groupFriendlyURL = friendlyURL.substring(0, index);
-		}
-		else {
-			groupFriendlyURL = friendlyURL;
-		}
-
-		return GroupLocalServiceUtil.fetchFriendlyURLGroup(
-			companyId, groupFriendlyURL);
 	}
 
 	private String _findLanguageId(String friendlyURL) {

--- a/portal-impl/src/com/liferay/portal/util/FriendlyURLUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/FriendlyURLUtil.java
@@ -1,0 +1,80 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.util;
+
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portlet.documentlibrary.constants.DLFriendlyURLConstants;
+
+/**
+ * @author Dante Wang
+ */
+public class FriendlyURLUtil {
+
+	public static Group fetchFriendlyURLGroup(
+		long companyId, String groupFriendlyURL) {
+
+		if (groupFriendlyURL == null) {
+			return null;
+		}
+
+		Group group = GroupLocalServiceUtil.fetchFriendlyURLGroup(
+			companyId, groupFriendlyURL);
+
+		if (group != null) {
+			return group;
+		}
+
+		User user = UserLocalServiceUtil.fetchUserByScreenName(
+			companyId, groupFriendlyURL.substring(1));
+
+		if (user != null) {
+			return user.getGroup();
+		}
+
+		return null;
+	}
+
+	public static String parseGroupFriendlyURL(String path) {
+		if ((path == null) || path.equals(StringPool.SLASH)) {
+			return null;
+		}
+
+		String groupFriendlyURL = path;
+
+		int index = path.indexOf(CharPool.SLASH, 1);
+
+		if (index != -1) {
+			String pathSuffix = path.substring(index);
+
+			if (pathSuffix.startsWith(
+					DLFriendlyURLConstants.PATH_PREFIX_DOCUMENT)) {
+
+				String documentFriendlyURL = pathSuffix.substring(
+					DLFriendlyURLConstants.PATH_PREFIX_DOCUMENT.length() - 1);
+
+				index = documentFriendlyURL.indexOf(CharPool.SLASH, 1);
+
+				if (index == -1) {
+					groupFriendlyURL = documentFriendlyURL;
+				}
+				else {
+					groupFriendlyURL = documentFriendlyURL.substring(0, index);
+				}
+			}
+			else {
+				groupFriendlyURL = path.substring(0, index);
+			}
+		}
+
+		return groupFriendlyURL;
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 79.0.0
+version 79.1.0

--- a/portal-impl/test/unit/com/liferay/portal/util/FriendlyURLUtilTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/util/FriendlyURLUtilTest.java
@@ -36,7 +36,8 @@ public class FriendlyURLUtilTest {
 			FriendlyURLUtil.parseGroupFriendlyURL(
 				StringBundler.concat(
 					groupURL1, DLFriendlyURLConstants.PATH_PREFIX_DOCUMENT,
-					groupURL2.substring(1), "/file")));
+					groupURL2.substring(1), StringPool.SLASH,
+					RandomTestUtil.randomString())));
 	}
 
 	@Test
@@ -45,7 +46,10 @@ public class FriendlyURLUtilTest {
 
 		Assert.assertEquals(
 			groupURL,
-			FriendlyURLUtil.parseGroupFriendlyURL(groupURL + "/home"));
+			FriendlyURLUtil.parseGroupFriendlyURL(
+				StringBundler.concat(
+					groupURL, StringPool.SLASH,
+					RandomTestUtil.randomString())));
 	}
 
 	@Test

--- a/portal-impl/test/unit/com/liferay/portal/util/FriendlyURLUtilTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/util/FriendlyURLUtilTest.java
@@ -1,0 +1,69 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.util;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portlet.documentlibrary.constants.DLFriendlyURLConstants;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Dante Wang
+ */
+public class FriendlyURLUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testParseGroupFriendlyURLWithDocumentPathPrefix() {
+		String groupURL1 = _getGroupURL();
+		String groupURL2 = _getGroupURL();
+
+		Assert.assertEquals(
+			groupURL2,
+			FriendlyURLUtil.parseGroupFriendlyURL(
+				StringBundler.concat(
+					groupURL1, DLFriendlyURLConstants.PATH_PREFIX_DOCUMENT,
+					groupURL2.substring(1), "/file")));
+	}
+
+	@Test
+	public void testParseGroupFriendlyURLWithLayoutSuffix() {
+		String groupURL = _getGroupURL();
+
+		Assert.assertEquals(
+			groupURL,
+			FriendlyURLUtil.parseGroupFriendlyURL(groupURL + "/home"));
+	}
+
+	@Test
+	public void testParseGroupFriendlyURLWithoutSuffix() {
+		String groupURL = _getGroupURL();
+
+		Assert.assertEquals(
+			groupURL, FriendlyURLUtil.parseGroupFriendlyURL(groupURL));
+	}
+
+	@Test
+	public void testParseGroupFriendlyURLWithRoot() {
+		Assert.assertNull(
+			FriendlyURLUtil.parseGroupFriendlyURL(StringPool.SLASH));
+	}
+
+	private String _getGroupURL() {
+		return StringPool.SLASH + RandomTestUtil.randomString();
+	}
+
+}

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 184.0.1
+Bundle-Version: 184.1.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java
@@ -188,11 +188,15 @@ public interface WebKeys {
 
 	public static final String FORWARD_URL = "FORWARD_URL";
 
+	public static final String FRIENDLY_URL_GROUP = "FRIENDLY_URL_GROUP";
+
 	public static final String FTL_VARIABLES = "FTL_VARIABLES";
 
 	public static final String GOOGLE_GADGET = "GOOGLE_GADGET";
 
 	public static final String GROUP = "GROUP";
+
+	public static final String GROUP_FRIENDLY_URL = "GROUP_FRIENDLY_URL";
 
 	public static final String HTTPS_INITIAL = "HTTPS_INITIAL";
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 98.0.0
+version 98.1.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-82451

## What Is Being Fixed

The logic that resolves a `Group` from a request's friendly URL was duplicated in `VirtualHostFilter` and `FriendlyURLServlet`. Each carried its own private parsing-and-lookup code (`_fetchGroupByFriendlyURLPrefix` and `_getGroup`), and the two had drifted: only the servlet handled the document-library path prefix. Because the filter and the servlet each resolved the group independently, the same lookup ran twice for a single request.

## How It Is Being Fixed

The shared logic is extracted into a new `com.liferay.portal.util.FriendlyURLUtil` exposing `parseGroupFriendlyURL` (parse the group friendly URL from the path, including the document-library prefix case) and `fetchFriendlyURLGroup` (look up the group by friendly URL, falling back to a user screen name). Both `VirtualHostFilter` and `FriendlyURLServlet` now call this util instead of their own copies. `VirtualHostFilter` resolves the group once and stores it together with the parsed group friendly URL on the request through two new `WebKeys` (`FRIENDLY_URL_GROUP` and `GROUP_FRIENDLY_URL`); `FriendlyURLServlet` reads those attributes and only recomputes them when they are absent, removing the redundant second lookup.