### PR TITLE
LPD-88081 Fix Stable failures: regen StyleBookEntryPersistenceImpl + bump portal-kernel.service

### DIFF
--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/persistence/impl/StyleBookEntryPersistenceImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/persistence/impl/StyleBookEntryPersistenceImpl.java
@@ -2897,8 +2897,8 @@ public class StyleBookEntryPersistenceImpl
 			_SQL_SELECT_STYLEBOOKENTRY_WHERE, _SQL_COUNT_STYLEBOOKENTRY_WHERE,
 			StyleBookEntryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 			new FinderColumn<>(
-				"styleBookEntry.", "uuid", FinderColumn.Type.STRING, "=", true,
-				true, StyleBookEntry::getUuid));
+				"styleBookEntry.", "uuid", "uuid_", FinderColumn.Type.STRING,
+				"=", true, true, StyleBookEntry::getUuid));
 
 		_collectionPersistenceFinderByUuid_Head =
 			new CollectionPersistenceFinder<>(
@@ -2929,8 +2929,9 @@ public class StyleBookEntryPersistenceImpl
 				_SQL_COUNT_STYLEBOOKENTRY_WHERE,
 				StyleBookEntryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
-					"styleBookEntry.", "uuid", FinderColumn.Type.STRING, "=",
-					true, true, StyleBookEntry::getUuid),
+					"styleBookEntry.", "uuid", "uuid_",
+					FinderColumn.Type.STRING, "=", true, true,
+					StyleBookEntry::getUuid),
 				new FinderColumn<>(
 					"styleBookEntry.", "head", FinderColumn.Type.BOOLEAN, "=",
 					true, true, StyleBookEntry::isHead));
@@ -2958,8 +2959,9 @@ public class StyleBookEntryPersistenceImpl
 				_SQL_COUNT_STYLEBOOKENTRY_WHERE,
 				StyleBookEntryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
-					"styleBookEntry.", "uuid", FinderColumn.Type.STRING, "=",
-					true, true, StyleBookEntry::getUuid),
+					"styleBookEntry.", "uuid", "uuid_",
+					FinderColumn.Type.STRING, "=", true, true,
+					StyleBookEntry::getUuid),
 				new FinderColumn<>(
 					"styleBookEntry.", "groupId", FinderColumn.Type.LONG, "=",
 					true, true, StyleBookEntry::getGroupId));
@@ -2977,8 +2979,8 @@ public class StyleBookEntryPersistenceImpl
 				StyleBookEntry::getGroupId, StyleBookEntry::isHead),
 			_SQL_SELECT_STYLEBOOKENTRY_WHERE, "",
 			new FinderColumn<>(
-				"styleBookEntry.", "uuid", FinderColumn.Type.STRING, "=", true,
-				true, StyleBookEntry::getUuid),
+				"styleBookEntry.", "uuid", "uuid_", FinderColumn.Type.STRING,
+				"=", true, true, StyleBookEntry::getUuid),
 			new FinderColumn<>(
 				"styleBookEntry.", "groupId", FinderColumn.Type.LONG, "=", true,
 				true, StyleBookEntry::getGroupId),
@@ -3009,8 +3011,9 @@ public class StyleBookEntryPersistenceImpl
 				_SQL_COUNT_STYLEBOOKENTRY_WHERE,
 				StyleBookEntryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
-					"styleBookEntry.", "uuid", FinderColumn.Type.STRING, "=",
-					true, true, StyleBookEntry::getUuid),
+					"styleBookEntry.", "uuid", "uuid_",
+					FinderColumn.Type.STRING, "=", true, true,
+					StyleBookEntry::getUuid),
 				new FinderColumn<>(
 					"styleBookEntry.", "companyId", FinderColumn.Type.LONG, "=",
 					true, true, StyleBookEntry::getCompanyId));
@@ -3049,8 +3052,9 @@ public class StyleBookEntryPersistenceImpl
 				_SQL_COUNT_STYLEBOOKENTRY_WHERE,
 				StyleBookEntryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
 				new FinderColumn<>(
-					"styleBookEntry.", "uuid", FinderColumn.Type.STRING, "=",
-					true, true, StyleBookEntry::getUuid),
+					"styleBookEntry.", "uuid", "uuid_",
+					FinderColumn.Type.STRING, "=", true, true,
+					StyleBookEntry::getUuid),
 				new FinderColumn<>(
 					"styleBookEntry.", "companyId", FinderColumn.Type.LONG, "=",
 					true, true, StyleBookEntry::getCompanyId),
@@ -3676,4 +3680,4 @@ public class StyleBookEntryPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1514538721
+// LIFERAY-SERVICE-BUILDER-HASH:745950

--- a/portal-kernel/src/com/liferay/portal/kernel/model/impl/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/impl/packageinfo
@@ -1,1 +1,1 @@
-version 15.1.0
+version 15.2.0

--- a/portal-kernel/src/com/liferay/portal/kernel/model/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/packageinfo
@@ -1,1 +1,1 @@
-version 50.0.0
+version 50.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 53.0.0
+version 54.0.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88081

Follow-up fixing the two Stable failures reported on https://github.com/brianchandotcom/liferay-portal/pull/175869 (range b03e827..64093dc).

## What Is Being Fixed

1. **Service Builder regen — StyleBookEntryPersistenceImpl is stale.** The new FinderColumn `dbColumnName` constructor (LPD-92139) requires the uuid finder columns to be emitted as `new FinderColumn<>("styleBookEntry.", "uuid", "uuid_", ...)`. The stylebook PR landed an older form (`new FinderColumn<>("styleBookEntry.", "uuid", FinderColumn.Type.STRING, ...)`), which now diverges from what Service Builder emits.

2. **Semantic versioning baseline on portal-kernel.** The `LayoutLocalService` and `LayoutService` interfaces lost `updateStyleBookEntryERC` (renamed to `updateStyleBookEntry`) and `updateLayout` was widened by one parameter. Both are binary-incompatible changes on exported interfaces. The `com.liferay.portal.kernel.service` package version was not bumped accordingly.

## How It Is Being Fixed

Two commits, mirroring the pattern of the original PR's regen / bump split:

- `LPD-88081 portal-impl build-service-portal` — re-runs `ant build-service-portal` so the SB output is consistent with the current SB tool. It updates `StyleBookEntryPersistenceImpl` to use the new FinderColumn constructor and minor-bumps the auto-generated `model` and `model/impl` packageinfos.
- `LPD-88081 Bump portal-kernel.service to 54.0.0` — major bump on `com.liferay.portal.kernel.service` to cover the binary-incompatible interface changes.

## Why Are There No Tests?

This is a Service Builder regen plus a packageinfo bump. The behavior is identical to what the original PR intended; the change exists only to satisfy the SB output check and the bnd baseline check that started failing after the original PR merged.