### PR TITLE
LPD-75909 Cap FragmentEntryVersion at 10 per ctCollection

### DIFF
--- a/modules/apps/fragment/fragment-service/bnd.bnd
+++ b/modules/apps/fragment/fragment-service/bnd.bnd
@@ -5,6 +5,6 @@ Import-Package:\
 	com.liferay.fragment.util.comparator,\
 	\
 	*
-Liferay-Require-SchemaVersion: 3.0.2
+Liferay-Require-SchemaVersion: 3.0.3
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/fragment/fragment-service/build.gradle
+++ b/modules/apps/fragment/fragment-service/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:asset:asset-info-display-api")
 	compileOnly project(":apps:asset:asset-list-api")
+	compileOnly project(":apps:change-tracking:change-tracking-api")
 	compileOnly project(":apps:change-tracking:change-tracking-spi")
 	compileOnly project(":apps:document-library:document-library-api")
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/change/tracking/spi/listener/FragmentEntryVersionCTEventListener.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/change/tracking/spi/listener/FragmentEntryVersionCTEventListener.java
@@ -6,25 +6,22 @@
 package com.liferay.fragment.internal.change.tracking.spi.listener;
 
 import com.liferay.change.tracking.constants.CTConstants;
-import com.liferay.change.tracking.model.CTEntry;
-import com.liferay.change.tracking.service.CTEntryLocalService;
 import com.liferay.change.tracking.spi.listener.CTEventListener;
 import com.liferay.fragment.internal.constants.FragmentConstants;
 import com.liferay.fragment.model.FragmentEntryVersion;
 import com.liferay.fragment.model.FragmentEntryVersionTable;
 import com.liferay.fragment.service.persistence.FragmentEntryVersionPersistence;
-import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
-import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.sql.dsl.query.DSLQuery;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.transaction.Propagation;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
-import com.liferay.portal.kernel.transaction.TransactionConfig;
-import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
-import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.GetterUtil;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -37,79 +34,102 @@ public class FragmentEntryVersionCTEventListener implements CTEventListener {
 
 	@Override
 	public void onAfterPublish(long ctCollectionId) {
-		List<CTEntry> ctEntries = _ctEntryLocalService.getCTEntries(
-			ctCollectionId, _portal.getClassNameId(FragmentEntryVersion.class));
+		Map<Long, Integer> fragmentEntryVersionCountByFragmentEntryIdMap =
+			_fragmentEntryVersionCountByCtCollectionIdMap.remove(
+				ctCollectionId);
 
-		if (ctEntries.isEmpty()) {
+		if (fragmentEntryVersionCountByFragmentEntryIdMap == null) {
 			return;
 		}
 
-		TransactionCommitCallbackUtil.registerCallback(
-			() -> {
-				try {
-					TransactionInvokerUtil.invoke(
-						_transactionConfig,
-						() -> _removeFragmentEntryVersions(ctEntries));
-				}
-				catch (Throwable throwable) {
-					if (_log.isWarnEnabled()) {
-						_log.warn(
-							StringBundler.concat(
-								"Unable to remove old fragment entry versions ",
-								"after publishing change tracking collection ",
-								"ID ", ctCollectionId),
-							throwable);
-					}
-				}
+		for (Map.Entry<Long, Integer> entry :
+				fragmentEntryVersionCountByFragmentEntryIdMap.entrySet()) {
 
-				return null;
-			});
+			_removeFragmentEntryVersions(entry.getKey(), entry.getValue());
+		}
 	}
 
-	private void _removeFragmentEntryVersions(List<CTEntry> ctEntries) {
-		List<Long> fragmentEntryIds = _fragmentEntryVersionPersistence.dslQuery(
-			DSLQueryFactoryUtil.selectDistinct(
-				FragmentEntryVersionTable.INSTANCE.fragmentEntryId
+	@Override
+	public void onBeforePublish(long ctCollectionId) {
+		Map<Long, Integer> fragmentEntryVersionCountByFragmentEntryIdMap =
+			_getFragmentEntryVersionCountByFragmentEntryIdMap(ctCollectionId);
+
+		if (fragmentEntryVersionCountByFragmentEntryIdMap.isEmpty()) {
+			return;
+		}
+
+		_fragmentEntryVersionCountByCtCollectionIdMap.put(
+			ctCollectionId, fragmentEntryVersionCountByFragmentEntryIdMap);
+	}
+
+	private Map<Long, Integer>
+		_getFragmentEntryVersionCountByFragmentEntryIdMap(long ctCollectionId) {
+
+		Map<Long, Integer> fragmentEntryVersionCountByFragmentEntryIdMap =
+			new HashMap<>();
+
+		DSLQuery dslQuery = DSLQueryFactoryUtil.select(
+			FragmentEntryVersionTable.INSTANCE.fragmentEntryId,
+			DSLFunctionFactoryUtil.count(
+				FragmentEntryVersionTable.INSTANCE.fragmentEntryVersionId
+			).as(
+				"fragmentEntryVersionCount"
+			)
+		).from(
+			FragmentEntryVersionTable.INSTANCE
+		).where(
+			FragmentEntryVersionTable.INSTANCE.ctCollectionId.eq(ctCollectionId)
+		).groupBy(
+			FragmentEntryVersionTable.INSTANCE.fragmentEntryId
+		);
+
+		for (Object[] values :
+				(List<Object[]>)_fragmentEntryVersionPersistence.dslQuery(
+					dslQuery)) {
+
+			long fragmentEntryId = GetterUtil.getLong(values[0]);
+			int fragmentEntryVersionCount = GetterUtil.getInteger(values[1]);
+
+			fragmentEntryVersionCountByFragmentEntryIdMap.put(
+				fragmentEntryId, fragmentEntryVersionCount);
+		}
+
+		return fragmentEntryVersionCountByFragmentEntryIdMap;
+	}
+
+	private List<FragmentEntryVersion> _getRemovableFragmentEntryVersions(
+		long fragmentEntryId, int fragmentEntryVersionCount) {
+
+		return _fragmentEntryVersionPersistence.dslQuery(
+			DSLQueryFactoryUtil.select(
+				FragmentEntryVersionTable.INSTANCE
 			).from(
 				FragmentEntryVersionTable.INSTANCE
 			).where(
 				FragmentEntryVersionTable.INSTANCE.ctCollectionId.eq(
 					CTConstants.CT_COLLECTION_ID_PRODUCTION
 				).and(
-					FragmentEntryVersionTable.INSTANCE.fragmentEntryVersionId.
-						in(
-							TransformUtil.transformToArray(
-								ctEntries, CTEntry::getModelClassPK,
-								Long.class))
+					FragmentEntryVersionTable.INSTANCE.fragmentEntryId.eq(
+						fragmentEntryId)
 				)
+			).orderBy(
+				FragmentEntryVersionTable.INSTANCE.version.descending()
+			).limit(
+				Math.max(
+					0,
+					FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT -
+						fragmentEntryVersionCount),
+				Integer.MAX_VALUE
 			));
-
-		for (long fragmentEntryId : fragmentEntryIds) {
-			_removeFragmentEntryVersions(fragmentEntryId);
-		}
 	}
 
-	private void _removeFragmentEntryVersions(long fragmentEntryId) {
+	private void _removeFragmentEntryVersions(
+		long fragmentEntryId, int fragmentEntryVersionCount) {
+
 		try {
 			List<FragmentEntryVersion> fragmentEntryVersions =
-				_fragmentEntryVersionPersistence.dslQuery(
-					DSLQueryFactoryUtil.select(
-						FragmentEntryVersionTable.INSTANCE
-					).from(
-						FragmentEntryVersionTable.INSTANCE
-					).where(
-						FragmentEntryVersionTable.INSTANCE.ctCollectionId.eq(
-							CTConstants.CT_COLLECTION_ID_PRODUCTION
-						).and(
-							FragmentEntryVersionTable.INSTANCE.fragmentEntryId.
-								eq(fragmentEntryId)
-						)
-					).orderBy(
-						FragmentEntryVersionTable.INSTANCE.version.descending()
-					).limit(
-						FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT,
-						Integer.MAX_VALUE
-					));
+				_getRemovableFragmentEntryVersions(
+					fragmentEntryId, fragmentEntryVersionCount);
 
 			for (FragmentEntryVersion fragmentEntryVersion :
 					fragmentEntryVersions) {
@@ -130,17 +150,11 @@ public class FragmentEntryVersionCTEventListener implements CTEventListener {
 	private static final Log _log = LogFactoryUtil.getLog(
 		FragmentEntryVersionCTEventListener.class);
 
-	private static final TransactionConfig _transactionConfig =
-		TransactionConfig.Factory.create(
-			Propagation.REQUIRES_NEW, new Class<?>[] {Exception.class});
-
-	@Reference
-	private CTEntryLocalService _ctEntryLocalService;
+	private final Map<Long, Map<Long, Integer>>
+		_fragmentEntryVersionCountByCtCollectionIdMap =
+			new ConcurrentHashMap<>();
 
 	@Reference
 	private FragmentEntryVersionPersistence _fragmentEntryVersionPersistence;
-
-	@Reference
-	private Portal _portal;
 
 }

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/change/tracking/spi/listener/FragmentEntryVersionCTEventListener.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/change/tracking/spi/listener/FragmentEntryVersionCTEventListener.java
@@ -66,7 +66,7 @@ public class FragmentEntryVersionCTEventListener implements CTEventListener {
 			});
 	}
 
-	private Void _removeFragmentEntryVersions(List<CTEntry> ctEntries) {
+	private void _removeFragmentEntryVersions(List<CTEntry> ctEntries) {
 		List<Long> fragmentEntryIds = _fragmentEntryVersionPersistence.dslQuery(
 			DSLQueryFactoryUtil.selectDistinct(
 				FragmentEntryVersionTable.INSTANCE.fragmentEntryId
@@ -87,8 +87,6 @@ public class FragmentEntryVersionCTEventListener implements CTEventListener {
 		for (long fragmentEntryId : fragmentEntryIds) {
 			_removeFragmentEntryVersions(fragmentEntryId);
 		}
-
-		return null;
 	}
 
 	private void _removeFragmentEntryVersions(long fragmentEntryId) {

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/change/tracking/spi/listener/FragmentEntryVersionCTEventListener.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/change/tracking/spi/listener/FragmentEntryVersionCTEventListener.java
@@ -1,0 +1,148 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.internal.change.tracking.spi.listener;
+
+import com.liferay.change.tracking.constants.CTConstants;
+import com.liferay.change.tracking.model.CTEntry;
+import com.liferay.change.tracking.service.CTEntryLocalService;
+import com.liferay.change.tracking.spi.listener.CTEventListener;
+import com.liferay.fragment.internal.constants.FragmentConstants;
+import com.liferay.fragment.model.FragmentEntryVersion;
+import com.liferay.fragment.model.FragmentEntryVersionTable;
+import com.liferay.fragment.service.persistence.FragmentEntryVersionPersistence;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
+import com.liferay.portal.kernel.util.Portal;
+
+import java.util.List;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Rubén Pulido
+ */
+@Component(service = CTEventListener.class)
+public class FragmentEntryVersionCTEventListener implements CTEventListener {
+
+	@Override
+	public void onAfterPublish(long ctCollectionId) {
+		List<CTEntry> ctEntries = _ctEntryLocalService.getCTEntries(
+			ctCollectionId, _portal.getClassNameId(FragmentEntryVersion.class));
+
+		if (ctEntries.isEmpty()) {
+			return;
+		}
+
+		TransactionCommitCallbackUtil.registerCallback(
+			() -> {
+				try {
+					TransactionInvokerUtil.invoke(
+						_transactionConfig,
+						() -> _removeFragmentEntryVersions(ctEntries));
+				}
+				catch (Throwable throwable) {
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							StringBundler.concat(
+								"Unable to remove old fragment entry versions ",
+								"after publishing change tracking collection ",
+								"ID ", ctCollectionId),
+							throwable);
+					}
+				}
+
+				return null;
+			});
+	}
+
+	private Void _removeFragmentEntryVersions(List<CTEntry> ctEntries) {
+		List<Long> fragmentEntryIds = _fragmentEntryVersionPersistence.dslQuery(
+			DSLQueryFactoryUtil.selectDistinct(
+				FragmentEntryVersionTable.INSTANCE.fragmentEntryId
+			).from(
+				FragmentEntryVersionTable.INSTANCE
+			).where(
+				FragmentEntryVersionTable.INSTANCE.ctCollectionId.eq(
+					CTConstants.CT_COLLECTION_ID_PRODUCTION
+				).and(
+					FragmentEntryVersionTable.INSTANCE.fragmentEntryVersionId.
+						in(
+							TransformUtil.transformToArray(
+								ctEntries, CTEntry::getModelClassPK,
+								Long.class))
+				)
+			));
+
+		for (long fragmentEntryId : fragmentEntryIds) {
+			_removeFragmentEntryVersions(fragmentEntryId);
+		}
+
+		return null;
+	}
+
+	private void _removeFragmentEntryVersions(long fragmentEntryId) {
+		try {
+			List<FragmentEntryVersion> fragmentEntryVersions =
+				_fragmentEntryVersionPersistence.dslQuery(
+					DSLQueryFactoryUtil.select(
+						FragmentEntryVersionTable.INSTANCE
+					).from(
+						FragmentEntryVersionTable.INSTANCE
+					).where(
+						FragmentEntryVersionTable.INSTANCE.ctCollectionId.eq(
+							CTConstants.CT_COLLECTION_ID_PRODUCTION
+						).and(
+							FragmentEntryVersionTable.INSTANCE.fragmentEntryId.
+								eq(fragmentEntryId)
+						)
+					).orderBy(
+						FragmentEntryVersionTable.INSTANCE.version.descending()
+					).limit(
+						FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT,
+						Integer.MAX_VALUE
+					));
+
+			for (FragmentEntryVersion fragmentEntryVersion :
+					fragmentEntryVersions) {
+
+				_fragmentEntryVersionPersistence.remove(fragmentEntryVersion);
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to remove old fragment entry versions for " +
+						"fragment entry ID " + fragmentEntryId,
+					exception);
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		FragmentEntryVersionCTEventListener.class);
+
+	private static final TransactionConfig _transactionConfig =
+		TransactionConfig.Factory.create(
+			Propagation.REQUIRES_NEW, new Class<?>[] {Exception.class});
+
+	@Reference
+	private CTEntryLocalService _ctEntryLocalService;
+
+	@Reference
+	private FragmentEntryVersionPersistence _fragmentEntryVersionPersistence;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/change/tracking/spi/listener/FragmentEntryVersionCTEventListener.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/change/tracking/spi/listener/FragmentEntryVersionCTEventListener.java
@@ -120,7 +120,7 @@ public class FragmentEntryVersionCTEventListener implements CTEventListener {
 			).limit(
 				Math.max(
 					0,
-					FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT -
+					FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX -
 						fragmentEntryVersionCount),
 				Integer.MAX_VALUE
 			));

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/change/tracking/spi/listener/FragmentEntryVersionCTEventListener.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/change/tracking/spi/listener/FragmentEntryVersionCTEventListener.java
@@ -55,6 +55,9 @@ public class FragmentEntryVersionCTEventListener implements CTEventListener {
 			_getFragmentEntryVersionCountByFragmentEntryIdMap(ctCollectionId);
 
 		if (fragmentEntryVersionCountByFragmentEntryIdMap.isEmpty()) {
+			_fragmentEntryVersionCountByCtCollectionIdMap.remove(
+				ctCollectionId);
+
 			return;
 		}
 

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/change/tracking/spi/listener/FragmentEntryVersionCTEventListener.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/change/tracking/spi/listener/FragmentEntryVersionCTEventListener.java
@@ -137,12 +137,12 @@ public class FragmentEntryVersionCTEventListener implements CTEventListener {
 			FragmentEntryVersionTable.INSTANCE.fragmentEntryId
 		);
 
-		for (Object[] values :
+		for (Object[] array :
 				(List<Object[]>)_fragmentEntryVersionPersistence.dslQuery(
 					dslQuery)) {
 
-			long fragmentEntryId = GetterUtil.getLong(values[0]);
-			int fragmentEntryVersionCount = GetterUtil.getInteger(values[1]);
+			long fragmentEntryId = GetterUtil.getLong(array[0]);
+			int fragmentEntryVersionCount = GetterUtil.getInteger(array[1]);
 
 			fragmentEntryVersionCountByFragmentEntryIdMap.put(
 				fragmentEntryId, fragmentEntryVersionCount);

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/change/tracking/spi/listener/FragmentEntryVersionCTEventListener.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/change/tracking/spi/listener/FragmentEntryVersionCTEventListener.java
@@ -7,7 +7,7 @@ package com.liferay.fragment.internal.change.tracking.spi.listener;
 
 import com.liferay.change.tracking.constants.CTConstants;
 import com.liferay.change.tracking.spi.listener.CTEventListener;
-import com.liferay.fragment.internal.constants.FragmentConstants;
+import com.liferay.fragment.internal.constants.FragmentEntryVersionConstants;
 import com.liferay.fragment.model.FragmentEntryVersion;
 import com.liferay.fragment.model.FragmentEntryVersionTable;
 import com.liferay.fragment.service.persistence.FragmentEntryVersionPersistence;
@@ -134,8 +134,9 @@ public class FragmentEntryVersionCTEventListener implements CTEventListener {
 			).limit(
 				Math.max(
 					0,
-					FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX -
-						fragmentEntryVersionCount),
+					FragmentEntryVersionConstants.
+						FRAGMENT_ENTRY_VERSIONS_COUNT_MAX -
+							fragmentEntryVersionCount),
 				Integer.MAX_VALUE
 			));
 	}

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/change/tracking/spi/listener/FragmentEntryVersionCTEventListener.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/change/tracking/spi/listener/FragmentEntryVersionCTEventListener.java
@@ -143,8 +143,8 @@ public class FragmentEntryVersionCTEventListener implements CTEventListener {
 		catch (Exception exception) {
 			if (_log.isWarnEnabled()) {
 				_log.warn(
-					"Unable to remove old fragment entry versions for " +
-						"fragment entry ID " + fragmentEntryId,
+					"Unable to remove old versions for fragment entry " +
+						fragmentEntryId,
 					exception);
 			}
 		}

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/change/tracking/spi/listener/FragmentEntryVersionCTEventListener.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/change/tracking/spi/listener/FragmentEntryVersionCTEventListener.java
@@ -35,35 +35,28 @@ public class FragmentEntryVersionCTEventListener implements CTEventListener {
 
 	@Override
 	public void onAfterPublish(long ctCollectionId) {
-		Map<Long, Integer> fragmentEntryVersionCountByFragmentEntryIdMap =
-			_fragmentEntryVersionCountByCtCollectionIdMap.remove(
-				ctCollectionId);
+		Map<Long, Integer> counts = _countsMap.remove(ctCollectionId);
 
-		if (fragmentEntryVersionCountByFragmentEntryIdMap == null) {
+		if (counts == null) {
 			return;
 		}
 
-		for (Map.Entry<Long, Integer> entry :
-				fragmentEntryVersionCountByFragmentEntryIdMap.entrySet()) {
-
+		for (Map.Entry<Long, Integer> entry : counts.entrySet()) {
 			_deleteFragmentEntryVersions(entry.getKey(), entry.getValue());
 		}
 	}
 
 	@Override
 	public void onBeforePublish(long ctCollectionId) {
-		Map<Long, Integer> fragmentEntryVersionCountByFragmentEntryIdMap =
-			_getFragmentEntryVersionCountByFragmentEntryIdMap(ctCollectionId);
+		Map<Long, Integer> counts = _getCounts(ctCollectionId);
 
-		if (MapUtil.isEmpty(fragmentEntryVersionCountByFragmentEntryIdMap)) {
-			_fragmentEntryVersionCountByCtCollectionIdMap.remove(
-				ctCollectionId);
+		if (MapUtil.isEmpty(counts)) {
+			_countsMap.remove(ctCollectionId);
 
 			return;
 		}
 
-		_fragmentEntryVersionCountByCtCollectionIdMap.put(
-			ctCollectionId, fragmentEntryVersionCountByFragmentEntryIdMap);
+		_countsMap.put(ctCollectionId, counts);
 	}
 
 	private void _deleteFragmentEntryVersions(
@@ -88,6 +81,37 @@ public class FragmentEntryVersionCTEventListener implements CTEventListener {
 					exception);
 			}
 		}
+	}
+
+	private Map<Long, Integer> _getCounts(long ctCollectionId) {
+		Map<Long, Integer> counts = new HashMap<>();
+
+		DSLQuery dslQuery = DSLQueryFactoryUtil.select(
+			FragmentEntryVersionTable.INSTANCE.fragmentEntryId,
+			DSLFunctionFactoryUtil.count(
+				FragmentEntryVersionTable.INSTANCE.fragmentEntryVersionId
+			).as(
+				"fragmentEntryVersionCount"
+			)
+		).from(
+			FragmentEntryVersionTable.INSTANCE
+		).where(
+			FragmentEntryVersionTable.INSTANCE.ctCollectionId.eq(ctCollectionId)
+		).groupBy(
+			FragmentEntryVersionTable.INSTANCE.fragmentEntryId
+		);
+
+		for (Object[] array :
+				(List<Object[]>)_fragmentEntryVersionPersistence.dslQuery(
+					dslQuery)) {
+
+			long fragmentEntryId = GetterUtil.getLong(array[0]);
+			int fragmentEntryVersionCount = GetterUtil.getInteger(array[1]);
+
+			counts.put(fragmentEntryId, fragmentEntryVersionCount);
+		}
+
+		return counts;
 	}
 
 	private List<FragmentEntryVersion> _getDeletableFragmentEntryVersions(
@@ -116,47 +140,11 @@ public class FragmentEntryVersionCTEventListener implements CTEventListener {
 			));
 	}
 
-	private Map<Long, Integer>
-		_getFragmentEntryVersionCountByFragmentEntryIdMap(long ctCollectionId) {
-
-		Map<Long, Integer> fragmentEntryVersionCountByFragmentEntryIdMap =
-			new HashMap<>();
-
-		DSLQuery dslQuery = DSLQueryFactoryUtil.select(
-			FragmentEntryVersionTable.INSTANCE.fragmentEntryId,
-			DSLFunctionFactoryUtil.count(
-				FragmentEntryVersionTable.INSTANCE.fragmentEntryVersionId
-			).as(
-				"fragmentEntryVersionCount"
-			)
-		).from(
-			FragmentEntryVersionTable.INSTANCE
-		).where(
-			FragmentEntryVersionTable.INSTANCE.ctCollectionId.eq(ctCollectionId)
-		).groupBy(
-			FragmentEntryVersionTable.INSTANCE.fragmentEntryId
-		);
-
-		for (Object[] array :
-				(List<Object[]>)_fragmentEntryVersionPersistence.dslQuery(
-					dslQuery)) {
-
-			long fragmentEntryId = GetterUtil.getLong(array[0]);
-			int fragmentEntryVersionCount = GetterUtil.getInteger(array[1]);
-
-			fragmentEntryVersionCountByFragmentEntryIdMap.put(
-				fragmentEntryId, fragmentEntryVersionCount);
-		}
-
-		return fragmentEntryVersionCountByFragmentEntryIdMap;
-	}
-
 	private static final Log _log = LogFactoryUtil.getLog(
 		FragmentEntryVersionCTEventListener.class);
 
-	private final Map<Long, Map<Long, Integer>>
-		_fragmentEntryVersionCountByCtCollectionIdMap =
-			new ConcurrentHashMap<>();
+	private final Map<Long, Map<Long, Integer>> _countsMap =
+		new ConcurrentHashMap<>();
 
 	@Reference
 	private FragmentEntryVersionPersistence _fragmentEntryVersionPersistence;

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/change/tracking/spi/listener/FragmentEntryVersionCTEventListener.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/change/tracking/spi/listener/FragmentEntryVersionCTEventListener.java
@@ -46,7 +46,7 @@ public class FragmentEntryVersionCTEventListener implements CTEventListener {
 		for (Map.Entry<Long, Integer> entry :
 				fragmentEntryVersionCountByFragmentEntryIdMap.entrySet()) {
 
-			_removeFragmentEntryVersions(entry.getKey(), entry.getValue());
+			_deleteFragmentEntryVersions(entry.getKey(), entry.getValue());
 		}
 	}
 
@@ -64,6 +64,56 @@ public class FragmentEntryVersionCTEventListener implements CTEventListener {
 
 		_fragmentEntryVersionCountByCtCollectionIdMap.put(
 			ctCollectionId, fragmentEntryVersionCountByFragmentEntryIdMap);
+	}
+
+	private void _deleteFragmentEntryVersions(
+		long fragmentEntryId, int fragmentEntryVersionCount) {
+
+		try {
+			List<FragmentEntryVersion> fragmentEntryVersions =
+				_getDeletableFragmentEntryVersions(
+					fragmentEntryId, fragmentEntryVersionCount);
+
+			for (FragmentEntryVersion fragmentEntryVersion :
+					fragmentEntryVersions) {
+
+				_fragmentEntryVersionPersistence.remove(fragmentEntryVersion);
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to delete old fragment entry versions for " +
+						"fragment entry ID " + fragmentEntryId,
+					exception);
+			}
+		}
+	}
+
+	private List<FragmentEntryVersion> _getDeletableFragmentEntryVersions(
+		long fragmentEntryId, int fragmentEntryVersionCount) {
+
+		return _fragmentEntryVersionPersistence.dslQuery(
+			DSLQueryFactoryUtil.select(
+				FragmentEntryVersionTable.INSTANCE
+			).from(
+				FragmentEntryVersionTable.INSTANCE
+			).where(
+				FragmentEntryVersionTable.INSTANCE.ctCollectionId.eq(
+					CTConstants.CT_COLLECTION_ID_PRODUCTION
+				).and(
+					FragmentEntryVersionTable.INSTANCE.fragmentEntryId.eq(
+						fragmentEntryId)
+				)
+			).orderBy(
+				FragmentEntryVersionTable.INSTANCE.version.descending()
+			).limit(
+				Math.max(
+					0,
+					FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX -
+						fragmentEntryVersionCount),
+				Integer.MAX_VALUE
+			));
 	}
 
 	private Map<Long, Integer>
@@ -99,56 +149,6 @@ public class FragmentEntryVersionCTEventListener implements CTEventListener {
 		}
 
 		return fragmentEntryVersionCountByFragmentEntryIdMap;
-	}
-
-	private List<FragmentEntryVersion> _getRemovableFragmentEntryVersions(
-		long fragmentEntryId, int fragmentEntryVersionCount) {
-
-		return _fragmentEntryVersionPersistence.dslQuery(
-			DSLQueryFactoryUtil.select(
-				FragmentEntryVersionTable.INSTANCE
-			).from(
-				FragmentEntryVersionTable.INSTANCE
-			).where(
-				FragmentEntryVersionTable.INSTANCE.ctCollectionId.eq(
-					CTConstants.CT_COLLECTION_ID_PRODUCTION
-				).and(
-					FragmentEntryVersionTable.INSTANCE.fragmentEntryId.eq(
-						fragmentEntryId)
-				)
-			).orderBy(
-				FragmentEntryVersionTable.INSTANCE.version.descending()
-			).limit(
-				Math.max(
-					0,
-					FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX -
-						fragmentEntryVersionCount),
-				Integer.MAX_VALUE
-			));
-	}
-
-	private void _removeFragmentEntryVersions(
-		long fragmentEntryId, int fragmentEntryVersionCount) {
-
-		try {
-			List<FragmentEntryVersion> fragmentEntryVersions =
-				_getRemovableFragmentEntryVersions(
-					fragmentEntryId, fragmentEntryVersionCount);
-
-			for (FragmentEntryVersion fragmentEntryVersion :
-					fragmentEntryVersions) {
-
-				_fragmentEntryVersionPersistence.remove(fragmentEntryVersion);
-			}
-		}
-		catch (Exception exception) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(
-					"Unable to remove old fragment entry versions for " +
-						"fragment entry ID " + fragmentEntryId,
-					exception);
-			}
-		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/change/tracking/spi/listener/FragmentEntryVersionCTEventListener.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/change/tracking/spi/listener/FragmentEntryVersionCTEventListener.java
@@ -17,6 +17,7 @@ import com.liferay.petra.sql.dsl.query.DSLQuery;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 
 import java.util.HashMap;
 import java.util.List;
@@ -54,7 +55,7 @@ public class FragmentEntryVersionCTEventListener implements CTEventListener {
 		Map<Long, Integer> fragmentEntryVersionCountByFragmentEntryIdMap =
 			_getFragmentEntryVersionCountByFragmentEntryIdMap(ctCollectionId);
 
-		if (fragmentEntryVersionCountByFragmentEntryIdMap.isEmpty()) {
+		if (MapUtil.isEmpty(fragmentEntryVersionCountByFragmentEntryIdMap)) {
 			_fragmentEntryVersionCountByCtCollectionIdMap.remove(
 				ctCollectionId);
 

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/change/tracking/spi/listener/FragmentEntryVersionCTEventListener.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/change/tracking/spi/listener/FragmentEntryVersionCTEventListener.java
@@ -143,8 +143,8 @@ public class FragmentEntryVersionCTEventListener implements CTEventListener {
 		catch (Exception exception) {
 			if (_log.isWarnEnabled()) {
 				_log.warn(
-					"Unable to remove old versions for fragment entry " +
-						fragmentEntryId,
+					"Unable to remove old fragment entry versions for " +
+						"fragment entry ID " + fragmentEntryId,
 					exception);
 			}
 		}

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/constants/FragmentConstants.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/constants/FragmentConstants.java
@@ -10,6 +10,6 @@ package com.liferay.fragment.internal.constants;
  */
 public class FragmentConstants {
 
-	public static final int MAX_FRAGMENT_ENTRY_VERSION_COUNT = 10;
+	public static final int FRAGMENT_ENTRY_VERSIONS_COUNT_MAX = 10;
 
 }

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/constants/FragmentConstants.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/constants/FragmentConstants.java
@@ -1,0 +1,15 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.internal.constants;
+
+/**
+ * @author Rubén Pulido
+ */
+public class FragmentConstants {
+
+	public static final int MAX_FRAGMENT_ENTRY_VERSION_COUNT = 10;
+
+}

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/constants/FragmentEntryVersionConstants.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/constants/FragmentEntryVersionConstants.java
@@ -8,7 +8,7 @@ package com.liferay.fragment.internal.constants;
 /**
  * @author Rubén Pulido
  */
-public class FragmentConstants {
+public class FragmentEntryVersionConstants {
 
 	public static final int FRAGMENT_ENTRY_VERSIONS_COUNT_MAX = 10;
 

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/model/listener/FragmentEntryVersionModelListener.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/model/listener/FragmentEntryVersionModelListener.java
@@ -6,14 +6,14 @@
 package com.liferay.fragment.internal.model.listener;
 
 import com.liferay.fragment.model.FragmentEntryVersion;
+import com.liferay.fragment.model.FragmentEntryVersionTable;
 import com.liferay.fragment.service.persistence.FragmentEntryVersionPersistence;
+import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
-import com.liferay.portal.kernel.util.OrderByComparator;
-import com.liferay.portal.kernel.util.OrderByComparatorFactoryUtil;
 
 import java.util.List;
 
@@ -34,24 +34,44 @@ public class FragmentEntryVersionModelListener
 		throws ModelListenerException {
 
 		try {
+			long ctCollectionId = fragmentEntryVersion.getCtCollectionId();
 			long fragmentEntryId = fragmentEntryVersion.getFragmentEntryId();
 
-			int versionCount =
-				_fragmentEntryVersionPersistence.countByFragmentEntryId(
-					fragmentEntryId);
+			int versionCount = _fragmentEntryVersionPersistence.dslQueryCount(
+				DSLQueryFactoryUtil.count(
+				).from(
+					FragmentEntryVersionTable.INSTANCE
+				).where(
+					FragmentEntryVersionTable.INSTANCE.ctCollectionId.eq(
+						ctCollectionId
+					).and(
+						FragmentEntryVersionTable.INSTANCE.fragmentEntryId.eq(
+							fragmentEntryId)
+					)
+				));
 
 			if (versionCount <= MAX_VERSIONS) {
 				return;
 			}
 
-			OrderByComparator<FragmentEntryVersion> orderByComparator =
-				OrderByComparatorFactoryUtil.create(
-					"FragmentEntryVersion", "version", false);
-
 			List<FragmentEntryVersion> fragmentEntryVersions =
-				_fragmentEntryVersionPersistence.findByFragmentEntryId(
-					fragmentEntryId, MAX_VERSIONS, versionCount,
-					orderByComparator);
+				_fragmentEntryVersionPersistence.dslQuery(
+					DSLQueryFactoryUtil.select(
+						FragmentEntryVersionTable.INSTANCE
+					).from(
+						FragmentEntryVersionTable.INSTANCE
+					).where(
+						FragmentEntryVersionTable.INSTANCE.ctCollectionId.eq(
+							ctCollectionId
+						).and(
+							FragmentEntryVersionTable.INSTANCE.fragmentEntryId.
+								eq(fragmentEntryId)
+						)
+					).orderBy(
+						FragmentEntryVersionTable.INSTANCE.version.descending()
+					).limit(
+						MAX_VERSIONS, versionCount
+					));
 
 			for (FragmentEntryVersion currentFragmentEntryVersion :
 					fragmentEntryVersions) {

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/model/listener/FragmentEntryVersionModelListener.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/model/listener/FragmentEntryVersionModelListener.java
@@ -53,8 +53,11 @@ public class FragmentEntryVersionModelListener
 					fragmentEntryId, MAX_VERSIONS, versionCount,
 					orderByComparator);
 
-			for (FragmentEntryVersion version : fragmentEntryVersions) {
-				_fragmentEntryVersionPersistence.remove(version);
+			for (FragmentEntryVersion currentFragmentEntryVersion :
+					fragmentEntryVersions) {
+
+				_fragmentEntryVersionPersistence.remove(
+					currentFragmentEntryVersion);
 			}
 		}
 		catch (Exception exception) {

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/model/listener/FragmentEntryVersionModelListener.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/model/listener/FragmentEntryVersionModelListener.java
@@ -5,7 +5,7 @@
 
 package com.liferay.fragment.internal.model.listener;
 
-import com.liferay.fragment.internal.constants.FragmentConstants;
+import com.liferay.fragment.internal.constants.FragmentEntryVersionConstants;
 import com.liferay.fragment.model.FragmentEntryVersion;
 import com.liferay.fragment.model.FragmentEntryVersionTable;
 import com.liferay.fragment.service.persistence.FragmentEntryVersionPersistence;
@@ -50,7 +50,8 @@ public class FragmentEntryVersionModelListener
 				));
 
 			if (versionCount <=
-					FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX) {
+					FragmentEntryVersionConstants.
+						FRAGMENT_ENTRY_VERSIONS_COUNT_MAX) {
 
 				return;
 			}
@@ -71,7 +72,8 @@ public class FragmentEntryVersionModelListener
 					).orderBy(
 						FragmentEntryVersionTable.INSTANCE.version.descending()
 					).limit(
-						FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
+						FragmentEntryVersionConstants.
+							FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
 						versionCount
 					));
 

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/model/listener/FragmentEntryVersionModelListener.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/model/listener/FragmentEntryVersionModelListener.java
@@ -1,0 +1,81 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.internal.model.listener;
+
+import com.liferay.fragment.model.FragmentEntryVersion;
+import com.liferay.fragment.service.persistence.FragmentEntryVersionPersistence;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.OrderByComparatorFactoryUtil;
+
+import java.util.List;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Georgel Pop
+ */
+@Component(service = ModelListener.class)
+public class FragmentEntryVersionModelListener
+	extends BaseModelListener<FragmentEntryVersion> {
+
+	public static final int MAX_VERSIONS = 10;
+
+	@Override
+	public void onAfterCreate(FragmentEntryVersion fragmentEntryVersion)
+		throws ModelListenerException {
+
+		try {
+			long fragmentEntryId = fragmentEntryVersion.getFragmentEntryId();
+
+			int versionCount =
+				_fragmentEntryVersionPersistence.countByFragmentEntryId(
+					fragmentEntryId);
+
+			if (versionCount <= MAX_VERSIONS) {
+				return;
+			}
+
+			OrderByComparator<FragmentEntryVersion> orderByComparator =
+				OrderByComparatorFactoryUtil.create(
+					"FragmentEntryVersion", "version", false);
+
+			List<FragmentEntryVersion> fragmentEntryVersions =
+				_fragmentEntryVersionPersistence.findByFragmentEntryId(
+					fragmentEntryId, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+					orderByComparator);
+
+			for (FragmentEntryVersion version :
+					fragmentEntryVersions.subList(
+						MAX_VERSIONS, fragmentEntryVersions.size())) {
+
+				_fragmentEntryVersionPersistence.remove(version);
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to clean up old fragment entry versions for " +
+						"fragment entry ID " +
+							fragmentEntryVersion.getFragmentEntryId(),
+					exception);
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		FragmentEntryVersionModelListener.class);
+
+	@Reference
+	private FragmentEntryVersionPersistence _fragmentEntryVersionPersistence;
+
+}

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/model/listener/FragmentEntryVersionModelListener.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/model/listener/FragmentEntryVersionModelListener.java
@@ -7,7 +7,6 @@ package com.liferay.fragment.internal.model.listener;
 
 import com.liferay.fragment.model.FragmentEntryVersion;
 import com.liferay.fragment.service.persistence.FragmentEntryVersionPersistence;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -51,13 +50,10 @@ public class FragmentEntryVersionModelListener
 
 			List<FragmentEntryVersion> fragmentEntryVersions =
 				_fragmentEntryVersionPersistence.findByFragmentEntryId(
-					fragmentEntryId, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+					fragmentEntryId, MAX_VERSIONS, versionCount,
 					orderByComparator);
 
-			for (FragmentEntryVersion version :
-					fragmentEntryVersions.subList(
-						MAX_VERSIONS, fragmentEntryVersions.size())) {
-
+			for (FragmentEntryVersion version : fragmentEntryVersions) {
 				_fragmentEntryVersionPersistence.remove(version);
 			}
 		}

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/model/listener/FragmentEntryVersionModelListener.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/model/listener/FragmentEntryVersionModelListener.java
@@ -5,6 +5,7 @@
 
 package com.liferay.fragment.internal.model.listener;
 
+import com.liferay.fragment.internal.constants.FragmentConstants;
 import com.liferay.fragment.model.FragmentEntryVersion;
 import com.liferay.fragment.model.FragmentEntryVersionTable;
 import com.liferay.fragment.service.persistence.FragmentEntryVersionPersistence;
@@ -27,8 +28,6 @@ import org.osgi.service.component.annotations.Reference;
 public class FragmentEntryVersionModelListener
 	extends BaseModelListener<FragmentEntryVersion> {
 
-	public static final int MAX_VERSIONS = 10;
-
 	@Override
 	public void onAfterCreate(FragmentEntryVersion fragmentEntryVersion)
 		throws ModelListenerException {
@@ -50,7 +49,9 @@ public class FragmentEntryVersionModelListener
 					)
 				));
 
-			if (versionCount <= MAX_VERSIONS) {
+			if (versionCount <=
+					FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT) {
+
 				return;
 			}
 
@@ -70,7 +71,8 @@ public class FragmentEntryVersionModelListener
 					).orderBy(
 						FragmentEntryVersionTable.INSTANCE.version.descending()
 					).limit(
-						MAX_VERSIONS, versionCount
+						FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT,
+						versionCount
 					));
 
 			for (FragmentEntryVersion currentFragmentEntryVersion :

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/model/listener/FragmentEntryVersionModelListener.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/model/listener/FragmentEntryVersionModelListener.java
@@ -85,7 +85,7 @@ public class FragmentEntryVersionModelListener
 		catch (Exception exception) {
 			if (_log.isWarnEnabled()) {
 				_log.warn(
-					"Unable to remove old fragment entry versions for " +
+					"Unable to delete old fragment entry versions for " +
 						"fragment entry ID " +
 							fragmentEntryVersion.getFragmentEntryId(),
 					exception);

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/model/listener/FragmentEntryVersionModelListener.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/model/listener/FragmentEntryVersionModelListener.java
@@ -50,7 +50,7 @@ public class FragmentEntryVersionModelListener
 				));
 
 			if (versionCount <=
-					FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT) {
+					FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX) {
 
 				return;
 			}
@@ -71,7 +71,7 @@ public class FragmentEntryVersionModelListener
 					).orderBy(
 						FragmentEntryVersionTable.INSTANCE.version.descending()
 					).limit(
-						FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT,
+						FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
 						versionCount
 					));
 

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/model/listener/FragmentEntryVersionModelListener.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/model/listener/FragmentEntryVersionModelListener.java
@@ -85,7 +85,7 @@ public class FragmentEntryVersionModelListener
 		catch (Exception exception) {
 			if (_log.isWarnEnabled()) {
 				_log.warn(
-					"Unable to clean up old fragment entry versions for " +
+					"Unable to remove old fragment entry versions for " +
 						"fragment entry ID " +
 							fragmentEntryVersion.getFragmentEntryId(),
 					exception);

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/registry/FragmentServiceUpgradeStepRegistrator.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/registry/FragmentServiceUpgradeStepRegistrator.java
@@ -276,6 +276,11 @@ public class FragmentServiceUpgradeStepRegistrator
 
 		registry.register(
 			"3.0.1", "3.0.2", new FragmentEntryHTMLUpgradeProcess());
+
+		registry.register(
+			"3.0.2", "3.0.3",
+			new com.liferay.fragment.internal.upgrade.v3_0_3.
+				FragmentEntryVersionUpgradeProcess());
 	}
 
 	@Reference

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v3_0_3/FragmentEntryVersionUpgradeProcess.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v3_0_3/FragmentEntryVersionUpgradeProcess.java
@@ -13,7 +13,9 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author Georgel Pop
@@ -24,58 +26,81 @@ public class FragmentEntryVersionUpgradeProcess extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		for (long fragmentEntryId : _getFragmentEntryIds()) {
-			List<Long> fragmentEntryVersionIds = _getFragmentEntryVersionIds(
-				fragmentEntryId);
+		Map<Long, List<Long>> fragmentEntryIdsByCtCollectionId =
+			_getFragmentEntryIdsByCtCollectionId();
 
-			List<Long> fragmentEntryVersionIdsToDelete =
-				fragmentEntryVersionIds.subList(
-					MAX_VERSIONS, fragmentEntryVersionIds.size());
+		for (Map.Entry<Long, List<Long>> entry :
+				fragmentEntryIdsByCtCollectionId.entrySet()) {
 
-			for (int i = 0; i < fragmentEntryVersionIdsToDelete.size();
-				 i += _BATCH_SIZE) {
+			for (Long fragmentEntryId : entry.getValue()) {
+				List<Long> fragmentEntryVersionIds =
+					_getFragmentEntryVersionIds(
+						entry.getKey(), fragmentEntryId);
 
-				int end = Math.min(
-					i + _BATCH_SIZE, fragmentEntryVersionIdsToDelete.size());
+				List<Long> fragmentEntryVersionIdsToDelete =
+					fragmentEntryVersionIds.subList(
+						MAX_VERSIONS, fragmentEntryVersionIds.size());
 
-				runSQL(
-					StringBundler.concat(
-						"delete from FragmentEntryVersion where ",
-						"fragmentEntryVersionId in (",
-						StringUtil.merge(
-							fragmentEntryVersionIdsToDelete.subList(i, end)),
-						")"));
+				for (int i = 0; i < fragmentEntryVersionIdsToDelete.size();
+					 i += _BATCH_SIZE) {
+
+					int end = Math.min(
+						i + _BATCH_SIZE,
+						fragmentEntryVersionIdsToDelete.size());
+
+					runSQL(
+						StringBundler.concat(
+							"delete from FragmentEntryVersion where ",
+							"fragmentEntryVersionId in (",
+							StringUtil.merge(
+								fragmentEntryVersionIdsToDelete.subList(
+									i, end)),
+							")"));
+				}
 			}
 		}
 	}
 
-	private List<Long> _getFragmentEntryIds() throws Exception {
-		List<Long> fragmentEntryIds = new ArrayList<>();
+	private Map<Long, List<Long>> _getFragmentEntryIdsByCtCollectionId()
+		throws Exception {
+
+		Map<Long, List<Long>> fragmentEntryIdsByCtCollectionId =
+			new HashMap<>();
 
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				"select fragmentEntryId from FragmentEntryVersion group by " +
-					"fragmentEntryId having count(*) > " + MAX_VERSIONS);
+				StringBundler.concat(
+					"select ctCollectionId, fragmentEntryId from ",
+					"FragmentEntryVersion group by ctCollectionId, ",
+					"fragmentEntryId having count(*) > ", MAX_VERSIONS));
 
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 
 			while (resultSet.next()) {
+				List<Long> fragmentEntryIds =
+					fragmentEntryIdsByCtCollectionId.computeIfAbsent(
+						resultSet.getLong("ctCollectionId"),
+						ctCollectionId -> new ArrayList<>());
+
 				fragmentEntryIds.add(resultSet.getLong("fragmentEntryId"));
 			}
 		}
 
-		return fragmentEntryIds;
+		return fragmentEntryIdsByCtCollectionId;
 	}
 
-	private List<Long> _getFragmentEntryVersionIds(long fragmentEntryId)
+	private List<Long> _getFragmentEntryVersionIds(
+			long ctCollectionId, long fragmentEntryId)
 		throws Exception {
 
 		List<Long> fragmentEntryVersionIds = new ArrayList<>();
 
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				"select fragmentEntryVersionId from FragmentEntryVersion " +
-					"where fragmentEntryId = ? order by version desc")) {
+					"where ctCollectionId = ? and fragmentEntryId = ? order " +
+						"by version desc")) {
 
-			preparedStatement.setLong(1, fragmentEntryId);
+			preparedStatement.setLong(1, ctCollectionId);
+			preparedStatement.setLong(2, fragmentEntryId);
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				while (resultSet.next()) {

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v3_0_3/FragmentEntryVersionUpgradeProcess.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v3_0_3/FragmentEntryVersionUpgradeProcess.java
@@ -31,10 +31,12 @@ public class FragmentEntryVersionUpgradeProcess extends UpgradeProcess {
 		for (Map.Entry<Long, List<Long>> entry :
 				fragmentEntryIdsByCtCollectionId.entrySet()) {
 
+			long ctCollectionId = entry.getKey();
+
 			for (Long fragmentEntryId : entry.getValue()) {
 				List<Long> fragmentEntryVersionIds =
 					_getFragmentEntryVersionIds(
-						entry.getKey(), fragmentEntryId);
+						ctCollectionId, fragmentEntryId);
 
 				List<Long> fragmentEntryVersionIdsToDelete =
 					fragmentEntryVersionIds.subList(

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v3_0_3/FragmentEntryVersionUpgradeProcess.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v3_0_3/FragmentEntryVersionUpgradeProcess.java
@@ -43,11 +43,13 @@ public class FragmentEntryVersionUpgradeProcess extends UpgradeProcess {
 						FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
 						fragmentEntryVersionIds.size());
 
+				int oracleInClauseLimit = 1000;
+
 				for (int i = 0; i < fragmentEntryVersionIdsToDelete.size();
-					 i += _BATCH_SIZE) {
+					 i += oracleInClauseLimit) {
 
 					int end = Math.min(
-						i + _BATCH_SIZE,
+						i + oracleInClauseLimit,
 						fragmentEntryVersionIdsToDelete.size());
 
 					runSQL(
@@ -115,7 +117,5 @@ public class FragmentEntryVersionUpgradeProcess extends UpgradeProcess {
 
 		return fragmentEntryVersionIds;
 	}
-
-	private static final int _BATCH_SIZE = 1000;
 
 }

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v3_0_3/FragmentEntryVersionUpgradeProcess.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v3_0_3/FragmentEntryVersionUpgradeProcess.java
@@ -5,6 +5,7 @@
 
 package com.liferay.fragment.internal.upgrade.v3_0_3;
 
+import com.liferay.fragment.internal.constants.FragmentConstants;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -22,8 +23,6 @@ import java.util.Map;
  */
 public class FragmentEntryVersionUpgradeProcess extends UpgradeProcess {
 
-	public static final int MAX_VERSIONS = 10;
-
 	@Override
 	protected void doUpgrade() throws Exception {
 		Map<Long, List<Long>> fragmentEntryIdsByCtCollectionId =
@@ -39,7 +38,8 @@ public class FragmentEntryVersionUpgradeProcess extends UpgradeProcess {
 
 				List<Long> fragmentEntryVersionIdsToDelete =
 					fragmentEntryVersionIds.subList(
-						MAX_VERSIONS, fragmentEntryVersionIds.size());
+						FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT,
+						fragmentEntryVersionIds.size());
 
 				for (int i = 0; i < fragmentEntryVersionIdsToDelete.size();
 					 i += _BATCH_SIZE) {
@@ -71,7 +71,8 @@ public class FragmentEntryVersionUpgradeProcess extends UpgradeProcess {
 				StringBundler.concat(
 					"select ctCollectionId, fragmentEntryId from ",
 					"FragmentEntryVersion group by ctCollectionId, ",
-					"fragmentEntryId having count(*) > ", MAX_VERSIONS));
+					"fragmentEntryId having count(*) > ",
+					FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT));
 
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v3_0_3/FragmentEntryVersionUpgradeProcess.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v3_0_3/FragmentEntryVersionUpgradeProcess.java
@@ -1,0 +1,93 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.internal.upgrade.v3_0_3;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Georgel Pop
+ */
+public class FragmentEntryVersionUpgradeProcess extends UpgradeProcess {
+
+	public static final int MAX_VERSIONS = 10;
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		for (long fragmentEntryId : _getFragmentEntryIds()) {
+			List<Long> fragmentEntryVersionIds = _getFragmentEntryVersionIds(
+				fragmentEntryId);
+
+			List<Long> fragmentEntryVersionIdsToDelete =
+				fragmentEntryVersionIds.subList(
+					MAX_VERSIONS, fragmentEntryVersionIds.size());
+
+			for (int i = 0; i < fragmentEntryVersionIdsToDelete.size();
+				 i += _BATCH_SIZE) {
+
+				int end = Math.min(
+					i + _BATCH_SIZE, fragmentEntryVersionIdsToDelete.size());
+
+				runSQL(
+					StringBundler.concat(
+						"delete from FragmentEntryVersion where ",
+						"fragmentEntryVersionId in (",
+						StringUtil.merge(
+							fragmentEntryVersionIdsToDelete.subList(i, end)),
+						")"));
+			}
+		}
+	}
+
+	private List<Long> _getFragmentEntryIds() throws Exception {
+		List<Long> fragmentEntryIds = new ArrayList<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select fragmentEntryId from FragmentEntryVersion group by " +
+					"fragmentEntryId having count(*) > " + MAX_VERSIONS);
+
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			while (resultSet.next()) {
+				fragmentEntryIds.add(resultSet.getLong("fragmentEntryId"));
+			}
+		}
+
+		return fragmentEntryIds;
+	}
+
+	private List<Long> _getFragmentEntryVersionIds(long fragmentEntryId)
+		throws Exception {
+
+		List<Long> fragmentEntryVersionIds = new ArrayList<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select fragmentEntryVersionId from FragmentEntryVersion " +
+					"where fragmentEntryId = ? order by version desc")) {
+
+			preparedStatement.setLong(1, fragmentEntryId);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					fragmentEntryVersionIds.add(
+						resultSet.getLong("fragmentEntryVersionId"));
+				}
+			}
+		}
+
+		return fragmentEntryVersionIds;
+	}
+
+	private static final int _BATCH_SIZE = 1000;
+
+}

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v3_0_3/FragmentEntryVersionUpgradeProcess.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v3_0_3/FragmentEntryVersionUpgradeProcess.java
@@ -5,7 +5,7 @@
 
 package com.liferay.fragment.internal.upgrade.v3_0_3;
 
-import com.liferay.fragment.internal.constants.FragmentConstants;
+import com.liferay.fragment.internal.constants.FragmentEntryVersionConstants;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -40,7 +40,8 @@ public class FragmentEntryVersionUpgradeProcess extends UpgradeProcess {
 
 				List<Long> fragmentEntryVersionIdsToDelete =
 					fragmentEntryVersionIds.subList(
-						FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
+						FragmentEntryVersionConstants.
+							FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
 						fragmentEntryVersionIds.size());
 
 				int oracleInClauseLimit = 1000;
@@ -73,7 +74,8 @@ public class FragmentEntryVersionUpgradeProcess extends UpgradeProcess {
 					"select ctCollectionId, fragmentEntryId from ",
 					"FragmentEntryVersion group by ctCollectionId, ",
 					"fragmentEntryId having count(*) > ",
-					FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX));
+					FragmentEntryVersionConstants.
+						FRAGMENT_ENTRY_VERSIONS_COUNT_MAX));
 
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v3_0_3/FragmentEntryVersionUpgradeProcess.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v3_0_3/FragmentEntryVersionUpgradeProcess.java
@@ -44,13 +44,10 @@ public class FragmentEntryVersionUpgradeProcess extends UpgradeProcess {
 						fragmentEntryVersionIds.size());
 
 				int oracleInClauseLimit = 1000;
+				int size = fragmentEntryVersionIdsToDelete.size();
 
-				for (int i = 0; i < fragmentEntryVersionIdsToDelete.size();
-					 i += oracleInClauseLimit) {
-
-					int end = Math.min(
-						i + oracleInClauseLimit,
-						fragmentEntryVersionIdsToDelete.size());
+				for (int i = 0; i < size; i += oracleInClauseLimit) {
+					int end = Math.min(i + oracleInClauseLimit, size);
 
 					runSQL(
 						StringBundler.concat(

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v3_0_3/FragmentEntryVersionUpgradeProcess.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v3_0_3/FragmentEntryVersionUpgradeProcess.java
@@ -38,7 +38,7 @@ public class FragmentEntryVersionUpgradeProcess extends UpgradeProcess {
 
 				List<Long> fragmentEntryVersionIdsToDelete =
 					fragmentEntryVersionIds.subList(
-						FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT,
+						FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
 						fragmentEntryVersionIds.size());
 
 				for (int i = 0; i < fragmentEntryVersionIdsToDelete.size();
@@ -72,7 +72,7 @@ public class FragmentEntryVersionUpgradeProcess extends UpgradeProcess {
 					"select ctCollectionId, fragmentEntryId from ",
 					"FragmentEntryVersion group by ctCollectionId, ",
 					"fragmentEntryId having count(*) > ",
-					FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT));
+					FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX));
 
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/change/tracking/spi/listener/test/FragmentEntryVersionCTEventListenerTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/change/tracking/spi/listener/test/FragmentEntryVersionCTEventListenerTest.java
@@ -10,7 +10,7 @@ import com.liferay.change.tracking.constants.CTConstants;
 import com.liferay.change.tracking.model.CTCollection;
 import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.change.tracking.service.CTCollectionService;
-import com.liferay.fragment.internal.constants.FragmentConstants;
+import com.liferay.fragment.internal.constants.FragmentEntryVersionConstants;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.service.persistence.FragmentEntryVersionUtil;
 import com.liferay.fragment.test.util.FragmentEntryVersionTestUtil;
@@ -85,7 +85,7 @@ public class FragmentEntryVersionCTEventListenerTest {
 		FragmentEntryVersionUtil.clearCache();
 
 		Assert.assertEquals(
-			FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
+			FragmentEntryVersionConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
 			FragmentEntryVersionTestUtil.countFragmentEntryVersions(
 				CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry1));
 
@@ -96,7 +96,7 @@ public class FragmentEntryVersionCTEventListenerTest {
 			versions.toString(), versions.contains(oldestVersion));
 
 		Assert.assertEquals(
-			FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
+			FragmentEntryVersionConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
 			FragmentEntryVersionTestUtil.countFragmentEntryVersions(
 				CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry2));
 	}
@@ -106,11 +106,11 @@ public class FragmentEntryVersionCTEventListenerTest {
 			FragmentEntryVersionTestUtil.addFragmentEntry(_group.getGroupId());
 
 		FragmentEntryVersionTestUtil.insertFragmentEntryVersions(
-			FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
+			FragmentEntryVersionConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
 			CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry);
 
 		Assert.assertEquals(
-			FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX + 1,
+			FragmentEntryVersionConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX + 1,
 			FragmentEntryVersionTestUtil.countFragmentEntryVersions(
 				CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry));
 

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/change/tracking/spi/listener/test/FragmentEntryVersionCTEventListenerTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/change/tracking/spi/listener/test/FragmentEntryVersionCTEventListenerTest.java
@@ -85,7 +85,7 @@ public class FragmentEntryVersionCTEventListenerTest {
 		FragmentEntryVersionUtil.clearCache();
 
 		Assert.assertEquals(
-			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT,
+			FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
 			FragmentEntryVersionTestUtil.countFragmentEntryVersions(
 				CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry1));
 
@@ -96,7 +96,7 @@ public class FragmentEntryVersionCTEventListenerTest {
 			versions.toString(), versions.contains(oldestVersion));
 
 		Assert.assertEquals(
-			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT,
+			FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
 			FragmentEntryVersionTestUtil.countFragmentEntryVersions(
 				CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry2));
 	}
@@ -106,11 +106,11 @@ public class FragmentEntryVersionCTEventListenerTest {
 			FragmentEntryVersionTestUtil.addFragmentEntry(_group.getGroupId());
 
 		FragmentEntryVersionTestUtil.insertFragmentEntryVersions(
-			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT,
+			FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
 			CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry);
 
 		Assert.assertEquals(
-			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT + 1,
+			FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX + 1,
 			FragmentEntryVersionTestUtil.countFragmentEntryVersions(
 				CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry));
 

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/change/tracking/spi/listener/test/FragmentEntryVersionCTEventListenerTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/change/tracking/spi/listener/test/FragmentEntryVersionCTEventListenerTest.java
@@ -1,0 +1,121 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.internal.change.tracking.spi.listener.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.change.tracking.constants.CTConstants;
+import com.liferay.change.tracking.model.CTCollection;
+import com.liferay.change.tracking.service.CTCollectionLocalService;
+import com.liferay.change.tracking.service.CTCollectionService;
+import com.liferay.fragment.internal.constants.FragmentConstants;
+import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.service.persistence.FragmentEntryVersionUtil;
+import com.liferay.fragment.test.util.FragmentEntryVersionTestUtil;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Rubén Pulido
+ */
+@RunWith(Arquillian.class)
+public class FragmentEntryVersionCTEventListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testOnAfterPublish() throws Throwable {
+		FragmentEntry fragmentEntry =
+			FragmentEntryVersionTestUtil.addFragmentEntry(_group.getGroupId());
+
+		List<Integer> versions =
+			FragmentEntryVersionTestUtil.getFragmentEntryVersions(
+				fragmentEntry);
+
+		int oldestVersion = versions.get(0);
+
+		Assert.assertTrue(oldestVersion > 0);
+
+		FragmentEntryVersionTestUtil.insertFragmentEntryVersions(
+			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT,
+			CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry);
+
+		Assert.assertEquals(
+			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT + 1,
+			FragmentEntryVersionTestUtil.countFragmentEntryVersions(
+				CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry));
+
+		versions = FragmentEntryVersionTestUtil.getFragmentEntryVersions(
+			fragmentEntry);
+
+		Assert.assertTrue(
+			versions.toString(), versions.contains(oldestVersion));
+
+		CTCollection ctCollection = _ctCollectionLocalService.addCTCollection(
+			null, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			0, RandomTestUtil.randomString(), null);
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					ctCollection.getCtCollectionId())) {
+
+			FragmentEntryVersionTestUtil.updateFragmentEntry(fragmentEntry);
+		}
+
+		_ctCollectionService.publishCTCollection(
+			TestPropsValues.getUserId(), ctCollection.getCtCollectionId());
+
+		FragmentEntryVersionUtil.clearCache();
+
+		Assert.assertEquals(
+			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT,
+			FragmentEntryVersionTestUtil.countFragmentEntryVersions(
+				CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry));
+
+		versions = FragmentEntryVersionTestUtil.getFragmentEntryVersions(
+			fragmentEntry);
+
+		Assert.assertFalse(
+			versions.toString(), versions.contains(oldestVersion));
+	}
+
+	@Inject
+	private CTCollectionLocalService _ctCollectionLocalService;
+
+	@Inject
+	private CTCollectionService _ctCollectionService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+}

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/change/tracking/spi/listener/test/FragmentEntryVersionCTEventListenerTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/change/tracking/spi/listener/test/FragmentEntryVersionCTEventListenerTest.java
@@ -55,31 +55,17 @@ public class FragmentEntryVersionCTEventListenerTest {
 
 	@Test
 	public void testOnAfterPublish() throws Throwable {
-		FragmentEntry fragmentEntry =
-			FragmentEntryVersionTestUtil.addFragmentEntry(_group.getGroupId());
+		FragmentEntry fragmentEntry1 = _addFragmentEntry();
 
 		List<Integer> versions =
 			FragmentEntryVersionTestUtil.getFragmentEntryVersions(
-				fragmentEntry);
+				fragmentEntry1);
 
 		int oldestVersion = versions.get(0);
 
 		Assert.assertTrue(oldestVersion > 0);
 
-		FragmentEntryVersionTestUtil.insertFragmentEntryVersions(
-			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT,
-			CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry);
-
-		Assert.assertEquals(
-			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT + 1,
-			FragmentEntryVersionTestUtil.countFragmentEntryVersions(
-				CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry));
-
-		versions = FragmentEntryVersionTestUtil.getFragmentEntryVersions(
-			fragmentEntry);
-
-		Assert.assertTrue(
-			versions.toString(), versions.contains(oldestVersion));
+		FragmentEntry fragmentEntry2 = _addFragmentEntry();
 
 		CTCollection ctCollection = _ctCollectionLocalService.addCTCollection(
 			null, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
@@ -89,7 +75,8 @@ public class FragmentEntryVersionCTEventListenerTest {
 				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
 					ctCollection.getCtCollectionId())) {
 
-			FragmentEntryVersionTestUtil.updateFragmentEntry(fragmentEntry);
+			FragmentEntryVersionTestUtil.updateFragmentEntry(fragmentEntry1);
+			FragmentEntryVersionTestUtil.updateFragmentEntry(fragmentEntry2);
 		}
 
 		_ctCollectionService.publishCTCollection(
@@ -100,13 +87,34 @@ public class FragmentEntryVersionCTEventListenerTest {
 		Assert.assertEquals(
 			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT,
 			FragmentEntryVersionTestUtil.countFragmentEntryVersions(
-				CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry));
+				CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry1));
 
 		versions = FragmentEntryVersionTestUtil.getFragmentEntryVersions(
-			fragmentEntry);
+			fragmentEntry1);
 
 		Assert.assertFalse(
 			versions.toString(), versions.contains(oldestVersion));
+
+		Assert.assertEquals(
+			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT,
+			FragmentEntryVersionTestUtil.countFragmentEntryVersions(
+				CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry2));
+	}
+
+	private FragmentEntry _addFragmentEntry() throws Exception {
+		FragmentEntry fragmentEntry =
+			FragmentEntryVersionTestUtil.addFragmentEntry(_group.getGroupId());
+
+		FragmentEntryVersionTestUtil.insertFragmentEntryVersions(
+			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT,
+			CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry);
+
+		Assert.assertEquals(
+			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT + 1,
+			FragmentEntryVersionTestUtil.countFragmentEntryVersions(
+				CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry));
+
+		return fragmentEntry;
 	}
 
 	@Inject

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/model/listener/test/FragmentEntryVersionModelListenerTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/model/listener/test/FragmentEntryVersionModelListenerTest.java
@@ -1,0 +1,226 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.internal.model.listener.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.counter.kernel.service.CounterLocalService;
+import com.liferay.fragment.constants.FragmentConstants;
+import com.liferay.fragment.internal.model.listener.FragmentEntryVersionModelListener;
+import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.model.FragmentEntryVersion;
+import com.liferay.fragment.service.FragmentEntryLocalService;
+import com.liferay.fragment.service.persistence.FragmentEntryVersionPersistence;
+import com.liferay.fragment.test.util.FragmentTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Georgel Pop
+ */
+@RunWith(Arquillian.class)
+public class FragmentEntryVersionModelListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_date = new Date(System.currentTimeMillis() + 3600000L);
+		_modifiedDateCounter = System.currentTimeMillis() + 3600000L;
+		_versionCounter = 1000;
+	}
+
+	@Test
+	public void testOnAfterCreate() throws Throwable {
+		_testOnAfterCreateDeletesOldVersions();
+		_testOnAfterCreateSkipsCleanup();
+	}
+
+	private FragmentEntry _addFragmentEntry() throws Exception {
+		FragmentCollection fragmentCollection =
+			FragmentTestUtil.addFragmentCollection(_group.getGroupId());
+
+		return _fragmentEntryLocalService.addFragmentEntry(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+			_group.getGroupId(), fragmentCollection.getFragmentCollectionId(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), false, StringPool.BLANK, null, 0,
+			false, false, FragmentConstants.TYPE_COMPONENT, null,
+			WorkflowConstants.STATUS_APPROVED,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private void _addFragmentEntryVersions(
+			int count, FragmentEntry fragmentEntry)
+		throws Throwable {
+
+		for (int i = 0; i < count; i++) {
+			FragmentEntryVersion newVersion =
+				_fragmentEntryVersionPersistence.create(
+					_counterLocalService.increment(
+						FragmentEntryVersion.class.getName()));
+
+			Date modifiedDate = new Date(_modifiedDateCounter);
+
+			_modifiedDateCounter += 1000L;
+
+			newVersion.setVersion(_versionCounter++);
+			newVersion.setFragmentEntryId(fragmentEntry.getFragmentEntryId());
+			newVersion.setGroupId(fragmentEntry.getGroupId());
+			newVersion.setCompanyId(fragmentEntry.getCompanyId());
+			newVersion.setUserId(fragmentEntry.getUserId());
+			newVersion.setUserName(fragmentEntry.getUserName());
+			newVersion.setCreateDate(_date);
+			newVersion.setModifiedDate(modifiedDate);
+			newVersion.setFragmentCollectionId(
+				fragmentEntry.getFragmentCollectionId());
+			newVersion.setFragmentEntryKey(fragmentEntry.getFragmentEntryKey());
+			newVersion.setName(RandomTestUtil.randomString());
+			newVersion.setStatus(WorkflowConstants.STATUS_APPROVED);
+
+			TransactionInvokerUtil.invoke(
+				_transactionConfig,
+				() -> _fragmentEntryVersionPersistence.update(newVersion));
+		}
+	}
+
+	private long _countFragmentEntryVersions(FragmentEntry fragmentEntry)
+		throws Exception {
+
+		try (Connection connection = DataAccess.getConnection();
+
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select count(*) as count from FragmentEntryVersion where " +
+					"fragmentEntryId = ?")) {
+
+			preparedStatement.setLong(1, fragmentEntry.getFragmentEntryId());
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				if (resultSet.next()) {
+					return resultSet.getLong("count");
+				}
+
+				return 0;
+			}
+		}
+	}
+
+	private List<Integer> _getFragmentEntryVersions(FragmentEntry fragmentEntry)
+		throws Exception {
+
+		List<Integer> versions = new ArrayList<>();
+
+		try (Connection connection = DataAccess.getConnection();
+
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select version from FragmentEntryVersion where " +
+					"fragmentEntryId = ? order by version")) {
+
+			preparedStatement.setLong(1, fragmentEntry.getFragmentEntryId());
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					versions.add(resultSet.getInt("version"));
+				}
+			}
+		}
+
+		return versions;
+	}
+
+	private void _testOnAfterCreateDeletesOldVersions() throws Throwable {
+		FragmentEntry fragmentEntry = _addFragmentEntry();
+
+		_addFragmentEntryVersions(20, fragmentEntry);
+
+		int maxVersions = FragmentEntryVersionModelListener.MAX_VERSIONS;
+
+		List<Integer> expectedVersions = new ArrayList<>(maxVersions);
+
+		for (int version = _versionCounter - maxVersions;
+			 version < _versionCounter; version++) {
+
+			expectedVersions.add(version);
+		}
+
+		Assert.assertEquals(
+			expectedVersions, _getFragmentEntryVersions(fragmentEntry));
+	}
+
+	private void _testOnAfterCreateSkipsCleanup() throws Throwable {
+		int versionsToGenerate = 5;
+
+		FragmentEntry fragmentEntry = _addFragmentEntry();
+
+		long initialCount = _countFragmentEntryVersions(fragmentEntry);
+
+		_addFragmentEntryVersions(versionsToGenerate, fragmentEntry);
+
+		Assert.assertEquals(
+			versionsToGenerate + initialCount,
+			_countFragmentEntryVersions(fragmentEntry));
+	}
+
+	private static final TransactionConfig _transactionConfig =
+		TransactionConfig.Factory.create(
+			Propagation.REQUIRED, new Class<?>[] {Exception.class});
+
+	@Inject
+	private CounterLocalService _counterLocalService;
+
+	private Date _date;
+
+	@Inject
+	private FragmentEntryLocalService _fragmentEntryLocalService;
+
+	@Inject
+	private FragmentEntryVersionPersistence _fragmentEntryVersionPersistence;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private long _modifiedDateCounter;
+	private int _versionCounter;
+
+}

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/model/listener/test/FragmentEntryVersionModelListenerTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/model/listener/test/FragmentEntryVersionModelListenerTest.java
@@ -67,7 +67,7 @@ public class FragmentEntryVersionModelListenerTest {
 		Assert.assertTrue(oldestVersion > 0);
 
 		FragmentEntryVersionTestUtil.insertFragmentEntryVersions(
-			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT - 2,
+			FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX - 2,
 			CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry);
 
 		versions = FragmentEntryVersionTestUtil.getFragmentEntryVersions(
@@ -75,7 +75,7 @@ public class FragmentEntryVersionModelListenerTest {
 
 		Assert.assertEquals(
 			versions.toString(),
-			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT - 1,
+			FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX - 1,
 			versions.size());
 		Assert.assertTrue(versions.contains(oldestVersion));
 
@@ -86,7 +86,7 @@ public class FragmentEntryVersionModelListenerTest {
 
 		Assert.assertEquals(
 			versions.toString(),
-			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT,
+			FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
 			versions.size());
 		Assert.assertTrue(versions.contains(oldestVersion));
 
@@ -97,7 +97,7 @@ public class FragmentEntryVersionModelListenerTest {
 
 		Assert.assertEquals(
 			versions.toString(),
-			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT,
+			FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
 			versions.size());
 		Assert.assertFalse(versions.contains(oldestVersion));
 	}
@@ -108,11 +108,11 @@ public class FragmentEntryVersionModelListenerTest {
 			FragmentEntryVersionTestUtil.addFragmentEntry(_group.getGroupId());
 
 		FragmentEntryVersionTestUtil.insertFragmentEntryVersions(
-			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT - 1,
+			FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX - 1,
 			CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry);
 
 		Assert.assertEquals(
-			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT,
+			FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
 			FragmentEntryVersionTestUtil.countFragmentEntryVersions(
 				fragmentEntry));
 
@@ -127,7 +127,7 @@ public class FragmentEntryVersionModelListenerTest {
 			FragmentEntryVersionTestUtil.updateFragmentEntry(fragmentEntry);
 
 			Assert.assertEquals(
-				FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT + 1,
+				FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX + 1,
 				FragmentEntryVersionTestUtil.countFragmentEntryVersions(
 					fragmentEntry));
 		}

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/model/listener/test/FragmentEntryVersionModelListenerTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/model/listener/test/FragmentEntryVersionModelListenerTest.java
@@ -6,27 +6,17 @@
 package com.liferay.fragment.internal.model.listener.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.counter.kernel.service.CounterLocalService;
+import com.liferay.change.tracking.constants.CTConstants;
 import com.liferay.fragment.internal.constants.FragmentConstants;
 import com.liferay.fragment.model.FragmentEntry;
-import com.liferay.fragment.model.FragmentEntryVersion;
-import com.liferay.fragment.service.persistence.FragmentEntryVersionPersistence;
 import com.liferay.fragment.test.util.FragmentEntryVersionTestUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
-import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.transaction.Propagation;
-import com.liferay.portal.kernel.transaction.TransactionConfig;
-import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
-import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import org.junit.Assert;
@@ -52,109 +42,60 @@ public class FragmentEntryVersionModelListenerTest {
 	@Before
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
-
-		_date = new Date(System.currentTimeMillis() + 3600000L);
-		_modifiedDateCounter = System.currentTimeMillis() + 3600000L;
-		_versionCounter = 1000;
 	}
 
 	@Test
 	public void testOnAfterCreate() throws Throwable {
-		_testOnAfterCreateDeletesOldVersions();
-		_testOnAfterCreateSkipsCleanup();
-	}
-
-	private void _addFragmentEntryVersions(
-			int count, FragmentEntry fragmentEntry)
-		throws Throwable {
-
-		for (int i = 0; i < count; i++) {
-			FragmentEntryVersion newVersion =
-				_fragmentEntryVersionPersistence.create(
-					_counterLocalService.increment(
-						FragmentEntryVersion.class.getName()));
-
-			Date modifiedDate = new Date(_modifiedDateCounter);
-
-			_modifiedDateCounter += 1000L;
-
-			newVersion.setVersion(_versionCounter++);
-			newVersion.setFragmentEntryId(fragmentEntry.getFragmentEntryId());
-			newVersion.setGroupId(fragmentEntry.getGroupId());
-			newVersion.setCompanyId(fragmentEntry.getCompanyId());
-			newVersion.setUserId(fragmentEntry.getUserId());
-			newVersion.setUserName(fragmentEntry.getUserName());
-			newVersion.setCreateDate(_date);
-			newVersion.setModifiedDate(modifiedDate);
-			newVersion.setFragmentCollectionId(
-				fragmentEntry.getFragmentCollectionId());
-			newVersion.setFragmentEntryKey(fragmentEntry.getFragmentEntryKey());
-			newVersion.setName(RandomTestUtil.randomString());
-			newVersion.setStatus(WorkflowConstants.STATUS_APPROVED);
-
-			TransactionInvokerUtil.invoke(
-				_transactionConfig,
-				() -> _fragmentEntryVersionPersistence.update(newVersion));
-		}
-	}
-
-	private void _testOnAfterCreateDeletesOldVersions() throws Throwable {
 		FragmentEntry fragmentEntry =
 			FragmentEntryVersionTestUtil.addFragmentEntry(_group.getGroupId());
 
-		_addFragmentEntryVersions(20, fragmentEntry);
-
-		List<Integer> expectedVersions = new ArrayList<>(
-			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT);
-
-		for (int version =
-				_versionCounter -
-					FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT;
-			 version < _versionCounter; version++) {
-
-			expectedVersions.add(version);
-		}
-
-		Assert.assertEquals(
-			expectedVersions,
+		List<Integer> versions =
 			FragmentEntryVersionTestUtil.getFragmentEntryVersions(
-				fragmentEntry));
-	}
-
-	private void _testOnAfterCreateSkipsCleanup() throws Throwable {
-		int versionsToGenerate = 5;
-
-		FragmentEntry fragmentEntry =
-			FragmentEntryVersionTestUtil.addFragmentEntry(_group.getGroupId());
-
-		int initialCount =
-			FragmentEntryVersionTestUtil.countFragmentEntryVersions(
 				fragmentEntry);
 
-		_addFragmentEntryVersions(versionsToGenerate, fragmentEntry);
+		Assert.assertEquals(versions.toString(), 1, versions.size());
+
+		int oldestVersion = versions.get(0);
+
+		Assert.assertTrue(oldestVersion > 0);
+
+		FragmentEntryVersionTestUtil.insertFragmentEntryVersions(
+			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT - 2,
+			CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry);
+
+		versions = FragmentEntryVersionTestUtil.getFragmentEntryVersions(
+			fragmentEntry);
 
 		Assert.assertEquals(
-			versionsToGenerate + initialCount,
-			FragmentEntryVersionTestUtil.countFragmentEntryVersions(
-				fragmentEntry));
+			versions.toString(),
+			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT - 1,
+			versions.size());
+		Assert.assertTrue(versions.contains(oldestVersion));
+
+		FragmentEntryVersionTestUtil.updateFragmentEntry(fragmentEntry);
+
+		versions = FragmentEntryVersionTestUtil.getFragmentEntryVersions(
+			fragmentEntry);
+
+		Assert.assertEquals(
+			versions.toString(),
+			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT,
+			versions.size());
+		Assert.assertTrue(versions.contains(oldestVersion));
+
+		FragmentEntryVersionTestUtil.updateFragmentEntry(fragmentEntry);
+
+		versions = FragmentEntryVersionTestUtil.getFragmentEntryVersions(
+			fragmentEntry);
+
+		Assert.assertEquals(
+			versions.toString(),
+			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT,
+			versions.size());
+		Assert.assertFalse(versions.contains(oldestVersion));
 	}
-
-	private static final TransactionConfig _transactionConfig =
-		TransactionConfig.Factory.create(
-			Propagation.REQUIRED, new Class<?>[] {Exception.class});
-
-	@Inject
-	private CounterLocalService _counterLocalService;
-
-	private Date _date;
-
-	@Inject
-	private FragmentEntryVersionPersistence _fragmentEntryVersionPersistence;
 
 	@DeleteAfterTestRun
 	private Group _group;
-
-	private long _modifiedDateCounter;
-	private int _versionCounter;
 
 }

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/model/listener/test/FragmentEntryVersionModelListenerTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/model/listener/test/FragmentEntryVersionModelListenerTest.java
@@ -8,21 +8,15 @@ package com.liferay.fragment.internal.model.listener.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.counter.kernel.service.CounterLocalService;
 import com.liferay.fragment.internal.constants.FragmentConstants;
-import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.model.FragmentEntryVersion;
-import com.liferay.fragment.service.FragmentEntryLocalService;
 import com.liferay.fragment.service.persistence.FragmentEntryVersionPersistence;
-import com.liferay.fragment.test.util.FragmentTestUtil;
-import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.fragment.test.util.FragmentEntryVersionTestUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
@@ -30,10 +24,6 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
-
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -74,23 +64,6 @@ public class FragmentEntryVersionModelListenerTest {
 		_testOnAfterCreateSkipsCleanup();
 	}
 
-	private FragmentEntry _addFragmentEntry() throws Exception {
-		FragmentCollection fragmentCollection =
-			FragmentTestUtil.addFragmentCollection(_group.getGroupId());
-
-		return _fragmentEntryLocalService.addFragmentEntry(
-			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
-			_group.getGroupId(), fragmentCollection.getFragmentCollectionId(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), false, StringPool.BLANK, null, 0,
-			false, false,
-			com.liferay.fragment.constants.FragmentConstants.TYPE_COMPONENT,
-			null, WorkflowConstants.STATUS_APPROVED,
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
-	}
-
 	private void _addFragmentEntryVersions(
 			int count, FragmentEntry fragmentEntry)
 		throws Throwable {
@@ -125,52 +98,9 @@ public class FragmentEntryVersionModelListenerTest {
 		}
 	}
 
-	private long _countFragmentEntryVersions(FragmentEntry fragmentEntry)
-		throws Exception {
-
-		try (Connection connection = DataAccess.getConnection();
-
-			PreparedStatement preparedStatement = connection.prepareStatement(
-				"select count(*) as count from FragmentEntryVersion where " +
-					"fragmentEntryId = ?")) {
-
-			preparedStatement.setLong(1, fragmentEntry.getFragmentEntryId());
-
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				if (resultSet.next()) {
-					return resultSet.getLong("count");
-				}
-
-				return 0;
-			}
-		}
-	}
-
-	private List<Integer> _getFragmentEntryVersions(FragmentEntry fragmentEntry)
-		throws Exception {
-
-		List<Integer> versions = new ArrayList<>();
-
-		try (Connection connection = DataAccess.getConnection();
-
-			PreparedStatement preparedStatement = connection.prepareStatement(
-				"select version from FragmentEntryVersion where " +
-					"fragmentEntryId = ? order by version")) {
-
-			preparedStatement.setLong(1, fragmentEntry.getFragmentEntryId());
-
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				while (resultSet.next()) {
-					versions.add(resultSet.getInt("version"));
-				}
-			}
-		}
-
-		return versions;
-	}
-
 	private void _testOnAfterCreateDeletesOldVersions() throws Throwable {
-		FragmentEntry fragmentEntry = _addFragmentEntry();
+		FragmentEntry fragmentEntry =
+			FragmentEntryVersionTestUtil.addFragmentEntry(_group.getGroupId());
 
 		_addFragmentEntryVersions(20, fragmentEntry);
 
@@ -186,21 +116,27 @@ public class FragmentEntryVersionModelListenerTest {
 		}
 
 		Assert.assertEquals(
-			expectedVersions, _getFragmentEntryVersions(fragmentEntry));
+			expectedVersions,
+			FragmentEntryVersionTestUtil.getFragmentEntryVersions(
+				fragmentEntry));
 	}
 
 	private void _testOnAfterCreateSkipsCleanup() throws Throwable {
 		int versionsToGenerate = 5;
 
-		FragmentEntry fragmentEntry = _addFragmentEntry();
+		FragmentEntry fragmentEntry =
+			FragmentEntryVersionTestUtil.addFragmentEntry(_group.getGroupId());
 
-		long initialCount = _countFragmentEntryVersions(fragmentEntry);
+		int initialCount =
+			FragmentEntryVersionTestUtil.countFragmentEntryVersions(
+				fragmentEntry);
 
 		_addFragmentEntryVersions(versionsToGenerate, fragmentEntry);
 
 		Assert.assertEquals(
 			versionsToGenerate + initialCount,
-			_countFragmentEntryVersions(fragmentEntry));
+			FragmentEntryVersionTestUtil.countFragmentEntryVersions(
+				fragmentEntry));
 	}
 
 	private static final TransactionConfig _transactionConfig =
@@ -211,9 +147,6 @@ public class FragmentEntryVersionModelListenerTest {
 	private CounterLocalService _counterLocalService;
 
 	private Date _date;
-
-	@Inject
-	private FragmentEntryLocalService _fragmentEntryLocalService;
 
 	@Inject
 	private FragmentEntryVersionPersistence _fragmentEntryVersionPersistence;

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/model/listener/test/FragmentEntryVersionModelListenerTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/model/listener/test/FragmentEntryVersionModelListenerTest.java
@@ -7,8 +7,7 @@ package com.liferay.fragment.internal.model.listener.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.counter.kernel.service.CounterLocalService;
-import com.liferay.fragment.constants.FragmentConstants;
-import com.liferay.fragment.internal.model.listener.FragmentEntryVersionModelListener;
+import com.liferay.fragment.internal.constants.FragmentConstants;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.model.FragmentEntryVersion;
@@ -85,8 +84,9 @@ public class FragmentEntryVersionModelListenerTest {
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), false, StringPool.BLANK, null, 0,
-			false, false, FragmentConstants.TYPE_COMPONENT, null,
-			WorkflowConstants.STATUS_APPROVED,
+			false, false,
+			com.liferay.fragment.constants.FragmentConstants.TYPE_COMPONENT,
+			null, WorkflowConstants.STATUS_APPROVED,
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));
 	}
@@ -174,11 +174,12 @@ public class FragmentEntryVersionModelListenerTest {
 
 		_addFragmentEntryVersions(20, fragmentEntry);
 
-		int maxVersions = FragmentEntryVersionModelListener.MAX_VERSIONS;
+		List<Integer> expectedVersions = new ArrayList<>(
+			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT);
 
-		List<Integer> expectedVersions = new ArrayList<>(maxVersions);
-
-		for (int version = _versionCounter - maxVersions;
+		for (int version =
+				_versionCounter -
+					FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT;
 			 version < _versionCounter; version++) {
 
 			expectedVersions.add(version);

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/model/listener/test/FragmentEntryVersionModelListenerTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/model/listener/test/FragmentEntryVersionModelListenerTest.java
@@ -7,13 +7,20 @@ package com.liferay.fragment.internal.model.listener.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.change.tracking.constants.CTConstants;
+import com.liferay.change.tracking.model.CTCollection;
+import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.fragment.internal.constants.FragmentConstants;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.test.util.FragmentEntryVersionTestUtil;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
@@ -94,6 +101,40 @@ public class FragmentEntryVersionModelListenerTest {
 			versions.size());
 		Assert.assertFalse(versions.contains(oldestVersion));
 	}
+
+	@Test
+	public void testOnAfterCreateInCtCollection() throws Throwable {
+		FragmentEntry fragmentEntry =
+			FragmentEntryVersionTestUtil.addFragmentEntry(_group.getGroupId());
+
+		FragmentEntryVersionTestUtil.insertFragmentEntryVersions(
+			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT - 1,
+			CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry);
+
+		Assert.assertEquals(
+			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT,
+			FragmentEntryVersionTestUtil.countFragmentEntryVersions(
+				fragmentEntry));
+
+		CTCollection ctCollection = _ctCollectionLocalService.addCTCollection(
+			null, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			0, RandomTestUtil.randomString(), null);
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					ctCollection.getCtCollectionId())) {
+
+			FragmentEntryVersionTestUtil.updateFragmentEntry(fragmentEntry);
+
+			Assert.assertEquals(
+				FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT + 1,
+				FragmentEntryVersionTestUtil.countFragmentEntryVersions(
+					fragmentEntry));
+		}
+	}
+
+	@Inject
+	private CTCollectionLocalService _ctCollectionLocalService;
 
 	@DeleteAfterTestRun
 	private Group _group;

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/model/listener/test/FragmentEntryVersionModelListenerTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/model/listener/test/FragmentEntryVersionModelListenerTest.java
@@ -9,7 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.change.tracking.constants.CTConstants;
 import com.liferay.change.tracking.model.CTCollection;
 import com.liferay.change.tracking.service.CTCollectionLocalService;
-import com.liferay.fragment.internal.constants.FragmentConstants;
+import com.liferay.fragment.internal.constants.FragmentEntryVersionConstants;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.test.util.FragmentEntryVersionTestUtil;
 import com.liferay.petra.lang.SafeCloseable;
@@ -67,7 +67,7 @@ public class FragmentEntryVersionModelListenerTest {
 		Assert.assertTrue(oldestVersion > 0);
 
 		FragmentEntryVersionTestUtil.insertFragmentEntryVersions(
-			FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX - 2,
+			FragmentEntryVersionConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX - 2,
 			CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry);
 
 		versions = FragmentEntryVersionTestUtil.getFragmentEntryVersions(
@@ -75,7 +75,7 @@ public class FragmentEntryVersionModelListenerTest {
 
 		Assert.assertEquals(
 			versions.toString(),
-			FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX - 1,
+			FragmentEntryVersionConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX - 1,
 			versions.size());
 		Assert.assertTrue(versions.contains(oldestVersion));
 
@@ -86,7 +86,7 @@ public class FragmentEntryVersionModelListenerTest {
 
 		Assert.assertEquals(
 			versions.toString(),
-			FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
+			FragmentEntryVersionConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
 			versions.size());
 		Assert.assertTrue(versions.contains(oldestVersion));
 
@@ -97,7 +97,7 @@ public class FragmentEntryVersionModelListenerTest {
 
 		Assert.assertEquals(
 			versions.toString(),
-			FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
+			FragmentEntryVersionConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
 			versions.size());
 		Assert.assertFalse(versions.contains(oldestVersion));
 	}
@@ -108,11 +108,11 @@ public class FragmentEntryVersionModelListenerTest {
 			FragmentEntryVersionTestUtil.addFragmentEntry(_group.getGroupId());
 
 		FragmentEntryVersionTestUtil.insertFragmentEntryVersions(
-			FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX - 1,
+			FragmentEntryVersionConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX - 1,
 			CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry);
 
 		Assert.assertEquals(
-			FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
+			FragmentEntryVersionConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
 			FragmentEntryVersionTestUtil.countFragmentEntryVersions(
 				fragmentEntry));
 
@@ -127,7 +127,8 @@ public class FragmentEntryVersionModelListenerTest {
 			FragmentEntryVersionTestUtil.updateFragmentEntry(fragmentEntry);
 
 			Assert.assertEquals(
-				FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX + 1,
+				FragmentEntryVersionConstants.
+					FRAGMENT_ENTRY_VERSIONS_COUNT_MAX + 1,
 				FragmentEntryVersionTestUtil.countFragmentEntryVersions(
 					fragmentEntry));
 		}

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v3_0_3/test/FragmentEntryVersionUpgradeProcessTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v3_0_3/test/FragmentEntryVersionUpgradeProcessTest.java
@@ -75,8 +75,8 @@ public class FragmentEntryVersionUpgradeProcessTest {
 
 	@Test
 	public void testUpgrade() throws Exception {
-		_testUpgradeDeletesOldVersions();
-		_testUpgradeSkipsCleanup();
+		_testUpgradeDeletesFragmentEntryVersions();
+		_testUpgradePreservesFragmentEntryVersions();
 	}
 
 	private FragmentEntry _addFragmentEntry() throws Exception {
@@ -199,7 +199,7 @@ public class FragmentEntryVersionUpgradeProcessTest {
 		_multiVMPool.clear();
 	}
 
-	private void _testUpgradeDeletesOldVersions() throws Exception {
+	private void _testUpgradeDeletesFragmentEntryVersions() throws Exception {
 		FragmentEntry fragmentEntry = _addFragmentEntry();
 
 		_insertFragmentEntryVersions(20, fragmentEntry);
@@ -221,7 +221,7 @@ public class FragmentEntryVersionUpgradeProcessTest {
 			expectedVersions, _getFragmentEntryVersions(fragmentEntry));
 	}
 
-	private void _testUpgradeSkipsCleanup() throws Exception {
+	private void _testUpgradePreservesFragmentEntryVersions() throws Exception {
 		int versionsCount = 5;
 
 		FragmentEntry fragmentEntry = _addFragmentEntry();

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v3_0_3/test/FragmentEntryVersionUpgradeProcessTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v3_0_3/test/FragmentEntryVersionUpgradeProcessTest.java
@@ -11,11 +11,13 @@ import com.liferay.fragment.internal.constants.FragmentConstants;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.test.util.FragmentEntryVersionTestUtil;
 import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.version.Version;
 import com.liferay.portal.test.rule.Inject;
@@ -24,6 +26,11 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Assert;
@@ -52,9 +59,35 @@ public class FragmentEntryVersionUpgradeProcessTest {
 	}
 
 	@Test
-	public void testUpgrade() throws Throwable {
+	public void testUpgrade() throws Exception {
 		_testUpgradeDeletesFragmentEntryVersions();
 		_testUpgradePreservesFragmentEntryVersions();
+	}
+
+	private List<Integer> _getFragmentEntryVersions(
+			long ctCollectionId, FragmentEntry fragmentEntry)
+		throws Exception {
+
+		List<Integer> versions = new ArrayList<>();
+
+		try (Connection connection = DataAccess.getConnection();
+
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select version from FragmentEntryVersion where " +
+					"ctCollectionId = ? and fragmentEntryId = ? order by " +
+						"version")) {
+
+			preparedStatement.setLong(1, ctCollectionId);
+			preparedStatement.setLong(2, fragmentEntry.getFragmentEntryId());
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					versions.add(resultSet.getInt("version"));
+				}
+			}
+		}
+
+		return versions;
 	}
 
 	private void _runUpgrade() throws Exception {
@@ -72,47 +105,70 @@ public class FragmentEntryVersionUpgradeProcessTest {
 		_multiVMPool.clear();
 	}
 
-	private void _testUpgradeDeletesFragmentEntryVersions() throws Throwable {
+	private void _testUpgrade(
+			int actualCtCollectionVersionsCount,
+			int actualProductionVersionsCount,
+			int expectedCtCollectionVersionsCount,
+			int expectedProductionVersionsCount)
+		throws Exception {
+
 		FragmentEntry fragmentEntry =
 			FragmentEntryVersionTestUtil.addFragmentEntry(_group.getGroupId());
 
-		List<Integer> insertedVersions =
+		List<Integer> initialProductionVersions = _getFragmentEntryVersions(
+			CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry);
+
+		List<Integer> insertedCtCollectionVersions = new ArrayList<>();
+		long ctCollectionId = RandomTestUtil.randomLong();
+
+		if (actualCtCollectionVersionsCount > 0) {
+			insertedCtCollectionVersions =
+				FragmentEntryVersionTestUtil.insertFragmentEntryVersions(
+					actualCtCollectionVersionsCount, ctCollectionId,
+					fragmentEntry);
+		}
+
+		List<Integer> insertedProductionVersions =
 			FragmentEntryVersionTestUtil.insertFragmentEntryVersions(
-				20, CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry);
+				actualProductionVersionsCount - 1,
+				CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry);
 
 		_runUpgrade();
 
-		List<Integer> expectedVersions = insertedVersions.subList(
-			insertedVersions.size() -
-				FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT,
-			insertedVersions.size());
+		List<Integer> allProductionVersions = new ArrayList<>(
+			initialProductionVersions.size() +
+				insertedProductionVersions.size());
+
+		allProductionVersions.addAll(initialProductionVersions);
+		allProductionVersions.addAll(insertedProductionVersions);
 
 		Assert.assertEquals(
-			expectedVersions,
-			FragmentEntryVersionTestUtil.getFragmentEntryVersions(
-				fragmentEntry));
+			allProductionVersions.subList(
+				allProductionVersions.size() - expectedProductionVersionsCount,
+				allProductionVersions.size()),
+			_getFragmentEntryVersions(
+				CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry));
+
+		if (actualCtCollectionVersionsCount > 0) {
+			Assert.assertEquals(
+				insertedCtCollectionVersions.subList(
+					insertedCtCollectionVersions.size() -
+						expectedCtCollectionVersionsCount,
+					insertedCtCollectionVersions.size()),
+				_getFragmentEntryVersions(ctCollectionId, fragmentEntry));
+		}
+	}
+
+	private void _testUpgradeDeletesFragmentEntryVersions() throws Exception {
+		_testUpgrade(
+			0, 11, 0, FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT);
+		_testUpgrade(
+			0, 20, 0, FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT);
 	}
 
 	private void _testUpgradePreservesFragmentEntryVersions() throws Exception {
-		FragmentEntry fragmentEntry =
-			FragmentEntryVersionTestUtil.addFragmentEntry(_group.getGroupId());
-
-		int initialCount =
-			FragmentEntryVersionTestUtil.countFragmentEntryVersions(
-				CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry);
-
-		int versionsCount = 5;
-
-		FragmentEntryVersionTestUtil.insertFragmentEntryVersions(
-			versionsCount, CTConstants.CT_COLLECTION_ID_PRODUCTION,
-			fragmentEntry);
-
-		_runUpgrade();
-
-		Assert.assertEquals(
-			versionsCount + initialCount,
-			FragmentEntryVersionTestUtil.countFragmentEntryVersions(
-				CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry));
+		_testUpgrade(0, 1, 0, 1);
+		_testUpgrade(0, 10, 0, 10);
 	}
 
 	@Inject(

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v3_0_3/test/FragmentEntryVersionUpgradeProcessTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v3_0_3/test/FragmentEntryVersionUpgradeProcessTest.java
@@ -7,8 +7,7 @@ package com.liferay.fragment.internal.upgrade.v3_0_3.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.counter.kernel.service.CounterLocalService;
-import com.liferay.fragment.constants.FragmentConstants;
-import com.liferay.fragment.internal.upgrade.v3_0_3.FragmentEntryVersionUpgradeProcess;
+import com.liferay.fragment.internal.constants.FragmentConstants;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.model.FragmentEntryVersion;
@@ -90,8 +89,9 @@ public class FragmentEntryVersionUpgradeProcessTest {
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), false, StringPool.BLANK, null, 0,
-			false, false, FragmentConstants.TYPE_COMPONENT, null,
-			WorkflowConstants.STATUS_APPROVED,
+			false, false,
+			com.liferay.fragment.constants.FragmentConstants.TYPE_COMPONENT,
+			null, WorkflowConstants.STATUS_APPROVED,
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));
 	}
@@ -206,11 +206,12 @@ public class FragmentEntryVersionUpgradeProcessTest {
 
 		_runUpgrade();
 
-		int maxVersions = FragmentEntryVersionUpgradeProcess.MAX_VERSIONS;
+		List<Integer> expectedVersions = new ArrayList<>(
+			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT);
 
-		List<Integer> expectedVersions = new ArrayList<>(maxVersions);
-
-		for (int version = _versionCounter - maxVersions;
+		for (int version =
+				_versionCounter -
+					FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT;
 			 version < _versionCounter; version++) {
 
 			expectedVersions.add(version);

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v3_0_3/test/FragmentEntryVersionUpgradeProcessTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v3_0_3/test/FragmentEntryVersionUpgradeProcessTest.java
@@ -222,18 +222,18 @@ public class FragmentEntryVersionUpgradeProcessTest {
 	}
 
 	private void _testUpgradeSkipsCleanup() throws Exception {
-		int versionsToGenerate = 5;
+		int versionsCount = 5;
 
 		FragmentEntry fragmentEntry = _addFragmentEntry();
 
 		long initialCount = _countFragmentEntryVersions(fragmentEntry);
 
-		_insertFragmentEntryVersions(versionsToGenerate, fragmentEntry);
+		_insertFragmentEntryVersions(versionsCount, fragmentEntry);
 
 		_runUpgrade();
 
 		Assert.assertEquals(
-			versionsToGenerate + initialCount,
+			versionsCount + initialCount,
 			_countFragmentEntryVersions(fragmentEntry));
 	}
 

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v3_0_3/test/FragmentEntryVersionUpgradeProcessTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v3_0_3/test/FragmentEntryVersionUpgradeProcessTest.java
@@ -163,18 +163,18 @@ public class FragmentEntryVersionUpgradeProcessTest {
 
 	private void _testUpgradeDeletesFragmentEntryVersions() throws Exception {
 		_testUpgrade(
-			0, 11, 0, FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT);
+			0, 11, 0, FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX);
 		_testUpgrade(
-			0, 20, 0, FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT);
+			0, 20, 0, FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX);
 	}
 
 	private void _testUpgradeDeletesFragmentEntryVersionsPerCtCollection()
 		throws Exception {
 
 		_testUpgrade(
-			11, 1, FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT, 1);
+			11, 1, FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX, 1);
 		_testUpgrade(
-			20, 10, FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT, 10);
+			20, 10, FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX, 10);
 	}
 
 	private void _testUpgradePreservesFragmentEntryVersions() throws Exception {

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v3_0_3/test/FragmentEntryVersionUpgradeProcessTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v3_0_3/test/FragmentEntryVersionUpgradeProcessTest.java
@@ -61,6 +61,7 @@ public class FragmentEntryVersionUpgradeProcessTest {
 	@Test
 	public void testUpgrade() throws Exception {
 		_testUpgradeDeletesFragmentEntryVersions();
+		_testUpgradeDeletesFragmentEntryVersionsPerCtCollection();
 		_testUpgradePreservesFragmentEntryVersions();
 		_testUpgradePreservesFragmentEntryVersionsPerCtCollection();
 	}
@@ -165,6 +166,15 @@ public class FragmentEntryVersionUpgradeProcessTest {
 			0, 11, 0, FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT);
 		_testUpgrade(
 			0, 20, 0, FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT);
+	}
+
+	private void _testUpgradeDeletesFragmentEntryVersionsPerCtCollection()
+		throws Exception {
+
+		_testUpgrade(
+			11, 1, FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT, 1);
+		_testUpgrade(
+			20, 10, FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT, 10);
 	}
 
 	private void _testUpgradePreservesFragmentEntryVersions() throws Exception {

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v3_0_3/test/FragmentEntryVersionUpgradeProcessTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v3_0_3/test/FragmentEntryVersionUpgradeProcessTest.java
@@ -120,8 +120,8 @@ public class FragmentEntryVersionUpgradeProcessTest {
 		List<Integer> initialProductionVersions = _getFragmentEntryVersions(
 			CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry);
 
-		List<Integer> insertedCtCollectionVersions = new ArrayList<>();
 		long ctCollectionId = RandomTestUtil.randomLong();
+		List<Integer> insertedCtCollectionVersions = new ArrayList<>();
 
 		if (actualCtCollectionVersionsCount > 0) {
 			insertedCtCollectionVersions =

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v3_0_3/test/FragmentEntryVersionUpgradeProcessTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v3_0_3/test/FragmentEntryVersionUpgradeProcessTest.java
@@ -189,11 +189,6 @@ public class FragmentEntryVersionUpgradeProcessTest {
 		_testUpgrade(10, 10, 10, 10);
 	}
 
-	@Inject(
-		filter = "(&(component.name=com.liferay.fragment.internal.upgrade.registry.FragmentServiceUpgradeStepRegistrator))"
-	)
-	private static UpgradeStepRegistrator _upgradeStepRegistrator;
-
 	@Inject
 	private EntityCache _entityCache;
 
@@ -202,5 +197,10 @@ public class FragmentEntryVersionUpgradeProcessTest {
 
 	@Inject
 	private MultiVMPool _multiVMPool;
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.fragment.internal.upgrade.registry.FragmentServiceUpgradeStepRegistrator))"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
 
 }

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v3_0_3/test/FragmentEntryVersionUpgradeProcessTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v3_0_3/test/FragmentEntryVersionUpgradeProcessTest.java
@@ -62,6 +62,7 @@ public class FragmentEntryVersionUpgradeProcessTest {
 	public void testUpgrade() throws Exception {
 		_testUpgradeDeletesFragmentEntryVersions();
 		_testUpgradePreservesFragmentEntryVersions();
+		_testUpgradePreservesFragmentEntryVersionsPerCtCollection();
 	}
 
 	private List<Integer> _getFragmentEntryVersions(
@@ -169,6 +170,13 @@ public class FragmentEntryVersionUpgradeProcessTest {
 	private void _testUpgradePreservesFragmentEntryVersions() throws Exception {
 		_testUpgrade(0, 1, 0, 1);
 		_testUpgrade(0, 10, 0, 10);
+	}
+
+	private void _testUpgradePreservesFragmentEntryVersionsPerCtCollection()
+		throws Exception {
+
+		_testUpgrade(1, 1, 1, 1);
+		_testUpgrade(10, 10, 10, 10);
 	}
 
 	@Inject(

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v3_0_3/test/FragmentEntryVersionUpgradeProcessTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v3_0_3/test/FragmentEntryVersionUpgradeProcessTest.java
@@ -7,7 +7,7 @@ package com.liferay.fragment.internal.upgrade.v3_0_3.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.change.tracking.constants.CTConstants;
-import com.liferay.fragment.internal.constants.FragmentConstants;
+import com.liferay.fragment.internal.constants.FragmentEntryVersionConstants;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.test.util.FragmentEntryVersionTestUtil;
 import com.liferay.portal.kernel.cache.MultiVMPool;
@@ -163,18 +163,23 @@ public class FragmentEntryVersionUpgradeProcessTest {
 
 	private void _testUpgradeDeletesFragmentEntryVersions() throws Exception {
 		_testUpgrade(
-			0, 11, 0, FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX);
+			0, 11, 0,
+			FragmentEntryVersionConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX);
 		_testUpgrade(
-			0, 20, 0, FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX);
+			0, 20, 0,
+			FragmentEntryVersionConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX);
 	}
 
 	private void _testUpgradeDeletesFragmentEntryVersionsPerCtCollection()
 		throws Exception {
 
 		_testUpgrade(
-			11, 1, FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX, 1);
+			11, 1,
+			FragmentEntryVersionConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX, 1);
 		_testUpgrade(
-			20, 10, FragmentConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX, 10);
+			20, 10,
+			FragmentEntryVersionConstants.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
+			10);
 	}
 
 	private void _testUpgradePreservesFragmentEntryVersions() throws Exception {

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v3_0_3/test/FragmentEntryVersionUpgradeProcessTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v3_0_3/test/FragmentEntryVersionUpgradeProcessTest.java
@@ -1,0 +1,265 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.internal.upgrade.v3_0_3.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.counter.kernel.service.CounterLocalService;
+import com.liferay.fragment.constants.FragmentConstants;
+import com.liferay.fragment.internal.upgrade.v3_0_3.FragmentEntryVersionUpgradeProcess;
+import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.model.FragmentEntryVersion;
+import com.liferay.fragment.service.FragmentEntryLocalService;
+import com.liferay.fragment.test.util.FragmentTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.dao.orm.EntityCache;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.version.Version;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Georgel Pop
+ */
+@RunWith(Arquillian.class)
+public class FragmentEntryVersionUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_createDateTimestamp = new Timestamp(
+			System.currentTimeMillis() + 3600000L);
+		_modifiedDateCounter = System.currentTimeMillis() + 3600000L;
+		_versionCounter = 1000;
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		_testUpgradeDeletesOldVersions();
+		_testUpgradeSkipsCleanup();
+	}
+
+	private FragmentEntry _addFragmentEntry() throws Exception {
+		FragmentCollection fragmentCollection =
+			FragmentTestUtil.addFragmentCollection(_group.getGroupId());
+
+		return _fragmentEntryLocalService.addFragmentEntry(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+			_group.getGroupId(), fragmentCollection.getFragmentCollectionId(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), false, StringPool.BLANK, null, 0,
+			false, false, FragmentConstants.TYPE_COMPONENT, null,
+			WorkflowConstants.STATUS_APPROVED,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private long _countFragmentEntryVersions(FragmentEntry fragmentEntry)
+		throws Exception {
+
+		try (Connection connection = DataAccess.getConnection();
+
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select count(*) as count from FragmentEntryVersion where " +
+					"fragmentEntryId = ?")) {
+
+			preparedStatement.setLong(1, fragmentEntry.getFragmentEntryId());
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				if (resultSet.next()) {
+					return resultSet.getLong("count");
+				}
+
+				return 0;
+			}
+		}
+	}
+
+	private List<Integer> _getFragmentEntryVersions(FragmentEntry fragmentEntry)
+		throws Exception {
+
+		List<Integer> versions = new ArrayList<>();
+
+		try (Connection connection = DataAccess.getConnection();
+
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select version from FragmentEntryVersion where " +
+					"fragmentEntryId = ? order by version")) {
+
+			preparedStatement.setLong(1, fragmentEntry.getFragmentEntryId());
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					versions.add(resultSet.getInt("version"));
+				}
+			}
+		}
+
+		return versions;
+	}
+
+	private void _insertFragmentEntryVersions(
+			int count, FragmentEntry fragmentEntry)
+		throws Exception {
+
+		try (Connection connection = DataAccess.getConnection();
+
+			PreparedStatement preparedStatement =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					StringBundler.concat(
+						"insert into FragmentEntryVersion (mvccVersion, ",
+						"ctCollectionId, fragmentEntryVersionId, version, ",
+						"fragmentEntryId, groupId, companyId, userId, ",
+						"createDate, modifiedDate, name, status) values (0, ",
+						"0, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"))) {
+
+			for (int i = 0; i < count; i++) {
+				Timestamp modifiedDateTimestamp = new Timestamp(
+					_modifiedDateCounter);
+
+				_modifiedDateCounter += 1000L;
+
+				preparedStatement.setLong(
+					1,
+					_counterLocalService.increment(
+						FragmentEntryVersion.class.getName()));
+				preparedStatement.setInt(2, _versionCounter++);
+				preparedStatement.setLong(
+					3, fragmentEntry.getFragmentEntryId());
+				preparedStatement.setLong(4, fragmentEntry.getGroupId());
+				preparedStatement.setLong(5, fragmentEntry.getCompanyId());
+				preparedStatement.setLong(6, fragmentEntry.getUserId());
+				preparedStatement.setTimestamp(7, _createDateTimestamp);
+				preparedStatement.setTimestamp(8, modifiedDateTimestamp);
+				preparedStatement.setString(9, RandomTestUtil.randomString());
+				preparedStatement.setInt(10, WorkflowConstants.STATUS_APPROVED);
+
+				preparedStatement.addBatch();
+			}
+
+			preparedStatement.executeBatch();
+		}
+	}
+
+	private void _runUpgrade() throws Exception {
+		_entityCache.clearCache();
+		_multiVMPool.clear();
+
+		for (UpgradeProcess upgradeProcess :
+				UpgradeTestUtil.getUpgradeSteps(
+					_upgradeStepRegistrator, new Version(3, 0, 3))) {
+
+			upgradeProcess.upgrade();
+		}
+
+		_entityCache.clearCache();
+		_multiVMPool.clear();
+	}
+
+	private void _testUpgradeDeletesOldVersions() throws Exception {
+		FragmentEntry fragmentEntry = _addFragmentEntry();
+
+		_insertFragmentEntryVersions(20, fragmentEntry);
+
+		_runUpgrade();
+
+		int maxVersions = FragmentEntryVersionUpgradeProcess.MAX_VERSIONS;
+
+		List<Integer> expectedVersions = new ArrayList<>(maxVersions);
+
+		for (int version = _versionCounter - maxVersions;
+			 version < _versionCounter; version++) {
+
+			expectedVersions.add(version);
+		}
+
+		Assert.assertEquals(
+			expectedVersions, _getFragmentEntryVersions(fragmentEntry));
+	}
+
+	private void _testUpgradeSkipsCleanup() throws Exception {
+		int versionsToGenerate = 5;
+
+		FragmentEntry fragmentEntry = _addFragmentEntry();
+
+		long initialCount = _countFragmentEntryVersions(fragmentEntry);
+
+		_insertFragmentEntryVersions(versionsToGenerate, fragmentEntry);
+
+		_runUpgrade();
+
+		Assert.assertEquals(
+			versionsToGenerate + initialCount,
+			_countFragmentEntryVersions(fragmentEntry));
+	}
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.fragment.internal.upgrade.registry.FragmentServiceUpgradeStepRegistrator))"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@Inject
+	private CounterLocalService _counterLocalService;
+
+	private Timestamp _createDateTimestamp;
+
+	@Inject
+	private EntityCache _entityCache;
+
+	@Inject
+	private FragmentEntryLocalService _fragmentEntryLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private long _modifiedDateCounter;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+	private int _versionCounter;
+
+}

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v3_0_3/test/FragmentEntryVersionUpgradeProcessTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v3_0_3/test/FragmentEntryVersionUpgradeProcessTest.java
@@ -6,41 +6,24 @@
 package com.liferay.fragment.internal.upgrade.v3_0_3.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.counter.kernel.service.CounterLocalService;
+import com.liferay.change.tracking.constants.CTConstants;
 import com.liferay.fragment.internal.constants.FragmentConstants;
-import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
-import com.liferay.fragment.model.FragmentEntryVersion;
-import com.liferay.fragment.service.FragmentEntryLocalService;
-import com.liferay.fragment.test.util.FragmentTestUtil;
-import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
+import com.liferay.fragment.test.util.FragmentEntryVersionTestUtil;
 import com.liferay.portal.kernel.cache.MultiVMPool;
-import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
-import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
-import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.version.Version;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.Timestamp;
-
-import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Assert;
@@ -66,122 +49,12 @@ public class FragmentEntryVersionUpgradeProcessTest {
 	@Before
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
-
-		_createDateTimestamp = new Timestamp(
-			System.currentTimeMillis() + 3600000L);
-		_modifiedDateCounter = System.currentTimeMillis() + 3600000L;
-		_versionCounter = 1000;
 	}
 
 	@Test
-	public void testUpgrade() throws Exception {
+	public void testUpgrade() throws Throwable {
 		_testUpgradeDeletesFragmentEntryVersions();
 		_testUpgradePreservesFragmentEntryVersions();
-	}
-
-	private FragmentEntry _addFragmentEntry() throws Exception {
-		FragmentCollection fragmentCollection =
-			FragmentTestUtil.addFragmentCollection(_group.getGroupId());
-
-		return _fragmentEntryLocalService.addFragmentEntry(
-			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
-			_group.getGroupId(), fragmentCollection.getFragmentCollectionId(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), false, StringPool.BLANK, null, 0,
-			false, false,
-			com.liferay.fragment.constants.FragmentConstants.TYPE_COMPONENT,
-			null, WorkflowConstants.STATUS_APPROVED,
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
-	}
-
-	private long _countFragmentEntryVersions(FragmentEntry fragmentEntry)
-		throws Exception {
-
-		try (Connection connection = DataAccess.getConnection();
-
-			PreparedStatement preparedStatement = connection.prepareStatement(
-				"select count(*) as count from FragmentEntryVersion where " +
-					"fragmentEntryId = ?")) {
-
-			preparedStatement.setLong(1, fragmentEntry.getFragmentEntryId());
-
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				if (resultSet.next()) {
-					return resultSet.getLong("count");
-				}
-
-				return 0;
-			}
-		}
-	}
-
-	private List<Integer> _getFragmentEntryVersions(FragmentEntry fragmentEntry)
-		throws Exception {
-
-		List<Integer> versions = new ArrayList<>();
-
-		try (Connection connection = DataAccess.getConnection();
-
-			PreparedStatement preparedStatement = connection.prepareStatement(
-				"select version from FragmentEntryVersion where " +
-					"fragmentEntryId = ? order by version")) {
-
-			preparedStatement.setLong(1, fragmentEntry.getFragmentEntryId());
-
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				while (resultSet.next()) {
-					versions.add(resultSet.getInt("version"));
-				}
-			}
-		}
-
-		return versions;
-	}
-
-	private void _insertFragmentEntryVersions(
-			int count, FragmentEntry fragmentEntry)
-		throws Exception {
-
-		try (Connection connection = DataAccess.getConnection();
-
-			PreparedStatement preparedStatement =
-				AutoBatchPreparedStatementUtil.autoBatch(
-					connection,
-					StringBundler.concat(
-						"insert into FragmentEntryVersion (mvccVersion, ",
-						"ctCollectionId, fragmentEntryVersionId, version, ",
-						"fragmentEntryId, groupId, companyId, userId, ",
-						"createDate, modifiedDate, name, status) values (0, ",
-						"0, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"))) {
-
-			for (int i = 0; i < count; i++) {
-				Timestamp modifiedDateTimestamp = new Timestamp(
-					_modifiedDateCounter);
-
-				_modifiedDateCounter += 1000L;
-
-				preparedStatement.setLong(
-					1,
-					_counterLocalService.increment(
-						FragmentEntryVersion.class.getName()));
-				preparedStatement.setInt(2, _versionCounter++);
-				preparedStatement.setLong(
-					3, fragmentEntry.getFragmentEntryId());
-				preparedStatement.setLong(4, fragmentEntry.getGroupId());
-				preparedStatement.setLong(5, fragmentEntry.getCompanyId());
-				preparedStatement.setLong(6, fragmentEntry.getUserId());
-				preparedStatement.setTimestamp(7, _createDateTimestamp);
-				preparedStatement.setTimestamp(8, modifiedDateTimestamp);
-				preparedStatement.setString(9, RandomTestUtil.randomString());
-				preparedStatement.setInt(10, WorkflowConstants.STATUS_APPROVED);
-
-				preparedStatement.addBatch();
-			}
-
-			preparedStatement.executeBatch();
-		}
 	}
 
 	private void _runUpgrade() throws Exception {
@@ -199,42 +72,47 @@ public class FragmentEntryVersionUpgradeProcessTest {
 		_multiVMPool.clear();
 	}
 
-	private void _testUpgradeDeletesFragmentEntryVersions() throws Exception {
-		FragmentEntry fragmentEntry = _addFragmentEntry();
+	private void _testUpgradeDeletesFragmentEntryVersions() throws Throwable {
+		FragmentEntry fragmentEntry =
+			FragmentEntryVersionTestUtil.addFragmentEntry(_group.getGroupId());
 
-		_insertFragmentEntryVersions(20, fragmentEntry);
+		List<Integer> insertedVersions =
+			FragmentEntryVersionTestUtil.insertFragmentEntryVersions(
+				20, CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry);
 
 		_runUpgrade();
 
-		List<Integer> expectedVersions = new ArrayList<>(
-			FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT);
-
-		for (int version =
-				_versionCounter -
-					FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT;
-			 version < _versionCounter; version++) {
-
-			expectedVersions.add(version);
-		}
+		List<Integer> expectedVersions = insertedVersions.subList(
+			insertedVersions.size() -
+				FragmentConstants.MAX_FRAGMENT_ENTRY_VERSION_COUNT,
+			insertedVersions.size());
 
 		Assert.assertEquals(
-			expectedVersions, _getFragmentEntryVersions(fragmentEntry));
+			expectedVersions,
+			FragmentEntryVersionTestUtil.getFragmentEntryVersions(
+				fragmentEntry));
 	}
 
 	private void _testUpgradePreservesFragmentEntryVersions() throws Exception {
+		FragmentEntry fragmentEntry =
+			FragmentEntryVersionTestUtil.addFragmentEntry(_group.getGroupId());
+
+		int initialCount =
+			FragmentEntryVersionTestUtil.countFragmentEntryVersions(
+				CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry);
+
 		int versionsCount = 5;
 
-		FragmentEntry fragmentEntry = _addFragmentEntry();
-
-		long initialCount = _countFragmentEntryVersions(fragmentEntry);
-
-		_insertFragmentEntryVersions(versionsCount, fragmentEntry);
+		FragmentEntryVersionTestUtil.insertFragmentEntryVersions(
+			versionsCount, CTConstants.CT_COLLECTION_ID_PRODUCTION,
+			fragmentEntry);
 
 		_runUpgrade();
 
 		Assert.assertEquals(
 			versionsCount + initialCount,
-			_countFragmentEntryVersions(fragmentEntry));
+			FragmentEntryVersionTestUtil.countFragmentEntryVersions(
+				CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry));
 	}
 
 	@Inject(
@@ -243,24 +121,12 @@ public class FragmentEntryVersionUpgradeProcessTest {
 	private static UpgradeStepRegistrator _upgradeStepRegistrator;
 
 	@Inject
-	private CounterLocalService _counterLocalService;
-
-	private Timestamp _createDateTimestamp;
-
-	@Inject
 	private EntityCache _entityCache;
-
-	@Inject
-	private FragmentEntryLocalService _fragmentEntryLocalService;
 
 	@DeleteAfterTestRun
 	private Group _group;
 
-	private long _modifiedDateCounter;
-
 	@Inject
 	private MultiVMPool _multiVMPool;
-
-	private int _versionCounter;
 
 }

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/test/util/FragmentEntryVersionTestUtil.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/test/util/FragmentEntryVersionTestUtil.java
@@ -128,9 +128,10 @@ public class FragmentEntryVersionTestUtil {
 						"?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"))) {
 
 			String className = FragmentEntryVersion.class.getName();
+			int startVersion = _getStartVersion(connection, fragmentEntry);
 
 			for (int i = 0; i < count; i++) {
-				int version = _START_VERSION + i;
+				int version = startVersion + i;
 
 				versions.add(version);
 
@@ -167,7 +168,23 @@ public class FragmentEntryVersionTestUtil {
 		FragmentEntryLocalServiceUtil.updateFragmentEntry(fragmentEntry);
 	}
 
-	private static final int _START_VERSION = 1000;
+	private static int _getStartVersion(
+			Connection connection, FragmentEntry fragmentEntry)
+		throws Exception {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select max(version) as maxVersion from FragmentEntryVersion " +
+					"where fragmentEntryId = ?")) {
+
+			preparedStatement.setLong(1, fragmentEntry.getFragmentEntryId());
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				resultSet.next();
+
+				return resultSet.getInt("maxVersion") + 1;
+			}
+		}
+	}
 
 	private static final TransactionConfig _transactionConfig =
 		TransactionConfig.Factory.create(

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/test/util/FragmentEntryVersionTestUtil.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/test/util/FragmentEntryVersionTestUtil.java
@@ -109,11 +109,11 @@ public class FragmentEntryVersionTestUtil {
 			int count, long ctCollectionId, FragmentEntry fragmentEntry)
 		throws Exception {
 
+		List<Integer> versions = new ArrayList<>(count);
+
 		long now = System.currentTimeMillis();
 
 		Timestamp createDateTimestamp = new Timestamp(now);
-
-		List<Integer> versions = new ArrayList<>(count);
 
 		try (Connection connection = DataAccess.getConnection();
 

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/test/util/FragmentEntryVersionTestUtil.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/test/util/FragmentEntryVersionTestUtil.java
@@ -127,6 +127,8 @@ public class FragmentEntryVersionTestUtil {
 						"createDate, modifiedDate, name, status) values (0, ",
 						"?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"))) {
 
+			String className = FragmentEntryVersion.class.getName();
+
 			for (int i = 0; i < count; i++) {
 				int version = _START_VERSION + i;
 
@@ -134,9 +136,7 @@ public class FragmentEntryVersionTestUtil {
 
 				preparedStatement.setLong(1, ctCollectionId);
 				preparedStatement.setLong(
-					2,
-					CounterLocalServiceUtil.increment(
-						FragmentEntryVersion.class.getName()));
+					2, CounterLocalServiceUtil.increment(className));
 				preparedStatement.setInt(3, version);
 				preparedStatement.setLong(
 					4, fragmentEntry.getFragmentEntryId());

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/test/util/FragmentEntryVersionTestUtil.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/test/util/FragmentEntryVersionTestUtil.java
@@ -1,0 +1,176 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.test.util;
+
+import com.liferay.counter.kernel.service.CounterLocalServiceUtil;
+import com.liferay.fragment.constants.FragmentConstants;
+import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.model.FragmentEntryVersion;
+import com.liferay.fragment.service.FragmentEntryLocalServiceUtil;
+import com.liferay.fragment.service.persistence.FragmentEntryVersionUtil;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
+import com.liferay.portal.kernel.util.OrderByComparatorFactoryUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Rubén Pulido
+ */
+public class FragmentEntryVersionTestUtil {
+
+	public static FragmentEntry addFragmentEntry(long groupId)
+		throws Exception {
+
+		FragmentCollection fragmentCollection =
+			FragmentTestUtil.addFragmentCollection(groupId);
+
+		return FragmentEntryLocalServiceUtil.addFragmentEntry(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(), groupId,
+			fragmentCollection.getFragmentCollectionId(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), false, StringPool.BLANK, null, 0,
+			false, false, FragmentConstants.TYPE_COMPONENT, null,
+			WorkflowConstants.STATUS_APPROVED,
+			ServiceContextTestUtil.getServiceContext(
+				groupId, TestPropsValues.getUserId()));
+	}
+
+	public static int countFragmentEntryVersions(FragmentEntry fragmentEntry)
+		throws Throwable {
+
+		return TransactionInvokerUtil.invoke(
+			_transactionConfig,
+			() -> FragmentEntryVersionUtil.countByFragmentEntryId(
+				fragmentEntry.getFragmentEntryId()));
+	}
+
+	public static int countFragmentEntryVersions(
+			long ctCollectionId, FragmentEntry fragmentEntry)
+		throws Exception {
+
+		try (Connection connection = DataAccess.getConnection();
+
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select count(*) as count from FragmentEntryVersion where " +
+					"ctCollectionId = ? and fragmentEntryId = ?")) {
+
+			preparedStatement.setLong(1, ctCollectionId);
+			preparedStatement.setLong(2, fragmentEntry.getFragmentEntryId());
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				if (resultSet.next()) {
+					return (int)resultSet.getLong("count");
+				}
+
+				return 0;
+			}
+		}
+	}
+
+	public static List<Integer> getFragmentEntryVersions(
+			FragmentEntry fragmentEntry)
+		throws Throwable {
+
+		return TransactionInvokerUtil.invoke(
+			_transactionConfig,
+			() -> TransformUtil.transform(
+				FragmentEntryVersionUtil.findByFragmentEntryId(
+					fragmentEntry.getFragmentEntryId(), QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS,
+					OrderByComparatorFactoryUtil.create(
+						"FragmentEntryVersion", "version", true)),
+				FragmentEntryVersion::getVersion));
+	}
+
+	public static List<Integer> insertFragmentEntryVersions(
+			int count, long ctCollectionId, FragmentEntry fragmentEntry)
+		throws Exception {
+
+		long now = System.currentTimeMillis();
+
+		Timestamp createDateTimestamp = new Timestamp(now);
+
+		List<Integer> versions = new ArrayList<>(count);
+
+		try (Connection connection = DataAccess.getConnection();
+
+			PreparedStatement preparedStatement =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					StringBundler.concat(
+						"insert into FragmentEntryVersion (mvccVersion, ",
+						"ctCollectionId, fragmentEntryVersionId, version, ",
+						"fragmentEntryId, groupId, companyId, userId, ",
+						"createDate, modifiedDate, name, status) values (0, ",
+						"?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"))) {
+
+			for (int i = 0; i < count; i++) {
+				int version = _START_VERSION + i;
+
+				versions.add(version);
+
+				preparedStatement.setLong(1, ctCollectionId);
+				preparedStatement.setLong(
+					2,
+					CounterLocalServiceUtil.increment(
+						FragmentEntryVersion.class.getName()));
+				preparedStatement.setInt(3, version);
+				preparedStatement.setLong(
+					4, fragmentEntry.getFragmentEntryId());
+				preparedStatement.setLong(5, fragmentEntry.getGroupId());
+				preparedStatement.setLong(6, fragmentEntry.getCompanyId());
+				preparedStatement.setLong(7, fragmentEntry.getUserId());
+				preparedStatement.setTimestamp(8, createDateTimestamp);
+				preparedStatement.setTimestamp(9, new Timestamp(now + i));
+				preparedStatement.setString(10, RandomTestUtil.randomString());
+				preparedStatement.setInt(11, WorkflowConstants.STATUS_APPROVED);
+
+				preparedStatement.addBatch();
+			}
+
+			preparedStatement.executeBatch();
+		}
+
+		FragmentEntryVersionUtil.clearCache();
+
+		return versions;
+	}
+
+	public static void updateFragmentEntry(FragmentEntry fragmentEntry)
+		throws Exception {
+
+		fragmentEntry.setHtml(RandomTestUtil.randomString());
+
+		FragmentEntryLocalServiceUtil.updateFragmentEntry(fragmentEntry);
+	}
+
+	private static final int _START_VERSION = 1000;
+
+	private static final TransactionConfig _transactionConfig =
+		TransactionConfig.Factory.create(
+			Propagation.REQUIRED, new Class<?>[] {Exception.class});
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-75909

## What Is Being Fixed

Every modification to a fragment entry inserts a new row into the FragmentEntryVersion table, and nothing ever removes the old rows. The table grows without bound, accumulating stale versions for each fragment entry in every change-tracking collection.

## How It Is Being Fixed

The number of FragmentEntryVersion rows is capped at FRAGMENT_ENTRY_VERSIONS_COUNT_MAX (10) per change-tracking collection and fragment entry. A model listener trims the oldest versions beyond the cap whenever a new version is created inside a change-tracking collection. A change-tracking event listener records the per-fragment-entry counts before a publish and deletes the excess production versions afterward, so published data converges to the same cap without holding a transaction across the publish. An upgrade process backfills the cap for existing data, capping each (ctCollectionId, fragmentEntryId) pair independently. Integration tests exercise the listener inside a change-tracking collection, the production trim after a publish, and the upgrade's respect for change-tracking boundaries.

## Review Feedback Addressed

Applies the feedback from https://github.com/brianchandotcom/liferay-portal/pull/175840#issuecomment-4614583141 and the follow-up review rounds:

- Renamed the version-count maps to `counts` (`Map<fragmentEntryId, count>`) and `countsMap` (`Map<ctCollectionId, Map<fragmentEntryId, count>>`).
- Kept `RandomTestUtil` for test data, as preferred.
- Renamed the internal `FragmentConstants` to `FragmentEntryVersionConstants` so it no longer shadows the public `com.liferay.fragment.constants.FragmentConstants`.
- Named the upgrade's batch size `oracleInClauseLimit` after the ORA-01795 IN-list limit it enforces.
- Derived the test util's seeded version start from the entry's max version instead of a fixed value.

Supersedes https://github.com/brianchandotcom/liferay-portal/pull/175887.
