### PR TITLE
LPD-83094 Allow creating site pages with a content page specification

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/DisplayPageTemplate.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/DisplayPageTemplate.java
@@ -604,7 +604,7 @@ public class DisplayPageTemplate implements Serializable {
 	private Supplier<String> _nameSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "The display page template's specifications. A display page template will contain 1 page specifications for its draft layout and 1 page specifications for its published layout. This field is not returned by default. It can be requested via nestedFields."
+		description = "The display page template's specifications. A display page template will contain 1 page specification for its draft layout and 1 page specification for its published layout. This field is not returned by default. It can be requested via nestedFields."
 	)
 	@Valid
 	public PageSpecification[] getPageSpecifications() {
@@ -642,7 +642,7 @@ public class DisplayPageTemplate implements Serializable {
 	}
 
 	@GraphQLField(
-		description = "The display page template's specifications. A display page template will contain 1 page specifications for its draft layout and 1 page specifications for its published layout. This field is not returned by default. It can be requested via nestedFields."
+		description = "The display page template's specifications. A display page template will contain 1 page specification for its draft layout and 1 page specification for its published layout. This field is not returned by default. It can be requested via nestedFields."
 	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected PageSpecification[] pageSpecifications;
@@ -1218,4 +1218,4 @@ public class DisplayPageTemplate implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:2117674020
+// LIFERAY-REST-BUILDER-HASH:-2092366492

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/MasterPage.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/MasterPage.java
@@ -451,7 +451,7 @@ public class MasterPage implements Serializable {
 	private Supplier<String> _nameSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "The master page's specifications. A master page will contain 1 page specifications for its draft layout and 1 page specifications for its published layout. This field is not returned by default. It can be requested via nestedFields."
+		description = "The master page's specifications. A master page will contain 1 page specification for its draft layout and 1 page specification for its published layout. This field is not returned by default. It can be requested via nestedFields."
 	)
 	@Valid
 	public PageSpecification[] getPageSpecifications() {
@@ -489,7 +489,7 @@ public class MasterPage implements Serializable {
 	}
 
 	@GraphQLField(
-		description = "The master page's specifications. A master page will contain 1 page specifications for its draft layout and 1 page specifications for its published layout. This field is not returned by default. It can be requested via nestedFields."
+		description = "The master page's specifications. A master page will contain 1 page specification for its draft layout and 1 page specification for its published layout. This field is not returned by default. It can be requested via nestedFields."
 	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected PageSpecification[] pageSpecifications;
@@ -1057,4 +1057,4 @@ public class MasterPage implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:272785235
+// LIFERAY-REST-BUILDER-HASH:1558124051

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageSpecification.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageSpecification.java
@@ -41,7 +41,7 @@ import java.util.function.Supplier;
  */
 @Generated("")
 @GraphQLName(
-	description = "A page specification of a content page, content page template, widget page, or widget page template. A content page will contain 1 page specifications for its draft layout and 1 page specifications for its published layout. A widget page contains only 1 page specification for its published layout.",
+	description = "A page specification of a content page, content page template, widget page, or widget page template. A content page will contain 1 page specification for its draft layout and 1 page specification for its published layout. A widget page contains only 1 page specification for its published layout.",
 	value = "PageSpecification"
 )
 @JsonFilter("Liferay.Vulcan")
@@ -646,4 +646,4 @@ public abstract class PageSpecification implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1493561160
+// LIFERAY-REST-BUILDER-HASH:1992942068

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageTemplate.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageTemplate.java
@@ -420,7 +420,7 @@ public abstract class PageTemplate implements Serializable {
 	private Supplier<String> _nameSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "The page template's specifications. A page template of type content will contain 1 page specifications for its draft layout and 1 page specifications for its published layout. A page template of type widget contains only 1 page specification for its published layout. This field is not returned by default. It can be requested via nestedFields."
+		description = "The page template's specifications. A page template of type content will contain 1 page specification for its draft layout and 1 page specification for its published layout. A page template of type widget contains only 1 page specification for its published layout. This field is not returned by default. It can be requested via nestedFields."
 	)
 	@Valid
 	public PageSpecification[] getPageSpecifications() {
@@ -458,7 +458,7 @@ public abstract class PageTemplate implements Serializable {
 	}
 
 	@GraphQLField(
-		description = "The page template's specifications. A page template of type content will contain 1 page specifications for its draft layout and 1 page specifications for its published layout. A page template of type widget contains only 1 page specification for its published layout. This field is not returned by default. It can be requested via nestedFields."
+		description = "The page template's specifications. A page template of type content will contain 1 page specification for its draft layout and 1 page specification for its published layout. A page template of type widget contains only 1 page specification for its published layout. This field is not returned by default. It can be requested via nestedFields."
 	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected PageSpecification[] pageSpecifications;
@@ -1237,4 +1237,4 @@ public abstract class PageTemplate implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:310849038
+// LIFERAY-REST-BUILDER-HASH:-1391347890

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/SitePage.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/SitePage.java
@@ -555,7 +555,7 @@ public class SitePage implements Serializable {
 	private Supplier<PageSettings> _pageSettingsSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "The page's specifications. A page of type content will contain 1 page specifications for its draft layout and 1 page specifications for its published layout. A page of type widget contains only 1 page specification for its published layout. On creation (POST), a content page may also be created by sending a single ContentPageSpecification. The single-specification form is only accepted on POST. This field is not returned by default. It can be requested via nestedFields."
+		description = "The page's specifications. A page of type content will contain 1 page specification for its draft layout and 1 page specification for its published layout. A page of type widget contains only 1 page specification for its published layout. A page of type content may also be created by sending a single content page specification. This field is not returned by default. It can be requested via nestedFields."
 	)
 	@Valid
 	public PageSpecification[] getPageSpecifications() {
@@ -593,7 +593,7 @@ public class SitePage implements Serializable {
 	}
 
 	@GraphQLField(
-		description = "The page's specifications. A page of type content will contain 1 page specifications for its draft layout and 1 page specifications for its published layout. A page of type widget contains only 1 page specification for its published layout. On creation (POST), a content page may also be created by sending a single ContentPageSpecification. The single-specification form is only accepted on POST. This field is not returned by default. It can be requested via nestedFields."
+		description = "The page's specifications. A page of type content will contain 1 page specification for its draft layout and 1 page specification for its published layout. A page of type widget contains only 1 page specification for its published layout. A page of type content may also be created by sending a single content page specification. This field is not returned by default. It can be requested via nestedFields."
 	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected PageSpecification[] pageSpecifications;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/SitePage.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/SitePage.java
@@ -1418,4 +1418,4 @@ public class SitePage implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:661579706
+// LIFERAY-REST-BUILDER-HASH:-1685986652

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/SitePage.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/SitePage.java
@@ -555,7 +555,7 @@ public class SitePage implements Serializable {
 	private Supplier<PageSettings> _pageSettingsSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "The page's specifications. A page of type content will contain 1 page specifications for its draft layout and 1 page specifications for its published layout. A page of type widget contains only 1 page specification for its published layout. This field is not returned by default. It can be requested via nestedFields."
+		description = "The page's specifications. A page of type content will contain 1 page specifications for its draft layout and 1 page specifications for its published layout. A page of type widget contains only 1 page specification for its published layout. On creation (POST), a content page may also be created by sending a single ContentPageSpecification. The single-specification form is only accepted on POST. This field is not returned by default. It can be requested via nestedFields."
 	)
 	@Valid
 	public PageSpecification[] getPageSpecifications() {
@@ -593,7 +593,7 @@ public class SitePage implements Serializable {
 	}
 
 	@GraphQLField(
-		description = "The page's specifications. A page of type content will contain 1 page specifications for its draft layout and 1 page specifications for its published layout. A page of type widget contains only 1 page specification for its published layout. This field is not returned by default. It can be requested via nestedFields."
+		description = "The page's specifications. A page of type content will contain 1 page specifications for its draft layout and 1 page specifications for its published layout. A page of type widget contains only 1 page specification for its published layout. On creation (POST), a content page may also be created by sending a single ContentPageSpecification. The single-specification form is only accepted on POST. This field is not returned by default. It can be requested via nestedFields."
 	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected PageSpecification[] pageSpecifications;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/UtilityPage.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/UtilityPage.java
@@ -459,7 +459,7 @@ public class UtilityPage implements Serializable {
 	private Supplier<String> _nameSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "The utility page's specifications. A utility page will contain 1 page specifications for its draft layout and 1 page specifications for its published layout. This field is not returned by default. It can be requested via nestedFields."
+		description = "The utility page's specifications. A utility page will contain 1 page specification for its draft layout and 1 page specification for its published layout. This field is not returned by default. It can be requested via nestedFields."
 	)
 	@Valid
 	public PageSpecification[] getPageSpecifications() {
@@ -497,7 +497,7 @@ public class UtilityPage implements Serializable {
 	}
 
 	@GraphQLField(
-		description = "The utility page's specifications. A utility page will contain 1 page specifications for its draft layout and 1 page specifications for its published layout. This field is not returned by default. It can be requested via nestedFields."
+		description = "The utility page's specifications. A utility page will contain 1 page specification for its draft layout and 1 page specification for its published layout. This field is not returned by default. It can be requested via nestedFields."
 	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected PageSpecification[] pageSpecifications;
@@ -1144,4 +1144,4 @@ public class UtilityPage implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:308539788
+// LIFERAY-REST-BUILDER-HASH:498090572

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/resources/com/liferay/headless/admin/site/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/resources/com/liferay/headless/admin/site/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 24.4.0
+version 24.4.1

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
@@ -3582,8 +3582,9 @@ components:
                     description:
                         The page's specifications. A page of type content will contain 1 page specifications for its
                         draft layout and 1 page specifications for its published layout. A page of type widget contains
-                        only 1 page specification for its published layout. This field is not returned by default. It
-                        can be requested via nestedFields.
+                        only 1 page specification for its published layout. On creation (POST), a content page may also
+                        be created by sending a single ContentPageSpecification. The single-specification form is only
+                        accepted on POST. This field is not returned by default. It can be requested via nestedFields.
                     items:
                         $ref: "#/components/schemas/PageSpecification"
                     type: array

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
@@ -793,8 +793,8 @@ components:
                     # @review
                     description:
                         The display page template's specifications. A display page template will contain 1 page
-                        specifications for its draft layout and 1 page specifications for its published layout. This
-                        field is not returned by default. It can be requested via nestedFields.
+                        specification for its draft layout and 1 page specification for its published layout. This field
+                        is not returned by default. It can be requested via nestedFields.
                     items:
                         $ref: "#/components/schemas/PageSpecification"
                     type: array
@@ -2343,9 +2343,9 @@ components:
                 pageSpecifications:
                     # @review
                     description:
-                        The master page's specifications. A master page will contain 1 page specifications for its draft
-                        layout and 1 page specifications for its published layout. This field is not returned by
-                        default. It can be requested via nestedFields.
+                        The master page's specifications. A master page will contain 1 page specification for its draft
+                        layout and 1 page specification for its published layout. This field is not returned by default.
+                        It can be requested via nestedFields.
                     items:
                         $ref: "#/components/schemas/PageSpecification"
                     type: array
@@ -2944,7 +2944,7 @@ components:
             # @review
             description:
                 A page specification of a content page, content page template, widget page, or widget page template. A
-                content page will contain 1 page specifications for its draft layout and 1 page specifications for its
+                content page will contain 1 page specification for its draft layout and 1 page specification for its
                 published layout. A widget page contains only 1 page specification for its published layout.
             discriminator:
                 mapping:
@@ -3050,7 +3050,7 @@ components:
                     # @review
                     description:
                         The page template's specifications. A page template of type content will contain 1 page
-                        specifications for its draft layout and 1 page specifications for its published layout. A page
+                        specification for its draft layout and 1 page specification for its published layout. A page
                         template of type widget contains only 1 page specification for its published layout. This field
                         is not returned by default. It can be requested via nestedFields.
                     items:
@@ -3580,8 +3580,8 @@ components:
                 pageSpecifications:
                     # @review
                     description:
-                        The page's specifications. A page of type content will contain 1 page specifications for its
-                        draft layout and 1 page specifications for its published layout. A page of type widget contains
+                        The page's specifications. A page of type content will contain 1 page specification for its
+                        draft layout and 1 page specification for its published layout. A page of type widget contains
                         only 1 page specification for its published layout. On creation (POST), a content page may also
                         be created by sending a single ContentPageSpecification. The single-specification form is only
                         accepted on POST. This field is not returned by default. It can be requested via nestedFields.
@@ -4208,8 +4208,8 @@ components:
                 pageSpecifications:
                     # @review
                     description:
-                        The utility page's specifications. A utility page will contain 1 page specifications for its
-                        draft layout and 1 page specifications for its published layout. This field is not returned by
+                        The utility page's specifications. A utility page will contain 1 page specification for its
+                        draft layout and 1 page specification for its published layout. This field is not returned by
                         default. It can be requested via nestedFields.
                     items:
                         $ref: "#/components/schemas/PageSpecification"

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
@@ -3582,9 +3582,9 @@ components:
                     description:
                         The page's specifications. A page of type content will contain 1 page specification for its
                         draft layout and 1 page specification for its published layout. A page of type widget contains
-                        only 1 page specification for its published layout. On creation (POST), a content page may also
-                        be created by sending a single ContentPageSpecification. The single-specification form is only
-                        accepted on POST. This field is not returned by default. It can be requested via nestedFields.
+                        only 1 page specification for its published layout. A page of type content may also be created
+                        by sending a single content page specification. This field is not returned by default. It can be
+                        requested via nestedFields.
                     items:
                         $ref: "#/components/schemas/PageSpecification"
                     type: array

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
@@ -610,17 +610,11 @@ public class SitePageResourceImpl
 			return new CustomMetaTag[0];
 		}
 
-		if (pageSettings instanceof ContentPageSettings) {
-			ContentPageSettings contentPageSettings =
-				(ContentPageSettings)pageSettings;
-
+		if (pageSettings instanceof ContentPageSettings contentPageSettings) {
 			return contentPageSettings.getCustomMetaTags();
 		}
 
-		if (pageSettings instanceof WidgetPageSettings) {
-			WidgetPageSettings widgetPageSettings =
-				(WidgetPageSettings)pageSettings;
-
+		if (pageSettings instanceof WidgetPageSettings widgetPageSettings) {
 			return widgetPageSettings.getCustomMetaTags();
 		}
 
@@ -630,17 +624,11 @@ public class SitePageResourceImpl
 	private String _getDefaultAssetPublisherPortletId(
 		PageSettings pageSettings) {
 
-		if (pageSettings instanceof ContentPageSettings) {
-			ContentPageSettings contentPageSettings =
-				(ContentPageSettings)pageSettings;
-
+		if (pageSettings instanceof ContentPageSettings contentPageSettings) {
 			return contentPageSettings.getDefaultAssetPublisherPortletId();
 		}
 
-		if (pageSettings instanceof WidgetPageSettings) {
-			WidgetPageSettings widgetPageSettings =
-				(WidgetPageSettings)pageSettings;
-
+		if (pageSettings instanceof WidgetPageSettings widgetPageSettings) {
 			return widgetPageSettings.getDefaultAssetPublisherPortletId();
 		}
 
@@ -652,17 +640,11 @@ public class SitePageResourceImpl
 			return null;
 		}
 
-		if (pageSettings instanceof ContentPageSettings) {
-			ContentPageSettings contentPageSettings =
-				(ContentPageSettings)pageSettings;
-
+		if (pageSettings instanceof ContentPageSettings contentPageSettings) {
 			return contentPageSettings.getOpenGraphSettings();
 		}
 
-		if (pageSettings instanceof WidgetPageSettings) {
-			WidgetPageSettings widgetPageSettings =
-				(WidgetPageSettings)pageSettings;
-
+		if (pageSettings instanceof WidgetPageSettings widgetPageSettings) {
 			return widgetPageSettings.getOpenGraphSettings();
 		}
 
@@ -696,17 +678,11 @@ public class SitePageResourceImpl
 			return null;
 		}
 
-		if (pageSettings instanceof ContentPageSettings) {
-			ContentPageSettings contentPageSettings =
-				(ContentPageSettings)pageSettings;
-
+		if (pageSettings instanceof ContentPageSettings contentPageSettings) {
 			return contentPageSettings.getSeoSettings();
 		}
 
-		if (pageSettings instanceof WidgetPageSettings) {
-			WidgetPageSettings widgetPageSettings =
-				(WidgetPageSettings)pageSettings;
-
+		if (pageSettings instanceof WidgetPageSettings widgetPageSettings) {
 			return widgetPageSettings.getSeoSettings();
 		}
 
@@ -754,12 +730,11 @@ public class SitePageResourceImpl
 					getSiteTemplatePageSpecificationExternalReferenceCode());
 		}
 
-		if (!(sitePage.getPageSettings() instanceof WidgetPageSettings)) {
+		if (!(sitePage.getPageSettings() instanceof
+				WidgetPageSettings widgetPageSettings)) {
+
 			return serviceContext;
 		}
-
-		WidgetPageSettings widgetPageSettings =
-			(WidgetPageSettings)sitePage.getPageSettings();
 
 		ItemExternalReference itemExternalReference =
 			widgetPageSettings.getWidgetPageTemplateReference();

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
@@ -503,6 +503,25 @@ public class SitePageResourceImpl
 					"page's external reference code");
 		}
 
+		PageSpecification[] pageSpecifications =
+			sitePage.getPageSpecifications();
+
+		if (Objects.equals(sitePage.getType(), SitePage.Type.CONTENT_PAGE) &&
+			(pageSpecifications != null) && (pageSpecifications.length == 1)) {
+
+			if (!(pageSpecifications[0] instanceof
+					ContentPageSpecification contentPageSpecification)) {
+
+				throw new ValidationException(
+					"A content page specification is expected for a content " +
+						"page");
+			}
+
+			sitePage.setPageSpecifications(
+				() -> PageSpecificationUtil.toContentPageSpecifications(
+					contentPageSpecification, externalReferenceCode));
+		}
+
 		ServiceContext serviceContext = _getServiceContext(groupId, sitePage);
 
 		_validatePageSpecificationExternalReferenceCode(
@@ -532,17 +551,18 @@ public class SitePageResourceImpl
 		UnicodeProperties typeSettingsUnicodeProperties =
 			_getTypeSettingsUnicodeProperties(groupId, sitePage);
 
+		long parentLayoutId = _getParentLayoutId(
+			groupId, sitePage.getParentSitePageExternalReferenceCode(),
+			privateLayout, serviceContext);
+
 		Layout layout = null;
 
 		if (Objects.equals(sitePage.getType(), SitePage.Type.CONTENT_PAGE)) {
 			layout = LayoutUtil.addContentLayout(
 				_cetManager, _fragmentEntryProcessorRegistry, groupId,
 				_infoItemServiceRegistry, sitePage.getPageSpecifications(),
-				privateLayout,
-				_getParentLayoutId(
-					groupId, sitePage.getParentSitePageExternalReferenceCode(),
-					privateLayout, serviceContext),
-				nameMap, titleMap, descriptionMap, keywordsMap, robotsMap,
+				privateLayout, parentLayoutId, nameMap, titleMap,
+				descriptionMap, keywordsMap, robotsMap,
 				SitePageTypeUtil.toInternalType(sitePage.getType()),
 				typeSettingsUnicodeProperties,
 				_isHiddenFromNavigation(false, sitePage.getPageSettings()),
@@ -562,10 +582,8 @@ public class SitePageResourceImpl
 
 			layout = LayoutUtil.addLayout(
 				sitePage.getExternalReferenceCode(), groupId, privateLayout,
-				_getParentLayoutId(
-					groupId, sitePage.getParentSitePageExternalReferenceCode(),
-					privateLayout, serviceContext),
-				nameMap, SitePageTypeUtil.toInternalType(sitePage.getType()),
+				parentLayoutId, nameMap,
+				SitePageTypeUtil.toInternalType(sitePage.getType()),
 				typeSettingsUnicodeProperties,
 				_isHiddenFromNavigation(false, sitePage.getPageSettings()),
 				LocalizedMapUtil.getLocalizedMap(
@@ -578,11 +596,8 @@ public class SitePageResourceImpl
 			layout = LayoutUtil.addPortletLayout(
 				_cetManager, sitePage.getExternalReferenceCode(),
 				_infoItemServiceRegistry, groupId, privateLayout,
-				_getParentLayoutId(
-					groupId, sitePage.getParentSitePageExternalReferenceCode(),
-					privateLayout, serviceContext),
-				nameMap, titleMap, descriptionMap, keywordsMap, robotsMap,
-				typeSettingsUnicodeProperties,
+				parentLayoutId, nameMap, titleMap, descriptionMap, keywordsMap,
+				robotsMap, typeSettingsUnicodeProperties,
 				_isHiddenFromNavigation(false, sitePage.getPageSettings()),
 				LocalizedMapUtil.getLocalizedMap(
 					sitePage.getFriendlyUrlPath_i18n()),
@@ -699,13 +714,18 @@ public class SitePageResourceImpl
 			contextUser.getUserId(), sitePage.getUuid());
 
 		if (Objects.equals(sitePage.getType(), SitePage.Type.CONTENT_PAGE)) {
-			if (sitePage.getPageSpecifications() == null) {
+			PageSpecification[] pageSpecifications =
+				sitePage.getPageSpecifications();
+
+			if ((pageSpecifications == null) ||
+				(pageSpecifications.length != 2)) {
+
 				return serviceContext;
 			}
 
 			PageSpecification[] sortedContentPageSpecifications =
 				PageSpecificationUtil.getSortedContentPageSpecifications(
-					sitePage.getPageSpecifications());
+					pageSpecifications);
 
 			ContentPageSpecification draftContentPageSpecification =
 				(ContentPageSpecification)sortedContentPageSpecifications[0];
@@ -1007,6 +1027,9 @@ public class SitePageResourceImpl
 			Layout layout, ServiceContext serviceContext, SitePage sitePage)
 		throws Exception {
 
+		_validatePageSpecificationExternalReferenceCode(
+			serviceContext, sitePage);
+
 		Map<Locale, String> nameMap = layout.getNameMap();
 
 		if (sitePage.getName_i18n() != null) {
@@ -1205,6 +1228,13 @@ public class SitePageResourceImpl
 			return;
 		}
 
+		if (Objects.equals(sitePage.getType(), SitePage.Type.CONTENT_PAGE) &&
+			(pageSpecifications.length == 1)) {
+
+			throw new ValidationException(
+				"A single content page specification is only accepted on POST");
+		}
+
 		PageSpecification publishedPageSpecification = null;
 
 		if (Objects.equals(sitePage.getType(), SitePage.Type.CONTENT_PAGE) &&
@@ -1231,7 +1261,7 @@ public class SitePageResourceImpl
 			publishedPageSpecification = pageSpecifications[0];
 		}
 		else {
-			throw new IllegalArgumentException(
+			throw new ValidationException(
 				"The number of page specifications does not match the page " +
 					"type requirements");
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
@@ -513,8 +513,8 @@ public class SitePageResourceImpl
 					ContentPageSpecification contentPageSpecification)) {
 
 				throw new ValidationException(
-					"A content page specification is expected for a content " +
-						"page");
+					"The page specification type does not match the content " +
+						"page type");
 			}
 
 			sitePage.setPageSpecifications(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
@@ -527,6 +527,8 @@ public class SitePageResourceImpl
 		_validatePageSpecificationExternalReferenceCode(
 			serviceContext, sitePage);
 
+		Layout layout = null;
+
 		Map<Locale, String> nameMap = LocalizedMapUtil.getLocalizedMap(
 			sitePage.getName_i18n());
 
@@ -554,8 +556,6 @@ public class SitePageResourceImpl
 		long parentLayoutId = _getParentLayoutId(
 			groupId, sitePage.getParentSitePageExternalReferenceCode(),
 			privateLayout, serviceContext);
-
-		Layout layout = null;
 
 		if (Objects.equals(sitePage.getType(), SitePage.Type.CONTENT_PAGE)) {
 			layout = LayoutUtil.addContentLayout(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
@@ -1232,7 +1232,8 @@ public class SitePageResourceImpl
 			(pageSpecifications.length == 1)) {
 
 			throw new ValidationException(
-				"A single content page specification is only accepted on POST");
+				"A single content page specification cannot be applied to an " +
+					"existing page");
 		}
 
 		PageSpecification publishedPageSpecification = null;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
@@ -314,14 +314,15 @@ public class PageSpecificationUtil {
 
 					fragmentInstance.setUuid(() -> null);
 
-					String userDraftERC =
-						fragmentInstance.
-							getDraftFragmentInstanceExternalReferenceCode();
+					if (Validator.isNotNull(
+							fragmentInstance.
+								getDraftFragmentInstanceExternalReferenceCode())) {
 
-					if (Validator.isNotNull(userDraftERC)) {
 						fragmentInstance.
 							setFragmentInstanceExternalReferenceCode(
-								() -> userDraftERC);
+								() ->
+									fragmentInstance.
+										getDraftFragmentInstanceExternalReferenceCode());
 						fragmentInstance.
 							setDraftFragmentInstanceExternalReferenceCode(
 								() -> null);
@@ -342,14 +343,15 @@ public class PageSpecificationUtil {
 					}
 				},
 				widgetInstancePageElementDefinition -> {
-					String userDraftERC =
-						widgetInstancePageElementDefinition.
-							getDraftWidgetInstanceExternalReferenceCode();
+					if (Validator.isNotNull(
+							widgetInstancePageElementDefinition.
+								getDraftWidgetInstanceExternalReferenceCode())) {
 
-					if (Validator.isNotNull(userDraftERC)) {
 						widgetInstancePageElementDefinition.
 							setWidgetInstanceExternalReferenceCode(
-								() -> userDraftERC);
+								() ->
+									widgetInstancePageElementDefinition.
+										getDraftWidgetInstanceExternalReferenceCode());
 						widgetInstancePageElementDefinition.
 							setDraftWidgetInstanceExternalReferenceCode(
 								() -> null);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
@@ -202,10 +202,10 @@ public class PageSpecificationUtil {
 			fragmentInstance.getDraftFragmentInstanceExternalReferenceCode();
 
 		if (Validator.isNotNull(draftFragmentInstanceExternalReferenceCode)) {
-			fragmentInstance.setFragmentInstanceExternalReferenceCode(
-				() -> draftFragmentInstanceExternalReferenceCode);
 			fragmentInstance.setDraftFragmentInstanceExternalReferenceCode(
 				() -> null);
+			fragmentInstance.setFragmentInstanceExternalReferenceCode(
+				() -> draftFragmentInstanceExternalReferenceCode);
 
 			return;
 		}
@@ -228,12 +228,12 @@ public class PageSpecificationUtil {
 					getDraftWidgetInstanceExternalReferenceCode())) {
 
 			widgetInstancePageElementDefinition.
+				setDraftWidgetInstanceExternalReferenceCode(() -> null);
+			widgetInstancePageElementDefinition.
 				setWidgetInstanceExternalReferenceCode(
 					() ->
 						widgetInstancePageElementDefinition.
 							getDraftWidgetInstanceExternalReferenceCode());
-			widgetInstancePageElementDefinition.
-				setDraftWidgetInstanceExternalReferenceCode(() -> null);
 
 			return;
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
@@ -210,13 +210,13 @@ public class PageSpecificationUtil {
 			return;
 		}
 
-		String fragmentInstanceERC =
+		String fragmentInstanceExternalReferenceCode =
 			fragmentInstance.getFragmentInstanceExternalReferenceCode();
 
-		if (Validator.isNotNull(fragmentInstanceERC)) {
+		if (Validator.isNotNull(fragmentInstanceExternalReferenceCode)) {
 			fragmentInstance.setFragmentInstanceExternalReferenceCode(
 				() ->
-					fragmentInstanceERC +
+					fragmentInstanceExternalReferenceCode +
 						LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT);
 		}
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
@@ -509,7 +509,8 @@ public class PageSpecificationUtil {
 	private static void _visitPageElements(
 		PageElement[] pageElements,
 		Consumer<FragmentInstance> fragmentInstanceConsumer,
-		Consumer<WidgetInstancePageElementDefinition> widgetInstanceConsumer) {
+		Consumer<WidgetInstancePageElementDefinition>
+			widgetInstancePageElementDefinitionConsumer) {
 
 		if (pageElements == null) {
 			return;
@@ -539,13 +540,13 @@ public class PageSpecificationUtil {
 						WidgetInstancePageElementDefinition
 							widgetInstancePageElementDefinition) {
 
-				widgetInstanceConsumer.accept(
+				widgetInstancePageElementDefinitionConsumer.accept(
 					widgetInstancePageElementDefinition);
 			}
 
 			_visitPageElements(
 				pageElement.getPageElements(), fragmentInstanceConsumer,
-				widgetInstanceConsumer);
+				widgetInstancePageElementDefinitionConsumer);
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
@@ -273,8 +273,8 @@ public class PageSpecificationUtil {
 
 		for (PageExperience pageExperience : pageExperiences) {
 			_processPageElements(
-				pageExperience.getPageElements(),
 				PageSpecificationUtil::_processPublishedFragmentInstance,
+				pageExperience.getPageElements(),
 				PageSpecificationUtil::
 					_processPublishedWidgetInstancePageElementDefinition);
 		}
@@ -372,8 +372,8 @@ public class PageSpecificationUtil {
 			pageExperience.setUuid(() -> null);
 
 			_processPageElements(
-				pageExperience.getPageElements(),
 				PageSpecificationUtil::_processDraftFragmentInstance,
+				pageExperience.getPageElements(),
 				PageSpecificationUtil::
 					_processDraftWidgetInstancePageElementDefinition);
 		}
@@ -429,7 +429,6 @@ public class PageSpecificationUtil {
 				pageExperience.setUuid(() -> null);
 
 				_processPageElements(
-					pageExperience.getPageElements(),
 					fragmentInstance -> {
 						if (fragmentInstance == null) {
 							return;
@@ -460,6 +459,7 @@ public class PageSpecificationUtil {
 								() ->
 									publishedFragmentInstanceExternalReferenceCode);
 					},
+					pageExperience.getPageElements(),
 					widgetInstancePageElementDefinition -> {
 						String draftWidgetInstanceExternalReferenceCode =
 							widgetInstancePageElementDefinition.
@@ -505,10 +505,9 @@ public class PageSpecificationUtil {
 
 		return externalReferenceCode + LayoutConstants.ERC_SUFFIX_PUBLISHED;
 	}
-
 	private static void _processPageElements(
-		PageElement[] pageElements,
 		Consumer<FragmentInstance> fragmentInstanceConsumer,
+		PageElement[] pageElements,
 		Consumer<WidgetInstancePageElementDefinition>
 			widgetInstancePageElementDefinitionConsumer) {
 
@@ -545,7 +544,7 @@ public class PageSpecificationUtil {
 			}
 
 			_processPageElements(
-				pageElement.getPageElements(), fragmentInstanceConsumer,
+				fragmentInstanceConsumer, pageElement.getPageElements(),
 				widgetInstancePageElementDefinitionConsumer);
 		}
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
@@ -251,32 +251,47 @@ public class PageSpecificationUtil {
 		}
 	}
 
-	private static void _setDraftReferences(
-		String draftContentPageSpecificationExternalReferenceCode,
-		ContentPageSpecification publishedContentPageSpecification) {
+	private static void _processPageElements(
+		Consumer<FragmentInstance> fragmentInstanceConsumer,
+		PageElement[] pageElements,
+		Consumer<WidgetInstancePageElementDefinition>
+			widgetInstancePageElementDefinitionConsumer) {
 
-		if (Validator.isNull(
-				publishedContentPageSpecification.
-					getDraftContentPageSpecificationExternalReferenceCode())) {
-
-			publishedContentPageSpecification.
-				setDraftContentPageSpecificationExternalReferenceCode(
-					() -> draftContentPageSpecificationExternalReferenceCode);
-		}
-
-		PageExperience[] pageExperiences =
-			publishedContentPageSpecification.getPageExperiences();
-
-		if (pageExperiences == null) {
+		if (pageElements == null) {
 			return;
 		}
 
-		for (PageExperience pageExperience : pageExperiences) {
+		for (PageElement pageElement : pageElements) {
+			PageElementDefinition pageElementDefinition =
+				pageElement.getPageElementDefinition();
+
+			if (pageElementDefinition instanceof
+					BasicFragmentInstancePageElementDefinition
+						basicFragmentInstancePageElementDefinition) {
+
+				fragmentInstanceConsumer.accept(
+					basicFragmentInstancePageElementDefinition.
+						getFragmentInstance());
+			}
+			else if (pageElementDefinition instanceof
+						FormFragmentInstancePageElementDefinition
+							formFragmentInstancePageElementDefinition) {
+
+				fragmentInstanceConsumer.accept(
+					formFragmentInstancePageElementDefinition.
+						getFragmentInstance());
+			}
+			else if (pageElementDefinition instanceof
+						WidgetInstancePageElementDefinition
+							widgetInstancePageElementDefinition) {
+
+				widgetInstancePageElementDefinitionConsumer.accept(
+					widgetInstancePageElementDefinition);
+			}
+
 			_processPageElements(
-				PageSpecificationUtil::_processPublishedFragmentInstance,
-				pageExperience.getPageElements(),
-				PageSpecificationUtil::
-					_processPublishedWidgetInstancePageElementDefinition);
+				fragmentInstanceConsumer, pageElement.getPageElements(),
+				widgetInstancePageElementDefinitionConsumer);
 		}
 	}
 
@@ -323,6 +338,35 @@ public class PageSpecificationUtil {
 					() ->
 						widgetInstanceExternalReferenceCode +
 							LayoutConstants.ERC_SUFFIX_DRAFT);
+		}
+	}
+
+	private static void _setDraftReferences(
+		String draftContentPageSpecificationExternalReferenceCode,
+		ContentPageSpecification publishedContentPageSpecification) {
+
+		if (Validator.isNull(
+				publishedContentPageSpecification.
+					getDraftContentPageSpecificationExternalReferenceCode())) {
+
+			publishedContentPageSpecification.
+				setDraftContentPageSpecificationExternalReferenceCode(
+					() -> draftContentPageSpecificationExternalReferenceCode);
+		}
+
+		PageExperience[] pageExperiences =
+			publishedContentPageSpecification.getPageExperiences();
+
+		if (pageExperiences == null) {
+			return;
+		}
+
+		for (PageExperience pageExperience : pageExperiences) {
+			_processPageElements(
+				PageSpecificationUtil::_processPublishedFragmentInstance,
+				pageExperience.getPageElements(),
+				PageSpecificationUtil::
+					_processPublishedWidgetInstancePageElementDefinition);
 		}
 	}
 
@@ -507,49 +551,6 @@ public class PageSpecificationUtil {
 		}
 
 		return externalReferenceCode + LayoutConstants.ERC_SUFFIX_PUBLISHED;
-	}
-	private static void _processPageElements(
-		Consumer<FragmentInstance> fragmentInstanceConsumer,
-		PageElement[] pageElements,
-		Consumer<WidgetInstancePageElementDefinition>
-			widgetInstancePageElementDefinitionConsumer) {
-
-		if (pageElements == null) {
-			return;
-		}
-
-		for (PageElement pageElement : pageElements) {
-			PageElementDefinition pageElementDefinition =
-				pageElement.getPageElementDefinition();
-
-			if (pageElementDefinition instanceof
-					BasicFragmentInstancePageElementDefinition
-						basicFragmentInstancePageElementDefinition) {
-
-				fragmentInstanceConsumer.accept(
-					basicFragmentInstancePageElementDefinition.
-						getFragmentInstance());
-			}
-			else if (pageElementDefinition instanceof
-						FormFragmentInstancePageElementDefinition
-							formFragmentInstancePageElementDefinition) {
-
-				fragmentInstanceConsumer.accept(
-					formFragmentInstancePageElementDefinition.
-						getFragmentInstance());
-			}
-			else if (pageElementDefinition instanceof
-						WidgetInstancePageElementDefinition
-							widgetInstancePageElementDefinition) {
-
-				widgetInstancePageElementDefinitionConsumer.accept(
-					widgetInstancePageElementDefinition);
-			}
-
-			_processPageElements(
-				fragmentInstanceConsumer, pageElement.getPageElements(),
-				widgetInstancePageElementDefinitionConsumer);
-		}
 	}
 
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
@@ -349,24 +349,27 @@ public class PageSpecificationUtil {
 		}
 
 		for (PageExperience pageExperience : pageExperiences) {
-			String draftPageExperienceERC;
-
-			if (Objects.equals(
-					pageExperience.getKey(),
-					SegmentsExperienceConstants.KEY_DEFAULT)) {
-
-				draftPageExperienceERC =
-					draftContentPageSpecificationExternalReferenceCode +
-						LayoutConstants.ERC_SUFFIX_DEFAULT;
-			}
-			else {
-				draftPageExperienceERC =
-					pageExperience.getExternalReferenceCode() +
-						LayoutConstants.ERC_SUFFIX_DRAFT;
-			}
+			String pageExperienceExternalReferenceCode =
+				pageExperience.getExternalReferenceCode();
 
 			pageExperience.setExternalReferenceCode(
-				() -> draftPageExperienceERC);
+				() -> {
+					String externalReferenceCode =
+						draftContentPageSpecificationExternalReferenceCode +
+							LayoutConstants.ERC_SUFFIX_DEFAULT;
+
+					if (!Objects.equals(
+							pageExperience.getKey(),
+							SegmentsExperienceConstants.KEY_DEFAULT)) {
+
+						externalReferenceCode =
+							pageExperienceExternalReferenceCode +
+								LayoutConstants.ERC_SUFFIX_DRAFT;
+					}
+
+					return externalReferenceCode;
+				});
+
 			pageExperience.setPageSpecificationExternalReferenceCode(
 				() -> draftContentPageSpecificationExternalReferenceCode);
 			pageExperience.setUuid(() -> null);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
@@ -313,7 +313,7 @@ public class PageSpecificationUtil {
 		PageExperience[] pageExperiences =
 			publishedContentPageSpecification.getPageExperiences();
 
-		if (pageExperiences == null) {
+		if (ArrayUtil.isEmpty(pageExperiences)) {
 			return;
 		}
 
@@ -502,43 +502,43 @@ public class PageSpecificationUtil {
 		PageExperience[] pageExperiences =
 			publishedContentPageSpecification.getPageExperiences();
 
-		if (pageExperiences != null) {
-			for (PageExperience pageExperience : pageExperiences) {
-				String publishedPageExperienceExternalReferenceCode;
+		if (ArrayUtil.isEmpty(pageExperiences)) {
+			return publishedContentPageSpecification;
+		}
 
-				if (Objects.equals(
-						pageExperience.getKey(),
-						SegmentsExperienceConstants.KEY_DEFAULT)) {
+		for (PageExperience pageExperience : pageExperiences) {
+			String publishedPageExperienceExternalReferenceCode;
 
-					publishedPageExperienceExternalReferenceCode =
-						publishedContentPageSpecificationExternalReferenceCode +
-							LayoutConstants.
-								EXTERNAL_REFERENCE_CODE_SUFFIX_DEFAULT;
-				}
-				else {
-					publishedPageExperienceExternalReferenceCode =
-						_toPublishedExternalReferenceCode(
-							pageExperience.getExternalReferenceCode());
-				}
+			if (Objects.equals(
+					pageExperience.getKey(),
+					SegmentsExperienceConstants.KEY_DEFAULT)) {
 
-				String publishedPageExperienceExternalReferenceCodeFinal =
-					publishedPageExperienceExternalReferenceCode;
-
-				pageExperience.setExternalReferenceCode(
-					() -> publishedPageExperienceExternalReferenceCodeFinal);
-
-				pageExperience.setPageSpecificationExternalReferenceCode(
-					() ->
-						publishedContentPageSpecificationExternalReferenceCode);
-				pageExperience.setUuid(() -> null);
-
-				_processPageElements(
-					PageSpecificationUtil::
-						_processPublishedFromDraftFragmentInstance,
-					pageExperience.getPageElements(),
-					PageSpecificationUtil::
-						_processPublishedFromDraftWidgetInstancePageElementDefinition);
+				publishedPageExperienceExternalReferenceCode =
+					publishedContentPageSpecificationExternalReferenceCode +
+						LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DEFAULT;
 			}
+			else {
+				publishedPageExperienceExternalReferenceCode =
+					_toPublishedExternalReferenceCode(
+						pageExperience.getExternalReferenceCode());
+			}
+
+			String publishedPageExperienceExternalReferenceCodeFinal =
+				publishedPageExperienceExternalReferenceCode;
+
+			pageExperience.setExternalReferenceCode(
+				() -> publishedPageExperienceExternalReferenceCodeFinal);
+
+			pageExperience.setPageSpecificationExternalReferenceCode(
+				() -> publishedContentPageSpecificationExternalReferenceCode);
+			pageExperience.setUuid(() -> null);
+
+			_processPageElements(
+				PageSpecificationUtil::
+					_processPublishedFromDraftFragmentInstance,
+				pageExperience.getPageElements(),
+				PageSpecificationUtil::
+					_processPublishedFromDraftWidgetInstancePageElementDefinition);
 		}
 
 		return publishedContentPageSpecification;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
@@ -165,8 +165,8 @@ public class PageSpecificationUtil {
 			publishedContentPageSpecification = contentPageSpecification;
 
 			draftContentPageSpecification = _toDraftContentPageSpecification(
-				publishedContentPageSpecification,
-				draftContentPageSpecificationExternalReferenceCode);
+				draftContentPageSpecificationExternalReferenceCode,
+				publishedContentPageSpecification);
 
 			_setDraftReferences(
 				draftContentPageSpecificationExternalReferenceCode,
@@ -261,8 +261,8 @@ public class PageSpecificationUtil {
 	}
 
 	private static ContentPageSpecification _toDraftContentPageSpecification(
-		ContentPageSpecification publishedContentPageSpecification,
-		String draftContentPageSpecificationExternalReferenceCode) {
+		String draftContentPageSpecificationExternalReferenceCode,
+		ContentPageSpecification publishedContentPageSpecification) {
 
 		ContentPageSpecification draftContentPageSpecification =
 			ContentPageSpecification.unsafeToDTO(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
@@ -159,7 +159,7 @@ public class PageSpecificationUtil {
 
 				draftContentPageSpecificationExternalReferenceCode =
 					sitePageExternalReferenceCode +
-						LayoutConstants.ERC_SUFFIX_DRAFT;
+						LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT;
 			}
 
 			publishedContentPageSpecification = contentPageSpecification;
@@ -215,7 +215,9 @@ public class PageSpecificationUtil {
 
 		if (Validator.isNotNull(fragmentInstanceERC)) {
 			fragmentInstance.setFragmentInstanceExternalReferenceCode(
-				() -> fragmentInstanceERC + LayoutConstants.ERC_SUFFIX_DRAFT);
+				() ->
+					fragmentInstanceERC +
+						LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT);
 		}
 	}
 
@@ -247,7 +249,8 @@ public class PageSpecificationUtil {
 				setWidgetInstanceExternalReferenceCode(
 					() ->
 						widgetInstanceExternalReferenceCode +
-							LayoutConstants.ERC_SUFFIX_DRAFT);
+							LayoutConstants.
+								EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT);
 		}
 	}
 
@@ -313,7 +316,7 @@ public class PageSpecificationUtil {
 			fragmentInstance.setDraftFragmentInstanceExternalReferenceCode(
 				() ->
 					fragmentInstanceExternalReferenceCode +
-						LayoutConstants.ERC_SUFFIX_DRAFT);
+						LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT);
 		}
 	}
 
@@ -337,7 +340,8 @@ public class PageSpecificationUtil {
 				setDraftWidgetInstanceExternalReferenceCode(
 					() ->
 						widgetInstanceExternalReferenceCode +
-							LayoutConstants.ERC_SUFFIX_DRAFT);
+							LayoutConstants.
+								EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT);
 		}
 	}
 
@@ -400,7 +404,8 @@ public class PageSpecificationUtil {
 				() -> {
 					String externalReferenceCode =
 						draftContentPageSpecificationExternalReferenceCode +
-							LayoutConstants.ERC_SUFFIX_DEFAULT;
+							LayoutConstants.
+								EXTERNAL_REFERENCE_CODE_SUFFIX_DEFAULT;
 
 					if (!Objects.equals(
 							pageExperience.getKey(),
@@ -408,7 +413,8 @@ public class PageSpecificationUtil {
 
 						externalReferenceCode =
 							pageExperienceExternalReferenceCode +
-								LayoutConstants.ERC_SUFFIX_DRAFT;
+								LayoutConstants.
+									EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT;
 					}
 
 					return externalReferenceCode;
@@ -456,7 +462,8 @@ public class PageSpecificationUtil {
 
 					publishedPageExperienceExternalReferenceCode =
 						publishedContentPageSpecificationExternalReferenceCode +
-							LayoutConstants.ERC_SUFFIX_DEFAULT;
+							LayoutConstants.
+								EXTERNAL_REFERENCE_CODE_SUFFIX_DEFAULT;
 				}
 				else {
 					publishedPageExperienceExternalReferenceCode =
@@ -543,14 +550,18 @@ public class PageSpecificationUtil {
 			return externalReferenceCode;
 		}
 
-		if (externalReferenceCode.endsWith(LayoutConstants.ERC_SUFFIX_DRAFT)) {
+		if (externalReferenceCode.endsWith(
+				LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT)) {
+
+			int suffixDraftLength =
+				LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT.length();
+
 			return externalReferenceCode.substring(
-				0,
-				externalReferenceCode.length() -
-					LayoutConstants.ERC_SUFFIX_DRAFT.length());
+				0, externalReferenceCode.length() - suffixDraftLength);
 		}
 
-		return externalReferenceCode + LayoutConstants.ERC_SUFFIX_PUBLISHED;
+		return externalReferenceCode +
+			LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_PUBLISHED;
 	}
 
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
@@ -189,6 +189,68 @@ public class PageSpecificationUtil {
 		};
 	}
 
+	private static void _processDraftFragmentInstance(
+		FragmentInstance fragmentInstance) {
+
+		if (fragmentInstance == null) {
+			return;
+		}
+
+		fragmentInstance.setUuid(() -> null);
+
+		String draftFragmentInstanceExternalReferenceCode =
+			fragmentInstance.getDraftFragmentInstanceExternalReferenceCode();
+
+		if (Validator.isNotNull(draftFragmentInstanceExternalReferenceCode)) {
+			fragmentInstance.setFragmentInstanceExternalReferenceCode(
+				() -> draftFragmentInstanceExternalReferenceCode);
+			fragmentInstance.setDraftFragmentInstanceExternalReferenceCode(
+				() -> null);
+
+			return;
+		}
+
+		String fragmentInstanceERC =
+			fragmentInstance.getFragmentInstanceExternalReferenceCode();
+
+		if (Validator.isNotNull(fragmentInstanceERC)) {
+			fragmentInstance.setFragmentInstanceExternalReferenceCode(
+				() -> fragmentInstanceERC + LayoutConstants.ERC_SUFFIX_DRAFT);
+		}
+	}
+
+	private static void _processDraftWidgetInstancePageElementDefinition(
+		WidgetInstancePageElementDefinition
+			widgetInstancePageElementDefinition) {
+
+		if (Validator.isNotNull(
+				widgetInstancePageElementDefinition.
+					getDraftWidgetInstanceExternalReferenceCode())) {
+
+			widgetInstancePageElementDefinition.
+				setWidgetInstanceExternalReferenceCode(
+					() ->
+						widgetInstancePageElementDefinition.
+							getDraftWidgetInstanceExternalReferenceCode());
+			widgetInstancePageElementDefinition.
+				setDraftWidgetInstanceExternalReferenceCode(() -> null);
+
+			return;
+		}
+
+		String widgetInstanceExternalReferenceCode =
+			widgetInstancePageElementDefinition.
+				getWidgetInstanceExternalReferenceCode();
+
+		if (Validator.isNotNull(widgetInstanceExternalReferenceCode)) {
+			widgetInstancePageElementDefinition.
+				setWidgetInstanceExternalReferenceCode(
+					() ->
+						widgetInstanceExternalReferenceCode +
+							LayoutConstants.ERC_SUFFIX_DRAFT);
+		}
+	}
+
 	private static void _setDraftReferences(
 		String draftContentPageSpecificationExternalReferenceCode,
 		ContentPageSpecification publishedContentPageSpecification) {
@@ -212,51 +274,55 @@ public class PageSpecificationUtil {
 		for (PageExperience pageExperience : pageExperiences) {
 			_visitPageElements(
 				pageExperience.getPageElements(),
-				fragmentInstance -> {
-					if ((fragmentInstance == null) ||
-						Validator.isNotNull(
-							fragmentInstance.
-								getDraftFragmentInstanceExternalReferenceCode())) {
+				PageSpecificationUtil::_processPublishedFragmentInstance,
+				PageSpecificationUtil::
+					_processPublishedWidgetInstancePageElementDefinition);
+		}
+	}
 
-						return;
-					}
+	private static void _processPublishedFragmentInstance(
+		FragmentInstance fragmentInstance) {
 
-					String fragmentInstanceExternalReferenceCode =
-						fragmentInstance.
-							getFragmentInstanceExternalReferenceCode();
+		if ((fragmentInstance == null) ||
+			Validator.isNotNull(
+				fragmentInstance.
+					getDraftFragmentInstanceExternalReferenceCode())) {
 
-					if (Validator.isNotNull(
-							fragmentInstanceExternalReferenceCode)) {
+			return;
+		}
 
-						fragmentInstance.
-							setDraftFragmentInstanceExternalReferenceCode(
-								() ->
-									fragmentInstanceExternalReferenceCode +
-										LayoutConstants.ERC_SUFFIX_DRAFT);
-					}
-				},
-				widgetInstancePageElementDefinition -> {
-					if (Validator.isNotNull(
-							widgetInstancePageElementDefinition.
-								getDraftWidgetInstanceExternalReferenceCode())) {
+		String fragmentInstanceExternalReferenceCode =
+			fragmentInstance.getFragmentInstanceExternalReferenceCode();
 
-						return;
-					}
+		if (Validator.isNotNull(fragmentInstanceExternalReferenceCode)) {
+			fragmentInstance.setDraftFragmentInstanceExternalReferenceCode(
+				() ->
+					fragmentInstanceExternalReferenceCode +
+						LayoutConstants.ERC_SUFFIX_DRAFT);
+		}
+	}
 
-					String widgetInstanceExternalReferenceCode =
-						widgetInstancePageElementDefinition.
-							getWidgetInstanceExternalReferenceCode();
+	private static void _processPublishedWidgetInstancePageElementDefinition(
+		WidgetInstancePageElementDefinition
+			widgetInstancePageElementDefinition) {
 
-					if (Validator.isNotNull(
-							widgetInstanceExternalReferenceCode)) {
+		if (Validator.isNotNull(
+				widgetInstancePageElementDefinition.
+					getDraftWidgetInstanceExternalReferenceCode())) {
 
-						widgetInstancePageElementDefinition.
-							setDraftWidgetInstanceExternalReferenceCode(
-								() ->
-									widgetInstanceExternalReferenceCode +
-										LayoutConstants.ERC_SUFFIX_DRAFT);
-					}
-				});
+			return;
+		}
+
+		String widgetInstanceExternalReferenceCode =
+			widgetInstancePageElementDefinition.
+				getWidgetInstanceExternalReferenceCode();
+
+		if (Validator.isNotNull(widgetInstanceExternalReferenceCode)) {
+			widgetInstancePageElementDefinition.
+				setDraftWidgetInstanceExternalReferenceCode(
+					() ->
+						widgetInstanceExternalReferenceCode +
+							LayoutConstants.ERC_SUFFIX_DRAFT);
 		}
 	}
 
@@ -307,72 +373,9 @@ public class PageSpecificationUtil {
 
 			_visitPageElements(
 				pageExperience.getPageElements(),
-				fragmentInstance -> {
-					if (fragmentInstance == null) {
-						return;
-					}
-
-					fragmentInstance.setUuid(() -> null);
-
-					if (Validator.isNotNull(
-							fragmentInstance.
-								getDraftFragmentInstanceExternalReferenceCode())) {
-
-						fragmentInstance.
-							setFragmentInstanceExternalReferenceCode(
-								() ->
-									fragmentInstance.
-										getDraftFragmentInstanceExternalReferenceCode());
-						fragmentInstance.
-							setDraftFragmentInstanceExternalReferenceCode(
-								() -> null);
-
-						return;
-					}
-
-					String fragmentInstanceERC =
-						fragmentInstance.
-							getFragmentInstanceExternalReferenceCode();
-
-					if (Validator.isNotNull(fragmentInstanceERC)) {
-						fragmentInstance.
-							setFragmentInstanceExternalReferenceCode(
-								() ->
-									fragmentInstanceERC +
-										LayoutConstants.ERC_SUFFIX_DRAFT);
-					}
-				},
-				widgetInstancePageElementDefinition -> {
-					if (Validator.isNotNull(
-							widgetInstancePageElementDefinition.
-								getDraftWidgetInstanceExternalReferenceCode())) {
-
-						widgetInstancePageElementDefinition.
-							setWidgetInstanceExternalReferenceCode(
-								() ->
-									widgetInstancePageElementDefinition.
-										getDraftWidgetInstanceExternalReferenceCode());
-						widgetInstancePageElementDefinition.
-							setDraftWidgetInstanceExternalReferenceCode(
-								() -> null);
-
-						return;
-					}
-
-					String widgetInstanceExternalReferenceCode =
-						widgetInstancePageElementDefinition.
-							getWidgetInstanceExternalReferenceCode();
-
-					if (Validator.isNotNull(
-							widgetInstanceExternalReferenceCode)) {
-
-						widgetInstancePageElementDefinition.
-							setWidgetInstanceExternalReferenceCode(
-								() ->
-									widgetInstanceExternalReferenceCode +
-										LayoutConstants.ERC_SUFFIX_DRAFT);
-					}
-				});
+				PageSpecificationUtil::_processDraftFragmentInstance,
+				PageSpecificationUtil::
+					_processDraftWidgetInstancePageElementDefinition);
 		}
 
 		return draftContentPageSpecification;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
@@ -225,17 +225,16 @@ public class PageSpecificationUtil {
 		WidgetInstancePageElementDefinition
 			widgetInstancePageElementDefinition) {
 
-		if (Validator.isNotNull(
-				widgetInstancePageElementDefinition.
-					getDraftWidgetInstanceExternalReferenceCode())) {
+		String draftWidgetInstanceExternalReferenceCode =
+			widgetInstancePageElementDefinition.
+				getDraftWidgetInstanceExternalReferenceCode();
 
+		if (Validator.isNotNull(draftWidgetInstanceExternalReferenceCode)) {
 			widgetInstancePageElementDefinition.
 				setDraftWidgetInstanceExternalReferenceCode(() -> null);
 			widgetInstancePageElementDefinition.
 				setWidgetInstanceExternalReferenceCode(
-					() ->
-						widgetInstancePageElementDefinition.
-							getDraftWidgetInstanceExternalReferenceCode());
+					() -> draftWidgetInstanceExternalReferenceCode);
 
 			return;
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
@@ -272,7 +272,7 @@ public class PageSpecificationUtil {
 		}
 
 		for (PageExperience pageExperience : pageExperiences) {
-			_visitPageElements(
+			_processPageElements(
 				pageExperience.getPageElements(),
 				PageSpecificationUtil::_processPublishedFragmentInstance,
 				PageSpecificationUtil::
@@ -371,7 +371,7 @@ public class PageSpecificationUtil {
 				() -> draftContentPageSpecificationExternalReferenceCode);
 			pageExperience.setUuid(() -> null);
 
-			_visitPageElements(
+			_processPageElements(
 				pageExperience.getPageElements(),
 				PageSpecificationUtil::_processDraftFragmentInstance,
 				PageSpecificationUtil::
@@ -428,7 +428,7 @@ public class PageSpecificationUtil {
 						publishedContentPageSpecificationExternalReferenceCode);
 				pageExperience.setUuid(() -> null);
 
-				_visitPageElements(
+				_processPageElements(
 					pageExperience.getPageElements(),
 					fragmentInstance -> {
 						if (fragmentInstance == null) {
@@ -506,7 +506,7 @@ public class PageSpecificationUtil {
 		return externalReferenceCode + LayoutConstants.ERC_SUFFIX_PUBLISHED;
 	}
 
-	private static void _visitPageElements(
+	private static void _processPageElements(
 		PageElement[] pageElements,
 		Consumer<FragmentInstance> fragmentInstanceConsumer,
 		Consumer<WidgetInstancePageElementDefinition>
@@ -544,7 +544,7 @@ public class PageSpecificationUtil {
 					widgetInstancePageElementDefinition);
 			}
 
-			_visitPageElements(
+			_processPageElements(
 				pageElement.getPageElements(), fragmentInstanceConsumer,
 				widgetInstancePageElementDefinitionConsumer);
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
@@ -259,12 +259,12 @@ public class PageSpecificationUtil {
 	}
 
 	private static ContentPageSpecification _toDraftContentPageSpecification(
-		ContentPageSpecification contentPageSpecification,
+		ContentPageSpecification publishedContentPageSpecification,
 		String draftContentPageSpecificationExternalReferenceCode) {
 
 		ContentPageSpecification draftContentPageSpecification =
 			ContentPageSpecification.unsafeToDTO(
-				contentPageSpecification.toString());
+				publishedContentPageSpecification.toString());
 
 		draftContentPageSpecification.
 			setDraftContentPageSpecificationExternalReferenceCode(() -> null);
@@ -376,18 +376,18 @@ public class PageSpecificationUtil {
 
 	private static ContentPageSpecification
 		_toPublishedContentPageSpecification(
-			ContentPageSpecification contentPageSpecification,
+			ContentPageSpecification draftContentPageSpecification,
 			String publishedContentPageSpecificationExternalReferenceCode) {
 
 		ContentPageSpecification publishedContentPageSpecification =
 			ContentPageSpecification.unsafeToDTO(
-				contentPageSpecification.toString());
+				draftContentPageSpecification.toString());
 
 		publishedContentPageSpecification.setExternalReferenceCode(
 			() -> publishedContentPageSpecificationExternalReferenceCode);
 		publishedContentPageSpecification.
 			setDraftContentPageSpecificationExternalReferenceCode(
-				contentPageSpecification::getExternalReferenceCode);
+				draftContentPageSpecification::getExternalReferenceCode);
 
 		PageExperience[] pageExperiences =
 			publishedContentPageSpecification.getPageExperiences();

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
@@ -168,7 +168,7 @@ public class PageSpecificationUtil {
 				draftContentPageSpecificationExternalReferenceCode,
 				publishedContentPageSpecification);
 
-			_setDraftReferences(
+			_processPublishedContentPageSpecification(
 				draftContentPageSpecificationExternalReferenceCode,
 				publishedContentPageSpecification);
 		}
@@ -297,54 +297,7 @@ public class PageSpecificationUtil {
 		}
 	}
 
-	private static void _processPublishedFragmentInstance(
-		FragmentInstance fragmentInstance) {
-
-		if ((fragmentInstance == null) ||
-			Validator.isNotNull(
-				fragmentInstance.
-					getDraftFragmentInstanceExternalReferenceCode())) {
-
-			return;
-		}
-
-		String fragmentInstanceExternalReferenceCode =
-			fragmentInstance.getFragmentInstanceExternalReferenceCode();
-
-		if (Validator.isNotNull(fragmentInstanceExternalReferenceCode)) {
-			fragmentInstance.setDraftFragmentInstanceExternalReferenceCode(
-				() ->
-					fragmentInstanceExternalReferenceCode +
-						LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT);
-		}
-	}
-
-	private static void _processPublishedWidgetInstancePageElementDefinition(
-		WidgetInstancePageElementDefinition
-			widgetInstancePageElementDefinition) {
-
-		if (Validator.isNotNull(
-				widgetInstancePageElementDefinition.
-					getDraftWidgetInstanceExternalReferenceCode())) {
-
-			return;
-		}
-
-		String widgetInstanceExternalReferenceCode =
-			widgetInstancePageElementDefinition.
-				getWidgetInstanceExternalReferenceCode();
-
-		if (Validator.isNotNull(widgetInstanceExternalReferenceCode)) {
-			widgetInstancePageElementDefinition.
-				setDraftWidgetInstanceExternalReferenceCode(
-					() ->
-						widgetInstanceExternalReferenceCode +
-							LayoutConstants.
-								EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT);
-		}
-	}
-
-	private static void _setDraftReferences(
+	private static void _processPublishedContentPageSpecification(
 		String draftContentPageSpecificationExternalReferenceCode,
 		ContentPageSpecification publishedContentPageSpecification) {
 
@@ -370,6 +323,104 @@ public class PageSpecificationUtil {
 				pageExperience.getPageElements(),
 				PageSpecificationUtil::
 					_processPublishedWidgetInstancePageElementDefinition);
+		}
+	}
+
+	private static void _processPublishedFragmentInstance(
+		FragmentInstance fragmentInstance) {
+
+		if ((fragmentInstance == null) ||
+			Validator.isNotNull(
+				fragmentInstance.
+					getDraftFragmentInstanceExternalReferenceCode())) {
+
+			return;
+		}
+
+		String fragmentInstanceExternalReferenceCode =
+			fragmentInstance.getFragmentInstanceExternalReferenceCode();
+
+		if (Validator.isNotNull(fragmentInstanceExternalReferenceCode)) {
+			fragmentInstance.setDraftFragmentInstanceExternalReferenceCode(
+				() ->
+					fragmentInstanceExternalReferenceCode +
+						LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT);
+		}
+	}
+
+	private static void _processPublishedFromDraftFragmentInstance(
+		FragmentInstance fragmentInstance) {
+
+		if (fragmentInstance == null) {
+			return;
+		}
+
+		fragmentInstance.setUuid(() -> null);
+
+		String draftFragmentInstanceExternalReferenceCode =
+			fragmentInstance.getFragmentInstanceExternalReferenceCode();
+
+		if (Validator.isNull(draftFragmentInstanceExternalReferenceCode)) {
+			return;
+		}
+
+		String publishedFragmentInstanceExternalReferenceCode =
+			_toPublishedExternalReferenceCode(
+				draftFragmentInstanceExternalReferenceCode);
+
+		fragmentInstance.setDraftFragmentInstanceExternalReferenceCode(
+			() -> draftFragmentInstanceExternalReferenceCode);
+		fragmentInstance.setFragmentInstanceExternalReferenceCode(
+			() -> publishedFragmentInstanceExternalReferenceCode);
+	}
+
+	private static void
+		_processPublishedFromDraftWidgetInstancePageElementDefinition(
+			WidgetInstancePageElementDefinition
+				widgetInstancePageElementDefinition) {
+
+		String draftWidgetInstanceExternalReferenceCode =
+			widgetInstancePageElementDefinition.
+				getWidgetInstanceExternalReferenceCode();
+
+		if (Validator.isNull(draftWidgetInstanceExternalReferenceCode)) {
+			return;
+		}
+
+		String publishedWidgetInstanceExternalReferenceCode =
+			_toPublishedExternalReferenceCode(
+				draftWidgetInstanceExternalReferenceCode);
+
+		widgetInstancePageElementDefinition.
+			setDraftWidgetInstanceExternalReferenceCode(
+				() -> draftWidgetInstanceExternalReferenceCode);
+		widgetInstancePageElementDefinition.
+			setWidgetInstanceExternalReferenceCode(
+				() -> publishedWidgetInstanceExternalReferenceCode);
+	}
+
+	private static void _processPublishedWidgetInstancePageElementDefinition(
+		WidgetInstancePageElementDefinition
+			widgetInstancePageElementDefinition) {
+
+		if (Validator.isNotNull(
+				widgetInstancePageElementDefinition.
+					getDraftWidgetInstanceExternalReferenceCode())) {
+
+			return;
+		}
+
+		String widgetInstanceExternalReferenceCode =
+			widgetInstancePageElementDefinition.
+				getWidgetInstanceExternalReferenceCode();
+
+		if (Validator.isNotNull(widgetInstanceExternalReferenceCode)) {
+			widgetInstancePageElementDefinition.
+				setDraftWidgetInstanceExternalReferenceCode(
+					() ->
+						widgetInstanceExternalReferenceCode +
+							LayoutConstants.
+								EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT);
 		}
 	}
 
@@ -482,60 +533,11 @@ public class PageSpecificationUtil {
 				pageExperience.setUuid(() -> null);
 
 				_processPageElements(
-					fragmentInstance -> {
-						if (fragmentInstance == null) {
-							return;
-						}
-
-						fragmentInstance.setUuid(() -> null);
-
-						String draftFragmentInstanceExternalReferenceCode =
-							fragmentInstance.
-								getFragmentInstanceExternalReferenceCode();
-
-						if (Validator.isNull(
-								draftFragmentInstanceExternalReferenceCode)) {
-
-							return;
-						}
-
-						String publishedFragmentInstanceExternalReferenceCode =
-							_toPublishedExternalReferenceCode(
-								draftFragmentInstanceExternalReferenceCode);
-
-						fragmentInstance.
-							setDraftFragmentInstanceExternalReferenceCode(
-								() ->
-									draftFragmentInstanceExternalReferenceCode);
-						fragmentInstance.
-							setFragmentInstanceExternalReferenceCode(
-								() ->
-									publishedFragmentInstanceExternalReferenceCode);
-					},
+					PageSpecificationUtil::
+						_processPublishedFromDraftFragmentInstance,
 					pageExperience.getPageElements(),
-					widgetInstancePageElementDefinition -> {
-						String draftWidgetInstanceExternalReferenceCode =
-							widgetInstancePageElementDefinition.
-								getWidgetInstanceExternalReferenceCode();
-
-						if (Validator.isNull(
-								draftWidgetInstanceExternalReferenceCode)) {
-
-							return;
-						}
-
-						String publishedWidgetInstanceExternalReferenceCode =
-							_toPublishedExternalReferenceCode(
-								draftWidgetInstanceExternalReferenceCode);
-
-						widgetInstancePageElementDefinition.
-							setDraftWidgetInstanceExternalReferenceCode(
-								() -> draftWidgetInstanceExternalReferenceCode);
-						widgetInstancePageElementDefinition.
-							setWidgetInstanceExternalReferenceCode(
-								() ->
-									publishedWidgetInstanceExternalReferenceCode);
-					});
+					PageSpecificationUtil::
+						_processPublishedFromDraftWidgetInstancePageElementDefinition);
 			}
 		}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
@@ -162,11 +162,11 @@ public class PageSpecificationUtil {
 						LayoutConstants.ERC_SUFFIX_DRAFT;
 			}
 
-			draftContentPageSpecification = _toDraftContentPageSpecification(
-				contentPageSpecification,
-				draftContentPageSpecificationExternalReferenceCode);
-
 			publishedContentPageSpecification = contentPageSpecification;
+
+			draftContentPageSpecification = _toDraftContentPageSpecification(
+				publishedContentPageSpecification,
+				draftContentPageSpecificationExternalReferenceCode);
 
 			_setDraftReferences(
 				draftContentPageSpecificationExternalReferenceCode,
@@ -174,9 +174,11 @@ public class PageSpecificationUtil {
 		}
 		else {
 			draftContentPageSpecification = contentPageSpecification;
+
 			publishedContentPageSpecification =
 				_toPublishedContentPageSpecification(
-					contentPageSpecification, sitePageExternalReferenceCode);
+					draftContentPageSpecification,
+					sitePageExternalReferenceCode);
 
 			draftContentPageSpecification.setStatus(
 				() -> PageSpecification.Status.APPROVED);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
@@ -5,18 +5,28 @@
 
 package com.liferay.headless.admin.site.internal.resource.v1_0.util;
 
+import com.liferay.headless.admin.site.dto.v1_0.BasicFragmentInstancePageElementDefinition;
 import com.liferay.headless.admin.site.dto.v1_0.ContentPageSpecification;
 import com.liferay.headless.admin.site.dto.v1_0.EmbeddedPageSpecification;
+import com.liferay.headless.admin.site.dto.v1_0.FormFragmentInstancePageElementDefinition;
+import com.liferay.headless.admin.site.dto.v1_0.FragmentInstance;
 import com.liferay.headless.admin.site.dto.v1_0.LinkToPagePageSpecification;
 import com.liferay.headless.admin.site.dto.v1_0.LinkToURLPageSpecification;
+import com.liferay.headless.admin.site.dto.v1_0.PageElement;
+import com.liferay.headless.admin.site.dto.v1_0.PageElementDefinition;
+import com.liferay.headless.admin.site.dto.v1_0.PageExperience;
 import com.liferay.headless.admin.site.dto.v1_0.PageSetPageSpecification;
 import com.liferay.headless.admin.site.dto.v1_0.PageSpecification;
+import com.liferay.headless.admin.site.dto.v1_0.WidgetInstancePageElementDefinition;
 import com.liferay.headless.admin.site.dto.v1_0.WidgetPageSpecification;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.segments.constants.SegmentsExperienceConstants;
 
 import java.util.Objects;
+import java.util.function.Consumer;
 
 /**
  * @author Rubén Pulido
@@ -127,6 +137,409 @@ public class PageSpecificationUtil {
 
 		return (WidgetPageSpecification)getPageSpecification(
 			pageSpecifications);
+	}
+
+	public static PageSpecification[] toContentPageSpecifications(
+		ContentPageSpecification contentPageSpecification,
+		String sitePageExternalReferenceCode) {
+
+		ContentPageSpecification draftContentPageSpecification;
+		ContentPageSpecification publishedContentPageSpecification;
+
+		if (Objects.equals(
+				contentPageSpecification.getExternalReferenceCode(),
+				sitePageExternalReferenceCode)) {
+
+			String draftContentPageSpecificationExternalReferenceCode =
+				contentPageSpecification.
+					getDraftContentPageSpecificationExternalReferenceCode();
+
+			if (Validator.isNull(
+					draftContentPageSpecificationExternalReferenceCode)) {
+
+				draftContentPageSpecificationExternalReferenceCode =
+					sitePageExternalReferenceCode +
+						LayoutConstants.ERC_SUFFIX_DRAFT;
+			}
+
+			draftContentPageSpecification = _toDraftContentPageSpecification(
+				contentPageSpecification,
+				draftContentPageSpecificationExternalReferenceCode);
+
+			publishedContentPageSpecification = contentPageSpecification;
+
+			_setDraftReferences(
+				draftContentPageSpecificationExternalReferenceCode,
+				publishedContentPageSpecification);
+		}
+		else {
+			draftContentPageSpecification = contentPageSpecification;
+			publishedContentPageSpecification =
+				_toPublishedContentPageSpecification(
+					contentPageSpecification, sitePageExternalReferenceCode);
+
+			draftContentPageSpecification.setStatus(
+				() -> PageSpecification.Status.APPROVED);
+		}
+
+		return new PageSpecification[] {
+			publishedContentPageSpecification, draftContentPageSpecification
+		};
+	}
+
+	private static void _setDraftReferences(
+		String draftContentPageSpecificationExternalReferenceCode,
+		ContentPageSpecification publishedContentPageSpecification) {
+
+		if (Validator.isNull(
+				publishedContentPageSpecification.
+					getDraftContentPageSpecificationExternalReferenceCode())) {
+
+			publishedContentPageSpecification.
+				setDraftContentPageSpecificationExternalReferenceCode(
+					() -> draftContentPageSpecificationExternalReferenceCode);
+		}
+
+		PageExperience[] pageExperiences =
+			publishedContentPageSpecification.getPageExperiences();
+
+		if (pageExperiences == null) {
+			return;
+		}
+
+		for (PageExperience pageExperience : pageExperiences) {
+			_visitPageElements(
+				pageExperience.getPageElements(),
+				fragmentInstance -> {
+					if ((fragmentInstance == null) ||
+						Validator.isNotNull(
+							fragmentInstance.
+								getDraftFragmentInstanceExternalReferenceCode())) {
+
+						return;
+					}
+
+					String fragmentInstanceExternalReferenceCode =
+						fragmentInstance.
+							getFragmentInstanceExternalReferenceCode();
+
+					if (Validator.isNotNull(
+							fragmentInstanceExternalReferenceCode)) {
+
+						fragmentInstance.
+							setDraftFragmentInstanceExternalReferenceCode(
+								() ->
+									fragmentInstanceExternalReferenceCode +
+										LayoutConstants.ERC_SUFFIX_DRAFT);
+					}
+				},
+				widgetInstancePageElementDefinition -> {
+					if (Validator.isNotNull(
+							widgetInstancePageElementDefinition.
+								getDraftWidgetInstanceExternalReferenceCode())) {
+
+						return;
+					}
+
+					String widgetInstanceExternalReferenceCode =
+						widgetInstancePageElementDefinition.
+							getWidgetInstanceExternalReferenceCode();
+
+					if (Validator.isNotNull(
+							widgetInstanceExternalReferenceCode)) {
+
+						widgetInstancePageElementDefinition.
+							setDraftWidgetInstanceExternalReferenceCode(
+								() ->
+									widgetInstanceExternalReferenceCode +
+										LayoutConstants.ERC_SUFFIX_DRAFT);
+					}
+				});
+		}
+	}
+
+	private static ContentPageSpecification _toDraftContentPageSpecification(
+		ContentPageSpecification contentPageSpecification,
+		String draftContentPageSpecificationExternalReferenceCode) {
+
+		ContentPageSpecification draftContentPageSpecification =
+			ContentPageSpecification.unsafeToDTO(
+				contentPageSpecification.toString());
+
+		draftContentPageSpecification.
+			setDraftContentPageSpecificationExternalReferenceCode(() -> null);
+		draftContentPageSpecification.setExternalReferenceCode(
+			() -> draftContentPageSpecificationExternalReferenceCode);
+		draftContentPageSpecification.setStatus(
+			() -> PageSpecification.Status.APPROVED);
+
+		PageExperience[] pageExperiences =
+			draftContentPageSpecification.getPageExperiences();
+
+		if (ArrayUtil.isEmpty(pageExperiences)) {
+			return draftContentPageSpecification;
+		}
+
+		for (PageExperience pageExperience : pageExperiences) {
+			String draftPageExperienceERC;
+
+			if (Objects.equals(
+					pageExperience.getKey(),
+					SegmentsExperienceConstants.KEY_DEFAULT)) {
+
+				draftPageExperienceERC =
+					draftContentPageSpecificationExternalReferenceCode +
+						LayoutConstants.ERC_SUFFIX_DEFAULT;
+			}
+			else {
+				draftPageExperienceERC =
+					pageExperience.getExternalReferenceCode() +
+						LayoutConstants.ERC_SUFFIX_DRAFT;
+			}
+
+			pageExperience.setExternalReferenceCode(
+				() -> draftPageExperienceERC);
+			pageExperience.setPageSpecificationExternalReferenceCode(
+				() -> draftContentPageSpecificationExternalReferenceCode);
+			pageExperience.setUuid(() -> null);
+
+			_visitPageElements(
+				pageExperience.getPageElements(),
+				fragmentInstance -> {
+					if (fragmentInstance == null) {
+						return;
+					}
+
+					fragmentInstance.setUuid(() -> null);
+
+					String userDraftERC =
+						fragmentInstance.
+							getDraftFragmentInstanceExternalReferenceCode();
+
+					if (Validator.isNotNull(userDraftERC)) {
+						fragmentInstance.
+							setFragmentInstanceExternalReferenceCode(
+								() -> userDraftERC);
+						fragmentInstance.
+							setDraftFragmentInstanceExternalReferenceCode(
+								() -> null);
+
+						return;
+					}
+
+					String fragmentInstanceERC =
+						fragmentInstance.
+							getFragmentInstanceExternalReferenceCode();
+
+					if (Validator.isNotNull(fragmentInstanceERC)) {
+						fragmentInstance.
+							setFragmentInstanceExternalReferenceCode(
+								() ->
+									fragmentInstanceERC +
+										LayoutConstants.ERC_SUFFIX_DRAFT);
+					}
+				},
+				widgetInstancePageElementDefinition -> {
+					String userDraftERC =
+						widgetInstancePageElementDefinition.
+							getDraftWidgetInstanceExternalReferenceCode();
+
+					if (Validator.isNotNull(userDraftERC)) {
+						widgetInstancePageElementDefinition.
+							setWidgetInstanceExternalReferenceCode(
+								() -> userDraftERC);
+						widgetInstancePageElementDefinition.
+							setDraftWidgetInstanceExternalReferenceCode(
+								() -> null);
+
+						return;
+					}
+
+					String widgetInstanceExternalReferenceCode =
+						widgetInstancePageElementDefinition.
+							getWidgetInstanceExternalReferenceCode();
+
+					if (Validator.isNotNull(
+							widgetInstanceExternalReferenceCode)) {
+
+						widgetInstancePageElementDefinition.
+							setWidgetInstanceExternalReferenceCode(
+								() ->
+									widgetInstanceExternalReferenceCode +
+										LayoutConstants.ERC_SUFFIX_DRAFT);
+					}
+				});
+		}
+
+		return draftContentPageSpecification;
+	}
+
+	private static ContentPageSpecification
+		_toPublishedContentPageSpecification(
+			ContentPageSpecification contentPageSpecification,
+			String publishedContentPageSpecificationExternalReferenceCode) {
+
+		ContentPageSpecification publishedContentPageSpecification =
+			ContentPageSpecification.unsafeToDTO(
+				contentPageSpecification.toString());
+
+		publishedContentPageSpecification.setExternalReferenceCode(
+			() -> publishedContentPageSpecificationExternalReferenceCode);
+		publishedContentPageSpecification.
+			setDraftContentPageSpecificationExternalReferenceCode(
+				contentPageSpecification::getExternalReferenceCode);
+
+		PageExperience[] pageExperiences =
+			publishedContentPageSpecification.getPageExperiences();
+
+		if (pageExperiences != null) {
+			for (PageExperience pageExperience : pageExperiences) {
+				String publishedPageExperienceExternalReferenceCode;
+
+				if (Objects.equals(
+						pageExperience.getKey(),
+						SegmentsExperienceConstants.KEY_DEFAULT)) {
+
+					publishedPageExperienceExternalReferenceCode =
+						publishedContentPageSpecificationExternalReferenceCode +
+							LayoutConstants.ERC_SUFFIX_DEFAULT;
+				}
+				else {
+					publishedPageExperienceExternalReferenceCode =
+						_toPublishedExternalReferenceCode(
+							pageExperience.getExternalReferenceCode());
+				}
+
+				String publishedPageExperienceExternalReferenceCodeFinal =
+					publishedPageExperienceExternalReferenceCode;
+
+				pageExperience.setExternalReferenceCode(
+					() -> publishedPageExperienceExternalReferenceCodeFinal);
+
+				pageExperience.setPageSpecificationExternalReferenceCode(
+					() ->
+						publishedContentPageSpecificationExternalReferenceCode);
+				pageExperience.setUuid(() -> null);
+
+				_visitPageElements(
+					pageExperience.getPageElements(),
+					fragmentInstance -> {
+						if (fragmentInstance == null) {
+							return;
+						}
+
+						fragmentInstance.setUuid(() -> null);
+
+						String draftFragmentInstanceExternalReferenceCode =
+							fragmentInstance.
+								getFragmentInstanceExternalReferenceCode();
+
+						if (Validator.isNull(
+								draftFragmentInstanceExternalReferenceCode)) {
+
+							return;
+						}
+
+						String publishedFragmentInstanceExternalReferenceCode =
+							_toPublishedExternalReferenceCode(
+								draftFragmentInstanceExternalReferenceCode);
+
+						fragmentInstance.
+							setDraftFragmentInstanceExternalReferenceCode(
+								() ->
+									draftFragmentInstanceExternalReferenceCode);
+						fragmentInstance.
+							setFragmentInstanceExternalReferenceCode(
+								() ->
+									publishedFragmentInstanceExternalReferenceCode);
+					},
+					widgetInstancePageElementDefinition -> {
+						String draftWidgetInstanceExternalReferenceCode =
+							widgetInstancePageElementDefinition.
+								getWidgetInstanceExternalReferenceCode();
+
+						if (Validator.isNull(
+								draftWidgetInstanceExternalReferenceCode)) {
+
+							return;
+						}
+
+						String publishedWidgetInstanceExternalReferenceCode =
+							_toPublishedExternalReferenceCode(
+								draftWidgetInstanceExternalReferenceCode);
+
+						widgetInstancePageElementDefinition.
+							setDraftWidgetInstanceExternalReferenceCode(
+								() -> draftWidgetInstanceExternalReferenceCode);
+						widgetInstancePageElementDefinition.
+							setWidgetInstanceExternalReferenceCode(
+								() ->
+									publishedWidgetInstanceExternalReferenceCode);
+					});
+			}
+		}
+
+		return publishedContentPageSpecification;
+	}
+
+	private static String _toPublishedExternalReferenceCode(
+		String externalReferenceCode) {
+
+		if (Validator.isNull(externalReferenceCode)) {
+			return externalReferenceCode;
+		}
+
+		if (externalReferenceCode.endsWith(LayoutConstants.ERC_SUFFIX_DRAFT)) {
+			return externalReferenceCode.substring(
+				0,
+				externalReferenceCode.length() -
+					LayoutConstants.ERC_SUFFIX_DRAFT.length());
+		}
+
+		return externalReferenceCode + LayoutConstants.ERC_SUFFIX_PUBLISHED;
+	}
+
+	private static void _visitPageElements(
+		PageElement[] pageElements,
+		Consumer<FragmentInstance> fragmentInstanceConsumer,
+		Consumer<WidgetInstancePageElementDefinition> widgetInstanceConsumer) {
+
+		if (pageElements == null) {
+			return;
+		}
+
+		for (PageElement pageElement : pageElements) {
+			PageElementDefinition pageElementDefinition =
+				pageElement.getPageElementDefinition();
+
+			if (pageElementDefinition instanceof
+					BasicFragmentInstancePageElementDefinition
+						basicFragmentInstancePageElementDefinition) {
+
+				fragmentInstanceConsumer.accept(
+					basicFragmentInstancePageElementDefinition.
+						getFragmentInstance());
+			}
+			else if (pageElementDefinition instanceof
+						FormFragmentInstancePageElementDefinition
+							formFragmentInstancePageElementDefinition) {
+
+				fragmentInstanceConsumer.accept(
+					formFragmentInstancePageElementDefinition.
+						getFragmentInstance());
+			}
+			else if (pageElementDefinition instanceof
+						WidgetInstancePageElementDefinition
+							widgetInstancePageElementDefinition) {
+
+				widgetInstanceConsumer.accept(
+					widgetInstancePageElementDefinition);
+			}
+
+			_visitPageElements(
+				pageElement.getPageElements(), fragmentInstanceConsumer,
+				widgetInstanceConsumer);
+		}
 	}
 
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -1334,6 +1334,26 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		}
 	}
 
+	private String _getExpectedDraftFragmentEntryLinkExternalReferenceCode(
+		String publishedFragmentEntryLinkExternalReferenceCode) {
+
+		String expectedDraftFragmentEntryLinkExternalReferenceCode =
+			publishedFragmentEntryLinkExternalReferenceCode +
+				LayoutConstants.ERC_SUFFIX_DRAFT;
+
+		if (publishedFragmentEntryLinkExternalReferenceCode.endsWith(
+				LayoutConstants.ERC_SUFFIX_PUBLISHED)) {
+
+			expectedDraftFragmentEntryLinkExternalReferenceCode =
+				publishedFragmentEntryLinkExternalReferenceCode.substring(
+					0,
+					publishedFragmentEntryLinkExternalReferenceCode.length() -
+						LayoutConstants.ERC_SUFFIX_PUBLISHED.length());
+		}
+
+		return expectedDraftFragmentEntryLinkExternalReferenceCode;
+	}
+
 	private int _getExpectedPriority(
 			String defaultParentSitePageExternalReferenceCode,
 			String parentSitePageExternalReferenceCode, Integer priority)
@@ -1996,36 +2016,17 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		for (FragmentEntryLink publishedFragmentEntryLink :
 				publishedFragmentEntryLinks) {
 
-			String publishedFragmentEntryLinkExternalReferenceCode =
-				publishedFragmentEntryLink.getExternalReferenceCode();
-
-			String expectedDraftExternalReferenceCode;
-
-			if (publishedFragmentEntryLinkExternalReferenceCode.endsWith(
-					LayoutConstants.ERC_SUFFIX_PUBLISHED)) {
-
-				int publishedFragmentEntryLinkExternalReferenceCodeLength =
-					publishedFragmentEntryLinkExternalReferenceCode.length();
-
-				expectedDraftExternalReferenceCode =
-					publishedFragmentEntryLinkExternalReferenceCode.substring(
-						0,
-						publishedFragmentEntryLinkExternalReferenceCodeLength -
-							LayoutConstants.ERC_SUFFIX_PUBLISHED.length());
-			}
-			else {
-				expectedDraftExternalReferenceCode =
-					publishedFragmentEntryLinkExternalReferenceCode +
-						LayoutConstants.ERC_SUFFIX_DRAFT;
-			}
+			String expectedDraftFragmentEntryLinkExternalReferenceCode =
+				_getExpectedDraftFragmentEntryLinkExternalReferenceCode(
+					publishedFragmentEntryLink.getExternalReferenceCode());
 
 			Assert.assertEquals(
 				publishedFragmentEntryLink.toString(),
-				expectedDraftExternalReferenceCode,
+				expectedDraftFragmentEntryLinkExternalReferenceCode,
 				publishedFragmentEntryLink.getOriginalFragmentEntryLinkERC());
 			Assert.assertTrue(
 				draftFragmentEntryLinkExternalReferenceCodes.contains(
-					expectedDraftExternalReferenceCode));
+					expectedDraftFragmentEntryLinkExternalReferenceCode));
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -2946,7 +2946,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 	}
 
 	private void _testPostSiteSitePageWithDraftContentPageSpecification(
-			PageSpecification.Status status, boolean useDraftERCSuffix)
+			PageSpecification.Status status,
+			boolean useDraftExternalReferenceCodeSuffix)
 		throws Exception {
 
 		String pageExternalReferenceCode = RandomTestUtil.randomString();
@@ -2958,7 +2959,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		String pageExperienceExternalReferenceCode =
 			RandomTestUtil.randomString();
 
-		if (useDraftERCSuffix) {
+		if (useDraftExternalReferenceCodeSuffix) {
 			draftContentPageSpecificationExternalReferenceCode =
 				pageExternalReferenceCode +
 					LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -2575,7 +2575,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 	private void _testPatchSiteSitePageWithSingleContentPageSpecification()
 		throws Exception {
 
-		SitePage existingSitePage = sitePageResource.postSiteSitePage(
+		SitePage postSitePage = sitePageResource.postSiteSitePage(
 			testGroup.getExternalReferenceCode(), false,
 			_getRandomSitePage(SitePage.Type.CONTENT_PAGE));
 
@@ -2587,7 +2587,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 				PageSpecification.Status.APPROVED);
 
 		contentPageSpecification.setExternalReferenceCode(
-			existingSitePage.getExternalReferenceCode());
+			postSitePage.getExternalReferenceCode());
 
 		sitePage.setPageSpecifications(
 			() -> new PageSpecification[] {contentPageSpecification});
@@ -2599,7 +2599,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			"A single content page specification is only accepted on POST",
 			() -> sitePageResource.patchSiteSitePage(
 				testGroup.getExternalReferenceCode(),
-				existingSitePage.getExternalReferenceCode(), false, sitePage));
+				postSitePage.getExternalReferenceCode(), false, sitePage));
 	}
 
 	private void _testPatchSiteSitePageWithWidgetPageSettings()
@@ -4391,7 +4391,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 	private void _testPutSiteSitePageWithSingleContentPageSpecification()
 		throws Exception {
 
-		SitePage existingSitePage = sitePageResource.postSiteSitePage(
+		SitePage postSitePage = sitePageResource.postSiteSitePage(
 			testGroup.getExternalReferenceCode(), false,
 			_getRandomSitePage(SitePage.Type.CONTENT_PAGE));
 
@@ -4401,9 +4401,9 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 				PageSpecification.Status.APPROVED);
 
 		contentPageSpecification.setExternalReferenceCode(
-			existingSitePage.getExternalReferenceCode());
+			postSitePage.getExternalReferenceCode());
 
-		existingSitePage.setPageSpecifications(
+		postSitePage.setPageSpecifications(
 			() -> new PageSpecification[] {contentPageSpecification});
 
 		SitePageResource sitePageResource = _getSitePageResource(
@@ -4413,8 +4413,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			"A single content page specification is only accepted on POST",
 			() -> sitePageResource.putSiteSitePage(
 				testGroup.getExternalReferenceCode(),
-				existingSitePage.getExternalReferenceCode(), false,
-				existingSitePage));
+				postSitePage.getExternalReferenceCode(), false,
+				postSitePage));
 	}
 
 	private void _testPutSiteSitePageWithWidgetPageSettings() throws Exception {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -2819,7 +2819,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			boolean assertSuffixMirroredFragmentEntryLinks,
 			ContentPageSpecification contentPageSpecification,
 			String draftContentPageSpecificationExternalReferenceCode,
-			boolean inputIsDraft, String pageExternalReferenceCode,
+			boolean inputIsDraft, String sitePageExternalReferenceCode,
 			PageSpecification.Status status)
 		throws Exception {
 
@@ -2835,7 +2835,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 				pageExperiences,
 				draftPageExperience ->
 					PageExperiencesTestUtil.toPublishedPageExperience(
-						draftPageExperience, pageExternalReferenceCode),
+						draftPageExperience, sitePageExternalReferenceCode),
 				PageExperience.class);
 		}
 		else {
@@ -2863,13 +2863,13 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			new ContentPageSpecification();
 
 		expectedPublishedContentPageSpecification.setExternalReferenceCode(
-			pageExternalReferenceCode);
+			sitePageExternalReferenceCode);
 		expectedPublishedContentPageSpecification.setPageExperiences(
 			expectedPublishedPageExperiences);
 		expectedPublishedContentPageSpecification.setStatus(status);
 
 		SitePage sitePage = _getRandomSitePage(
-			pageExternalReferenceCode, null,
+			sitePageExternalReferenceCode, null,
 			ServiceContextTestUtil.getServiceContext(
 				testGroup, TestPropsValues.getUserId()),
 			SitePage.Type.CONTENT_PAGE,
@@ -2885,10 +2885,11 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			testGroup.getExternalReferenceCode(), false, sitePage);
 
 		SitePage getSitePage = sitePageResource.getSiteSitePage(
-			testGroup.getExternalReferenceCode(), pageExternalReferenceCode);
+			testGroup.getExternalReferenceCode(),
+			sitePageExternalReferenceCode);
 
 		Layout layout = _layoutLocalService.getLayoutByExternalReferenceCode(
-			pageExternalReferenceCode, testGroup.getGroupId());
+			sitePageExternalReferenceCode, testGroup.getGroupId());
 
 		if (Objects.equals(status, PageSpecification.Status.APPROVED)) {
 			Assert.assertTrue(layout.isPublished());
@@ -2950,7 +2951,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			boolean useDraftExternalReferenceCodeSuffix)
 		throws Exception {
 
-		String pageExternalReferenceCode = RandomTestUtil.randomString();
+		String sitePageExternalReferenceCode = RandomTestUtil.randomString();
 
 		String defaultPageExperienceExternalReferenceCode =
 			RandomTestUtil.randomString();
@@ -2961,7 +2962,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 		if (useDraftExternalReferenceCodeSuffix) {
 			draftContentPageSpecificationExternalReferenceCode =
-				pageExternalReferenceCode +
+				sitePageExternalReferenceCode +
 					LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT;
 
 			defaultPageExperienceExternalReferenceCode =
@@ -2986,7 +2987,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		_testPostSiteSitePageWithDraftContentPageSpecification(
 			true, draftContentPageSpecification,
 			draftContentPageSpecificationExternalReferenceCode, true,
-			pageExternalReferenceCode, status);
+			sitePageExternalReferenceCode, status);
 	}
 
 	private void _testPostSiteSitePageWithPageElements() throws Exception {
@@ -3133,12 +3134,13 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			PageSpecification.Status status)
 		throws Exception {
 
-		String pageExternalReferenceCode = RandomTestUtil.randomString();
+		String sitePageExternalReferenceCode = RandomTestUtil.randomString();
 
 		ContentPageSpecification publishedContentPageSpecification =
 			PageSpecificationsTestUtil.
 				getContentPageSpecificationWithPageExperiences(
-					pageExternalReferenceCode, RandomTestUtil.randomString(),
+					sitePageExternalReferenceCode,
+					RandomTestUtil.randomString(),
 					RandomTestUtil.randomString(), testGroup.getGroupId(),
 					RandomTestUtil.randomString(),
 					RandomTestUtil.randomString(),
@@ -3146,9 +3148,9 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 		_testPostSiteSitePageWithDraftContentPageSpecification(
 			true, publishedContentPageSpecification,
-			pageExternalReferenceCode +
+			sitePageExternalReferenceCode +
 				LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT,
-			false, pageExternalReferenceCode, status);
+			false, sitePageExternalReferenceCode, status);
 	}
 
 	private void _testPostSiteSitePageWithPublishedContentPageSpecificationAndDraftReferences()

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -1929,7 +1929,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			ContentPageSpecification expectedDraftContentPageSpecification,
 			ContentPageSpecification expectedPublishedContentPageSpecification,
 			Group group, String sitePageExternalReferenceCode,
-			PageSpecification.Status status)
+			PageSpecification.Status status,
+			boolean assertSuffixMirroredFragmentEntryLinks)
 		throws Exception {
 
 		SitePage sitePage = _getRandomSitePage(
@@ -1965,6 +1966,10 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			expectedDraftContentPageSpecification,
 			expectedPublishedContentPageSpecification,
 			getSitePage.getPageSpecifications(), layout, status);
+
+		if (!assertSuffixMirroredFragmentEntryLinks) {
+			return;
+		}
 
 		Layout draftLayout = layout.fetchDraftLayout();
 
@@ -2017,7 +2022,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			ContentPageSpecification contentPageSpecification,
 			String pageExternalReferenceCode,
 			String draftContentPageSpecificationExternalReferenceCode,
-			PageSpecification.Status status, boolean inputIsDraft)
+			PageSpecification.Status status, boolean inputIsDraft,
+			boolean assertSuffixMirroredFragmentEntryLinks)
 		throws Exception {
 
 		PageExperience[] inputPageExperiences =
@@ -2068,7 +2074,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		_postContentPageSpecification(
 			contentPageSpecification, expectedDraftContentPageSpecification,
 			expectedPublishedContentPageSpecification, testGroup,
-			pageExternalReferenceCode, status);
+			pageExternalReferenceCode, status,
+			assertSuffixMirroredFragmentEntryLinks);
 	}
 
 	private SitePage _postSiteSitePageWithPageSpecificationsWithCustomFields(
@@ -2974,7 +2981,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 		_postContentPageSpecification(
 			draftContentPageSpecification, pageExternalReferenceCode,
-			draftContentPageSpecificationExternalReferenceCode, status, true);
+			draftContentPageSpecificationExternalReferenceCode, status, true,
+			true);
 	}
 
 	private void _testPostSiteSitePageWithPageElements() throws Exception {
@@ -3135,7 +3143,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		_postContentPageSpecification(
 			publishedContentPageSpecification, pageExternalReferenceCode,
 			pageExternalReferenceCode + LayoutConstants.ERC_SUFFIX_DRAFT,
-			status, false);
+			status, false, true);
 	}
 
 	private void _testPostSiteSitePageWithPublishedContentPageSpecificationAndDraftReferences()
@@ -3152,54 +3160,34 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		List<String> userDraftFragmentInstanceERCs =
 			_setUserDraftFragmentInstanceERCs(pageElements);
 
-		PageExperience defaultPageExperience = new PageExperience();
-
-		defaultPageExperience.setExternalReferenceCode(
-			pageExternalReferenceCode + LayoutConstants.ERC_SUFFIX_DEFAULT);
-		defaultPageExperience.setKey(SegmentsExperienceConstants.KEY_DEFAULT);
-		defaultPageExperience.setName_i18n(
-			Collections.singletonMap("en-US", RandomTestUtil.randomString()));
-		defaultPageExperience.setPageElements(pageElements);
-		defaultPageExperience.setPageSpecificationExternalReferenceCode(
-			pageExternalReferenceCode);
-
-		ContentPageSpecification contentPageSpecification =
+		ContentPageSpecification publishedContentPageSpecification =
 			new ContentPageSpecification();
 
-		contentPageSpecification.
+		publishedContentPageSpecification.
 			setDraftContentPageSpecificationExternalReferenceCode(
 				userDraftSpecERC);
-		contentPageSpecification.setExternalReferenceCode(
+		publishedContentPageSpecification.setExternalReferenceCode(
 			pageExternalReferenceCode);
-		contentPageSpecification.setPageExperiences(
-			new PageExperience[] {defaultPageExperience});
-		contentPageSpecification.setStatus(PageSpecification.Status.APPROVED);
-		contentPageSpecification.setType(
+		publishedContentPageSpecification.setPageExperiences(
+			new PageExperience[] {
+				PageExperiencesTestUtil.getDefaultPageExperience(
+					pageExternalReferenceCode +
+						LayoutConstants.ERC_SUFFIX_DEFAULT,
+					pageElements, pageExternalReferenceCode, null)
+			});
+		publishedContentPageSpecification.setStatus(
+			PageSpecification.Status.APPROVED);
+		publishedContentPageSpecification.setType(
 			() -> ContentPageSpecification.Type.CONTENT_PAGE_SPECIFICATION);
 
-		SitePage sitePage = _getRandomSitePage(
-			pageExternalReferenceCode, null,
-			ServiceContextTestUtil.getServiceContext(
-				testGroup, TestPropsValues.getUserId()),
-			SitePage.Type.CONTENT_PAGE,
-			StringUtil.toLowerCase(RandomTestUtil.randomString()));
-
-		sitePage.setPageSpecifications(
-			() -> new PageSpecification[] {contentPageSpecification});
-
-		SitePageResource sitePageResource = _getSitePageResource(
-			"pageSpecifications");
-
-		sitePageResource.postSiteSitePage(
-			testGroup.getExternalReferenceCode(), false, sitePage);
+		_postContentPageSpecification(
+			publishedContentPageSpecification, pageExternalReferenceCode,
+			userDraftSpecERC, PageSpecification.Status.APPROVED, false, false);
 
 		Layout layout = _layoutLocalService.getLayoutByExternalReferenceCode(
 			pageExternalReferenceCode, groupId);
 
 		Layout draftLayout = layout.fetchDraftLayout();
-
-		Assert.assertEquals(
-			userDraftSpecERC, draftLayout.getExternalReferenceCode());
 
 		List<String> draftFragmentEntryLinkERCs = TransformUtil.transform(
 			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -1339,16 +1339,20 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 		String expectedDraftFragmentEntryLinkExternalReferenceCode =
 			publishedFragmentEntryLinkExternalReferenceCode +
-				LayoutConstants.ERC_SUFFIX_DRAFT;
+				LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT;
 
 		if (publishedFragmentEntryLinkExternalReferenceCode.endsWith(
-				LayoutConstants.ERC_SUFFIX_PUBLISHED)) {
+				LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_PUBLISHED)) {
+
+			int suffixPublishedLength =
+				LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_PUBLISHED.
+					length();
 
 			expectedDraftFragmentEntryLinkExternalReferenceCode =
 				publishedFragmentEntryLinkExternalReferenceCode.substring(
 					0,
 					publishedFragmentEntryLinkExternalReferenceCode.length() -
-						LayoutConstants.ERC_SUFFIX_PUBLISHED.length());
+						suffixPublishedLength);
 		}
 
 		return expectedDraftFragmentEntryLinkExternalReferenceCode;
@@ -2956,15 +2960,16 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 		if (useDraftERCSuffix) {
 			draftContentPageSpecificationExternalReferenceCode =
-				pageExternalReferenceCode + LayoutConstants.ERC_SUFFIX_DRAFT;
+				pageExternalReferenceCode +
+					LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT;
 
 			defaultPageExperienceExternalReferenceCode =
 				draftContentPageSpecificationExternalReferenceCode +
-					LayoutConstants.ERC_SUFFIX_DEFAULT;
+					LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DEFAULT;
 
 			pageExperienceExternalReferenceCode =
 				RandomTestUtil.randomString() +
-					LayoutConstants.ERC_SUFFIX_DRAFT;
+					LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT;
 		}
 
 		ContentPageSpecification draftContentPageSpecification =
@@ -3140,8 +3145,9 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 		_testPostSiteSitePageWithDraftContentPageSpecification(
 			true, publishedContentPageSpecification,
-			pageExternalReferenceCode + LayoutConstants.ERC_SUFFIX_DRAFT, false,
-			pageExternalReferenceCode, status);
+			pageExternalReferenceCode +
+				LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT,
+			false, pageExternalReferenceCode, status);
 	}
 
 	private void _testPostSiteSitePageWithPublishedContentPageSpecificationAndDraftReferences()
@@ -3170,7 +3176,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			new PageExperience[] {
 				PageExperiencesTestUtil.getDefaultPageExperience(
 					pageSpecificationExternalReferenceCode +
-						LayoutConstants.ERC_SUFFIX_DEFAULT,
+						LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DEFAULT,
 					pageElements, pageSpecificationExternalReferenceCode, null)
 			});
 		publishedContentPageSpecification.setStatus(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -2113,10 +2113,11 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		return postSitePage;
 	}
 
-	private List<String> _setUserDraftFragmentInstanceERCs(
+	private List<String> _setAndGetDraftFragmentInstanceExternalReferenceCodes(
 		PageElement[] pageElements) {
 
-		List<String> userDraftFragmentInstanceERCs = new ArrayList<>();
+		List<String> draftFragmentInstanceExternalReferenceCodes =
+			new ArrayList<>();
 
 		for (PageElement pageElement : pageElements) {
 			if (!(pageElement.getPageElementDefinition() instanceof
@@ -2130,17 +2131,18 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 				basicFragmentInstancePageElementDefinition.
 					getFragmentInstance();
 
-			String userDraftFragmentInstanceERC =
+			String draftFragmentInstanceExternalReferenceCode =
 				fragmentInstance.getFragmentInstanceExternalReferenceCode() +
 					_ERC_SUFFIX_USER_DRAFT;
 
 			fragmentInstance.setDraftFragmentInstanceExternalReferenceCode(
-				userDraftFragmentInstanceERC);
+				draftFragmentInstanceExternalReferenceCode);
 
-			userDraftFragmentInstanceERCs.add(userDraftFragmentInstanceERC);
+			draftFragmentInstanceExternalReferenceCodes.add(
+				draftFragmentInstanceExternalReferenceCode);
 		}
 
-		return userDraftFragmentInstanceERCs;
+		return draftFragmentInstanceExternalReferenceCodes;
 	}
 
 	private void _testDeleteSiteSitePage(Layout... layouts) throws Exception {
@@ -3156,7 +3158,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			3, StringPool.BLANK, testGroup.getGroupId());
 
 		List<String> userDraftFragmentInstanceERCs =
-			_setUserDraftFragmentInstanceERCs(pageElements);
+			_setAndGetDraftFragmentInstanceExternalReferenceCodes(pageElements);
 
 		ContentPageSpecification publishedContentPageSpecification =
 			new ContentPageSpecification();

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -1996,28 +1996,36 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		for (FragmentEntryLink publishedFragmentEntryLink :
 				publishedFragmentEntryLinks) {
 
-			String publishedERC =
+			String publishedFragmentEntryLinkExternalReferenceCode =
 				publishedFragmentEntryLink.getExternalReferenceCode();
 
-			String expectedDraftERC;
+			String expectedDraftExternalReferenceCode;
 
-			if (publishedERC.endsWith(LayoutConstants.ERC_SUFFIX_PUBLISHED)) {
-				expectedDraftERC = publishedERC.substring(
-					0,
-					publishedERC.length() -
-						LayoutConstants.ERC_SUFFIX_PUBLISHED.length());
+			if (publishedFragmentEntryLinkExternalReferenceCode.endsWith(
+					LayoutConstants.ERC_SUFFIX_PUBLISHED)) {
+
+				int publishedFragmentEntryLinkExternalReferenceCodeLength =
+					publishedFragmentEntryLinkExternalReferenceCode.length();
+
+				expectedDraftExternalReferenceCode =
+					publishedFragmentEntryLinkExternalReferenceCode.substring(
+						0,
+						publishedFragmentEntryLinkExternalReferenceCodeLength -
+							LayoutConstants.ERC_SUFFIX_PUBLISHED.length());
 			}
 			else {
-				expectedDraftERC =
-					publishedERC + LayoutConstants.ERC_SUFFIX_DRAFT;
+				expectedDraftExternalReferenceCode =
+					publishedFragmentEntryLinkExternalReferenceCode +
+						LayoutConstants.ERC_SUFFIX_DRAFT;
 			}
 
 			Assert.assertEquals(
-				publishedFragmentEntryLink.toString(), expectedDraftERC,
+				publishedFragmentEntryLink.toString(),
+				expectedDraftExternalReferenceCode,
 				publishedFragmentEntryLink.getOriginalFragmentEntryLinkERC());
 			Assert.assertTrue(
 				draftFragmentEntryLinkExternalReferenceCodes.contains(
-					expectedDraftERC));
+					expectedDraftExternalReferenceCode));
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -3152,10 +3152,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		String pageExternalReferenceCode = RandomTestUtil.randomString();
 		String userDraftSpecERC = RandomTestUtil.randomString();
 
-		long groupId = testGroup.getGroupId();
-
 		PageElement[] pageElements = PageElementsTestUtil.getPageElements(
-			3, StringPool.BLANK, groupId);
+			3, StringPool.BLANK, testGroup.getGroupId());
 
 		List<String> userDraftFragmentInstanceERCs =
 			_setUserDraftFragmentInstanceERCs(pageElements);
@@ -3185,13 +3183,13 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			userDraftSpecERC, PageSpecification.Status.APPROVED, false, false);
 
 		Layout layout = _layoutLocalService.getLayoutByExternalReferenceCode(
-			pageExternalReferenceCode, groupId);
+			pageExternalReferenceCode, testGroup.getGroupId());
 
 		Layout draftLayout = layout.fetchDraftLayout();
 
 		List<String> draftFragmentEntryLinkERCs = TransformUtil.transform(
 			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
-				groupId, draftLayout.getPlid()),
+				testGroup.getGroupId(), draftLayout.getPlid()),
 			FragmentEntryLink::getExternalReferenceCode);
 
 		for (String userDraftFragmentInstanceERC :

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -1944,92 +1944,6 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		};
 	}
 
-	private void _postContentPageSpecification(
-			ContentPageSpecification contentPageSpecification,
-			ContentPageSpecification expectedDraftContentPageSpecification,
-			ContentPageSpecification expectedPublishedContentPageSpecification,
-			Group group, String sitePageExternalReferenceCode,
-			PageSpecification.Status status,
-			boolean assertSuffixMirroredFragmentEntryLinks)
-		throws Exception {
-
-		SitePage sitePage = _getRandomSitePage(
-			sitePageExternalReferenceCode, null,
-			ServiceContextTestUtil.getServiceContext(
-				group, TestPropsValues.getUserId()),
-			SitePage.Type.CONTENT_PAGE,
-			StringUtil.toLowerCase(RandomTestUtil.randomString()));
-
-		sitePage.setPageSpecifications(
-			() -> new PageSpecification[] {contentPageSpecification});
-
-		SitePageResource sitePageResource = _getSitePageResource(
-			"pageSpecifications");
-
-		sitePageResource.postSiteSitePage(
-			group.getExternalReferenceCode(), false, sitePage);
-
-		SitePage getSitePage = sitePageResource.getSiteSitePage(
-			group.getExternalReferenceCode(), sitePageExternalReferenceCode);
-
-		Layout layout = _layoutLocalService.getLayoutByExternalReferenceCode(
-			sitePageExternalReferenceCode, group.getGroupId());
-
-		if (Objects.equals(status, PageSpecification.Status.APPROVED)) {
-			Assert.assertTrue(layout.isPublished());
-		}
-		else {
-			Assert.assertFalse(layout.isPublished());
-		}
-
-		PageSpecificationsTestUtil.assertPageSpecifications(
-			expectedDraftContentPageSpecification,
-			expectedPublishedContentPageSpecification,
-			getSitePage.getPageSpecifications(), layout, status);
-
-		if (!assertSuffixMirroredFragmentEntryLinks) {
-			return;
-		}
-
-		Layout draftLayout = layout.fetchDraftLayout();
-
-		List<FragmentEntryLink> draftFragmentEntryLinks =
-			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
-				group.getGroupId(), draftLayout.getPlid());
-
-		List<FragmentEntryLink> publishedFragmentEntryLinks =
-			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
-				group.getGroupId(), layout.getPlid());
-
-		Assert.assertEquals(
-			StringBundler.concat(
-				"Draft fragment entry links: ", draftFragmentEntryLinks,
-				", published fragment entry links: ",
-				publishedFragmentEntryLinks),
-			publishedFragmentEntryLinks.size(), draftFragmentEntryLinks.size());
-
-		List<String> draftFragmentEntryLinkExternalReferenceCodes =
-			TransformUtil.transform(
-				draftFragmentEntryLinks,
-				FragmentEntryLink::getExternalReferenceCode);
-
-		for (FragmentEntryLink publishedFragmentEntryLink :
-				publishedFragmentEntryLinks) {
-
-			String expectedDraftFragmentEntryLinkExternalReferenceCode =
-				_getExpectedDraftFragmentEntryLinkExternalReferenceCode(
-					publishedFragmentEntryLink.getExternalReferenceCode());
-
-			Assert.assertEquals(
-				publishedFragmentEntryLink.toString(),
-				expectedDraftFragmentEntryLinkExternalReferenceCode,
-				publishedFragmentEntryLink.getOriginalFragmentEntryLinkERC());
-			Assert.assertTrue(
-				draftFragmentEntryLinkExternalReferenceCodes.contains(
-					expectedDraftFragmentEntryLinkExternalReferenceCode));
-		}
-	}
-
 	private SitePage _postSiteSitePageWithPageSpecificationsWithCustomFields(
 			SitePage.Type type)
 		throws Exception {
@@ -2950,11 +2864,81 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			expectedPublishedPageExperiences);
 		expectedPublishedContentPageSpecification.setStatus(status);
 
-		_postContentPageSpecification(
-			contentPageSpecification, expectedDraftContentPageSpecification,
-			expectedPublishedContentPageSpecification, testGroup,
-			pageExternalReferenceCode, status,
-			assertSuffixMirroredFragmentEntryLinks);
+		SitePage sitePage = _getRandomSitePage(
+			pageExternalReferenceCode, null,
+			ServiceContextTestUtil.getServiceContext(
+				testGroup, TestPropsValues.getUserId()),
+			SitePage.Type.CONTENT_PAGE,
+			StringUtil.toLowerCase(RandomTestUtil.randomString()));
+
+		sitePage.setPageSpecifications(
+			() -> new PageSpecification[] {contentPageSpecification});
+
+		SitePageResource sitePageResource = _getSitePageResource(
+			"pageSpecifications");
+
+		sitePageResource.postSiteSitePage(
+			testGroup.getExternalReferenceCode(), false, sitePage);
+
+		SitePage getSitePage = sitePageResource.getSiteSitePage(
+			testGroup.getExternalReferenceCode(), pageExternalReferenceCode);
+
+		Layout layout = _layoutLocalService.getLayoutByExternalReferenceCode(
+			pageExternalReferenceCode, testGroup.getGroupId());
+
+		if (Objects.equals(status, PageSpecification.Status.APPROVED)) {
+			Assert.assertTrue(layout.isPublished());
+		}
+		else {
+			Assert.assertFalse(layout.isPublished());
+		}
+
+		PageSpecificationsTestUtil.assertPageSpecifications(
+			expectedDraftContentPageSpecification,
+			expectedPublishedContentPageSpecification,
+			getSitePage.getPageSpecifications(), layout, status);
+
+		if (!assertSuffixMirroredFragmentEntryLinks) {
+			return;
+		}
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		List<FragmentEntryLink> draftFragmentEntryLinks =
+			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
+				testGroup.getGroupId(), draftLayout.getPlid());
+
+		List<FragmentEntryLink> publishedFragmentEntryLinks =
+			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
+				testGroup.getGroupId(), layout.getPlid());
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"Draft fragment entry links: ", draftFragmentEntryLinks,
+				", published fragment entry links: ",
+				publishedFragmentEntryLinks),
+			publishedFragmentEntryLinks.size(), draftFragmentEntryLinks.size());
+
+		List<String> draftFragmentEntryLinkExternalReferenceCodes =
+			TransformUtil.transform(
+				draftFragmentEntryLinks,
+				FragmentEntryLink::getExternalReferenceCode);
+
+		for (FragmentEntryLink publishedFragmentEntryLink :
+				publishedFragmentEntryLinks) {
+
+			String expectedDraftFragmentEntryLinkExternalReferenceCode =
+				_getExpectedDraftFragmentEntryLinkExternalReferenceCode(
+					publishedFragmentEntryLink.getExternalReferenceCode());
+
+			Assert.assertEquals(
+				publishedFragmentEntryLink.toString(),
+				expectedDraftFragmentEntryLinkExternalReferenceCode,
+				publishedFragmentEntryLink.getOriginalFragmentEntryLinkERC());
+			Assert.assertTrue(
+				draftFragmentEntryLinkExternalReferenceCodes.contains(
+					expectedDraftFragmentEntryLinkExternalReferenceCode));
+		}
 	}
 
 	private void _testPostSiteSitePageWithDraftContentPageSpecification(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -2905,9 +2905,12 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 		String pageExternalReferenceCode = RandomTestUtil.randomString();
 
-		String defaultPageExperienceExternalReferenceCode;
-		String draftContentPageSpecificationExternalReferenceCode;
-		String pageExperienceExternalReferenceCode;
+		String defaultPageExperienceExternalReferenceCode =
+			RandomTestUtil.randomString();
+		String draftContentPageSpecificationExternalReferenceCode =
+			RandomTestUtil.randomString();
+		String pageExperienceExternalReferenceCode =
+			RandomTestUtil.randomString();
 
 		if (withDraftERCSuffix) {
 			draftContentPageSpecificationExternalReferenceCode =
@@ -2920,13 +2923,6 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			pageExperienceExternalReferenceCode =
 				RandomTestUtil.randomString() +
 					LayoutConstants.ERC_SUFFIX_DRAFT;
-		}
-		else {
-			defaultPageExperienceExternalReferenceCode =
-				RandomTestUtil.randomString();
-			draftContentPageSpecificationExternalReferenceCode =
-				RandomTestUtil.randomString();
-			pageExperienceExternalReferenceCode = RandomTestUtil.randomString();
 		}
 
 		ContentPageSpecification draftContentPageSpecification =

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -2133,7 +2133,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 			String draftFragmentInstanceExternalReferenceCode =
 				fragmentInstance.getFragmentInstanceExternalReferenceCode() +
-					_ERC_SUFFIX_USER_DRAFT;
+					RandomTestUtil.randomString();
 
 			fragmentInstance.setDraftFragmentInstanceExternalReferenceCode(
 				draftFragmentInstanceExternalReferenceCode);
@@ -4559,8 +4559,6 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			layout.getPlid(),
 			FileUtil.getBytes(getClass(), "dependencies/liferay.jpg"));
 	}
-
-	private static final String _ERC_SUFFIX_USER_DRAFT = "-user-draft";
 
 	private static final List<SitePage.Type> _types = Arrays.asList(
 		SitePage.Type.CONTENT_PAGE, SitePage.Type.WIDGET_PAGE);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -1982,7 +1982,10 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 				group.getGroupId(), layout.getPlid());
 
 		Assert.assertEquals(
-			draftFragmentEntryLinks + " vs " + publishedFragmentEntryLinks,
+			StringBundler.concat(
+				"Draft fragment entry links: ", draftFragmentEntryLinks,
+				", published fragment entry links: ",
+				publishedFragmentEntryLinks),
 			publishedFragmentEntryLinks.size(), draftFragmentEntryLinks.size());
 
 		List<String> draftFragmentEntryLinkExternalReferenceCodes =

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -2898,11 +2898,11 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 	}
 
 	private void _testPostSiteSitePageWithDraftContentPageSpecification(
+			boolean assertSuffixMirroredFragmentEntryLinks,
 			ContentPageSpecification contentPageSpecification,
-			String pageExternalReferenceCode,
 			String draftContentPageSpecificationExternalReferenceCode,
-			PageSpecification.Status status, boolean inputIsDraft,
-			boolean assertSuffixMirroredFragmentEntryLinks)
+			boolean inputIsDraft, String pageExternalReferenceCode,
+			PageSpecification.Status status)
 		throws Exception {
 
 		PageExperience[] pageExperiences =
@@ -2994,9 +2994,9 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 					RandomTestUtil.randomString(), status);
 
 		_testPostSiteSitePageWithDraftContentPageSpecification(
-			draftContentPageSpecification, pageExternalReferenceCode,
-			draftContentPageSpecificationExternalReferenceCode, status, true,
-			true);
+			true, draftContentPageSpecification,
+			draftContentPageSpecificationExternalReferenceCode, true,
+			pageExternalReferenceCode, status);
 	}
 
 	private void _testPostSiteSitePageWithPageElements() throws Exception {
@@ -3155,9 +3155,9 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 					RandomTestUtil.randomString(), status);
 
 		_testPostSiteSitePageWithDraftContentPageSpecification(
-			publishedContentPageSpecification, pageExternalReferenceCode,
-			pageExternalReferenceCode + LayoutConstants.ERC_SUFFIX_DRAFT,
-			status, false, true);
+			true, publishedContentPageSpecification,
+			pageExternalReferenceCode + LayoutConstants.ERC_SUFFIX_DRAFT, false,
+			pageExternalReferenceCode, status);
 	}
 
 	private void _testPostSiteSitePageWithPublishedContentPageSpecificationAndDraftReferences()
@@ -3195,10 +3195,10 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			() -> ContentPageSpecification.Type.CONTENT_PAGE_SPECIFICATION);
 
 		_testPostSiteSitePageWithDraftContentPageSpecification(
-			publishedContentPageSpecification,
+			false, publishedContentPageSpecification,
+			draftContentPageSpecificationExternalReferenceCode, false,
 			pageSpecificationExternalReferenceCode,
-			draftContentPageSpecificationExternalReferenceCode,
-			PageSpecification.Status.APPROVED, false, false);
+			PageSpecification.Status.APPROVED);
 
 		Layout layout = _layoutLocalService.getLayoutByExternalReferenceCode(
 			pageSpecificationExternalReferenceCode, testGroup.getGroupId());

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -319,7 +319,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		_testPatchSiteSitePage(SitePage.Type.WIDGET_PAGE);
 		_testPatchSiteSitePageWithPageSpecifications();
 		_testPatchSiteSitePageWithPriority();
-		_testPatchSiteSitePageWithSingleContentPageSpecification();
+		_testPatchSiteSitePageWithContentPageSpecification();
 		_testPatchSiteSitePageWithWidgetPageSettings();
 		_testPatchSiteSitePageWithWidgetPageSettingsWithWidgetPageTemplate();
 
@@ -373,7 +373,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 		_testPostSiteSitePageWithPageElements();
 		_testPostSiteSitePageWithPageSpecifications();
-		_testPostSiteSitePageWithSingleContentPageSpecification();
+		_testPostSiteSitePageWithContentPageSpecification();
 		_testPostSiteSitePageWithWidgetPageSettings();
 		_testPostSiteSitePageWithWidgetPageSettingsWithWidgetPageTemplate();
 		_testPostSiteSitePageWithWidgetPageTypeIsDeprecated();
@@ -462,7 +462,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		_testPutSiteSitePageWithPageSpecifications();
 		_testPutSiteSitePageWithParentLayout();
 		_testPutSiteSitePageWithPriority();
-		_testPutSiteSitePageWithSingleContentPageSpecification();
+		_testPutSiteSitePageWithContentPageSpecification();
 		_testPutSiteSitePageWithWidgetPageSettings();
 		_testPutSiteSitePageWithWidgetPageSettingsWithWidgetPageTemplate();
 
@@ -1924,7 +1924,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		};
 	}
 
-	private void _postSingleContentPageSpecification(
+	private void _postContentPageSpecification(
 			ContentPageSpecification contentPageSpecification,
 			ContentPageSpecification expectedDraftContentPageSpecification,
 			ContentPageSpecification expectedPublishedContentPageSpecification,
@@ -2281,6 +2281,37 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 				sitePage.getUuid()));
 	}
 
+	private void _testPatchSiteSitePageWithContentPageSpecification()
+		throws Exception {
+
+		SitePage postSitePage = sitePageResource.postSiteSitePage(
+			testGroup.getExternalReferenceCode(), false,
+			_getRandomSitePage(SitePage.Type.CONTENT_PAGE));
+
+		SitePage sitePage = new SitePage();
+
+		ContentPageSpecification contentPageSpecification =
+			PageSpecificationsTestUtil.getContentPageSpecification(
+				null, testGroup.getGroupId(),
+				PageSpecification.Status.APPROVED);
+
+		contentPageSpecification.setExternalReferenceCode(
+			postSitePage.getExternalReferenceCode());
+
+		sitePage.setPageSpecifications(
+			() -> new PageSpecification[] {contentPageSpecification});
+
+		SitePageResource sitePageResource = _getSitePageResource(
+			"pageSpecifications");
+
+		_assertProblemException(
+			"A single content page specification cannot be applied to an " +
+				"existing page",
+			() -> sitePageResource.patchSiteSitePage(
+				testGroup.getExternalReferenceCode(),
+				postSitePage.getExternalReferenceCode(), false, sitePage));
+	}
+
 	private void _testPatchSiteSitePageWithFriendlyUrlPath(
 			Layout layout, SitePage sitePage)
 		throws Exception {
@@ -2531,37 +2562,6 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 						testGroup.getGroupId()),
 					patchSitePage);
 			});
-	}
-
-	private void _testPatchSiteSitePageWithSingleContentPageSpecification()
-		throws Exception {
-
-		SitePage postSitePage = sitePageResource.postSiteSitePage(
-			testGroup.getExternalReferenceCode(), false,
-			_getRandomSitePage(SitePage.Type.CONTENT_PAGE));
-
-		SitePage sitePage = new SitePage();
-
-		ContentPageSpecification contentPageSpecification =
-			PageSpecificationsTestUtil.getContentPageSpecification(
-				null, testGroup.getGroupId(),
-				PageSpecification.Status.APPROVED);
-
-		contentPageSpecification.setExternalReferenceCode(
-			postSitePage.getExternalReferenceCode());
-
-		sitePage.setPageSpecifications(
-			() -> new PageSpecification[] {contentPageSpecification});
-
-		SitePageResource sitePageResource = _getSitePageResource(
-			"pageSpecifications");
-
-		_assertProblemException(
-			"A single content page specification cannot be applied to an " +
-				"existing page",
-			() -> sitePageResource.patchSiteSitePage(
-				testGroup.getExternalReferenceCode(),
-				postSitePage.getExternalReferenceCode(), false, sitePage));
 	}
 
 	private void _testPatchSiteSitePageWithWidgetPageSettings()
@@ -2860,7 +2860,25 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			postSitePage);
 	}
 
-	private void _testPostSiteSitePageWithDraftSingleContentPageSpecification(
+	private void _testPostSiteSitePageWithContentPageSpecification()
+		throws Exception {
+
+		_testPostSiteSitePageWithDraftContentPageSpecification(
+			PageSpecification.Status.APPROVED, true);
+		_testPostSiteSitePageWithDraftContentPageSpecification(
+			PageSpecification.Status.APPROVED, false);
+		_testPostSiteSitePageWithDraftContentPageSpecification(
+			PageSpecification.Status.DRAFT, true);
+		_testPostSiteSitePageWithDraftContentPageSpecification(
+			PageSpecification.Status.DRAFT, false);
+		_testPostSiteSitePageWithPublishedContentPageSpecification(
+			PageSpecification.Status.APPROVED);
+		_testPostSiteSitePageWithPublishedContentPageSpecification(
+			PageSpecification.Status.DRAFT);
+		_testPostSiteSitePageWithPublishedContentPageSpecificationAndDraftReferences();
+	}
+
+	private void _testPostSiteSitePageWithDraftContentPageSpecification(
 			PageSpecification.Status status, boolean useDraftERCSuffix)
 		throws Exception {
 
@@ -2920,7 +2938,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 				PageExperience.class));
 		expectedPublishedContentPageSpecification.setStatus(status);
 
-		_postSingleContentPageSpecification(
+		_postContentPageSpecification(
 			draftContentPageSpecification,
 			expectedDraftContentPageSpecification,
 			expectedPublishedContentPageSpecification, testGroup,
@@ -3067,9 +3085,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			sitePage.getPageSpecifications());
 	}
 
-	private void
-			_testPostSiteSitePageWithPublishedSingleContentPageSpecification(
-				PageSpecification.Status status)
+	private void _testPostSiteSitePageWithPublishedContentPageSpecification(
+			PageSpecification.Status status)
 		throws Exception {
 
 		String defaultPageExperienceExternalReferenceCode =
@@ -3118,14 +3135,14 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			publishedContentPageSpecification.getPageExperiences());
 		expectedPublishedContentPageSpecification.setStatus(status);
 
-		_postSingleContentPageSpecification(
+		_postContentPageSpecification(
 			publishedContentPageSpecification,
 			expectedDraftContentPageSpecification,
 			expectedPublishedContentPageSpecification, testGroup,
 			pageExternalReferenceCode, status);
 	}
 
-	private void _testPostSiteSitePageWithPublishedSingleContentPageSpecificationAndDraftReferences()
+	private void _testPostSiteSitePageWithPublishedContentPageSpecificationAndDraftReferences()
 		throws Exception {
 
 		String pageExternalReferenceCode = RandomTestUtil.randomString();
@@ -3201,24 +3218,6 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 				draftFragmentEntryLinkERCs.contains(
 					userDraftFragmentInstanceERC));
 		}
-	}
-
-	private void _testPostSiteSitePageWithSingleContentPageSpecification()
-		throws Exception {
-
-		_testPostSiteSitePageWithDraftSingleContentPageSpecification(
-			PageSpecification.Status.APPROVED, true);
-		_testPostSiteSitePageWithDraftSingleContentPageSpecification(
-			PageSpecification.Status.APPROVED, false);
-		_testPostSiteSitePageWithDraftSingleContentPageSpecification(
-			PageSpecification.Status.DRAFT, true);
-		_testPostSiteSitePageWithDraftSingleContentPageSpecification(
-			PageSpecification.Status.DRAFT, false);
-		_testPostSiteSitePageWithPublishedSingleContentPageSpecification(
-			PageSpecification.Status.APPROVED);
-		_testPostSiteSitePageWithPublishedSingleContentPageSpecification(
-			PageSpecification.Status.DRAFT);
-		_testPostSiteSitePageWithPublishedSingleContentPageSpecificationAndDraftReferences();
 	}
 
 	private void _testPostSiteSitePageWithWidgetPageSettings()
@@ -3416,6 +3415,35 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			putSitePage);
 
 		return putSitePage;
+	}
+
+	private void _testPutSiteSitePageWithContentPageSpecification()
+		throws Exception {
+
+		SitePage postSitePage = sitePageResource.postSiteSitePage(
+			testGroup.getExternalReferenceCode(), false,
+			_getRandomSitePage(SitePage.Type.CONTENT_PAGE));
+
+		ContentPageSpecification contentPageSpecification =
+			PageSpecificationsTestUtil.getContentPageSpecification(
+				null, testGroup.getGroupId(),
+				PageSpecification.Status.APPROVED);
+
+		contentPageSpecification.setExternalReferenceCode(
+			postSitePage.getExternalReferenceCode());
+
+		postSitePage.setPageSpecifications(
+			() -> new PageSpecification[] {contentPageSpecification});
+
+		SitePageResource sitePageResource = _getSitePageResource(
+			"pageSpecifications");
+
+		_assertProblemException(
+			"A single content page specification cannot be applied to an " +
+				"existing page",
+			() -> sitePageResource.putSiteSitePage(
+				testGroup.getExternalReferenceCode(),
+				postSitePage.getExternalReferenceCode(), false, postSitePage));
 	}
 
 	private void _testPutSiteSitePageWithDefaultAssetPublisher()
@@ -4348,35 +4376,6 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 						testGroup.getGroupId()),
 					putSitePage);
 			});
-	}
-
-	private void _testPutSiteSitePageWithSingleContentPageSpecification()
-		throws Exception {
-
-		SitePage postSitePage = sitePageResource.postSiteSitePage(
-			testGroup.getExternalReferenceCode(), false,
-			_getRandomSitePage(SitePage.Type.CONTENT_PAGE));
-
-		ContentPageSpecification contentPageSpecification =
-			PageSpecificationsTestUtil.getContentPageSpecification(
-				null, testGroup.getGroupId(),
-				PageSpecification.Status.APPROVED);
-
-		contentPageSpecification.setExternalReferenceCode(
-			postSitePage.getExternalReferenceCode());
-
-		postSitePage.setPageSpecifications(
-			() -> new PageSpecification[] {contentPageSpecification});
-
-		SitePageResource sitePageResource = _getSitePageResource(
-			"pageSpecifications");
-
-		_assertProblemException(
-			"A single content page specification cannot be applied to an " +
-				"existing page",
-			() -> sitePageResource.putSiteSitePage(
-				testGroup.getExternalReferenceCode(),
-				postSitePage.getExternalReferenceCode(), false, postSitePage));
 	}
 
 	private void _testPutSiteSitePageWithWidgetPageSettings() throws Exception {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -2030,66 +2030,6 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		}
 	}
 
-	private void _postContentPageSpecification(
-			ContentPageSpecification contentPageSpecification,
-			String pageExternalReferenceCode,
-			String draftContentPageSpecificationExternalReferenceCode,
-			PageSpecification.Status status, boolean inputIsDraft,
-			boolean assertSuffixMirroredFragmentEntryLinks)
-		throws Exception {
-
-		PageExperience[] pageExperiences =
-			contentPageSpecification.getPageExperiences();
-
-		PageExperience[] expectedDraftPageExperiences;
-		PageExperience[] expectedPublishedPageExperiences;
-
-		if (inputIsDraft) {
-			expectedDraftPageExperiences = pageExperiences;
-			expectedPublishedPageExperiences = TransformUtil.transform(
-				pageExperiences,
-				draftPageExperience ->
-					PageExperiencesTestUtil.toPublishedPageExperience(
-						draftPageExperience, pageExternalReferenceCode),
-				PageExperience.class);
-		}
-		else {
-			expectedDraftPageExperiences = TransformUtil.transform(
-				pageExperiences,
-				publishedPageExperience ->
-					PageExperiencesTestUtil.toDraftPageExperience(
-						draftContentPageSpecificationExternalReferenceCode,
-						publishedPageExperience),
-				PageExperience.class);
-			expectedPublishedPageExperiences = pageExperiences;
-		}
-
-		ContentPageSpecification expectedDraftContentPageSpecification =
-			new ContentPageSpecification();
-
-		expectedDraftContentPageSpecification.setExternalReferenceCode(
-			draftContentPageSpecificationExternalReferenceCode);
-		expectedDraftContentPageSpecification.setPageExperiences(
-			expectedDraftPageExperiences);
-		expectedDraftContentPageSpecification.setStatus(
-			PageSpecification.Status.APPROVED);
-
-		ContentPageSpecification expectedPublishedContentPageSpecification =
-			new ContentPageSpecification();
-
-		expectedPublishedContentPageSpecification.setExternalReferenceCode(
-			pageExternalReferenceCode);
-		expectedPublishedContentPageSpecification.setPageExperiences(
-			expectedPublishedPageExperiences);
-		expectedPublishedContentPageSpecification.setStatus(status);
-
-		_postContentPageSpecification(
-			contentPageSpecification, expectedDraftContentPageSpecification,
-			expectedPublishedContentPageSpecification, testGroup,
-			pageExternalReferenceCode, status,
-			assertSuffixMirroredFragmentEntryLinks);
-	}
-
 	private SitePage _postSiteSitePageWithPageSpecificationsWithCustomFields(
 			SitePage.Type type)
 		throws Exception {
@@ -2958,6 +2898,66 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 	}
 
 	private void _testPostSiteSitePageWithDraftContentPageSpecification(
+			ContentPageSpecification contentPageSpecification,
+			String pageExternalReferenceCode,
+			String draftContentPageSpecificationExternalReferenceCode,
+			PageSpecification.Status status, boolean inputIsDraft,
+			boolean assertSuffixMirroredFragmentEntryLinks)
+		throws Exception {
+
+		PageExperience[] pageExperiences =
+			contentPageSpecification.getPageExperiences();
+
+		PageExperience[] expectedDraftPageExperiences;
+		PageExperience[] expectedPublishedPageExperiences;
+
+		if (inputIsDraft) {
+			expectedDraftPageExperiences = pageExperiences;
+			expectedPublishedPageExperiences = TransformUtil.transform(
+				pageExperiences,
+				draftPageExperience ->
+					PageExperiencesTestUtil.toPublishedPageExperience(
+						draftPageExperience, pageExternalReferenceCode),
+				PageExperience.class);
+		}
+		else {
+			expectedDraftPageExperiences = TransformUtil.transform(
+				pageExperiences,
+				publishedPageExperience ->
+					PageExperiencesTestUtil.toDraftPageExperience(
+						draftContentPageSpecificationExternalReferenceCode,
+						publishedPageExperience),
+				PageExperience.class);
+			expectedPublishedPageExperiences = pageExperiences;
+		}
+
+		ContentPageSpecification expectedDraftContentPageSpecification =
+			new ContentPageSpecification();
+
+		expectedDraftContentPageSpecification.setExternalReferenceCode(
+			draftContentPageSpecificationExternalReferenceCode);
+		expectedDraftContentPageSpecification.setPageExperiences(
+			expectedDraftPageExperiences);
+		expectedDraftContentPageSpecification.setStatus(
+			PageSpecification.Status.APPROVED);
+
+		ContentPageSpecification expectedPublishedContentPageSpecification =
+			new ContentPageSpecification();
+
+		expectedPublishedContentPageSpecification.setExternalReferenceCode(
+			pageExternalReferenceCode);
+		expectedPublishedContentPageSpecification.setPageExperiences(
+			expectedPublishedPageExperiences);
+		expectedPublishedContentPageSpecification.setStatus(status);
+
+		_postContentPageSpecification(
+			contentPageSpecification, expectedDraftContentPageSpecification,
+			expectedPublishedContentPageSpecification, testGroup,
+			pageExternalReferenceCode, status,
+			assertSuffixMirroredFragmentEntryLinks);
+	}
+
+	private void _testPostSiteSitePageWithDraftContentPageSpecification(
 			PageSpecification.Status status, boolean useDraftERCSuffix)
 		throws Exception {
 
@@ -2993,7 +2993,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 					RandomTestUtil.randomString(),
 					RandomTestUtil.randomString(), status);
 
-		_postContentPageSpecification(
+		_testPostSiteSitePageWithDraftContentPageSpecification(
 			draftContentPageSpecification, pageExternalReferenceCode,
 			draftContentPageSpecificationExternalReferenceCode, status, true,
 			true);
@@ -3154,7 +3154,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 					RandomTestUtil.randomString(),
 					RandomTestUtil.randomString(), status);
 
-		_postContentPageSpecification(
+		_testPostSiteSitePageWithDraftContentPageSpecification(
 			publishedContentPageSpecification, pageExternalReferenceCode,
 			pageExternalReferenceCode + LayoutConstants.ERC_SUFFIX_DRAFT,
 			status, false, true);
@@ -3194,7 +3194,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		publishedContentPageSpecification.setType(
 			() -> ContentPageSpecification.Type.CONTENT_PAGE_SPECIFICATION);
 
-		_postContentPageSpecification(
+		_testPostSiteSitePageWithDraftContentPageSpecification(
 			publishedContentPageSpecification,
 			pageSpecificationExternalReferenceCode,
 			draftContentPageSpecificationExternalReferenceCode,

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -2900,7 +2900,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 	}
 
 	private void _testPostSiteSitePageWithDraftSingleContentPageSpecification(
-			PageSpecification.Status status, boolean withDraftERCSuffix)
+			PageSpecification.Status status, boolean useDraftERCSuffix)
 		throws Exception {
 
 		String pageExternalReferenceCode = RandomTestUtil.randomString();
@@ -2912,7 +2912,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		String pageExperienceExternalReferenceCode =
 			RandomTestUtil.randomString();
 
-		if (withDraftERCSuffix) {
+		if (useDraftERCSuffix) {
 			draftContentPageSpecificationExternalReferenceCode =
 				pageExternalReferenceCode + LayoutConstants.ERC_SUFFIX_DRAFT;
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -2900,7 +2900,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 	}
 
 	private void _testPostSiteSitePageWithDraftSingleContentPageSpecification(
-			PageSpecification.Status status, boolean withDraftErcSuffix)
+			PageSpecification.Status status, boolean withDraftERCSuffix)
 		throws Exception {
 
 		String pageExternalReferenceCode = RandomTestUtil.randomString();
@@ -2909,7 +2909,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		String draftContentPageSpecificationExternalReferenceCode;
 		String pageExperienceExternalReferenceCode;
 
-		if (withDraftErcSuffix) {
+		if (withDraftERCSuffix) {
 			draftContentPageSpecificationExternalReferenceCode =
 				pageExternalReferenceCode + LayoutConstants.ERC_SUFFIX_DRAFT;
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -3412,9 +3412,18 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 	private void _testPutSiteSitePageWithContentPageSpecification()
 		throws Exception {
 
-		SitePage postSitePage = sitePageResource.postSiteSitePage(
-			testGroup.getExternalReferenceCode(), false,
-			_getRandomSitePage(SitePage.Type.CONTENT_PAGE));
+		SitePageResource sitePageResource = _getSitePageResource(
+			"pageSpecifications");
+
+		String sitePageExternalReferenceCode = StringUtil.toLowerCase(
+			RandomTestUtil.randomString());
+
+		SitePage sitePage = _getRandomSitePage(
+			sitePageExternalReferenceCode, null,
+			ServiceContextTestUtil.getServiceContext(
+				testGroup, TestPropsValues.getUserId()),
+			SitePage.Type.CONTENT_PAGE,
+			StringUtil.toLowerCase(RandomTestUtil.randomString()));
 
 		ContentPageSpecification contentPageSpecification =
 			PageSpecificationsTestUtil.getContentPageSpecification(
@@ -3422,20 +3431,37 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 				PageSpecification.Status.APPROVED);
 
 		contentPageSpecification.setExternalReferenceCode(
-			postSitePage.getExternalReferenceCode());
+			sitePageExternalReferenceCode);
 
-		postSitePage.setPageSpecifications(
+		sitePage.setPageSpecifications(
 			() -> new PageSpecification[] {contentPageSpecification});
 
-		SitePageResource sitePageResource = _getSitePageResource(
-			"pageSpecifications");
+		sitePageResource.putSiteSitePage(
+			testGroup.getExternalReferenceCode(), sitePageExternalReferenceCode,
+			false, sitePage);
+
+		SitePage getSitePage = sitePageResource.getSiteSitePage(
+			testGroup.getExternalReferenceCode(),
+			sitePageExternalReferenceCode);
+
+		Layout layout = _layoutLocalService.getLayoutByExternalReferenceCode(
+			sitePageExternalReferenceCode, testGroup.getGroupId());
+
+		PageSpecificationsTestUtil.assertPageSpecifications(
+			layout, getSitePage.getPageSpecifications());
+
+		PageSpecification[] pageSpecifications =
+			getSitePage.getPageSpecifications();
+
+		getSitePage.setPageSpecifications(
+			() -> new PageSpecification[] {pageSpecifications[0]});
 
 		_assertProblemException(
 			"A single content page specification cannot be applied to an " +
 				"existing page",
 			() -> sitePageResource.putSiteSitePage(
 				testGroup.getExternalReferenceCode(),
-				postSitePage.getExternalReferenceCode(), false, postSitePage));
+				sitePageExternalReferenceCode, false, getSitePage));
 	}
 
 	private void _testPutSiteSitePageWithDefaultAssetPublisher()

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -2026,16 +2026,16 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			boolean assertSuffixMirroredFragmentEntryLinks)
 		throws Exception {
 
-		PageExperience[] inputPageExperiences =
+		PageExperience[] pageExperiences =
 			contentPageSpecification.getPageExperiences();
 
 		PageExperience[] expectedDraftPageExperiences;
 		PageExperience[] expectedPublishedPageExperiences;
 
 		if (inputIsDraft) {
-			expectedDraftPageExperiences = inputPageExperiences;
+			expectedDraftPageExperiences = pageExperiences;
 			expectedPublishedPageExperiences = TransformUtil.transform(
-				inputPageExperiences,
+				pageExperiences,
 				draftPageExperience ->
 					PageExperiencesTestUtil.toPublishedPageExperience(
 						draftPageExperience, pageExternalReferenceCode),
@@ -2043,13 +2043,13 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		}
 		else {
 			expectedDraftPageExperiences = TransformUtil.transform(
-				inputPageExperiences,
+				pageExperiences,
 				publishedPageExperience ->
 					PageExperiencesTestUtil.toDraftPageExperience(
 						draftContentPageSpecificationExternalReferenceCode,
 						publishedPageExperience),
 				PageExperience.class);
-			expectedPublishedPageExperiences = inputPageExperiences;
+			expectedPublishedPageExperiences = pageExperiences;
 		}
 
 		ContentPageSpecification expectedDraftContentPageSpecification =
@@ -3151,9 +3151,9 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 	private void _testPostSiteSitePageWithPublishedContentPageSpecificationAndDraftReferences()
 		throws Exception {
 
-		String pageSpecificationExternalReferenceCode =
-			RandomTestUtil.randomString();
 		String draftContentPageSpecificationExternalReferenceCode =
+			RandomTestUtil.randomString();
+		String pageSpecificationExternalReferenceCode =
 			RandomTestUtil.randomString();
 
 		PageElement[] pageElements = PageElementsTestUtil.getPageElements(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -2013,6 +2013,64 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		}
 	}
 
+	private void _postContentPageSpecification(
+			ContentPageSpecification contentPageSpecification,
+			String pageExternalReferenceCode,
+			String draftContentPageSpecificationExternalReferenceCode,
+			PageSpecification.Status status, boolean inputIsDraft)
+		throws Exception {
+
+		PageExperience[] inputPageExperiences =
+			contentPageSpecification.getPageExperiences();
+
+		PageExperience[] expectedDraftPageExperiences;
+		PageExperience[] expectedPublishedPageExperiences;
+
+		if (inputIsDraft) {
+			expectedDraftPageExperiences = inputPageExperiences;
+			expectedPublishedPageExperiences = TransformUtil.transform(
+				inputPageExperiences,
+				draftPageExperience ->
+					PageExperiencesTestUtil.toPublishedPageExperience(
+						draftPageExperience, pageExternalReferenceCode),
+				PageExperience.class);
+		}
+		else {
+			expectedDraftPageExperiences = TransformUtil.transform(
+				inputPageExperiences,
+				publishedPageExperience ->
+					PageExperiencesTestUtil.toDraftPageExperience(
+						draftContentPageSpecificationExternalReferenceCode,
+						publishedPageExperience),
+				PageExperience.class);
+			expectedPublishedPageExperiences = inputPageExperiences;
+		}
+
+		ContentPageSpecification expectedDraftContentPageSpecification =
+			new ContentPageSpecification();
+
+		expectedDraftContentPageSpecification.setExternalReferenceCode(
+			draftContentPageSpecificationExternalReferenceCode);
+		expectedDraftContentPageSpecification.setPageExperiences(
+			expectedDraftPageExperiences);
+		expectedDraftContentPageSpecification.setStatus(
+			PageSpecification.Status.APPROVED);
+
+		ContentPageSpecification expectedPublishedContentPageSpecification =
+			new ContentPageSpecification();
+
+		expectedPublishedContentPageSpecification.setExternalReferenceCode(
+			pageExternalReferenceCode);
+		expectedPublishedContentPageSpecification.setPageExperiences(
+			expectedPublishedPageExperiences);
+		expectedPublishedContentPageSpecification.setStatus(status);
+
+		_postContentPageSpecification(
+			contentPageSpecification, expectedDraftContentPageSpecification,
+			expectedPublishedContentPageSpecification, testGroup,
+			pageExternalReferenceCode, status);
+	}
+
 	private SitePage _postSiteSitePageWithPageSpecificationsWithCustomFields(
 			SitePage.Type type)
 		throws Exception {
@@ -2914,35 +2972,9 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 					RandomTestUtil.randomString(),
 					RandomTestUtil.randomString(), status);
 
-		ContentPageSpecification expectedDraftContentPageSpecification =
-			new ContentPageSpecification();
-
-		expectedDraftContentPageSpecification.setExternalReferenceCode(
-			draftContentPageSpecificationExternalReferenceCode);
-		expectedDraftContentPageSpecification.setPageExperiences(
-			draftContentPageSpecification.getPageExperiences());
-		expectedDraftContentPageSpecification.setStatus(
-			PageSpecification.Status.APPROVED);
-
-		ContentPageSpecification expectedPublishedContentPageSpecification =
-			new ContentPageSpecification();
-
-		expectedPublishedContentPageSpecification.setExternalReferenceCode(
-			pageExternalReferenceCode);
-		expectedPublishedContentPageSpecification.setPageExperiences(
-			TransformUtil.transform(
-				draftContentPageSpecification.getPageExperiences(),
-				draftPageExperience ->
-					PageExperiencesTestUtil.toPublishedPageExperience(
-						draftPageExperience, pageExternalReferenceCode),
-				PageExperience.class));
-		expectedPublishedContentPageSpecification.setStatus(status);
-
 		_postContentPageSpecification(
-			draftContentPageSpecification,
-			expectedDraftContentPageSpecification,
-			expectedPublishedContentPageSpecification, testGroup,
-			pageExternalReferenceCode, status);
+			draftContentPageSpecification, pageExternalReferenceCode,
+			draftContentPageSpecificationExternalReferenceCode, status, true);
 	}
 
 	private void _testPostSiteSitePageWithPageElements() throws Exception {
@@ -3089,57 +3121,21 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			PageSpecification.Status status)
 		throws Exception {
 
-		String defaultPageExperienceExternalReferenceCode =
-			RandomTestUtil.randomString();
-		String defaultPageExperienceUuid = RandomTestUtil.randomString();
-		String pageExperienceExternalReferenceCode =
-			RandomTestUtil.randomString();
-		String pageExperienceKey = RandomTestUtil.randomString();
-		String pageExperienceUuid = RandomTestUtil.randomString();
 		String pageExternalReferenceCode = RandomTestUtil.randomString();
 
 		ContentPageSpecification publishedContentPageSpecification =
 			PageSpecificationsTestUtil.
 				getContentPageSpecificationWithPageExperiences(
-					pageExternalReferenceCode,
-					defaultPageExperienceExternalReferenceCode,
-					defaultPageExperienceUuid, testGroup.getGroupId(),
-					pageExperienceExternalReferenceCode, pageExperienceKey,
-					pageExperienceUuid, status);
-
-		String draftContentPageSpecificationExternalReferenceCode =
-			pageExternalReferenceCode + LayoutConstants.ERC_SUFFIX_DRAFT;
-
-		ContentPageSpecification expectedDraftContentPageSpecification =
-			new ContentPageSpecification();
-
-		expectedDraftContentPageSpecification.setExternalReferenceCode(
-			draftContentPageSpecificationExternalReferenceCode);
-		expectedDraftContentPageSpecification.setPageExperiences(
-			TransformUtil.transform(
-				publishedContentPageSpecification.getPageExperiences(),
-				publishedPageExperience ->
-					PageExperiencesTestUtil.toDraftPageExperience(
-						draftContentPageSpecificationExternalReferenceCode,
-						publishedPageExperience),
-				PageExperience.class));
-		expectedDraftContentPageSpecification.setStatus(
-			PageSpecification.Status.APPROVED);
-
-		ContentPageSpecification expectedPublishedContentPageSpecification =
-			new ContentPageSpecification();
-
-		expectedPublishedContentPageSpecification.setExternalReferenceCode(
-			pageExternalReferenceCode);
-		expectedPublishedContentPageSpecification.setPageExperiences(
-			publishedContentPageSpecification.getPageExperiences());
-		expectedPublishedContentPageSpecification.setStatus(status);
+					pageExternalReferenceCode, RandomTestUtil.randomString(),
+					RandomTestUtil.randomString(), testGroup.getGroupId(),
+					RandomTestUtil.randomString(),
+					RandomTestUtil.randomString(),
+					RandomTestUtil.randomString(), status);
 
 		_postContentPageSpecification(
-			publishedContentPageSpecification,
-			expectedDraftContentPageSpecification,
-			expectedPublishedContentPageSpecification, testGroup,
-			pageExternalReferenceCode, status);
+			publishedContentPageSpecification, pageExternalReferenceCode,
+			pageExternalReferenceCode + LayoutConstants.ERC_SUFFIX_DRAFT,
+			status, false);
 	}
 
 	private void _testPostSiteSitePageWithPublishedContentPageSpecificationAndDraftReferences()

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -2596,7 +2596,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			"pageSpecifications");
 
 		_assertProblemException(
-			"A single content page specification is only accepted on POST",
+			"A single content page specification cannot be applied to an " +
+				"existing page",
 			() -> sitePageResource.patchSiteSitePage(
 				testGroup.getExternalReferenceCode(),
 				postSitePage.getExternalReferenceCode(), false, sitePage));
@@ -4410,11 +4411,11 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			"pageSpecifications");
 
 		_assertProblemException(
-			"A single content page specification is only accepted on POST",
+			"A single content page specification cannot be applied to an " +
+				"existing page",
 			() -> sitePageResource.putSiteSitePage(
 				testGroup.getExternalReferenceCode(),
-				postSitePage.getExternalReferenceCode(), false,
-				postSitePage));
+				postSitePage.getExternalReferenceCode(), false, postSitePage));
 	}
 
 	private void _testPutSiteSitePageWithWidgetPageSettings() throws Exception {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -1294,45 +1294,6 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		return _testPutSiteSitePage(sitePage, testGroup, sitePage);
 	}
 
-	private ContentPageSpecification
-		_getContentPageSpecificationWithPageExperiences(
-			String contentPageSpecificationExternalReferenceCode,
-			String defaultPageExperienceExternalReferenceCode,
-			String defaultPageExperienceUuid, long groupId,
-			String pageExperienceExternalReferenceCode,
-			String pageExperienceKey, String pageExperienceUuid,
-			PageSpecification.Status status) {
-
-		PageExperience defaultPageExperience = new PageExperience();
-
-		defaultPageExperience.setExternalReferenceCode(
-			defaultPageExperienceExternalReferenceCode);
-		defaultPageExperience.setKey(SegmentsExperienceConstants.KEY_DEFAULT);
-		defaultPageExperience.setName_i18n(
-			Collections.singletonMap("en-US", RandomTestUtil.randomString()));
-		defaultPageExperience.setPageElements(
-			PageElementsTestUtil.getPageElements(
-				RandomTestUtil.randomInt(1, 3), StringPool.BLANK, groupId));
-		defaultPageExperience.setPageSpecificationExternalReferenceCode(
-			contentPageSpecificationExternalReferenceCode);
-		defaultPageExperience.setUuid(defaultPageExperienceUuid);
-
-		PageExperience pageExperience = new PageExperience();
-
-		pageExperience.setExternalReferenceCode(
-			pageExperienceExternalReferenceCode);
-		pageExperience.setKey(pageExperienceKey);
-		pageExperience.setName_i18n(
-			Collections.singletonMap("en-US", RandomTestUtil.randomString()));
-		pageExperience.setPriority(1);
-		pageExperience.setUuid(pageExperienceUuid);
-
-		return PageSpecificationsTestUtil.getContentPageSpecification(
-			contentPageSpecificationExternalReferenceCode, null, null,
-			new PageExperience[] {defaultPageExperience, pageExperience},
-			groupId, status);
-	}
-
 	private CustomMetaTag[] _getCustomMetaTags() {
 		return new CustomMetaTag[] {
 			new CustomMetaTag() {
@@ -2926,13 +2887,14 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		}
 
 		ContentPageSpecification draftContentPageSpecification =
-			_getContentPageSpecificationWithPageExperiences(
-				draftContentPageSpecificationExternalReferenceCode,
-				defaultPageExperienceExternalReferenceCode,
-				RandomTestUtil.randomString(), testGroup.getGroupId(),
-				pageExperienceExternalReferenceCode,
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				status);
+			PageSpecificationsTestUtil.
+				getContentPageSpecificationWithPageExperiences(
+					draftContentPageSpecificationExternalReferenceCode,
+					defaultPageExperienceExternalReferenceCode,
+					RandomTestUtil.randomString(), testGroup.getGroupId(),
+					pageExperienceExternalReferenceCode,
+					RandomTestUtil.randomString(),
+					RandomTestUtil.randomString(), status);
 
 		ContentPageSpecification expectedDraftContentPageSpecification =
 			new ContentPageSpecification();
@@ -2952,8 +2914,9 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		expectedPublishedContentPageSpecification.setPageExperiences(
 			TransformUtil.transform(
 				draftContentPageSpecification.getPageExperiences(),
-				draftPageExperience -> _toPublishedPageExperience(
-					draftPageExperience, pageExternalReferenceCode),
+				draftPageExperience ->
+					PageExperiencesTestUtil.toPublishedPageExperience(
+						draftPageExperience, pageExternalReferenceCode),
 				PageExperience.class));
 		expectedPublishedContentPageSpecification.setStatus(status);
 
@@ -3119,12 +3082,13 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		String pageExternalReferenceCode = RandomTestUtil.randomString();
 
 		ContentPageSpecification publishedContentPageSpecification =
-			_getContentPageSpecificationWithPageExperiences(
-				pageExternalReferenceCode,
-				defaultPageExperienceExternalReferenceCode,
-				defaultPageExperienceUuid, testGroup.getGroupId(),
-				pageExperienceExternalReferenceCode, pageExperienceKey,
-				pageExperienceUuid, status);
+			PageSpecificationsTestUtil.
+				getContentPageSpecificationWithPageExperiences(
+					pageExternalReferenceCode,
+					defaultPageExperienceExternalReferenceCode,
+					defaultPageExperienceUuid, testGroup.getGroupId(),
+					pageExperienceExternalReferenceCode, pageExperienceKey,
+					pageExperienceUuid, status);
 
 		String draftContentPageSpecificationExternalReferenceCode =
 			pageExternalReferenceCode + LayoutConstants.ERC_SUFFIX_DRAFT;
@@ -3137,9 +3101,10 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		expectedDraftContentPageSpecification.setPageExperiences(
 			TransformUtil.transform(
 				publishedContentPageSpecification.getPageExperiences(),
-				publishedPageExperience -> _toDraftPageExperience(
-					publishedPageExperience,
-					draftContentPageSpecificationExternalReferenceCode),
+				publishedPageExperience ->
+					PageExperiencesTestUtil.toDraftPageExperience(
+						draftContentPageSpecificationExternalReferenceCode,
+						publishedPageExperience),
 				PageExperience.class));
 		expectedDraftContentPageSpecification.setStatus(
 			PageSpecification.Status.APPROVED);
@@ -4584,69 +4549,6 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			sitePage1.getExternalReferenceCode(), 1, sitePage2);
 		_assertParentAndPriority(
 			sitePage1.getExternalReferenceCode(), 2, sitePage4);
-	}
-
-	private PageExperience _toDraftPageExperience(
-		PageExperience publishedPageExperience,
-		String draftContentPageSpecificationExternalReferenceCode) {
-
-		PageExperience pageExperience = new PageExperience();
-
-		pageExperience.setKey(publishedPageExperience.getKey());
-
-		if (SegmentsExperienceConstants.KEY_DEFAULT.equals(
-				publishedPageExperience.getKey())) {
-
-			pageExperience.setExternalReferenceCode(
-				draftContentPageSpecificationExternalReferenceCode +
-					LayoutConstants.ERC_SUFFIX_DEFAULT);
-		}
-		else {
-			pageExperience.setExternalReferenceCode(
-				publishedPageExperience.getExternalReferenceCode() +
-					LayoutConstants.ERC_SUFFIX_DRAFT);
-		}
-
-		return pageExperience;
-	}
-
-	private PageExperience _toPublishedPageExperience(
-		PageExperience draftPageExperience,
-		String publishedContentPageSpecificationExternalReferenceCode) {
-
-		PageExperience pageExperience = new PageExperience();
-
-		pageExperience.setKey(draftPageExperience.getKey());
-
-		if (SegmentsExperienceConstants.KEY_DEFAULT.equals(
-				draftPageExperience.getKey())) {
-
-			pageExperience.setExternalReferenceCode(
-				publishedContentPageSpecificationExternalReferenceCode +
-					LayoutConstants.ERC_SUFFIX_DEFAULT);
-
-			return pageExperience;
-		}
-
-		String draftExternalReferenceCode =
-			draftPageExperience.getExternalReferenceCode();
-
-		if (draftExternalReferenceCode.endsWith(
-				LayoutConstants.ERC_SUFFIX_DRAFT)) {
-
-			pageExperience.setExternalReferenceCode(
-				draftExternalReferenceCode.substring(
-					0,
-					draftExternalReferenceCode.length() -
-						LayoutConstants.ERC_SUFFIX_DRAFT.length()));
-		}
-		else {
-			pageExperience.setExternalReferenceCode(
-				draftExternalReferenceCode +
-					LayoutConstants.ERC_SUFFIX_PUBLISHED);
-		}
-
-		return pageExperience;
 	}
 
 	private Layout _updateFriendlyURL(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -3151,13 +3151,15 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 	private void _testPostSiteSitePageWithPublishedContentPageSpecificationAndDraftReferences()
 		throws Exception {
 
-		String pageExternalReferenceCode = RandomTestUtil.randomString();
-		String userDraftSpecERC = RandomTestUtil.randomString();
+		String pageSpecificationExternalReferenceCode =
+			RandomTestUtil.randomString();
+		String draftContentPageSpecificationExternalReferenceCode =
+			RandomTestUtil.randomString();
 
 		PageElement[] pageElements = PageElementsTestUtil.getPageElements(
 			3, StringPool.BLANK, testGroup.getGroupId());
 
-		List<String> userDraftFragmentInstanceERCs =
+		List<String> draftFragmentInstanceExternalReferenceCodes =
 			_setAndGetDraftFragmentInstanceExternalReferenceCodes(pageElements);
 
 		ContentPageSpecification publishedContentPageSpecification =
@@ -3165,15 +3167,15 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 		publishedContentPageSpecification.
 			setDraftContentPageSpecificationExternalReferenceCode(
-				userDraftSpecERC);
+				draftContentPageSpecificationExternalReferenceCode);
 		publishedContentPageSpecification.setExternalReferenceCode(
-			pageExternalReferenceCode);
+			pageSpecificationExternalReferenceCode);
 		publishedContentPageSpecification.setPageExperiences(
 			new PageExperience[] {
 				PageExperiencesTestUtil.getDefaultPageExperience(
-					pageExternalReferenceCode +
+					pageSpecificationExternalReferenceCode +
 						LayoutConstants.ERC_SUFFIX_DEFAULT,
-					pageElements, pageExternalReferenceCode, null)
+					pageElements, pageSpecificationExternalReferenceCode, null)
 			});
 		publishedContentPageSpecification.setStatus(
 			PageSpecification.Status.APPROVED);
@@ -3181,26 +3183,29 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			() -> ContentPageSpecification.Type.CONTENT_PAGE_SPECIFICATION);
 
 		_postContentPageSpecification(
-			publishedContentPageSpecification, pageExternalReferenceCode,
-			userDraftSpecERC, PageSpecification.Status.APPROVED, false, false);
+			publishedContentPageSpecification,
+			pageSpecificationExternalReferenceCode,
+			draftContentPageSpecificationExternalReferenceCode,
+			PageSpecification.Status.APPROVED, false, false);
 
 		Layout layout = _layoutLocalService.getLayoutByExternalReferenceCode(
-			pageExternalReferenceCode, testGroup.getGroupId());
+			pageSpecificationExternalReferenceCode, testGroup.getGroupId());
 
 		Layout draftLayout = layout.fetchDraftLayout();
 
-		List<String> draftFragmentEntryLinkERCs = TransformUtil.transform(
-			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
-				testGroup.getGroupId(), draftLayout.getPlid()),
-			FragmentEntryLink::getExternalReferenceCode);
+		List<String> draftFragmentEntryLinkExternalReferenceCodes =
+			TransformUtil.transform(
+				_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
+					testGroup.getGroupId(), draftLayout.getPlid()),
+				FragmentEntryLink::getExternalReferenceCode);
 
-		for (String userDraftFragmentInstanceERC :
-				userDraftFragmentInstanceERCs) {
+		for (String draftFragmentInstanceExternalReferenceCode :
+				draftFragmentInstanceExternalReferenceCodes) {
 
 			Assert.assertTrue(
-				draftFragmentEntryLinkERCs.toString(),
-				draftFragmentEntryLinkERCs.contains(
-					userDraftFragmentInstanceERC));
+				draftFragmentEntryLinkExternalReferenceCodes.toString(),
+				draftFragmentEntryLinkExternalReferenceCodes.contains(
+					draftFragmentInstanceExternalReferenceCode));
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -44,6 +44,7 @@ import com.liferay.headless.admin.site.client.dto.v1_0.LinkToPagePageSettings;
 import com.liferay.headless.admin.site.client.dto.v1_0.LinkToURLPageSettings;
 import com.liferay.headless.admin.site.client.dto.v1_0.OpenGraphSettings;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageElement;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageElementDefinition;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageExperience;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageSetPageSettings;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageSettings;
@@ -55,6 +56,7 @@ import com.liferay.headless.admin.site.client.dto.v1_0.SitePage;
 import com.liferay.headless.admin.site.client.dto.v1_0.SitePageNavigationSettings;
 import com.liferay.headless.admin.site.client.dto.v1_0.SitemapSettings;
 import com.liferay.headless.admin.site.client.dto.v1_0.TaxonomyCategoryBrief;
+import com.liferay.headless.admin.site.client.dto.v1_0.WidgetInstancePageElementDefinition;
 import com.liferay.headless.admin.site.client.dto.v1_0.WidgetPageSettings;
 import com.liferay.headless.admin.site.client.dto.v1_0.WidgetPageSpecification;
 import com.liferay.headless.admin.site.client.http.HttpInvoker;
@@ -1983,36 +1985,60 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		return postSitePage;
 	}
 
-	private List<String> _setAndGetDraftFragmentInstanceExternalReferenceCodes(
-		PageElement[] pageElements) {
+	private List<String>
+		_setAndGetDraftFragmentOrWidgetInstanceExternalReferenceCodes(
+			PageElement[] pageElements) {
 
-		List<String> draftFragmentInstanceExternalReferenceCodes =
+		List<String> draftFragmentOrWidgetInstanceExternalReferenceCodes =
 			new ArrayList<>();
 
 		for (PageElement pageElement : pageElements) {
-			if (!(pageElement.getPageElementDefinition() instanceof
+			PageElementDefinition pageElementDefinition =
+				pageElement.getPageElementDefinition();
+
+			if (pageElementDefinition instanceof
 					BasicFragmentInstancePageElementDefinition
-						basicFragmentInstancePageElementDefinition)) {
+						basicFragmentInstancePageElementDefinition) {
 
-				continue;
+				FragmentInstance fragmentInstance =
+					basicFragmentInstancePageElementDefinition.
+						getFragmentInstance();
+
+				String fragmentInstanceExternalReferenceCode =
+					fragmentInstance.getFragmentInstanceExternalReferenceCode();
+
+				String draftFragmentInstanceExternalReferenceCode =
+					fragmentInstanceExternalReferenceCode +
+						RandomTestUtil.randomString();
+
+				fragmentInstance.setDraftFragmentInstanceExternalReferenceCode(
+					draftFragmentInstanceExternalReferenceCode);
+
+				draftFragmentOrWidgetInstanceExternalReferenceCodes.add(
+					draftFragmentInstanceExternalReferenceCode);
 			}
+			else if (pageElementDefinition instanceof
+						WidgetInstancePageElementDefinition
+							widgetInstancePageElementDefinition) {
 
-			FragmentInstance fragmentInstance =
-				basicFragmentInstancePageElementDefinition.
-					getFragmentInstance();
+				String widgetInstanceExternalReferenceCode =
+					widgetInstancePageElementDefinition.
+						getWidgetInstanceExternalReferenceCode();
 
-			String draftFragmentInstanceExternalReferenceCode =
-				fragmentInstance.getFragmentInstanceExternalReferenceCode() +
-					RandomTestUtil.randomString();
+				String draftWidgetInstanceExternalReferenceCode =
+					widgetInstanceExternalReferenceCode +
+						RandomTestUtil.randomString();
 
-			fragmentInstance.setDraftFragmentInstanceExternalReferenceCode(
-				draftFragmentInstanceExternalReferenceCode);
+				widgetInstancePageElementDefinition.
+					setDraftWidgetInstanceExternalReferenceCode(
+						draftWidgetInstanceExternalReferenceCode);
 
-			draftFragmentInstanceExternalReferenceCodes.add(
-				draftFragmentInstanceExternalReferenceCode);
+				draftFragmentOrWidgetInstanceExternalReferenceCodes.add(
+					draftWidgetInstanceExternalReferenceCode);
+			}
 		}
 
-		return draftFragmentInstanceExternalReferenceCodes;
+		return draftFragmentOrWidgetInstanceExternalReferenceCodes;
 	}
 
 	private void _testDeleteSiteSitePage(Layout... layouts) throws Exception {
@@ -3161,11 +3187,23 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		String pageSpecificationExternalReferenceCode =
 			RandomTestUtil.randomString();
 
-		PageElement[] pageElements = PageElementsTestUtil.getPageElements(
-			3, StringPool.BLANK, testGroup.getGroupId());
+		PageElement pageElement = new PageElement();
 
-		List<String> draftFragmentInstanceExternalReferenceCodes =
-			_setAndGetDraftFragmentInstanceExternalReferenceCodes(pageElements);
+		pageElement.setExternalReferenceCode(RandomTestUtil.randomString());
+		pageElement.setPageElementDefinition(
+			PageElementsTestUtil.getPageElementDefinition(
+				PageElementDefinition.Type.WIDGET, testGroup.getGroupId()));
+		pageElement.setPageElements(new PageElement[0]);
+		pageElement.setPosition(3);
+
+		PageElement[] pageElements = ArrayUtil.append(
+			PageElementsTestUtil.getPageElements(
+				3, StringPool.BLANK, testGroup.getGroupId()),
+			pageElement);
+
+		List<String> draftFragmentOrWidgetInstanceExternalReferenceCodes =
+			_setAndGetDraftFragmentOrWidgetInstanceExternalReferenceCodes(
+				pageElements);
 
 		ContentPageSpecification publishedContentPageSpecification =
 			new ContentPageSpecification();
@@ -3204,13 +3242,13 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 					testGroup.getGroupId(), draftLayout.getPlid()),
 				FragmentEntryLink::getExternalReferenceCode);
 
-		for (String draftFragmentInstanceExternalReferenceCode :
-				draftFragmentInstanceExternalReferenceCodes) {
+		for (String draftFragmentOrWidgetInstanceExternalReferenceCode :
+				draftFragmentOrWidgetInstanceExternalReferenceCodes) {
 
 			Assert.assertTrue(
 				draftFragmentEntryLinkExternalReferenceCodes.toString(),
 				draftFragmentEntryLinkExternalReferenceCodes.contains(
-					draftFragmentInstanceExternalReferenceCode));
+					draftFragmentOrWidgetInstanceExternalReferenceCode));
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -313,12 +313,13 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 	@Override
 	@Test
-	@TestInfo({"LPD-74225", "LPD-75413"})
+	@TestInfo({"LPD-74225", "LPD-75413", "LPD-83094"})
 	public void testPatchSiteSitePage() throws Exception {
 		_testPatchSiteSitePage(SitePage.Type.CONTENT_PAGE);
 		_testPatchSiteSitePage(SitePage.Type.WIDGET_PAGE);
 		_testPatchSiteSitePageWithPageSpecifications();
 		_testPatchSiteSitePageWithPriority();
+		_testPatchSiteSitePageWithSingleContentPageSpecification();
 		_testPatchSiteSitePageWithWidgetPageSettings();
 		_testPatchSiteSitePageWithWidgetPageSettingsWithWidgetPageTemplate();
 
@@ -345,6 +346,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 	@FeatureFlag("LPD-38869")
 	@Override
 	@Test
+	@TestInfo("LPD-83094")
 	public void testPostSiteSitePage() throws Exception {
 		super.testPostSiteSitePage();
 
@@ -371,6 +373,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 		_testPostSiteSitePageWithPageElements();
 		_testPostSiteSitePageWithPageSpecifications();
+		_testPostSiteSitePageWithSingleContentPageSpecification();
 		_testPostSiteSitePageWithWidgetPageSettings();
 		_testPostSiteSitePageWithWidgetPageSettingsWithWidgetPageTemplate();
 		_testPostSiteSitePageWithWidgetPageTypeIsDeprecated();
@@ -423,7 +426,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		{
 			"LPD-72013", "LPD-74331", "LPD-75450", "LPD-77124", "LPD-77505",
 			"LPD-77576", "LPD-77852", "LPD-78667", "LPD-79415", "LPD-80061",
-			"LPD-81793"
+			"LPD-81793", "LPD-83094"
 		}
 	)
 	public void testPutSiteSitePage() throws Exception {
@@ -459,6 +462,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		_testPutSiteSitePageWithPageSpecifications();
 		_testPutSiteSitePageWithParentLayout();
 		_testPutSiteSitePageWithPriority();
+		_testPutSiteSitePageWithSingleContentPageSpecification();
 		_testPutSiteSitePageWithWidgetPageSettings();
 		_testPutSiteSitePageWithWidgetPageSettingsWithWidgetPageTemplate();
 
@@ -1290,6 +1294,45 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		return _testPutSiteSitePage(sitePage, testGroup, sitePage);
 	}
 
+	private ContentPageSpecification
+		_getContentPageSpecificationWithPageExperiences(
+			String contentPageSpecificationExternalReferenceCode,
+			String defaultPageExperienceExternalReferenceCode,
+			String defaultPageExperienceUuid, long groupId,
+			String pageExperienceExternalReferenceCode,
+			String pageExperienceKey, String pageExperienceUuid,
+			PageSpecification.Status status) {
+
+		PageExperience defaultPageExperience = new PageExperience();
+
+		defaultPageExperience.setExternalReferenceCode(
+			defaultPageExperienceExternalReferenceCode);
+		defaultPageExperience.setKey(SegmentsExperienceConstants.KEY_DEFAULT);
+		defaultPageExperience.setName_i18n(
+			Collections.singletonMap("en-US", RandomTestUtil.randomString()));
+		defaultPageExperience.setPageElements(
+			PageElementsTestUtil.getPageElements(
+				RandomTestUtil.randomInt(1, 3), StringPool.BLANK, groupId));
+		defaultPageExperience.setPageSpecificationExternalReferenceCode(
+			contentPageSpecificationExternalReferenceCode);
+		defaultPageExperience.setUuid(defaultPageExperienceUuid);
+
+		PageExperience pageExperience = new PageExperience();
+
+		pageExperience.setExternalReferenceCode(
+			pageExperienceExternalReferenceCode);
+		pageExperience.setKey(pageExperienceKey);
+		pageExperience.setName_i18n(
+			Collections.singletonMap("en-US", RandomTestUtil.randomString()));
+		pageExperience.setPriority(1);
+		pageExperience.setUuid(pageExperienceUuid);
+
+		return PageSpecificationsTestUtil.getContentPageSpecification(
+			contentPageSpecificationExternalReferenceCode, null, null,
+			new PageExperience[] {defaultPageExperience, pageExperience},
+			groupId, status);
+	}
+
 	private CustomMetaTag[] _getCustomMetaTags() {
 		return new CustomMetaTag[] {
 			new CustomMetaTag() {
@@ -1920,6 +1963,95 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		};
 	}
 
+	private void _postSingleContentPageSpecification(
+			ContentPageSpecification contentPageSpecification,
+			ContentPageSpecification expectedDraftContentPageSpecification,
+			ContentPageSpecification expectedPublishedContentPageSpecification,
+			Group group, String sitePageExternalReferenceCode,
+			PageSpecification.Status status)
+		throws Exception {
+
+		SitePage sitePage = _getRandomSitePage(
+			sitePageExternalReferenceCode, null,
+			ServiceContextTestUtil.getServiceContext(
+				group, TestPropsValues.getUserId()),
+			SitePage.Type.CONTENT_PAGE,
+			StringUtil.toLowerCase(RandomTestUtil.randomString()));
+
+		sitePage.setPageSpecifications(
+			() -> new PageSpecification[] {contentPageSpecification});
+
+		SitePageResource sitePageResource = _getSitePageResource(
+			"pageSpecifications");
+
+		sitePageResource.postSiteSitePage(
+			group.getExternalReferenceCode(), false, sitePage);
+
+		SitePage getSitePage = sitePageResource.getSiteSitePage(
+			group.getExternalReferenceCode(), sitePageExternalReferenceCode);
+
+		Layout layout = _layoutLocalService.getLayoutByExternalReferenceCode(
+			sitePageExternalReferenceCode, group.getGroupId());
+
+		if (Objects.equals(status, PageSpecification.Status.APPROVED)) {
+			Assert.assertTrue(layout.isPublished());
+		}
+		else {
+			Assert.assertFalse(layout.isPublished());
+		}
+
+		PageSpecificationsTestUtil.assertPageSpecifications(
+			expectedDraftContentPageSpecification,
+			expectedPublishedContentPageSpecification,
+			getSitePage.getPageSpecifications(), layout, status);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		List<FragmentEntryLink> draftFragmentEntryLinks =
+			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
+				group.getGroupId(), draftLayout.getPlid());
+
+		List<FragmentEntryLink> publishedFragmentEntryLinks =
+			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
+				group.getGroupId(), layout.getPlid());
+
+		Assert.assertEquals(
+			draftFragmentEntryLinks + " vs " + publishedFragmentEntryLinks,
+			publishedFragmentEntryLinks.size(), draftFragmentEntryLinks.size());
+
+		List<String> draftFragmentEntryLinkExternalReferenceCodes =
+			TransformUtil.transform(
+				draftFragmentEntryLinks,
+				FragmentEntryLink::getExternalReferenceCode);
+
+		for (FragmentEntryLink publishedFragmentEntryLink :
+				publishedFragmentEntryLinks) {
+
+			String publishedERC =
+				publishedFragmentEntryLink.getExternalReferenceCode();
+
+			String expectedDraftERC;
+
+			if (publishedERC.endsWith(LayoutConstants.ERC_SUFFIX_PUBLISHED)) {
+				expectedDraftERC = publishedERC.substring(
+					0,
+					publishedERC.length() -
+						LayoutConstants.ERC_SUFFIX_PUBLISHED.length());
+			}
+			else {
+				expectedDraftERC =
+					publishedERC + LayoutConstants.ERC_SUFFIX_DRAFT;
+			}
+
+			Assert.assertEquals(
+				publishedFragmentEntryLink.toString(), expectedDraftERC,
+				publishedFragmentEntryLink.getOriginalFragmentEntryLinkERC());
+			Assert.assertTrue(
+				draftFragmentEntryLinkExternalReferenceCodes.contains(
+					expectedDraftERC));
+		}
+	}
+
 	private SitePage _postSiteSitePageWithPageSpecificationsWithCustomFields(
 			SitePage.Type type)
 		throws Exception {
@@ -1953,6 +2085,36 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			testGroup.getGroupId(), postSitePage.getPageSpecifications());
 
 		return postSitePage;
+	}
+
+	private List<String> _setUserDraftFragmentInstanceERCs(
+		PageElement[] pageElements) {
+
+		List<String> userDraftFragmentInstanceERCs = new ArrayList<>();
+
+		for (PageElement pageElement : pageElements) {
+			if (!(pageElement.getPageElementDefinition() instanceof
+					BasicFragmentInstancePageElementDefinition
+						basicFragmentInstancePageElementDefinition)) {
+
+				continue;
+			}
+
+			FragmentInstance fragmentInstance =
+				basicFragmentInstancePageElementDefinition.
+					getFragmentInstance();
+
+			String userDraftFragmentInstanceERC =
+				fragmentInstance.getFragmentInstanceExternalReferenceCode() +
+					_ERC_SUFFIX_USER_DRAFT;
+
+			fragmentInstance.setDraftFragmentInstanceExternalReferenceCode(
+				userDraftFragmentInstanceERC);
+
+			userDraftFragmentInstanceERCs.add(userDraftFragmentInstanceERC);
+		}
+
+		return userDraftFragmentInstanceERCs;
 	}
 
 	private void _testDeleteSiteSitePage(Layout... layouts) throws Exception {
@@ -2410,6 +2572,36 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			});
 	}
 
+	private void _testPatchSiteSitePageWithSingleContentPageSpecification()
+		throws Exception {
+
+		SitePage existingSitePage = sitePageResource.postSiteSitePage(
+			testGroup.getExternalReferenceCode(), false,
+			_getRandomSitePage(SitePage.Type.CONTENT_PAGE));
+
+		SitePage sitePage = new SitePage();
+
+		ContentPageSpecification contentPageSpecification =
+			PageSpecificationsTestUtil.getContentPageSpecification(
+				null, testGroup.getGroupId(),
+				PageSpecification.Status.APPROVED);
+
+		contentPageSpecification.setExternalReferenceCode(
+			existingSitePage.getExternalReferenceCode());
+
+		sitePage.setPageSpecifications(
+			() -> new PageSpecification[] {contentPageSpecification});
+
+		SitePageResource sitePageResource = _getSitePageResource(
+			"pageSpecifications");
+
+		_assertProblemException(
+			"A single content page specification is only accepted on POST",
+			() -> sitePageResource.patchSiteSitePage(
+				testGroup.getExternalReferenceCode(),
+				existingSitePage.getExternalReferenceCode(), false, sitePage));
+	}
+
 	private void _testPatchSiteSitePageWithWidgetPageSettings()
 		throws Exception {
 
@@ -2706,6 +2898,75 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			postSitePage);
 	}
 
+	private void _testPostSiteSitePageWithDraftSingleContentPageSpecification(
+			PageSpecification.Status status, boolean withDraftErcSuffix)
+		throws Exception {
+
+		String pageExternalReferenceCode = RandomTestUtil.randomString();
+
+		String defaultPageExperienceExternalReferenceCode;
+		String draftContentPageSpecificationExternalReferenceCode;
+		String pageExperienceExternalReferenceCode;
+
+		if (withDraftErcSuffix) {
+			draftContentPageSpecificationExternalReferenceCode =
+				pageExternalReferenceCode + LayoutConstants.ERC_SUFFIX_DRAFT;
+
+			defaultPageExperienceExternalReferenceCode =
+				draftContentPageSpecificationExternalReferenceCode +
+					LayoutConstants.ERC_SUFFIX_DEFAULT;
+
+			pageExperienceExternalReferenceCode =
+				RandomTestUtil.randomString() +
+					LayoutConstants.ERC_SUFFIX_DRAFT;
+		}
+		else {
+			defaultPageExperienceExternalReferenceCode =
+				RandomTestUtil.randomString();
+			draftContentPageSpecificationExternalReferenceCode =
+				RandomTestUtil.randomString();
+			pageExperienceExternalReferenceCode = RandomTestUtil.randomString();
+		}
+
+		ContentPageSpecification draftContentPageSpecification =
+			_getContentPageSpecificationWithPageExperiences(
+				draftContentPageSpecificationExternalReferenceCode,
+				defaultPageExperienceExternalReferenceCode,
+				RandomTestUtil.randomString(), testGroup.getGroupId(),
+				pageExperienceExternalReferenceCode,
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				status);
+
+		ContentPageSpecification expectedDraftContentPageSpecification =
+			new ContentPageSpecification();
+
+		expectedDraftContentPageSpecification.setExternalReferenceCode(
+			draftContentPageSpecificationExternalReferenceCode);
+		expectedDraftContentPageSpecification.setPageExperiences(
+			draftContentPageSpecification.getPageExperiences());
+		expectedDraftContentPageSpecification.setStatus(
+			PageSpecification.Status.APPROVED);
+
+		ContentPageSpecification expectedPublishedContentPageSpecification =
+			new ContentPageSpecification();
+
+		expectedPublishedContentPageSpecification.setExternalReferenceCode(
+			pageExternalReferenceCode);
+		expectedPublishedContentPageSpecification.setPageExperiences(
+			TransformUtil.transform(
+				draftContentPageSpecification.getPageExperiences(),
+				draftPageExperience -> _toPublishedPageExperience(
+					draftPageExperience, pageExternalReferenceCode),
+				PageExperience.class));
+		expectedPublishedContentPageSpecification.setStatus(status);
+
+		_postSingleContentPageSpecification(
+			draftContentPageSpecification,
+			expectedDraftContentPageSpecification,
+			expectedPublishedContentPageSpecification, testGroup,
+			pageExternalReferenceCode, status);
+	}
+
 	private void _testPostSiteSitePageWithPageElements() throws Exception {
 		PageElement[] pageElements = PageElementsTestUtil.getPageElements(
 			testGroup.getGroupId());
@@ -2844,6 +3105,158 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		PageSpecificationsTestUtil.assertWidgetPageSpecifications(
 			randomSitePage.getPageSpecifications(),
 			sitePage.getPageSpecifications());
+	}
+
+	private void
+			_testPostSiteSitePageWithPublishedSingleContentPageSpecification(
+				PageSpecification.Status status)
+		throws Exception {
+
+		String defaultPageExperienceExternalReferenceCode =
+			RandomTestUtil.randomString();
+		String defaultPageExperienceUuid = RandomTestUtil.randomString();
+		String pageExperienceExternalReferenceCode =
+			RandomTestUtil.randomString();
+		String pageExperienceKey = RandomTestUtil.randomString();
+		String pageExperienceUuid = RandomTestUtil.randomString();
+		String pageExternalReferenceCode = RandomTestUtil.randomString();
+
+		ContentPageSpecification publishedContentPageSpecification =
+			_getContentPageSpecificationWithPageExperiences(
+				pageExternalReferenceCode,
+				defaultPageExperienceExternalReferenceCode,
+				defaultPageExperienceUuid, testGroup.getGroupId(),
+				pageExperienceExternalReferenceCode, pageExperienceKey,
+				pageExperienceUuid, status);
+
+		String draftContentPageSpecificationExternalReferenceCode =
+			pageExternalReferenceCode + LayoutConstants.ERC_SUFFIX_DRAFT;
+
+		ContentPageSpecification expectedDraftContentPageSpecification =
+			new ContentPageSpecification();
+
+		expectedDraftContentPageSpecification.setExternalReferenceCode(
+			draftContentPageSpecificationExternalReferenceCode);
+		expectedDraftContentPageSpecification.setPageExperiences(
+			TransformUtil.transform(
+				publishedContentPageSpecification.getPageExperiences(),
+				publishedPageExperience -> _toDraftPageExperience(
+					publishedPageExperience,
+					draftContentPageSpecificationExternalReferenceCode),
+				PageExperience.class));
+		expectedDraftContentPageSpecification.setStatus(
+			PageSpecification.Status.APPROVED);
+
+		ContentPageSpecification expectedPublishedContentPageSpecification =
+			new ContentPageSpecification();
+
+		expectedPublishedContentPageSpecification.setExternalReferenceCode(
+			pageExternalReferenceCode);
+		expectedPublishedContentPageSpecification.setPageExperiences(
+			publishedContentPageSpecification.getPageExperiences());
+		expectedPublishedContentPageSpecification.setStatus(status);
+
+		_postSingleContentPageSpecification(
+			publishedContentPageSpecification,
+			expectedDraftContentPageSpecification,
+			expectedPublishedContentPageSpecification, testGroup,
+			pageExternalReferenceCode, status);
+	}
+
+	private void _testPostSiteSitePageWithPublishedSingleContentPageSpecificationAndDraftReferences()
+		throws Exception {
+
+		String pageExternalReferenceCode = RandomTestUtil.randomString();
+		String userDraftSpecERC = RandomTestUtil.randomString();
+
+		long groupId = testGroup.getGroupId();
+
+		PageElement[] pageElements = PageElementsTestUtil.getPageElements(
+			3, StringPool.BLANK, groupId);
+
+		List<String> userDraftFragmentInstanceERCs =
+			_setUserDraftFragmentInstanceERCs(pageElements);
+
+		PageExperience defaultPageExperience = new PageExperience();
+
+		defaultPageExperience.setExternalReferenceCode(
+			pageExternalReferenceCode + LayoutConstants.ERC_SUFFIX_DEFAULT);
+		defaultPageExperience.setKey(SegmentsExperienceConstants.KEY_DEFAULT);
+		defaultPageExperience.setName_i18n(
+			Collections.singletonMap("en-US", RandomTestUtil.randomString()));
+		defaultPageExperience.setPageElements(pageElements);
+		defaultPageExperience.setPageSpecificationExternalReferenceCode(
+			pageExternalReferenceCode);
+
+		ContentPageSpecification contentPageSpecification =
+			new ContentPageSpecification();
+
+		contentPageSpecification.
+			setDraftContentPageSpecificationExternalReferenceCode(
+				userDraftSpecERC);
+		contentPageSpecification.setExternalReferenceCode(
+			pageExternalReferenceCode);
+		contentPageSpecification.setPageExperiences(
+			new PageExperience[] {defaultPageExperience});
+		contentPageSpecification.setStatus(PageSpecification.Status.APPROVED);
+		contentPageSpecification.setType(
+			() -> ContentPageSpecification.Type.CONTENT_PAGE_SPECIFICATION);
+
+		SitePage sitePage = _getRandomSitePage(
+			pageExternalReferenceCode, null,
+			ServiceContextTestUtil.getServiceContext(
+				testGroup, TestPropsValues.getUserId()),
+			SitePage.Type.CONTENT_PAGE,
+			StringUtil.toLowerCase(RandomTestUtil.randomString()));
+
+		sitePage.setPageSpecifications(
+			() -> new PageSpecification[] {contentPageSpecification});
+
+		SitePageResource sitePageResource = _getSitePageResource(
+			"pageSpecifications");
+
+		sitePageResource.postSiteSitePage(
+			testGroup.getExternalReferenceCode(), false, sitePage);
+
+		Layout layout = _layoutLocalService.getLayoutByExternalReferenceCode(
+			pageExternalReferenceCode, groupId);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		Assert.assertEquals(
+			userDraftSpecERC, draftLayout.getExternalReferenceCode());
+
+		List<String> draftFragmentEntryLinkERCs = TransformUtil.transform(
+			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
+				groupId, draftLayout.getPlid()),
+			FragmentEntryLink::getExternalReferenceCode);
+
+		for (String userDraftFragmentInstanceERC :
+				userDraftFragmentInstanceERCs) {
+
+			Assert.assertTrue(
+				draftFragmentEntryLinkERCs.toString(),
+				draftFragmentEntryLinkERCs.contains(
+					userDraftFragmentInstanceERC));
+		}
+	}
+
+	private void _testPostSiteSitePageWithSingleContentPageSpecification()
+		throws Exception {
+
+		_testPostSiteSitePageWithDraftSingleContentPageSpecification(
+			PageSpecification.Status.APPROVED, true);
+		_testPostSiteSitePageWithDraftSingleContentPageSpecification(
+			PageSpecification.Status.APPROVED, false);
+		_testPostSiteSitePageWithDraftSingleContentPageSpecification(
+			PageSpecification.Status.DRAFT, true);
+		_testPostSiteSitePageWithDraftSingleContentPageSpecification(
+			PageSpecification.Status.DRAFT, false);
+		_testPostSiteSitePageWithPublishedSingleContentPageSpecification(
+			PageSpecification.Status.APPROVED);
+		_testPostSiteSitePageWithPublishedSingleContentPageSpecification(
+			PageSpecification.Status.DRAFT);
+		_testPostSiteSitePageWithPublishedSingleContentPageSpecificationAndDraftReferences();
 	}
 
 	private void _testPostSiteSitePageWithWidgetPageSettings()
@@ -3975,6 +4388,35 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			});
 	}
 
+	private void _testPutSiteSitePageWithSingleContentPageSpecification()
+		throws Exception {
+
+		SitePage existingSitePage = sitePageResource.postSiteSitePage(
+			testGroup.getExternalReferenceCode(), false,
+			_getRandomSitePage(SitePage.Type.CONTENT_PAGE));
+
+		ContentPageSpecification contentPageSpecification =
+			PageSpecificationsTestUtil.getContentPageSpecification(
+				null, testGroup.getGroupId(),
+				PageSpecification.Status.APPROVED);
+
+		contentPageSpecification.setExternalReferenceCode(
+			existingSitePage.getExternalReferenceCode());
+
+		existingSitePage.setPageSpecifications(
+			() -> new PageSpecification[] {contentPageSpecification});
+
+		SitePageResource sitePageResource = _getSitePageResource(
+			"pageSpecifications");
+
+		_assertProblemException(
+			"A single content page specification is only accepted on POST",
+			() -> sitePageResource.putSiteSitePage(
+				testGroup.getExternalReferenceCode(),
+				existingSitePage.getExternalReferenceCode(), false,
+				existingSitePage));
+	}
+
 	private void _testPutSiteSitePageWithWidgetPageSettings() throws Exception {
 		SitePage randomSitePage = _getRandomSitePage(SitePage.Type.WIDGET_PAGE);
 
@@ -4147,6 +4589,69 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			sitePage1.getExternalReferenceCode(), 2, sitePage4);
 	}
 
+	private PageExperience _toDraftPageExperience(
+		PageExperience publishedPageExperience,
+		String draftContentPageSpecificationExternalReferenceCode) {
+
+		PageExperience pageExperience = new PageExperience();
+
+		pageExperience.setKey(publishedPageExperience.getKey());
+
+		if (SegmentsExperienceConstants.KEY_DEFAULT.equals(
+				publishedPageExperience.getKey())) {
+
+			pageExperience.setExternalReferenceCode(
+				draftContentPageSpecificationExternalReferenceCode +
+					LayoutConstants.ERC_SUFFIX_DEFAULT);
+		}
+		else {
+			pageExperience.setExternalReferenceCode(
+				publishedPageExperience.getExternalReferenceCode() +
+					LayoutConstants.ERC_SUFFIX_DRAFT);
+		}
+
+		return pageExperience;
+	}
+
+	private PageExperience _toPublishedPageExperience(
+		PageExperience draftPageExperience,
+		String publishedContentPageSpecificationExternalReferenceCode) {
+
+		PageExperience pageExperience = new PageExperience();
+
+		pageExperience.setKey(draftPageExperience.getKey());
+
+		if (SegmentsExperienceConstants.KEY_DEFAULT.equals(
+				draftPageExperience.getKey())) {
+
+			pageExperience.setExternalReferenceCode(
+				publishedContentPageSpecificationExternalReferenceCode +
+					LayoutConstants.ERC_SUFFIX_DEFAULT);
+
+			return pageExperience;
+		}
+
+		String draftExternalReferenceCode =
+			draftPageExperience.getExternalReferenceCode();
+
+		if (draftExternalReferenceCode.endsWith(
+				LayoutConstants.ERC_SUFFIX_DRAFT)) {
+
+			pageExperience.setExternalReferenceCode(
+				draftExternalReferenceCode.substring(
+					0,
+					draftExternalReferenceCode.length() -
+						LayoutConstants.ERC_SUFFIX_DRAFT.length()));
+		}
+		else {
+			pageExperience.setExternalReferenceCode(
+				draftExternalReferenceCode +
+					LayoutConstants.ERC_SUFFIX_PUBLISHED);
+		}
+
+		return pageExperience;
+	}
+
 	private Layout _updateFriendlyURL(
 			Map<Locale, String> friendlyURLMap, Layout layout)
 		throws Exception {
@@ -4172,6 +4677,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			layout.getPlid(),
 			FileUtil.getBytes(getClass(), "dependencies/liferay.jpg"));
 	}
+
+	private static final String _ERC_SUFFIX_USER_DRAFT = "-user-draft";
 
 	private static final List<SitePage.Type> _types = Arrays.asList(
 		SitePage.Type.CONTENT_PAGE, SitePage.Type.WIDGET_PAGE);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageExperiencesTestUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageExperiencesTestUtil.java
@@ -81,8 +81,6 @@ public class PageExperiencesTestUtil {
 		PageExperience defaultPageExperience = pageExperiencesByKey.get(
 			SegmentsExperienceConstants.KEY_DEFAULT);
 
-		Assert.assertNotNull(defaultPageExperience);
-
 		SegmentsExperience segmentsExperience =
 			SegmentsExperienceLocalServiceUtil.fetchDefaultSegmentsExperience(
 				layout.getPlid());

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageExperiencesTestUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageExperiencesTestUtil.java
@@ -42,7 +42,7 @@ public class PageExperiencesTestUtil {
 		PageExperience[] expectedPageExperiences, Layout layout,
 		PageExperience[] pageExperiences) {
 
-		if (_supportsMultiplePageExperiences(layout)) {
+		if (_isMultiplePageExperiencesSupported(layout)) {
 			Assert.assertEquals(
 				Arrays.toString(pageExperiences),
 				expectedPageExperiences.length, pageExperiences.length);
@@ -347,7 +347,7 @@ public class PageExperiencesTestUtil {
 		return pageExperience;
 	}
 
-	private static boolean _supportsMultiplePageExperiences(Layout layout) {
+	private static boolean _isMultiplePageExperiencesSupported(Layout layout) {
 		if (!layout.isTypeContent()) {
 			return false;
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageExperiencesTestUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageExperiencesTestUtil.java
@@ -13,6 +13,7 @@ import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalServ
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -107,6 +108,24 @@ public class PageExperiencesTestUtil {
 		return null;
 	}
 
+	public static PageExperience getDefaultPageExperience(
+		String externalReferenceCode, PageElement[] pageElements,
+		String pageSpecificationExternalReferenceCode, String uuid) {
+
+		PageExperience pageExperience = new PageExperience();
+
+		pageExperience.setExternalReferenceCode(externalReferenceCode);
+		pageExperience.setKey(SegmentsExperienceConstants.KEY_DEFAULT);
+		pageExperience.setName_i18n(
+			Collections.singletonMap("en-US", RandomTestUtil.randomString()));
+		pageExperience.setPageElements(pageElements);
+		pageExperience.setPageSpecificationExternalReferenceCode(
+			pageSpecificationExternalReferenceCode);
+		pageExperience.setUuid(uuid);
+
+		return pageExperience;
+	}
+
 	public static PageExperience[] getDefaultPageExperiences(
 		PageElement[] pageElements,
 		String pageSpecificationExternalReferenceCode) {
@@ -173,6 +192,21 @@ public class PageExperiencesTestUtil {
 		return pageExperience;
 	}
 
+	public static PageExperience getPageExperience(
+		String externalReferenceCode, String key, int priority, String uuid) {
+
+		PageExperience pageExperience = new PageExperience();
+
+		pageExperience.setExternalReferenceCode(externalReferenceCode);
+		pageExperience.setKey(key);
+		pageExperience.setName_i18n(
+			Collections.singletonMap("en-US", RandomTestUtil.randomString()));
+		pageExperience.setPriority(priority);
+		pageExperience.setUuid(uuid);
+
+		return pageExperience;
+	}
+
 	public static PageExperience[] getPageExperiences(
 			long companyGroupId, long groupId,
 			String pageSpecificationExternalReferenceCode)
@@ -233,6 +267,69 @@ public class PageExperiencesTestUtil {
 						dropZonePageElements.toArray(new PageElement[0]));
 				});
 		}
+	}
+
+	public static PageExperience toDraftPageExperience(
+		String draftContentPageSpecificationExternalReferenceCode,
+		PageExperience publishedPageExperience) {
+
+		PageExperience pageExperience = new PageExperience();
+
+		pageExperience.setKey(publishedPageExperience.getKey());
+
+		if (SegmentsExperienceConstants.KEY_DEFAULT.equals(
+				publishedPageExperience.getKey())) {
+
+			pageExperience.setExternalReferenceCode(
+				draftContentPageSpecificationExternalReferenceCode +
+					LayoutConstants.ERC_SUFFIX_DEFAULT);
+		}
+		else {
+			pageExperience.setExternalReferenceCode(
+				publishedPageExperience.getExternalReferenceCode() +
+					LayoutConstants.ERC_SUFFIX_DRAFT);
+		}
+
+		return pageExperience;
+	}
+
+	public static PageExperience toPublishedPageExperience(
+		PageExperience draftPageExperience,
+		String publishedContentPageSpecificationExternalReferenceCode) {
+
+		PageExperience pageExperience = new PageExperience();
+
+		pageExperience.setKey(draftPageExperience.getKey());
+
+		if (SegmentsExperienceConstants.KEY_DEFAULT.equals(
+				draftPageExperience.getKey())) {
+
+			pageExperience.setExternalReferenceCode(
+				publishedContentPageSpecificationExternalReferenceCode +
+					LayoutConstants.ERC_SUFFIX_DEFAULT);
+
+			return pageExperience;
+		}
+
+		String draftExternalReferenceCode =
+			draftPageExperience.getExternalReferenceCode();
+
+		if (draftExternalReferenceCode.endsWith(
+				LayoutConstants.ERC_SUFFIX_DRAFT)) {
+
+			pageExperience.setExternalReferenceCode(
+				draftExternalReferenceCode.substring(
+					0,
+					draftExternalReferenceCode.length() -
+						LayoutConstants.ERC_SUFFIX_DRAFT.length()));
+		}
+		else {
+			pageExperience.setExternalReferenceCode(
+				draftExternalReferenceCode +
+					LayoutConstants.ERC_SUFFIX_PUBLISHED);
+		}
+
+		return pageExperience;
 	}
 
 	private static PageExperience _getPageExperience(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageExperiencesTestUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageExperiencesTestUtil.java
@@ -277,12 +277,12 @@ public class PageExperiencesTestUtil {
 
 			pageExperience.setExternalReferenceCode(
 				draftContentPageSpecificationExternalReferenceCode +
-					LayoutConstants.ERC_SUFFIX_DEFAULT);
+					LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DEFAULT);
 		}
 		else {
 			pageExperience.setExternalReferenceCode(
 				publishedPageExperience.getExternalReferenceCode() +
-					LayoutConstants.ERC_SUFFIX_DRAFT);
+					LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT);
 		}
 
 		pageExperience.setKey(publishedPageExperience.getKey());
@@ -303,7 +303,7 @@ public class PageExperiencesTestUtil {
 
 			pageExperience.setExternalReferenceCode(
 				publishedContentPageSpecificationExternalReferenceCode +
-					LayoutConstants.ERC_SUFFIX_DEFAULT);
+					LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DEFAULT);
 
 			return pageExperience;
 		}
@@ -312,18 +312,20 @@ public class PageExperiencesTestUtil {
 			draftPageExperience.getExternalReferenceCode();
 
 		if (draftExternalReferenceCode.endsWith(
-				LayoutConstants.ERC_SUFFIX_DRAFT)) {
+				LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT)) {
+
+			int suffixDraftLength =
+				LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT.length();
 
 			pageExperience.setExternalReferenceCode(
 				draftExternalReferenceCode.substring(
 					0,
-					draftExternalReferenceCode.length() -
-						LayoutConstants.ERC_SUFFIX_DRAFT.length()));
+					draftExternalReferenceCode.length() - suffixDraftLength));
 		}
 		else {
 			pageExperience.setExternalReferenceCode(
 				draftExternalReferenceCode +
-					LayoutConstants.ERC_SUFFIX_PUBLISHED);
+					LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_PUBLISHED);
 		}
 
 		return pageExperience;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageExperiencesTestUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageExperiencesTestUtil.java
@@ -65,7 +65,6 @@ public class PageExperiencesTestUtil {
 			PageExperience pageExperience = pageExperiencesByKey.get(
 				expectedPageExperience.getKey());
 
-			Assert.assertNotNull(pageExperience);
 			Assert.assertEquals(
 				expectedPageExperience.getExternalReferenceCode(),
 				pageExperience.getExternalReferenceCode());

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageExperiencesTestUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageExperiencesTestUtil.java
@@ -112,16 +112,13 @@ public class PageExperiencesTestUtil {
 		String externalReferenceCode, PageElement[] pageElements,
 		String pageSpecificationExternalReferenceCode, String uuid) {
 
-		PageExperience pageExperience = new PageExperience();
+		PageExperience pageExperience = getPageExperience(
+			externalReferenceCode, SegmentsExperienceConstants.KEY_DEFAULT, 0,
+			uuid);
 
-		pageExperience.setExternalReferenceCode(externalReferenceCode);
-		pageExperience.setKey(SegmentsExperienceConstants.KEY_DEFAULT);
-		pageExperience.setName_i18n(
-			Collections.singletonMap("en-US", RandomTestUtil.randomString()));
 		pageExperience.setPageElements(pageElements);
 		pageExperience.setPageSpecificationExternalReferenceCode(
 			pageSpecificationExternalReferenceCode);
-		pageExperience.setUuid(uuid);
 
 		return pageExperience;
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageExperiencesTestUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageExperiencesTestUtil.java
@@ -272,8 +272,6 @@ public class PageExperiencesTestUtil {
 
 		PageExperience pageExperience = new PageExperience();
 
-		pageExperience.setKey(publishedPageExperience.getKey());
-
 		if (SegmentsExperienceConstants.KEY_DEFAULT.equals(
 				publishedPageExperience.getKey())) {
 
@@ -286,6 +284,8 @@ public class PageExperiencesTestUtil {
 				publishedPageExperience.getExternalReferenceCode() +
 					LayoutConstants.ERC_SUFFIX_DRAFT);
 		}
+
+		pageExperience.setKey(publishedPageExperience.getKey());
 
 		return pageExperience;
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageExperiencesTestUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageExperiencesTestUtil.java
@@ -8,6 +8,8 @@ package com.liferay.headless.admin.site.resource.v1_0.test.util;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageElement;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageElementDefinition;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageExperience;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalServiceUtil;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Layout;
@@ -21,8 +23,11 @@ import com.liferay.segments.model.SegmentsExperience;
 import com.liferay.segments.service.SegmentsExperienceLocalServiceUtil;
 import com.liferay.segments.test.util.SegmentsTestUtil;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.junit.Assert;
@@ -36,19 +41,47 @@ public class PageExperiencesTestUtil {
 		PageExperience[] expectedPageExperiences, Layout layout,
 		PageExperience[] pageExperiences) {
 
-		PageExperience expectedPageExperience = expectedPageExperiences[0];
+		if (_supportsMultiplePageExperiences(layout)) {
+			Assert.assertEquals(
+				Arrays.toString(pageExperiences),
+				expectedPageExperiences.length, pageExperiences.length);
+		}
+		else {
+			Assert.assertEquals(
+				Arrays.toString(expectedPageExperiences), 1,
+				expectedPageExperiences.length);
+			Assert.assertEquals(
+				Arrays.toString(pageExperiences), 1, pageExperiences.length);
+		}
 
-		Assert.assertEquals(
-			pageExperiences.toString(), 1, pageExperiences.length);
+		Map<String, PageExperience> pageExperiencesByKey = new HashMap<>();
 
-		PageExperience pageExperience = pageExperiences[0];
+		for (PageExperience pageExperience : pageExperiences) {
+			pageExperiencesByKey.put(pageExperience.getKey(), pageExperience);
+		}
 
-		Assert.assertEquals(
-			expectedPageExperience.getExternalReferenceCode(),
-			pageExperience.getExternalReferenceCode());
-		Assert.assertEquals(
-			layout.getExternalReferenceCode(),
-			pageExperience.getPageSpecificationExternalReferenceCode());
+		for (PageExperience expectedPageExperience : expectedPageExperiences) {
+			PageExperience pageExperience = pageExperiencesByKey.get(
+				expectedPageExperience.getKey());
+
+			Assert.assertNotNull(pageExperience);
+			Assert.assertEquals(
+				expectedPageExperience.getExternalReferenceCode(),
+				pageExperience.getExternalReferenceCode());
+			Assert.assertEquals(
+				layout.getExternalReferenceCode(),
+				pageExperience.getPageSpecificationExternalReferenceCode());
+
+			if (expectedPageExperience.getUuid() != null) {
+				Assert.assertEquals(
+					expectedPageExperience.getUuid(), pageExperience.getUuid());
+			}
+		}
+
+		PageExperience defaultPageExperience = pageExperiencesByKey.get(
+			SegmentsExperienceConstants.KEY_DEFAULT);
+
+		Assert.assertNotNull(defaultPageExperience);
 
 		SegmentsExperience segmentsExperience =
 			SegmentsExperienceLocalServiceUtil.fetchDefaultSegmentsExperience(
@@ -56,10 +89,7 @@ public class PageExperiencesTestUtil {
 
 		Assert.assertEquals(
 			segmentsExperience.getExternalReferenceCode(),
-			pageExperience.getExternalReferenceCode());
-
-		Assert.assertEquals(
-			expectedPageExperience.getUuid(), pageExperience.getUuid());
+			defaultPageExperience.getExternalReferenceCode());
 	}
 
 	public static PageExperience getDefaultPageExperience(
@@ -219,6 +249,22 @@ public class PageExperiencesTestUtil {
 		pageExperience.setPriority(priority);
 
 		return pageExperience;
+	}
+
+	private static boolean _supportsMultiplePageExperiences(Layout layout) {
+		if (!layout.isTypeContent()) {
+			return false;
+		}
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			LayoutPageTemplateEntryLocalServiceUtil.
+				fetchLayoutPageTemplateEntryByPlid(layout.getPlid());
+
+		if (layoutPageTemplateEntry == null) {
+			return true;
+		}
+
+		return false;
 	}
 
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageSpecificationsTestUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageSpecificationsTestUtil.java
@@ -424,6 +424,34 @@ public class PageSpecificationsTestUtil {
 			null, scopeGroupId);
 	}
 
+	public static ContentPageSpecification
+		getContentPageSpecificationWithPageExperiences(
+			String contentPageSpecificationExternalReferenceCode,
+			String defaultPageExperienceExternalReferenceCode,
+			String defaultPageExperienceUuid, long groupId,
+			String pageExperienceExternalReferenceCode,
+			String pageExperienceKey, String pageExperienceUuid,
+			PageSpecification.Status status) {
+
+		PageExperience defaultPageExperience =
+			PageExperiencesTestUtil.getDefaultPageExperience(
+				defaultPageExperienceExternalReferenceCode,
+				PageElementsTestUtil.getPageElements(
+					RandomTestUtil.randomInt(1, 3), StringPool.BLANK, groupId),
+				contentPageSpecificationExternalReferenceCode,
+				defaultPageExperienceUuid);
+
+		PageExperience pageExperience =
+			PageExperiencesTestUtil.getPageExperience(
+				pageExperienceExternalReferenceCode, pageExperienceKey, 1,
+				pageExperienceUuid);
+
+		return getContentPageSpecification(
+			contentPageSpecificationExternalReferenceCode, null, null,
+			new PageExperience[] {defaultPageExperience, pageExperience},
+			groupId, status);
+	}
+
 	public static CustomField[] getCustomFields() {
 		return new CustomField[] {
 			_getCustomField(_EXPANDO_ATTRIBUTE_NAMES[0], (String)null),

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/model/listener/LayoutModelListener.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/model/listener/LayoutModelListener.java
@@ -167,7 +167,7 @@ public class LayoutModelListener extends BaseModelListener<Layout> {
 			GetterUtil.getString(
 				defaultSegmentsExperienceExternalReferenceCode,
 				layout.getExternalReferenceCode() +
-					LayoutConstants.ERC_SUFFIX_DEFAULT),
+					LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DEFAULT),
 			layout.getUserId(), layout.getPlid(), serviceContext);
 	}
 

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/model/listener/LayoutModelListener.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/model/listener/LayoutModelListener.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
@@ -36,6 +37,8 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.segments.constants.SegmentsExperienceConstants;
 import com.liferay.segments.model.SegmentsExperience;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
+
+import java.io.Serializable;
 
 import java.util.Objects;
 
@@ -156,11 +159,15 @@ public class LayoutModelListener extends BaseModelListener<Layout> {
 			GetterUtil.getString(
 				serviceContext.getAttribute("defaultSegmentsExperienceUuid")));
 
+		Serializable defaultSegmentsExperienceExternalReferenceCode =
+			serviceContext.getAttribute(
+				"defaultSegmentsExperienceExternalReferenceCode");
+
 		return _segmentsExperienceLocalService.addDefaultSegmentsExperience(
 			GetterUtil.getString(
-				serviceContext.getAttribute(
-					"defaultSegmentsExperienceExternalReferenceCode"),
-				layout.getExternalReferenceCode() + "-default"),
+				defaultSegmentsExperienceExternalReferenceCode,
+				layout.getExternalReferenceCode() +
+					LayoutConstants.ERC_SUFFIX_DEFAULT),
 			layout.getUserId(), layout.getPlid(), serviceContext);
 	}
 

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutLocalServiceTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutLocalServiceTest.java
@@ -154,29 +154,30 @@ public class LayoutLocalServiceTest {
 
 		Map<String, String> expectedExternalReferenceCodesMap =
 			HashMapBuilder.put(
-				LayoutConstants.ERC_SUFFIX_DEFAULT,
+				LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DEFAULT,
 				RandomTestUtil.randomString()
 			).put(
-				LayoutConstants.ERC_SUFFIX_DRAFT, RandomTestUtil.randomString()
+				LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT,
+				RandomTestUtil.randomString()
 			).put(
-				LayoutConstants.ERC_SUFFIX_DRAFT +
-					LayoutConstants.ERC_SUFFIX_DEFAULT,
+				LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT +
+					LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DEFAULT,
 				RandomTestUtil.randomString()
 			).build();
 
 		_serviceContext.setAttribute(
 			"defaultSegmentsExperienceExternalReferenceCode",
 			expectedExternalReferenceCodesMap.get(
-				LayoutConstants.ERC_SUFFIX_DEFAULT));
+				LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DEFAULT));
 		_serviceContext.setAttribute(
 			"draftLayoutDefaultSegmentsExperienceExternalReferenceCode",
 			expectedExternalReferenceCodesMap.get(
-				LayoutConstants.ERC_SUFFIX_DRAFT +
-					LayoutConstants.ERC_SUFFIX_DEFAULT));
+				LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT +
+					LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DEFAULT));
 		_serviceContext.setAttribute(
 			"draftLayoutExternalReferenceCode",
 			expectedExternalReferenceCodesMap.get(
-				LayoutConstants.ERC_SUFFIX_DRAFT));
+				LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT));
 
 		try {
 			layout = _layoutLocalService.addLayout(
@@ -1189,13 +1190,13 @@ public class LayoutLocalServiceTest {
 			segmentsExperience.getExternalReferenceCode(),
 			unsafeBiFunction.apply(
 				segmentsExperience.getExternalReferenceCode(),
-				LayoutConstants.ERC_SUFFIX_DEFAULT));
+				LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DEFAULT));
 
 		Assert.assertTrue(
 			draftLayout.getExternalReferenceCode(),
 			unsafeBiFunction.apply(
 				draftLayout.getExternalReferenceCode(),
-				LayoutConstants.ERC_SUFFIX_DRAFT));
+				LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT));
 
 		segmentsExperience =
 			_segmentsExperienceLocalService.fetchDefaultSegmentsExperience(
@@ -1205,8 +1206,8 @@ public class LayoutLocalServiceTest {
 			segmentsExperience.getExternalReferenceCode(),
 			unsafeBiFunction.apply(
 				segmentsExperience.getExternalReferenceCode(),
-				LayoutConstants.ERC_SUFFIX_DRAFT +
-					LayoutConstants.ERC_SUFFIX_DEFAULT));
+				LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT +
+					LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DEFAULT));
 	}
 
 	private void _assertSearch(

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutLocalServiceTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutLocalServiceTest.java
@@ -154,22 +154,29 @@ public class LayoutLocalServiceTest {
 
 		Map<String, String> expectedExternalReferenceCodesMap =
 			HashMapBuilder.put(
-				"-default", RandomTestUtil.randomString()
+				LayoutConstants.ERC_SUFFIX_DEFAULT,
+				RandomTestUtil.randomString()
 			).put(
-				"-draft", RandomTestUtil.randomString()
+				LayoutConstants.ERC_SUFFIX_DRAFT, RandomTestUtil.randomString()
 			).put(
-				"-draft-default", RandomTestUtil.randomString()
+				LayoutConstants.ERC_SUFFIX_DRAFT +
+					LayoutConstants.ERC_SUFFIX_DEFAULT,
+				RandomTestUtil.randomString()
 			).build();
 
 		_serviceContext.setAttribute(
 			"defaultSegmentsExperienceExternalReferenceCode",
-			expectedExternalReferenceCodesMap.get("-default"));
+			expectedExternalReferenceCodesMap.get(
+				LayoutConstants.ERC_SUFFIX_DEFAULT));
 		_serviceContext.setAttribute(
 			"draftLayoutDefaultSegmentsExperienceExternalReferenceCode",
-			expectedExternalReferenceCodesMap.get("-draft-default"));
+			expectedExternalReferenceCodesMap.get(
+				LayoutConstants.ERC_SUFFIX_DRAFT +
+					LayoutConstants.ERC_SUFFIX_DEFAULT));
 		_serviceContext.setAttribute(
 			"draftLayoutExternalReferenceCode",
-			expectedExternalReferenceCodesMap.get("-draft"));
+			expectedExternalReferenceCodesMap.get(
+				LayoutConstants.ERC_SUFFIX_DRAFT));
 
 		try {
 			layout = _layoutLocalService.addLayout(
@@ -1181,12 +1188,14 @@ public class LayoutLocalServiceTest {
 		Assert.assertTrue(
 			segmentsExperience.getExternalReferenceCode(),
 			unsafeBiFunction.apply(
-				segmentsExperience.getExternalReferenceCode(), "-default"));
+				segmentsExperience.getExternalReferenceCode(),
+				LayoutConstants.ERC_SUFFIX_DEFAULT));
 
 		Assert.assertTrue(
 			draftLayout.getExternalReferenceCode(),
 			unsafeBiFunction.apply(
-				draftLayout.getExternalReferenceCode(), "-draft"));
+				draftLayout.getExternalReferenceCode(),
+				LayoutConstants.ERC_SUFFIX_DRAFT));
 
 		segmentsExperience =
 			_segmentsExperienceLocalService.fetchDefaultSegmentsExperience(
@@ -1196,7 +1205,8 @@ public class LayoutLocalServiceTest {
 			segmentsExperience.getExternalReferenceCode(),
 			unsafeBiFunction.apply(
 				segmentsExperience.getExternalReferenceCode(),
-				"-draft-default"));
+				LayoutConstants.ERC_SUFFIX_DRAFT +
+					LayoutConstants.ERC_SUFFIX_DEFAULT));
 	}
 
 	private void _assertSearch(

--- a/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/internal/upgrade/v1_4_2/LayoutUtilityPageEntryLayoutExternalReferenceCodeUpgradeProcess.java
+++ b/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/internal/upgrade/v1_4_2/LayoutUtilityPageEntryLayoutExternalReferenceCodeUpgradeProcess.java
@@ -8,6 +8,7 @@ package com.liferay.layout.utility.page.internal.upgrade.v1_4_2;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.LoggingTimer;
 
@@ -54,7 +55,8 @@ public class LayoutUtilityPageEntryLayoutExternalReferenceCodeUpgradeProcess
 					long plid = (Long)values[1];
 
 					String draftLayoutExternalReferenceCode =
-						layoutExternalReferenceCode + "-draft";
+						layoutExternalReferenceCode +
+							LayoutConstants.ERC_SUFFIX_DRAFT;
 
 					preparedStatement.setString(
 						1, draftLayoutExternalReferenceCode);
@@ -77,7 +79,8 @@ public class LayoutUtilityPageEntryLayoutExternalReferenceCodeUpgradeProcess
 				"update SegmentsExperience set externalReferenceCode = ? " +
 					"where plid = ? and segmentsExperienceKey = 'DEFAULT'")) {
 
-			preparedStatement.setString(1, externalReferenceCode + "-default");
+			preparedStatement.setString(
+				1, externalReferenceCode + LayoutConstants.ERC_SUFFIX_DEFAULT);
 			preparedStatement.setLong(2, plid);
 
 			preparedStatement.executeUpdate();

--- a/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/internal/upgrade/v1_4_2/LayoutUtilityPageEntryLayoutExternalReferenceCodeUpgradeProcess.java
+++ b/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/internal/upgrade/v1_4_2/LayoutUtilityPageEntryLayoutExternalReferenceCodeUpgradeProcess.java
@@ -56,7 +56,8 @@ public class LayoutUtilityPageEntryLayoutExternalReferenceCodeUpgradeProcess
 
 					String draftLayoutExternalReferenceCode =
 						layoutExternalReferenceCode +
-							LayoutConstants.ERC_SUFFIX_DRAFT;
+							LayoutConstants.
+								EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT;
 
 					preparedStatement.setString(
 						1, draftLayoutExternalReferenceCode);
@@ -80,7 +81,9 @@ public class LayoutUtilityPageEntryLayoutExternalReferenceCodeUpgradeProcess
 					"where plid = ? and segmentsExperienceKey = 'DEFAULT'")) {
 
 			preparedStatement.setString(
-				1, externalReferenceCode + LayoutConstants.ERC_SUFFIX_DEFAULT);
+				1,
+				externalReferenceCode +
+					LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DEFAULT);
 			preparedStatement.setLong(2, plid);
 
 			preparedStatement.executeUpdate();

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
@@ -501,7 +501,7 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 				GetterUtil.getString(
 					draftLayoutExternalReferenceCode,
 					layout.getExternalReferenceCode() +
-						LayoutConstants.ERC_SUFFIX_DRAFT),
+						LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT),
 				userId, groupId, privateLayout, parentLayoutId,
 				_classNameLocalService.getClassNameId(Layout.class),
 				layout.getPlid(), nameMap, titleMap, descriptionMap,
@@ -862,7 +862,7 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 				GetterUtil.getString(
 					draftLayoutExternalReferenceCode,
 					layout.getExternalReferenceCode() +
-						LayoutConstants.ERC_SUFFIX_DRAFT),
+						LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT),
 				userId, layout.getGroupId(), layout.isPrivateLayout(),
 				layout.getParentLayoutId(),
 				_classNameLocalService.getClassNameId(Layout.class),

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
@@ -494,11 +494,14 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 			serviceContext.setModifiedDate(
 				serviceContext.getModifiedDate(date));
 
+			Serializable draftLayoutExternalReferenceCode =
+				serviceContext.getAttribute("draftLayoutExternalReferenceCode");
+
 			addLayout(
 				GetterUtil.getString(
-					serviceContext.getAttribute(
-						"draftLayoutExternalReferenceCode"),
-					layout.getExternalReferenceCode() + "-draft"),
+					draftLayoutExternalReferenceCode,
+					layout.getExternalReferenceCode() +
+						LayoutConstants.ERC_SUFFIX_DRAFT),
 				userId, groupId, privateLayout, parentLayoutId,
 				_classNameLocalService.getClassNameId(Layout.class),
 				layout.getPlid(), nameMap, titleMap, descriptionMap,
@@ -852,11 +855,14 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 					"draftLayoutLayoutSetPrototypeLayoutERC"));
 			serviceContext.setModifiedDate(new Date());
 
+			Serializable draftLayoutExternalReferenceCode =
+				serviceContext.getAttribute("draftLayoutExternalReferenceCode");
+
 			layoutLocalService.addLayout(
 				GetterUtil.getString(
-					serviceContext.getAttribute(
-						"draftLayoutExternalReferenceCode"),
-					layout.getExternalReferenceCode() + "-draft"),
+					draftLayoutExternalReferenceCode,
+					layout.getExternalReferenceCode() +
+						LayoutConstants.ERC_SUFFIX_DRAFT),
 				userId, layout.getGroupId(), layout.isPrivateLayout(),
 				layout.getParentLayoutId(),
 				_classNameLocalService.getClassNameId(Layout.class),

--- a/portal-kernel/src/com/liferay/portal/kernel/model/LayoutConstants.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/LayoutConstants.java
@@ -16,6 +16,12 @@ public class LayoutConstants {
 
 	public static final long DEFAULT_PLID = 0;
 
+	public static final String ERC_SUFFIX_DEFAULT = "-default";
+
+	public static final String ERC_SUFFIX_DRAFT = "-draft";
+
+	public static final String ERC_SUFFIX_PUBLISHED = "-published";
+
 	public static final int FIRST_PRIORITY = 0;
 
 	public static final int FRIENDLY_URL_MAX_LENGTH = 255;

--- a/portal-kernel/src/com/liferay/portal/kernel/model/LayoutConstants.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/LayoutConstants.java
@@ -16,11 +16,13 @@ public class LayoutConstants {
 
 	public static final long DEFAULT_PLID = 0;
 
-	public static final String ERC_SUFFIX_DEFAULT = "-default";
+	public static final String EXTERNAL_REFERENCE_CODE_SUFFIX_DEFAULT =
+		"-default";
 
-	public static final String ERC_SUFFIX_DRAFT = "-draft";
+	public static final String EXTERNAL_REFERENCE_CODE_SUFFIX_DRAFT = "-draft";
 
-	public static final String ERC_SUFFIX_PUBLISHED = "-published";
+	public static final String EXTERNAL_REFERENCE_CODE_SUFFIX_PUBLISHED =
+		"-published";
 
 	public static final int FIRST_PRIORITY = 0;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-83094

/cc @ruben-pulido

## What Is Being Fixed

The headless-admin-site API did not allow creating a content page from a single ContentPageSpecification that carries its draft and/or published variant along with their page experiences. A client that supplied only one specification had no way to create the page and let the server derive the counterpart, so creating a content page together with its experiences in a single request was not possible.

## How It Is Being Fixed

POST and PUT /site-pages now accept a single ContentPageSpecification. The expansion lives in the new PageSpecificationUtil, which derives the missing counterpart specification, rewrites the external reference codes with the draft and published suffixes, and walks the page-element tree of every page experience to adjust the fragment and widget instance external reference codes accordingly. The ERC suffix constants were extracted to LayoutConstants so the headless layer and the portal service share a single definition. Integration tests cover the POST and PUT round-trips for both fragment and widget instances and for content pages with multiple page experiences.

## PR Check

**pr-check: PASS** — tested on `162666a65d292c3118d77ec39c9ced801c187b77`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Service Builder | PASS |
| Source Format | PASS |
| Full Portal Build | PASS |
| Structural Smoke | PASS (see note) |

> Note: Structural Smoke ran all five smoke classes; four pass. `Log4jConfigUtilTest` fails locally on a Whip code-coverage assertion (`Log4jConfigUtil` lines 146–152, coverage 0.95) under a JVM class-sharing (CDS) warning. `Log4jConfigUtil` and its test are not in this branch's diff — they were last changed by LPD-82616 and LPD-81938, both already on master — so the failure is a pre-existing local-environment baseline artifact, not a regression from this branch. Recorded as a baseline exclusion.

<!-- pr-check {"result": "success", "sha": "162666a65d292c3118d77ec39c9ced801c187b77"} -->
