### PR TITLE
LRDOCS-17032 Add modules/util/semantic-search-cli/

### DIFF
--- a/modules/util/semantic-search-cli/README.md
+++ b/modules/util/semantic-search-cli/README.md
@@ -1,0 +1,218 @@
+# modules/util/semantic-search-cli
+
+A jar-based CLI for semantic search over a project's text corpus.
+Talks HTTP to Hugging Face's text-embeddings-inference (TEI) for
+embeddings, and uses the Qdrant Java client for vector ops. The
+bundled `docker-compose.yml` brings up both containers; the jar
+itself stays small and dependency-light.
+
+Skills and other agents invoke this jar by shell command — the
+subcommands, flags, and JSON output schema are the stable interface.
+
+## What gets indexed
+
+Files are selected by extension. The default is `.md`; set the
+`SEARCH_FILE_EXTS` env var to a comma-separated list to widen the
+walk:
+
+| Setting | Effect |
+| :--- | :--- |
+| (default) | Markdown only (`.md`). |
+| `SEARCH_FILE_EXTS=.java` | Java source only. |
+| `SEARCH_FILE_EXTS=.md,.java` | Markdown plus Java. |
+
+A language-appropriate chunker handles each extension. Markdown is
+split by `##` sections (heading-path becomes `[H1, H2]`); Java is
+split at top-level method signatures (heading-path becomes
+`[ClassName, methodName]`), after stripping the license header,
+`package` line, and the entire `import` block. A method larger than
+the size limit is split further at top-level statement boundaries, so
+a chunk never cuts mid-statement. Each Java chunk's embedded text is
+prefixed with a metadata header (file path and class/method scope) so
+the vector reflects where the code lives; the stored snippet stays the
+raw body.
+
+## Embedding model
+
+The model is a `docker-compose` concern, set by `SEARCH_MODEL_ID`
+(default `nomic-ai/CodeRankEmbed` — code-tuned, MIT, 768-dim — used for
+both Markdown and Java). A 384-dim model is a lighter, faster option
+where code-search quality is not needed.
+
+The model is asymmetric: `SEARCH_QUERY_PREFIX` supplies its query
+instruction (`Represent this query for searching relevant code: `),
+applied to query text only, never to indexed documents.
+
+Switching models forces a rebuild — the next ingest detects the changed
+vector dimension and drops the index automatically.
+
+## CLI contract
+
+```
+search ingest <dir> [--force]
+search query "<text>" [--top N] [--format text|json] [--path <dir-prefix>]
+search similar <file> [--top N] [--format text|json] [--path <dir-prefix>]
+search status
+```
+
+### Scoping a Search with `--path`
+
+`--path <dir-prefix>` restricts `query` and `similar` to chunks whose file lives under that directory prefix, relative to the index's ingest root. For example, against a whole-repo index:
+
+```
+search query "permission check on create" --path modules/apps/headless
+```
+
+returns only hits under `modules/apps/headless`, ignoring identical patterns elsewhere in the repo.
+
+This exists because retrieval precision falls as an index grows: similarity scores do not change, but a large corpus holds more near-duplicate chunks (generated `Base*` classes, repeated CRUD and permission patterns across modules) that can outrank the specific one you want. The filter is applied *inside* the vector search — Qdrant returns the closest chunks **under the prefix**, not the closest overall then filtered — so a focused query stays precise even against a whole-repo index. The intended pattern is **index wide, query narrow**: keep one comprehensive index and scope each query to the subtree in question.
+
+The prefix is matched against each chunk's ancestor directories (stored as `dir_prefixes` at ingest), so it must be relative to the root the index was built from. An index built from the liferay-portal checkout root takes repo-relative prefixes like `modules/apps/headless`. `--path` requires an index built with this field; re-ingest an older index to populate it.
+
+Exit codes:
+
+| Code | Meaning |
+| ---: | :--- |
+| 0 | Success. |
+| 1 | Bad input. |
+| 2 | Bad CLI usage. |
+| 3 | Index does not exist. |
+| 4 | Target file for `similar` has no extractable content. |
+| 5 | Qdrant unreachable. |
+| 6 | Internal error. |
+
+JSON output schema for `query` and `similar`:
+
+```json
+{
+	"chunk_id": "...",
+	"heading_path": [
+		"H1",
+		"H2"
+	],
+	"path": "...",
+	"score": 0.0,
+	"snippet": "..."
+}
+```
+
+## Runtime data location
+
+Persistent state — the Qdrant index and the downloaded embedding
+model — lives outside the calling project's checkout, as a sibling.
+The caller sets `SEARCH_DATA_HOME`; the default layout is:
+
+```
+<parent-of-project>/<project-basename>-tools/search/
+├── qdrant-data/   (vector index)
+└── model-cache/   (TEI's model cache)
+```
+
+Each worktree of a repo gets its own data home automatically because
+each worktree has a unique basename. Override the whole path with
+`SEARCH_DATA_HOME` to point at a shared or per-corpus directory.
+
+## Ports
+
+The stack binds three host ports, all on `127.0.0.1`. The defaults
+avoid Liferay's (notably Tomcat's 8080):
+
+| Service | Default host port | Override |
+| :--- | ---: | :--- |
+| TEI (HTTP) | 7997 | `SEARCH_TEI_PORT` |
+| Qdrant (HTTP) | 6333 | `SEARCH_QDRANT_HTTP_PORT` |
+| Qdrant (gRPC) | 6334 | `SEARCH_QDRANT_GRPC_PORT` |
+
+Only one stack runs at a time (fixed container names), so repeated runs
+never collide with each other. Override a port if another local service
+already holds it (for example, a Qdrant you run on 6333). The container
+ports and the CLI's connection target move together.
+
+## Acceleration
+
+The default `cpu-1.6` TEI image works on every supported platform —
+Intel/AMD x86, Apple Silicon (via ARM), any laptop with Docker. If
+your hardware can do better, override `TEI_IMAGE_TAG` before bringing
+the stack up:
+
+| Hardware | Recommended | Speedup over default |
+| :--- | :--- | :--- |
+| Intel CPU (10th gen+, Core Ultra, Xeon) | `TEI_IMAGE_TAG=cpu-ipex-1.6` | ~2–4× |
+| Apple Silicon (M1/M2/M3) | default (`cpu-1.6`) | already fast via native ARM + AMX |
+| NVIDIA discrete GPU | `TEI_IMAGE_TAG=89-1.6` (match your compute capability) + add a `deploy.resources.reservations.devices` block to docker-compose.yml | 10–50× |
+| Intel Arc iGPU (Arc 140T etc.) / Apple Metal | not supported by TEI today | — |
+| AMD ROCm | not supported by TEI today | — |
+
+```bash
+TEI_IMAGE_TAG=cpu-ipex-1.6 docker compose up -d
+```
+
+Intel Arc and Apple Silicon GPU acceleration would require switching
+the inference backend (Optimum-Intel / OpenVINO, or CoreML); not in
+scope for this module. Until that lands, the practical answer for
+laptops without NVIDIA is: index once on the fastest available
+machine, share the result. The data layout supports this — see
+`SEARCH_DATA_HOME` above; the index is a self-contained directory
+that can be tarred up and distributed.
+
+## Use cases
+
+### Technical writer in `liferay-learn`
+
+Index the English docs corpus, then surface related articles when
+writing or reviewing.
+
+```bash
+cd ~/projects/liferay-learn
+search ingest docs/dxp/latest/en/                            # ~14 min first run, seconds incremental
+search query "client extension deployment"                   # natural-language → article
+search similar docs/dxp/latest/en/some-article.md            # related-article surface
+```
+
+Default extension (`.md`) is the right setting; no env var needed.
+
+### Developer working in `liferay-portal`
+
+Index the Java source of one or more modules, then find code by
+intent or by example.
+
+```bash
+cd ~/projects/liferay-portal
+SEARCH_FILE_EXTS=.java search ingest modules/apps/headless/headless-delivery/
+
+search query "REST endpoint that lists comments for a blog posting"
+search similar modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/CommentResourceImpl.java
+```
+
+`search query` returns method-level hits with a `Class > method`
+heading path. `search similar <path>` finds peer implementations
+across the indexed subtree.
+
+Scope each ingest to what you actually need (a module or two);
+indexing the entire `modules/apps/` tree is possible but takes
+hours and is rarely what you want.
+
+### Content engineer cross-referencing docs against portal source
+
+Maintain two indices side by side — one per repo, one per corpus.
+Because `SEARCH_DATA_HOME` defaults to a per-checkout sibling
+directory, the two indices stay isolated automatically.
+
+```bash
+# Index 1: liferay-learn docs (default extension)
+cd ~/projects/liferay-learn
+search ingest docs/dxp/latest/en/
+
+# Index 2: liferay-portal Java for the same feature area
+cd ~/projects/liferay-portal
+SEARCH_FILE_EXTS=.java search ingest modules/apps/headless/headless-delivery/
+
+# Query each in its own checkout
+( cd ~/projects/liferay-learn   && search query "client extension manifest" )
+( cd ~/projects/liferay-portal  && search query "client extension manifest" )
+```
+
+The pattern generalizes to any number of repos: cd into the
+checkout that contains the corpus you want to search, run the same
+CLI. The data-home resolution handles separation; you don't need to
+juggle collection names.

--- a/modules/util/semantic-search-cli/README.md
+++ b/modules/util/semantic-search-cli/README.md
@@ -144,7 +144,7 @@ the stack up:
 | AMD ROCm | not supported by TEI today | — |
 
 ```bash
-TEI_IMAGE_TAG=cpu-ipex-1.6 docker compose up -d
+TEI_IMAGE_TAG=cpu-ipex-1.6 docker compose up --detach
 ```
 
 Intel Arc and Apple Silicon GPU acceleration would require switching
@@ -164,7 +164,7 @@ writing or reviewing.
 
 ```bash
 cd ~/projects/liferay-learn
-search ingest docs/dxp/latest/en/                            # ~14 min first run, seconds incremental
+search ingest docs/dxp/latest/en                            # ~14 min first run, seconds incremental
 search query "client extension deployment"                   # natural-language → article
 search similar docs/dxp/latest/en/some-article.md            # related-article surface
 ```
@@ -178,7 +178,7 @@ intent or by example.
 
 ```bash
 cd ~/projects/liferay-portal
-SEARCH_FILE_EXTS=.java search ingest modules/apps/headless/headless-delivery/
+SEARCH_FILE_EXTS=.java search ingest modules/apps/headless/headless-delivery
 
 search query "REST endpoint that lists comments for a blog posting"
 search similar modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/CommentResourceImpl.java
@@ -201,11 +201,11 @@ directory, the two indices stay isolated automatically.
 ```bash
 # Index 1: liferay-learn docs (default extension)
 cd ~/projects/liferay-learn
-search ingest docs/dxp/latest/en/
+search ingest docs/dxp/latest/en
 
 # Index 2: liferay-portal Java for the same feature area
 cd ~/projects/liferay-portal
-SEARCH_FILE_EXTS=.java search ingest modules/apps/headless/headless-delivery/
+SEARCH_FILE_EXTS=.java search ingest modules/apps/headless/headless-delivery
 
 # Query each in its own checkout
 ( cd ~/projects/liferay-learn   && search query "client extension manifest" )
@@ -214,5 +214,5 @@ SEARCH_FILE_EXTS=.java search ingest modules/apps/headless/headless-delivery/
 
 The pattern generalizes to any number of repos: cd into the
 checkout that contains the corpus you want to search, run the same
-CLI. The data-home resolution handles separation; you don't need to
+CLI. The data-home resolution handles separation; you do not need to
 juggle collection names.

--- a/modules/util/semantic-search-cli/bnd.bnd
+++ b/modules/util/semantic-search-cli/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Semantic Search CLI
+Bundle-SymbolicName: com.liferay.semantic.search.cli
+Bundle-Version: 1.0.0
+Main-Class: com.liferay.semantic.search.cli.SemanticSearchCLI

--- a/modules/util/semantic-search-cli/build.gradle
+++ b/modules/util/semantic-search-cli/build.gradle
@@ -1,0 +1,23 @@
+sourceCompatibility = "11"
+targetCompatibility = "11"
+
+dependencies {
+	api group: "com.google.protobuf", name: "protobuf-java", version: "3.25.5"
+	api group: "io.grpc", name: "grpc-netty-shaded", version: "1.75.0"
+	api group: "io.grpc", name: "grpc-protobuf", version: "1.75.0"
+	api group: "io.grpc", name: "grpc-stub", version: "1.75.0"
+	api group: "io.qdrant", name: "client", version: "1.13.0"
+	api group: "org.json", name: "json", version: "20231013"
+	compileInclude group: "com.liferay", name: "com.liferay.petra.lang", version: "6.0.0"
+	compileInclude group: "com.liferay", name: "com.liferay.petra.string", version: "5.3.7"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	testImplementation group: "junit", name: "junit", version: "4.13.1"
+}
+
+liferay {
+	deployDir = "../../../tools/sdk/dependencies/com.liferay.semantic.search.cli/lib"
+}
+
+test {
+	jvmArgs "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED"
+}

--- a/modules/util/semantic-search-cli/docker-compose.yml
+++ b/modules/util/semantic-search-cli/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+    qdrant:
+        container_name: search-qdrant
+        image: qdrant/qdrant:v1.12.4
+        ports:
+            -   "127.0.0.1:${SEARCH_QDRANT_HTTP_PORT:-6333}:6333"
+            -   "127.0.0.1:${SEARCH_QDRANT_GRPC_PORT:-6334}:6334"
+        restart: unless-stopped
+        volumes:
+            -   ${SEARCH_DATA_HOME:?must be set; see modules/util/semantic-search-cli/README.md}/qdrant-data:/qdrant/storage
+    tei:
+        container_name: search-tei
+        environment:
+            AUTO_TRUNCATE: "true"
+            MAX_CLIENT_BATCH_SIZE: "64"
+            MODEL_ID: ${SEARCH_MODEL_ID:-nomic-ai/CodeRankEmbed}
+        image: ghcr.io/huggingface/text-embeddings-inference:${TEI_IMAGE_TAG:-cpu-1.6}
+        ports:
+            -   "127.0.0.1:${SEARCH_TEI_PORT:-7997}:80"
+        restart: unless-stopped
+        volumes:
+            -   ${SEARCH_DATA_HOME:?must be set; see modules/util/semantic-search-cli/README.md}/model-cache:/data

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/SemanticSearchCLI.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/SemanticSearchCLI.java
@@ -1,0 +1,93 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
+import com.liferay.semantic.search.cli.command.Command;
+import com.liferay.semantic.search.cli.command.IngestCommand;
+import com.liferay.semantic.search.cli.command.QueryCommand;
+import com.liferay.semantic.search.cli.command.SimilarCommand;
+import com.liferay.semantic.search.cli.command.StatusCommand;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Entry point for the semantic-search CLI. Subcommands, flags, and the
+ * JSON output schema are the stable interface; skills and agents shell
+ * out to this jar by command.
+ *
+ * @author JR Houn
+ */
+public class SemanticSearchCLI {
+
+	public static void main(String[] args) {
+		Map<String, Command> commands =
+			LinkedHashMapBuilder.<String, Command>put(
+				"ingest", new IngestCommand()
+			).put(
+				"query", new QueryCommand()
+			).put(
+				"similar", new SimilarCommand()
+			).put(
+				"status", new StatusCommand()
+			).build();
+
+		if ((args.length == 0) || Objects.equals(args[0], "--help") ||
+			Objects.equals(args[0], "-h")) {
+
+			_printUsage(commands);
+
+			System.exit((args.length == 0) ? 2 : 0);
+		}
+
+		String commandName = args[0];
+
+		Command command = commands.get(commandName);
+
+		if (command == null) {
+			System.err.println("search: unknown command: " + commandName);
+			System.err.println();
+
+			_printUsage(commands);
+
+			System.exit(2);
+		}
+
+		String[] commandArgs = Arrays.copyOfRange(args, 1, args.length);
+
+		try {
+			int exitCode = command.run(commandArgs);
+
+			System.exit(exitCode);
+		}
+		catch (Exception exception) {
+			System.err.println(
+				"search: internal error: " + exception.getMessage());
+
+			exception.printStackTrace(System.err);
+
+			System.exit(6);
+		}
+	}
+
+	private static void _printUsage(Map<String, Command> commands) {
+		System.err.println("Usage: search <command> [args...]");
+		System.err.println();
+		System.err.println("Commands:");
+
+		for (Map.Entry<String, Command> entry : commands.entrySet()) {
+			Command command = entry.getValue();
+
+			System.err.println(
+				StringBundler.concat(
+					"  ", entry.getKey(), "  ", command.description()));
+		}
+	}
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/chunker/Chunker.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/chunker/Chunker.java
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.chunker;
+
+import com.liferay.semantic.search.cli.util.Chunk;
+
+import java.util.List;
+
+/**
+ * Contract for a language-specific chunker: splits one file's text into
+ * embeddable {@link Chunk}s. {@link Chunkers} selects an implementation by
+ * file extension.
+ *
+ * @author JR Houn
+ */
+public interface Chunker {
+
+	public List<Chunk> parse(String text, String relPath);
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/chunker/Chunkers.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/chunker/Chunkers.java
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.chunker;
+
+import com.liferay.semantic.search.cli.util.Chunk;
+
+import java.util.List;
+
+/**
+ * Dispatches to a language-specific chunker by file extension.
+ *
+ * @author JR Houn
+ */
+public class Chunkers {
+
+	public static List<Chunk> parse(String text, String relPath) {
+		if (relPath.endsWith(".java")) {
+			return _JAVA_CHUNKER.parse(text, relPath);
+		}
+
+		return _MARKDOWN_CHUNKER.parse(text, relPath);
+	}
+
+	private static final JavaChunker _JAVA_CHUNKER = new JavaChunker();
+
+	private static final MarkdownChunker _MARKDOWN_CHUNKER =
+		new MarkdownChunker();
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/chunker/Chunkers.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/chunker/Chunkers.java
@@ -24,9 +24,8 @@ public class Chunkers {
 		return _MARKDOWN_CHUNKER.parse(text, relPath);
 	}
 
-	private static final JavaChunker _JAVA_CHUNKER = new JavaChunker();
+	private static final Chunker _JAVA_CHUNKER = new JavaChunker();
 
-	private static final MarkdownChunker _MARKDOWN_CHUNKER =
-		new MarkdownChunker();
+	private static final Chunker _MARKDOWN_CHUNKER = new MarkdownChunker();
 
 }

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/chunker/JavaChunker.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/chunker/JavaChunker.java
@@ -8,6 +8,7 @@ package com.liferay.semantic.search.cli.chunker;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.semantic.search.cli.util.Chunk;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import java.util.ArrayList;
@@ -40,8 +41,9 @@ import java.util.regex.Pattern;
  *
  * @author JR Houn
  */
-public class JavaChunker {
+public class JavaChunker implements Chunker {
 
+	@Override
 	public List<Chunk> parse(String text, String relPath) {
 		String className = _classNameFromFile(relPath);
 
@@ -117,10 +119,9 @@ public class JavaChunker {
 	}
 
 	private String _classNameFromFile(String relPath) {
-		String name = String.valueOf(
-			Paths.get(
-				relPath
-			).getFileName());
+		Path path = Paths.get(relPath);
+
+		String name = String.valueOf(path.getFileName());
 
 		return name.replaceFirst("\\.java$", "");
 	}
@@ -135,13 +136,13 @@ public class JavaChunker {
 			return;
 		}
 
-		List<String> parts = _splitCode(stripped, _MAX_CODE_CHARS);
+		List<String> parts = _splitCode(stripped, 4000);
 
 		String headingSlug = String.join(" > ", headingPath);
 
-		// Prepended to the embedded text (not the stored snippet) so the
-		// vector reflects where the code lives — file path and class/method
-		// scope. See Chunk.embeddingText.
+		// The header is prepended to the embedded text (not the stored
+		// snippet) so the vector reflects where the code lives: its file
+		// path and class/method scope. See Chunk.embeddingText.
 
 		String header = StringBundler.concat(
 			"// File: ", relPath, "\n// ", headingSlug);
@@ -171,15 +172,17 @@ public class JavaChunker {
 			return parts;
 		}
 
-		StringBuilder current = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		int depth = 0;
 
 		for (String line : text.split("\n", -1)) {
-			current.append(line);
-			current.append("\n");
+			sb.append(line);
+			sb.append("\n");
 
-			for (int i = 0; i < line.length(); i++) {
+			int lineLength = line.length();
+
+			for (int i = 0; i < lineLength; i++) {
 				char c = line.charAt(i);
 
 				if (c == '{') {
@@ -201,8 +204,8 @@ public class JavaChunker {
 				atBoundary = true;
 			}
 
-			if ((current.length() >= maxChars) && atBoundary) {
-				String part = current.toString();
+			if ((sb.length() >= maxChars) && atBoundary) {
+				String part = sb.toString();
 
 				part = part.strip();
 
@@ -210,11 +213,11 @@ public class JavaChunker {
 					parts.add(part);
 				}
 
-				current.setLength(0);
+				sb.setIndex(0);
 			}
 		}
 
-		String tail = current.toString();
+		String tail = sb.toString();
 
 		tail = tail.strip();
 
@@ -224,8 +227,6 @@ public class JavaChunker {
 
 		return parts;
 	}
-
-	private static final int _MAX_CODE_CHARS = 4000;
 
 	private static final Pattern _classPattern = Pattern.compile(
 		"\\b(class|interface|enum|@interface)\\s+(\\w+)");

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/chunker/JavaChunker.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/chunker/JavaChunker.java
@@ -1,0 +1,242 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.chunker;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.semantic.search.cli.util.Chunk;
+
+import java.nio.file.Paths;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Splits a Java source file into method-scoped chunks.
+ *
+ *   1. Strip the license header (everything before the {@code package}
+ *      line).
+ *   2. Strip the {@code package} declaration and the entire
+ *      {@code import} block — both are pure boilerplate that
+ *      otherwise produces near-identical first chunks across every
+ *      file in the same package and ruins code-to-code similarity.
+ *   3. Capture the top-level class/interface name as the H1 analog.
+ *   4. Each top-level method signature begins a chunk; the chunk runs
+ *      to just before the next method signature.
+ *   5. The class-level content before the first method (class javadoc,
+ *      fields, constants) is the intro chunk with heading
+ *      {@code [className]}.
+ *   6. Methods longer than the size limit are split at top-level
+ *      statement boundaries, never mid-statement, sharing the same
+ *      heading_path.
+ *   7. Each chunk's embedded text is prefixed with a metadata header
+ *      (file path and class/method scope) so the vector reflects where
+ *      the code lives; the stored snippet stays the raw body.
+ *
+ * @author JR Houn
+ */
+public class JavaChunker {
+
+	public List<Chunk> parse(String text, String relPath) {
+		String className = _classNameFromFile(relPath);
+
+		Matcher classMatcher = _classPattern.matcher(text);
+
+		if (classMatcher.find()) {
+			className = classMatcher.group(2);
+		}
+
+		Matcher packageMatcher = _packagePattern.matcher(text);
+
+		String body = text;
+
+		if (packageMatcher.find()) {
+			body = text.substring(packageMatcher.end());
+		}
+
+		Matcher importsMatcher = _importsPattern.matcher(body);
+
+		if (importsMatcher.find() && (importsMatcher.start() < 100)) {
+			body = body.substring(importsMatcher.end());
+		}
+
+		body = body.replaceFirst("\\A\\s+", "");
+
+		List<int[]> methodSigs = new ArrayList<>();
+
+		Matcher sigMatcher = _methodSigPattern.matcher(body);
+
+		while (sigMatcher.find()) {
+			methodSigs.add(new int[] {sigMatcher.start(), sigMatcher.end()});
+		}
+
+		List<Chunk> chunks = new ArrayList<>();
+
+		if (methodSigs.isEmpty()) {
+			_emit(chunks, relPath, Arrays.asList(className), body);
+
+			return chunks;
+		}
+
+		String intro = body.substring(0, methodSigs.get(0)[0]);
+
+		_emit(chunks, relPath, Arrays.asList(className), intro);
+
+		for (int i = 0; i < methodSigs.size(); i++) {
+			int[] sig = methodSigs.get(i);
+
+			int end = body.length();
+
+			if ((i + 1) < methodSigs.size()) {
+				end = methodSigs.get(i + 1)[0];
+			}
+
+			String signatureLine = body.substring(sig[0], sig[1]);
+
+			Matcher nameMatcher = _methodNamePattern.matcher(signatureLine);
+
+			String methodName = "method";
+
+			if (nameMatcher.find()) {
+				methodName = nameMatcher.group(1);
+			}
+
+			String methodBlock = body.substring(sig[0], end);
+
+			_emit(
+				chunks, relPath, Arrays.asList(className, methodName),
+				methodBlock);
+		}
+
+		return chunks;
+	}
+
+	private String _classNameFromFile(String relPath) {
+		String name = String.valueOf(
+			Paths.get(
+				relPath
+			).getFileName());
+
+		return name.replaceFirst("\\.java$", "");
+	}
+
+	private void _emit(
+		List<Chunk> chunks, String relPath, List<String> headingPath,
+		String sectionText) {
+
+		String stripped = sectionText.strip();
+
+		if (stripped.isEmpty()) {
+			return;
+		}
+
+		List<String> parts = _splitCode(stripped, _MAX_CODE_CHARS);
+
+		String headingSlug = String.join(" > ", headingPath);
+
+		// Prepended to the embedded text (not the stored snippet) so the
+		// vector reflects where the code lives — file path and class/method
+		// scope. See Chunk.embeddingText.
+
+		String header = StringBundler.concat(
+			"// File: ", relPath, "\n// ", headingSlug);
+
+		for (int idx = 0; idx < parts.size(); idx++) {
+			String chunkId = StringBundler.concat(
+				relPath, "#", headingSlug, "#", idx);
+
+			chunks.add(
+				new Chunk(
+					chunkId, relPath, headingPath, parts.get(idx), header));
+		}
+	}
+
+	/**
+	 * Splits an oversized section at top-level statement boundaries rather
+	 * than at arbitrary word offsets, so a chunk never cuts mid-statement.
+	 * A break is allowed only after a line that ends a statement or block
+	 * while the running brace depth is back at body level.
+	 */
+	private List<String> _splitCode(String text, int maxChars) {
+		List<String> parts = new ArrayList<>();
+
+		if (text.length() <= maxChars) {
+			parts.add(text);
+
+			return parts;
+		}
+
+		StringBuilder current = new StringBuilder();
+
+		int depth = 0;
+
+		for (String line : text.split("\n", -1)) {
+			current.append(line);
+			current.append("\n");
+
+			for (int i = 0; i < line.length(); i++) {
+				char c = line.charAt(i);
+
+				if (c == '{') {
+					depth++;
+				}
+				else if (c == '}') {
+					depth = Math.max(0, depth - 1);
+				}
+			}
+
+			String trimmed = line.strip();
+
+			boolean atBoundary = false;
+
+			if ((depth <= 1) &&
+				(trimmed.isEmpty() || trimmed.endsWith(";") ||
+				 trimmed.endsWith("}"))) {
+
+				atBoundary = true;
+			}
+
+			if ((current.length() >= maxChars) && atBoundary) {
+				String part = current.toString();
+
+				part = part.strip();
+
+				if (!part.isEmpty()) {
+					parts.add(part);
+				}
+
+				current.setLength(0);
+			}
+		}
+
+		String tail = current.toString();
+
+		tail = tail.strip();
+
+		if (!tail.isEmpty()) {
+			parts.add(tail);
+		}
+
+		return parts;
+	}
+
+	private static final int _MAX_CODE_CHARS = 4000;
+
+	private static final Pattern _classPattern = Pattern.compile(
+		"\\b(class|interface|enum|@interface)\\s+(\\w+)");
+	private static final Pattern _importsPattern = Pattern.compile(
+		"(?m)(^import\\s+[^\\n]+;\\s*\\n)" +
+			"(?:\\s*(?:import\\s+[^\\n]+;\\s*\\n)?\\n?)*");
+	private static final Pattern _methodNamePattern = Pattern.compile(
+		"\\s(\\w+)\\s*\\(");
+	private static final Pattern _methodSigPattern = Pattern.compile(
+		"(?m)^\\t(?:public|protected|private)\\b[^=\\n]*\\([^)]*\\)[^\\n]*$");
+	private static final Pattern _packagePattern = Pattern.compile(
+		"(?m)^package\\s+[\\w.]+;\\s*\\n");
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/chunker/MarkdownChunker.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/chunker/MarkdownChunker.java
@@ -1,0 +1,214 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.chunker;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.semantic.search.cli.util.Chunk;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Splits a Markdown document into chunks for embedding:
+ *
+ *   1. Strip YAML front matter (`---` block at the start).
+ *   2. Capture the H1 as the document title. If absent, use the file
+ *      path as the title.
+ *   3. The intro between H1 and the first H2 is one chunk with
+ *      heading_path = [h1].
+ *   4. Each ## section is one chunk with heading_path = [h1, h2].
+ *   5. Sections longer than CHUNK_WINDOW_WORDS are split with a
+ *      sliding window of CHUNK_WINDOW_WORDS / CHUNK_OVERLAP_WORDS,
+ *      sharing the same heading_path.
+ *   6. H3+ headings stay inside the chunk body.
+ *
+ * @author JR Houn
+ */
+public class MarkdownChunker {
+
+	public static final int CHUNK_OVERLAP_WORDS = 60;
+
+	public static final int CHUNK_WINDOW_WORDS = 350;
+
+	public List<Chunk> parse(String text, String relPath) {
+		String body = _stripFrontMatter(text);
+
+		Matcher h1Matcher = _h1Pattern.matcher(body);
+
+		String h1 = relPath;
+
+		int introStart = 0;
+
+		if (h1Matcher.find()) {
+			String h1Group = h1Matcher.group(1);
+
+			h1 = h1Group.trim();
+
+			introStart = h1Matcher.end();
+		}
+
+		List<int[]> h2Matches = new ArrayList<>();
+
+		Matcher h2Matcher = _h2Pattern.matcher(body);
+
+		while (h2Matcher.find()) {
+			h2Matches.add(
+				new int[] {
+					h2Matcher.start(), h2Matcher.end(),
+					_findEndOfLine(body, h2Matcher.end())
+				});
+		}
+
+		List<RawSection> rawSections = new ArrayList<>();
+
+		if (h2Matches.isEmpty()) {
+			String content = body.substring(introStart);
+
+			content = content.trim();
+
+			if (!content.isEmpty()) {
+				rawSections.add(new RawSection(Arrays.asList(h1), content));
+			}
+		}
+		else {
+			int firstH2Start = h2Matches.get(0)[0];
+
+			String intro = body.substring(introStart, firstH2Start);
+
+			intro = intro.trim();
+
+			if (!intro.isEmpty()) {
+				rawSections.add(new RawSection(Arrays.asList(h1), intro));
+			}
+
+			for (int i = 0; i < h2Matches.size(); i++) {
+				int[] match = h2Matches.get(i);
+
+				String h2Heading = _h2Text(body, match);
+
+				int sectionStart = match[1];
+
+				int sectionEnd =
+					((i + 1) < h2Matches.size()) ? h2Matches.get(i + 1)[0] :
+						body.length();
+
+				String sectionBody = body.substring(sectionStart, sectionEnd);
+
+				sectionBody = sectionBody.trim();
+
+				if (!sectionBody.isEmpty()) {
+					rawSections.add(
+						new RawSection(
+							Arrays.asList(h1, h2Heading), sectionBody));
+				}
+			}
+		}
+
+		List<Chunk> chunks = new ArrayList<>();
+
+		for (RawSection rawSection : rawSections) {
+			List<String> parts = _splitByWords(
+				rawSection._text, CHUNK_WINDOW_WORDS, CHUNK_OVERLAP_WORDS);
+
+			String headingSlug = String.join(" > ", rawSection._headingPath);
+
+			for (int idx = 0; idx < parts.size(); idx++) {
+				String chunkId = StringBundler.concat(
+					relPath, "#", headingSlug, "#", idx);
+
+				chunks.add(
+					new Chunk(
+						chunkId, relPath, rawSection._headingPath,
+						parts.get(idx)));
+			}
+		}
+
+		return chunks;
+	}
+
+	private int _findEndOfLine(String body, int from) {
+		int newline = body.indexOf('\n', from);
+
+		if (newline < 0) {
+			return body.length();
+		}
+
+		return newline;
+	}
+
+	private String _h2Text(String body, int[] match) {
+		String fullMatch = body.substring(match[0], match[1]);
+
+		String head = fullMatch.substring(3);
+
+		return head.trim();
+	}
+
+	private List<String> _splitByWords(String text, int window, int overlap) {
+		String[] words = text.split("\\s+");
+
+		List<String> result = new ArrayList<>();
+
+		if (words.length <= window) {
+			result.add(text);
+
+			return result;
+		}
+
+		int step = Math.max(window - overlap, 1);
+
+		for (int start = 0; start < words.length; start += step) {
+			int end = Math.min(start + window, words.length);
+
+			List<String> sub = Arrays.asList(words);
+
+			result.add(String.join(" ", sub.subList(start, end)));
+
+			if ((start + window) >= words.length) {
+				break;
+			}
+		}
+
+		return result;
+	}
+
+	private String _stripFrontMatter(String text) {
+		if (!text.startsWith("---\n") && !text.startsWith("---\r\n")) {
+			return text;
+		}
+
+		Matcher matcher = _frontMatterEndPattern.matcher(text);
+
+		if (matcher.find()) {
+			return text.substring(matcher.end());
+		}
+
+		return text;
+	}
+
+	private static final Pattern _frontMatterEndPattern = Pattern.compile(
+		"\\n---\\s*\\n");
+	private static final Pattern _h1Pattern = Pattern.compile(
+		"^#\\s+(.+?)\\s*$", Pattern.MULTILINE);
+	private static final Pattern _h2Pattern = Pattern.compile(
+		"^##\\s+.+?\\s*$", Pattern.MULTILINE);
+
+	private static class RawSection {
+
+		private RawSection(List<String> headingPath, String text) {
+			_headingPath = headingPath;
+			_text = text;
+		}
+
+		private final List<String> _headingPath;
+		private final String _text;
+
+	}
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/chunker/MarkdownChunker.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/chunker/MarkdownChunker.java
@@ -30,12 +30,13 @@ import java.util.regex.Pattern;
  *
  * @author JR Houn
  */
-public class MarkdownChunker {
+public class MarkdownChunker implements Chunker {
 
 	public static final int CHUNK_OVERLAP_WORDS = 60;
 
 	public static final int CHUNK_WINDOW_WORDS = 350;
 
+	@Override
 	public List<Chunk> parse(String text, String relPath) {
 		String body = _stripFrontMatter(text);
 
@@ -163,12 +164,12 @@ public class MarkdownChunker {
 
 		int step = Math.max(window - overlap, 1);
 
+		List<String> wordList = Arrays.asList(words);
+
 		for (int start = 0; start < words.length; start += step) {
 			int end = Math.min(start + window, words.length);
 
-			List<String> sub = Arrays.asList(words);
-
-			result.add(String.join(" ", sub.subList(start, end)));
+			result.add(String.join(" ", wordList.subList(start, end)));
 
 			if ((start + window) >= words.length) {
 				break;

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/client/QdrantClientWrapper.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/client/QdrantClientWrapper.java
@@ -42,21 +42,12 @@ public class QdrantClientWrapper {
 
 	public static final String META_COLLECTION = "meta";
 
-	public boolean collectionExists(String name) throws Exception {
-		QdrantClient qdrantClient = _client();
-
-		List<String> names = qdrantClient.listCollectionsAsync(
-		).get();
-
-		return names.contains(name);
-	}
-
 	public void deleteByRelPaths(List<String> relPaths) throws Exception {
 		if (relPaths.isEmpty()) {
 			return;
 		}
 
-		QdrantClient qdrantClient = _client();
+		QdrantClient qdrantClient = _getQdrantClient();
 
 		for (String relPath : relPaths) {
 			Points.Filter filter = Points.Filter.newBuilder(
@@ -86,7 +77,7 @@ public class QdrantClientWrapper {
 			return;
 		}
 
-		QdrantClient qdrantClient = _client();
+		QdrantClient qdrantClient = _getQdrantClient();
 
 		List<Points.PointId> ids = new ArrayList<>();
 
@@ -115,7 +106,7 @@ public class QdrantClientWrapper {
 	public void dropCollectionsIfVectorSizeChanged(int vectorSize)
 		throws Exception {
 
-		QdrantClient qdrantClient = _client();
+		QdrantClient qdrantClient = _getQdrantClient();
 
 		List<String> existing = qdrantClient.listCollectionsAsync(
 		).get();
@@ -141,7 +132,7 @@ public class QdrantClientWrapper {
 		System.err.println(
 			StringBundler.concat(
 				"search: embedding dimension changed (", storedSize, " -> ",
-				vectorSize, "); rebuilding the index."));
+				vectorSize, "); rebuilding the index"));
 
 		qdrantClient.deleteCollectionAsync(
 			COLLECTION
@@ -155,7 +146,7 @@ public class QdrantClientWrapper {
 	}
 
 	public void ensureCollection(String name, int vectorSize) throws Exception {
-		QdrantClient qdrantClient = _client();
+		QdrantClient qdrantClient = _getQdrantClient();
 
 		List<String> existing = qdrantClient.listCollectionsAsync(
 		).get();
@@ -191,7 +182,7 @@ public class QdrantClientWrapper {
 	}
 
 	public int getChunkCount() throws Exception {
-		QdrantClient qdrantClient = _client();
+		QdrantClient qdrantClient = _getQdrantClient();
 
 		Collections.CollectionInfo info = qdrantClient.getCollectionInfoAsync(
 			COLLECTION
@@ -200,13 +191,22 @@ public class QdrantClientWrapper {
 		return (int)info.getPointsCount();
 	}
 
-	public String getQdrantUrl() {
+	public String getQdrantURL() {
 		return StringBundler.concat("http://", _host(), ":", _port());
+	}
+
+	public boolean hasCollection(String name) throws Exception {
+		QdrantClient qdrantClient = _getQdrantClient();
+
+		List<String> names = qdrantClient.listCollectionsAsync(
+		).get();
+
+		return names.contains(name);
 	}
 
 	public boolean isReachable() {
 		try {
-			QdrantClient qdrantClient = _client();
+			QdrantClient qdrantClient = _getQdrantClient();
 
 			qdrantClient.listCollectionsAsync(
 			).get();
@@ -219,7 +219,7 @@ public class QdrantClientWrapper {
 	}
 
 	public Map<String, String> loadFileHashes() throws Exception {
-		QdrantClient qdrantClient = _client();
+		QdrantClient qdrantClient = _getQdrantClient();
 
 		Points.Filter filter = Points.Filter.newBuilder(
 		).addMust(
@@ -290,7 +290,7 @@ public class QdrantClientWrapper {
 	}
 
 	public MetaState readMetaState() throws Exception {
-		QdrantClient qdrantClient = _client();
+		QdrantClient qdrantClient = _getQdrantClient();
 
 		Points.ScrollResponse response = qdrantClient.scrollAsync(
 			Points.ScrollPoints.newBuilder(
@@ -341,14 +341,17 @@ public class QdrantClientWrapper {
 			(docCount != null) ? (int)docCount.getIntegerValue() : 0);
 	}
 
-	public List<Hit> search(float[] vector, int limit) throws Exception {
+	public List<SearchResult> search(float[] vector, int limit)
+		throws Exception {
+
 		return search(vector, limit, null);
 	}
 
-	public List<Hit> search(float[] vector, int limit, String pathPrefix)
+	public List<SearchResult> search(
+			float[] vector, int limit, String pathPrefix)
 		throws Exception {
 
-		QdrantClient qdrantClient = _client();
+		QdrantClient qdrantClient = _getQdrantClient();
 
 		List<Float> vectorList = new ArrayList<>(vector.length);
 
@@ -401,17 +404,19 @@ public class QdrantClientWrapper {
 			searchPointsBuilder.build()
 		).get();
 
-		List<Hit> hits = new ArrayList<>();
+		List<SearchResult> searchResults = new ArrayList<>();
 
-		for (Points.ScoredPoint scored : scoredPoints) {
-			Map<String, JsonWithInt.Value> payload = scored.getPayloadMap();
+		for (Points.ScoredPoint scoredPoint : scoredPoints) {
+			Map<String, JsonWithInt.Value> payload =
+				scoredPoint.getPayloadMap();
 
 			List<String> headingPath = new ArrayList<>();
 
-			JsonWithInt.Value hp = payload.get("heading_path");
+			JsonWithInt.Value headingPathValue = payload.get("heading_path");
 
-			if ((hp != null) && hp.hasListValue()) {
-				JsonWithInt.ListValue listValue = hp.getListValue();
+			if ((headingPathValue != null) && headingPathValue.hasListValue()) {
+				JsonWithInt.ListValue listValue =
+					headingPathValue.getListValue();
 
 				for (JsonWithInt.Value entry : listValue.getValuesList()) {
 					headingPath.add(entry.getStringValue());
@@ -422,14 +427,14 @@ public class QdrantClientWrapper {
 			JsonWithInt.Value chunkIdValue = payload.get("chunk_id");
 			JsonWithInt.Value textValue = payload.get("text");
 
-			hits.add(
-				new Hit(
-					relPathValue.getStringValue(), scored.getScore(),
+			searchResults.add(
+				new SearchResult(
+					relPathValue.getStringValue(), scoredPoint.getScore(),
 					chunkIdValue.getStringValue(), textValue.getStringValue(),
 					headingPath));
 		}
 
-		return hits;
+		return searchResults;
 	}
 
 	public void upsertChunks(List<Chunk> chunks, float[][] vectors)
@@ -439,7 +444,7 @@ public class QdrantClientWrapper {
 			return;
 		}
 
-		QdrantClient qdrantClient = _client();
+		QdrantClient qdrantClient = _getQdrantClient();
 
 		List<Points.PointStruct> points = new ArrayList<>();
 
@@ -455,46 +460,23 @@ public class QdrantClientWrapper {
 			JsonWithInt.ListValue.Builder listBuilder =
 				JsonWithInt.ListValue.newBuilder();
 
-			for (String heading : chunk.headingPath()) {
+			for (String heading : chunk.getHeadingPath()) {
 				listBuilder.addValues(_stringValue(heading));
 			}
 
 			JsonWithInt.ListValue.Builder dirPrefixesBuilder =
 				JsonWithInt.ListValue.newBuilder();
 
-			for (String dirPrefix : _dirPrefixes(chunk.relPath())) {
+			for (String dirPrefix : _dirPrefixes(chunk.getRelPath())) {
 				dirPrefixesBuilder.addValues(_stringValue(dirPrefix));
 			}
-
-			Map<String, JsonWithInt.Value> payload =
-				HashMapBuilder.<String, JsonWithInt.Value>put(
-					"chunk_id", _stringValue(chunk.chunkId())
-				).put(
-					"dir_prefixes",
-					JsonWithInt.Value.newBuilder(
-					).setListValue(
-						dirPrefixesBuilder.build()
-					).build()
-				).put(
-					"heading_path",
-					JsonWithInt.Value.newBuilder(
-					).setListValue(
-						listBuilder.build()
-					).build()
-				).put(
-					"rel_path", _stringValue(chunk.relPath())
-				).put(
-					"text", _stringValue(chunk.text())
-				).build();
-
-			UUID pointId = chunk.pointId();
 
 			points.add(
 				Points.PointStruct.newBuilder(
 				).setId(
 					Points.PointId.newBuilder(
 					).setUuid(
-						pointId.toString()
+						String.valueOf(chunk.getPointId())
 					).build()
 				).setVectors(
 					Points.Vectors.newBuilder(
@@ -505,7 +487,25 @@ public class QdrantClientWrapper {
 						).build()
 					).build()
 				).putAllPayload(
-					payload
+					HashMapBuilder.<String, JsonWithInt.Value>put(
+						"chunk_id", _stringValue(chunk.getChunkId())
+					).put(
+						"dir_prefixes",
+						JsonWithInt.Value.newBuilder(
+						).setListValue(
+							dirPrefixesBuilder.build()
+						).build()
+					).put(
+						"heading_path",
+						JsonWithInt.Value.newBuilder(
+						).setListValue(
+							listBuilder.build()
+						).build()
+					).put(
+						"rel_path", _stringValue(chunk.getRelPath())
+					).put(
+						"text", _stringValue(chunk.getText())
+					).build()
 				).build());
 		}
 
@@ -515,7 +515,7 @@ public class QdrantClientWrapper {
 	}
 
 	public void writeMetaFile(String relPath, String sha256) throws Exception {
-		QdrantClient qdrantClient = _client();
+		QdrantClient qdrantClient = _getQdrantClient();
 
 		Map<String, JsonWithInt.Value> payload =
 			HashMapBuilder.<String, JsonWithInt.Value>put(
@@ -552,7 +552,9 @@ public class QdrantClientWrapper {
 	}
 
 	public void writeMetaState(String rootPath, int docCount) throws Exception {
-		QdrantClient qdrantClient = _client();
+		QdrantClient qdrantClient = _getQdrantClient();
+
+		UUID pointId = _metaStateRecordId();
 
 		qdrantClient.upsertAsync(
 			META_COLLECTION,
@@ -561,7 +563,7 @@ public class QdrantClientWrapper {
 				).setId(
 					Points.PointId.newBuilder(
 					).setUuid(
-						_metaStateRecordId().toString()
+						pointId.toString()
 					).build()
 				).setVectors(
 					Points.Vectors.newBuilder(
@@ -595,9 +597,29 @@ public class QdrantClientWrapper {
 		).get();
 	}
 
-	public static class Hit {
+	public static class MetaState {
 
-		public Hit(
+		public MetaState(String lastIngest, int docCount) {
+			_lastIngest = lastIngest;
+			_docCount = docCount;
+		}
+
+		public int getDocCount() {
+			return _docCount;
+		}
+
+		public String getLastIngest() {
+			return _lastIngest;
+		}
+
+		private final int _docCount;
+		private final String _lastIngest;
+
+	}
+
+	public static class SearchResult {
+
+		public SearchResult(
 			String relPath, double score, String chunkId, String text,
 			List<String> headingPath) {
 
@@ -608,23 +630,23 @@ public class QdrantClientWrapper {
 			_headingPath = headingPath;
 		}
 
-		public String chunkId() {
+		public String getChunkId() {
 			return _chunkId;
 		}
 
-		public List<String> headingPath() {
+		public List<String> getHeadingPath() {
 			return _headingPath;
 		}
 
-		public String relPath() {
+		public String getRelPath() {
 			return _relPath;
 		}
 
-		public double score() {
+		public double getScore() {
 			return _score;
 		}
 
-		public String text() {
+		public String getText() {
 			return _text;
 		}
 
@@ -634,37 +656,6 @@ public class QdrantClientWrapper {
 		private final double _score;
 		private final String _text;
 
-	}
-
-	public static class MetaState {
-
-		public MetaState(String lastIngest, int docCount) {
-			_lastIngest = lastIngest;
-			_docCount = docCount;
-		}
-
-		public int docCount() {
-			return _docCount;
-		}
-
-		public String lastIngest() {
-			return _lastIngest;
-		}
-
-		private final int _docCount;
-		private final String _lastIngest;
-
-	}
-
-	private synchronized QdrantClient _client() {
-		if (_qdrantClient == null) {
-			_qdrantClient = new QdrantClient(
-				QdrantGrpcClient.newBuilder(
-					_host(), _grpcPort(), false
-				).build());
-		}
-
-		return _qdrantClient;
 	}
 
 	private List<String> _dirPrefixes(String relPath) {
@@ -681,6 +672,17 @@ public class QdrantClientWrapper {
 		}
 
 		return dirPrefixes;
+	}
+
+	private synchronized QdrantClient _getQdrantClient() {
+		if (_qdrantClient == null) {
+			_qdrantClient = new QdrantClient(
+				QdrantGrpcClient.newBuilder(
+					_host(), _grpcPort(), false
+				).build());
+		}
+
+		return _qdrantClient;
 	}
 
 	private int _grpcPort() {

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/client/QdrantClientWrapper.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/client/QdrantClientWrapper.java
@@ -1,0 +1,735 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.client;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.semantic.search.cli.util.Chunk;
+
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import io.qdrant.client.grpc.Collections;
+import io.qdrant.client.grpc.JsonWithInt;
+import io.qdrant.client.grpc.Points;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Thin wrapper around io.qdrant:client for this tool's vector ops.
+ * Stays lazy — the gRPC channel opens on first call so the `status`
+ * subcommand can fail fast with a clear unreachable message before
+ * incurring connection cost.
+ *
+ * @author JR Houn
+ */
+public class QdrantClientWrapper {
+
+	public static final String COLLECTION = "documents";
+
+	public static final String META_COLLECTION = "meta";
+
+	public boolean collectionExists(String name) throws Exception {
+		QdrantClient qdrantClient = _client();
+
+		List<String> names = qdrantClient.listCollectionsAsync(
+		).get();
+
+		return names.contains(name);
+	}
+
+	public void deleteByRelPaths(List<String> relPaths) throws Exception {
+		if (relPaths.isEmpty()) {
+			return;
+		}
+
+		QdrantClient qdrantClient = _client();
+
+		for (String relPath : relPaths) {
+			Points.Filter filter = Points.Filter.newBuilder(
+			).addMust(
+				Points.Condition.newBuilder(
+				).setField(
+					Points.FieldCondition.newBuilder(
+					).setKey(
+						"rel_path"
+					).setMatch(
+						Points.Match.newBuilder(
+						).setKeyword(
+							relPath
+						).build()
+					).build()
+				).build()
+			).build();
+
+			qdrantClient.deleteAsync(
+				COLLECTION, filter
+			).get();
+		}
+	}
+
+	public void deleteMetaFiles(List<String> relPaths) throws Exception {
+		if (relPaths.isEmpty()) {
+			return;
+		}
+
+		QdrantClient qdrantClient = _client();
+
+		List<Points.PointId> ids = new ArrayList<>();
+
+		for (String relPath : relPaths) {
+			UUID uuid = _metaFileRecordId(relPath);
+
+			ids.add(
+				Points.PointId.newBuilder(
+				).setUuid(
+					uuid.toString()
+				).build());
+		}
+
+		qdrantClient.deleteAsync(
+			META_COLLECTION, ids
+		).get();
+	}
+
+	/**
+	 * Drops the index when its stored vector size no longer matches the
+	 * current embedding model (for example after switching to a model with
+	 * a different dimension). Both the document and meta collections are
+	 * removed so the next ingest rebuilds from scratch rather than failing
+	 * on a dimension mismatch or silently skipping unchanged files.
+	 */
+	public void dropCollectionsIfVectorSizeChanged(int vectorSize)
+		throws Exception {
+
+		QdrantClient qdrantClient = _client();
+
+		List<String> existing = qdrantClient.listCollectionsAsync(
+		).get();
+
+		if (!existing.contains(COLLECTION)) {
+			return;
+		}
+
+		Collections.CollectionInfo info = qdrantClient.getCollectionInfoAsync(
+			COLLECTION
+		).get();
+
+		int storedSize = (int)info.getConfig(
+		).getParams(
+		).getVectorsConfig(
+		).getParams(
+		).getSize();
+
+		if (storedSize == vectorSize) {
+			return;
+		}
+
+		System.err.println(
+			StringBundler.concat(
+				"search: embedding dimension changed (", storedSize, " -> ",
+				vectorSize, "); rebuilding the index."));
+
+		qdrantClient.deleteCollectionAsync(
+			COLLECTION
+		).get();
+
+		if (existing.contains(META_COLLECTION)) {
+			qdrantClient.deleteCollectionAsync(
+				META_COLLECTION
+			).get();
+		}
+	}
+
+	public void ensureCollection(String name, int vectorSize) throws Exception {
+		QdrantClient qdrantClient = _client();
+
+		List<String> existing = qdrantClient.listCollectionsAsync(
+		).get();
+
+		if (!existing.contains(name)) {
+			qdrantClient.createCollectionAsync(
+				name,
+				Collections.VectorParams.newBuilder(
+				).setSize(
+					vectorSize
+				).setDistance(
+					Collections.Distance.Cosine
+				).build()
+			).get();
+
+			if (name.equals(COLLECTION)) {
+				qdrantClient.createPayloadIndexAsync(
+					COLLECTION, "rel_path",
+					Collections.PayloadSchemaType.Keyword, null, null, null,
+					null
+				).get();
+
+				// Indexes each chunk's ancestor directory paths so a query
+				// can be scoped to a subtree with --path. See _dirPrefixes.
+
+				qdrantClient.createPayloadIndexAsync(
+					COLLECTION, "dir_prefixes",
+					Collections.PayloadSchemaType.Keyword, null, null, null,
+					null
+				).get();
+			}
+		}
+	}
+
+	public int getChunkCount() throws Exception {
+		QdrantClient qdrantClient = _client();
+
+		Collections.CollectionInfo info = qdrantClient.getCollectionInfoAsync(
+			COLLECTION
+		).get();
+
+		return (int)info.getPointsCount();
+	}
+
+	public String getQdrantUrl() {
+		return StringBundler.concat("http://", _host(), ":", _port());
+	}
+
+	public boolean isReachable() {
+		try {
+			QdrantClient qdrantClient = _client();
+
+			qdrantClient.listCollectionsAsync(
+			).get();
+
+			return true;
+		}
+		catch (Exception exception) {
+			return false;
+		}
+	}
+
+	public Map<String, String> loadFileHashes() throws Exception {
+		QdrantClient qdrantClient = _client();
+
+		Points.Filter filter = Points.Filter.newBuilder(
+		).addMust(
+			Points.Condition.newBuilder(
+			).setField(
+				Points.FieldCondition.newBuilder(
+				).setKey(
+					"kind"
+				).setMatch(
+					Points.Match.newBuilder(
+					).setKeyword(
+						"file"
+					).build()
+				).build()
+			).build()
+		).build();
+
+		Map<String, String> hashes = new HashMap<>();
+
+		Points.PointId offset = null;
+
+		while (true) {
+			Points.ScrollPoints.Builder builder =
+				Points.ScrollPoints.newBuilder(
+				).setCollectionName(
+					META_COLLECTION
+				).setFilter(
+					filter
+				).setLimit(
+					512
+				).setWithPayload(
+					Points.WithPayloadSelector.newBuilder(
+					).setEnable(
+						true
+					).build()
+				);
+
+			if (offset != null) {
+				builder.setOffset(offset);
+			}
+
+			Points.ScrollResponse response = qdrantClient.scrollAsync(
+				builder.build()
+			).get();
+
+			for (Points.RetrievedPoint point : response.getResultList()) {
+				Map<String, JsonWithInt.Value> payload = point.getPayloadMap();
+
+				JsonWithInt.Value relPathValue = payload.get("rel_path");
+
+				JsonWithInt.Value sha256Value = payload.get("sha256");
+
+				if ((relPathValue != null) && (sha256Value != null)) {
+					hashes.put(
+						relPathValue.getStringValue(),
+						sha256Value.getStringValue());
+				}
+			}
+
+			if (!response.hasNextPageOffset()) {
+				break;
+			}
+
+			offset = response.getNextPageOffset();
+		}
+
+		return hashes;
+	}
+
+	public MetaState readMetaState() throws Exception {
+		QdrantClient qdrantClient = _client();
+
+		Points.ScrollResponse response = qdrantClient.scrollAsync(
+			Points.ScrollPoints.newBuilder(
+			).setCollectionName(
+				META_COLLECTION
+			).setFilter(
+				Points.Filter.newBuilder(
+				).addMust(
+					Points.Condition.newBuilder(
+					).setField(
+						Points.FieldCondition.newBuilder(
+						).setKey(
+							"kind"
+						).setMatch(
+							Points.Match.newBuilder(
+							).setKeyword(
+								"state"
+							).build()
+						).build()
+					).build()
+				).build()
+			).setLimit(
+				1
+			).setWithPayload(
+				Points.WithPayloadSelector.newBuilder(
+				).setEnable(
+					true
+				).build()
+			).build()
+		).get();
+
+		List<Points.RetrievedPoint> points = response.getResultList();
+
+		if (points.isEmpty()) {
+			return null;
+		}
+
+		Points.RetrievedPoint point = points.get(0);
+
+		Map<String, JsonWithInt.Value> payload = point.getPayloadMap();
+
+		JsonWithInt.Value lastIngest = payload.get("last_ingest");
+
+		JsonWithInt.Value docCount = payload.get("doc_count");
+
+		return new MetaState(
+			(lastIngest != null) ? lastIngest.getStringValue() : null,
+			(docCount != null) ? (int)docCount.getIntegerValue() : 0);
+	}
+
+	public List<Hit> search(float[] vector, int limit) throws Exception {
+		return search(vector, limit, null);
+	}
+
+	public List<Hit> search(float[] vector, int limit, String pathPrefix)
+		throws Exception {
+
+		QdrantClient qdrantClient = _client();
+
+		List<Float> vectorList = new ArrayList<>(vector.length);
+
+		for (float f : vector) {
+			vectorList.add(f);
+		}
+
+		Points.SearchPoints.Builder searchPointsBuilder =
+			Points.SearchPoints.newBuilder(
+			).setCollectionName(
+				COLLECTION
+			).addAllVector(
+				vectorList
+			).setLimit(
+				limit
+			).setWithPayload(
+				Points.WithPayloadSelector.newBuilder(
+				).setEnable(
+					true
+				).build()
+			);
+
+		// Scope to a subtree: Qdrant applies the filter during the vector
+		// search, so the top hits are the closest chunks *under pathPrefix*,
+		// not the closest overall then filtered. This keeps precision in a
+		// large (whole-repo) index. dir_prefixes holds each chunk's ancestor
+		// directories, so an exact keyword match on the array selects the
+		// subtree.
+
+		if ((pathPrefix != null) && !pathPrefix.isEmpty()) {
+			searchPointsBuilder.setFilter(
+				Points.Filter.newBuilder(
+				).addMust(
+					Points.Condition.newBuilder(
+					).setField(
+						Points.FieldCondition.newBuilder(
+						).setKey(
+							"dir_prefixes"
+						).setMatch(
+							Points.Match.newBuilder(
+							).setKeyword(
+								pathPrefix
+							).build()
+						).build()
+					).build()
+				).build());
+		}
+
+		List<Points.ScoredPoint> scoredPoints = qdrantClient.searchAsync(
+			searchPointsBuilder.build()
+		).get();
+
+		List<Hit> hits = new ArrayList<>();
+
+		for (Points.ScoredPoint scored : scoredPoints) {
+			Map<String, JsonWithInt.Value> payload = scored.getPayloadMap();
+
+			List<String> headingPath = new ArrayList<>();
+
+			JsonWithInt.Value hp = payload.get("heading_path");
+
+			if ((hp != null) && hp.hasListValue()) {
+				JsonWithInt.ListValue listValue = hp.getListValue();
+
+				for (JsonWithInt.Value entry : listValue.getValuesList()) {
+					headingPath.add(entry.getStringValue());
+				}
+			}
+
+			JsonWithInt.Value relPathValue = payload.get("rel_path");
+			JsonWithInt.Value chunkIdValue = payload.get("chunk_id");
+			JsonWithInt.Value textValue = payload.get("text");
+
+			hits.add(
+				new Hit(
+					relPathValue.getStringValue(), scored.getScore(),
+					chunkIdValue.getStringValue(), textValue.getStringValue(),
+					headingPath));
+		}
+
+		return hits;
+	}
+
+	public void upsertChunks(List<Chunk> chunks, float[][] vectors)
+		throws Exception {
+
+		if (chunks.isEmpty()) {
+			return;
+		}
+
+		QdrantClient qdrantClient = _client();
+
+		List<Points.PointStruct> points = new ArrayList<>();
+
+		for (int i = 0; i < chunks.size(); i++) {
+			Chunk chunk = chunks.get(i);
+
+			List<Float> vector = new ArrayList<>(vectors[i].length);
+
+			for (float f : vectors[i]) {
+				vector.add(f);
+			}
+
+			JsonWithInt.ListValue.Builder listBuilder =
+				JsonWithInt.ListValue.newBuilder();
+
+			for (String heading : chunk.headingPath()) {
+				listBuilder.addValues(_stringValue(heading));
+			}
+
+			JsonWithInt.ListValue.Builder dirPrefixesBuilder =
+				JsonWithInt.ListValue.newBuilder();
+
+			for (String dirPrefix : _dirPrefixes(chunk.relPath())) {
+				dirPrefixesBuilder.addValues(_stringValue(dirPrefix));
+			}
+
+			Map<String, JsonWithInt.Value> payload =
+				HashMapBuilder.<String, JsonWithInt.Value>put(
+					"chunk_id", _stringValue(chunk.chunkId())
+				).put(
+					"dir_prefixes",
+					JsonWithInt.Value.newBuilder(
+					).setListValue(
+						dirPrefixesBuilder.build()
+					).build()
+				).put(
+					"heading_path",
+					JsonWithInt.Value.newBuilder(
+					).setListValue(
+						listBuilder.build()
+					).build()
+				).put(
+					"rel_path", _stringValue(chunk.relPath())
+				).put(
+					"text", _stringValue(chunk.text())
+				).build();
+
+			UUID pointId = chunk.pointId();
+
+			points.add(
+				Points.PointStruct.newBuilder(
+				).setId(
+					Points.PointId.newBuilder(
+					).setUuid(
+						pointId.toString()
+					).build()
+				).setVectors(
+					Points.Vectors.newBuilder(
+					).setVector(
+						Points.Vector.newBuilder(
+						).addAllData(
+							vector
+						).build()
+					).build()
+				).putAllPayload(
+					payload
+				).build());
+		}
+
+		qdrantClient.upsertAsync(
+			COLLECTION, points
+		).get();
+	}
+
+	public void writeMetaFile(String relPath, String sha256) throws Exception {
+		QdrantClient qdrantClient = _client();
+
+		Map<String, JsonWithInt.Value> payload =
+			HashMapBuilder.<String, JsonWithInt.Value>put(
+				"kind", _stringValue("file")
+			).put(
+				"rel_path", _stringValue(relPath)
+			).put(
+				"sha256", _stringValue(sha256)
+			).build();
+
+		UUID pointId = _metaFileRecordId(relPath);
+
+		qdrantClient.upsertAsync(
+			META_COLLECTION,
+			Arrays.asList(
+				Points.PointStruct.newBuilder(
+				).setId(
+					Points.PointId.newBuilder(
+					).setUuid(
+						pointId.toString()
+					).build()
+				).setVectors(
+					Points.Vectors.newBuilder(
+					).setVector(
+						Points.Vector.newBuilder(
+						).addData(
+							0.0F
+						).build()
+					).build()
+				).putAllPayload(
+					payload
+				).build())
+		).get();
+	}
+
+	public void writeMetaState(String rootPath, int docCount) throws Exception {
+		QdrantClient qdrantClient = _client();
+
+		qdrantClient.upsertAsync(
+			META_COLLECTION,
+			Arrays.asList(
+				Points.PointStruct.newBuilder(
+				).setId(
+					Points.PointId.newBuilder(
+					).setUuid(
+						_metaStateRecordId().toString()
+					).build()
+				).setVectors(
+					Points.Vectors.newBuilder(
+					).setVector(
+						Points.Vector.newBuilder(
+						).addData(
+							0.0F
+						).build()
+					).build()
+				).putAllPayload(
+					HashMapBuilder.<String, JsonWithInt.Value>put(
+						"doc_count",
+						JsonWithInt.Value.newBuilder(
+						).setIntegerValue(
+							docCount
+						).build()
+					).put(
+						"ingest_root", _stringValue(rootPath)
+					).put(
+						"kind", _stringValue("state")
+					).put(
+						"last_ingest",
+						() -> _stringValue(
+							OffsetDateTime.now(
+								ZoneOffset.UTC
+							).format(
+								DateTimeFormatter.ISO_OFFSET_DATE_TIME
+							))
+					).build()
+				).build())
+		).get();
+	}
+
+	public static class Hit {
+
+		public Hit(
+			String relPath, double score, String chunkId, String text,
+			List<String> headingPath) {
+
+			_relPath = relPath;
+			_score = score;
+			_chunkId = chunkId;
+			_text = text;
+			_headingPath = headingPath;
+		}
+
+		public String chunkId() {
+			return _chunkId;
+		}
+
+		public List<String> headingPath() {
+			return _headingPath;
+		}
+
+		public String relPath() {
+			return _relPath;
+		}
+
+		public double score() {
+			return _score;
+		}
+
+		public String text() {
+			return _text;
+		}
+
+		private final String _chunkId;
+		private final List<String> _headingPath;
+		private final String _relPath;
+		private final double _score;
+		private final String _text;
+
+	}
+
+	public static class MetaState {
+
+		public MetaState(String lastIngest, int docCount) {
+			_lastIngest = lastIngest;
+			_docCount = docCount;
+		}
+
+		public int docCount() {
+			return _docCount;
+		}
+
+		public String lastIngest() {
+			return _lastIngest;
+		}
+
+		private final int _docCount;
+		private final String _lastIngest;
+
+	}
+
+	private synchronized QdrantClient _client() {
+		if (_qdrantClient == null) {
+			_qdrantClient = new QdrantClient(
+				QdrantGrpcClient.newBuilder(
+					_host(), _grpcPort(), false
+				).build());
+		}
+
+		return _qdrantClient;
+	}
+
+	private List<String> _dirPrefixes(String relPath) {
+		List<String> dirPrefixes = new ArrayList<>();
+
+		String normalized = StringUtil.replace(relPath, '\\', '/');
+
+		int slash = normalized.indexOf('/');
+
+		while (slash >= 0) {
+			dirPrefixes.add(normalized.substring(0, slash));
+
+			slash = normalized.indexOf('/', slash + 1);
+		}
+
+		return dirPrefixes;
+	}
+
+	private int _grpcPort() {
+		String port = System.getenv("QDRANT_GRPC_PORT");
+
+		if ((port == null) || port.isEmpty()) {
+			return 6334;
+		}
+
+		return GetterUtil.getInteger(port, 6334);
+	}
+
+	private String _host() {
+		String host = System.getenv("QDRANT_HOST");
+
+		if ((host == null) || host.isEmpty()) {
+			return "localhost";
+		}
+
+		return host;
+	}
+
+	private UUID _metaFileRecordId(String relPath) {
+		String name = "semsearch:meta:file:" + relPath;
+
+		return UUID.nameUUIDFromBytes(name.getBytes());
+	}
+
+	private UUID _metaStateRecordId() {
+		return UUID.nameUUIDFromBytes("semsearch:meta:state".getBytes());
+	}
+
+	private int _port() {
+		String port = System.getenv("QDRANT_PORT");
+
+		if ((port == null) || port.isEmpty()) {
+			return 6333;
+		}
+
+		return GetterUtil.getInteger(port, 6333);
+	}
+
+	private JsonWithInt.Value _stringValue(String string) {
+		return JsonWithInt.Value.newBuilder(
+		).setStringValue(
+			string
+		).build();
+	}
+
+	private QdrantClient _qdrantClient;
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/client/TextEmbeddingsClient.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/client/TextEmbeddingsClient.java
@@ -1,0 +1,197 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.client;
+
+import com.liferay.petra.string.StringBundler;
+
+import java.io.IOException;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import java.time.Duration;
+
+import java.util.List;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * HTTP client for Hugging Face's text-embeddings-inference (TEI)
+ * server. TEI exposes /embed (batch) and /info (model metadata).
+ *
+ * Configuration via env vars:
+ *   TEI_URL    default "http://localhost:7997"
+ *
+ * No retry, no auth — TEI runs on localhost behind the docker-compose
+ * network. If we ever move it to a remote host, add a connect-timeout
+ * retry loop here.
+ *
+ * @author JR Houn
+ */
+public class TextEmbeddingsClient {
+
+	public TextEmbeddingsClient() {
+		String url = System.getenv("TEI_URL");
+
+		if ((url == null) || url.isEmpty()) {
+
+			// Not 8080: that is Liferay Tomcat's default HTTP port, so the
+			// stack must avoid it to run alongside a portal bundle.
+
+			url = "http://localhost:7997";
+		}
+
+		_baseUrl = url;
+
+		_httpClient = HttpClient.newBuilder(
+		).connectTimeout(
+			Duration.ofSeconds(5)
+		).build();
+	}
+
+	public float[][] embedDocuments(List<String> texts) throws IOException {
+		return _embedBatch(texts);
+	}
+
+	public float[] embedQuery(String text) throws IOException {
+
+		// Asymmetric code models (e.g. CodeRankEmbed) require a static task
+		// instruction on the query side only; omitting it drops recall
+		// sharply. The prefix is a per-model concern, supplied by the
+		// caller via SEARCH_QUERY_PREFIX so this client stays model-neutral.
+		// Document embedding (embedDocuments) never gets the prefix.
+
+		String prefix = System.getenv("SEARCH_QUERY_PREFIX");
+
+		if ((prefix != null) && !prefix.isEmpty()) {
+			text = prefix + text;
+		}
+
+		float[][] all = _embedBatch(List.of(text));
+
+		return all[0];
+	}
+
+	public int getDimension() throws IOException {
+		HttpRequest httpRequest = HttpRequest.newBuilder(
+			URI.create(_baseUrl + "/info")
+		).GET(
+		).timeout(
+			Duration.ofSeconds(5)
+		).build();
+
+		try {
+			HttpResponse<String> httpResponse = _httpClient.send(
+				httpRequest, HttpResponse.BodyHandlers.ofString());
+
+			if (httpResponse.statusCode() != 200) {
+				throw new IOException(
+					"TEI /info returned " + httpResponse.statusCode());
+			}
+
+			JSONObject responseJSONObject = new JSONObject(httpResponse.body());
+
+			return responseJSONObject.getInt("max_input_length");
+		}
+		catch (InterruptedException interruptedException) {
+			Thread currentThread = Thread.currentThread();
+
+			currentThread.interrupt();
+
+			throw new IOException("interrupted", interruptedException);
+		}
+	}
+
+	public boolean isReachable() {
+		try {
+			HttpRequest httpRequest = HttpRequest.newBuilder(
+				URI.create(_baseUrl + "/health")
+			).GET(
+			).timeout(
+				Duration.ofSeconds(2)
+			).build();
+
+			HttpResponse<Void> httpResponse = _httpClient.send(
+				httpRequest, HttpResponse.BodyHandlers.discarding());
+
+			if (httpResponse.statusCode() == 200) {
+				return true;
+			}
+
+			return false;
+		}
+		catch (Exception exception) {
+			return false;
+		}
+	}
+
+	private float[][] _embedBatch(List<String> texts) throws IOException {
+		JSONObject bodyJSONObject = new JSONObject();
+
+		bodyJSONObject.put(
+			"inputs", new JSONArray(texts)
+		).put(
+			"normalize", true
+		);
+
+		HttpRequest httpRequest = HttpRequest.newBuilder(
+			URI.create(_baseUrl + "/embed")
+		).header(
+			"Content-Type", "application/json"
+		).POST(
+			HttpRequest.BodyPublishers.ofString(bodyJSONObject.toString())
+		).timeout(
+
+			// Generous: a heavier code model (e.g. CodeRankEmbed) embedding a
+			// batch of large methods in full takes far longer than the
+			// general-purpose default, which truncates hard at 512 tokens.
+
+			Duration.ofMinutes(10)
+		).build();
+
+		try {
+			HttpResponse<String> httpResponse = _httpClient.send(
+				httpRequest, HttpResponse.BodyHandlers.ofString());
+
+			if (httpResponse.statusCode() != 200) {
+				throw new IOException(
+					StringBundler.concat(
+						"TEI /embed returned ", httpResponse.statusCode(), ": ",
+						httpResponse.body()));
+			}
+
+			JSONArray responseJSONArray = new JSONArray(httpResponse.body());
+
+			float[][] vectors = new float[responseJSONArray.length()][];
+
+			for (int i = 0; i < responseJSONArray.length(); i++) {
+				JSONArray vectorJSONArray = responseJSONArray.getJSONArray(i);
+
+				vectors[i] = new float[vectorJSONArray.length()];
+
+				for (int j = 0; j < vectorJSONArray.length(); j++) {
+					vectors[i][j] = (float)vectorJSONArray.getDouble(j);
+				}
+			}
+
+			return vectors;
+		}
+		catch (InterruptedException interruptedException) {
+			Thread currentThread = Thread.currentThread();
+
+			currentThread.interrupt();
+
+			throw new IOException("interrupted", interruptedException);
+		}
+	}
+
+	private final String _baseUrl;
+	private final HttpClient _httpClient;
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/client/TextEmbeddingsClient.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/client/TextEmbeddingsClient.java
@@ -47,7 +47,7 @@ public class TextEmbeddingsClient {
 			url = "http://localhost:7997";
 		}
 
-		_baseUrl = url;
+		_baseURL = url;
 
 		_httpClient = HttpClient.newBuilder(
 		).connectTimeout(
@@ -80,7 +80,7 @@ public class TextEmbeddingsClient {
 
 	public int getDimension() throws IOException {
 		HttpRequest httpRequest = HttpRequest.newBuilder(
-			URI.create(_baseUrl + "/info")
+			URI.create(_baseURL + "/info")
 		).GET(
 		).timeout(
 			Duration.ofSeconds(5)
@@ -111,7 +111,7 @@ public class TextEmbeddingsClient {
 	public boolean isReachable() {
 		try {
 			HttpRequest httpRequest = HttpRequest.newBuilder(
-				URI.create(_baseUrl + "/health")
+				URI.create(_baseURL + "/health")
 			).GET(
 			).timeout(
 				Duration.ofSeconds(2)
@@ -141,7 +141,7 @@ public class TextEmbeddingsClient {
 		);
 
 		HttpRequest httpRequest = HttpRequest.newBuilder(
-			URI.create(_baseUrl + "/embed")
+			URI.create(_baseURL + "/embed")
 		).header(
 			"Content-Type", "application/json"
 		).POST(
@@ -168,14 +168,18 @@ public class TextEmbeddingsClient {
 
 			JSONArray responseJSONArray = new JSONArray(httpResponse.body());
 
-			float[][] vectors = new float[responseJSONArray.length()][];
+			int responseLength = responseJSONArray.length();
 
-			for (int i = 0; i < responseJSONArray.length(); i++) {
+			float[][] vectors = new float[responseLength][];
+
+			for (int i = 0; i < responseLength; i++) {
 				JSONArray vectorJSONArray = responseJSONArray.getJSONArray(i);
 
-				vectors[i] = new float[vectorJSONArray.length()];
+				int vectorLength = vectorJSONArray.length();
 
-				for (int j = 0; j < vectorJSONArray.length(); j++) {
+				vectors[i] = new float[vectorLength];
+
+				for (int j = 0; j < vectorLength; j++) {
 					vectors[i][j] = (float)vectorJSONArray.getDouble(j);
 				}
 			}
@@ -191,7 +195,7 @@ public class TextEmbeddingsClient {
 		}
 	}
 
-	private final String _baseUrl;
+	private final String _baseURL;
 	private final HttpClient _httpClient;
 
 }

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/Command.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/Command.java
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.command;
+
+/**
+ * Contract for every CLI subcommand.
+ *
+ * Exit codes:
+ *   0  success
+ *   1  bad input (no .md files under target, etc.)
+ *   2  bad CLI usage
+ *   3  index does not exist
+ *   4  target file has no extractable content
+ *   5  Qdrant unreachable
+ *   6  internal error reading the index
+ *
+ * @author JR Houn
+ */
+public interface Command {
+
+	public String description();
+
+	public int run(String[] args) throws Exception;
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/IngestCommand.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/IngestCommand.java
@@ -10,7 +10,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.semantic.search.cli.chunker.Chunkers;
 import com.liferay.semantic.search.cli.client.QdrantClientWrapper;
 import com.liferay.semantic.search.cli.client.TextEmbeddingsClient;
-import com.liferay.semantic.search.cli.util.Args;
+import com.liferay.semantic.search.cli.util.Arguments;
 import com.liferay.semantic.search.cli.util.Chunk;
 
 import java.io.IOException;
@@ -46,9 +46,9 @@ public class IngestCommand implements Command {
 
 	@Override
 	public int run(String[] args) throws Exception {
-		Args parsed = new Args(args);
+		Arguments arguments = new Arguments(args);
 
-		List<String> positional = parsed.positional();
+		List<String> positional = arguments.getPositional();
 
 		if (positional.isEmpty()) {
 			System.err.println("search: ingest requires a <dir> argument");
@@ -56,49 +56,53 @@ public class IngestCommand implements Command {
 			return 2;
 		}
 
-		Path root = Paths.get(
-			positional.get(0)
-		).toAbsolutePath();
+		Path targetPath = Paths.get(positional.get(0));
 
-		if (!Files.exists(root)) {
-			System.err.println("search: ingest target does not exist: " + root);
+		Path rootPath = targetPath.toAbsolutePath();
 
-			return 1;
-		}
-
-		List<Path> files = _indexableFiles(root);
-
-		if (files.isEmpty()) {
+		if (!Files.exists(rootPath)) {
 			System.err.println(
-				"search: no indexable files found under " + root);
+				"search: ingest target does not exist: " + rootPath);
 
 			return 1;
 		}
 
-		QdrantClientWrapper qdrantClient = new QdrantClientWrapper();
+		List<Path> paths = _indexableFiles(rootPath);
 
-		if (!qdrantClient.isReachable()) {
+		if (paths.isEmpty()) {
+			System.err.println(
+				"search: no indexable files found under " + rootPath);
+
+			return 1;
+		}
+
+		QdrantClientWrapper qdrantClientWrapper = new QdrantClientWrapper();
+
+		if (!qdrantClientWrapper.isReachable()) {
 			System.err.println(
 				"search: cannot reach Qdrant at " +
-					qdrantClient.getQdrantUrl());
+					qdrantClientWrapper.getQdrantURL());
 
 			return 5;
 		}
 
-		Path base = Files.isDirectory(root) ? root : root.getParent();
+		Path basePath =
+			Files.isDirectory(rootPath) ? rootPath : rootPath.getParent();
 
-		TextEmbeddingsClient teiClient = new TextEmbeddingsClient();
+		TextEmbeddingsClient textEmbeddingsClient = new TextEmbeddingsClient();
 
-		int vectorDim = teiClient.embedQuery("warmup").length;
+		int vectorDim = textEmbeddingsClient.embedQuery("warmup").length;
 
-		qdrantClient.dropCollectionsIfVectorSizeChanged(vectorDim);
+		qdrantClientWrapper.dropCollectionsIfVectorSizeChanged(vectorDim);
 
-		qdrantClient.ensureCollection(
+		qdrantClientWrapper.ensureCollection(
 			QdrantClientWrapper.COLLECTION, vectorDim);
 
-		qdrantClient.ensureCollection(QdrantClientWrapper.META_COLLECTION, 1);
+		qdrantClientWrapper.ensureCollection(
+			QdrantClientWrapper.META_COLLECTION, 1);
 
-		Map<String, String> existingHashes = qdrantClient.loadFileHashes();
+		Map<String, String> existingHashes =
+			qdrantClientWrapper.loadFileHashes();
 
 		Set<String> seenRelPaths = new HashSet<>();
 
@@ -110,21 +114,21 @@ public class IngestCommand implements Command {
 
 		System.err.println(
 			StringBundler.concat(
-				"Scanning ", files.size(), " file(s) under ", root));
+				"Scanning ", paths.size(), " file(s) under ", rootPath));
 
-		for (Path file : files) {
+		for (Path filePath : paths) {
 			String text = new String(
-				Files.readAllBytes(file), StandardCharsets.UTF_8);
+				Files.readAllBytes(filePath), StandardCharsets.UTF_8);
 
 			String sha = _sha256(text);
 
-			String relPath = base.relativize(
-				file
-			).toString();
+			String relPath = String.valueOf(basePath.relativize(filePath));
 
 			seenRelPaths.add(relPath);
 
-			if (!parsed.force() && sha.equals(existingHashes.get(relPath))) {
+			if (!arguments.isForce() &&
+				sha.equals(existingHashes.get(relPath))) {
+
 				skipped++;
 
 				continue;
@@ -143,10 +147,11 @@ public class IngestCommand implements Command {
 			Set<String> changedRelPaths = new TreeSet<>();
 
 			for (Chunk chunk : pendingChunks) {
-				changedRelPaths.add(chunk.relPath());
+				changedRelPaths.add(chunk.getRelPath());
 			}
 
-			qdrantClient.deleteByRelPaths(new ArrayList<>(changedRelPaths));
+			qdrantClientWrapper.deleteByRelPaths(
+				new ArrayList<>(changedRelPaths));
 
 			// A smaller default than the embedding server's client-batch cap:
 			// a heavier code model embedding large method chunks needs fewer
@@ -158,37 +163,39 @@ public class IngestCommand implements Command {
 
 			int upserted = 0;
 
-			for (int from = 0; from < pendingChunks.size(); from += batchSize) {
-				int to = Math.min(from + batchSize, pendingChunks.size());
+			int pendingChunksSize = pendingChunks.size();
+
+			for (int from = 0; from < pendingChunksSize; from += batchSize) {
+				int to = Math.min(from + batchSize, pendingChunksSize);
 
 				List<Chunk> batch = pendingChunks.subList(from, to);
 
 				List<String> texts = new ArrayList<>();
 
 				for (Chunk chunk : batch) {
-					texts.add(chunk.embeddingText());
+					texts.add(chunk.getEmbeddingText());
 				}
 
-				float[][] vectors = teiClient.embedDocuments(texts);
+				float[][] vectors = textEmbeddingsClient.embedDocuments(texts);
 
-				qdrantClient.upsertChunks(batch, vectors);
+				qdrantClientWrapper.upsertChunks(batch, vectors);
 
 				upserted += batch.size();
 
 				System.err.println(
 					StringBundler.concat(
-						"  embedded ", upserted, "/", pendingChunks.size(),
+						"  embedded ", upserted, "/", pendingChunksSize,
 						" chunks"));
 			}
 		}
 
 		for (String[] fileEntry : pendingFiles) {
-			qdrantClient.writeMetaFile(fileEntry[0], fileEntry[1]);
+			qdrantClientWrapper.writeMetaFile(fileEntry[0], fileEntry[1]);
 		}
 
 		List<String> removed = new ArrayList<>();
 
-		if (Files.isDirectory(root)) {
+		if (Files.isDirectory(rootPath)) {
 			Set<String> stale = new HashSet<>(existingHashes.keySet());
 
 			stale.removeAll(seenRelPaths);
@@ -198,13 +205,14 @@ public class IngestCommand implements Command {
 			}
 
 			if (!removed.isEmpty()) {
-				qdrantClient.deleteByRelPaths(removed);
+				qdrantClientWrapper.deleteByRelPaths(removed);
 
-				qdrantClient.deleteMetaFiles(removed);
+				qdrantClientWrapper.deleteMetaFiles(removed);
 			}
 		}
 
-		qdrantClient.writeMetaState(base.toString(), seenRelPaths.size());
+		qdrantClientWrapper.writeMetaState(
+			basePath.toString(), seenRelPaths.size());
 
 		System.err.println(
 			StringBundler.concat(
@@ -236,23 +244,23 @@ public class IngestCommand implements Command {
 		return exts.toArray(new String[0]);
 	}
 
-	private List<Path> _indexableFiles(Path root) throws Exception {
+	private List<Path> _indexableFiles(Path rootPath) throws Exception {
 		String[] exts = _fileExtensions();
 
-		List<Path> files = new ArrayList<>();
+		List<Path> paths = new ArrayList<>();
 
-		if (Files.isRegularFile(root)) {
-			String name = String.valueOf(root.getFileName());
+		if (Files.isRegularFile(rootPath)) {
+			String name = String.valueOf(rootPath.getFileName());
 
-			if (_matchesExtension(name, exts) && !name.startsWith(".")) {
-				files.add(root);
+			if (_isMatchingExtension(name, exts) && !name.startsWith(".")) {
+				paths.add(rootPath);
 			}
 
-			return files;
+			return paths;
 		}
 
 		Files.walkFileTree(
-			root,
+			rootPath,
 			new SimpleFileVisitor<Path>() {
 
 				@Override
@@ -288,10 +296,10 @@ public class IngestCommand implements Command {
 
 					String fileName = fileNamePath.toString();
 
-					if (_matchesExtension(fileName, exts) &&
+					if (_isMatchingExtension(fileName, exts) &&
 						!fileName.startsWith(".")) {
 
-						files.add(file);
+						paths.add(file);
 					}
 
 					return FileVisitResult.CONTINUE;
@@ -299,12 +307,12 @@ public class IngestCommand implements Command {
 
 			});
 
-		Collections.sort(files);
+		Collections.sort(paths);
 
-		return files;
+		return paths;
 	}
 
-	private boolean _matchesExtension(String name, String[] exts) {
+	private boolean _isMatchingExtension(String name, String[] exts) {
 		for (String ext : exts) {
 			if (name.endsWith(ext)) {
 				return true;
@@ -315,17 +323,18 @@ public class IngestCommand implements Command {
 	}
 
 	private String _sha256(String text) throws Exception {
-		MessageDigest digest = MessageDigest.getInstance("SHA-256");
+		MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
 
-		byte[] bytes = digest.digest(text.getBytes(StandardCharsets.UTF_8));
+		byte[] bytes = messageDigest.digest(
+			text.getBytes(StandardCharsets.UTF_8));
 
-		StringBuilder stringBuilder = new StringBuilder();
+		StringBundler sb = new StringBundler(bytes.length);
 
 		for (byte b : bytes) {
-			stringBuilder.append(String.format("%02x", b));
+			sb.append(String.format("%02x", b));
 		}
 
-		return stringBuilder.toString();
+		return sb.toString();
 	}
 
 }

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/IngestCommand.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/IngestCommand.java
@@ -1,0 +1,331 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.command;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.semantic.search.cli.chunker.Chunkers;
+import com.liferay.semantic.search.cli.client.QdrantClientWrapper;
+import com.liferay.semantic.search.cli.client.TextEmbeddingsClient;
+import com.liferay.semantic.search.cli.util.Args;
+import com.liferay.semantic.search.cli.util.Chunk;
+
+import java.io.IOException;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+import java.security.MessageDigest;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * @author JR Houn
+ */
+public class IngestCommand implements Command {
+
+	@Override
+	public String description() {
+		return "Index every file under <dir> matching SEARCH_FILE_EXTS " +
+			"[--force]";
+	}
+
+	@Override
+	public int run(String[] args) throws Exception {
+		Args parsed = new Args(args);
+
+		List<String> positional = parsed.positional();
+
+		if (positional.isEmpty()) {
+			System.err.println("search: ingest requires a <dir> argument");
+
+			return 2;
+		}
+
+		Path root = Paths.get(
+			positional.get(0)
+		).toAbsolutePath();
+
+		if (!Files.exists(root)) {
+			System.err.println("search: ingest target does not exist: " + root);
+
+			return 1;
+		}
+
+		List<Path> files = _indexableFiles(root);
+
+		if (files.isEmpty()) {
+			System.err.println(
+				"search: no indexable files found under " + root);
+
+			return 1;
+		}
+
+		QdrantClientWrapper qdrantClient = new QdrantClientWrapper();
+
+		if (!qdrantClient.isReachable()) {
+			System.err.println(
+				"search: cannot reach Qdrant at " +
+					qdrantClient.getQdrantUrl());
+
+			return 5;
+		}
+
+		Path base = Files.isDirectory(root) ? root : root.getParent();
+
+		TextEmbeddingsClient teiClient = new TextEmbeddingsClient();
+
+		int vectorDim = teiClient.embedQuery("warmup").length;
+
+		qdrantClient.dropCollectionsIfVectorSizeChanged(vectorDim);
+
+		qdrantClient.ensureCollection(
+			QdrantClientWrapper.COLLECTION, vectorDim);
+
+		qdrantClient.ensureCollection(QdrantClientWrapper.META_COLLECTION, 1);
+
+		Map<String, String> existingHashes = qdrantClient.loadFileHashes();
+
+		Set<String> seenRelPaths = new HashSet<>();
+
+		List<Chunk> pendingChunks = new ArrayList<>();
+
+		List<String[]> pendingFiles = new ArrayList<>();
+
+		int skipped = 0;
+
+		System.err.println(
+			StringBundler.concat(
+				"Scanning ", files.size(), " file(s) under ", root));
+
+		for (Path file : files) {
+			String text = new String(
+				Files.readAllBytes(file), StandardCharsets.UTF_8);
+
+			String sha = _sha256(text);
+
+			String relPath = base.relativize(
+				file
+			).toString();
+
+			seenRelPaths.add(relPath);
+
+			if (!parsed.force() && sha.equals(existingHashes.get(relPath))) {
+				skipped++;
+
+				continue;
+			}
+
+			List<Chunk> chunks = Chunkers.parse(text, relPath);
+
+			pendingFiles.add(new String[] {relPath, sha});
+
+			pendingChunks.addAll(chunks);
+		}
+
+		int indexed = pendingFiles.size();
+
+		if (!pendingChunks.isEmpty()) {
+			Set<String> changedRelPaths = new TreeSet<>();
+
+			for (Chunk chunk : pendingChunks) {
+				changedRelPaths.add(chunk.relPath());
+			}
+
+			qdrantClient.deleteByRelPaths(new ArrayList<>(changedRelPaths));
+
+			// A smaller default than the embedding server's client-batch cap:
+			// a heavier code model embedding large method chunks needs fewer
+			// per request to stay within the request timeout. Override with
+			// SEARCH_EMBED_BATCH.
+
+			int batchSize = GetterUtil.getInteger(
+				System.getenv("SEARCH_EMBED_BATCH"), 16);
+
+			int upserted = 0;
+
+			for (int from = 0; from < pendingChunks.size(); from += batchSize) {
+				int to = Math.min(from + batchSize, pendingChunks.size());
+
+				List<Chunk> batch = pendingChunks.subList(from, to);
+
+				List<String> texts = new ArrayList<>();
+
+				for (Chunk chunk : batch) {
+					texts.add(chunk.embeddingText());
+				}
+
+				float[][] vectors = teiClient.embedDocuments(texts);
+
+				qdrantClient.upsertChunks(batch, vectors);
+
+				upserted += batch.size();
+
+				System.err.println(
+					StringBundler.concat(
+						"  embedded ", upserted, "/", pendingChunks.size(),
+						" chunks"));
+			}
+		}
+
+		for (String[] fileEntry : pendingFiles) {
+			qdrantClient.writeMetaFile(fileEntry[0], fileEntry[1]);
+		}
+
+		List<String> removed = new ArrayList<>();
+
+		if (Files.isDirectory(root)) {
+			Set<String> stale = new HashSet<>(existingHashes.keySet());
+
+			stale.removeAll(seenRelPaths);
+
+			for (String relPath : stale) {
+				removed.add(relPath);
+			}
+
+			if (!removed.isEmpty()) {
+				qdrantClient.deleteByRelPaths(removed);
+
+				qdrantClient.deleteMetaFiles(removed);
+			}
+		}
+
+		qdrantClient.writeMetaState(base.toString(), seenRelPaths.size());
+
+		System.err.println(
+			StringBundler.concat(
+				"Done. indexed=", indexed, " skipped=", skipped, " removed=",
+				removed.size(), " total_files=", seenRelPaths.size()));
+
+		return 0;
+	}
+
+	private String[] _fileExtensions() {
+		String env = System.getenv("SEARCH_FILE_EXTS");
+
+		if ((env == null) || env.isEmpty()) {
+			return new String[] {".md"};
+		}
+
+		String[] split = env.split(",");
+
+		List<String> exts = new ArrayList<>();
+
+		for (String ext : split) {
+			String trimmed = ext.trim();
+
+			if (!trimmed.isEmpty()) {
+				exts.add(trimmed);
+			}
+		}
+
+		return exts.toArray(new String[0]);
+	}
+
+	private List<Path> _indexableFiles(Path root) throws Exception {
+		String[] exts = _fileExtensions();
+
+		List<Path> files = new ArrayList<>();
+
+		if (Files.isRegularFile(root)) {
+			String name = String.valueOf(root.getFileName());
+
+			if (_matchesExtension(name, exts) && !name.startsWith(".")) {
+				files.add(root);
+			}
+
+			return files;
+		}
+
+		Files.walkFileTree(
+			root,
+			new SimpleFileVisitor<Path>() {
+
+				@Override
+				public FileVisitResult preVisitDirectory(
+						Path dir, BasicFileAttributes basicFileAttributes)
+					throws IOException {
+
+					Path dirFileName = dir.getFileName();
+
+					if (dirFileName == null) {
+						return FileVisitResult.CONTINUE;
+					}
+
+					String dirName = dirFileName.toString();
+
+					if (dirName.startsWith(".")) {
+						return FileVisitResult.SKIP_SUBTREE;
+					}
+
+					return FileVisitResult.CONTINUE;
+				}
+
+				@Override
+				public FileVisitResult visitFile(
+						Path file, BasicFileAttributes basicFileAttributes)
+					throws IOException {
+
+					Path fileNamePath = file.getFileName();
+
+					if (fileNamePath == null) {
+						return FileVisitResult.CONTINUE;
+					}
+
+					String fileName = fileNamePath.toString();
+
+					if (_matchesExtension(fileName, exts) &&
+						!fileName.startsWith(".")) {
+
+						files.add(file);
+					}
+
+					return FileVisitResult.CONTINUE;
+				}
+
+			});
+
+		Collections.sort(files);
+
+		return files;
+	}
+
+	private boolean _matchesExtension(String name, String[] exts) {
+		for (String ext : exts) {
+			if (name.endsWith(ext)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private String _sha256(String text) throws Exception {
+		MessageDigest digest = MessageDigest.getInstance("SHA-256");
+
+		byte[] bytes = digest.digest(text.getBytes(StandardCharsets.UTF_8));
+
+		StringBuilder stringBuilder = new StringBuilder();
+
+		for (byte b : bytes) {
+			stringBuilder.append(String.format("%02x", b));
+		}
+
+		return stringBuilder.toString();
+	}
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/QueryCommand.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/QueryCommand.java
@@ -1,0 +1,92 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.command;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.semantic.search.cli.client.QdrantClientWrapper;
+import com.liferay.semantic.search.cli.client.TextEmbeddingsClient;
+import com.liferay.semantic.search.cli.util.Args;
+import com.liferay.semantic.search.cli.util.Hit;
+import com.liferay.semantic.search.cli.util.Output;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author JR Houn
+ */
+public class QueryCommand implements Command {
+
+	@Override
+	public String description() {
+		return "Search by string: query \"<text>\" [--format text|json] " +
+			"[--path <dir-prefix>] [--top N]";
+	}
+
+	@Override
+	public int run(String[] args) throws Exception {
+		Args parsed = new Args(args);
+
+		List<String> positional = parsed.positional();
+
+		if (positional.isEmpty()) {
+			System.err.println("search: query requires a \"<text>\" argument");
+
+			return 2;
+		}
+
+		QdrantClientWrapper qdrantClient = new QdrantClientWrapper();
+
+		if (!qdrantClient.isReachable()) {
+			System.err.println(
+				"search: cannot reach Qdrant at " +
+					qdrantClient.getQdrantUrl());
+
+			return 5;
+		}
+
+		if (!qdrantClient.collectionExists(QdrantClientWrapper.COLLECTION)) {
+			System.err.println(
+				"search: index does not exist. Run ingest first.");
+
+			return 3;
+		}
+
+		String text = positional.get(0);
+
+		TextEmbeddingsClient teiClient = new TextEmbeddingsClient();
+
+		float[] vector = teiClient.embedQuery(text);
+
+		String path = parsed.path();
+
+		List<QdrantClientWrapper.Hit> rawHits = qdrantClient.search(
+			vector, parsed.top(), path);
+
+		List<Hit> hits = new ArrayList<>();
+
+		for (QdrantClientWrapper.Hit rawHit : rawHits) {
+			hits.add(
+				new Hit(
+					rawHit.relPath(), rawHit.score(), rawHit.chunkId(),
+					Output.snippet(rawHit.text()), rawHit.headingPath()));
+		}
+
+		if (hits.isEmpty() && !path.isEmpty()) {
+			System.err.println(
+				StringBundler.concat(
+					"search: no results under \"", path,
+					"\". The --path prefix is relative to the index's ingest ",
+					"root; confirm the prefix and that the index was built ",
+					"with --path support."));
+		}
+
+		System.out.println(Output.formatHits(hits, parsed.format()));
+
+		return 0;
+	}
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/QueryCommand.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/QueryCommand.java
@@ -8,7 +8,7 @@ package com.liferay.semantic.search.cli.command;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.semantic.search.cli.client.QdrantClientWrapper;
 import com.liferay.semantic.search.cli.client.TextEmbeddingsClient;
-import com.liferay.semantic.search.cli.util.Args;
+import com.liferay.semantic.search.cli.util.Arguments;
 import com.liferay.semantic.search.cli.util.Hit;
 import com.liferay.semantic.search.cli.util.Output;
 
@@ -28,9 +28,9 @@ public class QueryCommand implements Command {
 
 	@Override
 	public int run(String[] args) throws Exception {
-		Args parsed = new Args(args);
+		Arguments arguments = new Arguments(args);
 
-		List<String> positional = parsed.positional();
+		List<String> positional = arguments.getPositional();
 
 		if (positional.isEmpty()) {
 			System.err.println("search: query requires a \"<text>\" argument");
@@ -38,41 +38,45 @@ public class QueryCommand implements Command {
 			return 2;
 		}
 
-		QdrantClientWrapper qdrantClient = new QdrantClientWrapper();
+		QdrantClientWrapper qdrantClientWrapper = new QdrantClientWrapper();
 
-		if (!qdrantClient.isReachable()) {
+		if (!qdrantClientWrapper.isReachable()) {
 			System.err.println(
 				"search: cannot reach Qdrant at " +
-					qdrantClient.getQdrantUrl());
+					qdrantClientWrapper.getQdrantURL());
 
 			return 5;
 		}
 
-		if (!qdrantClient.collectionExists(QdrantClientWrapper.COLLECTION)) {
+		if (!qdrantClientWrapper.hasCollection(
+				QdrantClientWrapper.COLLECTION)) {
+
 			System.err.println(
-				"search: index does not exist. Run ingest first.");
+				"search: index does not exist; run ingest first");
 
 			return 3;
 		}
 
 		String text = positional.get(0);
 
-		TextEmbeddingsClient teiClient = new TextEmbeddingsClient();
+		TextEmbeddingsClient textEmbeddingsClient = new TextEmbeddingsClient();
 
-		float[] vector = teiClient.embedQuery(text);
+		float[] vector = textEmbeddingsClient.embedQuery(text);
 
-		String path = parsed.path();
+		String path = arguments.getPath();
 
-		List<QdrantClientWrapper.Hit> rawHits = qdrantClient.search(
-			vector, parsed.top(), path);
+		List<QdrantClientWrapper.SearchResult> searchResults =
+			qdrantClientWrapper.search(vector, arguments.getTop(), path);
 
 		List<Hit> hits = new ArrayList<>();
 
-		for (QdrantClientWrapper.Hit rawHit : rawHits) {
+		for (QdrantClientWrapper.SearchResult searchResult : searchResults) {
 			hits.add(
 				new Hit(
-					rawHit.relPath(), rawHit.score(), rawHit.chunkId(),
-					Output.snippet(rawHit.text()), rawHit.headingPath()));
+					searchResult.getRelPath(), searchResult.getScore(),
+					searchResult.getChunkId(),
+					Output.snippet(searchResult.getText()),
+					searchResult.getHeadingPath()));
 		}
 
 		if (hits.isEmpty() && !path.isEmpty()) {
@@ -84,7 +88,7 @@ public class QueryCommand implements Command {
 					"with --path support."));
 		}
 
-		System.out.println(Output.formatHits(hits, parsed.format()));
+		System.out.println(Output.formatHits(hits, arguments.getFormat()));
 
 		return 0;
 	}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/SimilarCommand.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/SimilarCommand.java
@@ -1,0 +1,127 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.command;
+
+import com.liferay.semantic.search.cli.chunker.Chunkers;
+import com.liferay.semantic.search.cli.client.QdrantClientWrapper;
+import com.liferay.semantic.search.cli.client.TextEmbeddingsClient;
+import com.liferay.semantic.search.cli.util.Args;
+import com.liferay.semantic.search.cli.util.Chunk;
+import com.liferay.semantic.search.cli.util.Hit;
+import com.liferay.semantic.search.cli.util.Output;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author JR Houn
+ */
+public class SimilarCommand implements Command {
+
+	@Override
+	public String description() {
+		return "Search by file: similar <file> [--format text|json] [--path " +
+			"<dir-prefix>] [--top N]";
+	}
+
+	@Override
+	public int run(String[] args) throws Exception {
+		Args parsed = new Args(args);
+
+		List<String> positional = parsed.positional();
+
+		if (positional.isEmpty()) {
+			System.err.println("search: similar requires a <path> argument");
+
+			return 2;
+		}
+
+		Path targetPath = Paths.get(positional.get(0));
+
+		if (!Files.exists(targetPath)) {
+			System.err.println("search: file not found: " + targetPath);
+
+			return 1;
+		}
+
+		String text = new String(
+			Files.readAllBytes(targetPath), StandardCharsets.UTF_8);
+
+		String targetBaseName = String.valueOf(targetPath.getFileName());
+
+		List<Chunk> chunks = Chunkers.parse(text, targetBaseName);
+
+		if (chunks.isEmpty()) {
+			System.err.println(
+				"search: target file has no extractable content.");
+
+			return 4;
+		}
+
+		QdrantClientWrapper qdrantClient = new QdrantClientWrapper();
+
+		if (!qdrantClient.isReachable()) {
+			System.err.println(
+				"search: cannot reach Qdrant at " +
+					qdrantClient.getQdrantUrl());
+
+			return 5;
+		}
+
+		if (!qdrantClient.collectionExists(QdrantClientWrapper.COLLECTION)) {
+			System.err.println(
+				"search: index does not exist. Run ingest first.");
+
+			return 3;
+		}
+
+		Chunk seed = chunks.get(0);
+
+		String queryText =
+			String.join(" > ", seed.headingPath()) + "\n\n" + seed.text();
+
+		TextEmbeddingsClient teiClient = new TextEmbeddingsClient();
+
+		// similar is code-to-code: embed the seed as a document (no query
+		// instruction prefix), matching the document side of the model.
+
+		float[] vector = teiClient.embedDocuments(List.of(queryText))[0];
+
+		List<QdrantClientWrapper.Hit> rawHits = qdrantClient.search(
+			vector, (parsed.top() * 3) + 10, parsed.path());
+
+		List<Hit> hits = new ArrayList<>();
+
+		for (QdrantClientWrapper.Hit rawHit : rawHits) {
+			String relPath = rawHit.relPath();
+
+			if (relPath.equals(targetBaseName) ||
+				relPath.endsWith("/" + targetBaseName)) {
+
+				continue;
+			}
+
+			hits.add(
+				new Hit(
+					relPath, rawHit.score(), rawHit.chunkId(),
+					Output.snippet(rawHit.text()), rawHit.headingPath()));
+
+			if (hits.size() >= parsed.top()) {
+				break;
+			}
+		}
+
+		System.out.println(Output.formatHits(hits, parsed.format()));
+
+		return 0;
+	}
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/SimilarCommand.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/SimilarCommand.java
@@ -8,7 +8,7 @@ package com.liferay.semantic.search.cli.command;
 import com.liferay.semantic.search.cli.chunker.Chunkers;
 import com.liferay.semantic.search.cli.client.QdrantClientWrapper;
 import com.liferay.semantic.search.cli.client.TextEmbeddingsClient;
-import com.liferay.semantic.search.cli.util.Args;
+import com.liferay.semantic.search.cli.util.Arguments;
 import com.liferay.semantic.search.cli.util.Chunk;
 import com.liferay.semantic.search.cli.util.Hit;
 import com.liferay.semantic.search.cli.util.Output;
@@ -34,9 +34,9 @@ public class SimilarCommand implements Command {
 
 	@Override
 	public int run(String[] args) throws Exception {
-		Args parsed = new Args(args);
+		Arguments arguments = new Arguments(args);
 
-		List<String> positional = parsed.positional();
+		List<String> positional = arguments.getPositional();
 
 		if (positional.isEmpty()) {
 			System.err.println("search: similar requires a <path> argument");
@@ -61,24 +61,26 @@ public class SimilarCommand implements Command {
 
 		if (chunks.isEmpty()) {
 			System.err.println(
-				"search: target file has no extractable content.");
+				"search: target file has no extractable content");
 
 			return 4;
 		}
 
-		QdrantClientWrapper qdrantClient = new QdrantClientWrapper();
+		QdrantClientWrapper qdrantClientWrapper = new QdrantClientWrapper();
 
-		if (!qdrantClient.isReachable()) {
+		if (!qdrantClientWrapper.isReachable()) {
 			System.err.println(
 				"search: cannot reach Qdrant at " +
-					qdrantClient.getQdrantUrl());
+					qdrantClientWrapper.getQdrantURL());
 
 			return 5;
 		}
 
-		if (!qdrantClient.collectionExists(QdrantClientWrapper.COLLECTION)) {
+		if (!qdrantClientWrapper.hasCollection(
+				QdrantClientWrapper.COLLECTION)) {
+
 			System.err.println(
-				"search: index does not exist. Run ingest first.");
+				"search: index does not exist; run ingest first");
 
 			return 3;
 		}
@@ -86,22 +88,24 @@ public class SimilarCommand implements Command {
 		Chunk seed = chunks.get(0);
 
 		String queryText =
-			String.join(" > ", seed.headingPath()) + "\n\n" + seed.text();
+			String.join(" > ", seed.getHeadingPath()) + "\n\n" + seed.getText();
 
-		TextEmbeddingsClient teiClient = new TextEmbeddingsClient();
+		TextEmbeddingsClient textEmbeddingsClient = new TextEmbeddingsClient();
 
-		// similar is code-to-code: embed the seed as a document (no query
+		// Similar is code-to-code: embed the seed as a document (no query
 		// instruction prefix), matching the document side of the model.
 
-		float[] vector = teiClient.embedDocuments(List.of(queryText))[0];
+		float[] vector =
+			textEmbeddingsClient.embedDocuments(List.of(queryText))[0];
 
-		List<QdrantClientWrapper.Hit> rawHits = qdrantClient.search(
-			vector, (parsed.top() * 3) + 10, parsed.path());
+		List<QdrantClientWrapper.SearchResult> searchResults =
+			qdrantClientWrapper.search(
+				vector, (arguments.getTop() * 3) + 10, arguments.getPath());
 
 		List<Hit> hits = new ArrayList<>();
 
-		for (QdrantClientWrapper.Hit rawHit : rawHits) {
-			String relPath = rawHit.relPath();
+		for (QdrantClientWrapper.SearchResult searchResult : searchResults) {
+			String relPath = searchResult.getRelPath();
 
 			if (relPath.equals(targetBaseName) ||
 				relPath.endsWith("/" + targetBaseName)) {
@@ -111,15 +115,16 @@ public class SimilarCommand implements Command {
 
 			hits.add(
 				new Hit(
-					relPath, rawHit.score(), rawHit.chunkId(),
-					Output.snippet(rawHit.text()), rawHit.headingPath()));
+					relPath, searchResult.getScore(), searchResult.getChunkId(),
+					Output.snippet(searchResult.getText()),
+					searchResult.getHeadingPath()));
 
-			if (hits.size() >= parsed.top()) {
+			if (hits.size() >= arguments.getTop()) {
 				break;
 			}
 		}
 
-		System.out.println(Output.formatHits(hits, parsed.format()));
+		System.out.println(Output.formatHits(hits, arguments.getFormat()));
 
 		return 0;
 	}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/StatusCommand.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/StatusCommand.java
@@ -1,0 +1,106 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.command;
+
+import com.liferay.semantic.search.cli.client.QdrantClientWrapper;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+
+import org.json.JSONObject;
+
+/**
+ * @author JR Houn
+ */
+public class StatusCommand implements Command {
+
+	@Override
+	public String description() {
+		return "Print index status as JSON (always JSON; ignores --format)";
+	}
+
+	@Override
+	public int run(String[] args) throws Exception {
+		QdrantClientWrapper qdrantClient = new QdrantClientWrapper();
+
+		JSONObject statusJSONObject = new JSONObject();
+
+		statusJSONObject.put(
+			"doc_count", 0
+		).put(
+			"index_exists", false
+		).put(
+			"last_ingest", JSONObject.NULL
+		).put(
+			"qdrant_reachable", false
+		).put(
+			"qdrant_url", qdrantClient.getQdrantUrl()
+		).put(
+			"stale_days", JSONObject.NULL
+		);
+
+		if (!qdrantClient.isReachable()) {
+			System.out.println(statusJSONObject.toString(2));
+
+			System.err.println(
+				"search: cannot reach Qdrant at " +
+					qdrantClient.getQdrantUrl() +
+						". Start it: docker compose up -d qdrant");
+
+			return 5;
+		}
+
+		statusJSONObject.put("qdrant_reachable", true);
+
+		boolean indexExists = qdrantClient.collectionExists(
+			QdrantClientWrapper.COLLECTION);
+
+		statusJSONObject.put("index_exists", indexExists);
+
+		boolean metaExists = qdrantClient.collectionExists(
+			QdrantClientWrapper.META_COLLECTION);
+
+		QdrantClientWrapper.MetaState metaState =
+			metaExists ? qdrantClient.readMetaState() : null;
+
+		if (metaState != null) {
+			statusJSONObject.put(
+				"doc_count", metaState.docCount()
+			).put(
+				"last_ingest", metaState.lastIngest()
+			);
+
+			String lastIngest = metaState.lastIngest();
+
+			if (lastIngest != null) {
+				OffsetDateTime when = OffsetDateTime.parse(lastIngest);
+
+				Duration elapsed = Duration.between(when, OffsetDateTime.now());
+
+				double elapsedSeconds = elapsed.toSeconds();
+
+				double days = elapsedSeconds / 86400.0;
+
+				statusJSONObject.put("stale_days", _round(days, 2));
+			}
+		}
+
+		if (indexExists && (metaState == null)) {
+			statusJSONObject.put("chunk_count", qdrantClient.getChunkCount());
+		}
+
+		System.out.println(statusJSONObject.toString(2));
+
+		return 0;
+	}
+
+	private double _round(double value, int decimals) {
+		double scale = Math.pow(10, decimals);
+
+		return Math.round(value * scale) / scale;
+	}
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/StatusCommand.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/command/StatusCommand.java
@@ -24,7 +24,7 @@ public class StatusCommand implements Command {
 
 	@Override
 	public int run(String[] args) throws Exception {
-		QdrantClientWrapper qdrantClient = new QdrantClientWrapper();
+		QdrantClientWrapper qdrantClientWrapper = new QdrantClientWrapper();
 
 		JSONObject statusJSONObject = new JSONObject();
 
@@ -37,50 +37,52 @@ public class StatusCommand implements Command {
 		).put(
 			"qdrant_reachable", false
 		).put(
-			"qdrant_url", qdrantClient.getQdrantUrl()
+			"qdrant_url", qdrantClientWrapper.getQdrantURL()
 		).put(
 			"stale_days", JSONObject.NULL
 		);
 
-		if (!qdrantClient.isReachable()) {
+		if (!qdrantClientWrapper.isReachable()) {
 			System.out.println(statusJSONObject.toString(2));
 
 			System.err.println(
 				"search: cannot reach Qdrant at " +
-					qdrantClient.getQdrantUrl() +
-						". Start it: docker compose up -d qdrant");
+					qdrantClientWrapper.getQdrantURL() +
+						". Start it: docker compose up --detach qdrant");
 
 			return 5;
 		}
 
 		statusJSONObject.put("qdrant_reachable", true);
 
-		boolean indexExists = qdrantClient.collectionExists(
+		boolean indexExists = qdrantClientWrapper.hasCollection(
 			QdrantClientWrapper.COLLECTION);
 
 		statusJSONObject.put("index_exists", indexExists);
 
-		boolean metaExists = qdrantClient.collectionExists(
+		boolean metaExists = qdrantClientWrapper.hasCollection(
 			QdrantClientWrapper.META_COLLECTION);
 
 		QdrantClientWrapper.MetaState metaState =
-			metaExists ? qdrantClient.readMetaState() : null;
+			metaExists ? qdrantClientWrapper.readMetaState() : null;
 
 		if (metaState != null) {
 			statusJSONObject.put(
-				"doc_count", metaState.docCount()
+				"doc_count", metaState.getDocCount()
 			).put(
-				"last_ingest", metaState.lastIngest()
+				"last_ingest", metaState.getLastIngest()
 			);
 
-			String lastIngest = metaState.lastIngest();
+			String lastIngest = metaState.getLastIngest();
 
 			if (lastIngest != null) {
-				OffsetDateTime when = OffsetDateTime.parse(lastIngest);
+				OffsetDateTime offsetDateTime = OffsetDateTime.parse(
+					lastIngest);
 
-				Duration elapsed = Duration.between(when, OffsetDateTime.now());
+				Duration duration = Duration.between(
+					offsetDateTime, OffsetDateTime.now());
 
-				double elapsedSeconds = elapsed.toSeconds();
+				double elapsedSeconds = duration.toSeconds();
 
 				double days = elapsedSeconds / 86400.0;
 
@@ -89,7 +91,8 @@ public class StatusCommand implements Command {
 		}
 
 		if (indexExists && (metaState == null)) {
-			statusJSONObject.put("chunk_count", qdrantClient.getChunkCount());
+			statusJSONObject.put(
+				"chunk_count", qdrantClientWrapper.getChunkCount());
 		}
 
 		System.out.println(statusJSONObject.toString(2));

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/util/Args.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/util/Args.java
@@ -1,0 +1,108 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.util;
+
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tiny argument parser. Recognizes long flags only:
+ *   --top N
+ *   --format text|json
+ *   --force
+ *   --path PREFIX
+ *
+ * Anything else is a positional argument, accumulated in order.
+ *
+ * Intentionally limited. Subcommands validate their own positional
+ * counts and unknown-flag handling; this class is just the split.
+ *
+ * @author JR Houn
+ */
+public class Args {
+
+	public Args(String[] args) {
+		List<String> positional = new ArrayList<>();
+
+		boolean force = false;
+
+		int i = 0;
+
+		while (i < args.length) {
+			String arg = args[i];
+
+			if (arg.equals("--top")) {
+				_top = GetterUtil.getInteger(args[++i], _top);
+			}
+			else if (arg.equals("--format")) {
+				_format = args[++i];
+			}
+			else if (arg.equals("--force")) {
+				force = true;
+			}
+			else if (arg.equals("--path")) {
+				_path = _normalizePath(args[++i]);
+			}
+			else {
+				positional.add(arg);
+			}
+
+			i++;
+		}
+
+		_force = force;
+		_positional = positional;
+	}
+
+	public boolean force() {
+		return _force;
+	}
+
+	public String format() {
+		return _format;
+	}
+
+	/**
+	 * The directory-prefix scope for a query, relative to the index's
+	 * ingest root (for example, "modules/apps/headless"). Empty when no
+	 * --path flag was given, meaning the whole index is searched.
+	 */
+	public String path() {
+		return _path;
+	}
+
+	public List<String> positional() {
+		return _positional;
+	}
+
+	public int top() {
+		return _top;
+	}
+
+	private String _normalizePath(String path) {
+		String normalized = StringUtil.replace(path, '\\', '/');
+
+		while (normalized.startsWith("./")) {
+			normalized = normalized.substring(2);
+		}
+
+		while (normalized.endsWith("/")) {
+			normalized = normalized.substring(0, normalized.length() - 1);
+		}
+
+		return normalized;
+	}
+
+	private final boolean _force;
+	private String _format = "text";
+	private String _path = "";
+	private final List<String> _positional;
+	private int _top = 5;
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/util/Arguments.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/util/Arguments.java
@@ -25,9 +25,9 @@ import java.util.List;
  *
  * @author JR Houn
  */
-public class Args {
+public class Arguments {
 
-	public Args(String[] args) {
+	public Arguments(String[] args) {
 		List<String> positional = new ArrayList<>();
 
 		boolean force = false;
@@ -60,11 +60,7 @@ public class Args {
 		_positional = positional;
 	}
 
-	public boolean force() {
-		return _force;
-	}
-
-	public String format() {
+	public String getFormat() {
 		return _format;
 	}
 
@@ -73,16 +69,20 @@ public class Args {
 	 * ingest root (for example, "modules/apps/headless"). Empty when no
 	 * --path flag was given, meaning the whole index is searched.
 	 */
-	public String path() {
+	public String getPath() {
 		return _path;
 	}
 
-	public List<String> positional() {
+	public List<String> getPositional() {
 		return _positional;
 	}
 
-	public int top() {
+	public int getTop() {
 		return _top;
+	}
+
+	public boolean isForce() {
+		return _force;
 	}
 
 	private String _normalizePath(String path) {

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/util/Chunk.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/util/Chunk.java
@@ -1,0 +1,137 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.util;
+
+import java.nio.charset.StandardCharsets;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * One unit of indexable content — a section (or sliding-window slice
+ * of a section) of a Markdown document. The chunk_id field is the
+ * stable opaque identifier used as the Qdrant point ID after a
+ * UUID5 transform.
+ *
+ * @author JR Houn
+ */
+public class Chunk {
+
+	public static final UUID NAMESPACE = UUID.fromString(
+		"6f1f0d6c-1c4a-4f6e-9b1a-7c0b8d9e0f11");
+
+	public Chunk(
+		String chunkId, String relPath, List<String> headingPath, String text) {
+
+		this(chunkId, relPath, headingPath, text, "");
+	}
+
+	public Chunk(
+		String chunkId, String relPath, List<String> headingPath, String text,
+		String header) {
+
+		_chunkId = chunkId;
+		_relPath = relPath;
+		_headingPath = headingPath;
+		_text = text;
+		_header = header;
+	}
+
+	public String chunkId() {
+		return _chunkId;
+	}
+
+	/**
+	 * The text actually sent to the embedding model. When a header is
+	 * present (code chunks prepend file path and scope), it is embedded
+	 * along with the body so the vector reflects where the code lives;
+	 * the stored snippet ({@link #text()}) stays the raw body.
+	 */
+	public String embeddingText() {
+		if ((_header == null) || _header.isEmpty()) {
+			return _text;
+		}
+
+		return _header + "\n\n" + _text;
+	}
+
+	public List<String> headingPath() {
+		return _headingPath;
+	}
+
+	public UUID pointId() {
+		return _uuid5(NAMESPACE, _chunkId);
+	}
+
+	public String relPath() {
+		return _relPath;
+	}
+
+	public String text() {
+		return _text;
+	}
+
+	private byte[] _toBytes(UUID uuid) {
+		byte[] bytes = new byte[16];
+
+		long msb = uuid.getMostSignificantBits();
+
+		long lsb = uuid.getLeastSignificantBits();
+
+		for (int i = 0; i < 8; i++) {
+			bytes[i] = (byte)(msb >>> (8 * (7 - i)));
+		}
+
+		for (int i = 0; i < 8; i++) {
+			bytes[8 + i] = (byte)(lsb >>> (8 * (7 - i)));
+		}
+
+		return bytes;
+	}
+
+	private UUID _uuid5(UUID namespace, String name) {
+		try {
+			MessageDigest messageDigest = MessageDigest.getInstance("SHA-1");
+
+			messageDigest.update(_toBytes(namespace));
+			messageDigest.update(name.getBytes(StandardCharsets.UTF_8));
+
+			byte[] hash = messageDigest.digest();
+
+			hash[6] &= 0x0f;
+			hash[6] |= 0x50;
+			hash[8] &= 0x3f;
+			hash[8] |= 0x80;
+
+			long msb = 0;
+
+			long lsb = 0;
+
+			for (int i = 0; i < 8; i++) {
+				msb = (msb << 8) | (hash[i] & 0xff);
+			}
+
+			for (int i = 8; i < 16; i++) {
+				lsb = (lsb << 8) | (hash[i] & 0xff);
+			}
+
+			return new UUID(msb, lsb);
+		}
+		catch (NoSuchAlgorithmException noSuchAlgorithmException) {
+			throw new RuntimeException(noSuchAlgorithmException);
+		}
+	}
+
+	private final String _chunkId;
+	private final String _header;
+	private final List<String> _headingPath;
+	private final String _relPath;
+	private final String _text;
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/util/Chunk.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/util/Chunk.java
@@ -43,7 +43,7 @@ public class Chunk {
 		_header = header;
 	}
 
-	public String chunkId() {
+	public String getChunkId() {
 		return _chunkId;
 	}
 
@@ -51,9 +51,9 @@ public class Chunk {
 	 * The text actually sent to the embedding model. When a header is
 	 * present (code chunks prepend file path and scope), it is embedded
 	 * along with the body so the vector reflects where the code lives;
-	 * the stored snippet ({@link #text()}) stays the raw body.
+	 * the stored snippet ({@link #getText()}) stays the raw body.
 	 */
-	public String embeddingText() {
+	public String getEmbeddingText() {
 		if ((_header == null) || _header.isEmpty()) {
 			return _text;
 		}
@@ -61,19 +61,19 @@ public class Chunk {
 		return _header + "\n\n" + _text;
 	}
 
-	public List<String> headingPath() {
+	public List<String> getHeadingPath() {
 		return _headingPath;
 	}
 
-	public UUID pointId() {
+	public UUID getPointId() {
 		return _uuid5(NAMESPACE, _chunkId);
 	}
 
-	public String relPath() {
+	public String getRelPath() {
 		return _relPath;
 	}
 
-	public String text() {
+	public String getText() {
 		return _text;
 	}
 

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/util/Hit.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/util/Hit.java
@@ -1,0 +1,55 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.util;
+
+import java.util.List;
+
+/**
+ * One element of the JSON output array emitted by `query` and
+ * `similar`. Field names are part of the stable contract.
+ *
+ * @author JR Houn
+ */
+public class Hit {
+
+	public Hit(
+		String path, double score, String chunkId, String snippet,
+		List<String> headingPath) {
+
+		_path = path;
+		_score = score;
+		_chunkId = chunkId;
+		_snippet = snippet;
+		_headingPath = headingPath;
+	}
+
+	public String chunkId() {
+		return _chunkId;
+	}
+
+	public List<String> headingPath() {
+		return _headingPath;
+	}
+
+	public String path() {
+		return _path;
+	}
+
+	public double score() {
+		return _score;
+	}
+
+	public String snippet() {
+		return _snippet;
+	}
+
+	private final String _chunkId;
+	private final List<String> _headingPath;
+	private final String _path;
+	private final double _score;
+	private final String _snippet;
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/util/Hit.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/util/Hit.java
@@ -26,23 +26,23 @@ public class Hit {
 		_headingPath = headingPath;
 	}
 
-	public String chunkId() {
+	public String getChunkId() {
 		return _chunkId;
 	}
 
-	public List<String> headingPath() {
+	public List<String> getHeadingPath() {
 		return _headingPath;
 	}
 
-	public String path() {
+	public String getPath() {
 		return _path;
 	}
 
-	public double score() {
+	public double getScore() {
 		return _score;
 	}
 
-	public String snippet() {
+	public String getSnippet() {
 		return _snippet;
 	}
 

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/util/Output.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/util/Output.java
@@ -1,0 +1,116 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.util;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * Formats result lists as the two output styles `query` and `similar`
+ * accept. The JSON shape is the stable contract — field names and
+ * types must not change without bumping the contract version.
+ *
+ * @author JR Houn
+ */
+public class Output {
+
+	public static String formatHits(List<Hit> hits, String format) {
+		if (Objects.equals(format, "json")) {
+			return _formatHitsJSON(hits);
+		}
+
+		return _formatHitsText(hits);
+	}
+
+	public static String snippet(String text) {
+		String collapsed = text.replaceAll("\\s+", " ");
+
+		collapsed = collapsed.trim();
+
+		if (collapsed.length() <= _SNIPPET_MAX_CHARS) {
+			return collapsed;
+		}
+
+		String cut = collapsed.substring(0, _SNIPPET_MAX_CHARS);
+
+		int lastSpace = cut.lastIndexOf(' ');
+
+		if (lastSpace > (_SNIPPET_MAX_CHARS * 0.6)) {
+			cut = cut.substring(0, lastSpace);
+		}
+
+		return cut + "...";
+	}
+
+	private static String _formatHitsJSON(List<Hit> hits) {
+		JSONArray hitsJSONArray = new JSONArray();
+
+		for (Hit hit : hits) {
+			JSONObject hitJSONObject = new JSONObject();
+
+			hitJSONObject.put(
+				"chunk_id", hit.chunkId()
+			).put(
+				"heading_path", new JSONArray(hit.headingPath())
+			).put(
+				"path", hit.path()
+			).put(
+				"score", _round(hit.score(), 4)
+			).put(
+				"snippet", hit.snippet()
+			);
+
+			hitsJSONArray.put(hitJSONObject);
+		}
+
+		return hitsJSONArray.toString(2);
+	}
+
+	private static String _formatHitsText(List<Hit> hits) {
+		if (hits.isEmpty()) {
+			return "(no results)";
+		}
+
+		StringBuilder stringBuilder = new StringBuilder();
+
+		int i = 1;
+
+		for (Hit hit : hits) {
+			String head = String.join(" > ", hit.headingPath());
+
+			if (head.isEmpty()) {
+				head = "(no heading)";
+			}
+
+			stringBuilder.append(i++);
+			stringBuilder.append(". ");
+			stringBuilder.append(hit.path());
+			stringBuilder.append("  [");
+			stringBuilder.append(String.format("%.3f", hit.score()));
+			stringBuilder.append("]\n   ");
+			stringBuilder.append(head);
+			stringBuilder.append("\n   ");
+			stringBuilder.append(hit.snippet());
+			stringBuilder.append('\n');
+		}
+
+		stringBuilder.setLength(stringBuilder.length() - 1);
+
+		return stringBuilder.toString();
+	}
+
+	private static double _round(double value, int decimals) {
+		double scale = Math.pow(10, decimals);
+
+		return Math.round(value * scale) / scale;
+	}
+
+	private static final int _SNIPPET_MAX_CHARS = 300;
+
+}

--- a/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/util/Output.java
+++ b/modules/util/semantic-search-cli/src/main/java/com/liferay/semantic/search/cli/util/Output.java
@@ -5,6 +5,8 @@
 
 package com.liferay.semantic.search.cli.util;
 
+import com.liferay.petra.string.StringBundler;
+
 import java.util.List;
 import java.util.Objects;
 
@@ -55,15 +57,15 @@ public class Output {
 			JSONObject hitJSONObject = new JSONObject();
 
 			hitJSONObject.put(
-				"chunk_id", hit.chunkId()
+				"chunk_id", hit.getChunkId()
 			).put(
-				"heading_path", new JSONArray(hit.headingPath())
+				"heading_path", new JSONArray(hit.getHeadingPath())
 			).put(
-				"path", hit.path()
+				"path", hit.getPath()
 			).put(
-				"score", _round(hit.score(), 4)
+				"score", _round(hit.getScore(), 4)
 			).put(
-				"snippet", hit.snippet()
+				"snippet", hit.getSnippet()
 			);
 
 			hitsJSONArray.put(hitJSONObject);
@@ -77,32 +79,32 @@ public class Output {
 			return "(no results)";
 		}
 
-		StringBuilder stringBuilder = new StringBuilder();
+		StringBundler sb = new StringBundler();
 
 		int i = 1;
 
 		for (Hit hit : hits) {
-			String head = String.join(" > ", hit.headingPath());
+			String head = String.join(" > ", hit.getHeadingPath());
 
 			if (head.isEmpty()) {
 				head = "(no heading)";
 			}
 
-			stringBuilder.append(i++);
-			stringBuilder.append(". ");
-			stringBuilder.append(hit.path());
-			stringBuilder.append("  [");
-			stringBuilder.append(String.format("%.3f", hit.score()));
-			stringBuilder.append("]\n   ");
-			stringBuilder.append(head);
-			stringBuilder.append("\n   ");
-			stringBuilder.append(hit.snippet());
-			stringBuilder.append('\n');
+			sb.append(i++);
+			sb.append(". ");
+			sb.append(hit.getPath());
+			sb.append("  [");
+			sb.append(String.format("%.3f", hit.getScore()));
+			sb.append("]\n   ");
+			sb.append(head);
+			sb.append("\n   ");
+			sb.append(hit.getSnippet());
+			sb.append('\n');
 		}
 
-		stringBuilder.setLength(stringBuilder.length() - 1);
+		sb.setIndex(sb.index() - 1);
 
-		return stringBuilder.toString();
+		return sb.toString();
 	}
 
 	private static double _round(double value, int decimals) {

--- a/modules/util/semantic-search-cli/src/test/java/com/liferay/semantic/search/cli/chunker/JavaChunkerTest.java
+++ b/modules/util/semantic-search-cli/src/test/java/com/liferay/semantic/search/cli/chunker/JavaChunkerTest.java
@@ -1,0 +1,134 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.chunker;
+
+import com.liferay.semantic.search.cli.util.Chunk;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author JR Houn
+ */
+public class JavaChunkerTest {
+
+	@Test
+	public void testClassNameDrivesHeadingPath() {
+		String text = _read("SampleResourceImpl.java.txt");
+
+		JavaChunker javaChunker = new JavaChunker();
+
+		List<Chunk> chunks = javaChunker.parse(text, "SampleResourceImpl.java");
+
+		for (Chunk chunk : chunks) {
+			List<String> headingPath = chunk.headingPath();
+
+			Assert.assertEquals("SampleResourceImpl", headingPath.get(0));
+		}
+	}
+
+	@Test
+	public void testImportBlockIsStripped() {
+		String text = _read("SampleResourceImpl.java.txt");
+
+		JavaChunker javaChunker = new JavaChunker();
+
+		List<Chunk> chunks = javaChunker.parse(text, "SampleResourceImpl.java");
+
+		for (Chunk chunk : chunks) {
+			Assert.assertFalse(
+				"chunks must not contain raw import lines",
+				chunk.text(
+				).contains(
+					"import com.example.other.SampleService"
+				));
+		}
+	}
+
+	@Test
+	public void testLicenseHeaderIsStripped() {
+		String text = _read("SampleResourceImpl.java.txt");
+
+		JavaChunker javaChunker = new JavaChunker();
+
+		List<Chunk> chunks = javaChunker.parse(text, "SampleResourceImpl.java");
+
+		for (Chunk chunk : chunks) {
+			Assert.assertFalse(
+				"chunks must not contain license-header text",
+				chunk.text(
+				).contains(
+					"SPDX-FileCopyrightText"
+				));
+		}
+	}
+
+	@Test
+	public void testMethodNamesBecomeSecondHeadingElement() {
+		String text = _read("SampleResourceImpl.java.txt");
+
+		JavaChunker javaChunker = new JavaChunker();
+
+		List<Chunk> chunks = javaChunker.parse(text, "SampleResourceImpl.java");
+
+		List<String> methodNames = new ArrayList<>();
+
+		for (Chunk chunk : chunks) {
+			List<String> headingPath = chunk.headingPath();
+
+			if (headingPath.size() == 2) {
+				methodNames.add(headingPath.get(1));
+			}
+		}
+
+		Assert.assertEquals(
+			"three top-level methods",
+			Arrays.asList("getItems", "postItem", "_validate"), methodNames);
+	}
+
+	@Test
+	public void testOneChunkPerMethodPlusIntro() {
+		String text = _read("SampleResourceImpl.java.txt");
+
+		JavaChunker javaChunker = new JavaChunker();
+
+		List<Chunk> chunks = javaChunker.parse(text, "SampleResourceImpl.java");
+
+		Assert.assertEquals("intro + 3 methods", 4, chunks.size());
+	}
+
+	private String _read(String fixtureName) {
+		String resourcePath =
+			"com/liferay/semantic/search/cli/chunker/dependencies/" +
+				fixtureName;
+
+		ClassLoader classLoader = JavaChunkerTest.class.getClassLoader();
+
+		try (InputStream inputStream = classLoader.getResourceAsStream(
+				resourcePath)) {
+
+			if (inputStream == null) {
+				throw new RuntimeException("missing fixture: " + resourcePath);
+			}
+
+			return new String(
+				inputStream.readAllBytes(), StandardCharsets.UTF_8);
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
+	}
+
+}

--- a/modules/util/semantic-search-cli/src/test/java/com/liferay/semantic/search/cli/chunker/JavaChunkerTest.java
+++ b/modules/util/semantic-search-cli/src/test/java/com/liferay/semantic/search/cli/chunker/JavaChunkerTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 public class JavaChunkerTest {
 
 	@Test
-	public void testClassNameDrivesHeadingPath() {
+	public void testParseClassNameDrivesHeadingPath() {
 		String text = _read("SampleResourceImpl.java.txt");
 
 		JavaChunker javaChunker = new JavaChunker();
@@ -33,14 +33,14 @@ public class JavaChunkerTest {
 		List<Chunk> chunks = javaChunker.parse(text, "SampleResourceImpl.java");
 
 		for (Chunk chunk : chunks) {
-			List<String> headingPath = chunk.headingPath();
+			List<String> headingPath = chunk.getHeadingPath();
 
 			Assert.assertEquals("SampleResourceImpl", headingPath.get(0));
 		}
 	}
 
 	@Test
-	public void testImportBlockIsStripped() {
+	public void testParseImportBlockIsStripped() {
 		String text = _read("SampleResourceImpl.java.txt");
 
 		JavaChunker javaChunker = new JavaChunker();
@@ -50,7 +50,7 @@ public class JavaChunkerTest {
 		for (Chunk chunk : chunks) {
 			Assert.assertFalse(
 				"chunks must not contain raw import lines",
-				chunk.text(
+				chunk.getText(
 				).contains(
 					"import com.example.other.SampleService"
 				));
@@ -58,7 +58,7 @@ public class JavaChunkerTest {
 	}
 
 	@Test
-	public void testLicenseHeaderIsStripped() {
+	public void testParseLicenseHeaderIsStripped() {
 		String text = _read("SampleResourceImpl.java.txt");
 
 		JavaChunker javaChunker = new JavaChunker();
@@ -68,7 +68,7 @@ public class JavaChunkerTest {
 		for (Chunk chunk : chunks) {
 			Assert.assertFalse(
 				"chunks must not contain license-header text",
-				chunk.text(
+				chunk.getText(
 				).contains(
 					"SPDX-FileCopyrightText"
 				));
@@ -76,7 +76,7 @@ public class JavaChunkerTest {
 	}
 
 	@Test
-	public void testMethodNamesBecomeSecondHeadingElement() {
+	public void testParseMethodNamesBecomeSecondHeadingElement() {
 		String text = _read("SampleResourceImpl.java.txt");
 
 		JavaChunker javaChunker = new JavaChunker();
@@ -86,7 +86,7 @@ public class JavaChunkerTest {
 		List<String> methodNames = new ArrayList<>();
 
 		for (Chunk chunk : chunks) {
-			List<String> headingPath = chunk.headingPath();
+			List<String> headingPath = chunk.getHeadingPath();
 
 			if (headingPath.size() == 2) {
 				methodNames.add(headingPath.get(1));
@@ -99,7 +99,7 @@ public class JavaChunkerTest {
 	}
 
 	@Test
-	public void testOneChunkPerMethodPlusIntro() {
+	public void testParseOneChunkPerMethodPlusIntro() {
 		String text = _read("SampleResourceImpl.java.txt");
 
 		JavaChunker javaChunker = new JavaChunker();

--- a/modules/util/semantic-search-cli/src/test/java/com/liferay/semantic/search/cli/chunker/MarkdownChunkerTest.java
+++ b/modules/util/semantic-search-cli/src/test/java/com/liferay/semantic/search/cli/chunker/MarkdownChunkerTest.java
@@ -1,0 +1,156 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.semantic.search.cli.chunker;
+
+import com.liferay.semantic.search.cli.util.Chunk;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author JR Houn
+ */
+public class MarkdownChunkerTest {
+
+	@Test
+	public void testFrontMatterIsStripped() {
+		String text = _read("simple.md");
+
+		MarkdownChunker chunker = new MarkdownChunker();
+
+		List<Chunk> chunks = chunker.parse(text, "simple.md");
+
+		Chunk firstChunk = chunks.get(0);
+
+		String firstChunkText = firstChunk.text();
+
+		Assert.assertFalse(
+			"chunk text should not contain front matter",
+			firstChunkText.contains("uuid:"));
+	}
+
+	@Test
+	public void testH2SectionsGetH1H2HeadingPath() {
+		String text = _read("simple.md");
+
+		MarkdownChunker chunker = new MarkdownChunker();
+
+		List<Chunk> chunks = chunker.parse(text, "simple.md");
+
+		List<List<String>> headingPaths = new ArrayList<>();
+
+		for (Chunk chunk : chunks) {
+			headingPaths.add(chunk.headingPath());
+		}
+
+		Assert.assertEquals(List.of("Simple Document"), headingPaths.get(0));
+
+		Assert.assertEquals(
+			List.of("Simple Document", "First Section"), headingPaths.get(1));
+
+		Assert.assertEquals(
+			List.of("Simple Document", "Second Section"), headingPaths.get(2));
+	}
+
+	@Test
+	public void testIntroBecomesH1Chunk() {
+		String text = _read("simple.md");
+
+		MarkdownChunker chunker = new MarkdownChunker();
+
+		List<Chunk> chunks = chunker.parse(text, "simple.md");
+
+		Chunk intro = chunks.get(0);
+
+		List<String> headingPath = intro.headingPath();
+
+		Assert.assertEquals(headingPath.toString(), 1, headingPath.size());
+
+		Assert.assertEquals(
+			headingPath.toString(), "Simple Document", headingPath.get(0));
+
+		String introText = intro.text();
+
+		Assert.assertTrue(introText.startsWith("This is the intro"));
+	}
+
+	@Test
+	public void testNoH2_singleChunkUnderH1() {
+		String text = _read("no-h2.md");
+
+		MarkdownChunker chunker = new MarkdownChunker();
+
+		List<Chunk> chunks = chunker.parse(text, "no-h2.md");
+
+		Assert.assertEquals(chunks.toString(), 1, chunks.size());
+
+		Chunk only = chunks.get(0);
+
+		Assert.assertEquals(List.of("Just an H1"), only.headingPath());
+	}
+
+	@Test
+	public void testSimpleDocumentChunkCount() {
+		String text = _read("simple.md");
+
+		MarkdownChunker chunker = new MarkdownChunker();
+
+		List<Chunk> chunks = chunker.parse(text, "simple.md");
+
+		Assert.assertEquals(chunks.toString(), 3, chunks.size());
+	}
+
+	@Test
+	public void testSlidingWindowSplitsLongSections() {
+		StringBuilder stringBuilder = new StringBuilder("# Long Doc\n\n");
+
+		for (int i = 0; i < 500; i++) {
+			stringBuilder.append("word ");
+		}
+
+		MarkdownChunker chunker = new MarkdownChunker();
+
+		List<Chunk> chunks = chunker.parse(stringBuilder.toString(), "long.md");
+
+		Assert.assertTrue(
+			"long intro should produce more than one chunk", chunks.size() > 1);
+
+		for (Chunk chunk : chunks) {
+			Assert.assertEquals(List.of("Long Doc"), chunk.headingPath());
+		}
+	}
+
+	private String _read(String fixtureName) {
+		String resourcePath =
+			"com/liferay/semantic/search/cli/chunker/dependencies/" +
+				fixtureName;
+
+		ClassLoader classLoader = MarkdownChunkerTest.class.getClassLoader();
+
+		try (InputStream inputStream = classLoader.getResourceAsStream(
+				resourcePath)) {
+
+			if (inputStream == null) {
+				throw new RuntimeException("missing fixture: " + resourcePath);
+			}
+
+			return new String(
+				inputStream.readAllBytes(), StandardCharsets.UTF_8);
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
+	}
+
+}

--- a/modules/util/semantic-search-cli/src/test/java/com/liferay/semantic/search/cli/chunker/MarkdownChunkerTest.java
+++ b/modules/util/semantic-search-cli/src/test/java/com/liferay/semantic/search/cli/chunker/MarkdownChunkerTest.java
@@ -5,6 +5,7 @@
 
 package com.liferay.semantic.search.cli.chunker;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.semantic.search.cli.util.Chunk;
 
 import java.io.IOException;
@@ -24,7 +25,7 @@ import org.junit.Test;
 public class MarkdownChunkerTest {
 
 	@Test
-	public void testFrontMatterIsStripped() {
+	public void testParseFrontMatterIsStripped() {
 		String text = _read("simple.md");
 
 		MarkdownChunker chunker = new MarkdownChunker();
@@ -33,7 +34,7 @@ public class MarkdownChunkerTest {
 
 		Chunk firstChunk = chunks.get(0);
 
-		String firstChunkText = firstChunk.text();
+		String firstChunkText = firstChunk.getText();
 
 		Assert.assertFalse(
 			"chunk text should not contain front matter",
@@ -41,7 +42,7 @@ public class MarkdownChunkerTest {
 	}
 
 	@Test
-	public void testH2SectionsGetH1H2HeadingPath() {
+	public void testParseH2SectionsGetH1H2HeadingPath() {
 		String text = _read("simple.md");
 
 		MarkdownChunker chunker = new MarkdownChunker();
@@ -51,7 +52,7 @@ public class MarkdownChunkerTest {
 		List<List<String>> headingPaths = new ArrayList<>();
 
 		for (Chunk chunk : chunks) {
-			headingPaths.add(chunk.headingPath());
+			headingPaths.add(chunk.getHeadingPath());
 		}
 
 		Assert.assertEquals(List.of("Simple Document"), headingPaths.get(0));
@@ -64,7 +65,7 @@ public class MarkdownChunkerTest {
 	}
 
 	@Test
-	public void testIntroBecomesH1Chunk() {
+	public void testParseIntroBecomesH1Chunk() {
 		String text = _read("simple.md");
 
 		MarkdownChunker chunker = new MarkdownChunker();
@@ -73,20 +74,20 @@ public class MarkdownChunkerTest {
 
 		Chunk intro = chunks.get(0);
 
-		List<String> headingPath = intro.headingPath();
+		List<String> headingPath = intro.getHeadingPath();
 
 		Assert.assertEquals(headingPath.toString(), 1, headingPath.size());
 
 		Assert.assertEquals(
 			headingPath.toString(), "Simple Document", headingPath.get(0));
 
-		String introText = intro.text();
+		String introText = intro.getText();
 
 		Assert.assertTrue(introText.startsWith("This is the intro"));
 	}
 
 	@Test
-	public void testNoH2_singleChunkUnderH1() {
+	public void testParseNoH2SingleChunkUnderH1() {
 		String text = _read("no-h2.md");
 
 		MarkdownChunker chunker = new MarkdownChunker();
@@ -97,11 +98,11 @@ public class MarkdownChunkerTest {
 
 		Chunk only = chunks.get(0);
 
-		Assert.assertEquals(List.of("Just an H1"), only.headingPath());
+		Assert.assertEquals(List.of("Just an H1"), only.getHeadingPath());
 	}
 
 	@Test
-	public void testSimpleDocumentChunkCount() {
+	public void testParseSimpleDocumentChunkCount() {
 		String text = _read("simple.md");
 
 		MarkdownChunker chunker = new MarkdownChunker();
@@ -112,22 +113,24 @@ public class MarkdownChunkerTest {
 	}
 
 	@Test
-	public void testSlidingWindowSplitsLongSections() {
-		StringBuilder stringBuilder = new StringBuilder("# Long Doc\n\n");
+	public void testParseSlidingWindowSplitsLongSections() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("# Long Doc\n\n");
 
 		for (int i = 0; i < 500; i++) {
-			stringBuilder.append("word ");
+			sb.append("word ");
 		}
 
 		MarkdownChunker chunker = new MarkdownChunker();
 
-		List<Chunk> chunks = chunker.parse(stringBuilder.toString(), "long.md");
+		List<Chunk> chunks = chunker.parse(sb.toString(), "long.md");
 
 		Assert.assertTrue(
 			"long intro should produce more than one chunk", chunks.size() > 1);
 
 		for (Chunk chunk : chunks) {
-			Assert.assertEquals(List.of("Long Doc"), chunk.headingPath());
+			Assert.assertEquals(List.of("Long Doc"), chunk.getHeadingPath());
 		}
 	}
 

--- a/modules/util/semantic-search-cli/src/test/resources/com/liferay/semantic/search/cli/chunker/dependencies/SampleResourceImpl.java.txt
+++ b/modules/util/semantic-search-cli/src/test/resources/com/liferay/semantic/search/cli/chunker/dependencies/SampleResourceImpl.java.txt
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.example.sample;
+
+import com.example.other.SampleService;
+import com.example.other.SampleUtil;
+
+import java.util.List;
+
+/**
+ * @author JR Houn
+ */
+public class SampleResourceImpl {
+
+	public List<String> getItems() {
+		return _sampleService.getItems();
+	}
+
+	public void postItem(String item) {
+		_sampleService.add(item);
+	}
+
+	private void _validate(String item) {
+		if (item == null) {
+			throw new IllegalArgumentException();
+		}
+	}
+
+	private static final SampleService _sampleService = SampleUtil.getService();
+
+}

--- a/modules/util/semantic-search-cli/src/test/resources/com/liferay/semantic/search/cli/chunker/dependencies/no-h2.md
+++ b/modules/util/semantic-search-cli/src/test/resources/com/liferay/semantic/search/cli/chunker/dependencies/no-h2.md
@@ -1,0 +1,4 @@
+# Just an H1
+
+The whole body sits under the H1, no H2 sections exist. It should
+become a single chunk with heading_path = [h1].

--- a/modules/util/semantic-search-cli/src/test/resources/com/liferay/semantic/search/cli/chunker/dependencies/simple.md
+++ b/modules/util/semantic-search-cli/src/test/resources/com/liferay/semantic/search/cli/chunker/dependencies/simple.md
@@ -1,0 +1,20 @@
+---
+
+uuid: abc-123
+
+---
+
+# Simple Document
+
+This is the intro under the H1, before any H2.
+
+## First Section
+
+Body of the first section.
+
+## Second Section
+
+Body of the second section, with a list:
+
+- item one
+- item two


### PR DESCRIPTION
# Semantic Search CLI — `modules/util/semantic-search-cli/`

A small jar for semantic search over a repo's Markdown and Java source. It embeds content through a Hugging Face TEI container and stores/searches vectors in a Qdrant container, both brought up by the bundled `docker-compose.yml`. The subcommands, flags, and JSON output are the stable contract that skills and agents call by shell command.

## Note on the automated review

`./gradlew formatSource` passes clean on this module, and the legitimate conventions from the bot review are applied: full-acronym caps, `is`/`has` booleans, type-named variables, `StringBundler` over `StringBuilder`, statement-boundary chunk splitting, `testParse*` test names, loop-invariant hoisting, and no trailing slashes in paths.

Some bot flags are **not** enforced by the source-formatter and were intentionally not applied:

- **Parameter alphabetical-ordering** — Liferay does not sort method/constructor parameters (e.g. `countByG_C_C(long groupId, long classNameId, long classPK)`), and `formatSource` does not flag it.
- **README single-line paragraphs / de-hyphenated compounds** — existing `modules/util/*` READMEs are hard-wrapped and use ordinary hyphenation.

Held as deliberate, `formatSource`-clean choices: blocking on `xxxAsync().get()`; `org.json` for the small JSON surface (keeps the jar dependency-light); and the two map-building loops where `TransformUtil` would require bundling `petra.function` (not in the pinned `portal.kernel`).

## Why

This **complements `grep`/`ripgrep`, it does not replace it.** grep stays the fast, exhaustive choice when you know the string; semantic search adds retrieval by *intent* for when you don't — and in an LLM-driven cycle the assistant reaches for both. The payoff is largest for that second case: to answer "where does the API stop an anonymous user from creating a comment?" — no obvious symbol to grep — an assistant otherwise reads several `*ResourceImpl` files (tens of thousands of tokens) and may still miss it. One query returns the method:

```
query "permission check preventing anonymous users from creating content"
  → MessageBoardThreadResourceImpl > _checkPermission       (~1 KB snippet)

similar CommentResourceImpl.java
  → BlogPostingResourceImpl, WikiPageResourceImpl, …         (peer resources)

query "is content versioning already documented?"
  → the relevant article, even if it never says "versioning" verbatim
```

- **Fewer tokens.** A query returns a handful of snippets (a few KB, ~1–2K tokens) instead of the model reading a dozen candidate files (tens of KB) to find them — typically an order-of-magnitude cut on a task's context-gathering.
- **Faster.** One call instead of a grep-read loop; sub-second once indexed.
- **Better grounding.** Finds by meaning, so the related article or implementing method surfaces even when the wording differs — fewer wrong guesses.
- **Build once, reuse.** Deterministic, cacheable index: build per repo, reuse across sessions, distribute so nobody re-pays.

Two roles: a **developer** locating code by description or example, and a **technical content writer** finding related or duplicate articles and verifying doc claims against the implementation.

## Architecture

```mermaid
flowchart LR
    subgraph Caller["Caller (skill / agent / dev shell)"]
        CLI["<b>semantic-search-cli</b> jar (~30 MB)<br/>ingest · query · similar · status"]
    end
    subgraph Repo["Project checkout (any repo)"]
        SRC[("Markdown / Java source<br/>walked per <code>SEARCH_FILE_EXTS</code>")]
    end
    subgraph Compose["docker-compose (this module)"]
        TEI["<b>TEI</b> · CodeRankEmbed, 768-dim (~547 MB)<br/>HTTP :7997"]
        QD["<b>Qdrant</b><br/>HTTP :6333 · gRPC :6334"]
    end
    subgraph Data["SEARCH_DATA_HOME (sibling to repo)"]
        MC[("model-cache/<br/>~547 MB")]
        QDD[("qdrant-data/<br/>grows with corpus")]
    end
    CLI -->|reads| SRC
    CLI -->|"HTTP /embed"| TEI
    CLI -->|"gRPC"| QD
    TEI -.->|persists| MC
    QD -.->|persists| QDD
```

The jar stays small (~30 MB); embeddings and vector storage are container concerns. Data lives outside the repo so git stays clean and worktrees don't collide.

## Interface

```
search ingest <dir> [--force]
search query "<text>" [--top N] [--format text|json] [--path <dir-prefix>]
search similar <file> [--top N] [--format text|json] [--path <dir-prefix>]
search status
```

JSON shape: `{path, score, chunk_id, snippet, heading_path}`. Exit codes: `0` ok · `1` bad input · `2` usage · `3` no index · `4` empty target · `5` Qdrant down · `6` internal.

- **Chunking.** Markdown by `##` section (`[H1, H2]`); Java by method (`[Class, method]`), stripping license/package/imports, splitting oversized methods at statement boundaries, and prefixing each embedded chunk with a path + scope header.
- **`--path <dir-prefix>`** scopes `query`/`similar` to a subtree; the filter runs inside the vector search, so precision holds on a whole-repo index. *Index wide, query narrow.*
- **Model.** `nomic-ai/CodeRankEmbed` (code-tuned, MIT, 768-dim) for both corpora, set via `MODEL_ID`; changing it auto-rebuilds the index on dimension change. `SEARCH_QUERY_PREFIX` carries the model's query instruction, applied to queries only.
- **Data.** `SEARCH_DATA_HOME` (a `*-tools/search` sibling) holds the Qdrant index and model cache — out of the repo, per-worktree.

## Ports

`127.0.0.1`-bound, overridable; fixed container names keep the stack a singleton.

| Service | Default | Override |
| :--- | ---: | :--- |
| TEI | 7997 | `SEARCH_TEI_PORT` |
| Qdrant HTTP | 6333 | `SEARCH_QDRANT_HTTP_PORT` |
| Qdrant gRPC | 6334 | `SEARCH_QDRANT_GRPC_PORT` |

## Validation

`ingest`, `query`, `similar`, and `--path` scoping verified end-to-end on a Markdown corpus and a Java corpus. On both, CodeRankEmbed ranked the known-correct target at or near the top across an 8-query set (strongest on code: the exact file first 7–8/8). Embeddings are deterministic — identical input yields identical vectors — so an index built once is reusable and distributable. Index size is roughly 5–8× the indexed source bytes for a sizeable corpus (small corpora skew higher on fixed overhead, and the 768-dim model runs above the 384-dim measurement) — and that is actual on-disk use, not the much larger *apparent* size of Qdrant's sparse, pre-allocated files. A full `modules/**/*.java` build is roughly an overnight CPU job, intended to be built once and distributed.

## Design choices

- **TEI, not in-process embeddings.** Keeps the jar small; the model is a compose concern, swappable without rebuilding.
- **No lexical / BM25 hybrid.** `grep` already owns exact-symbol lookup — faster, exhaustive, no infra. Semantic search owns intent (find code by description when the symbol is unknown); `--path` owns scale. A BM25 stage would reinvent grep and blur that separation, so it is intentionally excluded.
- **Method-level chunks with a metadata header.** The header gives the vector locational signal; statement-boundary splitting avoids cutting mid-statement. Regex-based, no parser dependency.
- **Data outside the repo.** Vector indices are large binaries; sibling placement mirrors `bundles/`, isolated per worktree.
- **Rollback.** Delete the module — nothing else depends on the jar.

## Structure

Two signed commits: the module itself (24 files — `bnd.bnd`, `build.gradle`, `docker-compose.yml`, `README.md`, the CLI sources, and 11 chunker unit tests) and a Liferay code-conventions pass. `formatSource` clean, `test` green.

## Follow-ups (not in this PR)

- **Distribution.** `SEARCH_CODE_INDEX_URL` is the consumer hook to pull a published, commit-keyed index instead of indexing locally; standing up the publisher (one machine builds the whole-repo index from the checkout root per commit) is the next step. Consider excluding test/generated sources.
- **JDK flag.** `--add-opens=java.base/java.lang.invoke=ALL-UNNAMED` is needed for petra.string on JDK 17+ (the test JVM sets it; a production launcher needs the same).
- **Optional precision lifts** if needed later: a stronger code→code model for `similar`, or a cross-encoder rerank stage.
