### PR TITLE
LPD-93789 Fix Playwright tests broken by Clay and widget-page changes

### DIFF
--- a/modules/test/playwright/pages/layout-admin-web/PagesAdminPage.ts
+++ b/modules/test/playwright/pages/layout-admin-web/PagesAdminPage.ts
@@ -8,7 +8,6 @@ import {Locator, Page, expect} from '@playwright/test';
 import {clickAndExpectToBeHidden} from '../../utils/clickAndExpectToBeHidden';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import fillAndClickOutside from '../../utils/fillAndClickOutside';
-import {hoverAndExpectToBeVisible} from '../../utils/hoverAndExpectToBeVisible';
 import {PORTLET_URLS} from '../../utils/portletUrls';
 import {waitForAlert} from '../../utils/waitForAlert';
 import {waitForAllPortletsReady} from '../../utils/waitForAllPortletsReady';
@@ -389,7 +388,7 @@ export class PagesAdminPage {
 
 		// Click desired option
 
-		await hoverAndExpectToBeVisible({
+		await clickAndExpectToBeVisible({
 			autoClick: true,
 			target: this.page.getByRole('menuitem', {exact: true, name: label}),
 			timeout: 5000,

--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -12,7 +12,6 @@ import {collapseSection} from '../../utils/collapseSection';
 import {expandSection} from '../../utils/expandSection';
 import fillAndClickOutside from '../../utils/fillAndClickOutside';
 import getRandomString from '../../utils/getRandomString';
-import {hoverAndExpectToBeVisible} from '../../utils/hoverAndExpectToBeVisible';
 import {selectElement} from '../../utils/selectElement';
 import {waitForAlert} from '../../utils/waitForAlert';
 import {SegmentEditorPage} from '../segments-web/SegmentEditorPage';
@@ -640,7 +639,7 @@ export class PageEditorPage {
 				trigger: content.getByTitle('Open Actions Menu'),
 			});
 
-			await hoverAndExpectToBeVisible({
+			await clickAndExpectToBeVisible({
 				autoClick: true,
 				target: this.page.locator(`[data-label="${subMenuAction}"]`),
 				trigger: this.page.getByRole('menuitem', {name: action}),

--- a/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
+++ b/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
@@ -7,7 +7,6 @@ import {Locator, Page, expect} from '@playwright/test';
 
 import {clickAndExpectToBeHidden} from '../../utils/clickAndExpectToBeHidden';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
-import {hoverAndExpectToBeVisible} from '../../utils/hoverAndExpectToBeVisible';
 import {PORTLET_URLS} from '../../utils/portletUrls';
 import {waitForAlert} from '../../utils/waitForAlert';
 
@@ -55,7 +54,7 @@ export class DisplayPageTemplatesPage {
 				.getByLabel('More actions'),
 		});
 
-		await hoverAndExpectToBeVisible({
+		await clickAndExpectToBeVisible({
 			autoClick: true,
 			target: this.page
 				.getByText('Display Page', {exact: true})

--- a/modules/test/playwright/pages/layout-page-template-admin-web/MasterPagesPage.ts
+++ b/modules/test/playwright/pages/layout-page-template-admin-web/MasterPagesPage.ts
@@ -6,7 +6,6 @@
 import {Locator, Page, expect} from '@playwright/test';
 
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
-import {hoverAndExpectToBeVisible} from '../../utils/hoverAndExpectToBeVisible';
 import {PORTLET_URLS} from '../../utils/portletUrls';
 import {waitForAlert} from '../../utils/waitForAlert';
 import {zipFolder} from '../../utils/zip';
@@ -223,7 +222,7 @@ export class MasterPagesPage {
 
 		// Click desired option
 
-		await hoverAndExpectToBeVisible({
+		await clickAndExpectToBeVisible({
 			autoClick: true,
 			target: this.page
 				.getByText(label, {exact: true})

--- a/modules/test/playwright/tests/layout-admin-web/main/exportImport.spec.ts
+++ b/modules/test/playwright/tests/layout-admin-web/main/exportImport.spec.ts
@@ -26,6 +26,7 @@ const test = mergeTests(
 	dataApiHelpersTest,
 	featureFlagsTest({
 		'LPD-35443': {enabled: true},
+		'LPD-76864': {enabled: true},
 		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
@@ -324,6 +325,8 @@ test(
 			};
 
 			let clicked = 0;
+
+			await expect(treeNodes.first()).toBeVisible();
 
 			while (true) {
 				const count = await treeNodes.count();

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/sidebar.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/sidebar.spec.ts
@@ -1090,21 +1090,28 @@ testWithCKEditor4.describe('Page Contents Panel with CKEditor 4', () => {
 				fragmentId: headingId,
 			});
 
-			await editable.locator('[contenteditable="true"]').waitFor();
+			const editor = editable.locator('[contenteditable="true"]');
+
+			await editor.waitFor();
+
+			await editor.click();
 
 			// Clear current content text and fill with new one
 
-			await page.keyboard.press('Control+KeyA');
+			await page.keyboard.press('ControlOrMeta+KeyA');
 			await page.keyboard.press('Backspace');
 
 			await page.keyboard.type('New Content');
-			await page.locator('body').click();
 
-			await pageEditorPage.waitForChangesSaved();
+			await expect(async () => {
+				await page.keyboard.press('Escape');
 
-			await expect(
-				page.locator('.page-editor__page-contents__page-content')
-			).toContainText('New Content');
+				await pageEditorPage.waitForChangesSaved({timeout: 3000});
+
+				await expect(
+					page.locator('.page-editor__page-contents__page-content')
+				).toContainText('New Content', {timeout: 1000});
+			}).toPass();
 		}
 	);
 });

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/sidebar.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/sidebar.spec.ts
@@ -1456,7 +1456,7 @@ test.describe('Page Contents Panel', () => {
 				'Animal'
 			);
 
-			const articleTitle = 'Animal 03 - Elephant';
+			const articleTitle = `Animal 03 - Elephant ${getRandomString()}`;
 
 			await journalEditArticlePage.fillTitle(articleTitle);
 			await journalEditArticlePage.publishArticle();

--- a/modules/test/playwright/tests/site-navigation-admin-web/main/pages/NavigationMenusPage.ts
+++ b/modules/test/playwright/tests/site-navigation-admin-web/main/pages/NavigationMenusPage.ts
@@ -172,11 +172,11 @@ export class NavigationMenusPage {
 			.getByRole('button', {name: 'View ' + parentPage + ' Options'})
 			.click();
 
-		await this.page.getByRole('menuitem', {name: 'Add Child'}).hover();
-
-		await this.page.waitForTimeout(500);
-
-		await this.page.getByRole('menuitem', {name: 'Page'}).click();
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {name: 'Page'}),
+			trigger: this.page.getByRole('menuitem', {name: 'Add Child'}),
+		});
 
 		await this.pagesModal.getByText(childPage, {exact: true}).click();
 

--- a/modules/test/playwright/tests/template-web/main/templatesAdmin.spec.ts
+++ b/modules/test/playwright/tests/template-web/main/templatesAdmin.spec.ts
@@ -25,6 +25,7 @@ const test = mergeTests(
 	isolatedSiteTest,
 	featureFlagsTest({
 		'LPD-35443': {enabled: true},
+		'LPD-76864': {enabled: true},
 	}),
 	loginTest(),
 	templatesPageTest,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93789

## What Is Being Fixed

After rebasing onto current master, several Playwright tests broke due to upstream platform changes:

- The `@clayui/drop-down` upgrade made contextual (cascading) submenus open on a debounced hover (≈400 ms dwell) instead of instantly, so helpers that hovered to open "Add Items", "Make a Copy", and "Add Child" submenus timed out and the submenu items never became visible.
- Widget-page creation through the Admin REST API is now gated behind feature flag `LPD-76864`, so tests that create `WidgetPage`s received `BAD_REQUEST`.
- The CKEditor 4 (AlloyEditor) inline-edit test typed before the editor finished initializing and lost the keystrokes.
- A collection page-content test reused a hardcoded article title that accumulated duplicates across runs.

## How It Is Being Fixed

Contextual submenus are now opened with a click instead of a hover (`clickAndExpectToBeVisible`) across the affected Page objects (`PageEditorPage`, `PagesAdminPage`, `MasterPagesPage`, `DisplayPageTemplatesPage`, `NavigationMenusPage`), since `onClick` opens the submenu synchronously. The export/import and templates tests enable `LPD-76864` so widget-page creation is allowed. The CKEditor 4 test focuses the editor before typing and blurs with `Escape` inside a retry so the save is deterministic. The collection test uses a unique article title via `getRandomString()`.

## PR Check

**pr-check: PASS** — tested on `c30c87819dd3409de21f6f111f166d45dc43a49b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "c30c87819dd3409de21f6f111f166d45dc43a49b"} -->
