### PR TITLE
LPD-93390 Skip deprecated widget pages in site initializers

### DIFF
--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle-1/src/main/resources/site-initializer/layouts/2_test-private-layout/test-private-child-layout/test-private-grandchild-layout/page.json
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle-1/src/main/resources/site-initializer/layouts/2_test-private-layout/test-private-child-layout/test-private-grandchild-layout/page.json
@@ -1,0 +1,10 @@
+{
+	"friendlyURL": "/test-private-grandchild-layout-1",
+	"hidden": false,
+	"name_i18n": {
+		"en_US": "Test Private Grandchild Layout 1"
+	},
+	"private": true,
+	"system": false,
+	"type": "Content"
+}

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
@@ -199,7 +199,11 @@ import com.liferay.portal.language.override.service.PLOEntryLocalService;
 import com.liferay.portal.security.script.management.test.rule.ScriptManagementConfigurationTestRule;
 import com.liferay.portal.security.service.access.policy.model.SAPEntry;
 import com.liferay.portal.security.service.access.policy.service.SAPEntryLocalService;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -353,6 +357,7 @@ public class BundleSiteInitializerTest {
 		}
 	}
 
+	@FeatureFlag("LPD-76864")
 	@Test
 	public void testInitializeFromBundle() throws Exception {
 		Bundle bundle1 = _getBundle(
@@ -360,13 +365,27 @@ public class BundleSiteInitializerTest {
 		Bundle bundle2 = _getBundle(
 			"/com.liferay.site.initializer.extender.test.bundle.2.jar");
 
-		try {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.site.initializer.extender.internal." +
+					"BundleSiteInitializer",
+				LoggerTestUtil.WARN)) {
+
 			_test1(
 				_siteInitializerRegistry.getSiteInitializer(
 					bundle1.getSymbolicName()));
 			_test2(
 				_siteInitializerRegistry.getSiteInitializer(
 					bundle2.getSymbolicName()));
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertTrue(
+				logEntries.toString(),
+				_hasLogEntryMessage(
+					logEntries,
+					"Widget page with friendly URL " +
+						"/test-private-child-layout-1 is deprecated " +
+							"(LPD-76864)"));
 		}
 		finally {
 			bundle1.uninstall();
@@ -374,6 +393,63 @@ public class BundleSiteInitializerTest {
 		}
 	}
 
+	@FeatureFlag(enable = false, value = "LPD-76864")
+	@Test
+	public void testInitializeFromBundleSkipsWidgetPages() throws Exception {
+		Bundle bundle1 = _getBundle(
+			"/com.liferay.site.initializer.extender.test.bundle.1.jar");
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.site.initializer.extender.internal." +
+					"BundleSiteInitializer",
+				LoggerTestUtil.WARN)) {
+
+			SiteInitializer siteInitializer =
+				_siteInitializerRegistry.getSiteInitializer(
+					bundle1.getSymbolicName());
+
+			siteInitializer.initialize(_group.getGroupId());
+
+			List<Layout> privateLayouts = _layoutLocalService.getLayouts(
+				_group.getGroupId(), true,
+				LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
+
+			Assert.assertEquals(
+				privateLayouts.toString(), 1, privateLayouts.size());
+
+			Layout privateLayout = privateLayouts.get(0);
+
+			Assert.assertEquals(
+				LayoutConstants.TYPE_CONTENT, privateLayout.getType());
+
+			List<Layout> privateChildLayouts = privateLayout.getAllChildren();
+
+			Assert.assertEquals(
+				privateChildLayouts.toString(), 0, privateChildLayouts.size());
+
+			Assert.assertNull(
+				_layoutLocalService.fetchLayoutByFriendlyURL(
+					_group.getGroupId(), true,
+					"/test-private-grandchild-layout-1"));
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertTrue(
+				logEntries.toString(),
+				_hasLogEntryMessage(
+					logEntries,
+					StringBundler.concat(
+						"Skipping page with friendly URL ",
+						"/test-private-child-layout-1 and any associated ",
+						"child pages because widget pages are deprecated ",
+						"(LPD-76864)")));
+		}
+		finally {
+			bundle1.uninstall();
+		}
+	}
+
+	@FeatureFlag("LPD-76864")
 	@Test
 	public void testInitializeFromFile() throws Exception {
 		File tempDir1 = _getTempDir(
@@ -395,7 +471,9 @@ public class BundleSiteInitializerTest {
 		}
 	}
 
-	@FeatureFlag("LPD-19870")
+	@FeatureFlags(
+		featureFlags = {@FeatureFlag("LPD-19870"), @FeatureFlag("LPD-76864")}
+	)
 	@Test
 	public void testSerialize() throws Exception {
 		File tempDir1 = _getTempDir(
@@ -3128,7 +3206,7 @@ public class BundleSiteInitializerTest {
 		List<Layout> privateChildLayouts = privateLayout.getAllChildren();
 
 		Assert.assertEquals(
-			privateChildLayouts.toString(), 1, privateChildLayouts.size());
+			privateChildLayouts.toString(), 2, privateChildLayouts.size());
 
 		Layout privateChildLayout = privateChildLayouts.get(0);
 
@@ -3136,6 +3214,14 @@ public class BundleSiteInitializerTest {
 			"Test Private Child Layout 1",
 			privateChildLayout.getName(LocaleUtil.getSiteDefault()));
 		Assert.assertEquals("portlet", privateChildLayout.getType());
+
+		Layout privateGrandchildLayout = privateChildLayouts.get(1);
+
+		Assert.assertEquals(
+			"Test Private Grandchild Layout 1",
+			privateGrandchildLayout.getName(LocaleUtil.getSiteDefault()));
+		Assert.assertEquals(
+			LayoutConstants.TYPE_CONTENT, privateGrandchildLayout.getType());
 	}
 
 	private void _assertPrivateLayouts2() {
@@ -3157,7 +3243,7 @@ public class BundleSiteInitializerTest {
 		List<Layout> privateChildLayouts = privateLayout.getAllChildren();
 
 		Assert.assertEquals(
-			privateChildLayouts.toString(), 2, privateChildLayouts.size());
+			privateChildLayouts.toString(), 3, privateChildLayouts.size());
 
 		Layout privateChildLayout = privateChildLayouts.get(0);
 
@@ -3167,6 +3253,14 @@ public class BundleSiteInitializerTest {
 		Assert.assertEquals("content", privateChildLayout.getType());
 
 		privateChildLayout = privateChildLayouts.get(1);
+
+		Assert.assertEquals(
+			"Test Private Grandchild Layout 1",
+			privateChildLayout.getName(LocaleUtil.getSiteDefault()));
+		Assert.assertEquals(
+			LayoutConstants.TYPE_CONTENT, privateChildLayout.getType());
+
+		privateChildLayout = privateChildLayouts.get(2);
 
 		Assert.assertEquals(
 			"Test Private Child Layout 2",
@@ -4579,6 +4673,18 @@ public class BundleSiteInitializerTest {
 		tempFile.delete();
 
 		return tempDir1;
+	}
+
+	private boolean _hasLogEntryMessage(
+		List<LogEntry> logEntries, String message) {
+
+		for (LogEntry logEntry : logEntries) {
+			if (Objects.equals(logEntry.getMessage(), message)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private void _test1(SiteInitializer siteInitializer) throws Exception {

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -2784,6 +2784,32 @@ public class BundleSiteInitializer implements SiteInitializer {
 			pageJSONObject.getBoolean("private"),
 			pageJSONObject.getString("friendlyURL"));
 
+		if (Objects.equals(type, LayoutConstants.TYPE_PORTLET) &&
+			((layout == null) ||
+			 !Objects.equals(layout.getType(), LayoutConstants.TYPE_PORTLET))) {
+
+			if (!FeatureFlagManagerUtil.isEnabled(
+					serviceContext.getCompanyId(), "LPD-76864")) {
+
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						StringBundler.concat(
+							"Skipping page with friendly URL ",
+							pageJSONObject.getString("friendlyURL"),
+							" and any associated child pages because widget ",
+							"pages are deprecated (LPD-76864)"));
+				}
+
+				return Collections.emptyMap();
+			}
+			else if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Widget page with friendly URL " +
+						pageJSONObject.getString("friendlyURL") +
+							" is deprecated (LPD-76864)");
+			}
+		}
+
 		if ((layout != null) && !Objects.equals(layout.getType(), type)) {
 			_layoutLocalService.deleteLayout(layout);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93390

## What Is Being Fixed

`BundleSiteInitializer` creates pages by calling the layout service directly, which bypasses the headless REST guard that rejects widget pages while the LPD-76864 deprecation is active. A site initializer bundle could therefore still create new widget pages even when the feature flag forbids them.

## How It Is Being Fixed

The same policy is now enforced during site initialization: when the LPD-76864 flag is disabled and the page definition would create a new widget (portlet-type) page, the page and its child pages are skipped with a warning instead of being created. Existing widget pages remain untouched, and when the flag is enabled the initializer only logs the deprecation warning. An integration test covers both the skip and the warning paths through a test site initializer bundle with a nested widget page layout.

## PR Check

**pr-check: FAIL** — tested on `a8089e21f0c0e92da8cb718c4d774d175541b784`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | FAIL |
| Java Unit Tests | PASS |

The Structural Smoke failure (`Log4jConfigUtilTest`, code coverage assertion on `Log4jConfigUtil` lines 146-152) is pre-existing on master from LPD-82616 — this branch touches no portal-kernel files. All branch-relevant validations pass. The formatter's unrelated `portal.properties` feature flag regen was split into its own PR.

<!-- pr-check {"result": "failure", "sha": "a8089e21f0c0e92da8cb718c4d774d175541b784"} -->
