### PR TITLE
LPD-93606 Fix locators for staging publish content range radio buttons

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/staging/StagingPublishToLive.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/staging/StagingPublishToLive.path
@@ -220,12 +220,12 @@
 </tr>
 <tr>
 	<td>CONTENT_LAST</td>
-	<td>//span[contains(.,'Last...')]</td>
+	<td>//label[.//input[contains(@id,'rangeLast') and @type='radio']]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>CONTENT_ALL</td>
-	<td>//span[contains(.,'All')]</td>
+	<td>//label[.//input[contains(@id,'rangeAll') and @type='radio']]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
The CONTENT_ALL and CONTENT_LAST XPath locators targeted span elements by text content, which no longer match the rendered HTML. The fix targets the label elements wrapping the radio inputs by their id attributes (rangeAll, rangeLast), which is a more robust selector.

This resolves failures in LocalFile.RemoteStaging, StagingUsecase, and StagingUpgrade ViewWarningMessage tests.

https://liferay.atlassian.net/browse/LPD-93606