### PR TITLE
LPD-93390 LPD-83537 Adapt test assertions to reworded messages

### DIFF
--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
@@ -384,8 +384,7 @@ public class BundleSiteInitializerTest {
 				_hasLogEntryMessage(
 					logEntries,
 					"Widget page with friendly URL " +
-						"/test-private-child-layout-1 is deprecated " +
-							"(LPD-76864)"));
+						"/test-private-child-layout-1 is deprecated"));
 		}
 		finally {
 			bundle1.uninstall();
@@ -436,8 +435,7 @@ public class BundleSiteInitializerTest {
 					StringBundler.concat(
 						"Skipping page with friendly URL ",
 						"/test-private-child-layout-1 and any associated ",
-						"child pages because widget pages are deprecated ",
-						"(LPD-76864)")));
+						"child pages because widget pages are deprecated")));
 		}
 		finally {
 			bundle.uninstall();

--- a/modules/test/playwright/tests/asset-publisher-web/main/assetPublisherAnalyticsAttributes.spec.ts
+++ b/modules/test/playwright/tests/asset-publisher-web/main/assetPublisherAnalyticsAttributes.spec.ts
@@ -243,7 +243,7 @@ test(
 
 		await expect(
 			page.getByText(
-				'Builds the data-analytics-asset-* attributes for an asset entry.'
+				'Build the data-analytics-asset-* attributes for an asset entry.'
 			)
 		).toBeVisible();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93390

## What Is Being Fixed

Two tests assert on message strings that were reworded in earlier commits, leaving each assertion failing against the current text.

The BundleSiteInitializer widget-page deprecation log messages dropped the (LPD-76864) suffix in commit ab19824, but BundleSiteInitializerTest still expected it. Separately, the asset-analytics-attributes-helper-help language key was reworded from "Builds" to "Build" in a source-format pass, leaving the Playwright tooltip assertion in assetPublisherAnalyticsAttributes.spec.ts failing.

## How It Is Being Fixed

Each assertion is updated to match the current wording. BundleSiteInitializerTest now expects the deprecation messages without the (LPD-76864) suffix, and the Playwright spec expects "Build" instead of "Builds". Both are test-only changes that realign the assertions with production strings already on master.

## PR Check

**pr-check: PASS** — tested on `9d6ca4ba6cfca61c2f212cba255638e01a3a3209`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "9d6ca4ba6cfca61c2f212cba255638e01a3a3209"} -->