### PR TITLE
LPD-93525 Expire each web content article in its own transaction

### DIFF
--- a/modules/apps/journal/journal-api/bnd.bnd
+++ b/modules/apps/journal/journal-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Journal API
 Bundle-SymbolicName: com.liferay.journal.api
-Bundle-Version: 43.0.1
+Bundle-Version: 43.1.0
 Export-Package:\
 	com.liferay.journal.configuration,\
 	com.liferay.journal.constants,\

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalService.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalService.java
@@ -603,6 +603,12 @@ public interface JournalArticleLocalService
 	public long dynamicQueryCount(
 		DynamicQuery dynamicQuery, Projection projection);
 
+	@Transactional(
+		propagation = Propagation.REQUIRES_NEW,
+		rollbackFor = {PortalException.class, SystemException.class}
+	)
+	public JournalArticle expireArticle(long articleId) throws PortalException;
+
 	/**
 	 * Expires the web content article matching the group, article ID, and
 	 * version.
@@ -2631,4 +2637,4 @@ public interface JournalArticleLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1488310260
+// LIFERAY-SERVICE-BUILDER-HASH:502448300

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceUtil.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceUtil.java
@@ -680,6 +680,12 @@ public class JournalArticleLocalServiceUtil {
 		return getService().dynamicQueryCount(dynamicQuery, projection);
 	}
 
+	public static JournalArticle expireArticle(long articleId)
+		throws PortalException {
+
+		return getService().expireArticle(articleId);
+	}
+
 	/**
 	 * Expires the web content article matching the group, article ID, and
 	 * version.
@@ -3128,4 +3134,4 @@ public class JournalArticleLocalServiceUtil {
 			JournalArticleLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1821916815
+// LIFERAY-SERVICE-BUILDER-HASH:534208057

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceWrapper.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceWrapper.java
@@ -719,6 +719,13 @@ public class JournalArticleLocalServiceWrapper
 			dynamicQuery, projection);
 	}
 
+	@Override
+	public JournalArticle expireArticle(long articleId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _journalArticleLocalService.expireArticle(articleId);
+	}
+
 	/**
 	 * Expires the web content article matching the group, article ID, and
 	 * version.
@@ -3377,4 +3384,4 @@ public class JournalArticleLocalServiceWrapper
 	private JournalArticleLocalService _journalArticleLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2010132391
+// LIFERAY-SERVICE-BUILDER-HASH:-479237326

--- a/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/service/packageinfo
+++ b/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/service/packageinfo
@@ -1,1 +1,1 @@
-version 19.0.0
+version 19.1.0

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -170,7 +170,9 @@ import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.systemevent.SystemEventHierarchyEntryThreadLocal;
 import com.liferay.portal.kernel.templateparser.TransformerListener;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -1478,6 +1480,56 @@ public class JournalArticleLocalServiceImpl
 
 			journalArticlePersistence.update(article);
 		}
+	}
+
+	@Override
+	@Transactional(
+		propagation = Propagation.REQUIRES_NEW,
+		rollbackFor = {PortalException.class, SystemException.class}
+	)
+	public JournalArticle expireArticle(long articleId) throws PortalException {
+		JournalArticle article = journalArticleLocalService.getArticle(
+			articleId);
+
+		if (_log.isDebugEnabled()) {
+			_log.debug("Expiring article " + article.getId());
+		}
+
+		if (isExpireAllArticleVersions(article.getCompanyId())) {
+			List<JournalArticle> currentArticles =
+				journalArticleLocalService.getArticles(
+					article.getGroupId(), article.getArticleId(),
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+					ArticleVersionComparator.getInstance(true));
+
+			for (JournalArticle currentArticle : currentArticles) {
+				if (currentArticle.getVersion() >= article.getVersion()) {
+					continue;
+				}
+
+				currentArticle.setExpirationDate(article.getExpirationDate());
+				currentArticle.setStatus(WorkflowConstants.STATUS_EXPIRED);
+
+				currentArticle = journalArticlePersistence.update(
+					currentArticle);
+
+				notifySubscribers(
+					0, currentArticle, "expired", new ServiceContext());
+			}
+		}
+
+		article.setStatus(WorkflowConstants.STATUS_EXPIRED);
+
+		article = journalArticleLocalService.updateJournalArticle(article);
+
+		sendEmail(
+			article, _getArticleURL(article), "expired", new ServiceContext());
+
+		notifySubscribers(0, article, "expired", new ServiceContext());
+
+		updatePreviousApprovedArticle(article);
+
+		return article;
 	}
 
 	/**
@@ -6052,51 +6104,8 @@ public class JournalArticleLocalServiceImpl
 		indexableActionableDynamicQuery.setPerformActionMethod(
 			(JournalArticle article) -> {
 				try {
-					if (_log.isDebugEnabled()) {
-						_log.debug("Expiring article " + article.getId());
-					}
-
-					if (isExpireAllArticleVersions(companyId)) {
-						List<JournalArticle> currentArticles =
-							journalArticleLocalService.getArticles(
-								article.getGroupId(), article.getArticleId(),
-								QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-								ArticleVersionComparator.getInstance(true));
-
-						for (JournalArticle currentArticle : currentArticles) {
-							if (currentArticle.getVersion() >=
-									article.getVersion()) {
-
-								continue;
-							}
-
-							currentArticle.setExpirationDate(
-								article.getExpirationDate());
-							currentArticle.setStatus(
-								WorkflowConstants.STATUS_EXPIRED);
-
-							currentArticle = journalArticlePersistence.update(
-								currentArticle);
-
-							notifySubscribers(
-								0, currentArticle, "expired",
-								new ServiceContext());
-						}
-					}
-
-					article.setStatus(WorkflowConstants.STATUS_EXPIRED);
-
-					article = journalArticleLocalService.updateJournalArticle(
-						article);
-
-					sendEmail(
-						article, _getArticleURL(article), "expired",
-						new ServiceContext());
-
-					notifySubscribers(
-						0, article, "expired", new ServiceContext());
-
-					updatePreviousApprovedArticle(article);
+					article = journalArticleLocalService.expireArticle(
+						article.getId());
 
 					if (indexer != null) {
 						return indexer.getDocument(article);

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceCheckArticlesTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceCheckArticlesTest.java
@@ -130,6 +130,26 @@ public class JournalArticleLocalServiceCheckArticlesTest {
 	}
 
 	@Test
+	public void testExpireMultipleArticlesWhenOneFails() throws Exception {
+		JournalArticle article1 = _addExpiringArticle();
+		JournalArticle article2 = _addExpiringArticle();
+		JournalArticle article3 = _addExpiringArticle();
+
+		_assetEntryLocalService.deleteEntry(
+			JournalArticle.class.getName(), article2.getResourcePrimKey());
+
+		_journalArticleLocalService.checkArticles(_group.getCompanyId());
+
+		article1 = _journalArticleLocalService.getArticle(article1.getId());
+		article2 = _journalArticleLocalService.getArticle(article2.getId());
+		article3 = _journalArticleLocalService.getArticle(article3.getId());
+
+		Assert.assertTrue(article1.isExpired());
+		Assert.assertFalse(article2.isExpired());
+		Assert.assertTrue(article3.isExpired());
+	}
+
+	@Test
 	public void testExpireScheduledJournalArticleDisplayDateAndExpirationDateWithinTheSameInterval()
 		throws Exception {
 
@@ -366,6 +386,17 @@ public class JournalArticleLocalServiceCheckArticlesTest {
 		}
 
 		return article;
+	}
+
+	private JournalArticle _addExpiringArticle() throws Exception {
+		JournalArticle article = addArticle(
+			_group.getGroupId(), false, true, false);
+
+		Calendar calendar = getExpirationCalendar(Time.HOUR, -2);
+
+		article.setExpirationDate(calendar.getTime());
+
+		return _journalArticleLocalService.updateJournalArticle(article);
 	}
 
 	private void _assertCheckArticles(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93525

## What Is Being Fixed

The scheduled job that expires web content (`JournalArticleLocalService.checkArticles`) expired every matching article inside a single transaction. When expiring one article failed — for example with a `PessimisticLockException` under lock contention — the whole batch rolled back, so the next scheduler tick restarted from scratch and the job got stuck in an endless retry loop that never made forward progress.

## How It Is Being Fixed

The per-article expiration logic moved into a new `JournalArticleLocalService.expireArticle(long)` method annotated with `@Transactional(propagation = REQUIRES_NEW)`. The `checkArticles` perform-action now invokes it through the service proxy, so each article expires in its own transaction and commits independently; a failure on one article no longer rolls back the rest, and the job always makes forward progress.

The method takes the article ID and reloads the entity inside the new transaction, keeping it attached to that transaction's session instead of mutating a stale entity loaded by the outer scrollable query.