### PR TITLE
LPD-88506 Avoid NPE in asset entry search when the sort is null

### DIFF
--- a/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/service/test/AssetEntryLocalServiceTest.java
+++ b/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/service/test/AssetEntryLocalServiceTest.java
@@ -18,6 +18,8 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.SystemEvent;
 import com.liferay.portal.kernel.model.SystemEventConstants;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.SystemEventLocalService;
@@ -28,6 +30,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -86,6 +89,18 @@ public class AssetEntryLocalServiceTest {
 			assetEntry1.getClassUuid() + StringPool.POUND +
 				assetEntry2.getClassUuid(),
 			systemEvent.getClassUuid());
+	}
+
+	@Test
+	public void testSearchWithNullSort() throws Exception {
+		Hits hits = _assetEntryLocalService.search(
+			TestPropsValues.getCompanyId(),
+			new long[] {TestPropsValues.getGroupId()},
+			TestPropsValues.getUserId(), AssetEntry.class.getName(), 0,
+			StringPool.BLANK, false, new int[] {WorkflowConstants.STATUS_ANY},
+			0, 10, (Sort)null);
+
+		Assert.assertNotNull(hits);
 	}
 
 	@Test

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -1107,7 +1107,7 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 		return buildSearchContext(
 			companyId, groupIds, userId, classTypeId, assetCategoryIds,
 			assetTagNames, showNonindexable, statuses, andSearch, start, end,
-			(sort == null) ? null : new Sort[] {sort});
+			(sort == null) ? new Sort[0] : new Sort[] {sort});
 	}
 
 	protected SearchContext buildSearchContext(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88506

## What Is Being Fixed

The `Sort[]` overloads added to `AssetEntryLocalService.search` under LPD-88506 rewrote the single-`Sort` `buildSearchContext` to forward `(sort == null) ? null : new Sort[] {sort}`. When no sort is supplied, this passes a genuine null array to `SearchContext.setSorts`, so `SearchContext.getSorts()` returns null instead of the previously guaranteed non-null array. `AssetEntryLocalServiceImpl._hasScoreSort` iterates `getSorts()` without a null guard, so any asset search without a sort throws a NullPointerException — surfaced as the BundleSiteInitializerTest failures.

## How It Is Being Fixed

When no sort is provided, pass an empty `Sort[0]` instead of null, restoring the never-null contract the search code relies on. An empty array is cleaner than the historical `[null]` element and is treated as "no sort" by both `_hasScoreSort` and the engine layer's `ArrayUtil.isEmpty` checks. A regression test, `AssetEntryLocalServiceTest.testSearchWithNullSort`, drives `search(..., (Sort)null)` through `_hasScoreSort` and would have caught the regression at the service level.

## PR Check

**pr-check: PASS** — tested on `24a366498d254`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "24a366498d254525f16110acbe67233f12b4ac7a"} -->