### PR TITLE
LPD-89588 Reduce externalReferenceCode column length to VARCHAR(500)

### DIFF
--- a/modules/apps/changeset/changeset-service/bnd.bnd
+++ b/modules/apps/changeset/changeset-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Changeset Service
 Bundle-SymbolicName: com.liferay.changeset.service
 Bundle-Version: 4.0.39
-Liferay-Require-SchemaVersion: 2.1.0
+Liferay-Require-SchemaVersion: 2.2.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/changeset/changeset-service/src/main/java/com/liferay/changeset/internal/upgrade/registry/ChangesetServiceUpgradeStepRegistrator.java
+++ b/modules/apps/changeset/changeset-service/src/main/java/com/liferay/changeset/internal/upgrade/registry/ChangesetServiceUpgradeStepRegistrator.java
@@ -34,6 +34,11 @@ public class ChangesetServiceUpgradeStepRegistrator
 			UpgradeProcessFactory.addColumns(
 				"ChangesetEntry",
 				"classExternalReferenceCode VARCHAR(1000) null"));
+
+		registry.register(
+			"2.1.0", "2.2.0",
+			new com.liferay.changeset.internal.upgrade.v2_2_0.
+				ChangesetEntryIndexedColumnSizeUpgradeProcess());
 	}
 
 }

--- a/modules/apps/changeset/changeset-service/src/main/java/com/liferay/changeset/internal/upgrade/v2_2_0/ChangesetEntryIndexedColumnSizeUpgradeProcess.java
+++ b/modules/apps/changeset/changeset-service/src/main/java/com/liferay/changeset/internal/upgrade/v2_2_0/ChangesetEntryIndexedColumnSizeUpgradeProcess.java
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.changeset.internal.upgrade.v2_2_0;
+
+import com.liferay.portal.kernel.upgrade.BaseIndexedColumnSizeUpgradeProcess;
+
+/**
+ * @author Roselaine Marques
+ */
+public class ChangesetEntryIndexedColumnSizeUpgradeProcess
+	extends BaseIndexedColumnSizeUpgradeProcess {
+
+	@Override
+	protected String getColumnName() {
+		return "classExternalReferenceCode";
+	}
+
+	@Override
+	protected String[] getGroupByColumnNames() {
+		return new String[] {"changesetCollectionId", "classNameId"};
+	}
+
+	@Override
+	protected int getMaxColumnLength() {
+		return 500;
+	}
+
+	@Override
+	protected String getTableName() {
+		return "ChangesetEntry";
+	}
+
+}

--- a/modules/apps/changeset/changeset-service/src/main/java/com/liferay/changeset/model/impl/ChangesetEntryModelImpl.java
+++ b/modules/apps/changeset/changeset-service/src/main/java/com/liferay/changeset/model/impl/ChangesetEntryModelImpl.java
@@ -89,7 +89,7 @@ public class ChangesetEntryModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table ChangesetEntry (changesetEntryId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,changesetCollectionId LONG,classExternalReferenceCode VARCHAR(1000) null,classNameId LONG,classPK LONG)";
+		"create table ChangesetEntry (changesetEntryId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,changesetCollectionId LONG,classExternalReferenceCode VARCHAR(500) null,classNameId LONG,classPK LONG)";
 
 	public static final String TABLE_SQL_DROP = "drop table ChangesetEntry";
 
@@ -998,4 +998,4 @@ public class ChangesetEntryModelImpl
 	private ChangesetEntry _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1408157551
+// LIFERAY-SERVICE-BUILDER-HASH:28292003

--- a/modules/apps/changeset/changeset-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/changeset/changeset-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -22,7 +22,7 @@
 		<field name="modifiedDate" type="Date" />
 		<field name="changesetCollectionId" type="long" />
 		<field name="classExternalReferenceCode" type="String">
-			<hint name="max-length">1000</hint>
+			<hint name="max-length">500</hint>
 		</field>
 		<field name="classNameId" type="long" />
 		<field name="classPK" type="long" />

--- a/modules/apps/changeset/changeset-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/changeset/changeset-service/src/main/resources/META-INF/sql/indexes.sql
@@ -2,7 +2,7 @@ create index IX_9AC55E11 on ChangesetCollection (companyId, name[$COLUMN_LENGTH:
 create unique index IX_ABEEE793 on ChangesetCollection (groupId, name[$COLUMN_LENGTH:75$]);
 create index IX_EE4B4B0E on ChangesetCollection (groupId, userId);
 
-create unique index IX_71B99FC2 on ChangesetEntry (changesetCollectionId, classNameId, classExternalReferenceCode[$COLUMN_LENGTH:1000$]);
+create unique index IX_71B99FC2 on ChangesetEntry (changesetCollectionId, classNameId, classExternalReferenceCode[$COLUMN_LENGTH:500$]);
 create unique index IX_EF48912A on ChangesetEntry (changesetCollectionId, classNameId, classPK);
 create index IX_A9985762 on ChangesetEntry (classNameId, groupId);
 create index IX_CEB6AFA2 on ChangesetEntry (companyId);

--- a/modules/apps/changeset/changeset-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/changeset/changeset-service/src/main/resources/META-INF/sql/tables.sql
@@ -19,7 +19,7 @@ create table ChangesetEntry (
 	createDate DATE null,
 	modifiedDate DATE null,
 	changesetCollectionId LONG,
-	classExternalReferenceCode VARCHAR(1000) null,
+	classExternalReferenceCode VARCHAR(500) null,
 	classNameId LONG,
 	classPK LONG
 );

--- a/modules/apps/changeset/changeset-service/src/main/resources/service.properties
+++ b/modules/apps/changeset/changeset-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.changeset.service
-    build.number=2
-    build.date=1771891431368
+    build.number=3
+    build.date=1779972556861

--- a/modules/apps/changeset/changeset-test/build.gradle
+++ b/modules/apps/changeset/changeset-test/build.gradle
@@ -1,4 +1,6 @@
 dependencies {
 	testIntegrationImplementation project(":apps:changeset:changeset-api")
+	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
+	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/changeset/changeset-test/src/testIntegration/java/com/liferay/changeset/internal/upgrade/v2_2_0/test/ChangesetEntryIndexedColumnSizeUpgradeProcessTest.java
+++ b/modules/apps/changeset/changeset-test/src/testIntegration/java/com/liferay/changeset/internal/upgrade/v2_2_0/test/ChangesetEntryIndexedColumnSizeUpgradeProcessTest.java
@@ -1,0 +1,78 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.changeset.internal.upgrade.v2_2_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.BaseIndexedColumnSizeUpgradeProcessTestCase;
+
+import org.junit.runner.RunWith;
+
+/**
+ * @author Roselaine Marques
+ */
+@RunWith(Arquillian.class)
+public class ChangesetEntryIndexedColumnSizeUpgradeProcessTest
+	extends BaseIndexedColumnSizeUpgradeProcessTestCase {
+
+	@Override
+	protected String getColumnName() {
+		return "classExternalReferenceCode";
+	}
+
+	@Override
+	protected String getIndexName() {
+		return "IX_71B99FC2";
+	}
+
+	@Override
+	protected String getInsertSQL(
+		String columnName, String columnValue, long id, String tableName) {
+
+		return StringBundler.concat(
+			"insert into ", tableName, " (", getPrimaryKeyColumnName(), ", ",
+			columnName, ") values (", id, ", '", columnValue, "')");
+	}
+
+	@Override
+	protected int getNewColumnLength() {
+		return 500;
+	}
+
+	@Override
+	protected int getOldColumnLength() {
+		return 1000;
+	}
+
+	@Override
+	protected String getPrimaryKeyColumnName() {
+		return "changesetEntryId";
+	}
+
+	@Override
+	protected String getTableName() {
+		return "ChangesetEntry";
+	}
+
+	@Override
+	protected String getUpgradeProcessClassName() {
+		return "com.liferay.changeset.internal.upgrade.v2_2_0." +
+			"ChangesetEntryIndexedColumnSizeUpgradeProcess";
+	}
+
+	@Override
+	protected UpgradeStepRegistrator getUpgradeStepRegistrator() {
+		return _upgradeStepRegistrator;
+	}
+
+	@Inject(
+		filter = "component.name=com.liferay.changeset.internal.upgrade.registry.ChangesetServiceUpgradeStepRegistrator"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-service/bnd.bnd
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay OAuth2 Provider Service
 Bundle-SymbolicName: com.liferay.oauth2.provider.service
 Bundle-Version: 4.0.111
-Liferay-Require-SchemaVersion: 4.2.8
+Liferay-Require-SchemaVersion: 4.3.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/registry/OAuth2ServiceUpgradeStepRegistrator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/registry/OAuth2ServiceUpgradeStepRegistrator.java
@@ -149,6 +149,11 @@ public class OAuth2ServiceUpgradeStepRegistrator
 			"4.2.7", "4.2.8",
 			UpgradeProcessFactory.addColumns(
 				"OAuth2Authorization", "audiences TEXT null"));
+
+		registry.register(
+			"4.2.8", "4.3.0",
+			new com.liferay.oauth2.provider.internal.upgrade.v4_3_0.
+				OAuth2ApplicationIndexedColumnSizeUpgradeProcess());
 	}
 
 	@Reference

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/v4_3_0/OAuth2ApplicationIndexedColumnSizeUpgradeProcess.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/v4_3_0/OAuth2ApplicationIndexedColumnSizeUpgradeProcess.java
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth2.provider.internal.upgrade.v4_3_0;
+
+import com.liferay.portal.kernel.upgrade.BaseIndexedColumnSizeUpgradeProcess;
+
+/**
+ * @author Roselaine Marques
+ */
+public class OAuth2ApplicationIndexedColumnSizeUpgradeProcess
+	extends BaseIndexedColumnSizeUpgradeProcess {
+
+	@Override
+	protected String getColumnName() {
+		return "externalReferenceCode";
+	}
+
+	@Override
+	protected String[] getGroupByColumnNames() {
+		return new String[] {"companyId"};
+	}
+
+	@Override
+	protected int getMaxColumnLength() {
+		return 500;
+	}
+
+	@Override
+	protected String getTableName() {
+		return "OAuth2Application";
+	}
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2ApplicationModelImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2ApplicationModelImpl.java
@@ -115,7 +115,7 @@ public class OAuth2ApplicationModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table OAuth2Application (uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(1000) null,oAuth2ApplicationId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,oA2AScopeAliasesId LONG,allowedGrantTypes VARCHAR(128) null,clientAuthenticationMethod VARCHAR(75) null,clientCredentialUserId LONG,clientCredentialUserName VARCHAR(75) null,clientId VARCHAR(75) null,clientProfile INTEGER,clientSecret VARCHAR(75) null,description STRING null,features STRING null,homePageURL STRING null,iconFileEntryId LONG,jwks VARCHAR(3999) null,name VARCHAR(255) null,privacyPolicyURL STRING null,redirectURIs STRING null,rememberDevice BOOLEAN,trustedApplication BOOLEAN)";
+		"create table OAuth2Application (uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(500) null,oAuth2ApplicationId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,oA2AScopeAliasesId LONG,allowedGrantTypes VARCHAR(128) null,clientAuthenticationMethod VARCHAR(75) null,clientCredentialUserId LONG,clientCredentialUserName VARCHAR(75) null,clientId VARCHAR(75) null,clientProfile INTEGER,clientSecret VARCHAR(75) null,description STRING null,features STRING null,homePageURL STRING null,iconFileEntryId LONG,jwks VARCHAR(3999) null,name VARCHAR(255) null,privacyPolicyURL STRING null,redirectURIs STRING null,rememberDevice BOOLEAN,trustedApplication BOOLEAN)";
 
 	public static final String TABLE_SQL_DROP = "drop table OAuth2Application";
 
@@ -1678,4 +1678,4 @@ public class OAuth2ApplicationModelImpl
 	private OAuth2Application _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:308768319
+// LIFERAY-SERVICE-BUILDER-HASH:-123573437

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -4,7 +4,7 @@
 	<model name="com.liferay.oauth2.provider.model.OAuth2Application">
 		<field name="uuid" type="String" />
 		<field name="externalReferenceCode" type="String">
-			<hint name="max-length">1000</hint>
+			<hint name="max-length">500</hint>
 		</field>
 		<field name="oAuth2ApplicationId" type="long" />
 		<field name="companyId" type="long" />

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/sql/indexes.sql
@@ -3,7 +3,7 @@ create index IX_2F541817 on OA2Auths_OA2ScopeGrants (oAuth2ScopeGrantId);
 
 create index IX_523E5C67 on OAuth2Application (companyId, clientId[$COLUMN_LENGTH:75$]);
 create index IX_949C9C01 on OAuth2Application (companyId, clientProfile);
-create unique index IX_67BC29B0 on OAuth2Application (companyId, externalReferenceCode[$COLUMN_LENGTH:1000$]);
+create unique index IX_67BC29B0 on OAuth2Application (companyId, externalReferenceCode[$COLUMN_LENGTH:500$]);
 create index IX_361558F9 on OAuth2Application (uuid_[$COLUMN_LENGTH:75$]);
 
 create index IX_282ECE83 on OAuth2ApplicationScopeAliases (companyId);

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/sql/tables.sql
@@ -7,7 +7,7 @@ create table OA2Auths_OA2ScopeGrants (
 
 create table OAuth2Application (
 	uuid_ VARCHAR(75) null,
-	externalReferenceCode VARCHAR(1000) null,
+	externalReferenceCode VARCHAR(500) null,
 	oAuth2ApplicationId LONG not null primary key,
 	companyId LONG,
 	userId LONG,

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/service.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.oauth2.provider.service
-    build.number=3
-    build.date=1778151133558
+    build.number=4
+    build.date=1780331622524

--- a/modules/apps/oauth2-provider/oauth2-provider-test/build.gradle
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/build.gradle
@@ -25,5 +25,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:document-library:document-library-api")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal-remote:portal-remote-cors-api")
+	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
+	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/internal/upgrade/v4_3_0/test/OAuth2ApplicationIndexedColumnSizeUpgradeProcessTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/internal/upgrade/v4_3_0/test/OAuth2ApplicationIndexedColumnSizeUpgradeProcessTest.java
@@ -1,0 +1,78 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth2.provider.internal.upgrade.v4_3_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.BaseIndexedColumnSizeUpgradeProcessTestCase;
+
+import org.junit.runner.RunWith;
+
+/**
+ * @author Roselaine Marques
+ */
+@RunWith(Arquillian.class)
+public class OAuth2ApplicationIndexedColumnSizeUpgradeProcessTest
+	extends BaseIndexedColumnSizeUpgradeProcessTestCase {
+
+	@Override
+	protected String getColumnName() {
+		return "externalReferenceCode";
+	}
+
+	@Override
+	protected String getIndexName() {
+		return "IX_67BC29B0";
+	}
+
+	@Override
+	protected String getInsertSQL(
+		String columnName, String columnValue, long id, String tableName) {
+
+		return StringBundler.concat(
+			"insert into ", tableName, " (", getPrimaryKeyColumnName(), ", ",
+			columnName, ") values (", id, ", '", columnValue, "')");
+	}
+
+	@Override
+	protected int getNewColumnLength() {
+		return 500;
+	}
+
+	@Override
+	protected int getOldColumnLength() {
+		return 1000;
+	}
+
+	@Override
+	protected String getPrimaryKeyColumnName() {
+		return "oAuth2ApplicationId";
+	}
+
+	@Override
+	protected String getTableName() {
+		return "OAuth2Application";
+	}
+
+	@Override
+	protected String getUpgradeProcessClassName() {
+		return "com.liferay.oauth2.provider.internal.upgrade.v4_3_0." +
+			"OAuth2ApplicationIndexedColumnSizeUpgradeProcess";
+	}
+
+	@Override
+	protected UpgradeStepRegistrator getUpgradeStepRegistrator() {
+		return _upgradeStepRegistrator;
+	}
+
+	@Inject(
+		filter = "component.name=com.liferay.oauth2.provider.internal.upgrade.registry.OAuth2ServiceUpgradeStepRegistrator"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/object/object-service/bnd.bnd
+++ b/modules/apps/object/object-service/bnd.bnd
@@ -2,6 +2,6 @@ Bundle-Name: Liferay Object Service
 Bundle-SymbolicName: com.liferay.object.service
 Bundle-Version: 1.0.246
 Liferay-Client-Extension-Batch: com/liferay/object/internal/batch
-Liferay-Require-SchemaVersion: 12.1.1
+Liferay-Require-SchemaVersion: 12.2.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/registry/ObjectServiceUpgradeStepRegistrator.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/registry/ObjectServiceUpgradeStepRegistrator.java
@@ -713,6 +713,11 @@ public class ObjectServiceUpgradeStepRegistrator
 			"12.1.0", "12.1.1",
 			new com.liferay.object.internal.upgrade.v12_1_1.
 				ObjectEntryPicklistDefaultValueUpgradeProcess());
+
+		registry.register(
+			"12.1.1", "12.2.0",
+			new com.liferay.object.internal.upgrade.v12_2_0.
+				ObjectEntryIndexedColumnSizeUpgradeProcess());
 	}
 
 	@Reference

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v12_2_0/ObjectEntryIndexedColumnSizeUpgradeProcess.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v12_2_0/ObjectEntryIndexedColumnSizeUpgradeProcess.java
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.upgrade.v12_2_0;
+
+import com.liferay.portal.kernel.upgrade.BaseIndexedColumnSizeUpgradeProcess;
+
+/**
+ * @author Roselaine Marques
+ */
+public class ObjectEntryIndexedColumnSizeUpgradeProcess
+	extends BaseIndexedColumnSizeUpgradeProcess {
+
+	@Override
+	protected String getColumnName() {
+		return "externalReferenceCode";
+	}
+
+	@Override
+	protected String[] getGroupByColumnNames() {
+		return new String[] {"companyId", "groupId", "objectDefinitionId"};
+	}
+
+	@Override
+	protected int getMaxColumnLength() {
+		return 500;
+	}
+
+	@Override
+	protected String getTableName() {
+		return "ObjectEntry";
+	}
+
+}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectEntryModelImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectEntryModelImpl.java
@@ -114,7 +114,7 @@ public class ObjectEntryModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table ObjectEntry (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(1000) null,objectEntryId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,headObjectEntryId LONG,objectDefinitionId LONG,objectEntryFolderId LONG,rootObjectEntryId LONG,defaultLanguageId VARCHAR(75) null,displayDate DATE null,expirationDate DATE null,reviewDate DATE null,treePath STRING null,version INTEGER,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null)";
+		"create table ObjectEntry (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(500) null,objectEntryId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,headObjectEntryId LONG,objectDefinitionId LONG,objectEntryFolderId LONG,rootObjectEntryId LONG,defaultLanguageId VARCHAR(75) null,displayDate DATE null,expirationDate DATE null,reviewDate DATE null,treePath STRING null,version INTEGER,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null)";
 
 	public static final String TABLE_SQL_DROP = "drop table ObjectEntry";
 
@@ -1696,4 +1696,4 @@ public class ObjectEntryModelImpl
 	private ObjectEntry _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:671948158
+// LIFERAY-SERVICE-BUILDER-HASH:-1138446778

--- a/modules/apps/object/object-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/object/object-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -103,7 +103,7 @@
 		<field name="mvccVersion" type="long" />
 		<field name="uuid" type="String" />
 		<field name="externalReferenceCode" type="String">
-			<hint name="max-length">1000</hint>
+			<hint name="max-length">500</hint>
 		</field>
 		<field name="objectEntryId" type="long" />
 		<field name="groupId" type="long" />

--- a/modules/apps/object/object-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/object/object-service/src/main/resources/META-INF/sql/indexes.sql
@@ -28,7 +28,7 @@ create index IX_46A48D35 on ObjectEntry (groupId, companyId, objectEntryFolderId
 create index IX_4F10AA1B on ObjectEntry (groupId, objectEntryFolderId);
 create unique index IX_28B2B723 on ObjectEntry (groupId, uuid_[$COLUMN_LENGTH:75$]);
 create index IX_FBF73125 on ObjectEntry (headObjectEntryId);
-create unique index IX_11E61545 on ObjectEntry (objectDefinitionId, groupId, companyId, externalReferenceCode[$COLUMN_LENGTH:1000$]);
+create unique index IX_11E61545 on ObjectEntry (objectDefinitionId, groupId, companyId, externalReferenceCode[$COLUMN_LENGTH:500$]);
 create index IX_622DB416 on ObjectEntry (objectDefinitionId, groupId, status);
 create index IX_A388E5A0 on ObjectEntry (objectDefinitionId, status);
 create index IX_68B7FB2 on ObjectEntry (objectDefinitionId, userId, createDate);

--- a/modules/apps/object/object-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/object/object-service/src/main/resources/META-INF/sql/tables.sql
@@ -84,7 +84,7 @@ create table ObjectDefinitionSetting (
 create table ObjectEntry (
 	mvccVersion LONG default 0 not null,
 	uuid_ VARCHAR(75) null,
-	externalReferenceCode VARCHAR(1000) null,
+	externalReferenceCode VARCHAR(500) null,
 	objectEntryId LONG not null primary key,
 	groupId LONG,
 	companyId LONG,

--- a/modules/apps/object/object-service/src/main/resources/service.properties
+++ b/modules/apps/object/object-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.object.service
-    build.number=14
-    build.date=1772637766496
+    build.number=15
+    build.date=1779972841986

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v12_2_0/test/ObjectEntryIndexedColumnSizeUpgradeProcessTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v12_2_0/test/ObjectEntryIndexedColumnSizeUpgradeProcessTest.java
@@ -1,0 +1,79 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.upgrade.v12_2_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.BaseIndexedColumnSizeUpgradeProcessTestCase;
+
+import org.junit.runner.RunWith;
+
+/**
+ * @author Roselaine Marques
+ */
+@RunWith(Arquillian.class)
+public class ObjectEntryIndexedColumnSizeUpgradeProcessTest
+	extends BaseIndexedColumnSizeUpgradeProcessTestCase {
+
+	@Override
+	protected String getColumnName() {
+		return "externalReferenceCode";
+	}
+
+	@Override
+	protected String getIndexName() {
+		return "IX_11E61545";
+	}
+
+	@Override
+	protected String getInsertSQL(
+		String columnName, String columnValue, long id, String tableName) {
+
+		return StringBundler.concat(
+			"insert into ", tableName, " (mvccVersion, ",
+			getPrimaryKeyColumnName(), ", ", columnName, ") values (0, ", id,
+			", '", columnValue, "')");
+	}
+
+	@Override
+	protected int getNewColumnLength() {
+		return 500;
+	}
+
+	@Override
+	protected int getOldColumnLength() {
+		return 1000;
+	}
+
+	@Override
+	protected String getPrimaryKeyColumnName() {
+		return "objectEntryId";
+	}
+
+	@Override
+	protected String getTableName() {
+		return "ObjectEntry";
+	}
+
+	@Override
+	protected String getUpgradeProcessClassName() {
+		return "com.liferay.object.internal.upgrade.v12_2_0." +
+			"ObjectEntryIndexedColumnSizeUpgradeProcess";
+	}
+
+	@Override
+	protected UpgradeStepRegistrator getUpgradeStepRegistrator() {
+		return _upgradeStepRegistrator;
+	}
+
+	@Inject(
+		filter = "component.name=com.liferay.object.internal.upgrade.registry.ObjectServiceUpgradeStepRegistrator"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/portal/portal-upgrade-test-util/src/main/java/com/liferay/portal/upgrade/test/util/BaseIndexedColumnSizeUpgradeProcessTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test-util/src/main/java/com/liferay/portal/upgrade/test/util/BaseIndexedColumnSizeUpgradeProcessTestCase.java
@@ -1,0 +1,175 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.upgrade.test.util;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeException;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Marcela Cunha
+ */
+public abstract class BaseIndexedColumnSizeUpgradeProcessTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() {
+		db = DBManagerUtil.getDB();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if (_maxValueRowId != 0) {
+			db.runSQL(
+				StringBundler.concat(
+					"delete from ", getTableName(), " where ",
+					getPrimaryKeyColumnName(), " in (", _maxValueRowId, ", ",
+					_oversizedValueRowId, ")"));
+		}
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		try (Connection connection = DataAccess.getConnection()) {
+			db.alterColumnType(
+				connection, getTableName(), getColumnName(),
+				"VARCHAR(" + getOldColumnLength() + ") null");
+		}
+
+		String maxValue = RandomTestUtil.randomString(getNewColumnLength());
+
+		_maxValueRowId = RandomTestUtil.nextLong();
+
+		db.runSQL(_getInsertSQL(maxValue, _maxValueRowId));
+
+		String oversizedValue = RandomTestUtil.randomString(
+			getNewColumnLength() + 1);
+
+		_oversizedValueRowId = RandomTestUtil.nextLong();
+
+		db.runSQL(_getInsertSQL(oversizedValue, _oversizedValueRowId));
+
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			getUpgradeStepRegistrator(), getUpgradeProcessClassName());
+
+		upgradeProcess.upgrade();
+
+		try (Connection connection = DataAccess.getConnection()) {
+			DBInspector dbInspector = new DBInspector(connection);
+
+			Assert.assertTrue(
+				dbInspector.hasColumnType(
+					getTableName(), getColumnName(),
+					StringBundler.concat(
+						"VARCHAR(", getNewColumnLength(), ") null")));
+			Assert.assertTrue(
+				dbInspector.hasIndex(getTableName(), getIndexName()));
+		}
+
+		_assertColumnValue(maxValue, _maxValueRowId);
+		_assertColumnValue(
+			oversizedValue.substring(0, getNewColumnLength()),
+			_oversizedValueRowId);
+	}
+
+	@Test
+	public void testUpgradeWithDuplicateUniqueIndexEntries() throws Exception {
+		try (Connection connection = DataAccess.getConnection()) {
+			db.alterColumnType(
+				connection, getTableName(), getColumnName(),
+				"VARCHAR(" + getOldColumnLength() + ") null");
+		}
+
+		String maxValue = RandomTestUtil.randomString(getNewColumnLength());
+
+		_maxValueRowId = RandomTestUtil.nextLong();
+
+		db.runSQL(_getInsertSQL(maxValue, _maxValueRowId));
+
+		String oversizedValue = maxValue + "x";
+
+		_oversizedValueRowId = RandomTestUtil.nextLong();
+
+		db.runSQL(_getInsertSQL(oversizedValue, _oversizedValueRowId));
+
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			getUpgradeStepRegistrator(), getUpgradeProcessClassName());
+
+		Assert.assertThrows(UpgradeException.class, upgradeProcess::upgrade);
+	}
+
+	protected abstract String getColumnName();
+
+	protected abstract String getIndexName();
+
+	protected abstract String getInsertSQL(
+		String columnName, String columnValue, long id, String tableName);
+
+	protected abstract int getNewColumnLength();
+
+	protected abstract int getOldColumnLength();
+
+	protected abstract String getPrimaryKeyColumnName();
+
+	protected abstract String getTableName();
+
+	protected abstract String getUpgradeProcessClassName();
+
+	protected abstract UpgradeStepRegistrator getUpgradeStepRegistrator();
+
+	protected static DB db;
+
+	private void _assertColumnValue(String expectedValue, long id)
+		throws Exception {
+
+		try (Connection connection = DataAccess.getConnection();
+
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"select ", getColumnName(), " from ", getTableName(),
+					" where ", getPrimaryKeyColumnName(), " = ?"))) {
+
+			preparedStatement.setLong(1, id);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				Assert.assertTrue(resultSet.next());
+
+				Assert.assertEquals(
+					expectedValue, resultSet.getString(getColumnName()));
+			}
+		}
+	}
+
+	private String _getInsertSQL(String columnValue, long id) {
+		return getInsertSQL(getColumnName(), columnValue, id, getTableName());
+	}
+
+	private long _maxValueRowId;
+	private long _oversizedValueRowId;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseIndexedColumnSizeUpgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseIndexedColumnSizeUpgradeProcess.java
@@ -1,0 +1,91 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.upgrade;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBType;
+import com.liferay.portal.kernel.dao.db.IndexMetadata;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.List;
+
+/**
+ * @author Marcela Cunha
+ */
+public abstract class BaseIndexedColumnSizeUpgradeProcess
+	extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		DB db = DBManagerUtil.getDB();
+
+		DBType dbType = db.getDBType();
+
+		String lengthFunctionName = "CHAR_LENGTH";
+		String substringFunctionName = "SUBSTRING";
+
+		if (dbType == DBType.ORACLE) {
+			lengthFunctionName = "LENGTH";
+			substringFunctionName = "SUBSTR";
+		}
+		else if (dbType == DBType.SQLSERVER) {
+			lengthFunctionName = "LEN";
+		}
+
+		String columnName = getColumnName();
+		int maxColumnLength = getMaxColumnLength();
+		String tableName = getTableName();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"select 1 from ", tableName, " group by ",
+					StringUtil.merge(getGroupByColumnNames(), ", "), ", ",
+					substringFunctionName, "(", columnName, ", 1, ",
+					maxColumnLength, ") having count(*) > 1 and max(",
+					lengthFunctionName, "(", columnName, ")) > ",
+					maxColumnLength));
+
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			if (resultSet.next()) {
+				throw new UpgradeException(
+					StringBundler.concat(
+						"Unable to truncate \"", columnName, "\" in \"",
+						tableName, "\" because it would produce duplicate ",
+						"unique index entries"));
+			}
+		}
+
+		runSQL(
+			StringBundler.concat(
+				"update ", tableName, " set ", columnName, " = ",
+				substringFunctionName, "(", columnName, ", 1, ",
+				maxColumnLength, ") where ", lengthFunctionName, "(",
+				columnName, ") > ", maxColumnLength));
+
+		List<IndexMetadata> indexMetadatas = dropIndexes(tableName, columnName);
+
+		alterColumnType(
+			tableName, columnName,
+			StringBundler.concat("VARCHAR(", maxColumnLength, ") null"));
+
+		addIndexes(connection, indexMetadatas);
+	}
+
+	protected abstract String getColumnName();
+
+	protected abstract String[] getGroupByColumnNames();
+
+	protected abstract int getMaxColumnLength();
+
+	protected abstract String getTableName();
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/packageinfo
@@ -1,1 +1,1 @@
-version 31.1.0
+version 31.2.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89588

Forward manually from https://github.com/liferay-bpm/liferay-portal/pull/6205 because SF unrelated errors.
PR Check after rebase with Brian master: https://github.com/liferay-bpm/liferay-portal/pull/6205#issuecomment-4653860085 :heavy_check_mark: 

## What Is Being Fixed

SQL Server emits warning 1945 because three tables (ObjectEntry, OAuth2Application, ChangesetEntry) declare `externalReferenceCode` as `VARCHAR(1000)`, which maps to `NVARCHAR(1000)` on SQL Server and consumes 2000 bytes — exceeding the 1700-byte nonclustered index key limit.

## How It Is Being Fixed

The schema baseline drops these three columns to `VARCHAR(500)`. To migrate existing installations, three per-table upgrade processes share a new abstract `BaseIndexedColumnSizeUpgradeProcess` in `portal-kernel` that handles the full workflow: detect rows that would produce duplicate unique index entries after truncation (aborting with a clear message when found), truncate oversized values via `UPDATE ... SUBSTRING`, drop the unique indexes covering the column, alter the column type, and recreate the indexes. Each concrete subclass contributes only the column name, table name, group-by columns, and max length. A matching abstract `BaseIndexedColumnSizeUpgradeProcessTestCase` in `portal-upgrade-test-util` drives integration tests for each upgrade against a real database.

## PR Check

**pr-check: PASS** — tested on `1821dd1a7654599950e8268e70b55223a1f13668`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Full Portal Build | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "1821dd1a7654599950e8268e70b55223a1f13668"} -->