### PR TITLE
LPD-93148 Restrict concurrent agent executions per account

### DIFF
--- a/modules/apps/journal/journal-api/bnd.bnd
+++ b/modules/apps/journal/journal-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Journal API
 Bundle-SymbolicName: com.liferay.journal.api
-Bundle-Version: 43.0.1
+Bundle-Version: 43.1.0
 Export-Package:\
 	com.liferay.journal.configuration,\
 	com.liferay.journal.constants,\

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalService.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalService.java
@@ -603,6 +603,12 @@ public interface JournalArticleLocalService
 	public long dynamicQueryCount(
 		DynamicQuery dynamicQuery, Projection projection);
 
+	@Transactional(
+		propagation = Propagation.REQUIRES_NEW,
+		rollbackFor = {PortalException.class, SystemException.class}
+	)
+	public JournalArticle expireArticle(long articleId) throws PortalException;
+
 	/**
 	 * Expires the web content article matching the group, article ID, and
 	 * version.
@@ -2631,4 +2637,4 @@ public interface JournalArticleLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1488310260
+// LIFERAY-SERVICE-BUILDER-HASH:502448300

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceUtil.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceUtil.java
@@ -680,6 +680,12 @@ public class JournalArticleLocalServiceUtil {
 		return getService().dynamicQueryCount(dynamicQuery, projection);
 	}
 
+	public static JournalArticle expireArticle(long articleId)
+		throws PortalException {
+
+		return getService().expireArticle(articleId);
+	}
+
 	/**
 	 * Expires the web content article matching the group, article ID, and
 	 * version.
@@ -3128,4 +3134,4 @@ public class JournalArticleLocalServiceUtil {
 			JournalArticleLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1821916815
+// LIFERAY-SERVICE-BUILDER-HASH:534208057

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceWrapper.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceWrapper.java
@@ -719,6 +719,13 @@ public class JournalArticleLocalServiceWrapper
 			dynamicQuery, projection);
 	}
 
+	@Override
+	public JournalArticle expireArticle(long articleId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _journalArticleLocalService.expireArticle(articleId);
+	}
+
 	/**
 	 * Expires the web content article matching the group, article ID, and
 	 * version.
@@ -3377,4 +3384,4 @@ public class JournalArticleLocalServiceWrapper
 	private JournalArticleLocalService _journalArticleLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2010132391
+// LIFERAY-SERVICE-BUILDER-HASH:-479237326

--- a/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/service/packageinfo
+++ b/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/service/packageinfo
@@ -1,1 +1,1 @@
-version 19.0.0
+version 19.1.0

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6111,11 +6111,11 @@ public class JournalArticleLocalServiceImpl
 						return indexer.getDocument(article);
 					}
 				}
-				catch (PortalException portalException) {
+				catch (Exception exception) {
 					if (_log.isDebugEnabled()) {
 						_log.debug(
 							"Unable to expire article " + article.getId(),
-							portalException);
+							exception);
 					}
 				}
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -170,7 +170,9 @@ import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.systemevent.SystemEventHierarchyEntryThreadLocal;
 import com.liferay.portal.kernel.templateparser.TransformerListener;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -1478,6 +1480,56 @@ public class JournalArticleLocalServiceImpl
 
 			journalArticlePersistence.update(article);
 		}
+	}
+
+	@Override
+	@Transactional(
+		propagation = Propagation.REQUIRES_NEW,
+		rollbackFor = {PortalException.class, SystemException.class}
+	)
+	public JournalArticle expireArticle(long articleId) throws PortalException {
+		JournalArticle article = journalArticleLocalService.getArticle(
+			articleId);
+
+		if (_log.isDebugEnabled()) {
+			_log.debug("Expiring article " + article.getId());
+		}
+
+		if (isExpireAllArticleVersions(article.getCompanyId())) {
+			List<JournalArticle> currentArticles =
+				journalArticleLocalService.getArticles(
+					article.getGroupId(), article.getArticleId(),
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+					ArticleVersionComparator.getInstance(true));
+
+			for (JournalArticle currentArticle : currentArticles) {
+				if (currentArticle.getVersion() >= article.getVersion()) {
+					continue;
+				}
+
+				currentArticle.setExpirationDate(article.getExpirationDate());
+				currentArticle.setStatus(WorkflowConstants.STATUS_EXPIRED);
+
+				currentArticle = journalArticlePersistence.update(
+					currentArticle);
+
+				notifySubscribers(
+					0, currentArticle, "expired", new ServiceContext());
+			}
+		}
+
+		article.setStatus(WorkflowConstants.STATUS_EXPIRED);
+
+		article = journalArticleLocalService.updateJournalArticle(article);
+
+		sendEmail(
+			article, _getArticleURL(article), "expired", new ServiceContext());
+
+		notifySubscribers(0, article, "expired", new ServiceContext());
+
+		updatePreviousApprovedArticle(article);
+
+		return article;
 	}
 
 	/**
@@ -6052,51 +6104,8 @@ public class JournalArticleLocalServiceImpl
 		indexableActionableDynamicQuery.setPerformActionMethod(
 			(JournalArticle article) -> {
 				try {
-					if (_log.isDebugEnabled()) {
-						_log.debug("Expiring article " + article.getId());
-					}
-
-					if (isExpireAllArticleVersions(companyId)) {
-						List<JournalArticle> currentArticles =
-							journalArticleLocalService.getArticles(
-								article.getGroupId(), article.getArticleId(),
-								QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-								ArticleVersionComparator.getInstance(true));
-
-						for (JournalArticle currentArticle : currentArticles) {
-							if (currentArticle.getVersion() >=
-									article.getVersion()) {
-
-								continue;
-							}
-
-							currentArticle.setExpirationDate(
-								article.getExpirationDate());
-							currentArticle.setStatus(
-								WorkflowConstants.STATUS_EXPIRED);
-
-							currentArticle = journalArticlePersistence.update(
-								currentArticle);
-
-							notifySubscribers(
-								0, currentArticle, "expired",
-								new ServiceContext());
-						}
-					}
-
-					article.setStatus(WorkflowConstants.STATUS_EXPIRED);
-
-					article = journalArticleLocalService.updateJournalArticle(
-						article);
-
-					sendEmail(
-						article, _getArticleURL(article), "expired",
-						new ServiceContext());
-
-					notifySubscribers(
-						0, article, "expired", new ServiceContext());
-
-					updatePreviousApprovedArticle(article);
+					article = journalArticleLocalService.expireArticle(
+						article.getId());
 
 					if (indexer != null) {
 						return indexer.getDocument(article);

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceCheckArticlesTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceCheckArticlesTest.java
@@ -130,6 +130,26 @@ public class JournalArticleLocalServiceCheckArticlesTest {
 	}
 
 	@Test
+	public void testExpireMultipleArticlesWhenOneFails() throws Exception {
+		JournalArticle article1 = _addExpiringArticle();
+		JournalArticle article2 = _addExpiringArticle();
+		JournalArticle article3 = _addExpiringArticle();
+
+		_assetEntryLocalService.deleteEntry(
+			JournalArticle.class.getName(), article2.getResourcePrimKey());
+
+		_journalArticleLocalService.checkArticles(_group.getCompanyId());
+
+		article1 = _journalArticleLocalService.getArticle(article1.getId());
+		article2 = _journalArticleLocalService.getArticle(article2.getId());
+		article3 = _journalArticleLocalService.getArticle(article3.getId());
+
+		Assert.assertTrue(article1.isExpired());
+		Assert.assertFalse(article2.isExpired());
+		Assert.assertTrue(article3.isExpired());
+	}
+
+	@Test
 	public void testExpireScheduledJournalArticleDisplayDateAndExpirationDateWithinTheSameInterval()
 		throws Exception {
 
@@ -366,6 +386,17 @@ public class JournalArticleLocalServiceCheckArticlesTest {
 		}
 
 		return article;
+	}
+
+	private JournalArticle _addExpiringArticle() throws Exception {
+		JournalArticle article = addArticle(
+			_group.getGroupId(), false, true, false);
+
+		Calendar calendar = getExpirationCalendar(Time.HOUR, -2);
+
+		article.setExpirationDate(calendar.getTime());
+
+		return _journalArticleLocalService.updateJournalArticle(article);
 	}
 
 	private void _assertCheckArticles(

--- a/modules/dxp/apps/ai-hub/ai-hub-api/src/main/java/com/liferay/ai/hub/quota/QuotaManager.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-api/src/main/java/com/liferay/ai/hub/quota/QuotaManager.java
@@ -7,6 +7,8 @@ package com.liferay.ai.hub.quota;
 
 import com.liferay.portal.kernel.exception.PortalException;
 
+import java.io.Closeable;
+
 /**
  * @author Carolina Barbosa
  */
@@ -15,7 +17,11 @@ public interface QuotaManager {
 	public void addQuotas(long accountEntryId, long companyId, long userId)
 		throws PortalException;
 
-	public void checkUsage(long companyId, long userId) throws PortalException;
+	public Closeable checkConcurrentRequests(long userId)
+		throws PortalException;
+
+	public void checkTokensUsage(long companyId, long userId)
+		throws PortalException;
 
 	public void updateUsage(long companyId, Usage usage, long userId)
 		throws PortalException;

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/DefaultAgentImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/DefaultAgentImpl.java
@@ -8,6 +8,7 @@ package com.liferay.ai.hub.internal.agent;
 import com.liferay.ai.hub.agent.AgentContext;
 import com.liferay.ai.hub.agent.DefaultAgent;
 import com.liferay.ai.hub.internal.langchain4j.agentic.internal.InternalAgentImpl;
+import com.liferay.ai.hub.quota.QuotaManager;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.workflow.WorkflowInstanceManager;
 import com.liferay.portal.workflow.manager.WorkflowDefinitionManager;
@@ -16,6 +17,7 @@ import dev.langchain4j.agentic.planner.AgentArgument;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Feliphe Marinho
@@ -26,7 +28,8 @@ public class DefaultAgentImpl implements DefaultAgent {
 	@Override
 	public long invoke(AgentContext agentContext) {
 		InternalAgentImpl internalAgentImpl = new InternalAgentImpl(
-			agentContext, _workflowDefinitionManager, _workflowInstanceManager);
+			agentContext, _quotaManager, _workflowDefinitionManager,
+			_workflowInstanceManager);
 
 		internalAgentImpl.setAgentArguments(
 			TransformUtil.transform(
@@ -43,6 +46,9 @@ public class DefaultAgentImpl implements DefaultAgent {
 
 		return (Long)internalAgentImpl.invoke(agentContext.getInput());
 	}
+
+	@Reference(policyOption = ReferencePolicyOption.GREEDY)
+	private QuotaManager _quotaManager;
 
 	@Reference
 	private WorkflowDefinitionManager _workflowDefinitionManager;

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/InternalAgentFactory.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/InternalAgentFactory.java
@@ -7,6 +7,7 @@ package com.liferay.ai.hub.internal.agent;
 
 import com.liferay.ai.hub.agent.AgentContext;
 import com.liferay.ai.hub.internal.langchain4j.agentic.internal.InternalAgentImpl;
+import com.liferay.ai.hub.quota.QuotaManager;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -26,18 +27,19 @@ import dev.langchain4j.agentic.planner.AgentArgument;
 public class InternalAgentFactory {
 
 	public InternalAgentFactory(
-		AgentContext agentContext,
+		AgentContext agentContext, QuotaManager quotaManager,
 		WorkflowDefinitionManager workflowDefinitionManager,
 		WorkflowInstanceManager workflowInstanceManager) {
 
 		_agentContext = agentContext;
+		_quotaManager = quotaManager;
 		_workflowDefinitionManager = workflowDefinitionManager;
 		_workflowInstanceManager = workflowInstanceManager;
 	}
 
 	public InternalAgent create(ObjectEntry objectEntry) {
 		InternalAgentImpl internalAgentImpl = new InternalAgentImpl(
-			_agentContext, _workflowDefinitionManager,
+			_agentContext, _quotaManager, _workflowDefinitionManager,
 			_workflowInstanceManager);
 
 		internalAgentImpl.setAgentArguments(
@@ -70,6 +72,7 @@ public class InternalAgentFactory {
 	}
 
 	private final AgentContext _agentContext;
+	private final QuotaManager _quotaManager;
 	private final WorkflowDefinitionManager _workflowDefinitionManager;
 	private final WorkflowInstanceManager _workflowInstanceManager;
 

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/SupervisorAgentImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/agent/SupervisorAgentImpl.java
@@ -119,7 +119,7 @@ public class SupervisorAgentImpl implements SupervisorAgent {
 
 			InternalAgentFactory internalAgentFactory =
 				new InternalAgentFactory(
-					agentContext, _workflowDefinitionManager,
+					agentContext, _quotaManager, _workflowDefinitionManager,
 					_workflowInstanceManager);
 
 			return TransformUtil.transformToArray(
@@ -226,7 +226,7 @@ public class SupervisorAgentImpl implements SupervisorAgent {
 
 		String message = MapUtil.getString(agentContext.getInput(), "message");
 
-		_quotaManager.checkUsage(
+		_quotaManager.checkTokensUsage(
 			agentContext.getCompanyId(), agentContext.getUserId());
 
 		dev.langchain4j.agentic.supervisor.SupervisorAgent supervisorAgent =

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/langchain4j/agentic/internal/InternalAgentImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/langchain4j/agentic/internal/InternalAgentImpl.java
@@ -9,6 +9,7 @@ import com.liferay.ai.hub.agent.AgentContext;
 import com.liferay.ai.hub.internal.agent.util.AgentUtil;
 import com.liferay.ai.hub.internal.audit.constants.AIHubEventTypes;
 import com.liferay.ai.hub.internal.constants.AIHubDestinationNames;
+import com.liferay.ai.hub.quota.QuotaManager;
 import com.liferay.portal.kernel.encryptor.EncryptorUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.messaging.Message;
@@ -30,6 +31,7 @@ import dev.langchain4j.agentic.planner.AgentArgument;
 import dev.langchain4j.agentic.planner.AgentInstance;
 import dev.langchain4j.agentic.planner.AgenticSystemTopology;
 
+import java.io.Closeable;
 import java.io.Serializable;
 
 import java.lang.reflect.InvocationHandler;
@@ -46,11 +48,12 @@ import java.util.Map;
 public class InternalAgentImpl implements InternalAgent, InvocationHandler {
 
 	public InternalAgentImpl(
-		AgentContext agentContext,
+		AgentContext agentContext, QuotaManager quotaManager,
 		WorkflowDefinitionManager workflowDefinitionManager,
 		WorkflowInstanceManager workflowInstanceManager) {
 
 		_agentContext = agentContext;
+		_quotaManager = quotaManager;
 		_workflowDefinitionManager = workflowDefinitionManager;
 		_workflowInstanceManager = workflowInstanceManager;
 	}
@@ -80,7 +83,9 @@ public class InternalAgentImpl implements InternalAgent, InvocationHandler {
 	}
 
 	public Object invoke(Map<String, ?> inputObjects) {
-		try {
+		try (Closeable closeable = _quotaManager.checkConcurrentRequests(
+				_agentContext.getUserId())) {
+
 			Company company = CompanyLocalServiceUtil.getCompany(
 				_agentContext.getCompanyId());
 
@@ -263,6 +268,7 @@ public class InternalAgentImpl implements InternalAgent, InvocationHandler {
 	private String _name;
 	private String _outBoundEventName;
 	private String _outputKey;
+	private final QuotaManager _quotaManager;
 	private final WorkflowDefinitionManager _workflowDefinitionManager;
 	private String _workflowDefinitionName;
 	private final WorkflowInstanceManager _workflowInstanceManager;

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/quota/DummyQuotaManagerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/quota/DummyQuotaManagerImpl.java
@@ -7,6 +7,9 @@ package com.liferay.ai.hub.internal.quota;
 
 import com.liferay.ai.hub.quota.QuotaManager;
 import com.liferay.ai.hub.quota.Usage;
+import com.liferay.portal.kernel.exception.PortalException;
+
+import java.io.Closeable;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -23,7 +26,15 @@ public class DummyQuotaManagerImpl implements QuotaManager {
 	}
 
 	@Override
-	public void checkUsage(long companyId, long userId) {
+	public Closeable checkConcurrentRequests(long userId)
+		throws PortalException {
+
+		return () -> {
+		};
+	}
+
+	@Override
+	public void checkTokensUsage(long companyId, long userId) {
 	}
 
 	@Override

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/QuotaUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/QuotaUtil.java
@@ -30,7 +30,7 @@ public class QuotaUtil {
 		throws PortalException {
 
 		try {
-			quotaManager.checkUsage(companyId, userId);
+			quotaManager.checkTokensUsage(companyId, userId);
 
 			return false;
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93148

## What Is Being Fixed

AI Hub agent executions had no cap on concurrency. The `QuotaManager` exposed a single `checkUsage` method that enforced only token-usage quota, so an account could trigger an unbounded number of simultaneous agent runs.

## How It Is Being Fixed

The `QuotaManager` API is split so that quota enforcement covers concurrency as well as tokens. The original `checkUsage` is renamed to `checkTokensUsage` to reflect its token-quota role, and a new `checkConcurrentRequests(userId)` returns a `Closeable` that brackets a single agent invocation: a slot is acquired before the run starts and released when the `Closeable` is closed.

`InternalAgentImpl.invoke` now wraps its body in a try-with-resources over `checkConcurrentRequests`, so every agent execution holds a concurrency slot for its duration. The new dependency is threaded through `InternalAgentFactory`, `DefaultAgentImpl`, and `SupervisorAgentImpl`, and `DummyQuotaManagerImpl` provides a no-op implementation. The actual limit (10 concurrent executions per account per minute) is enforced in the `QuotaManager` implementation in ai-hub-cell.

## Why Are There No Tests?

This commit is a pure interface/plumbing change in portal: it splits `checkUsage` into `checkTokensUsage` and adds the `checkConcurrentRequests` hook wired through the agent factory and implementations. The concurrency-limit behavior and its test coverage live in the real `QuotaManager` implementation in ai-hub-cell.

## PR Check

**pr-check: SKIPPED** — Branch is based on bchan-master, not local master; the local-master baseline would diff 239 unrelated commits and the SF autocommit could rewrite unrelated code. The change is a small interface refactor.

<!-- pr-check {"reason": "Branch is based on bchan-master, not local master; the local-master baseline would diff 239 unrelated commits and the SF autocommit could rewrite unrelated code. The change is a small interface refactor.", "result": "skipped", "sha": "07240249522ccf9c297355e84f22adcb2b0d1ca4"} -->