### PR TITLE
LPD-93931 Fix objects panel app startup warnings

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/entries/application/list/test/ObjectEntriesPanelAppTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/entries/application/list/test/ObjectEntriesPanelAppTest.java
@@ -89,6 +89,37 @@ public class ObjectEntriesPanelAppTest {
 		Assert.assertEquals(
 			"site_administration.content",
 			portlet.getControlPanelEntryCategory());
+
+		objectDefinition =
+			_objectDefinitionLocalService.addCustomObjectDefinition(
+				null, TestPropsValues.getUserId(), 0, null, true, false, true,
+				true, true, false, false, false, false, null,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				ObjectDefinitionTestUtil.getRandomName(), null,
+				"site_administration.content",
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				false, ObjectDefinitionConstants.SCOPE_SITE,
+				ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT,
+				Collections.emptyList(),
+				Collections.singletonList(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING,
+						RandomTestUtil.randomString(), StringUtil.randomId())),
+				Collections.emptyList(), new ServiceContext());
+
+		objectDefinition =
+			_objectDefinitionLocalService.publishCustomObjectDefinition(
+				TestPropsValues.getUserId(),
+				objectDefinition.getObjectDefinitionId());
+
+		panelApps = _panelAppRegistry.getPanelApps(
+			objectDefinition.getPanelCategoryKey());
+
+		for (PanelApp panelApp : panelApps) {
+			Assert.assertNotEquals(
+				objectDefinition.getPortletId(), panelApp.getPortletId());
+		}
 	}
 
 	@Inject

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -687,37 +687,39 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		// Register ObjectEntriesPanelApp after ObjectEntriesPortlet. See
 		// LPS-140379.
 
-		String panelCategoryKey = objectDefinition.getPanelCategoryKey();
+		if (objectDefinition.isPortlet()) {
+			String panelCategoryKey = objectDefinition.getPanelCategoryKey();
 
-		if (FeatureFlagManagerUtil.isEnabled(
-				objectDefinition.getCompanyId(), "LPD-69877") &&
-			!objectDefinition.isAllowStandaloneObjectEntry()) {
+			if (FeatureFlagManagerUtil.isEnabled(
+					objectDefinition.getCompanyId(), "LPD-69877") &&
+				!objectDefinition.isAllowStandaloneObjectEntry()) {
 
-			panelCategoryKey = StringPool.BLANK;
+				panelCategoryKey = StringPool.BLANK;
+			}
+
+			serviceRegistrations.add(
+				_bundleContext.registerService(
+					PanelApp.class,
+					new ObjectEntriesPanelApp(
+						objectDefinition,
+						() -> {
+							com.liferay.portal.kernel.model.Portlet portlet =
+								_portletLocalService.getPortletById(
+									objectDefinition.getCompanyId(),
+									objectDefinition.getPortletId());
+
+							portlet.setControlPanelEntryCategory(
+								objectDefinition.getPanelCategoryKey());
+
+							return portlet;
+						}),
+					HashMapDictionaryBuilder.<String, Object>put(
+						"panel.app.order:Integer",
+						objectDefinition.getPanelAppOrder()
+					).put(
+						"panel.category.key", panelCategoryKey
+					).build()));
 		}
-
-		serviceRegistrations.add(
-			_bundleContext.registerService(
-				PanelApp.class,
-				new ObjectEntriesPanelApp(
-					objectDefinition,
-					() -> {
-						com.liferay.portal.kernel.model.Portlet portlet =
-							_portletLocalService.getPortletById(
-								objectDefinition.getCompanyId(),
-								objectDefinition.getPortletId());
-
-						portlet.setControlPanelEntryCategory(
-							objectDefinition.getPanelCategoryKey());
-
-						return portlet;
-					}),
-				HashMapDictionaryBuilder.<String, Object>put(
-					"panel.app.order:Integer",
-					objectDefinition.getPanelAppOrder()
-				).put(
-					"panel.category.key", panelCategoryKey
-				).build()));
 
 		if (objectDefinition.isCMS() &&
 			Objects.equals(


### PR DESCRIPTION
> [!NOTE]
> Forwarded manually from https://github.com/liferay-content-management/liferay-portal/pull/8447

https://liferay.atlassian.net/browse/LPD-93931

## What Is Being Fixed

On startup, PanelAppRegistry logged a warning for every pair of object
definitions that are not exposed as a portlet (such as CMS content
structures and file types). The deployer registered an
ObjectEntriesPanelApp for every object definition regardless of whether
it is a portlet. Non-portlet definitions have no panel app order or
category key, so multiple of them collided on the same empty order and
category, and the registry warned on each collision.

## How It Is Being Fixed

The panel app registration is now gated on ObjectDefinition.isPortlet().
This keeps the panel app aligned with the portlet display category,
which already branches on the same flag, so only object definitions that
are actually exposed as portlets register an ObjectEntriesPanelApp and
the startup collisions no longer occur.

## PR Check

**pr-check: PASS** — tested on `93240577f4ad1d048d0b9182a0705b7f2cff0a18`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "93240577f4ad1d048d0b9182a0705b7f2cff0a18"} -->