### PR TITLE
LPD-93390 Capture widget page deprecation log in initializer tests

### DIFF
--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
@@ -450,7 +450,11 @@ public class BundleSiteInitializerTest {
 		File tempDir2 = _getTempDir(
 			"/com.liferay.site.initializer.extender.test.bundle.2.jar");
 
-		try {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.site.initializer.extender.internal." +
+					"BundleSiteInitializer",
+				LoggerTestUtil.WARN)) {
+
 			_test1(
 				_siteInitializerFactory.create(
 					new File(tempDir1, "site-initializer"), null));
@@ -472,7 +476,11 @@ public class BundleSiteInitializerTest {
 		File tempDir1 = _getTempDir(
 			"/com.liferay.site.initializer.extender.test.bundle.1.jar");
 
-		try {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.site.initializer.extender.internal." +
+					"BundleSiteInitializer",
+				LoggerTestUtil.WARN)) {
+
 			SiteInitializer siteInitializer = _siteInitializerFactory.create(
 				new File(tempDir1, "site-initializer"), null);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93390

## What Is Being Fixed

The integration tests testInitializeFromFile and testSerialize initialize a bundle site that contains a deprecated widget page with the LPD-76864 feature flag enabled. Unlike testInitializeFromBundle, they did not capture the BundleSiteInitializer logger, so the "Widget page with friendly URL /test-private-child-layout-1 is deprecated" warning propagated to the portal log and caused PortalLogAssertorTest to fail.

## How It Is Being Fixed

Both tests now wrap their initialization in the same LogCapture that testInitializeFromBundle already uses, which sets the BundleSiteInitializer logger non-additive for the duration of the test so the intentional deprecation warning is captured instead of leaking to the portal log. Production logging is unchanged, and testInitializeFromBundle still asserts that the warning is emitted.

## PR Check

**pr-check: SKIPPED** — Branch is based on master-brian, not master, so pr-check's master-diff baseline does not apply; the test-only change was verified by running BundleSiteInitializerTest live (4/4 passed, no deprecation warning left in the portal log).

<!-- pr-check {"reason": "Branch is based on master-brian, not master, so pr-check's master-diff baseline does not apply; the test-only change was verified by running BundleSiteInitializerTest live (4/4 passed, no deprecation warning left in the portal log).", "result": "skipped", "sha": "54806a38f0ed95bb1ab267527efdf698f1440334"} -->