### PR TITLE
LPD-94078 Can't Create Guardrail

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/ModelArmorTemplateManagerImpl.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-impl/src/main/java/com/liferay/ai/hub/rest/internal/manager/v1_0/ModelArmorTemplateManagerImpl.java
@@ -206,8 +206,7 @@ public class ModelArmorTemplateManagerImpl
 						"guardrailType",
 						String.valueOf(modelArmorTemplate.getGuardrailType())
 					).put(
-						"location",
-						GetterUtil.getString(modelArmorTemplate.getLocation())
+						"location", modelArmorTemplate.getLocation()
 					).put(
 						"maliciousUriFilterEnabled",
 						GetterUtil.getBoolean(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94078

## What Is Being Fixed

Creating a guardrail (Model Armor template) without an explicit location persisted an empty location instead of the default value declared in the object definition (europe-west1). The REST layer coerced a null location to an empty string, and the Object framework only applies a field's default value when the incoming value is null — so the default never took effect, leaving the template with an empty location and breaking guardrail creation.

## How It Is Being Fixed

The location value from the request DTO is now passed through to the object entry properties as-is instead of being coerced to an empty string with GetterUtil.getString. When the location is null, ObjectEntryLocalService fills in the default value (europe-west1) defined on the Model Armor template object definition, restoring the intended behavior.

## Why Are There No Tests?

The behavior is exercised by the existing ModelArmorTemplate integration tests. The change is a one-line null-pass that defers to the Object framework's existing default-value handling, so no new test is warranted.

## PR Check

**pr-check: PASS** — tested on `37df52039f803ee56a8ef50dcca5b49649d6d931`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "37df52039f803ee56a8ef50dcca5b49649d6d931"} -->