### PR TITLE
LRCI-6956 Add Testray run and factor objects

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BaseStandaloneBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BaseStandaloneBuildTestrayCaseResult.java
@@ -126,19 +126,19 @@ public abstract class BaseStandaloneBuildTestrayCaseResult
 	public void recordTestrayCaseResult(Job job) {
 		TestrayBuild testrayBuild = getTestrayBuild();
 
-		TestrayRun testrayRun = null;
+		String testSuiteName = null;
 
 		if (job instanceof TestSuiteJob) {
 			TestSuiteJob testSuiteJob = (TestSuiteJob)job;
 
-			testrayRun = TestrayFactory.newTestrayRun(
-				testrayBuild, getBatchName(), testSuiteJob.getTestSuiteName(),
-				job.getJobPropertiesFiles());
+			testSuiteName = testSuiteJob.getTestSuiteName();
 		}
-		else {
-			testrayRun = TestrayFactory.newTestrayRun(
-				testrayBuild, getBatchName(), job.getJobPropertiesFiles());
-		}
+
+		TestrayRun testrayRun = TestrayFactory.newTestrayRun(
+			testrayBuild, getBatchName(), testSuiteName,
+			job.getJobProperties());
+
+		setTestrayRun(testrayRun);
 
 		long start = JenkinsResultsParserUtil.getCurrentTimeMillis();
 
@@ -146,15 +146,7 @@ public abstract class BaseStandaloneBuildTestrayCaseResult
 
 		Element rootElement = document.addElement("testsuite");
 
-		Element environmentsElement = rootElement.addElement("environments");
-
-		for (TestrayRun.Factor factor : testrayRun.getFactors()) {
-			Element environmentElement = environmentsElement.addElement(
-				"environment");
-
-			environmentElement.addAttribute("type", factor.getName());
-			environmentElement.addAttribute("option", factor.getValue());
-		}
+		rootElement.add(testrayRun.getEnvironmentsElement());
 
 		Map<String, String> propertiesMap = new HashMap<>();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BaseTestrayFactor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BaseTestrayFactor.java
@@ -12,28 +12,35 @@ import org.json.JSONObject;
  */
 public abstract class BaseTestrayFactor implements TestrayFactor {
 
+	@Override
 	public Category getCategory() {
 		return _category;
 	}
 
+	@Override
 	public Long getID() {
-		return _jsonObject.getLong("id");
+		JSONObject jsonObject = getJSONObject();
+
+		return jsonObject.getLong("id");
 	}
 
+	@Override
 	public JSONObject getJSONObject() {
 		return _jsonObject;
 	}
 
-	public String getName() {
-		return _jsonObject.getString("name");
-	}
-
+	@Override
 	public Option getOption() {
 		return _option;
 	}
 
+	@Override
 	public TestrayServer getTestrayServer() {
 		return _testrayServer;
+	}
+
+	protected BaseTestrayFactor(TestrayServer testrayServer) {
+		_testrayServer = testrayServer;
 	}
 
 	protected BaseTestrayFactor(
@@ -45,22 +52,24 @@ public abstract class BaseTestrayFactor implements TestrayFactor {
 		JSONObject categoryJSONObject = jsonObject.getJSONObject(
 			"factorCategoryToFactors");
 
-		_category = new Category(categoryJSONObject);
+		_category = TestrayFactory.newTestrayFactorCategory(
+			_testrayServer, categoryJSONObject);
 
 		JSONObject optionJSONObject = jsonObject.optJSONObject(
 			"factorOptionToFactors");
 
 		if (optionJSONObject != null) {
-			_option = new Option(optionJSONObject);
+			_option = TestrayFactory.newTestrayFactorOption(
+				_testrayServer, optionJSONObject);
 		}
 		else {
 			_option = null;
 		}
 	}
 
-	private final Category _category;
-	private final JSONObject _jsonObject;
-	private final Option _option;
+	private Category _category;
+	private JSONObject _jsonObject;
+	private Option _option;
 	private final TestrayServer _testrayServer;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BaseTestrayFactor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BaseTestrayFactor.java
@@ -39,15 +39,11 @@ public abstract class BaseTestrayFactor implements TestrayFactor {
 		return _testrayServer;
 	}
 
-	protected BaseTestrayFactor(TestrayServer testrayServer) {
-		_testrayServer = testrayServer;
-	}
-
 	protected BaseTestrayFactor(
-		TestrayServer testrayServer, JSONObject jsonObject) {
+		JSONObject jsonObject, TestrayServer testrayServer) {
 
-		_testrayServer = testrayServer;
 		_jsonObject = jsonObject;
+		_testrayServer = testrayServer;
 
 		JSONObject categoryJSONObject = jsonObject.getJSONObject(
 			"factorCategoryToFactors");
@@ -65,6 +61,10 @@ public abstract class BaseTestrayFactor implements TestrayFactor {
 		else {
 			_option = null;
 		}
+	}
+
+	protected BaseTestrayFactor(TestrayServer testrayServer) {
+		_testrayServer = testrayServer;
 	}
 
 	private Category _category;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/RoutineTestrayFactor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/RoutineTestrayFactor.java
@@ -19,7 +19,7 @@ public class RoutineTestrayFactor extends BaseTestrayFactor {
 	protected RoutineTestrayFactor(
 		JSONObject jsonObject, TestrayRoutine testrayRoutine) {
 
-		super(testrayRoutine.getTestrayServer(), jsonObject);
+		super(jsonObject, testrayRoutine.getTestrayServer());
 
 		_testrayRoutine = testrayRoutine;
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/RunTestrayFactor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/RunTestrayFactor.java
@@ -56,7 +56,7 @@ public class RunTestrayFactor extends BaseTestrayFactor {
 
 		final TestrayRun testrayRun = getTestrayRun();
 
-		final String filter = JenkinsResultsParserUtil.combine(
+		final String filterString = JenkinsResultsParserUtil.combine(
 			"r_factorCategoryToFactors_c_factorCategoryId eq '",
 			String.valueOf(category.getID()),
 			"' and r_factorOptionToFactors_c_factorOptionId eq '",
@@ -72,7 +72,7 @@ public class RunTestrayFactor extends BaseTestrayFactor {
 					JSONObject existingJSONObject = new JSONObject(
 						testrayServer.requestGet(
 							"/o/c/factors?filter=" +
-								URLEncoder.encode(filter, "UTF-8")));
+								URLEncoder.encode(filterString, "UTF-8")));
 
 					JSONArray existingItemsJSONArray =
 						existingJSONObject.optJSONArray("items");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/RunTestrayFactor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/RunTestrayFactor.java
@@ -45,16 +45,14 @@ public class RunTestrayFactor extends BaseTestrayFactor {
 			return _jsonObject;
 		}
 
-		final Category category = getCategory();
-		final Option option = getOption();
+		Category category = getCategory();
+		Option option = getOption();
 
 		if ((category == null) || (option == null)) {
 			return null;
 		}
 
-		final TestrayServer testrayServer = _testrayBuild.getTestrayServer();
-
-		final TestrayRun testrayRun = getTestrayRun();
+		TestrayRun testrayRun = getTestrayRun();
 
 		final String filterString = JenkinsResultsParserUtil.combine(
 			"r_factorCategoryToFactors_c_factorCategoryId eq '",
@@ -63,11 +61,23 @@ public class RunTestrayFactor extends BaseTestrayFactor {
 			String.valueOf(option.getID()), "' and r_runToFactors_c_runId eq '",
 			String.valueOf(testrayRun.getID()), "'");
 
+		final JSONObject postRequestJSONObject = new JSONObject();
+
+		postRequestJSONObject.put(
+			"r_factorCategoryToFactors_c_factorCategoryId", category.getID()
+		).put(
+			"r_factorOptionToFactors_c_factorOptionId", option.getID()
+		).put(
+			"r_runToFactors_c_runId", testrayRun.getID()
+		);
+
 		Retryable<JSONObject> retryable = new Retryable<JSONObject>(
 			true, 3, 5, true) {
 
 			@Override
 			public JSONObject execute() {
+				TestrayServer testrayServer = _testrayBuild.getTestrayServer();
+
 				try {
 					JSONObject existingJSONObject = new JSONObject(
 						testrayServer.requestGet(
@@ -82,18 +92,6 @@ public class RunTestrayFactor extends BaseTestrayFactor {
 
 						return existingItemsJSONArray.getJSONObject(0);
 					}
-
-					JSONObject postRequestJSONObject = new JSONObject();
-
-					postRequestJSONObject.put(
-						"r_factorCategoryToFactors_c_factorCategoryId",
-						category.getID()
-					).put(
-						"r_factorOptionToFactors_c_factorOptionId",
-						option.getID()
-					).put(
-						"r_runToFactors_c_runId", testrayRun.getID()
-					);
 
 					return new JSONObject(
 						testrayServer.requestPost(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/RunTestrayFactor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/RunTestrayFactor.java
@@ -5,12 +5,115 @@
 
 package com.liferay.jenkins.results.parser.testray;
 
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+import com.liferay.jenkins.results.parser.Retryable;
+
+import java.io.IOException;
+
+import java.net.URLEncoder;
+
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 /**
  * @author Michael Hashimoto
  */
 public class RunTestrayFactor extends BaseTestrayFactor {
+
+	@Override
+	public Category getCategory() {
+		Option option = getOption();
+
+		if (option == null) {
+			return null;
+		}
+
+		return option.getCategory();
+	}
+
+	@Override
+	public synchronized JSONObject getJSONObject() {
+		if (_jsonObject != null) {
+			return _jsonObject;
+		}
+
+		JSONObject baseJSONObject = super.getJSONObject();
+
+		if (baseJSONObject != null) {
+			_jsonObject = baseJSONObject;
+
+			return _jsonObject;
+		}
+
+		final TestrayServer testrayServer = _testrayBuild.getTestrayServer();
+
+		final Category category = getCategory();
+		final Option option = getOption();
+		final TestrayRun testrayRun = getTestrayRun();
+
+		final String filter = JenkinsResultsParserUtil.combine(
+			"r_factorCategoryToFactors_c_factorCategoryId eq '",
+			String.valueOf(category.getID()),
+			"' and r_factorOptionToFactors_c_factorOptionId eq '",
+			String.valueOf(option.getID()), "' and r_runToFactors_c_runId eq '",
+			String.valueOf(testrayRun.getID()), "'");
+
+		Retryable<JSONObject> retryable = new Retryable<JSONObject>(
+			true, 3, 5, true) {
+
+			@Override
+			public JSONObject execute() {
+				try {
+					JSONObject existingJSONObject = new JSONObject(
+						testrayServer.requestGet(
+							"/o/c/factors?filter=" +
+								URLEncoder.encode(filter, "UTF-8")));
+
+					JSONArray existingItemsJSONArray =
+						existingJSONObject.optJSONArray("items");
+
+					if ((existingItemsJSONArray != null) &&
+						!existingItemsJSONArray.isEmpty()) {
+
+						return existingItemsJSONArray.getJSONObject(0);
+					}
+
+					JSONObject postRequestJSONObject = new JSONObject();
+
+					postRequestJSONObject.put(
+						"r_factorCategoryToFactors_c_factorCategoryId",
+						category.getID()
+					).put(
+						"r_factorOptionToFactors_c_factorOptionId",
+						option.getID()
+					).put(
+						"r_runToFactors_c_runId", testrayRun.getID()
+					);
+
+					return new JSONObject(
+						testrayServer.requestPost(
+							"/o/c/factors", postRequestJSONObject.toString()));
+				}
+				catch (IOException ioException) {
+					throw new RuntimeException(ioException);
+				}
+			}
+
+		};
+
+		_jsonObject = retryable.executeWithRetries();
+
+		return _jsonObject;
+	}
+
+	@Override
+	public Option getOption() {
+		if (_option != null) {
+			return _option;
+		}
+
+		return super.getOption();
+	}
 
 	public TestrayRun getTestrayRun() {
 		return _testrayRun;
@@ -19,9 +122,28 @@ public class RunTestrayFactor extends BaseTestrayFactor {
 	protected RunTestrayFactor(JSONObject jsonObject, TestrayRun testrayRun) {
 		super(testrayRun.getTestrayServer(), jsonObject);
 
+		_jsonObject = jsonObject;
 		_testrayRun = testrayRun;
+
+		_testrayBuild = testrayRun.getTestrayBuild();
+
+		_option = super.getOption();
 	}
 
+	protected RunTestrayFactor(
+		TestrayRun testrayRun, TestrayFactor.Option option) {
+
+		super(testrayRun.getTestrayServer());
+
+		_testrayRun = testrayRun;
+		_option = option;
+
+		_testrayBuild = testrayRun.getTestrayBuild();
+	}
+
+	private JSONObject _jsonObject;
+	private final Option _option;
+	private final TestrayBuild _testrayBuild;
 	private final TestrayRun _testrayRun;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/RunTestrayFactor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/RunTestrayFactor.java
@@ -45,10 +45,15 @@ public class RunTestrayFactor extends BaseTestrayFactor {
 			return _jsonObject;
 		}
 
-		final TestrayServer testrayServer = _testrayBuild.getTestrayServer();
-
 		final Category category = getCategory();
 		final Option option = getOption();
+
+		if ((category == null) || (option == null)) {
+			return null;
+		}
+
+		final TestrayServer testrayServer = _testrayBuild.getTestrayServer();
+
 		final TestrayRun testrayRun = getTestrayRun();
 
 		final String filter = JenkinsResultsParserUtil.combine(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/RunTestrayFactor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/RunTestrayFactor.java
@@ -123,14 +123,13 @@ public class RunTestrayFactor extends BaseTestrayFactor {
 	}
 
 	protected RunTestrayFactor(JSONObject jsonObject, TestrayRun testrayRun) {
-		super(testrayRun.getTestrayServer(), jsonObject);
+		super(jsonObject, testrayRun.getTestrayServer());
 
 		_jsonObject = jsonObject;
 		_testrayRun = testrayRun;
 
-		_testrayBuild = testrayRun.getTestrayBuild();
-
 		_option = super.getOption();
+		_testrayBuild = testrayRun.getTestrayBuild();
 	}
 
 	protected RunTestrayFactor(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
@@ -20,7 +20,6 @@ import java.text.SimpleDateFormat;
 
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -317,32 +316,6 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 		return null;
 	}
 
-	public synchronized Long getTestrayRunID(TestrayRun testrayRun) {
-		String runIDString = testrayRun.getRunIDString();
-
-		Long testrayRunID = _testrayRunIDs.get(runIDString);
-
-		if (testrayRunID != null) {
-			return testrayRunID;
-		}
-
-		JSONObject testrayRunJSONObject = _getTestrayRunJSONObject(testrayRun);
-
-		if ((testrayRunJSONObject == null) || !testrayRunJSONObject.has("id")) {
-			return null;
-		}
-
-		testrayRunID = testrayRunJSONObject.optLong("id");
-
-		if (testrayRunID <= 0) {
-			return null;
-		}
-
-		_testrayRunIDs.put(runIDString, testrayRunID);
-
-		return testrayRunID;
-	}
-
 	public synchronized List<TestrayRun> getTestrayRuns() {
 		if (_testrayRuns != null) {
 			return _testrayRuns;
@@ -363,20 +336,9 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 			JSONArray itemsJSONArray = responseJSONObject.getJSONArray("items");
 
 			for (int i = 0; i < itemsJSONArray.length(); i++) {
-				JSONObject itemJSONObject = itemsJSONArray.getJSONObject(i);
-
-				TestrayRun testrayRun = TestrayFactory.newTestrayRun(
-					this, itemJSONObject);
-
-				_testrayRuns.add(testrayRun);
-
-				long testrayRunID = testrayRun.getID();
-
-				if (testrayRunID <= 0) {
-					continue;
-				}
-
-				_testrayRunIDs.put(testrayRun.getRunIDString(), testrayRunID);
+				_testrayRuns.add(
+					TestrayFactory.newTestrayRun(
+						this, itemsJSONArray.getJSONObject(i)));
 			}
 		}
 		catch (IOException ioException) {
@@ -611,38 +573,6 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 		return null;
 	}
 
-	private JSONObject _getTestrayRunJSONObject(TestrayRun testrayRun) {
-		String runIDString = testrayRun.getRunIDString();
-
-		if (JenkinsResultsParserUtil.isNullOrEmpty(runIDString)) {
-			return null;
-		}
-
-		TestrayServer testrayServer = getTestrayServer();
-
-		String filterString = JenkinsResultsParserUtil.combine(
-			"name eq '", runIDString, "' and r_buildToRuns_c_buildId eq '",
-			String.valueOf(getID()), "'");
-
-		try {
-			Set<JSONObject> entityJSONObjects = testrayServer.requestGraphQL(
-				"runs", TestrayRun.FIELD_NAMES, filterString, null, 1, 1);
-
-			for (JSONObject entityJSONObject : entityJSONObjects) {
-				if (entityJSONObject == null) {
-					continue;
-				}
-
-				return entityJSONObject;
-			}
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
-
-		return null;
-	}
-
 	private static final MultiPattern _descriptionMultiPattern =
 		new MultiPattern(
 			JenkinsResultsParserUtil.combine(
@@ -672,7 +602,6 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 	private TestrayProductVersion _testrayProductVersion;
 	private TestrayProject _testrayProject;
 	private TestrayRoutine _testrayRoutine;
-	private final Map<String, Long> _testrayRunIDs = new HashMap<>();
 	private List<TestrayRun> _testrayRuns;
 	private final TestrayServer _testrayServer;
 	private TopLevelBuildReport _topLevelBuildReport;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactor.java
@@ -5,6 +5,13 @@
 
 package com.liferay.jenkins.results.parser.testray;
 
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+
+import java.io.IOException;
+
+import java.net.URLEncoder;
+
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 /**
@@ -23,55 +30,243 @@ public interface TestrayFactor {
 
 	public JSONObject getJSONObject();
 
-	public String getName();
-
 	public BaseTestrayFactor.Option getOption();
+
+	public TestrayServer getTestrayServer();
 
 	public static class Category {
 
-		public static final String[] FIELD_NAMES = {
-			"dateCreated", "dateModified", "id", "name"
-		};
-
 		public Long getID() {
+			if (_id <= 0) {
+				JSONObject jsonObject = _getJSONObject();
+
+				if (jsonObject == null) {
+					return _id;
+				}
+
+				_id = jsonObject.getLong("id");
+			}
+
 			return _id;
 		}
 
 		public String getName() {
+			if (JenkinsResultsParserUtil.isNullOrEmpty(_name)) {
+				JSONObject jsonObject = _getJSONObject();
+
+				if (jsonObject == null) {
+					return _name;
+				}
+
+				_name = jsonObject.getString("name");
+			}
+
 			return _name;
 		}
 
-		protected Category(JSONObject jsonObject) {
-			_id = jsonObject.getLong("id");
-			_name = jsonObject.getString("name");
+		public TestrayServer getTestrayServer() {
+			return _testrayServer;
 		}
 
-		private final long _id;
-		private final String _name;
+		protected Category(TestrayServer testrayServer, JSONObject jsonObject) {
+			_testrayServer = testrayServer;
+			_jsonObject = jsonObject;
+
+			_cached = true;
+
+			_id = _jsonObject.getLong("id");
+			_name = _jsonObject.getString("name");
+		}
+
+		protected Category(TestrayServer testrayServer, long id) {
+			_testrayServer = testrayServer;
+			_id = id;
+		}
+
+		protected Category(TestrayServer testrayServer, String name) {
+			_testrayServer = testrayServer;
+			_name = name;
+		}
+
+		private synchronized JSONObject _getJSONObject() {
+			if (_cached || (_jsonObject != null)) {
+				return _jsonObject;
+			}
+
+			String filter = null;
+
+			if (_id > 0) {
+				filter = "id eq '" + _id + "'";
+			}
+			else if (!JenkinsResultsParserUtil.isNullOrEmpty(_name)) {
+				filter = "name eq '" + _name + "'";
+			}
+
+			if (filter == null) {
+				_cached = true;
+
+				return null;
+			}
+
+			try {
+				JSONObject jsonObject = new JSONObject(
+					_testrayServer.requestGet(
+						"/o/c/factorcategories?filter=" +
+							URLEncoder.encode(filter, "UTF-8")));
+
+				JSONArray itemsJSONArray = jsonObject.optJSONArray("items");
+
+				if ((itemsJSONArray == null) || itemsJSONArray.isEmpty()) {
+					_cached = true;
+
+					return null;
+				}
+
+				_jsonObject = itemsJSONArray.getJSONObject(0);
+
+				_cached = true;
+
+				return _jsonObject;
+			}
+			catch (IOException ioException) {
+				throw new RuntimeException(ioException);
+			}
+		}
+
+		private boolean _cached;
+		private long _id;
+		private JSONObject _jsonObject;
+		private String _name;
+		private final TestrayServer _testrayServer;
 
 	}
 
 	public static class Option {
 
-		public static final String[] FIELD_NAMES = {
-			"dateCreated", "dateModified", "id", "name"
-		};
+		public Category getCategory() {
+			if (_category != null) {
+				return _category;
+			}
+
+			JSONObject jsonObject = _getJSONObject();
+
+			if (jsonObject == null) {
+				return null;
+			}
+
+			_category = TestrayFactory.newTestrayFactorCategory(
+				getTestrayServer(),
+				jsonObject.getLong(
+					"r_factorCategoryToOptions_c_factorCategoryId"));
+
+			return _category;
+		}
 
 		public Long getID() {
+			if (_cached || (_id > 0)) {
+				return _id;
+			}
+
+			JSONObject jsonObject = _getJSONObject();
+
+			if (jsonObject == null) {
+				return _id;
+			}
+
+			_id = jsonObject.getLong("id");
+
 			return _id;
 		}
 
 		public String getName() {
+			if (_cached || (_name != null)) {
+				return _name;
+			}
+
+			JSONObject jsonObject = _getJSONObject();
+
+			if (jsonObject == null) {
+				return _name;
+			}
+
+			_name = jsonObject.getString("name");
+
 			return _name;
 		}
 
-		protected Option(JSONObject jsonObject) {
+		public TestrayServer getTestrayServer() {
+			return _testrayServer;
+		}
+
+		protected Option(TestrayServer testrayServer, JSONObject jsonObject) {
+			_testrayServer = testrayServer;
+			_jsonObject = jsonObject;
+
 			_id = jsonObject.getLong("id");
 			_name = jsonObject.getString("name");
 		}
 
-		private final long _id;
-		private final String _name;
+		protected Option(TestrayServer testrayServer, long id) {
+			_testrayServer = testrayServer;
+			_id = id;
+		}
+
+		protected Option(TestrayServer testrayServer, String name) {
+			_testrayServer = testrayServer;
+			_name = name;
+		}
+
+		private synchronized JSONObject _getJSONObject() {
+			if (_cached) {
+				return _jsonObject;
+			}
+
+			String filter = null;
+
+			if (_id > 0) {
+				filter = "id eq '" + _id + "'";
+			}
+			else if (!JenkinsResultsParserUtil.isNullOrEmpty(_name)) {
+				filter = "name eq '" + _name + "'";
+			}
+
+			if (filter == null) {
+				_cached = true;
+
+				return null;
+			}
+
+			try {
+				JSONObject jsonObject = new JSONObject(
+					_testrayServer.requestGet(
+						"/o/c/factoroptions?filter=" +
+							URLEncoder.encode(filter, "UTF-8")));
+
+				JSONArray itemsJSONArray = jsonObject.optJSONArray("items");
+
+				if ((itemsJSONArray == null) || itemsJSONArray.isEmpty()) {
+					_cached = true;
+
+					return null;
+				}
+
+				_jsonObject = itemsJSONArray.getJSONObject(0);
+
+				_cached = true;
+
+				return _jsonObject;
+			}
+			catch (IOException ioException) {
+				throw new RuntimeException(ioException);
+			}
+		}
+
+		private boolean _cached;
+		private Category _category;
+		private long _id;
+		private JSONObject _jsonObject;
+		private String _name;
+		private final TestrayServer _testrayServer;
 
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactor.java
@@ -68,9 +68,9 @@ public interface TestrayFactor {
 			return _testrayServer;
 		}
 
-		protected Category(TestrayServer testrayServer, JSONObject jsonObject) {
-			_testrayServer = testrayServer;
+		protected Category(JSONObject jsonObject, TestrayServer testrayServer) {
 			_jsonObject = jsonObject;
+			_testrayServer = testrayServer;
 
 			_cached = true;
 
@@ -78,14 +78,14 @@ public interface TestrayFactor {
 			_name = _jsonObject.getString("name");
 		}
 
-		protected Category(TestrayServer testrayServer, long id) {
-			_testrayServer = testrayServer;
+		protected Category(long id, TestrayServer testrayServer) {
 			_id = id;
+			_testrayServer = testrayServer;
 		}
 
-		protected Category(TestrayServer testrayServer, String name) {
-			_testrayServer = testrayServer;
+		protected Category(String name, TestrayServer testrayServer) {
 			_name = name;
+			_testrayServer = testrayServer;
 		}
 
 		private synchronized JSONObject _getJSONObject() {
@@ -200,22 +200,22 @@ public interface TestrayFactor {
 			return _testrayServer;
 		}
 
-		protected Option(TestrayServer testrayServer, JSONObject jsonObject) {
-			_testrayServer = testrayServer;
+		protected Option(JSONObject jsonObject, TestrayServer testrayServer) {
 			_jsonObject = jsonObject;
+			_testrayServer = testrayServer;
 
 			_id = jsonObject.getLong("id");
 			_name = jsonObject.getString("name");
 		}
 
-		protected Option(TestrayServer testrayServer, long id) {
-			_testrayServer = testrayServer;
+		protected Option(long id, TestrayServer testrayServer) {
 			_id = id;
+			_testrayServer = testrayServer;
 		}
 
-		protected Option(TestrayServer testrayServer, String name) {
-			_testrayServer = testrayServer;
+		protected Option(String name, TestrayServer testrayServer) {
 			_name = name;
+			_testrayServer = testrayServer;
 		}
 
 		private synchronized JSONObject _getJSONObject() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactor.java
@@ -93,18 +93,18 @@ public interface TestrayFactor {
 				return _jsonObject;
 			}
 
-			String filter = null;
+			String filterString = null;
 
 			if (_id > 0) {
-				filter = JenkinsResultsParserUtil.combine(
+				filterString = JenkinsResultsParserUtil.combine(
 					"id eq '", String.valueOf(_id), "'");
 			}
 			else if (!JenkinsResultsParserUtil.isNullOrEmpty(_name)) {
-				filter = JenkinsResultsParserUtil.combine(
+				filterString = JenkinsResultsParserUtil.combine(
 					"name eq '", _name, "'");
 			}
 
-			if (filter == null) {
+			if (filterString == null) {
 				_cached = true;
 
 				return null;
@@ -114,7 +114,7 @@ public interface TestrayFactor {
 				JSONObject jsonObject = new JSONObject(
 					_testrayServer.requestGet(
 						"/o/c/factorcategories?filter=" +
-							URLEncoder.encode(filter, "UTF-8")));
+							URLEncoder.encode(filterString, "UTF-8")));
 
 				JSONArray itemsJSONArray = jsonObject.optJSONArray("items");
 
@@ -223,18 +223,18 @@ public interface TestrayFactor {
 				return _jsonObject;
 			}
 
-			String filter = null;
+			String filterString = null;
 
 			if (_id > 0) {
-				filter = JenkinsResultsParserUtil.combine(
+				filterString = JenkinsResultsParserUtil.combine(
 					"id eq '", String.valueOf(_id), "'");
 			}
 			else if (!JenkinsResultsParserUtil.isNullOrEmpty(_name)) {
-				filter = JenkinsResultsParserUtil.combine(
+				filterString = JenkinsResultsParserUtil.combine(
 					"name eq '", _name, "'");
 			}
 
-			if (filter == null) {
+			if (filterString == null) {
 				_cached = true;
 
 				return null;
@@ -244,7 +244,7 @@ public interface TestrayFactor {
 				JSONObject jsonObject = new JSONObject(
 					_testrayServer.requestGet(
 						"/o/c/factoroptions?filter=" +
-							URLEncoder.encode(filter, "UTF-8")));
+							URLEncoder.encode(filterString, "UTF-8")));
 
 				JSONArray itemsJSONArray = jsonObject.optJSONArray("items");
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactor.java
@@ -96,10 +96,12 @@ public interface TestrayFactor {
 			String filter = null;
 
 			if (_id > 0) {
-				filter = "id eq '" + _id + "'";
+				filter = JenkinsResultsParserUtil.combine(
+					"id eq '", String.valueOf(_id), "'");
 			}
 			else if (!JenkinsResultsParserUtil.isNullOrEmpty(_name)) {
-				filter = "name eq '" + _name + "'";
+				filter = JenkinsResultsParserUtil.combine(
+					"name eq '", _name, "'");
 			}
 
 			if (filter == null) {
@@ -224,10 +226,12 @@ public interface TestrayFactor {
 			String filter = null;
 
 			if (_id > 0) {
-				filter = "id eq '" + _id + "'";
+				filter = JenkinsResultsParserUtil.combine(
+					"id eq '", String.valueOf(_id), "'");
 			}
 			else if (!JenkinsResultsParserUtil.isNullOrEmpty(_name)) {
-				filter = "name eq '" + _name + "'";
+				filter = JenkinsResultsParserUtil.combine(
+					"name eq '", _name, "'");
 			}
 
 			if (filter == null) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactory.java
@@ -142,10 +142,10 @@ public class TestrayFactory {
 		TestrayRun testrayRun, TestrayFactor.Option testrayFactorOption) {
 
 		synchronized (_runTestrayFactors) {
+			TestrayBuild testrayBuild = testrayRun.getTestrayBuild();
+
 			TestrayFactor.Category testrayFactorCategory =
 				testrayFactorOption.getCategory();
-
-			TestrayBuild testrayBuild = testrayRun.getTestrayBuild();
 
 			String key = JenkinsResultsParserUtil.combine(
 				String.valueOf(testrayBuild.getID()), "__",
@@ -276,7 +276,7 @@ public class TestrayFactory {
 			}
 
 			testrayFactorCategory = new TestrayFactor.Category(
-				testrayServer, jsonObject);
+				jsonObject, testrayServer);
 
 			_testrayFactorCategoriesIDs.put(id, testrayFactorCategory);
 
@@ -303,7 +303,7 @@ public class TestrayFactory {
 			}
 
 			testrayFactorCategory = new TestrayFactor.Category(
-				testrayServer, id);
+				id, testrayServer);
 
 			_testrayFactorCategoriesIDs.put(id, testrayFactorCategory);
 
@@ -333,7 +333,7 @@ public class TestrayFactory {
 			}
 
 			testrayFactorCategory = new TestrayFactor.Category(
-				testrayServer, name);
+				name, testrayServer);
 
 			_testrayFactorCategoriesNames.put(name, testrayFactorCategory);
 
@@ -362,7 +362,7 @@ public class TestrayFactory {
 			}
 
 			testrayFactorOption = new TestrayFactor.Option(
-				testrayServer, jsonObject);
+				jsonObject, testrayServer);
 
 			_testrayFactorOptionsIDs.put(id, testrayFactorOption);
 
@@ -388,7 +388,7 @@ public class TestrayFactory {
 				return testrayFactorOption;
 			}
 
-			testrayFactorOption = new TestrayFactor.Option(testrayServer, id);
+			testrayFactorOption = new TestrayFactor.Option(id, testrayServer);
 
 			_testrayFactorOptionsIDs.put(id, testrayFactorOption);
 
@@ -413,7 +413,7 @@ public class TestrayFactory {
 				return testrayFactorOption;
 			}
 
-			testrayFactorOption = new TestrayFactor.Option(testrayServer, name);
+			testrayFactorOption = new TestrayFactor.Option(name, testrayServer);
 
 			_testrayFactorOptionsNames.put(name, testrayFactorOption);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactory.java
@@ -379,21 +379,21 @@ public class TestrayFactory {
 		}
 
 		synchronized (_testrayFactorOptionsNames) {
-			TestrayFactor.Option testrayFactorCategory =
+			TestrayFactor.Option testrayFactorOption =
 				_testrayFactorOptionsIDs.get(id);
 
-			if (testrayFactorCategory != null) {
-				return testrayFactorCategory;
+			if (testrayFactorOption != null) {
+				return testrayFactorOption;
 			}
 
-			testrayFactorCategory = new TestrayFactor.Option(testrayServer, id);
+			testrayFactorOption = new TestrayFactor.Option(testrayServer, id);
 
-			_testrayFactorOptionsIDs.put(id, testrayFactorCategory);
+			_testrayFactorOptionsIDs.put(id, testrayFactorOption);
 
 			_testrayFactorOptionsNames.put(
-				testrayFactorCategory.getName(), testrayFactorCategory);
+				testrayFactorOption.getName(), testrayFactorOption);
 
-			return testrayFactorCategory;
+			return testrayFactorOption;
 		}
 	}
 
@@ -401,22 +401,21 @@ public class TestrayFactory {
 		TestrayServer testrayServer, String name) {
 
 		synchronized (_testrayFactorOptionsNames) {
-			TestrayFactor.Option testrayFactorCategory =
+			TestrayFactor.Option testrayFactorOption =
 				_testrayFactorOptionsNames.get(name);
 
-			if (testrayFactorCategory != null) {
-				return testrayFactorCategory;
+			if (testrayFactorOption != null) {
+				return testrayFactorOption;
 			}
 
-			testrayFactorCategory = new TestrayFactor.Option(
-				testrayServer, name);
+			testrayFactorOption = new TestrayFactor.Option(testrayServer, name);
 
-			_testrayFactorOptionsNames.put(name, testrayFactorCategory);
+			_testrayFactorOptionsNames.put(name, testrayFactorOption);
 
 			_testrayFactorOptionsIDs.put(
-				testrayFactorCategory.getID(), testrayFactorCategory);
+				testrayFactorOption.getID(), testrayFactorOption);
 
-			return testrayFactorCategory;
+			return testrayFactorOption;
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactory.java
@@ -374,7 +374,7 @@ public class TestrayFactory {
 	public static TestrayFactor.Option newTestrayFactorOption(
 		TestrayServer testrayServer, Long id) {
 
-		if (id <= 0) {
+		if ((id == null) || (id <= 0)) {
 			return null;
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactory.java
@@ -18,14 +18,13 @@ import com.liferay.jenkins.results.parser.test.clazz.group.JUnitAxisTestClassGro
 import com.liferay.jenkins.results.parser.test.clazz.group.ModulesAxisTestClassGroup;
 import com.liferay.jenkins.results.parser.test.clazz.group.PlaywrightAxisTestClassGroup;
 
-import java.io.File;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -140,6 +139,36 @@ public class TestrayFactory {
 			axisTestClassGroup, testrayBuild, topLevelBuildReport);
 	}
 
+	public static TestrayFactor newRunTestrayFactor(
+		TestrayRun testrayRun, TestrayFactor.Option testrayFactorOption) {
+
+		synchronized (_runTestrayFactors) {
+			TestrayFactor.Category testrayFactorCategory =
+				testrayFactorOption.getCategory();
+
+			TestrayBuild testrayBuild = testrayRun.getTestrayBuild();
+
+			String key = JenkinsResultsParserUtil.combine(
+				String.valueOf(testrayBuild.getID()), "__",
+				testrayRun.getRunIDString(), "__",
+				testrayFactorCategory.getName(), "__",
+				testrayFactorOption.getName());
+
+			RunTestrayFactor runTestrayFactor = _runTestrayFactors.get(key);
+
+			if (runTestrayFactor != null) {
+				return runTestrayFactor;
+			}
+
+			runTestrayFactor = new RunTestrayFactor(
+				testrayRun, testrayFactorOption);
+
+			_runTestrayFactors.put(key, runTestrayFactor);
+
+			return runTestrayFactor;
+		}
+	}
+
 	public static TestrayAttachment newTestrayAttachment(
 		TestrayCaseResult testrayCaseResult, String name, String key) {
 
@@ -230,6 +259,167 @@ public class TestrayFactory {
 		return new TestrayComponent(testrayProject, jsonObject);
 	}
 
+	public static TestrayFactor.Category newTestrayFactorCategory(
+		TestrayServer testrayServer, JSONObject jsonObject) {
+
+		if (jsonObject == null) {
+			return null;
+		}
+
+		synchronized (_testrayFactorCategoriesNames) {
+			long id = jsonObject.getLong("id");
+
+			TestrayFactor.Category testrayFactorCategory =
+				_testrayFactorCategoriesIDs.get(id);
+
+			if (testrayFactorCategory != null) {
+				return testrayFactorCategory;
+			}
+
+			testrayFactorCategory = new TestrayFactor.Category(
+				testrayServer, jsonObject);
+
+			_testrayFactorCategoriesIDs.put(id, testrayFactorCategory);
+
+			_testrayFactorCategoriesNames.put(
+				testrayFactorCategory.getName(), testrayFactorCategory);
+
+			return testrayFactorCategory;
+		}
+	}
+
+	public static TestrayFactor.Category newTestrayFactorCategory(
+		TestrayServer testrayServer, long id) {
+
+		if (id <= 0) {
+			return null;
+		}
+
+		synchronized (_testrayFactorCategoriesNames) {
+			TestrayFactor.Category testrayFactorCategory =
+				_testrayFactorCategoriesIDs.get(id);
+
+			if (testrayFactorCategory != null) {
+				return testrayFactorCategory;
+			}
+
+			testrayFactorCategory = new TestrayFactor.Category(
+				testrayServer, id);
+
+			_testrayFactorCategoriesIDs.put(id, testrayFactorCategory);
+
+			_testrayFactorCategoriesNames.put(
+				testrayFactorCategory.getName(), testrayFactorCategory);
+
+			return testrayFactorCategory;
+		}
+	}
+
+	public static TestrayFactor.Category newTestrayFactorCategory(
+		TestrayServer testrayServer, String name) {
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(name)) {
+			return null;
+		}
+
+		synchronized (_testrayFactorCategoriesNames) {
+			TestrayFactor.Category testrayFactorCategory =
+				_testrayFactorCategoriesNames.get(name);
+
+			if (testrayFactorCategory != null) {
+				return testrayFactorCategory;
+			}
+
+			testrayFactorCategory = new TestrayFactor.Category(
+				testrayServer, name);
+
+			_testrayFactorCategoriesNames.put(name, testrayFactorCategory);
+
+			_testrayFactorCategoriesIDs.put(
+				testrayFactorCategory.getID(), testrayFactorCategory);
+
+			return testrayFactorCategory;
+		}
+	}
+
+	public static TestrayFactor.Option newTestrayFactorOption(
+		TestrayServer testrayServer, JSONObject jsonObject) {
+
+		if (jsonObject == null) {
+			return null;
+		}
+
+		synchronized (_testrayFactorOptionsNames) {
+			long id = jsonObject.getLong("id");
+
+			TestrayFactor.Option testrayFactorOption =
+				_testrayFactorOptionsIDs.get(id);
+
+			if (testrayFactorOption != null) {
+				return testrayFactorOption;
+			}
+
+			testrayFactorOption = new TestrayFactor.Option(
+				testrayServer, jsonObject);
+
+			_testrayFactorOptionsIDs.put(id, testrayFactorOption);
+
+			_testrayFactorOptionsNames.put(
+				testrayFactorOption.getName(), testrayFactorOption);
+
+			return testrayFactorOption;
+		}
+	}
+
+	public static TestrayFactor.Option newTestrayFactorOption(
+		TestrayServer testrayServer, Long id) {
+
+		if (id <= 0) {
+			return null;
+		}
+
+		synchronized (_testrayFactorOptionsNames) {
+			TestrayFactor.Option testrayFactorCategory =
+				_testrayFactorOptionsIDs.get(id);
+
+			if (testrayFactorCategory != null) {
+				return testrayFactorCategory;
+			}
+
+			testrayFactorCategory = new TestrayFactor.Option(testrayServer, id);
+
+			_testrayFactorOptionsIDs.put(id, testrayFactorCategory);
+
+			_testrayFactorOptionsNames.put(
+				testrayFactorCategory.getName(), testrayFactorCategory);
+
+			return testrayFactorCategory;
+		}
+	}
+
+	public static TestrayFactor.Option newTestrayFactorOption(
+		TestrayServer testrayServer, String name) {
+
+		synchronized (_testrayFactorOptionsNames) {
+			TestrayFactor.Option testrayFactorCategory =
+				_testrayFactorOptionsNames.get(name);
+
+			if (testrayFactorCategory != null) {
+				return testrayFactorCategory;
+			}
+
+			testrayFactorCategory = new TestrayFactor.Option(
+				testrayServer, name);
+
+			_testrayFactorOptionsNames.put(name, testrayFactorCategory);
+
+			_testrayFactorOptionsIDs.put(
+				testrayFactorCategory.getID(), testrayFactorCategory);
+
+			return testrayFactorCategory;
+		}
+	}
+
 	public static TestrayProductVersion newTestrayProductVersion(
 		TestrayProject testrayProject, JSONObject jsonObject) {
 
@@ -282,32 +472,53 @@ public class TestrayFactory {
 	}
 
 	public static TestrayRun newTestrayRun(
-		TestrayBuild testrayBuild, AxisTestClassGroup axisTestClassGroup,
-		List<File> propertiesFiles) {
-
-		return new TestrayRun(
-			testrayBuild, axisTestClassGroup, propertiesFiles);
-	}
-
-	public static TestrayRun newTestrayRun(
 		TestrayBuild testrayBuild, JSONObject jsonObject) {
 
-		return new TestrayRun(testrayBuild, jsonObject);
-	}
+		synchronized (_testrayRuns) {
+			String key =
+				testrayBuild.getID() + "__" + jsonObject.getString("name");
 
-	public static TestrayRun newTestrayRun(
-		TestrayBuild testrayBuild, String batchName,
-		List<File> propertiesFiles) {
+			TestrayRun testrayRun = _testrayRuns.get(key);
 
-		return new TestrayRun(testrayBuild, batchName, null, propertiesFiles);
+			if (testrayRun != null) {
+				return testrayRun;
+			}
+
+			testrayRun = new TestrayRun(testrayBuild, jsonObject);
+
+			_testrayRuns.put(key, testrayRun);
+
+			return testrayRun;
+		}
 	}
 
 	public static TestrayRun newTestrayRun(
 		TestrayBuild testrayBuild, String batchName, String testSuiteName,
-		List<File> propertiesFiles) {
+		Properties properties) {
 
-		return new TestrayRun(
-			testrayBuild, batchName, testSuiteName, propertiesFiles);
+		synchronized (_testrayRuns) {
+			String name = TestrayRun.getRunIDString(
+				batchName, testSuiteName, properties);
+
+			if (name == null) {
+				throw new RuntimeException(
+					"Please set testray.environment.default[master]");
+			}
+
+			String key = testrayBuild.getID() + "__" + name;
+
+			TestrayRun testrayRun = _testrayRuns.get(key);
+
+			if (testrayRun != null) {
+				return testrayRun;
+			}
+
+			testrayRun = new TestrayRun(testrayBuild, name);
+
+			_testrayRuns.put(key, testrayRun);
+
+			return testrayRun;
+		}
 	}
 
 	public static TestrayRunComparison newTestrayRunComparison(
@@ -371,12 +582,23 @@ public class TestrayFactory {
 		return _topLevelBuildTestrayCaseResults.get(testrayBuildID);
 	}
 
+	private static final Map<String, RunTestrayFactor> _runTestrayFactors =
+		new HashMap<>();
 	private static final Map<Build, TestrayAttachmentRecorder>
 		_testrayAttachmentRecorders = new ConcurrentHashMap<>();
 	private static final Map<String, TestrayAttachmentUploader>
 		_testrayAttachmentUploaders = new ConcurrentHashMap<>();
+	private static final Map<Long, TestrayFactor.Category>
+		_testrayFactorCategoriesIDs = new HashMap<>();
+	private static final Map<String, TestrayFactor.Category>
+		_testrayFactorCategoriesNames = new HashMap<>();
+	private static final Map<Long, TestrayFactor.Option>
+		_testrayFactorOptionsIDs = new HashMap<>();
+	private static final Map<String, TestrayFactor.Option>
+		_testrayFactorOptionsNames = new HashMap<>();
 	private static final Map<String, TestrayRoutine> _testrayRoutines =
 		new ConcurrentHashMap<>();
+	private static final Map<String, TestrayRun> _testrayRuns = new HashMap<>();
 	private static final Map<String, TestrayServer> _testrayServers =
 		new ConcurrentHashMap<>();
 	private static final Pattern _testrayURLPattern = Pattern.compile(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactory.java
@@ -21,7 +21,6 @@ import com.liferay.jenkins.results.parser.test.clazz.group.PlaywrightAxisTestCla
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
@@ -308,8 +307,11 @@ public class TestrayFactory {
 
 			_testrayFactorCategoriesIDs.put(id, testrayFactorCategory);
 
-			_testrayFactorCategoriesNames.put(
-				testrayFactorCategory.getName(), testrayFactorCategory);
+			String name = testrayFactorCategory.getName();
+
+			if (!JenkinsResultsParserUtil.isNullOrEmpty(name)) {
+				_testrayFactorCategoriesNames.put(name, testrayFactorCategory);
+			}
 
 			return testrayFactorCategory;
 		}
@@ -390,8 +392,11 @@ public class TestrayFactory {
 
 			_testrayFactorOptionsIDs.put(id, testrayFactorOption);
 
-			_testrayFactorOptionsNames.put(
-				testrayFactorOption.getName(), testrayFactorOption);
+			String name = testrayFactorOption.getName();
+
+			if (!JenkinsResultsParserUtil.isNullOrEmpty(name)) {
+				_testrayFactorOptionsNames.put(name, testrayFactorOption);
+			}
 
 			return testrayFactorOption;
 		}
@@ -582,22 +587,23 @@ public class TestrayFactory {
 	}
 
 	private static final Map<String, RunTestrayFactor> _runTestrayFactors =
-		new HashMap<>();
+		new ConcurrentHashMap<>();
 	private static final Map<Build, TestrayAttachmentRecorder>
 		_testrayAttachmentRecorders = new ConcurrentHashMap<>();
 	private static final Map<String, TestrayAttachmentUploader>
 		_testrayAttachmentUploaders = new ConcurrentHashMap<>();
 	private static final Map<Long, TestrayFactor.Category>
-		_testrayFactorCategoriesIDs = new HashMap<>();
+		_testrayFactorCategoriesIDs = new ConcurrentHashMap<>();
 	private static final Map<String, TestrayFactor.Category>
-		_testrayFactorCategoriesNames = new HashMap<>();
+		_testrayFactorCategoriesNames = new ConcurrentHashMap<>();
 	private static final Map<Long, TestrayFactor.Option>
-		_testrayFactorOptionsIDs = new HashMap<>();
+		_testrayFactorOptionsIDs = new ConcurrentHashMap<>();
 	private static final Map<String, TestrayFactor.Option>
-		_testrayFactorOptionsNames = new HashMap<>();
+		_testrayFactorOptionsNames = new ConcurrentHashMap<>();
 	private static final Map<String, TestrayRoutine> _testrayRoutines =
 		new ConcurrentHashMap<>();
-	private static final Map<String, TestrayRun> _testrayRuns = new HashMap<>();
+	private static final Map<String, TestrayRun> _testrayRuns =
+		new ConcurrentHashMap<>();
 	private static final Map<String, TestrayServer> _testrayServers =
 		new ConcurrentHashMap<>();
 	private static final Pattern _testrayURLPattern = Pattern.compile(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
@@ -993,16 +993,13 @@ public class TestrayImporter {
 				testBaseDir = axisTestClassGroup.getTestBaseDir();
 			}
 
-			_recordTopLevelTestrayCaseResult(job, testBaseDir);
-
 			_recordAppServerTestrayCaseResult(
 				job, PersistentResource.Type.ASAH_BUNDLE, testBaseDir);
-
 			_recordAppServerTestrayCaseResult(
 				job, PersistentResource.Type.FARO_BUNDLE, testBaseDir);
-
 			_recordAppServerTestrayCaseResult(
 				job, PersistentResource.Type.PORTAL_BUNDLE, testBaseDir);
+			_recordTopLevelTestrayCaseResult(job, testBaseDir);
 
 			for (final AxisTestClassGroup axisTestClassGroup :
 					axisTestClassGroups) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
@@ -993,13 +993,16 @@ public class TestrayImporter {
 				testBaseDir = axisTestClassGroup.getTestBaseDir();
 			}
 
+			_recordTopLevelTestrayCaseResult(job, testBaseDir);
+
 			_recordAppServerTestrayCaseResult(
 				job, PersistentResource.Type.ASAH_BUNDLE, testBaseDir);
+
 			_recordAppServerTestrayCaseResult(
 				job, PersistentResource.Type.FARO_BUNDLE, testBaseDir);
+
 			_recordAppServerTestrayCaseResult(
 				job, PersistentResource.Type.PORTAL_BUNDLE, testBaseDir);
-			_recordTopLevelTestrayCaseResult(job, testBaseDir);
 
 			for (final AxisTestClassGroup axisTestClassGroup :
 					axisTestClassGroups) {
@@ -1126,6 +1129,33 @@ public class TestrayImporter {
 		buildParameters.putAll(_topLevelBuildReport.getBuildParameters());
 
 		return buildParameters.get(buildParameterName);
+	}
+
+	private String _getEnhancedBatchName(
+		AxisTestClassGroup axisTestClassGroup) {
+
+		if (!(axisTestClassGroup instanceof FunctionalAxisTestClassGroup)) {
+			return axisTestClassGroup.getBatchName();
+		}
+
+		String batchName = axisTestClassGroup.getBatchName();
+
+		FunctionalAxisTestClassGroup functionalAxisTestClassGroup =
+			(FunctionalAxisTestClassGroup)axisTestClassGroup;
+
+		Properties poshiProperties =
+			functionalAxisTestClassGroup.getPoshiProperties();
+
+		String browserChromeVersion = poshiProperties.getProperty(
+			"browser.chrome.version");
+
+		if ((browserChromeVersion != null) &&
+			browserChromeVersion.equals("139.0")) {
+
+			batchName += "-chrome139";
+		}
+
+		return batchName;
 	}
 
 	private Element _getJenkinsBuildDescriptionCodeElement(
@@ -1371,7 +1401,7 @@ public class TestrayImporter {
 		return "Liferay CI";
 	}
 
-	private void _recordAppServerTestrayCaseResult(
+	private TestrayCaseResult _recordAppServerTestrayCaseResult(
 		Job job, PersistentResource.Type persistentResourceType,
 		File testBaseDir) {
 
@@ -1387,11 +1417,13 @@ public class TestrayImporter {
 			appServerBundleStandaloneBuildTestrayCaseResult.getBuildReport();
 
 		if (buildReport == null) {
-			return;
+			return null;
 		}
 
 		appServerBundleStandaloneBuildTestrayCaseResult.recordTestrayCaseResult(
 			job);
+
+		return appServerBundleStandaloneBuildTestrayCaseResult;
 	}
 
 	private void _recordAxisTestClassGroup(
@@ -1402,19 +1434,9 @@ public class TestrayImporter {
 		TestrayBuild testrayBuild = getTestrayBuild(
 			axisTestClassGroup.getTestBaseDir());
 
-		TestrayRun testrayRun = null;
-
-		String testSuiteName = _topLevelBuildReport.getTestSuiteName();
-
-		if (axisTestClassGroup instanceof FunctionalAxisTestClassGroup) {
-			testrayRun = TestrayFactory.newTestrayRun(
-				testrayBuild, axisTestClassGroup, job.getJobPropertiesFiles());
-		}
-		else {
-			testrayRun = TestrayFactory.newTestrayRun(
-				testrayBuild, axisTestClassGroup.getBatchName(), testSuiteName,
-				job.getJobPropertiesFiles());
-		}
+		TestrayRun testrayRun = TestrayFactory.newTestrayRun(
+			testrayBuild, _getEnhancedBatchName(axisTestClassGroup),
+			_topLevelBuildReport.getTestSuiteName(), job.getJobProperties());
 
 		long start = JenkinsResultsParserUtil.getCurrentTimeMillis();
 
@@ -1422,15 +1444,7 @@ public class TestrayImporter {
 
 		Element rootElement = document.addElement("testsuite");
 
-		Element environmentsElement = rootElement.addElement("environments");
-
-		for (TestrayRun.Factor factor : testrayRun.getFactors()) {
-			Element environmentElement = environmentsElement.addElement(
-				"environment");
-
-			environmentElement.addAttribute("type", factor.getName());
-			environmentElement.addAttribute("option", factor.getValue());
-		}
+		rootElement.add(testrayRun.getEnvironmentsElement());
 
 		Map<String, String> propertiesMap = new HashMap<>();
 
@@ -1472,6 +1486,14 @@ public class TestrayImporter {
 
 		List<TestrayCaseResult> testrayCaseResults = new ArrayList<>();
 
+		TestrayCaseResult buildTestrayCaseResult =
+			TestrayFactory.newBuildTestrayCaseResult(
+				axisTestClassGroup, testrayBuild, _topLevelBuildReport);
+
+		buildTestrayCaseResult.setTestrayRun(testrayRun);
+
+		testrayCaseResults.add(buildTestrayCaseResult);
+
 		if (axisTestClassGroup instanceof FunctionalAxisTestClassGroup ||
 			axisTestClassGroup instanceof JSUnitAxisTestClassGroup ||
 			axisTestClassGroup instanceof JUnitAxisTestClassGroup ||
@@ -1485,14 +1507,20 @@ public class TestrayImporter {
 			if (!JenkinsResultsParserUtil.isNullOrEmpty(
 					portalLogBatchBuildTestrayCaseResult.getErrors())) {
 
+				portalLogBatchBuildTestrayCaseResult.setTestrayRun(testrayRun);
+
 				testrayCaseResults.add(portalLogBatchBuildTestrayCaseResult);
 			}
 
 			for (TestClass testClass : axisTestClassGroup.getTestClasses()) {
-				testrayCaseResults.add(
+				TestrayCaseResult testClassTestrayCaseResult =
 					TestrayFactory.newBuildTestrayCaseResult(
 						axisTestClassGroup, testClass, testrayBuild,
-						_topLevelBuildReport));
+						_topLevelBuildReport);
+
+				testClassTestrayCaseResult.setTestrayRun(testrayRun);
+
+				testrayCaseResults.add(testClassTestrayCaseResult);
 			}
 		}
 		else if (axisTestClassGroup instanceof PlaywrightAxisTestClassGroup) {
@@ -1500,17 +1528,16 @@ public class TestrayImporter {
 				for (TestClassMethod testClassMethod :
 						testClass.getTestClassMethods()) {
 
-					testrayCaseResults.add(
+					TestrayCaseResult testClassMethodTestrayCaseResult =
 						TestrayFactory.newBuildTestrayCaseResult(
 							axisTestClassGroup, testClass, testClassMethod,
-							testrayBuild, _topLevelBuildReport));
+							testrayBuild, _topLevelBuildReport);
+
+					testClassMethodTestrayCaseResult.setTestrayRun(testrayRun);
+
+					testrayCaseResults.add(testClassMethodTestrayCaseResult);
 				}
 			}
-		}
-		else {
-			testrayCaseResults.add(
-				TestrayFactory.newBuildTestrayCaseResult(
-					axisTestClassGroup, testrayBuild, _topLevelBuildReport));
 		}
 
 		for (TestrayCaseResult testrayCaseResult : testrayCaseResults) {
@@ -1552,6 +1579,8 @@ public class TestrayImporter {
 
 			Element propertiesElement = testcaseElement.addElement(
 				"properties");
+
+			String testSuiteName = _topLevelBuildReport.getTestSuiteName();
 
 			if (testSuiteName.equals("upstream-dxp")) {
 				if (testrayCaseResult instanceof
@@ -1647,13 +1676,17 @@ public class TestrayImporter {
 					currentTimeMillis - start)));
 	}
 
-	private void _recordTopLevelTestrayCaseResult(Job job, File testBaseDir) {
+	private TestrayCaseResult _recordTopLevelTestrayCaseResult(
+		Job job, File testBaseDir) {
+
 		TopLevelStandaloneBuildTestrayCaseResult
 			topLevelStandaloneBuildTestrayCaseResult =
 				TestrayFactory.newTopLevelStandaloneBuildTestrayCaseResult(
 					getTestrayBuild(testBaseDir), _topLevelBuildReport);
 
 		topLevelStandaloneBuildTestrayCaseResult.recordTestrayCaseResult(job);
+
+		return topLevelStandaloneBuildTestrayCaseResult;
 	}
 
 	private String _replaceEnvVars(String string, boolean truncate) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayRun.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayRun.java
@@ -5,13 +5,13 @@
 
 package com.liferay.jenkins.results.parser.testray;
 
+import com.liferay.jenkins.results.parser.Dom4JUtil;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
-import com.liferay.jenkins.results.parser.test.clazz.group.AxisTestClassGroup;
-import com.liferay.jenkins.results.parser.test.clazz.group.BatchTestClassGroup;
-import com.liferay.jenkins.results.parser.test.clazz.group.FunctionalAxisTestClassGroup;
+import com.liferay.jenkins.results.parser.Retryable;
 
-import java.io.File;
 import java.io.IOException;
+
+import java.net.URLEncoder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,6 +22,9 @@ import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.dom4j.Element;
+
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 /**
@@ -34,11 +37,76 @@ public class TestrayRun {
 	};
 
 	public static String getDefaultRunIDString() {
-		return _properties.getProperty("testray.environment.default[master]");
+		try {
+			return JenkinsResultsParserUtil.getBuildProperty(
+				"testray.environment.default[master]");
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
 	}
 
-	public List<Factor> getFactors() {
-		return _factors;
+	public static String getRunIDString(
+		String batchName, String testSuiteName, Properties properties) {
+
+		List<String> factorValues = new ArrayList<>();
+
+		for (String factorNameKey : _getFactorNameKeys(properties)) {
+			String factoryName = _getFactorName(factorNameKey, properties);
+			String factoryValue = _getFactorValue(
+				batchName, testSuiteName, factorNameKey, properties);
+
+			if (JenkinsResultsParserUtil.isNullOrEmpty(factoryName) ||
+				JenkinsResultsParserUtil.isNullOrEmpty(factoryValue)) {
+
+				continue;
+			}
+
+			factorValues.add(factoryValue);
+		}
+
+		if (factorValues.isEmpty()) {
+			return getDefaultRunIDString();
+		}
+
+		return JenkinsResultsParserUtil.join("|", factorValues);
+	}
+
+	public String getEnvironmentHash() {
+		StringBuilder sb = new StringBuilder();
+
+		for (TestrayFactor testrayFactor : getTestrayFactors()) {
+			TestrayFactor.Category category = testrayFactor.getCategory();
+
+			sb.append(category.getID());
+
+			TestrayFactor.Option option = testrayFactor.getOption();
+
+			sb.append(option.getID());
+		}
+
+		String environment = sb.toString();
+
+		return String.valueOf(environment.hashCode());
+	}
+
+	public Element getEnvironmentsElement() {
+		Element environmentsElement = Dom4JUtil.getNewElement("environments");
+
+		for (TestrayFactor testrayFactor : getTestrayFactors()) {
+			Element environmentElement = environmentsElement.addElement(
+				"environment");
+
+			TestrayFactor.Category category = testrayFactor.getCategory();
+
+			environmentElement.addAttribute("type", category.getName());
+
+			TestrayFactor.Option option = testrayFactor.getOption();
+
+			environmentElement.addAttribute("option", option.getName());
+		}
+
+		return environmentsElement;
 	}
 
 	public long getID() {
@@ -46,37 +114,35 @@ public class TestrayRun {
 			return _id;
 		}
 
-		if (_jsonObject == null) {
-			_id = _testrayBuild.getTestrayRunID(this);
+		JSONObject jsonObject = getJSONObject();
 
-			if (_id != null) {
-				return _id;
-			}
-
-			return 0;
-		}
-
-		_id = _jsonObject.optLong("id");
+		_id = jsonObject.optLong("id");
 
 		return _id;
 	}
 
 	public String getRunIDString() {
-		if ((_jsonObject != null) && _jsonObject.has("name")) {
-			return _jsonObject.getString("name");
-		}
-
-		List<String> factorValues = new ArrayList<>();
-
-		for (Factor factor : getFactors()) {
-			factorValues.add(factor.getValue());
-		}
-
-		return JenkinsResultsParserUtil.join("|", factorValues);
+		return _name;
 	}
 
 	public TestrayBuild getTestrayBuild() {
 		return _testrayBuild;
+	}
+
+	public synchronized List<TestrayFactor> getTestrayFactors() {
+		if (_testrayFactors != null) {
+			return _testrayFactors;
+		}
+
+		List<TestrayFactor> testrayFactors = _getTestrayFactorsByRunID();
+
+		if (testrayFactors == null) {
+			testrayFactors = _getTestrayFactorsByName();
+		}
+
+		_testrayFactors = testrayFactors;
+
+		return _testrayFactors;
 	}
 
 	public TestrayServer getTestrayServer() {
@@ -93,271 +159,86 @@ public class TestrayRun {
 		_id = id;
 	}
 
-	public static class Factor {
-
-		public Factor(String name, String value) {
-			_name = name;
-			_value = value;
-		}
-
-		public String getName() {
-			return _name;
-		}
-
-		public String getValue() {
-			return _value;
-		}
-
-		@Override
-		public String toString() {
-			return getName() + "=" + getValue();
-		}
-
-		private final String _name;
-		private final String _value;
-
-	}
-
-	protected TestrayRun(
-		TestrayBuild testrayBuild, AxisTestClassGroup axisTestClassGroup,
-		List<File> propertiesFiles) {
-
-		_testrayBuild = testrayBuild;
-
-		try {
-			_properties.putAll(JenkinsResultsParserUtil.getBuildProperties());
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
-
-		for (int i = propertiesFiles.size() - 1; i >= 0; i--) {
-			_properties.putAll(
-				JenkinsResultsParserUtil.getProperties(propertiesFiles.get(i)));
-		}
-
-		initializeFactorsByAxisTestClassGroup(axisTestClassGroup);
-
-		JSONObject jsonObject = null;
-
-		String runIDString = getRunIDString();
-
-		for (TestrayRun testrayRun : testrayBuild.getTestrayRuns()) {
-			String testrayRunIDString = testrayRun.getRunIDString();
-
-			if (Objects.equals(
-					runIDString.toLowerCase(),
-					testrayRunIDString.toLowerCase())) {
-
-				jsonObject = testrayRun.getJSONObject();
-
-				break;
-			}
-		}
-
-		_jsonObject = jsonObject;
-	}
-
 	protected TestrayRun(TestrayBuild testrayBuild, JSONObject jsonObject) {
 		_testrayBuild = testrayBuild;
 		_jsonObject = jsonObject;
 
-		try {
-			_properties.putAll(JenkinsResultsParserUtil.getBuildProperties());
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
-
-		initializeFactorsByJSONObject(jsonObject);
+		_name = jsonObject.getString("name");
 	}
 
-	protected TestrayRun(
-		TestrayBuild testrayBuild, String batchName, String testSuiteName,
-		List<File> propertiesFiles) {
-
+	protected TestrayRun(TestrayBuild testrayBuild, String name) {
 		_testrayBuild = testrayBuild;
-
-		try {
-			_properties.putAll(JenkinsResultsParserUtil.getBuildProperties());
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
-
-		for (int i = propertiesFiles.size() - 1; i >= 0; i--) {
-			_properties.putAll(
-				JenkinsResultsParserUtil.getProperties(propertiesFiles.get(i)));
-		}
-
-		initializeFactorsByBatchName(batchName, testSuiteName);
-
-		JSONObject jsonObject = null;
-
-		String runIDString = getRunIDString();
-
-		for (TestrayRun testrayRun : testrayBuild.getTestrayRuns()) {
-			String testrayRunIDString = testrayRun.getRunIDString();
-
-			if (Objects.equals(
-					runIDString.toLowerCase(),
-					testrayRunIDString.toLowerCase())) {
-
-				jsonObject = testrayRun.getJSONObject();
-
-				break;
-			}
-		}
-
-		_jsonObject = jsonObject;
+		_name = name;
 	}
 
-	protected JSONObject getJSONObject() {
+	protected synchronized JSONObject getJSONObject() {
+		if (_cached || (_jsonObject != null)) {
+			return _jsonObject;
+		}
+
+		final TestrayBuild testrayBuild = getTestrayBuild();
+		final TestrayServer testrayServer = getTestrayServer();
+
+		final String filter = JenkinsResultsParserUtil.combine(
+			"environmentHash eq '", getEnvironmentHash(), "' and name eq '",
+			getRunIDString(), "' and r_buildToRuns_c_buildId eq '",
+			String.valueOf(testrayBuild.getID()), "'");
+
+		Retryable<JSONObject> retryable = new Retryable<JSONObject>(
+			true, 3, 5, true) {
+
+			@Override
+			public JSONObject execute() {
+				try {
+					JSONObject existingJSONObject = new JSONObject(
+						testrayServer.requestGet(
+							"/o/c/runs?filter=" +
+								URLEncoder.encode(filter, "UTF-8")));
+
+					JSONArray existingItemsJSONArray =
+						existingJSONObject.optJSONArray("items");
+
+					if ((existingItemsJSONArray != null) &&
+						!existingItemsJSONArray.isEmpty()) {
+
+						return existingItemsJSONArray.getJSONObject(0);
+					}
+
+					JSONObject postRequestJSONObject = new JSONObject();
+
+					postRequestJSONObject.put(
+						"environmentHash", getEnvironmentHash()
+					).put(
+						"name", getRunIDString()
+					).put(
+						"number", _getNextRunNumber()
+					).put(
+						"r_buildToRuns_c_buildId", testrayBuild.getID()
+					);
+
+					return new JSONObject(
+						testrayServer.requestPost(
+							"/o/c/runs", postRequestJSONObject.toString()));
+				}
+				catch (IOException ioException) {
+					throw new RuntimeException(ioException);
+				}
+			}
+
+		};
+
+		_jsonObject = retryable.executeWithRetries();
+
+		_cached = true;
+
 		return _jsonObject;
 	}
 
-	protected Properties getProperties() {
-		return _properties;
-	}
+	private static String _getFactorName(
+		String factorNameKey, Properties properties) {
 
-	protected void initializeFactorsByAxisTestClassGroup(
-		AxisTestClassGroup axisTestClassGroup) {
-
-		_factors = new ArrayList<>();
-
-		if (axisTestClassGroup == null) {
-			return;
-		}
-
-		String batchName = axisTestClassGroup.getBatchName();
-
-		if (axisTestClassGroup instanceof FunctionalAxisTestClassGroup) {
-			FunctionalAxisTestClassGroup functionalAxisTestClassGroup =
-				(FunctionalAxisTestClassGroup)axisTestClassGroup;
-
-			Properties poshiProperties =
-				functionalAxisTestClassGroup.getPoshiProperties();
-
-			String browserChromeVersion = poshiProperties.getProperty(
-				"browser.chrome.version");
-
-			if ((browserChromeVersion != null) &&
-				browserChromeVersion.equals("139.0")) {
-
-				batchName += "-chrome139";
-			}
-		}
-
-		for (String factorNameKey : _getFactorNameKeys()) {
-			if (factorNameKey.equals("search_engine")) {
-				continue;
-			}
-
-			String factoryName = _getFactorName(factorNameKey);
-			String factoryValue = _getFactorValue(batchName, factorNameKey);
-
-			if (JenkinsResultsParserUtil.isNullOrEmpty(factoryName) ||
-				JenkinsResultsParserUtil.isNullOrEmpty(factoryValue)) {
-
-				continue;
-			}
-
-			_factors.add(new Factor(factoryName, factoryValue));
-		}
-
-		BatchTestClassGroup batchTestClassGroup =
-			axisTestClassGroup.getBatchTestClassGroup();
-
-		_addSearchEngineFactor(
-			batchName, batchTestClassGroup.getTestSuiteName());
-	}
-
-	protected void initializeFactorsByBatchName(
-		String batchName, String testSuiteName) {
-
-		_factors = new ArrayList<>();
-
-		if (JenkinsResultsParserUtil.isNullOrEmpty(batchName)) {
-			return;
-		}
-
-		for (String factorNameKey : _getFactorNameKeys()) {
-			if (factorNameKey.equals("search_engine")) {
-				continue;
-			}
-
-			String factoryName = _getFactorName(factorNameKey);
-			String factoryValue = _getFactorValue(batchName, factorNameKey);
-
-			if (JenkinsResultsParserUtil.isNullOrEmpty(factoryName) ||
-				JenkinsResultsParserUtil.isNullOrEmpty(factoryValue)) {
-
-				continue;
-			}
-
-			_factors.add(new Factor(factoryName, factoryValue));
-		}
-
-		_addSearchEngineFactor(batchName, testSuiteName);
-	}
-
-	protected void initializeFactorsByJSONObject(JSONObject jsonObject) {
-		_factors = new ArrayList<>();
-
-		if (jsonObject == null) {
-			return;
-		}
-
-		String runIDString = jsonObject.optString("name");
-
-		if (JenkinsResultsParserUtil.isNullOrEmpty(runIDString)) {
-			return;
-		}
-
-		for (String factorValue : runIDString.split("\\|")) {
-			for (String propertyName : _properties.stringPropertyNames()) {
-				Matcher factorValueMatcher = _factorValuePattern.matcher(
-					propertyName);
-
-				if (!factorValueMatcher.find()) {
-					continue;
-				}
-
-				if (factorValue.equals(_properties.getProperty(propertyName))) {
-					String factorName = _getFactorName(
-						factorValueMatcher.group("nameKey"));
-
-					_factors.add(new Factor(factorName, factorValue));
-
-					break;
-				}
-			}
-		}
-	}
-
-	private void _addSearchEngineFactor(
-		String batchName, String testSuiteName) {
-
-		String searchEngineFactorValue = _getSearchEngineFactorValue(
-			batchName, testSuiteName);
-
-		if (JenkinsResultsParserUtil.isNullOrEmpty(searchEngineFactorValue)) {
-			return;
-		}
-
-		String searchEngineFactorName = _getFactorName("search_engine");
-
-		if (JenkinsResultsParserUtil.isNullOrEmpty(searchEngineFactorName)) {
-			return;
-		}
-
-		_factors.add(
-			new Factor(searchEngineFactorName, searchEngineFactorValue));
-	}
-
-	private String _getFactorName(String factorNameKey) {
 		String factorName = JenkinsResultsParserUtil.getProperty(
-			_properties,
+			properties,
 			JenkinsResultsParserUtil.combine(
 				_PROPERTY_KEY_FACTOR_NAME, "[", factorNameKey, "]"));
 
@@ -368,10 +249,10 @@ public class TestrayRun {
 		return null;
 	}
 
-	private Set<String> _getFactorNameKeys() {
+	private static Set<String> _getFactorNameKeys(Properties properties) {
 		Set<String> factorNameKeys = new TreeSet<>();
 
-		for (String propertyName : _properties.stringPropertyNames()) {
+		for (String propertyName : properties.stringPropertyNames()) {
 			Matcher matcher = _factorNamePattern.matcher(propertyName);
 
 			if (!matcher.find()) {
@@ -384,11 +265,23 @@ public class TestrayRun {
 		return factorNameKeys;
 	}
 
-	private String _getFactorValue(String batchName, String factorNameKey) {
+	private static String _getFactorValue(
+		String batchName, String testSuiteName, String factorNameKey,
+		Properties properties) {
+
+		if (Objects.equals(factorNameKey, "search_engine")) {
+			String factorValue = _getSearchEngineFactorValue(
+				batchName, testSuiteName, properties);
+
+			if (!JenkinsResultsParserUtil.isNullOrEmpty(factorValue)) {
+				return factorValue;
+			}
+		}
+
 		String matchingValueKey = null;
 		String matchingPropertyName = null;
 
-		for (String propertyName : _properties.stringPropertyNames()) {
+		for (String propertyName : properties.stringPropertyNames()) {
 			Matcher matcher = _factorValuePattern.matcher(propertyName);
 
 			if (!matcher.find()) {
@@ -417,11 +310,11 @@ public class TestrayRun {
 
 		if (!JenkinsResultsParserUtil.isNullOrEmpty(matchingPropertyName)) {
 			return JenkinsResultsParserUtil.getProperty(
-				_properties, matchingPropertyName);
+				properties, matchingPropertyName);
 		}
 
 		String factorValue = JenkinsResultsParserUtil.getProperty(
-			_properties,
+			properties,
 			JenkinsResultsParserUtil.combine(
 				_PROPERTY_KEY_FACTOR_VALUE, "[", factorNameKey, "]"));
 
@@ -432,25 +325,25 @@ public class TestrayRun {
 		return factorValue;
 	}
 
-	private String _getSearchEngineFactorValue(
-		String batchName, String testSuiteName) {
+	private static String _getSearchEngineFactorValue(
+		String batchName, String testSuiteName, Properties properties) {
 
 		if (!JenkinsResultsParserUtil.isNullOrEmpty(batchName) &&
 			!(batchName.startsWith("functional") ||
 			  batchName.startsWith("modules-integration") ||
 			  batchName.startsWith("modules-unit"))) {
 
-			return _properties.getProperty("search.engine.default");
+			return properties.getProperty("search.engine.default");
 		}
 
 		String searchEngine = null;
 		String searchEngineVersion = null;
 
 		if (!JenkinsResultsParserUtil.isNullOrEmpty(testSuiteName)) {
-			searchEngine = _properties.getProperty(
+			searchEngine = properties.getProperty(
 				"search.engine[" + testSuiteName + "]");
 
-			searchEngineVersion = _properties.getProperty(
+			searchEngineVersion = properties.getProperty(
 				"search.engine.version[" + testSuiteName + "]");
 		}
 
@@ -471,12 +364,12 @@ public class TestrayRun {
 		if (JenkinsResultsParserUtil.isNullOrEmpty(searchEngineVersion) &&
 			!JenkinsResultsParserUtil.isNullOrEmpty(searchEngine)) {
 
-			searchEngineVersion = _properties.getProperty(
+			searchEngineVersion = properties.getProperty(
 				"search.engine.version[" + searchEngine + "]");
 		}
 
 		if (JenkinsResultsParserUtil.isNullOrEmpty(searchEngine)) {
-			return _properties.getProperty("search.engine.default");
+			return properties.getProperty("search.engine.default");
 		}
 
 		String searchEngineFactorValue = _toTitleCase(searchEngine);
@@ -488,7 +381,7 @@ public class TestrayRun {
 		return searchEngineFactorValue;
 	}
 
-	private String _toTitleCase(String name) {
+	private static String _toTitleCase(String name) {
 		if (JenkinsResultsParserUtil.isNullOrEmpty(name)) {
 			return name;
 		}
@@ -511,6 +404,105 @@ public class TestrayRun {
 		return sb.toString();
 	}
 
+	private synchronized int _getNextRunNumber() {
+		TestrayBuild testrayBuild = getTestrayBuild();
+
+		String filter =
+			"r_buildToRuns_c_buildId eq '" + testrayBuild.getID() + "'";
+
+		try {
+			TestrayServer testrayServer = getTestrayServer();
+
+			JSONObject jsonObject = new JSONObject(
+				testrayServer.requestGet(
+					"/o/c/runs?filter=" + URLEncoder.encode(filter, "UTF-8")));
+
+			return jsonObject.optInt("totalCount") + 1;
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
+	}
+
+	private List<TestrayFactor> _getTestrayFactorsByName() {
+		List<TestrayFactor> testrayFactors = new ArrayList<>();
+
+		String name = getRunIDString();
+
+		for (String optionName : name.split("\\|")) {
+			TestrayFactor.Option testrayFactorOption =
+				TestrayFactory.newTestrayFactorOption(
+					_testrayBuild.getTestrayServer(), optionName);
+
+			testrayFactors.add(
+				TestrayFactory.newRunTestrayFactor(this, testrayFactorOption));
+		}
+
+		return testrayFactors;
+	}
+
+	private List<TestrayFactor> _getTestrayFactorsByRunID() {
+		long runID = 0;
+
+		if (_id != null) {
+			runID = _id;
+		}
+		else if (_jsonObject != null) {
+			runID = _jsonObject.optLong("id");
+		}
+
+		if (runID <= 0) {
+			return null;
+		}
+
+		String filter = "r_runToFactors_c_runId eq '" + runID + "'";
+
+		try {
+			JSONObject responseJSONObject = new JSONObject(
+				_testrayBuild.getTestrayServer(
+				).requestGet(
+					"/o/c/factors?filter=" +
+						URLEncoder.encode(filter, "UTF-8") + "&pageSize=100"
+				));
+
+			JSONArray itemsJSONArray = responseJSONObject.optJSONArray("items");
+
+			if ((itemsJSONArray == null) || itemsJSONArray.isEmpty()) {
+				return null;
+			}
+
+			List<TestrayFactor> testrayFactors = new ArrayList<>();
+
+			for (int i = 0; i < itemsJSONArray.length(); i++) {
+				JSONObject factorJSONObject = itemsJSONArray.getJSONObject(i);
+
+				JSONObject optionJSONObject = factorJSONObject.optJSONObject(
+					"factorOptionToFactors");
+
+				if (optionJSONObject == null) {
+					continue;
+				}
+
+				TestrayFactor.Option testrayFactorOption =
+					TestrayFactory.newTestrayFactorOption(
+						_testrayBuild.getTestrayServer(), optionJSONObject);
+
+				testrayFactors.add(
+					TestrayFactory.newRunTestrayFactor(
+						this, testrayFactorOption));
+			}
+
+			if (testrayFactors.isEmpty()) {
+				return null;
+			}
+
+			return testrayFactors;
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
+	}
+
 	private static final String _PROPERTY_KEY_FACTOR_NAME =
 		"testray.environment.factor.name";
 
@@ -522,11 +514,12 @@ public class TestrayRun {
 	private static final Pattern _factorValuePattern = Pattern.compile(
 		_PROPERTY_KEY_FACTOR_VALUE +
 			"\\[(?<nameKey>[^\\]]+)\\](\\[(?<valueKey>[^\\]]+)\\])?");
-	private static final Properties _properties = new Properties();
 
-	private List<Factor> _factors;
+	private boolean _cached;
 	private Long _id;
-	private final JSONObject _jsonObject;
+	private JSONObject _jsonObject;
+	private final String _name;
 	private final TestrayBuild _testrayBuild;
+	private List<TestrayFactor> _testrayFactors;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayRun.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayRun.java
@@ -179,7 +179,7 @@ public class TestrayRun {
 		final TestrayBuild testrayBuild = getTestrayBuild();
 		final TestrayServer testrayServer = getTestrayServer();
 
-		final String filter = JenkinsResultsParserUtil.combine(
+		final String filterString = JenkinsResultsParserUtil.combine(
 			"environmentHash eq '", getEnvironmentHash(), "' and name eq '",
 			getRunIDString(), "' and r_buildToRuns_c_buildId eq '",
 			String.valueOf(testrayBuild.getID()), "'");
@@ -193,7 +193,7 @@ public class TestrayRun {
 					JSONObject existingJSONObject = new JSONObject(
 						testrayServer.requestGet(
 							"/o/c/runs?filter=" +
-								URLEncoder.encode(filter, "UTF-8")));
+								URLEncoder.encode(filterString, "UTF-8")));
 
 					JSONArray existingItemsJSONArray =
 						existingJSONObject.optJSONArray("items");
@@ -407,7 +407,7 @@ public class TestrayRun {
 	private synchronized int _getNextRunNumber() {
 		TestrayBuild testrayBuild = getTestrayBuild();
 
-		String filter = JenkinsResultsParserUtil.combine(
+		String filterString = JenkinsResultsParserUtil.combine(
 			"r_buildToRuns_c_buildId eq '",
 			String.valueOf(testrayBuild.getID()), "'");
 
@@ -416,7 +416,8 @@ public class TestrayRun {
 
 			JSONObject jsonObject = new JSONObject(
 				testrayServer.requestGet(
-					"/o/c/runs?filter=" + URLEncoder.encode(filter, "UTF-8")));
+					"/o/c/runs?filter=" +
+						URLEncoder.encode(filterString, "UTF-8")));
 
 			return jsonObject.optInt("totalCount") + 1;
 		}
@@ -456,7 +457,7 @@ public class TestrayRun {
 			return null;
 		}
 
-		String filter = JenkinsResultsParserUtil.combine(
+		String filterString = JenkinsResultsParserUtil.combine(
 			"r_runToFactors_c_runId eq '", String.valueOf(runID), "'");
 
 		try {
@@ -465,7 +466,8 @@ public class TestrayRun {
 				).requestGet(
 					JenkinsResultsParserUtil.combine(
 						"/o/c/factors?filter=",
-						URLEncoder.encode(filter, "UTF-8"), "&pageSize=100")
+						URLEncoder.encode(filterString, "UTF-8"),
+						"&pageSize=100")
 				));
 
 			JSONArray itemsJSONArray = responseJSONObject.optJSONArray("items");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayRun.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayRun.java
@@ -407,8 +407,9 @@ public class TestrayRun {
 	private synchronized int _getNextRunNumber() {
 		TestrayBuild testrayBuild = getTestrayBuild();
 
-		String filter =
-			"r_buildToRuns_c_buildId eq '" + testrayBuild.getID() + "'";
+		String filter = JenkinsResultsParserUtil.combine(
+			"r_buildToRuns_c_buildId eq '",
+			String.valueOf(testrayBuild.getID()), "'");
 
 		try {
 			TestrayServer testrayServer = getTestrayServer();
@@ -455,14 +456,16 @@ public class TestrayRun {
 			return null;
 		}
 
-		String filter = "r_runToFactors_c_runId eq '" + runID + "'";
+		String filter = JenkinsResultsParserUtil.combine(
+			"r_runToFactors_c_runId eq '", String.valueOf(runID), "'");
 
 		try {
 			JSONObject responseJSONObject = new JSONObject(
 				_testrayBuild.getTestrayServer(
 				).requestGet(
-					"/o/c/factors?filter=" +
-						URLEncoder.encode(filter, "UTF-8") + "&pageSize=100"
+					JenkinsResultsParserUtil.combine(
+						"/o/c/factors?filter=",
+						URLEncoder.encode(filter, "UTF-8"), "&pageSize=100")
 				));
 
 			JSONArray itemsJSONArray = responseJSONObject.optJSONArray("items");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayRun.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayRun.java
@@ -177,7 +177,6 @@ public class TestrayRun {
 		}
 
 		final TestrayBuild testrayBuild = getTestrayBuild();
-		final TestrayServer testrayServer = getTestrayServer();
 
 		final String filterString = JenkinsResultsParserUtil.combine(
 			"environmentHash eq '", getEnvironmentHash(), "' and name eq '",
@@ -189,6 +188,8 @@ public class TestrayRun {
 
 			@Override
 			public JSONObject execute() {
+				TestrayServer testrayServer = getTestrayServer();
+
 				try {
 					JSONObject existingJSONObject = new JSONObject(
 						testrayServer.requestGet(
@@ -461,14 +462,14 @@ public class TestrayRun {
 			"r_runToFactors_c_runId eq '", String.valueOf(runID), "'");
 
 		try {
+			TestrayServer testrayServer = _testrayBuild.getTestrayServer();
+
 			JSONObject responseJSONObject = new JSONObject(
-				_testrayBuild.getTestrayServer(
-				).requestGet(
+				testrayServer.requestGet(
 					JenkinsResultsParserUtil.combine(
 						"/o/c/factors?filter=",
 						URLEncoder.encode(filterString, "UTF-8"),
-						"&pageSize=100")
-				));
+						"&pageSize=100")));
 
 			JSONArray itemsJSONArray = responseJSONObject.optJSONArray("items");
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-6956

## What Is Being Fixed

The jenkins-results-parser Testray importer lacked first-class model objects for a Testray run and its factors (the environment dimensions such as browser, database, and JDK). That logic was handled inline within TestrayBuild and TestrayImporter, which made computing a run's environment and reusing factor handling harder and more error prone.

## How It Is Being Fixed

This change introduces TestrayRun and a TestrayFactor hierarchy (BaseTestrayFactor, RunTestrayFactor, RoutineTestrayFactor), along with factory support in TestrayFactory to build them, and refactors TestrayBuild and TestrayImporter to use these objects. Along the way it guards against a null pointer dereference, switches shared maps to ConcurrentHashMap for thread safety, consolidates JSON construction through combine, renames filter to filterString and other identifiers for clarity, and moves a final computation outside the retryable block so it is not recomputed on each retry.

## Why Are There No Tests?

jenkins-results-parser is build and CI tooling that sits outside the standard portal test infrastructure, and these changes are a refactor — new value objects, renames, a null-pointer guard, consistency cleanups, and source formatting — with no functional behavior change. Behavior is exercised through the actual Testray import runs in CI.

## PR Check

**pr-check: PASS** — tested on `d2f3766fe8606f75996cf589667fb68383a5d5d0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "d2f3766fe8606f75996cf589667fb68383a5d5d0"} -->