### PR TITLE
LPD-88614 Add resource command to populate filterable object fields

### DIFF
--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
@@ -18,6 +18,7 @@ import com.liferay.asset.kernel.service.persistence.AssetEntryQuery;
 import com.liferay.asset.list.asset.entry.provider.AssetListAssetEntryProvider;
 import com.liferay.asset.list.constants.AssetListEntryTypeConstants;
 import com.liferay.asset.list.internal.configuration.AssetListConfiguration;
+import com.liferay.asset.list.internal.util.AssetListFiltersUtil;
 import com.liferay.asset.list.model.AssetListEntry;
 import com.liferay.asset.list.model.AssetListEntryAssetEntryRel;
 import com.liferay.asset.list.model.AssetListEntryAssetEntryRelModel;
@@ -44,6 +45,9 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -234,6 +238,27 @@ public class AssetListAssetEntryProviderImpl
 
 			assetEntryQuery.setAttribute(
 				"ddmStructureFieldValue", ddmStructureFieldValue);
+		}
+
+		if (FeatureFlagManagerUtil.isEnabled(
+				assetListEntry.getCompanyId(), "LPD-74731")) {
+
+			String filters = unicodeProperties.getProperty("filters");
+
+			if (Validator.isNotNull(filters)) {
+				try {
+					assetEntryQuery.setAttribute(
+						"filters",
+						JSONFactoryUtil.createJSONArray(filters));
+				}
+				catch (Exception exception) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(
+							"Unable to parse filters JSON: " + filters,
+							exception);
+					}
+				}
+			}
 		}
 
 		String orderByColumn1 = GetterUtil.getString(
@@ -676,7 +701,8 @@ public class AssetListAssetEntryProviderImpl
 				_getAssetCategoryIdsBooleanClauses(assetCategoryIds),
 				_getAssetTagNamesBooleanClauses(assetTagNames),
 				_getClassTypeIdsBooleanClauses(
-					assetEntryQuery.getClassTypeIds())));
+					assetEntryQuery.getClassTypeIds()),
+				_getFiltersBooleanClauses(assetEntryQuery, companyId)));
 		searchContext.setCompanyId(companyId);
 		searchContext.setEnd(assetEntryQuery.getEnd());
 		searchContext.setKeywords(keywords);
@@ -714,6 +740,16 @@ public class AssetListAssetEntryProviderImpl
 
 			return fieldName;
 		}
+	}
+
+	private BooleanClause[] _getFiltersBooleanClauses(
+		AssetEntryQuery assetEntryQuery, long companyId) {
+
+		JSONArray filtersJSONArray =
+			(JSONArray)assetEntryQuery.getAttribute("filters");
+
+		return AssetListFiltersUtil.getFiltersBooleanClauses(
+			filtersJSONArray, companyId, LocaleUtil.getMostRelevantLocale());
 	}
 
 	private long _getFirstSegmentsEntryId(

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
@@ -47,7 +47,7 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONArray;
-import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -248,8 +248,7 @@ public class AssetListAssetEntryProviderImpl
 			if (Validator.isNotNull(filters)) {
 				try {
 					assetEntryQuery.setAttribute(
-						"filters",
-						JSONFactoryUtil.createJSONArray(filters));
+						"filters", _jsonFactory.createJSONArray(filters));
 				}
 				catch (Exception exception) {
 					if (_log.isDebugEnabled()) {
@@ -745,8 +744,8 @@ public class AssetListAssetEntryProviderImpl
 	private BooleanClause[] _getFiltersBooleanClauses(
 		AssetEntryQuery assetEntryQuery, long companyId) {
 
-		JSONArray filtersJSONArray =
-			(JSONArray)assetEntryQuery.getAttribute("filters");
+		JSONArray filtersJSONArray = (JSONArray)assetEntryQuery.getAttribute(
+			"filters");
 
 		return AssetListFiltersUtil.getFiltersBooleanClauses(
 			filtersJSONArray, companyId, LocaleUtil.getMostRelevantLocale());
@@ -1173,6 +1172,9 @@ public class AssetListAssetEntryProviderImpl
 
 	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private JSONFactory _jsonFactory;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -60,17 +60,7 @@ public class AssetListFiltersUtil {
 	}
 
 	private static ObjectDefinition _resolveObjectDefinition(
-		long classNameId, long classTypeId, long companyId) {
-
-		if (classTypeId > 0) {
-			ObjectDefinition objectDefinition =
-				ObjectDefinitionLocalServiceUtil.fetchObjectDefinition(
-					classTypeId);
-
-			if (objectDefinition != null) {
-				return objectDefinition;
-			}
-		}
+		long classNameId, long companyId) {
 
 		if (classNameId <= 0) {
 			return null;
@@ -82,10 +72,10 @@ public class AssetListFiltersUtil {
 	}
 
 	private static ObjectField _resolveObjectField(
-		long classNameId, long classTypeId, long companyId, String name) {
+		long classNameId, long companyId, String name) {
 
 		ObjectDefinition objectDefinition = _resolveObjectDefinition(
-			classNameId, classTypeId, companyId);
+			classNameId, companyId);
 
 		if (objectDefinition == null) {
 			return null;
@@ -156,8 +146,7 @@ public class AssetListFiltersUtil {
 		}
 
 		ObjectField objectField = _resolveObjectField(
-			filterJSONObject.getLong("classNameId"),
-			filterJSONObject.getLong("classTypeId"), companyId, propertyName);
+			filterJSONObject.getLong("classNameId"), companyId, propertyName);
 
 		if (objectField == null) {
 			return null;

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/util/AssetListFiltersUtil.java
@@ -1,0 +1,193 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.list.internal.util;
+
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
+import com.liferay.object.service.ObjectFieldLocalServiceUtil;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.search.BooleanClause;
+import com.liferay.portal.kernel.search.BooleanClauseOccur;
+import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.MatchQuery;
+import com.liferay.portal.kernel.search.NestedQuery;
+import com.liferay.portal.kernel.search.Query;
+import com.liferay.portal.kernel.search.TermQuery;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Locale;
+
+/**
+ * @author Joshua Cords
+ */
+public class AssetListFiltersUtil {
+
+	public static BooleanClause[] getFiltersBooleanClauses(
+		JSONArray filtersJSONArray, long companyId, Locale locale) {
+
+		if ((filtersJSONArray == null) || (filtersJSONArray.length() == 0)) {
+			return new BooleanClause[0];
+		}
+
+		BooleanQuery booleanQuery = new BooleanQuery();
+
+		for (int i = 0; i < filtersJSONArray.length(); i++) {
+			NestedQuery nestedQuery = _toNestedQuery(
+				filtersJSONArray.getJSONObject(i), companyId, locale);
+
+			if (nestedQuery == null) {
+				continue;
+			}
+
+			booleanQuery.add(nestedQuery, BooleanClauseOccur.MUST);
+		}
+
+		if (!booleanQuery.hasClauses()) {
+			return new BooleanClause[0];
+		}
+
+		return new BooleanClause[] {
+			new BooleanClause<>(booleanQuery, BooleanClauseOccur.MUST)
+		};
+	}
+
+	private static ObjectDefinition _resolveObjectDefinition(
+		long classNameId, long classTypeId, long companyId) {
+
+		if (classTypeId > 0) {
+			ObjectDefinition objectDefinition =
+				ObjectDefinitionLocalServiceUtil.fetchObjectDefinition(
+					classTypeId);
+
+			if (objectDefinition != null) {
+				return objectDefinition;
+			}
+		}
+
+		if (classNameId <= 0) {
+			return null;
+		}
+
+		return ObjectDefinitionLocalServiceUtil.
+			fetchObjectDefinitionByClassName(
+				companyId, PortalUtil.getClassName(classNameId));
+	}
+
+	private static ObjectField _resolveObjectField(
+		long classNameId, long classTypeId, long companyId, String name) {
+
+		ObjectDefinition objectDefinition = _resolveObjectDefinition(
+			classNameId, classTypeId, companyId);
+
+		if (objectDefinition == null) {
+			return null;
+		}
+
+		return ObjectFieldLocalServiceUtil.fetchObjectField(
+			objectDefinition.getObjectDefinitionId(), name);
+	}
+
+	private static String _resolveSubfield(
+		ObjectField objectField, Locale locale) {
+
+		if (objectField.isIndexedAsKeyword()) {
+			return "nestedFieldArray.value_keyword";
+		}
+
+		String dbType = objectField.getDBType();
+
+		if (ObjectFieldConstants.DB_TYPE_BOOLEAN.equals(dbType)) {
+			return "nestedFieldArray.value_boolean";
+		}
+
+		if (ObjectFieldConstants.DB_TYPE_DATE.equals(dbType) ||
+			ObjectFieldConstants.DB_TYPE_DATE_TIME.equals(dbType)) {
+
+			return "nestedFieldArray.value_date";
+		}
+
+		if (ObjectFieldConstants.DB_TYPE_BIG_DECIMAL.equals(dbType) ||
+			ObjectFieldConstants.DB_TYPE_DOUBLE.equals(dbType)) {
+
+			return "nestedFieldArray.value_double";
+		}
+
+		if (ObjectFieldConstants.DB_TYPE_INTEGER.equals(dbType)) {
+			return "nestedFieldArray.value_integer";
+		}
+
+		if (ObjectFieldConstants.DB_TYPE_LONG.equals(dbType)) {
+			return "nestedFieldArray.value_long";
+		}
+
+		if (objectField.isLocalized()) {
+			return Field.getLocalizedName(locale, "nestedFieldArray.value");
+		}
+
+		String indexedLanguageId = objectField.getIndexedLanguageId();
+
+		if (Validator.isNotNull(indexedLanguageId)) {
+			return "nestedFieldArray.value_" + indexedLanguageId;
+		}
+
+		return "nestedFieldArray.value_text";
+	}
+
+	private static NestedQuery _toNestedQuery(
+		JSONObject filterJSONObject, long companyId, Locale locale) {
+
+		if (filterJSONObject == null) {
+			return null;
+		}
+
+		String propertyName = filterJSONObject.getString("propertyName");
+		String value = filterJSONObject.getString("value");
+
+		if (Validator.isNull(propertyName) || Validator.isNull(value)) {
+			return null;
+		}
+
+		ObjectField objectField = _resolveObjectField(
+			filterJSONObject.getLong("classNameId"),
+			filterJSONObject.getLong("classTypeId"), companyId, propertyName);
+
+		if (objectField == null) {
+			return null;
+		}
+
+		String subfield = _resolveSubfield(objectField, locale);
+
+		BooleanQuery nestedBooleanQuery = new BooleanQuery();
+
+		nestedBooleanQuery.add(
+			new TermQuery("nestedFieldArray.fieldName", propertyName),
+			BooleanClauseOccur.MUST);
+		nestedBooleanQuery.add(
+			_toValueQuery(subfield, value), BooleanClauseOccur.MUST);
+
+		return new NestedQuery("nestedFieldArray", nestedBooleanQuery);
+	}
+
+	private static Query _toValueQuery(String subfield, String value) {
+		if (subfield.endsWith(".value_keyword") ||
+			subfield.endsWith(".value_boolean") ||
+			subfield.endsWith(".value_date") ||
+			subfield.endsWith(".value_double") ||
+			subfield.endsWith(".value_integer") ||
+			subfield.endsWith(".value_long")) {
+
+			return new TermQuery(subfield, value);
+		}
+
+		return new MatchQuery(subfield, value);
+	}
+
+}

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -69,8 +69,36 @@ public class AssetListAssetEntryProviderFiltersTest {
 					"priority")));
 	}
 
+	@FeatureFlag(enable = false, value = "LPD-74731")
 	@Test
-	@FeatureFlags(featureFlags = {@FeatureFlag(value = "LPD-74731")})
+	public void testFiltersAreIgnoredWhenFeatureFlagDisabled()
+		throws Exception {
+
+		JSONArray filtersJSONArray = JSONUtil.putAll(
+			JSONUtil.put(
+				"classNameId",
+				_portal.getClassNameId(_objectDefinition.getClassName())
+			).put(
+				"classTypeId", _objectDefinition.getObjectDefinitionId()
+			).put(
+				"propertyName", "title"
+			).put(
+				"value", "keyword"
+			));
+
+		AssetListEntry assetListEntry = _addDynamicAssetListEntryWithFilters(
+			filtersJSONArray.toString());
+
+		AssetEntryQuery assetEntryQuery =
+			_assetListAssetEntryProvider.getAssetEntryQuery(
+				assetListEntry, new long[] {SegmentsEntryConstants.ID_DEFAULT},
+				null);
+
+		Assert.assertNull(assetEntryQuery.getAttribute("filters"));
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
+	@Test
 	public void testFiltersArePropagatedAsAttributeWhenFeatureFlagEnabled()
 		throws Exception {
 
@@ -105,11 +133,11 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 		AssetEntryQuery assetEntryQuery =
 			_assetListAssetEntryProvider.getAssetEntryQuery(
-				assetListEntry,
-				new long[] {SegmentsEntryConstants.ID_DEFAULT}, null);
+				assetListEntry, new long[] {SegmentsEntryConstants.ID_DEFAULT},
+				null);
 
-		JSONArray actualJSONArray =
-			(JSONArray)assetEntryQuery.getAttribute("filters");
+		JSONArray actualJSONArray = (JSONArray)assetEntryQuery.getAttribute(
+			"filters");
 
 		Assert.assertNotNull(actualJSONArray);
 		Assert.assertEquals(
@@ -124,35 +152,22 @@ public class AssetListAssetEntryProviderFiltersTest {
 			jsonObject.getLong("classNameId"));
 	}
 
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
 	@Test
-	public void testFiltersAreIgnoredWhenFeatureFlagDisabled()
-		throws Exception {
-
-		JSONArray filtersJSONArray = JSONUtil.putAll(
-			JSONUtil.put(
-				"classNameId",
-				_portal.getClassNameId(_objectDefinition.getClassName())
-			).put(
-				"classTypeId", _objectDefinition.getObjectDefinitionId()
-			).put(
-				"propertyName", "title"
-			).put(
-				"value", "keyword"
-			));
-
+	public void testInvalidFiltersJSONIsTolerated() throws Exception {
 		AssetListEntry assetListEntry = _addDynamicAssetListEntryWithFilters(
-			filtersJSONArray.toString());
+			"not-a-json-array");
 
 		AssetEntryQuery assetEntryQuery =
 			_assetListAssetEntryProvider.getAssetEntryQuery(
-				assetListEntry,
-				new long[] {SegmentsEntryConstants.ID_DEFAULT}, null);
+				assetListEntry, new long[] {SegmentsEntryConstants.ID_DEFAULT},
+				null);
 
 		Assert.assertNull(assetEntryQuery.getAttribute("filters"));
 	}
 
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-74731"))
 	@Test
-	@FeatureFlags(featureFlags = {@FeatureFlag(value = "LPD-74731")})
 	public void testNoFiltersAttributeWhenTypeSettingsHasNoFilters()
 		throws Exception {
 
@@ -161,22 +176,8 @@ public class AssetListAssetEntryProviderFiltersTest {
 
 		AssetEntryQuery assetEntryQuery =
 			_assetListAssetEntryProvider.getAssetEntryQuery(
-				assetListEntry,
-				new long[] {SegmentsEntryConstants.ID_DEFAULT}, null);
-
-		Assert.assertNull(assetEntryQuery.getAttribute("filters"));
-	}
-
-	@Test
-	@FeatureFlags(featureFlags = {@FeatureFlag(value = "LPD-74731")})
-	public void testInvalidFiltersJSONIsTolerated() throws Exception {
-		AssetListEntry assetListEntry = _addDynamicAssetListEntryWithFilters(
-			"not-a-json-array");
-
-		AssetEntryQuery assetEntryQuery =
-			_assetListAssetEntryProvider.getAssetEntryQuery(
-				assetListEntry,
-				new long[] {SegmentsEntryConstants.ID_DEFAULT}, null);
+				assetListEntry, new long[] {SegmentsEntryConstants.ID_DEFAULT},
+				null);
 
 		Assert.assertNull(assetEntryQuery.getAttribute("filters"));
 	}
@@ -201,27 +202,29 @@ public class AssetListAssetEntryProviderFiltersTest {
 				"filters", filters);
 		}
 
-		UnicodeProperties typeSettings = unicodePropertiesWrapper.build();
+		UnicodeProperties typeSettingsUnicodeProperties =
+			unicodePropertiesWrapper.build();
 
 		_assetListEntryLocalService.updateAssetListEntryTypeSettings(
 			assetListEntry.getAssetListEntryId(),
-			SegmentsEntryConstants.ID_DEFAULT, typeSettings.toString());
+			SegmentsEntryConstants.ID_DEFAULT,
+			typeSettingsUnicodeProperties.toString());
 
 		return _assetListEntryLocalService.getAssetListEntry(
 			assetListEntry.getAssetListEntryId());
 	}
-
-	@DeleteAfterTestRun
-	private Group _group;
-
-	@DeleteAfterTestRun
-	private ObjectDefinition _objectDefinition;
 
 	@Inject
 	private AssetListAssetEntryProvider _assetListAssetEntryProvider;
 
 	@Inject
 	private AssetListEntryLocalService _assetListEntryLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition;
 
 	@Inject
 	private Portal _portal;

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderFiltersTest.java
@@ -1,0 +1,229 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.list.asset.entry.provider.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.service.persistence.AssetEntryQuery;
+import com.liferay.asset.list.asset.entry.provider.AssetListAssetEntryProvider;
+import com.liferay.asset.list.model.AssetListEntry;
+import com.liferay.asset.list.service.AssetListEntryLocalService;
+import com.liferay.asset.list.test.util.AssetListTestUtil;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.segments.constants.SegmentsEntryConstants;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Joshua Cords
+ */
+@RunWith(Arquillian.class)
+public class AssetListAssetEntryProviderFiltersTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition(
+			Arrays.asList(
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING, "Title", "title"),
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
+					ObjectFieldConstants.DB_TYPE_INTEGER, "Priority",
+					"priority")));
+	}
+
+	@Test
+	@FeatureFlags(featureFlags = {@FeatureFlag(value = "LPD-74731")})
+	public void testFiltersArePropagatedAsAttributeWhenFeatureFlagEnabled()
+		throws Exception {
+
+		JSONArray filtersJSONArray = JSONUtil.putAll(
+			JSONUtil.put(
+				"classNameId",
+				_portal.getClassNameId(_objectDefinition.getClassName())
+			).put(
+				"classTypeId", _objectDefinition.getObjectDefinitionId()
+			).put(
+				"operatorName", "contains"
+			).put(
+				"propertyName", "title"
+			).put(
+				"value", "keyword"
+			),
+			JSONUtil.put(
+				"classNameId",
+				_portal.getClassNameId(_objectDefinition.getClassName())
+			).put(
+				"classTypeId", _objectDefinition.getObjectDefinitionId()
+			).put(
+				"operatorName", "eq"
+			).put(
+				"propertyName", "priority"
+			).put(
+				"value", "1"
+			));
+
+		AssetListEntry assetListEntry = _addDynamicAssetListEntryWithFilters(
+			filtersJSONArray.toString());
+
+		AssetEntryQuery assetEntryQuery =
+			_assetListAssetEntryProvider.getAssetEntryQuery(
+				assetListEntry,
+				new long[] {SegmentsEntryConstants.ID_DEFAULT}, null);
+
+		JSONArray actualJSONArray =
+			(JSONArray)assetEntryQuery.getAttribute("filters");
+
+		Assert.assertNotNull(actualJSONArray);
+		Assert.assertEquals(
+			actualJSONArray.toString(), 2, actualJSONArray.length());
+
+		JSONObject jsonObject = actualJSONArray.getJSONObject(0);
+
+		Assert.assertEquals("title", jsonObject.getString("propertyName"));
+		Assert.assertEquals("keyword", jsonObject.getString("value"));
+		Assert.assertEquals(
+			_portal.getClassNameId(_objectDefinition.getClassName()),
+			jsonObject.getLong("classNameId"));
+	}
+
+	@Test
+	public void testFiltersAreIgnoredWhenFeatureFlagDisabled()
+		throws Exception {
+
+		JSONArray filtersJSONArray = JSONUtil.putAll(
+			JSONUtil.put(
+				"classNameId",
+				_portal.getClassNameId(_objectDefinition.getClassName())
+			).put(
+				"classTypeId", _objectDefinition.getObjectDefinitionId()
+			).put(
+				"propertyName", "title"
+			).put(
+				"value", "keyword"
+			));
+
+		AssetListEntry assetListEntry = _addDynamicAssetListEntryWithFilters(
+			filtersJSONArray.toString());
+
+		AssetEntryQuery assetEntryQuery =
+			_assetListAssetEntryProvider.getAssetEntryQuery(
+				assetListEntry,
+				new long[] {SegmentsEntryConstants.ID_DEFAULT}, null);
+
+		Assert.assertNull(assetEntryQuery.getAttribute("filters"));
+	}
+
+	@Test
+	@FeatureFlags(featureFlags = {@FeatureFlag(value = "LPD-74731")})
+	public void testNoFiltersAttributeWhenTypeSettingsHasNoFilters()
+		throws Exception {
+
+		AssetListEntry assetListEntry = _addDynamicAssetListEntryWithFilters(
+			null);
+
+		AssetEntryQuery assetEntryQuery =
+			_assetListAssetEntryProvider.getAssetEntryQuery(
+				assetListEntry,
+				new long[] {SegmentsEntryConstants.ID_DEFAULT}, null);
+
+		Assert.assertNull(assetEntryQuery.getAttribute("filters"));
+	}
+
+	@Test
+	@FeatureFlags(featureFlags = {@FeatureFlag(value = "LPD-74731")})
+	public void testInvalidFiltersJSONIsTolerated() throws Exception {
+		AssetListEntry assetListEntry = _addDynamicAssetListEntryWithFilters(
+			"not-a-json-array");
+
+		AssetEntryQuery assetEntryQuery =
+			_assetListAssetEntryProvider.getAssetEntryQuery(
+				assetListEntry,
+				new long[] {SegmentsEntryConstants.ID_DEFAULT}, null);
+
+		Assert.assertNull(assetEntryQuery.getAttribute("filters"));
+	}
+
+	private AssetListEntry _addDynamicAssetListEntryWithFilters(String filters)
+		throws Exception {
+
+		AssetListEntry assetListEntry = AssetListTestUtil.addAssetListEntry(
+			_group.getGroupId(), 0);
+
+		UnicodePropertiesBuilder.UnicodePropertiesWrapper
+			unicodePropertiesWrapper = UnicodePropertiesBuilder.create(
+				true
+			).put(
+				"anyAssetType",
+				String.valueOf(
+					_portal.getClassNameId(_objectDefinition.getClassName()))
+			);
+
+		if (filters != null) {
+			unicodePropertiesWrapper = unicodePropertiesWrapper.put(
+				"filters", filters);
+		}
+
+		UnicodeProperties typeSettings = unicodePropertiesWrapper.build();
+
+		_assetListEntryLocalService.updateAssetListEntryTypeSettings(
+			assetListEntry.getAssetListEntryId(),
+			SegmentsEntryConstants.ID_DEFAULT, typeSettings.toString());
+
+		return _assetListEntryLocalService.getAssetListEntry(
+			assetListEntry.getAssetListEntryId());
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private AssetListAssetEntryProvider _assetListAssetEntryProvider;
+
+	@Inject
+	private AssetListEntryLocalService _assetListEntryLocalService;
+
+	@Inject
+	private Portal _portal;
+
+}

--- a/modules/apps/asset/asset-list-web/build.gradle
+++ b/modules/apps/asset/asset-list-web/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	compileOnly project(":apps:layout:layout-api")
 	compileOnly project(":apps:layout:layout-display-page-api")
 	compileOnly project(":apps:layout:layout-page-template-api")
+	compileOnly project(":apps:list-type:list-type-api")
 	compileOnly project(":apps:object:object-api")
 	compileOnly project(":apps:portal-workflow:portal-workflow-taglib")
 	compileOnly project(":apps:segments:segments-api")

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
@@ -26,7 +26,7 @@ import com.liferay.asset.list.service.AssetListEntryLocalServiceUtil;
 import com.liferay.asset.list.service.AssetListEntrySegmentsEntryRelLocalServiceUtil;
 import com.liferay.asset.list.util.comparator.ClassNameModelResourceComparator;
 import com.liferay.asset.list.web.internal.constants.AssetListWebKeys;
-import com.liferay.asset.list.web.internal.portlet.action.GetTypePropertiesMVCResourceCommand;
+import com.liferay.asset.list.web.internal.util.AssetListTypePropertiesUtil;
 import com.liferay.asset.tags.item.selector.AssetTagsItemSelectorCriterion;
 import com.liferay.asset.tags.item.selector.AssetTagsItemSelectorReturnType;
 import com.liferay.asset.util.AssetRendererFactoryClassProvider;
@@ -1102,8 +1102,9 @@ public class EditAssetListDisplayContext {
 			}
 		}
 
-		return GetTypePropertiesMVCResourceCommand.getTypePropertiesJSONArray(
-			classNameIds, ArrayUtil.toLongArray(classTypeIdsList));
+		return AssetListTypePropertiesUtil.getTypePropertiesJSONArray(
+			classNameIds, ArrayUtil.toLongArray(classTypeIdsList),
+			_themeDisplay.getCompanyId(), _themeDisplay.getLocale());
 	}
 
 	public String getTypePropertiesURL() {

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
@@ -1083,28 +1083,9 @@ public class EditAssetListDisplayContext {
 	}
 
 	public JSONArray getTypePropertiesJSONArray() {
-		long[] classNameIds = GetterUtil.getLongValues(
-			StringUtil.split(
-				_unicodeProperties.getProperty("classNameIds", null)));
-
-		List<Long> classTypeIdsList = new ArrayList<>();
-
-		for (String entryKey : _unicodeProperties.keySet()) {
-			if (!entryKey.startsWith("classTypeIds")) {
-				continue;
-			}
-
-			for (String classTypeId :
-					StringUtil.split(
-						_unicodeProperties.getProperty(entryKey))) {
-
-				classTypeIdsList.add(GetterUtil.getLong(classTypeId));
-			}
-		}
-
 		return AssetListTypePropertiesUtil.getTypePropertiesJSONArray(
-			classNameIds, ArrayUtil.toLongArray(classTypeIdsList),
-			_themeDisplay.getCompanyId(), _themeDisplay.getLocale());
+			getClassNameIds(), getClassTypeIds(), _themeDisplay.getCompanyId(),
+			_themeDisplay.getLocale());
 	}
 
 	public String getTypePropertiesURL() {

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
@@ -1083,8 +1083,22 @@ public class EditAssetListDisplayContext {
 	}
 
 	public JSONArray getTypePropertiesJSONArray() {
+		long[] classNameIds = new long[0];
+		long[] classTypeIds = new long[0];
+
+		boolean anyAssetType = GetterUtil.getBoolean(
+			_unicodeProperties.getProperty(
+				"anyAssetType", Boolean.TRUE.toString()));
+		String selectionStyle = _unicodeProperties.getProperty(
+			"selectionStyle", "dynamic");
+
+		if (!anyAssetType && !selectionStyle.equals("manual")) {
+			classNameIds = getClassNameIds();
+			classTypeIds = getClassTypeIds();
+		}
+
 		return AssetListTypePropertiesUtil.getTypePropertiesJSONArray(
-			getClassNameIds(), getClassTypeIds(), _themeDisplay.getCompanyId(),
+			classNameIds, classTypeIds, _themeDisplay.getCompanyId(),
 			_themeDisplay.getLocale());
 	}
 

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/portlet/action/GetTypePropertiesMVCResourceCommand.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/portlet/action/GetTypePropertiesMVCResourceCommand.java
@@ -6,14 +6,15 @@
 package com.liferay.asset.list.web.internal.portlet.action;
 
 import com.liferay.asset.list.constants.AssetListPortletKeys;
-import com.liferay.portal.kernel.json.JSONArray;
-import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.asset.list.web.internal.util.AssetListTypePropertiesUtil;
 import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import jakarta.portlet.ResourceRequest;
 import jakarta.portlet.ResourceResponse;
@@ -22,6 +23,7 @@ import org.osgi.service.component.annotations.Component;
 
 /**
  * @author Olivia Yu
+ * @author Joshua Cords
  */
 @Component(
 	property = {
@@ -33,69 +35,13 @@ import org.osgi.service.component.annotations.Component;
 public class GetTypePropertiesMVCResourceCommand
 	extends BaseMVCResourceCommand {
 
-	public static JSONArray getTypePropertiesJSONArray(
-		long[] classNameIds, long[] classTypeIds) {
-
-		return JSONUtil.putAll(
-			JSONUtil.put(
-				"label", "Title"
-			).put(
-				"name", "title"
-			).put(
-				"type", "string"
-			),
-			JSONUtil.put(
-				"label", "Views"
-			).put(
-				"name", "views"
-			).put(
-				"type", "integer"
-			),
-			JSONUtil.put(
-				"label", "Published"
-			).put(
-				"name", "published"
-			).put(
-				"type", "boolean"
-			),
-			JSONUtil.put(
-				"label", "Publish Date"
-			).put(
-				"name", "publishDate"
-			).put(
-				"type", "date"
-			),
-			JSONUtil.put(
-				"label", "Status"
-			).put(
-				"name", "status"
-			).put(
-				"options",
-				JSONUtil.putAll(
-					JSONUtil.put(
-						"label", "Approved"
-					).put(
-						"value", "approved"
-					),
-					JSONUtil.put(
-						"label", "Draft"
-					).put(
-						"value", "draft"
-					),
-					JSONUtil.put(
-						"label", "Pending"
-					).put(
-						"value", "pending"
-					))
-			).put(
-				"type", "picklist"
-			));
-	}
-
 	@Override
 	protected void doServeResource(
 			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
 		throws Exception {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)resourceRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
 
 		long[] classNameIds = GetterUtil.getLongValues(
 			StringUtil.split(
@@ -106,7 +52,9 @@ public class GetTypePropertiesMVCResourceCommand
 
 		JSONPortletResponseUtil.writeJSON(
 			resourceRequest, resourceResponse,
-			getTypePropertiesJSONArray(classNameIds, classTypeIds));
+			AssetListTypePropertiesUtil.getTypePropertiesJSONArray(
+				classNameIds, classTypeIds, themeDisplay.getCompanyId(),
+				themeDisplay.getLocale()));
 	}
 
 }

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
@@ -95,20 +95,6 @@ public class AssetListTypePropertiesUtil {
 	private static JSONArray _getCommonFieldsItemsJSONArray(Locale locale) {
 		return JSONUtil.putAll(
 			JSONUtil.put(
-				"label", LanguageUtil.get(locale, "title")
-			).put(
-				"name", Field.TITLE
-			).put(
-				"type", "text"
-			),
-			JSONUtil.put(
-				"label", LanguageUtil.get(locale, "description")
-			).put(
-				"name", Field.DESCRIPTION
-			).put(
-				"type", "text"
-			),
-			JSONUtil.put(
 				"label", LanguageUtil.get(locale, "author-name")
 			).put(
 				"name", Field.USER_NAME
@@ -123,23 +109,9 @@ public class AssetListTypePropertiesUtil {
 				"type", "date"
 			),
 			JSONUtil.put(
-				"label", LanguageUtil.get(locale, "modified-date")
-			).put(
-				"name", Field.MODIFIED_DATE
-			).put(
-				"type", "date"
-			),
-			JSONUtil.put(
 				"label", LanguageUtil.get(locale, "display-date")
 			).put(
 				"name", Field.DISPLAY_DATE
-			).put(
-				"type", "date"
-			),
-			JSONUtil.put(
-				"label", LanguageUtil.get(locale, "publish-date")
-			).put(
-				"name", Field.PUBLISH_DATE
 			).put(
 				"type", "date"
 			),
@@ -151,6 +123,20 @@ public class AssetListTypePropertiesUtil {
 				"type", "date"
 			),
 			JSONUtil.put(
+				"label", LanguageUtil.get(locale, "external-reference-code")
+			).put(
+				"name", "externalReferenceCode"
+			).put(
+				"type", "text"
+			),
+			JSONUtil.put(
+				"label", LanguageUtil.get(locale, "modified-date")
+			).put(
+				"name", Field.MODIFIED_DATE
+			).put(
+				"type", "date"
+			),
+			JSONUtil.put(
 				"label", LanguageUtil.get(locale, "priority")
 			).put(
 				"name", Field.PRIORITY
@@ -158,18 +144,11 @@ public class AssetListTypePropertiesUtil {
 				"type", "decimal"
 			),
 			JSONUtil.put(
-				"label", LanguageUtil.get(locale, "view-count")
+				"label", LanguageUtil.get(locale, "publish-date")
 			).put(
-				"name", "viewCount"
+				"name", Field.PUBLISH_DATE
 			).put(
-				"type", "integer"
-			),
-			JSONUtil.put(
-				"label", LanguageUtil.get(locale, "external-reference-code")
-			).put(
-				"name", "externalReferenceCode"
-			).put(
-				"type", "text"
+				"type", "date"
 			),
 			JSONUtil.put(
 				"label", LanguageUtil.get(locale, "review-date")
@@ -182,6 +161,20 @@ public class AssetListTypePropertiesUtil {
 				"label", LanguageUtil.get(locale, "status")
 			).put(
 				"name", Field.STATUS
+			).put(
+				"type", "integer"
+			),
+			JSONUtil.put(
+				"label", LanguageUtil.get(locale, "title")
+			).put(
+				"name", Field.TITLE
+			).put(
+				"type", "text"
+			),
+			JSONUtil.put(
+				"label", LanguageUtil.get(locale, "view-count")
+			).put(
+				"name", "viewCount"
 			).put(
 				"type", "integer"
 			));

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
@@ -1,0 +1,177 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.list.web.internal.util;
+
+import com.liferay.list.type.model.ListTypeEntry;
+import com.liferay.list.type.service.ListTypeEntryLocalServiceUtil;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
+import com.liferay.object.service.ObjectFieldLocalServiceUtil;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * @author Joshua Cords
+ */
+public class AssetListTypePropertiesUtil {
+
+	public static JSONArray getTypePropertiesJSONArray(
+		long[] classNameIds, long[] classTypeIds, long companyId,
+		Locale locale) {
+
+		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
+
+		Set<String> seenFieldNames = new HashSet<>();
+
+		for (int i = 0; i < classNameIds.length; i++) {
+			long classTypeId = 0;
+
+			if (i < classTypeIds.length) {
+				classTypeId = classTypeIds[i];
+			}
+
+			ObjectDefinition objectDefinition = _resolveObjectDefinition(
+				classNameIds[i], classTypeId, companyId);
+
+			if (objectDefinition == null) {
+				continue;
+			}
+
+			for (ObjectField objectField :
+					ObjectFieldLocalServiceUtil.getObjectFields(
+						objectDefinition.getObjectDefinitionId())) {
+
+				if (objectField.isMetadata()) {
+					continue;
+				}
+
+				String type = _toFilterType(objectField.getBusinessType());
+
+				if ((type == null) ||
+					!seenFieldNames.add(objectField.getName())) {
+
+					continue;
+				}
+
+				jsonArray.put(_toPropertyJSONObject(objectField, locale, type));
+			}
+		}
+
+		return jsonArray;
+	}
+
+	private static ObjectDefinition _resolveObjectDefinition(
+		long classNameId, long classTypeId, long companyId) {
+
+		if (classTypeId > 0) {
+			ObjectDefinition objectDefinition =
+				ObjectDefinitionLocalServiceUtil.fetchObjectDefinition(
+					classTypeId);
+
+			if (objectDefinition != null) {
+				return objectDefinition;
+			}
+		}
+
+		if (classNameId <= 0) {
+			return null;
+		}
+
+		return ObjectDefinitionLocalServiceUtil.
+			fetchObjectDefinitionByClassName(
+				companyId, PortalUtil.getClassName(classNameId));
+	}
+
+	private static String _toFilterType(String businessType) {
+		if (businessType.equals(ObjectFieldConstants.BUSINESS_TYPE_BOOLEAN)) {
+			return "boolean";
+		}
+
+		if (businessType.equals(ObjectFieldConstants.BUSINESS_TYPE_DATE)) {
+			return "date";
+		}
+
+		if (businessType.equals(ObjectFieldConstants.BUSINESS_TYPE_DATE_TIME)) {
+			return "date-time";
+		}
+
+		if (businessType.equals(ObjectFieldConstants.BUSINESS_TYPE_DECIMAL) ||
+			businessType.equals(
+				ObjectFieldConstants.BUSINESS_TYPE_PRECISION_DECIMAL)) {
+
+			return "double";
+		}
+
+		if (businessType.equals(ObjectFieldConstants.BUSINESS_TYPE_INTEGER) ||
+			businessType.equals(
+				ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER)) {
+
+			return "integer";
+		}
+
+		if (businessType.equals(
+				ObjectFieldConstants.BUSINESS_TYPE_MULTISELECT_PICKLIST) ||
+			businessType.equals(ObjectFieldConstants.BUSINESS_TYPE_PICKLIST)) {
+
+			return "picklist";
+		}
+
+		if (businessType.equals(ObjectFieldConstants.BUSINESS_TYPE_LONG_TEXT) ||
+			businessType.equals(
+				ObjectFieldConstants.BUSINESS_TYPE_PHONE_NUMBER) ||
+			businessType.equals(ObjectFieldConstants.BUSINESS_TYPE_RICH_TEXT) ||
+			businessType.equals(ObjectFieldConstants.BUSINESS_TYPE_TEXT)) {
+
+			return "string";
+		}
+
+		return null;
+	}
+
+	private static JSONObject _toPropertyJSONObject(
+		ObjectField objectField, Locale locale, String type) {
+
+		JSONObject jsonObject = JSONUtil.put(
+			"label", objectField.getLabel(locale, true)
+		).put(
+			"name", objectField.getName()
+		).put(
+			"type", type
+		);
+
+		if (!type.equals("picklist") ||
+			(objectField.getListTypeDefinitionId() <= 0)) {
+
+			return jsonObject;
+		}
+
+		JSONArray optionsJSONArray = JSONFactoryUtil.createJSONArray();
+
+		for (ListTypeEntry listTypeEntry :
+				ListTypeEntryLocalServiceUtil.getListTypeEntries(
+					objectField.getListTypeDefinitionId())) {
+
+			optionsJSONArray.put(
+				JSONUtil.put(
+					"label", listTypeEntry.getName(locale, true)
+				).put(
+					"value", listTypeEntry.getKey()
+				));
+		}
+
+		return jsonObject.put("options", optionsJSONArray);
+	}
+
+}

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
@@ -65,6 +65,10 @@ public class AssetListTypePropertiesUtil {
 					ObjectFieldLocalServiceUtil.getObjectFields(
 						objectDefinition.getObjectDefinitionId())) {
 
+				if (objectField.isMetadata()) {
+					continue;
+				}
+
 				String type = _toFilterType(objectField.getBusinessType());
 
 				if (type == null) {
@@ -157,6 +161,27 @@ public class AssetListTypePropertiesUtil {
 				"label", LanguageUtil.get(locale, "view-count")
 			).put(
 				"name", "viewCount"
+			).put(
+				"type", "integer"
+			),
+			JSONUtil.put(
+				"label", LanguageUtil.get(locale, "external-reference-code")
+			).put(
+				"name", "externalReferenceCode"
+			).put(
+				"type", "text"
+			),
+			JSONUtil.put(
+				"label", LanguageUtil.get(locale, "review-date")
+			).put(
+				"name", Field.REVIEW_DATE
+			).put(
+				"type", "date"
+			),
+			JSONUtil.put(
+				"label", LanguageUtil.get(locale, "status")
+			).put(
+				"name", Field.STATUS
 			).put(
 				"type", "integer"
 			));

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
@@ -17,6 +17,8 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.PortalUtil;
 
 import java.util.Locale;
@@ -35,6 +37,13 @@ public class AssetListTypePropertiesUtil {
 		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-74731")) {
 			return jsonArray;
 		}
+
+		jsonArray.put(
+			JSONUtil.put(
+				"items", _getCommonFieldsItemsJSONArray(locale)
+			).put(
+				"label", LanguageUtil.get(locale, "common-fields")
+			));
 
 		for (int i = 0; i < classNameIds.length; i++) {
 			long classTypeId = 0;
@@ -77,6 +86,80 @@ public class AssetListTypePropertiesUtil {
 		}
 
 		return jsonArray;
+	}
+
+	private static JSONArray _getCommonFieldsItemsJSONArray(Locale locale) {
+		return JSONUtil.putAll(
+			JSONUtil.put(
+				"label", LanguageUtil.get(locale, "title")
+			).put(
+				"name", Field.TITLE
+			).put(
+				"type", "text"
+			),
+			JSONUtil.put(
+				"label", LanguageUtil.get(locale, "description")
+			).put(
+				"name", Field.DESCRIPTION
+			).put(
+				"type", "text"
+			),
+			JSONUtil.put(
+				"label", LanguageUtil.get(locale, "author-name")
+			).put(
+				"name", Field.USER_NAME
+			).put(
+				"type", "text"
+			),
+			JSONUtil.put(
+				"label", LanguageUtil.get(locale, "created-date")
+			).put(
+				"name", Field.CREATE_DATE
+			).put(
+				"type", "date"
+			),
+			JSONUtil.put(
+				"label", LanguageUtil.get(locale, "modified-date")
+			).put(
+				"name", Field.MODIFIED_DATE
+			).put(
+				"type", "date"
+			),
+			JSONUtil.put(
+				"label", LanguageUtil.get(locale, "display-date")
+			).put(
+				"name", Field.DISPLAY_DATE
+			).put(
+				"type", "date"
+			),
+			JSONUtil.put(
+				"label", LanguageUtil.get(locale, "publish-date")
+			).put(
+				"name", Field.PUBLISH_DATE
+			).put(
+				"type", "date"
+			),
+			JSONUtil.put(
+				"label", LanguageUtil.get(locale, "expiration-date")
+			).put(
+				"name", Field.EXPIRATION_DATE
+			).put(
+				"type", "date"
+			),
+			JSONUtil.put(
+				"label", LanguageUtil.get(locale, "priority")
+			).put(
+				"name", Field.PRIORITY
+			).put(
+				"type", "decimal"
+			),
+			JSONUtil.put(
+				"label", LanguageUtil.get(locale, "view-count")
+			).put(
+				"name", "viewCount"
+			).put(
+				"type", "integer"
+			));
 	}
 
 	private static ObjectDefinition _resolveObjectDefinition(

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
@@ -50,6 +50,8 @@ public class AssetListTypePropertiesUtil {
 				continue;
 			}
 
+			JSONArray itemsJSONArray = JSONFactoryUtil.createJSONArray();
+
 			for (ObjectField objectField :
 					ObjectFieldLocalServiceUtil.getObjectFields(
 						objectDefinition.getObjectDefinitionId())) {
@@ -60,11 +62,18 @@ public class AssetListTypePropertiesUtil {
 					continue;
 				}
 
-				jsonArray.put(
+				itemsJSONArray.put(
 					_toPropertyJSONObject(
 						classNameIds[i], classTypeId, locale, objectField,
 						type));
 			}
+
+			jsonArray.put(
+				JSONUtil.put(
+					"items", itemsJSONArray
+				).put(
+					"label", objectDefinition.getLabel(locale, true)
+				));
 		}
 
 		return jsonArray;

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
@@ -12,6 +12,7 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectFieldLocalServiceUtil;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -30,6 +31,10 @@ public class AssetListTypePropertiesUtil {
 		Locale locale) {
 
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
+
+		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-74731")) {
+			return jsonArray;
+		}
 
 		for (int i = 0; i < classNameIds.length; i++) {
 			long classTypeId = 0;

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
@@ -18,9 +18,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 
-import java.util.HashSet;
 import java.util.Locale;
-import java.util.Set;
 
 /**
  * @author Joshua Cords
@@ -32,8 +30,6 @@ public class AssetListTypePropertiesUtil {
 		Locale locale) {
 
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
-
-		Set<String> seenFieldNames = new HashSet<>();
 
 		for (int i = 0; i < classNameIds.length; i++) {
 			long classTypeId = 0;
@@ -59,13 +55,14 @@ public class AssetListTypePropertiesUtil {
 
 				String type = _toFilterType(objectField.getBusinessType());
 
-				if ((type == null) ||
-					!seenFieldNames.add(objectField.getName())) {
-
+				if (type == null) {
 					continue;
 				}
 
-				jsonArray.put(_toPropertyJSONObject(objectField, locale, type));
+				jsonArray.put(
+					_toPropertyJSONObject(
+						classNameIds[i], classTypeId, locale, objectField,
+						type));
 			}
 		}
 
@@ -141,9 +138,14 @@ public class AssetListTypePropertiesUtil {
 	}
 
 	private static JSONObject _toPropertyJSONObject(
-		ObjectField objectField, Locale locale, String type) {
+		long classNameId, long classTypeId, Locale locale,
+		ObjectField objectField, String type) {
 
 		JSONObject jsonObject = JSONUtil.put(
+			"classNameId", classNameId
+		).put(
+			"classTypeId", classTypeId
+		).put(
 			"label", objectField.getLabel(locale, true)
 		).put(
 			"name", objectField.getName()

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
@@ -113,7 +113,7 @@ public class AssetListTypePropertiesUtil {
 			businessType.equals(
 				ObjectFieldConstants.BUSINESS_TYPE_PRECISION_DECIMAL)) {
 
-			return "double";
+			return "decimal";
 		}
 
 		if (businessType.equals(ObjectFieldConstants.BUSINESS_TYPE_INTEGER) ||
@@ -136,7 +136,7 @@ public class AssetListTypePropertiesUtil {
 			businessType.equals(ObjectFieldConstants.BUSINESS_TYPE_RICH_TEXT) ||
 			businessType.equals(ObjectFieldConstants.BUSINESS_TYPE_TEXT)) {
 
-			return "string";
+			return "text";
 		}
 
 		return null;

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
@@ -54,10 +54,6 @@ public class AssetListTypePropertiesUtil {
 					ObjectFieldLocalServiceUtil.getObjectFields(
 						objectDefinition.getObjectDefinitionId())) {
 
-				if (objectField.isMetadata()) {
-					continue;
-				}
-
 				String type = _toFilterType(objectField.getBusinessType());
 
 				if (type == null) {

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtil.java
@@ -53,7 +53,7 @@ public class AssetListTypePropertiesUtil {
 			}
 
 			ObjectDefinition objectDefinition = _resolveObjectDefinition(
-				classNameIds[i], classTypeId, companyId);
+				classNameIds[i], companyId);
 
 			if (objectDefinition == null) {
 				continue;
@@ -188,17 +188,7 @@ public class AssetListTypePropertiesUtil {
 	}
 
 	private static ObjectDefinition _resolveObjectDefinition(
-		long classNameId, long classTypeId, long companyId) {
-
-		if (classTypeId > 0) {
-			ObjectDefinition objectDefinition =
-				ObjectDefinitionLocalServiceUtil.fetchObjectDefinition(
-					classTypeId);
-
-			if (objectDefinition != null) {
-				return objectDefinition;
-			}
-		}
+		long classNameId, long companyId) {
 
 		if (classNameId <= 0) {
 			return null;

--- a/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
+++ b/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
@@ -47,6 +47,13 @@ public class AssetListTypePropertiesUtilTest {
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
 
+	@BeforeClass
+	public static void setUpClass() {
+		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
+
+		jsonFactoryUtil.setJSONFactory(new JSONFactoryImpl());
+	}
+
 	@AfterClass
 	public static void tearDownClass() {
 		_featureFlagManagerUtilMockedStatic.close();
@@ -54,13 +61,6 @@ public class AssetListTypePropertiesUtilTest {
 		_objectDefinitionLocalServiceUtilMockedStatic.close();
 		_objectFieldLocalServiceUtilMockedStatic.close();
 		_portalUtilMockedStatic.close();
-	}
-
-	@BeforeClass
-	public static void setUpClass() {
-		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
-
-		jsonFactoryUtil.setJSONFactory(new JSONFactoryImpl());
 	}
 
 	@Before
@@ -80,6 +80,34 @@ public class AssetListTypePropertiesUtilTest {
 	}
 
 	@Test
+	public void testExcludesMetadataAndUnfilterableFields() {
+		_stubObjectDefinition(
+			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1,
+			Arrays.asList(
+				_mockObjectField(
+					"creator", ObjectFieldConstants.BUSINESS_TYPE_TEXT, true),
+				_mockObjectField(
+					"attachment", ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT,
+					false),
+				_mockObjectField(
+					"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT, false)));
+
+		JSONArray jsonArray =
+			AssetListTypePropertiesUtil.getTypePropertiesJSONArray(
+				new long[] {_CLASS_NAME_ID_1}, new long[] {_CLASS_TYPE_ID_1},
+				_COMPANY_ID, LocaleUtil.US);
+
+		Assert.assertEquals(jsonArray.toString(), 1, jsonArray.length());
+		Assert.assertEquals(
+			"title",
+			jsonArray.getJSONObject(
+				0
+			).getString(
+				"name"
+			));
+	}
+
+	@Test
 	public void testFeatureFlagDisabledReturnsEmptyArray() {
 		_featureFlagManagerUtilMockedStatic.when(
 			() -> FeatureFlagManagerUtil.isEnabled(
@@ -92,8 +120,7 @@ public class AssetListTypePropertiesUtilTest {
 			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1,
 			Collections.singletonList(
 				_mockObjectField(
-					"title",
-					ObjectFieldConstants.BUSINESS_TYPE_TEXT, false)));
+					"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT, false)));
 
 		JSONArray jsonArray =
 			AssetListTypePropertiesUtil.getTypePropertiesJSONArray(
@@ -109,8 +136,7 @@ public class AssetListTypePropertiesUtilTest {
 			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1,
 			Collections.singletonList(
 				_mockObjectField(
-					"title",
-					ObjectFieldConstants.BUSINESS_TYPE_TEXT, false)));
+					"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT, false)));
 
 		JSONArray jsonArray =
 			AssetListTypePropertiesUtil.getTypePropertiesJSONArray(
@@ -121,56 +147,12 @@ public class AssetListTypePropertiesUtilTest {
 
 		JSONObject jsonObject = jsonArray.getJSONObject(0);
 
-		Assert.assertEquals(_CLASS_NAME_ID_1, jsonObject.getLong("classNameId"));
-		Assert.assertEquals(_CLASS_TYPE_ID_1, jsonObject.getLong("classTypeId"));
+		Assert.assertEquals(
+			_CLASS_NAME_ID_1, jsonObject.getLong("classNameId"));
+		Assert.assertEquals(
+			_CLASS_TYPE_ID_1, jsonObject.getLong("classTypeId"));
 		Assert.assertEquals("title", jsonObject.getString("name"));
 		Assert.assertEquals("string", jsonObject.getString("type"));
-	}
-
-	@Test
-	public void testProducesEntryPerPairWhenSameFieldNameIsShared() {
-		_stubObjectDefinition(
-			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1,
-			Collections.singletonList(
-				_mockObjectField(
-					"title",
-					ObjectFieldConstants.BUSINESS_TYPE_TEXT, false)));
-		_stubObjectDefinition(
-			_CLASS_NAME_ID_2, _CLASS_TYPE_ID_2,
-			Arrays.asList(
-				_mockObjectField(
-					"title",
-					ObjectFieldConstants.BUSINESS_TYPE_TEXT, false),
-				_mockObjectField(
-					"priority",
-					ObjectFieldConstants.BUSINESS_TYPE_INTEGER, false)));
-
-		JSONArray jsonArray =
-			AssetListTypePropertiesUtil.getTypePropertiesJSONArray(
-				new long[] {_CLASS_NAME_ID_1, _CLASS_NAME_ID_2},
-				new long[] {_CLASS_TYPE_ID_1, _CLASS_TYPE_ID_2}, _COMPANY_ID,
-				LocaleUtil.US);
-
-		Assert.assertEquals(jsonArray.toString(), 3, jsonArray.length());
-
-		JSONObject jsonObject1 = jsonArray.getJSONObject(0);
-
-		Assert.assertEquals(_CLASS_NAME_ID_1, jsonObject1.getLong("classNameId"));
-		Assert.assertEquals(_CLASS_TYPE_ID_1, jsonObject1.getLong("classTypeId"));
-		Assert.assertEquals("title", jsonObject1.getString("name"));
-
-		JSONObject jsonObject2 = jsonArray.getJSONObject(1);
-
-		Assert.assertEquals(_CLASS_NAME_ID_2, jsonObject2.getLong("classNameId"));
-		Assert.assertEquals(_CLASS_TYPE_ID_2, jsonObject2.getLong("classTypeId"));
-		Assert.assertEquals("title", jsonObject2.getString("name"));
-
-		JSONObject jsonObject3 = jsonArray.getJSONObject(2);
-
-		Assert.assertEquals(_CLASS_NAME_ID_2, jsonObject3.getLong("classNameId"));
-		Assert.assertEquals(_CLASS_TYPE_ID_2, jsonObject3.getLong("classTypeId"));
-		Assert.assertEquals("priority", jsonObject3.getString("name"));
-		Assert.assertEquals("integer", jsonObject3.getString("type"));
 	}
 
 	@Test
@@ -241,34 +223,69 @@ public class AssetListTypePropertiesUtilTest {
 		Assert.assertEquals(
 			optionsJSONArray.toString(), 2, optionsJSONArray.length());
 		Assert.assertEquals(
-			"Approved", optionsJSONArray.getJSONObject(0).getString("label"));
+			"Approved",
+			optionsJSONArray.getJSONObject(
+				0
+			).getString(
+				"label"
+			));
 		Assert.assertEquals(
-			"approved", optionsJSONArray.getJSONObject(0).getString("value"));
+			"approved",
+			optionsJSONArray.getJSONObject(
+				0
+			).getString(
+				"value"
+			));
 	}
 
 	@Test
-	public void testExcludesMetadataAndUnfilterableFields() {
+	public void testProducesEntryPerPairWhenSameFieldNameIsShared() {
 		_stubObjectDefinition(
 			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1,
+			Collections.singletonList(
+				_mockObjectField(
+					"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT, false)));
+		_stubObjectDefinition(
+			_CLASS_NAME_ID_2, _CLASS_TYPE_ID_2,
 			Arrays.asList(
 				_mockObjectField(
-					"creator",
-					ObjectFieldConstants.BUSINESS_TYPE_TEXT, true),
+					"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT, false),
 				_mockObjectField(
-					"attachment",
-					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT, false),
-				_mockObjectField(
-					"title",
-					ObjectFieldConstants.BUSINESS_TYPE_TEXT, false)));
+					"priority", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
+					false)));
 
 		JSONArray jsonArray =
 			AssetListTypePropertiesUtil.getTypePropertiesJSONArray(
-				new long[] {_CLASS_NAME_ID_1}, new long[] {_CLASS_TYPE_ID_1},
-				_COMPANY_ID, LocaleUtil.US);
+				new long[] {_CLASS_NAME_ID_1, _CLASS_NAME_ID_2},
+				new long[] {_CLASS_TYPE_ID_1, _CLASS_TYPE_ID_2}, _COMPANY_ID,
+				LocaleUtil.US);
 
-		Assert.assertEquals(jsonArray.toString(), 1, jsonArray.length());
+		Assert.assertEquals(jsonArray.toString(), 3, jsonArray.length());
+
+		JSONObject jsonObject1 = jsonArray.getJSONObject(0);
+
 		Assert.assertEquals(
-			"title", jsonArray.getJSONObject(0).getString("name"));
+			_CLASS_NAME_ID_1, jsonObject1.getLong("classNameId"));
+		Assert.assertEquals(
+			_CLASS_TYPE_ID_1, jsonObject1.getLong("classTypeId"));
+		Assert.assertEquals("title", jsonObject1.getString("name"));
+
+		JSONObject jsonObject2 = jsonArray.getJSONObject(1);
+
+		Assert.assertEquals(
+			_CLASS_NAME_ID_2, jsonObject2.getLong("classNameId"));
+		Assert.assertEquals(
+			_CLASS_TYPE_ID_2, jsonObject2.getLong("classTypeId"));
+		Assert.assertEquals("title", jsonObject2.getString("name"));
+
+		JSONObject jsonObject3 = jsonArray.getJSONObject(2);
+
+		Assert.assertEquals(
+			_CLASS_NAME_ID_2, jsonObject3.getLong("classNameId"));
+		Assert.assertEquals(
+			_CLASS_TYPE_ID_2, jsonObject3.getLong("classTypeId"));
+		Assert.assertEquals("priority", jsonObject3.getString("name"));
+		Assert.assertEquals("integer", jsonObject3.getString("type"));
 	}
 
 	private ObjectField _mockObjectField(
@@ -307,7 +324,8 @@ public class AssetListTypePropertiesUtilTest {
 		long classNameId, long objectDefinitionId,
 		List<ObjectField> objectFields) {
 
-		ObjectDefinition objectDefinition = Mockito.mock(ObjectDefinition.class);
+		ObjectDefinition objectDefinition = Mockito.mock(
+			ObjectDefinition.class);
 
 		Mockito.when(
 			objectDefinition.getObjectDefinitionId()

--- a/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
+++ b/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
@@ -72,6 +72,100 @@ public class AssetListTypePropertiesUtilTest {
 	}
 
 	@Test
+	public void testEmitsOneGroupPerPair() {
+		_stubObjectDefinition(
+			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1, _LABEL_1,
+			Collections.singletonList(
+				_mockObjectField(
+					"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT, false)));
+		_stubObjectDefinition(
+			_CLASS_NAME_ID_2, _CLASS_TYPE_ID_2, _LABEL_2,
+			Arrays.asList(
+				_mockObjectField(
+					"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT, false),
+				_mockObjectField(
+					"priority", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
+					false)));
+
+		JSONArray jsonArray =
+			AssetListTypePropertiesUtil.getTypePropertiesJSONArray(
+				new long[] {_CLASS_NAME_ID_1, _CLASS_NAME_ID_2},
+				new long[] {_CLASS_TYPE_ID_1, _CLASS_TYPE_ID_2}, _COMPANY_ID,
+				LocaleUtil.US);
+
+		Assert.assertEquals(jsonArray.toString(), 2, jsonArray.length());
+
+		JSONObject groupJSONObject1 = jsonArray.getJSONObject(0);
+
+		Assert.assertEquals(_LABEL_1, groupJSONObject1.getString("label"));
+
+		JSONArray itemsJSONArray1 = groupJSONObject1.getJSONArray("items");
+
+		Assert.assertEquals(
+			itemsJSONArray1.toString(), 1, itemsJSONArray1.length());
+
+		JSONObject itemJSONObject1 = itemsJSONArray1.getJSONObject(0);
+
+		Assert.assertEquals(
+			_CLASS_NAME_ID_1, itemJSONObject1.getLong("classNameId"));
+		Assert.assertEquals(
+			_CLASS_TYPE_ID_1, itemJSONObject1.getLong("classTypeId"));
+		Assert.assertEquals("title", itemJSONObject1.getString("name"));
+
+		JSONObject groupJSONObject2 = jsonArray.getJSONObject(1);
+
+		Assert.assertEquals(_LABEL_2, groupJSONObject2.getString("label"));
+
+		JSONArray itemsJSONArray2 = groupJSONObject2.getJSONArray("items");
+
+		Assert.assertEquals(
+			itemsJSONArray2.toString(), 2, itemsJSONArray2.length());
+
+		JSONObject itemJSONObject2 = itemsJSONArray2.getJSONObject(0);
+
+		Assert.assertEquals(
+			_CLASS_NAME_ID_2, itemJSONObject2.getLong("classNameId"));
+		Assert.assertEquals(
+			_CLASS_TYPE_ID_2, itemJSONObject2.getLong("classTypeId"));
+		Assert.assertEquals("title", itemJSONObject2.getString("name"));
+
+		JSONObject itemJSONObject3 = itemsJSONArray2.getJSONObject(1);
+
+		Assert.assertEquals(
+			_CLASS_NAME_ID_2, itemJSONObject3.getLong("classNameId"));
+		Assert.assertEquals(
+			_CLASS_TYPE_ID_2, itemJSONObject3.getLong("classTypeId"));
+		Assert.assertEquals("priority", itemJSONObject3.getString("name"));
+		Assert.assertEquals("integer", itemJSONObject3.getString("type"));
+	}
+
+	@Test
+	public void testEmitsTypeGroupWithEmptyItemsWhenNoFieldsFilterable() {
+		_stubObjectDefinition(
+			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1, _LABEL_1,
+			Collections.singletonList(
+				_mockObjectField(
+					"attachment", ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT,
+					false)));
+
+		JSONArray jsonArray =
+			AssetListTypePropertiesUtil.getTypePropertiesJSONArray(
+				new long[] {_CLASS_NAME_ID_1}, new long[] {_CLASS_TYPE_ID_1},
+				_COMPANY_ID, LocaleUtil.US);
+
+		Assert.assertEquals(jsonArray.toString(), 1, jsonArray.length());
+
+		JSONObject groupJSONObject = jsonArray.getJSONObject(0);
+
+		Assert.assertEquals(_LABEL_1, groupJSONObject.getString("label"));
+
+		JSONArray itemsJSONArray = groupJSONObject.getJSONArray("items");
+
+		Assert.assertEquals(
+			itemsJSONArray.toString(), 0, itemsJSONArray.length());
+	}
+
+	@Test
 	public void testFeatureFlagDisabledReturnsEmptyArray() {
 		_featureFlagManagerUtilMockedStatic.when(
 			() -> FeatureFlagManagerUtil.isEnabled(
@@ -81,7 +175,7 @@ public class AssetListTypePropertiesUtilTest {
 		);
 
 		_stubObjectDefinition(
-			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1,
+			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1, _LABEL_1,
 			Collections.singletonList(
 				_mockObjectField(
 					"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT, false)));
@@ -95,34 +189,9 @@ public class AssetListTypePropertiesUtilTest {
 	}
 
 	@Test
-	public void testIncludesClassNameIdAndClassTypeIdInEachEntry() {
-		_stubObjectDefinition(
-			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1,
-			Collections.singletonList(
-				_mockObjectField(
-					"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT, false)));
-
-		JSONArray jsonArray =
-			AssetListTypePropertiesUtil.getTypePropertiesJSONArray(
-				new long[] {_CLASS_NAME_ID_1}, new long[] {_CLASS_TYPE_ID_1},
-				_COMPANY_ID, LocaleUtil.US);
-
-		Assert.assertEquals(jsonArray.toString(), 1, jsonArray.length());
-
-		JSONObject jsonObject = jsonArray.getJSONObject(0);
-
-		Assert.assertEquals(
-			_CLASS_NAME_ID_1, jsonObject.getLong("classNameId"));
-		Assert.assertEquals(
-			_CLASS_TYPE_ID_1, jsonObject.getLong("classTypeId"));
-		Assert.assertEquals("title", jsonObject.getString("name"));
-		Assert.assertEquals("text", jsonObject.getString("type"));
-	}
-
-	@Test
 	public void testIncludesMetadataFieldsAndExcludesUnfilterableFields() {
 		_stubObjectDefinition(
-			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1,
+			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1, _LABEL_1,
 			Arrays.asList(
 				_mockObjectField(
 					"attachment", ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT,
@@ -137,21 +206,64 @@ public class AssetListTypePropertiesUtilTest {
 				new long[] {_CLASS_NAME_ID_1}, new long[] {_CLASS_TYPE_ID_1},
 				_COMPANY_ID, LocaleUtil.US);
 
-		Assert.assertEquals(jsonArray.toString(), 2, jsonArray.length());
+		Assert.assertEquals(jsonArray.toString(), 1, jsonArray.length());
+
+		JSONArray itemsJSONArray = jsonArray.getJSONObject(
+			0
+		).getJSONArray(
+			"items"
+		);
+
+		Assert.assertEquals(
+			itemsJSONArray.toString(), 2, itemsJSONArray.length());
 		Assert.assertEquals(
 			"creator",
-			jsonArray.getJSONObject(
+			itemsJSONArray.getJSONObject(
 				0
 			).getString(
 				"name"
 			));
 		Assert.assertEquals(
 			"title",
-			jsonArray.getJSONObject(
+			itemsJSONArray.getJSONObject(
 				1
 			).getString(
 				"name"
 			));
+	}
+
+	@Test
+	public void testIncludesOneTypeGroup() {
+		_stubObjectDefinition(
+			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1, _LABEL_1,
+			Collections.singletonList(
+				_mockObjectField(
+					"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT, false)));
+
+		JSONArray jsonArray =
+			AssetListTypePropertiesUtil.getTypePropertiesJSONArray(
+				new long[] {_CLASS_NAME_ID_1}, new long[] {_CLASS_TYPE_ID_1},
+				_COMPANY_ID, LocaleUtil.US);
+
+		Assert.assertEquals(jsonArray.toString(), 1, jsonArray.length());
+
+		JSONObject groupJSONObject = jsonArray.getJSONObject(0);
+
+		Assert.assertEquals(_LABEL_1, groupJSONObject.getString("label"));
+
+		JSONArray itemsJSONArray = groupJSONObject.getJSONArray("items");
+
+		Assert.assertEquals(
+			itemsJSONArray.toString(), 1, itemsJSONArray.length());
+
+		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
+
+		Assert.assertEquals(
+			_CLASS_NAME_ID_1, itemJSONObject.getLong("classNameId"));
+		Assert.assertEquals(
+			_CLASS_TYPE_ID_1, itemJSONObject.getLong("classTypeId"));
+		Assert.assertEquals("title", itemJSONObject.getString("name"));
+		Assert.assertEquals("text", itemJSONObject.getString("type"));
 	}
 
 	@Test
@@ -168,7 +280,7 @@ public class AssetListTypePropertiesUtilTest {
 		);
 
 		_stubObjectDefinition(
-			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1,
+			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1, _LABEL_1,
 			Collections.singletonList(objectField));
 
 		ListTypeEntry approvedListTypeEntry = Mockito.mock(ListTypeEntry.class);
@@ -213,11 +325,17 @@ public class AssetListTypePropertiesUtilTest {
 
 		Assert.assertEquals(jsonArray.toString(), 1, jsonArray.length());
 
-		JSONObject jsonObject = jsonArray.getJSONObject(0);
+		JSONObject itemJSONObject = jsonArray.getJSONObject(
+			0
+		).getJSONArray(
+			"items"
+		).getJSONObject(
+			0
+		);
 
-		Assert.assertEquals("picklist", jsonObject.getString("type"));
+		Assert.assertEquals("picklist", itemJSONObject.getString("type"));
 
-		JSONArray optionsJSONArray = jsonObject.getJSONArray("options");
+		JSONArray optionsJSONArray = itemJSONObject.getJSONArray("options");
 
 		Assert.assertEquals(
 			optionsJSONArray.toString(), 2, optionsJSONArray.length());
@@ -235,56 +353,6 @@ public class AssetListTypePropertiesUtilTest {
 			).getString(
 				"value"
 			));
-	}
-
-	@Test
-	public void testProducesEntryPerPairWhenSameFieldNameIsShared() {
-		_stubObjectDefinition(
-			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1,
-			Collections.singletonList(
-				_mockObjectField(
-					"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT, false)));
-		_stubObjectDefinition(
-			_CLASS_NAME_ID_2, _CLASS_TYPE_ID_2,
-			Arrays.asList(
-				_mockObjectField(
-					"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT, false),
-				_mockObjectField(
-					"priority", ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
-					false)));
-
-		JSONArray jsonArray =
-			AssetListTypePropertiesUtil.getTypePropertiesJSONArray(
-				new long[] {_CLASS_NAME_ID_1, _CLASS_NAME_ID_2},
-				new long[] {_CLASS_TYPE_ID_1, _CLASS_TYPE_ID_2}, _COMPANY_ID,
-				LocaleUtil.US);
-
-		Assert.assertEquals(jsonArray.toString(), 3, jsonArray.length());
-
-		JSONObject jsonObject1 = jsonArray.getJSONObject(0);
-
-		Assert.assertEquals(
-			_CLASS_NAME_ID_1, jsonObject1.getLong("classNameId"));
-		Assert.assertEquals(
-			_CLASS_TYPE_ID_1, jsonObject1.getLong("classTypeId"));
-		Assert.assertEquals("title", jsonObject1.getString("name"));
-
-		JSONObject jsonObject2 = jsonArray.getJSONObject(1);
-
-		Assert.assertEquals(
-			_CLASS_NAME_ID_2, jsonObject2.getLong("classNameId"));
-		Assert.assertEquals(
-			_CLASS_TYPE_ID_2, jsonObject2.getLong("classTypeId"));
-		Assert.assertEquals("title", jsonObject2.getString("name"));
-
-		JSONObject jsonObject3 = jsonArray.getJSONObject(2);
-
-		Assert.assertEquals(
-			_CLASS_NAME_ID_2, jsonObject3.getLong("classNameId"));
-		Assert.assertEquals(
-			_CLASS_TYPE_ID_2, jsonObject3.getLong("classTypeId"));
-		Assert.assertEquals("priority", jsonObject3.getString("name"));
-		Assert.assertEquals("integer", jsonObject3.getString("type"));
 	}
 
 	private static MockedStatic<FeatureFlagManagerUtil>
@@ -330,11 +398,17 @@ public class AssetListTypePropertiesUtilTest {
 	}
 
 	private void _stubObjectDefinition(
-		long classNameId, long objectDefinitionId,
+		long classNameId, long objectDefinitionId, String label,
 		List<ObjectField> objectFields) {
 
 		ObjectDefinition objectDefinition = Mockito.mock(
 			ObjectDefinition.class);
+
+		Mockito.when(
+			objectDefinition.getLabel(LocaleUtil.US, true)
+		).thenReturn(
+			label
+		);
 
 		Mockito.when(
 			objectDefinition.getObjectDefinitionId()
@@ -372,6 +446,10 @@ public class AssetListTypePropertiesUtilTest {
 	private static final long _CLASS_TYPE_ID_2 = 99L;
 
 	private static final long _COMPANY_ID = 12345L;
+
+	private static final String _LABEL_1 = "Task";
+
+	private static final String _LABEL_2 = "Project";
 
 	private static final MockedStatic<FeatureFlagManagerUtil>
 		_featureFlagManagerUtilMockedStatic =

--- a/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
+++ b/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
@@ -362,12 +362,12 @@ public class AssetListTypePropertiesUtilTest {
 		JSONArray itemsJSONArray = groupJSONObject.getJSONArray("items");
 
 		Assert.assertEquals(
-			itemsJSONArray.toString(), 13, itemsJSONArray.length());
+			itemsJSONArray.toString(), 12, itemsJSONArray.length());
 
 		String[] expectedNames = {
-			"title", "description", "userName", "createDate", "modified",
-			"displayDate", "publishDate", "expirationDate", "priority",
-			"viewCount", "externalReferenceCode", "reviewDate", "status"
+			"userName", "createDate", "displayDate", "expirationDate",
+			"externalReferenceCode", "modified", "priority", "publishDate",
+			"reviewDate", "status", "title", "viewCount"
 		};
 
 		for (int i = 0; i < expectedNames.length; i++) {

--- a/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
+++ b/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
@@ -171,30 +171,7 @@ public class AssetListTypePropertiesUtilTest {
 	}
 
 	@Test
-	public void testFeatureFlagDisabledReturnsEmptyArray() {
-		_featureFlagManagerUtilMockedStatic.when(
-			() -> FeatureFlagManagerUtil.isEnabled(
-				Mockito.anyLong(), Mockito.eq("LPD-74731"))
-		).thenReturn(
-			false
-		);
-
-		_stubObjectDefinition(
-			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1, _LABEL_1,
-			Collections.singletonList(
-				_mockObjectField(
-					"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT, false)));
-
-		JSONArray jsonArray =
-			AssetListTypePropertiesUtil.getTypePropertiesJSONArray(
-				new long[] {_CLASS_NAME_ID_1}, new long[] {_CLASS_TYPE_ID_1},
-				_COMPANY_ID, LocaleUtil.US);
-
-		Assert.assertEquals(jsonArray.toString(), 0, jsonArray.length());
-	}
-
-	@Test
-	public void testIncludesMetadataFieldsAndExcludesUnfilterableFields() {
+	public void testExcludesMetadataFieldsFromTypeGroup() {
 		_stubObjectDefinition(
 			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1, _LABEL_1,
 			Arrays.asList(
@@ -220,21 +197,37 @@ public class AssetListTypePropertiesUtilTest {
 		);
 
 		Assert.assertEquals(
-			itemsJSONArray.toString(), 2, itemsJSONArray.length());
+			itemsJSONArray.toString(), 1, itemsJSONArray.length());
 		Assert.assertEquals(
-			"creator",
+			"title",
 			itemsJSONArray.getJSONObject(
 				0
 			).getString(
 				"name"
 			));
-		Assert.assertEquals(
-			"title",
-			itemsJSONArray.getJSONObject(
-				1
-			).getString(
-				"name"
-			));
+	}
+
+	@Test
+	public void testFeatureFlagDisabledReturnsEmptyArray() {
+		_featureFlagManagerUtilMockedStatic.when(
+			() -> FeatureFlagManagerUtil.isEnabled(
+				Mockito.anyLong(), Mockito.eq("LPD-74731"))
+		).thenReturn(
+			false
+		);
+
+		_stubObjectDefinition(
+			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1, _LABEL_1,
+			Collections.singletonList(
+				_mockObjectField(
+					"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT, false)));
+
+		JSONArray jsonArray =
+			AssetListTypePropertiesUtil.getTypePropertiesJSONArray(
+				new long[] {_CLASS_NAME_ID_1}, new long[] {_CLASS_TYPE_ID_1},
+				_COMPANY_ID, LocaleUtil.US);
+
+		Assert.assertEquals(jsonArray.toString(), 0, jsonArray.length());
 	}
 
 	@Test
@@ -376,12 +369,12 @@ public class AssetListTypePropertiesUtilTest {
 		JSONArray itemsJSONArray = groupJSONObject.getJSONArray("items");
 
 		Assert.assertEquals(
-			itemsJSONArray.toString(), 10, itemsJSONArray.length());
+			itemsJSONArray.toString(), 13, itemsJSONArray.length());
 
 		String[] expectedNames = {
 			"title", "description", "userName", "createDate", "modified",
 			"displayDate", "publishDate", "expirationDate", "priority",
-			"viewCount"
+			"viewCount", "externalReferenceCode", "reviewDate", "status"
 		};
 
 		for (int i = 0; i < expectedNames.length; i++) {

--- a/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
+++ b/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
@@ -32,6 +32,7 @@ import java.util.Locale;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,6 +49,21 @@ public class AssetListTypePropertiesUtilTest {
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() {
+		_setUpJSONFactoryUtil();
+
+		_featureFlagManagerUtilMockedStatic = Mockito.mockStatic(
+			FeatureFlagManagerUtil.class);
+		_listTypeEntryLocalServiceUtilMockedStatic = Mockito.mockStatic(
+			ListTypeEntryLocalServiceUtil.class);
+		_objectDefinitionLocalServiceUtilMockedStatic = Mockito.mockStatic(
+			ObjectDefinitionLocalServiceUtil.class);
+		_objectFieldLocalServiceUtilMockedStatic = Mockito.mockStatic(
+			ObjectFieldLocalServiceUtil.class);
+		_portalUtilMockedStatic = Mockito.mockStatic(PortalUtil.class);
+	}
 
 	@AfterClass
 	public static void tearDownClass() {
@@ -365,14 +381,10 @@ public class AssetListTypePropertiesUtilTest {
 		}
 	}
 
-	private static MockedStatic<FeatureFlagManagerUtil>
-		_createFeatureFlagManagerUtilMockedStatic() {
-
+	private static void _setUpJSONFactoryUtil() {
 		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
 
 		jsonFactoryUtil.setJSONFactory(new JSONFactoryImpl());
-
-		return Mockito.mockStatic(FeatureFlagManagerUtil.class);
 	}
 
 	private ObjectField _mockObjectField(
@@ -475,19 +487,14 @@ public class AssetListTypePropertiesUtilTest {
 
 	private static final String _LABEL_2 = "Project";
 
-	private static final MockedStatic<FeatureFlagManagerUtil>
-		_featureFlagManagerUtilMockedStatic =
-			_createFeatureFlagManagerUtilMockedStatic();
-	private static final MockedStatic<ListTypeEntryLocalServiceUtil>
-		_listTypeEntryLocalServiceUtilMockedStatic = Mockito.mockStatic(
-			ListTypeEntryLocalServiceUtil.class);
-	private static final MockedStatic<ObjectDefinitionLocalServiceUtil>
-		_objectDefinitionLocalServiceUtilMockedStatic = Mockito.mockStatic(
-			ObjectDefinitionLocalServiceUtil.class);
-	private static final MockedStatic<ObjectFieldLocalServiceUtil>
-		_objectFieldLocalServiceUtilMockedStatic = Mockito.mockStatic(
-			ObjectFieldLocalServiceUtil.class);
-	private static final MockedStatic<PortalUtil> _portalUtilMockedStatic =
-		Mockito.mockStatic(PortalUtil.class);
+	private static MockedStatic<FeatureFlagManagerUtil>
+		_featureFlagManagerUtilMockedStatic;
+	private static MockedStatic<ListTypeEntryLocalServiceUtil>
+		_listTypeEntryLocalServiceUtilMockedStatic;
+	private static MockedStatic<ObjectDefinitionLocalServiceUtil>
+		_objectDefinitionLocalServiceUtilMockedStatic;
+	private static MockedStatic<ObjectFieldLocalServiceUtil>
+		_objectFieldLocalServiceUtilMockedStatic;
+	private static MockedStatic<PortalUtil> _portalUtilMockedStatic;
 
 }

--- a/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
+++ b/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
@@ -29,7 +29,6 @@ import java.util.List;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,13 +45,6 @@ public class AssetListTypePropertiesUtilTest {
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
-
-	@BeforeClass
-	public static void setUpClass() {
-		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
-
-		jsonFactoryUtil.setJSONFactory(new JSONFactoryImpl());
-	}
 
 	@AfterClass
 	public static void tearDownClass() {
@@ -152,7 +144,7 @@ public class AssetListTypePropertiesUtilTest {
 		Assert.assertEquals(
 			_CLASS_TYPE_ID_1, jsonObject.getLong("classTypeId"));
 		Assert.assertEquals("title", jsonObject.getString("name"));
-		Assert.assertEquals("string", jsonObject.getString("type"));
+		Assert.assertEquals("text", jsonObject.getString("type"));
 	}
 
 	@Test
@@ -288,6 +280,16 @@ public class AssetListTypePropertiesUtilTest {
 		Assert.assertEquals("integer", jsonObject3.getString("type"));
 	}
 
+	private static MockedStatic<FeatureFlagManagerUtil>
+		_createFeatureFlagManagerUtilMockedStatic() {
+
+		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
+
+		jsonFactoryUtil.setJSONFactory(new JSONFactoryImpl());
+
+		return Mockito.mockStatic(FeatureFlagManagerUtil.class);
+	}
+
 	private ObjectField _mockObjectField(
 		String name, String businessType, boolean metadata) {
 
@@ -365,8 +367,8 @@ public class AssetListTypePropertiesUtilTest {
 	private static final long _COMPANY_ID = 12345L;
 
 	private static final MockedStatic<FeatureFlagManagerUtil>
-		_featureFlagManagerUtilMockedStatic = Mockito.mockStatic(
-			FeatureFlagManagerUtil.class);
+		_featureFlagManagerUtilMockedStatic =
+			_createFeatureFlagManagerUtilMockedStatic();
 	private static final MockedStatic<ListTypeEntryLocalServiceUtil>
 		_listTypeEntryLocalServiceUtilMockedStatic = Mockito.mockStatic(
 			ListTypeEntryLocalServiceUtil.class);

--- a/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
+++ b/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
@@ -1,0 +1,364 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.list.web.internal.util;
+
+import com.liferay.list.type.model.ListTypeEntry;
+import com.liferay.list.type.service.ListTypeEntryLocalServiceUtil;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
+import com.liferay.object.service.ObjectFieldLocalServiceUtil;
+import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Joshua Cords
+ */
+public class AssetListTypePropertiesUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@AfterClass
+	public static void tearDownClass() {
+		_featureFlagManagerUtilMockedStatic.close();
+		_listTypeEntryLocalServiceUtilMockedStatic.close();
+		_objectDefinitionLocalServiceUtilMockedStatic.close();
+		_objectFieldLocalServiceUtilMockedStatic.close();
+		_portalUtilMockedStatic.close();
+	}
+
+	@BeforeClass
+	public static void setUpClass() {
+		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
+
+		jsonFactoryUtil.setJSONFactory(new JSONFactoryImpl());
+	}
+
+	@Before
+	public void setUp() {
+		_featureFlagManagerUtilMockedStatic.reset();
+		_listTypeEntryLocalServiceUtilMockedStatic.reset();
+		_objectDefinitionLocalServiceUtilMockedStatic.reset();
+		_objectFieldLocalServiceUtilMockedStatic.reset();
+		_portalUtilMockedStatic.reset();
+
+		_featureFlagManagerUtilMockedStatic.when(
+			() -> FeatureFlagManagerUtil.isEnabled(
+				Mockito.anyLong(), Mockito.eq("LPD-74731"))
+		).thenReturn(
+			true
+		);
+	}
+
+	@Test
+	public void testFeatureFlagDisabledReturnsEmptyArray() {
+		_featureFlagManagerUtilMockedStatic.when(
+			() -> FeatureFlagManagerUtil.isEnabled(
+				Mockito.anyLong(), Mockito.eq("LPD-74731"))
+		).thenReturn(
+			false
+		);
+
+		_stubObjectDefinition(
+			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1,
+			Collections.singletonList(
+				_mockObjectField(
+					"title",
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT, false)));
+
+		JSONArray jsonArray =
+			AssetListTypePropertiesUtil.getTypePropertiesJSONArray(
+				new long[] {_CLASS_NAME_ID_1}, new long[] {_CLASS_TYPE_ID_1},
+				_COMPANY_ID, LocaleUtil.US);
+
+		Assert.assertEquals(jsonArray.toString(), 0, jsonArray.length());
+	}
+
+	@Test
+	public void testIncludesClassNameIdAndClassTypeIdInEachEntry() {
+		_stubObjectDefinition(
+			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1,
+			Collections.singletonList(
+				_mockObjectField(
+					"title",
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT, false)));
+
+		JSONArray jsonArray =
+			AssetListTypePropertiesUtil.getTypePropertiesJSONArray(
+				new long[] {_CLASS_NAME_ID_1}, new long[] {_CLASS_TYPE_ID_1},
+				_COMPANY_ID, LocaleUtil.US);
+
+		Assert.assertEquals(jsonArray.toString(), 1, jsonArray.length());
+
+		JSONObject jsonObject = jsonArray.getJSONObject(0);
+
+		Assert.assertEquals(_CLASS_NAME_ID_1, jsonObject.getLong("classNameId"));
+		Assert.assertEquals(_CLASS_TYPE_ID_1, jsonObject.getLong("classTypeId"));
+		Assert.assertEquals("title", jsonObject.getString("name"));
+		Assert.assertEquals("string", jsonObject.getString("type"));
+	}
+
+	@Test
+	public void testProducesEntryPerPairWhenSameFieldNameIsShared() {
+		_stubObjectDefinition(
+			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1,
+			Collections.singletonList(
+				_mockObjectField(
+					"title",
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT, false)));
+		_stubObjectDefinition(
+			_CLASS_NAME_ID_2, _CLASS_TYPE_ID_2,
+			Arrays.asList(
+				_mockObjectField(
+					"title",
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT, false),
+				_mockObjectField(
+					"priority",
+					ObjectFieldConstants.BUSINESS_TYPE_INTEGER, false)));
+
+		JSONArray jsonArray =
+			AssetListTypePropertiesUtil.getTypePropertiesJSONArray(
+				new long[] {_CLASS_NAME_ID_1, _CLASS_NAME_ID_2},
+				new long[] {_CLASS_TYPE_ID_1, _CLASS_TYPE_ID_2}, _COMPANY_ID,
+				LocaleUtil.US);
+
+		Assert.assertEquals(jsonArray.toString(), 3, jsonArray.length());
+
+		JSONObject jsonObject1 = jsonArray.getJSONObject(0);
+
+		Assert.assertEquals(_CLASS_NAME_ID_1, jsonObject1.getLong("classNameId"));
+		Assert.assertEquals(_CLASS_TYPE_ID_1, jsonObject1.getLong("classTypeId"));
+		Assert.assertEquals("title", jsonObject1.getString("name"));
+
+		JSONObject jsonObject2 = jsonArray.getJSONObject(1);
+
+		Assert.assertEquals(_CLASS_NAME_ID_2, jsonObject2.getLong("classNameId"));
+		Assert.assertEquals(_CLASS_TYPE_ID_2, jsonObject2.getLong("classTypeId"));
+		Assert.assertEquals("title", jsonObject2.getString("name"));
+
+		JSONObject jsonObject3 = jsonArray.getJSONObject(2);
+
+		Assert.assertEquals(_CLASS_NAME_ID_2, jsonObject3.getLong("classNameId"));
+		Assert.assertEquals(_CLASS_TYPE_ID_2, jsonObject3.getLong("classTypeId"));
+		Assert.assertEquals("priority", jsonObject3.getString("name"));
+		Assert.assertEquals("integer", jsonObject3.getString("type"));
+	}
+
+	@Test
+	public void testIncludesPicklistOptions() {
+		long listTypeDefinitionId = RandomTestUtil.randomLong();
+
+		ObjectField objectField = _mockObjectField(
+			"status", ObjectFieldConstants.BUSINESS_TYPE_PICKLIST, false);
+
+		Mockito.when(
+			objectField.getListTypeDefinitionId()
+		).thenReturn(
+			listTypeDefinitionId
+		);
+
+		_stubObjectDefinition(
+			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1,
+			Collections.singletonList(objectField));
+
+		ListTypeEntry approvedListTypeEntry = Mockito.mock(ListTypeEntry.class);
+
+		Mockito.when(
+			approvedListTypeEntry.getKey()
+		).thenReturn(
+			"approved"
+		);
+
+		Mockito.when(
+			approvedListTypeEntry.getName(LocaleUtil.US, true)
+		).thenReturn(
+			"Approved"
+		);
+
+		ListTypeEntry draftListTypeEntry = Mockito.mock(ListTypeEntry.class);
+
+		Mockito.when(
+			draftListTypeEntry.getKey()
+		).thenReturn(
+			"draft"
+		);
+
+		Mockito.when(
+			draftListTypeEntry.getName(LocaleUtil.US, true)
+		).thenReturn(
+			"Draft"
+		);
+
+		_listTypeEntryLocalServiceUtilMockedStatic.when(
+			() -> ListTypeEntryLocalServiceUtil.getListTypeEntries(
+				listTypeDefinitionId)
+		).thenReturn(
+			Arrays.asList(approvedListTypeEntry, draftListTypeEntry)
+		);
+
+		JSONArray jsonArray =
+			AssetListTypePropertiesUtil.getTypePropertiesJSONArray(
+				new long[] {_CLASS_NAME_ID_1}, new long[] {_CLASS_TYPE_ID_1},
+				_COMPANY_ID, LocaleUtil.US);
+
+		Assert.assertEquals(jsonArray.toString(), 1, jsonArray.length());
+
+		JSONObject jsonObject = jsonArray.getJSONObject(0);
+
+		Assert.assertEquals("picklist", jsonObject.getString("type"));
+
+		JSONArray optionsJSONArray = jsonObject.getJSONArray("options");
+
+		Assert.assertEquals(
+			optionsJSONArray.toString(), 2, optionsJSONArray.length());
+		Assert.assertEquals(
+			"Approved", optionsJSONArray.getJSONObject(0).getString("label"));
+		Assert.assertEquals(
+			"approved", optionsJSONArray.getJSONObject(0).getString("value"));
+	}
+
+	@Test
+	public void testExcludesMetadataAndUnfilterableFields() {
+		_stubObjectDefinition(
+			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1,
+			Arrays.asList(
+				_mockObjectField(
+					"creator",
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT, true),
+				_mockObjectField(
+					"attachment",
+					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT, false),
+				_mockObjectField(
+					"title",
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT, false)));
+
+		JSONArray jsonArray =
+			AssetListTypePropertiesUtil.getTypePropertiesJSONArray(
+				new long[] {_CLASS_NAME_ID_1}, new long[] {_CLASS_TYPE_ID_1},
+				_COMPANY_ID, LocaleUtil.US);
+
+		Assert.assertEquals(jsonArray.toString(), 1, jsonArray.length());
+		Assert.assertEquals(
+			"title", jsonArray.getJSONObject(0).getString("name"));
+	}
+
+	private ObjectField _mockObjectField(
+		String name, String businessType, boolean metadata) {
+
+		ObjectField objectField = Mockito.mock(ObjectField.class);
+
+		Mockito.when(
+			objectField.getBusinessType()
+		).thenReturn(
+			businessType
+		);
+
+		Mockito.when(
+			objectField.getName()
+		).thenReturn(
+			name
+		);
+
+		Mockito.when(
+			objectField.getLabel(LocaleUtil.US, true)
+		).thenReturn(
+			name
+		);
+
+		Mockito.when(
+			objectField.isMetadata()
+		).thenReturn(
+			metadata
+		);
+
+		return objectField;
+	}
+
+	private void _stubObjectDefinition(
+		long classNameId, long objectDefinitionId,
+		List<ObjectField> objectFields) {
+
+		ObjectDefinition objectDefinition = Mockito.mock(ObjectDefinition.class);
+
+		Mockito.when(
+			objectDefinition.getObjectDefinitionId()
+		).thenReturn(
+			objectDefinitionId
+		);
+
+		_objectDefinitionLocalServiceUtilMockedStatic.when(
+			() -> ObjectDefinitionLocalServiceUtil.fetchObjectDefinition(
+				objectDefinitionId)
+		).thenReturn(
+			objectDefinition
+		);
+
+		_objectFieldLocalServiceUtilMockedStatic.when(
+			() -> ObjectFieldLocalServiceUtil.getObjectFields(
+				objectDefinitionId)
+		).thenReturn(
+			objectFields
+		);
+
+		_portalUtilMockedStatic.when(
+			() -> PortalUtil.getClassName(classNameId)
+		).thenReturn(
+			"com.liferay.test.Class" + classNameId
+		);
+	}
+
+	private static final long _CLASS_NAME_ID_1 = 30601L;
+
+	private static final long _CLASS_NAME_ID_2 = 30602L;
+
+	private static final long _CLASS_TYPE_ID_1 = 42L;
+
+	private static final long _CLASS_TYPE_ID_2 = 99L;
+
+	private static final long _COMPANY_ID = 12345L;
+
+	private static final MockedStatic<FeatureFlagManagerUtil>
+		_featureFlagManagerUtilMockedStatic = Mockito.mockStatic(
+			FeatureFlagManagerUtil.class);
+	private static final MockedStatic<ListTypeEntryLocalServiceUtil>
+		_listTypeEntryLocalServiceUtilMockedStatic = Mockito.mockStatic(
+			ListTypeEntryLocalServiceUtil.class);
+	private static final MockedStatic<ObjectDefinitionLocalServiceUtil>
+		_objectDefinitionLocalServiceUtilMockedStatic = Mockito.mockStatic(
+			ObjectDefinitionLocalServiceUtil.class);
+	private static final MockedStatic<ObjectFieldLocalServiceUtil>
+		_objectFieldLocalServiceUtilMockedStatic = Mockito.mockStatic(
+			ObjectFieldLocalServiceUtil.class);
+	private static final MockedStatic<PortalUtil> _portalUtilMockedStatic =
+		Mockito.mockStatic(PortalUtil.class);
+
+}

--- a/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
+++ b/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
@@ -72,34 +72,6 @@ public class AssetListTypePropertiesUtilTest {
 	}
 
 	@Test
-	public void testExcludesMetadataAndUnfilterableFields() {
-		_stubObjectDefinition(
-			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1,
-			Arrays.asList(
-				_mockObjectField(
-					"creator", ObjectFieldConstants.BUSINESS_TYPE_TEXT, true),
-				_mockObjectField(
-					"attachment", ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT,
-					false),
-				_mockObjectField(
-					"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT, false)));
-
-		JSONArray jsonArray =
-			AssetListTypePropertiesUtil.getTypePropertiesJSONArray(
-				new long[] {_CLASS_NAME_ID_1}, new long[] {_CLASS_TYPE_ID_1},
-				_COMPANY_ID, LocaleUtil.US);
-
-		Assert.assertEquals(jsonArray.toString(), 1, jsonArray.length());
-		Assert.assertEquals(
-			"title",
-			jsonArray.getJSONObject(
-				0
-			).getString(
-				"name"
-			));
-	}
-
-	@Test
 	public void testFeatureFlagDisabledReturnsEmptyArray() {
 		_featureFlagManagerUtilMockedStatic.when(
 			() -> FeatureFlagManagerUtil.isEnabled(
@@ -145,6 +117,41 @@ public class AssetListTypePropertiesUtilTest {
 			_CLASS_TYPE_ID_1, jsonObject.getLong("classTypeId"));
 		Assert.assertEquals("title", jsonObject.getString("name"));
 		Assert.assertEquals("text", jsonObject.getString("type"));
+	}
+
+	@Test
+	public void testIncludesMetadataFieldsAndExcludesUnfilterableFields() {
+		_stubObjectDefinition(
+			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1,
+			Arrays.asList(
+				_mockObjectField(
+					"attachment", ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT,
+					false),
+				_mockObjectField(
+					"creator", ObjectFieldConstants.BUSINESS_TYPE_TEXT, true),
+				_mockObjectField(
+					"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT, false)));
+
+		JSONArray jsonArray =
+			AssetListTypePropertiesUtil.getTypePropertiesJSONArray(
+				new long[] {_CLASS_NAME_ID_1}, new long[] {_CLASS_TYPE_ID_1},
+				_COMPANY_ID, LocaleUtil.US);
+
+		Assert.assertEquals(jsonArray.toString(), 2, jsonArray.length());
+		Assert.assertEquals(
+			"creator",
+			jsonArray.getJSONObject(
+				0
+			).getString(
+				"name"
+			));
+		Assert.assertEquals(
+			"title",
+			jsonArray.getJSONObject(
+				1
+			).getString(
+				"name"
+			));
 	}
 
 	@Test

--- a/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
+++ b/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
@@ -453,8 +453,10 @@ public class AssetListTypePropertiesUtilTest {
 		);
 
 		_objectDefinitionLocalServiceUtilMockedStatic.when(
-			() -> ObjectDefinitionLocalServiceUtil.fetchObjectDefinition(
-				objectDefinitionId)
+			() ->
+				ObjectDefinitionLocalServiceUtil.
+					fetchObjectDefinitionByClassName(
+						_COMPANY_ID, "com.liferay.test.Class" + classNameId)
 		).thenReturn(
 			objectDefinition
 		);

--- a/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
+++ b/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
@@ -17,6 +17,8 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -25,6 +27,7 @@ import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -69,6 +72,8 @@ public class AssetListTypePropertiesUtilTest {
 		).thenReturn(
 			true
 		);
+
+		_setUpLanguageUtil();
 	}
 
 	@Test
@@ -93,9 +98,9 @@ public class AssetListTypePropertiesUtilTest {
 				new long[] {_CLASS_TYPE_ID_1, _CLASS_TYPE_ID_2}, _COMPANY_ID,
 				LocaleUtil.US);
 
-		Assert.assertEquals(jsonArray.toString(), 2, jsonArray.length());
+		Assert.assertEquals(jsonArray.toString(), 3, jsonArray.length());
 
-		JSONObject groupJSONObject1 = jsonArray.getJSONObject(0);
+		JSONObject groupJSONObject1 = jsonArray.getJSONObject(1);
 
 		Assert.assertEquals(_LABEL_1, groupJSONObject1.getString("label"));
 
@@ -112,7 +117,7 @@ public class AssetListTypePropertiesUtilTest {
 			_CLASS_TYPE_ID_1, itemJSONObject1.getLong("classTypeId"));
 		Assert.assertEquals("title", itemJSONObject1.getString("name"));
 
-		JSONObject groupJSONObject2 = jsonArray.getJSONObject(1);
+		JSONObject groupJSONObject2 = jsonArray.getJSONObject(2);
 
 		Assert.assertEquals(_LABEL_2, groupJSONObject2.getString("label"));
 
@@ -153,9 +158,9 @@ public class AssetListTypePropertiesUtilTest {
 				new long[] {_CLASS_NAME_ID_1}, new long[] {_CLASS_TYPE_ID_1},
 				_COMPANY_ID, LocaleUtil.US);
 
-		Assert.assertEquals(jsonArray.toString(), 1, jsonArray.length());
+		Assert.assertEquals(jsonArray.toString(), 2, jsonArray.length());
 
-		JSONObject groupJSONObject = jsonArray.getJSONObject(0);
+		JSONObject groupJSONObject = jsonArray.getJSONObject(1);
 
 		Assert.assertEquals(_LABEL_1, groupJSONObject.getString("label"));
 
@@ -206,10 +211,10 @@ public class AssetListTypePropertiesUtilTest {
 				new long[] {_CLASS_NAME_ID_1}, new long[] {_CLASS_TYPE_ID_1},
 				_COMPANY_ID, LocaleUtil.US);
 
-		Assert.assertEquals(jsonArray.toString(), 1, jsonArray.length());
+		Assert.assertEquals(jsonArray.toString(), 2, jsonArray.length());
 
 		JSONArray itemsJSONArray = jsonArray.getJSONObject(
-			0
+			1
 		).getJSONArray(
 			"items"
 		);
@@ -245,9 +250,9 @@ public class AssetListTypePropertiesUtilTest {
 				new long[] {_CLASS_NAME_ID_1}, new long[] {_CLASS_TYPE_ID_1},
 				_COMPANY_ID, LocaleUtil.US);
 
-		Assert.assertEquals(jsonArray.toString(), 1, jsonArray.length());
+		Assert.assertEquals(jsonArray.toString(), 2, jsonArray.length());
 
-		JSONObject groupJSONObject = jsonArray.getJSONObject(0);
+		JSONObject groupJSONObject = jsonArray.getJSONObject(1);
 
 		Assert.assertEquals(_LABEL_1, groupJSONObject.getString("label"));
 
@@ -323,10 +328,10 @@ public class AssetListTypePropertiesUtilTest {
 				new long[] {_CLASS_NAME_ID_1}, new long[] {_CLASS_TYPE_ID_1},
 				_COMPANY_ID, LocaleUtil.US);
 
-		Assert.assertEquals(jsonArray.toString(), 1, jsonArray.length());
+		Assert.assertEquals(jsonArray.toString(), 2, jsonArray.length());
 
 		JSONObject itemJSONObject = jsonArray.getJSONObject(
-			0
+			1
 		).getJSONArray(
 			"items"
 		).getJSONObject(
@@ -353,6 +358,41 @@ public class AssetListTypePropertiesUtilTest {
 			).getString(
 				"value"
 			));
+	}
+
+	@Test
+	public void testReturnsOnlyCommonFieldsGroupWhenNoClassNameIds() {
+		JSONArray jsonArray =
+			AssetListTypePropertiesUtil.getTypePropertiesJSONArray(
+				new long[0], new long[0], _COMPANY_ID, LocaleUtil.US);
+
+		Assert.assertEquals(jsonArray.toString(), 1, jsonArray.length());
+
+		JSONObject groupJSONObject = jsonArray.getJSONObject(0);
+
+		Assert.assertEquals(
+			"common-fields", groupJSONObject.getString("label"));
+
+		JSONArray itemsJSONArray = groupJSONObject.getJSONArray("items");
+
+		Assert.assertEquals(
+			itemsJSONArray.toString(), 10, itemsJSONArray.length());
+
+		String[] expectedNames = {
+			"title", "description", "userName", "createDate", "modified",
+			"displayDate", "publishDate", "expirationDate", "priority",
+			"viewCount"
+		};
+
+		for (int i = 0; i < expectedNames.length; i++) {
+			Assert.assertEquals(
+				expectedNames[i],
+				itemsJSONArray.getJSONObject(
+					i
+				).getString(
+					"name"
+				));
+		}
 	}
 
 	private static MockedStatic<FeatureFlagManagerUtil>
@@ -395,6 +435,20 @@ public class AssetListTypePropertiesUtilTest {
 		);
 
 		return objectField;
+	}
+
+	private void _setUpLanguageUtil() {
+		LanguageUtil languageUtil = new LanguageUtil();
+
+		Language language = Mockito.mock(Language.class);
+
+		Mockito.when(
+			language.get(Mockito.any(Locale.class), Mockito.anyString())
+		).thenAnswer(
+			invocation -> invocation.getArgument(1)
+		);
+
+		languageUtil.setLanguage(language);
 	}
 
 	private void _stubObjectDefinition(

--- a/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
+++ b/modules/apps/asset/asset-list-web/src/test/java/com/liferay/asset/list/web/internal/util/AssetListTypePropertiesUtilTest.java
@@ -208,29 +208,6 @@ public class AssetListTypePropertiesUtilTest {
 	}
 
 	@Test
-	public void testFeatureFlagDisabledReturnsEmptyArray() {
-		_featureFlagManagerUtilMockedStatic.when(
-			() -> FeatureFlagManagerUtil.isEnabled(
-				Mockito.anyLong(), Mockito.eq("LPD-74731"))
-		).thenReturn(
-			false
-		);
-
-		_stubObjectDefinition(
-			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1, _LABEL_1,
-			Collections.singletonList(
-				_mockObjectField(
-					"title", ObjectFieldConstants.BUSINESS_TYPE_TEXT, false)));
-
-		JSONArray jsonArray =
-			AssetListTypePropertiesUtil.getTypePropertiesJSONArray(
-				new long[] {_CLASS_NAME_ID_1}, new long[] {_CLASS_TYPE_ID_1},
-				_COMPANY_ID, LocaleUtil.US);
-
-		Assert.assertEquals(jsonArray.toString(), 0, jsonArray.length());
-	}
-
-	@Test
 	public void testIncludesOneTypeGroup() {
 		_stubObjectDefinition(
 			_CLASS_NAME_ID_1, _CLASS_TYPE_ID_1, _LABEL_1,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88614

## What Is Being Fixed

The asset list (collection) filter UI needs the set of properties a user can filter on for the selected asset types, but no endpoint supplied them. Without a typed, grouped property list the front end cannot render filter controls for object-definition fields or for the fields common to every asset type.

## How It Is Being Fixed

A new `/asset_list/get_type_properties` MVC resource command returns a JSON array of property groups for the requested class name IDs and class type IDs. The new AssetListTypePropertiesUtil builds the response: a leading "Common Fields" group (author name, created, display, expiration and review dates, status, and external reference code) followed by one group per selected type holding that object definition's fields. Object definitions are resolved by class name, fields are rendered only for a selected type, metadata fields are excluded from the type groups, and each property carries a filter type derived from its object field business type. The endpoint is gated behind the LPD-74731 feature flag.

On the service side, AssetListFiltersUtil and AssetListAssetEntryProviderImpl construct nested-field queries from the collection typeSettings filters so the populated properties drive asset retrieval, covered by a new integration test.

## PR Check

**pr-check: PASS** — tested on `0c50b6a242a915fc9bcd4a0707bc95b0f32fa7e4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "0c50b6a242a915fc9bcd4a0707bc95b0f32fa7e4"} -->

Manually forwarded from here: https://github.com/liferay-search/liferay-portal/pull/1958 sf failure is not related