### PR TITLE
LPD-93390 Log deprecated widget pages at INFO instead of WARN

### DIFF
--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
@@ -368,7 +368,7 @@ public class BundleSiteInitializerTest {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				"com.liferay.site.initializer.extender.internal." +
 					"BundleSiteInitializer",
-				LoggerTestUtil.WARN)) {
+				LoggerTestUtil.INFO)) {
 
 			_test1(
 				_siteInitializerRegistry.getSiteInitializer(
@@ -401,7 +401,7 @@ public class BundleSiteInitializerTest {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				"com.liferay.site.initializer.extender.internal." +
 					"BundleSiteInitializer",
-				LoggerTestUtil.WARN)) {
+				LoggerTestUtil.INFO)) {
 
 			SiteInitializer siteInitializer =
 				_siteInitializerRegistry.getSiteInitializer(
@@ -450,11 +450,7 @@ public class BundleSiteInitializerTest {
 		File tempDir2 = _getTempDir(
 			"/com.liferay.site.initializer.extender.test.bundle.2.jar");
 
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.site.initializer.extender.internal." +
-					"BundleSiteInitializer",
-				LoggerTestUtil.WARN)) {
-
+		try {
 			_test1(
 				_siteInitializerFactory.create(
 					new File(tempDir1, "site-initializer"), null));
@@ -476,11 +472,7 @@ public class BundleSiteInitializerTest {
 		File tempDir1 = _getTempDir(
 			"/com.liferay.site.initializer.extender.test.bundle.1.jar");
 
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.site.initializer.extender.internal." +
-					"BundleSiteInitializer",
-				LoggerTestUtil.WARN)) {
-
+		try {
 			SiteInitializer siteInitializer = _siteInitializerFactory.create(
 				new File(tempDir1, "site-initializer"), null);
 

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -2791,8 +2791,8 @@ public class BundleSiteInitializer implements SiteInitializer {
 			if (!FeatureFlagManagerUtil.isEnabled(
 					serviceContext.getCompanyId(), "LPD-76864")) {
 
-				if (_log.isWarnEnabled()) {
-					_log.warn(
+				if (_log.isInfoEnabled()) {
+					_log.info(
 						StringBundler.concat(
 							"Skipping page with friendly URL ",
 							pageJSONObject.getString("friendlyURL"),
@@ -2803,8 +2803,8 @@ public class BundleSiteInitializer implements SiteInitializer {
 				return Collections.emptyMap();
 			}
 
-			if (_log.isWarnEnabled()) {
-				_log.warn(
+			if (_log.isInfoEnabled()) {
+				_log.info(
 					"Widget page with friendly URL " +
 						pageJSONObject.getString("friendlyURL") +
 							" is deprecated");


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93390

## What Is Being Fixed

PortalLogAssertorTest#testScanXMLLog fails on the stable build because BundleSiteInitializer logs widget page deprecation notices at WARN. They fire during routine site-initializer provisioning of a widget page (the test bundle's fixture), and PortalLogAssertorTest fails on any WARN left in the portal log.

## How It Is Being Fixed

Both deprecation notices in BundleSiteInitializer — the flag-enabled "is deprecated" notice and the flag-disabled "Skipping" notice — are now logged at INFO. Neither represents a fault: under the LPD-76864 flag the page is either preserved (upgraded installs) or skipped per policy (new installs), so INFO is the appropriate level and keeps the advisory without tripping the log assertor. The BundleSiteInitializer tests are updated to match: the two tests that assert the notice capture at INFO, and the two that only needed suppression no longer capture the log at all.

## PR Check

**pr-check: SKIPPED** — Branch is based on master-brian, not master, so pr-check's master-diff baseline does not apply; verified by running BundleSiteInitializerTest live against a clean bundle (4/4 passed, both deprecation notices logged at INFO, no WARN left in the portal log).

<!-- pr-check {"reason": "Branch is based on master-brian, not master, so pr-check's master-diff baseline does not apply; verified by running BundleSiteInitializerTest live against a clean bundle (4/4 passed, both deprecation notices logged at INFO, no WARN left in the portal log).", "result": "skipped", "sha": "c5a623f722e27fb0c9433f71e0b6716c4740a741"} -->