### PR TITLE
LPD-93618 LPD-93792 Fix audiences cookie decoding and handler cleanup

### DIFF
--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/detection/attributes/cookies.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/detection/attributes/cookies.ts
@@ -11,5 +11,16 @@ export function getCookies(): Set<string> {
 		return new Set();
 	}
 
-	return new Set(document.cookie.split(';').map((item) => item.trim()));
+	return new Set(
+		document.cookie.split(';').map((item) => {
+			const trimmedItem = item.trim();
+
+			try {
+				return decodeURIComponent(trimmedItem);
+			}
+			catch (_) {
+				return trimmedItem;
+			}
+		})
+	);
 }

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/implementation.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/implementation.ts
@@ -142,6 +142,10 @@ export async function runHandlers(): Promise<void> {
 			}
 		}
 	}
+
+	for (const key of Object.keys(handlers)) {
+		delete handlers[key];
+	}
 }
 
 export function setLogEnabled(enabled: boolean) {

--- a/modules/apps/frontend-js/frontend-js-audiences-web/test/attributes.test.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/test/attributes.test.ts
@@ -90,13 +90,48 @@ describe('attributes', () => {
 		expect(value).toBe('151.0');
 	});
 
-	it('attribute cookies works and returns a Set<string>', async () => {
-		const value = getCookies();
+	describe('attribute cookies', () => {
+		it('works and returns a Set<string>', async () => {
+			const value = getCookies();
 
-		expect(value).toBeInstanceOf(Set);
-		expect(value).toEqual(
-			new Set(['REMEMBER_ME=true', 'JSESSIONID=ba8e4d1c'])
-		);
+			expect(value).toBeInstanceOf(Set);
+			expect(value).toEqual(
+				new Set(['REMEMBER_ME=true', 'JSESSIONID=ba8e4d1c'])
+			);
+		});
+
+		it('decodes percent-encoded cookies', async () => {
+			Object.defineProperty(document, 'cookie', {
+				configurable: true,
+				value: 'greeting=hello%20world; city=S%C3%A3o%20Paulo',
+			});
+
+			expect(getCookies()).toEqual(
+				new Set(['greeting=hello world', 'city=São Paulo'])
+			);
+		});
+
+		it('passes cookies that are not encoded unchanged', async () => {
+			Object.defineProperty(document, 'cookie', {
+				configurable: true,
+				value: 'REMEMBER_ME=true; JSESSIONID=ba8e4d1c',
+			});
+
+			expect(getCookies()).toEqual(
+				new Set(['REMEMBER_ME=true', 'JSESSIONID=ba8e4d1c'])
+			);
+		});
+
+		it('passes cookies that are badly encoded unchanged', async () => {
+			Object.defineProperty(document, 'cookie', {
+				configurable: true,
+				value: 'discount=50%; valid=a%20b',
+			});
+
+			expect(getCookies()).toEqual(
+				new Set(['discount=50%', 'valid=a b'])
+			);
+		});
 	});
 
 	it('attribute hostname works and returns a string', async () => {

--- a/modules/apps/frontend-js/frontend-js-audiences-web/test/implementation.test.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/test/implementation.test.ts
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import * as audiences from '../src/main/resources/META-INF/resources/implementation';
+import {store} from '../src/main/resources/META-INF/resources/store';
+
+describe('implementation', () => {
+	afterEach(async () => {
+		store.clear();
+	});
+
+	describe('runHandlers', () => {
+		it('runs the handlers in the order they were registered and only once', async () => {
+			const executionOrder: string[] = [];
+
+			const audienceIds = ['a', 'b', 'c', 'd', 'e'];
+
+			// Store audiences in reverse order so that we really test the registration is honored
+
+			store.setPageAudienceIds(new Set(audienceIds.reverse()));
+
+			for (const audienceId of audienceIds) {
+				audiences.on(audienceId, () => {
+					executionOrder.push(audienceId);
+				});
+			}
+
+			await audiences.runHandlers();
+
+			expect(executionOrder).toEqual(audienceIds);
+			expect(executionOrder).toHaveLength(audienceIds.length);
+		});
+
+		it('clears the registered handlers after running', async () => {
+			let runCount = 0;
+
+			store.setPageAudienceIds(new Set(['a']));
+
+			audiences.on('a', () => {
+				runCount += 1;
+			});
+
+			await audiences.runHandlers();
+
+			expect(runCount).toBe(1);
+
+			// The handler was cleared, so a second run does not invoke it again
+
+			await audiences.runHandlers();
+
+			expect(runCount).toBe(1);
+		});
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93618
https://liferay.atlassian.net/browse/LPD-93792

## What Is Being Fixed

In `frontend-js-audiences-web`, `getCookies()` returned each cookie entry verbatim, so URL-encoded cookie values were never decoded and attribute matching against cookie content failed whenever the value contained percent-encoded characters.

Separately, `runHandlers()` left the personalization handlers registered after running them. Across repeated `runHandlers()` calls the handlers accumulated, so previously registered handlers executed again on every subsequent run.

## How It Is Being Fixed

`getCookies()` now decodes each trimmed cookie entry with `decodeURIComponent`, falling back to the raw value when decoding throws on malformed input.

`runHandlers()` now deletes every entry from the handlers map once it finishes processing, so each invocation starts from a clean set and handlers no longer persist across runs.

Both changes ship with unit tests: `attributes.test.ts` covers cookie decoding and `implementation.test.ts` covers handler cleanup.

## PR Check

**pr-check: PASS** — tested on `03c311072ccd739c657e53549ee70376273b3969`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "03c311072ccd739c657e53549ee70376273b3969"} -->