### PR TITLE
LPD-89991 Force predictable operation IDs for mcp-server-rest

### DIFF
--- a/.claude/rules/rest-builder.md
+++ b/.claude/rules/rest-builder.md
@@ -100,6 +100,7 @@ application:
 author: "<Your Name>"
 clientDir: "../<name>-rest-client/src/main/java"
 compatibilityVersion: 15
+forcePredictableOperationId: true
 javaEEPackage: "jakarta"
 testDir: "../<name>-rest-test/src/testIntegration/java"
 ```

--- a/modules/apps/mcp/mcp-server-rest-api/src/main/java/com/liferay/mcp/server/rest/resource/v1_0/ToolResource.java
+++ b/modules/apps/mcp/mcp-server-rest-api/src/main/java/com/liferay/mcp/server/rest/resource/v1_0/ToolResource.java
@@ -42,9 +42,10 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface ToolResource {
 
-	public Tool getTool(String toolSetName, String toolName) throws Exception;
+	public Tool getToolSetToolSetNameTool(String toolSetName, String toolName)
+		throws Exception;
 
-	public Response invokeToolObject(
+	public Response postToolSetToolSetNameToolInvokeObject(
 			String toolSetName, String toolName, Object object)
 		throws Exception;
 
@@ -136,4 +137,4 @@ public interface ToolResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1506309239
+// LIFERAY-REST-BUILDER-HASH:-2034767775

--- a/modules/apps/mcp/mcp-server-rest-api/src/main/java/com/liferay/mcp/server/rest/resource/v1_0/ToolSetResource.java
+++ b/modules/apps/mcp/mcp-server-rest-api/src/main/java/com/liferay/mcp/server/rest/resource/v1_0/ToolSetResource.java
@@ -42,7 +42,7 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface ToolSetResource {
 
-	public Page<ToolSet> getToolSets() throws Exception;
+	public Page<ToolSet> getToolSetsPage() throws Exception;
 
 	public default void setContextAcceptLanguage(
 		AcceptLanguage contextAcceptLanguage) {
@@ -132,4 +132,4 @@ public interface ToolSetResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1706257410
+// LIFERAY-REST-BUILDER-HASH:1121132273

--- a/modules/apps/mcp/mcp-server-rest-api/src/main/java/com/liferay/mcp/server/rest/resource/v1_0/ToolSummaryResource.java
+++ b/modules/apps/mcp/mcp-server-rest-api/src/main/java/com/liferay/mcp/server/rest/resource/v1_0/ToolSummaryResource.java
@@ -42,7 +42,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface ToolSummaryResource {
 
-	public Page<ToolSummary> getToolSummaries(String toolSetName)
+	public Page<ToolSummary> getToolSetToolSetNameToolSummariesPage(
+			String toolSetName)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(
@@ -133,4 +134,4 @@ public interface ToolSummaryResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1178464445
+// LIFERAY-REST-BUILDER-HASH:1341799841

--- a/modules/apps/mcp/mcp-server-rest-client/src/main/java/com/liferay/mcp/server/rest/client/resource/v1_0/ToolResource.java
+++ b/modules/apps/mcp/mcp-server-rest-client/src/main/java/com/liferay/mcp/server/rest/client/resource/v1_0/ToolResource.java
@@ -32,17 +32,20 @@ public interface ToolResource {
 		return new Builder();
 	}
 
-	public Tool getTool(String toolSetName, String toolName) throws Exception;
+	public Tool getToolSetToolSetNameTool(String toolSetName, String toolName)
+		throws Exception;
 
-	public HttpInvoker.HttpResponse getToolHttpResponse(
+	public HttpInvoker.HttpResponse getToolSetToolSetNameToolHttpResponse(
 			String toolSetName, String toolName)
 		throws Exception;
 
-	public void invokeTool(String toolSetName, String toolName, Object object)
+	public void postToolSetToolSetNameToolInvoke(
+			String toolSetName, String toolName, Object object)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse invokeToolHttpResponse(
-			String toolSetName, String toolName, Object object)
+	public HttpInvoker.HttpResponse
+			postToolSetToolSetNameToolInvokeHttpResponse(
+				String toolSetName, String toolName, Object object)
 		throws Exception;
 
 	public static class Builder {
@@ -153,11 +156,12 @@ public interface ToolResource {
 
 	public static class ToolResourceImpl implements ToolResource {
 
-		public Tool getTool(String toolSetName, String toolName)
+		public Tool getToolSetToolSetNameTool(
+				String toolSetName, String toolName)
 			throws Exception {
 
-			HttpInvoker.HttpResponse httpResponse = getToolHttpResponse(
-				toolSetName, toolName);
+			HttpInvoker.HttpResponse httpResponse =
+				getToolSetToolSetNameToolHttpResponse(toolSetName, toolName);
 
 			String content = httpResponse.getContent();
 
@@ -218,7 +222,7 @@ public interface ToolResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse getToolHttpResponse(
+		public HttpInvoker.HttpResponse getToolSetToolSetNameToolHttpResponse(
 				String toolSetName, String toolName)
 			throws Exception {
 
@@ -259,12 +263,13 @@ public interface ToolResource {
 			return httpInvoker.invoke();
 		}
 
-		public void invokeTool(
+		public void postToolSetToolSetNameToolInvoke(
 				String toolSetName, String toolName, Object object)
 			throws Exception {
 
-			HttpInvoker.HttpResponse httpResponse = invokeToolHttpResponse(
-				toolSetName, toolName, object);
+			HttpInvoker.HttpResponse httpResponse =
+				postToolSetToolSetNameToolInvokeHttpResponse(
+					toolSetName, toolName, object);
 
 			String content = httpResponse.getContent();
 
@@ -314,8 +319,9 @@ public interface ToolResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse invokeToolHttpResponse(
-				String toolSetName, String toolName, Object object)
+		public HttpInvoker.HttpResponse
+				postToolSetToolSetNameToolInvokeHttpResponse(
+					String toolSetName, String toolName, Object object)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -369,4 +375,4 @@ public interface ToolResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2081359495
+// LIFERAY-REST-BUILDER-HASH:1170961807

--- a/modules/apps/mcp/mcp-server-rest-client/src/main/java/com/liferay/mcp/server/rest/client/resource/v1_0/ToolSetResource.java
+++ b/modules/apps/mcp/mcp-server-rest-client/src/main/java/com/liferay/mcp/server/rest/client/resource/v1_0/ToolSetResource.java
@@ -33,9 +33,10 @@ public interface ToolSetResource {
 		return new Builder();
 	}
 
-	public Page<ToolSet> getToolSets() throws Exception;
+	public Page<ToolSet> getToolSetsPage() throws Exception;
 
-	public HttpInvoker.HttpResponse getToolSetsHttpResponse() throws Exception;
+	public HttpInvoker.HttpResponse getToolSetsPageHttpResponse()
+		throws Exception;
 
 	public static class Builder {
 
@@ -145,8 +146,9 @@ public interface ToolSetResource {
 
 	public static class ToolSetResourceImpl implements ToolSetResource {
 
-		public Page<ToolSet> getToolSets() throws Exception {
-			HttpInvoker.HttpResponse httpResponse = getToolSetsHttpResponse();
+		public Page<ToolSet> getToolSetsPage() throws Exception {
+			HttpInvoker.HttpResponse httpResponse =
+				getToolSetsPageHttpResponse();
 
 			String content = httpResponse.getContent();
 
@@ -207,7 +209,7 @@ public interface ToolSetResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse getToolSetsHttpResponse()
+		public HttpInvoker.HttpResponse getToolSetsPageHttpResponse()
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -256,4 +258,4 @@ public interface ToolSetResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:62739855
+// LIFERAY-REST-BUILDER-HASH:1784794432

--- a/modules/apps/mcp/mcp-server-rest-client/src/main/java/com/liferay/mcp/server/rest/client/resource/v1_0/ToolSummaryResource.java
+++ b/modules/apps/mcp/mcp-server-rest-client/src/main/java/com/liferay/mcp/server/rest/client/resource/v1_0/ToolSummaryResource.java
@@ -33,11 +33,13 @@ public interface ToolSummaryResource {
 		return new Builder();
 	}
 
-	public Page<ToolSummary> getToolSummaries(String toolSetName)
+	public Page<ToolSummary> getToolSetToolSetNameToolSummariesPage(
+			String toolSetName)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse getToolSummariesHttpResponse(
-			String toolSetName)
+	public HttpInvoker.HttpResponse
+			getToolSetToolSetNameToolSummariesPageHttpResponse(
+				String toolSetName)
 		throws Exception;
 
 	public static class Builder {
@@ -148,11 +150,12 @@ public interface ToolSummaryResource {
 
 	public static class ToolSummaryResourceImpl implements ToolSummaryResource {
 
-		public Page<ToolSummary> getToolSummaries(String toolSetName)
+		public Page<ToolSummary> getToolSetToolSetNameToolSummariesPage(
+				String toolSetName)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getToolSummariesHttpResponse(toolSetName);
+				getToolSetToolSetNameToolSummariesPageHttpResponse(toolSetName);
 
 			String content = httpResponse.getContent();
 
@@ -213,8 +216,9 @@ public interface ToolSummaryResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse getToolSummariesHttpResponse(
-				String toolSetName)
+		public HttpInvoker.HttpResponse
+				getToolSetToolSetNameToolSummariesPageHttpResponse(
+					String toolSetName)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -265,4 +269,4 @@ public interface ToolSummaryResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1770733473
+// LIFERAY-REST-BUILDER-HASH:1762417275

--- a/modules/apps/mcp/mcp-server-rest-impl/build.gradle
+++ b/modules/apps/mcp/mcp-server-rest-impl/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 	compileInclude group: "io.modelcontextprotocol.sdk", name: "mcp-json-jackson2", version: "1.0.1"
 	compileInclude group: "io.projectreactor", name: "reactor-core", version: "3.6.5"
 	compileInclude group: "org.yaml", name: "snakeyaml", version: "2.3"
+	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.18.6"
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.18.6"
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.18.6"
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"

--- a/modules/apps/mcp/mcp-server-rest-impl/rest-config.yaml
+++ b/modules/apps/mcp/mcp-server-rest-impl/rest-config.yaml
@@ -7,6 +7,7 @@ application:
 author: Alejandro Tardín
 clientDir: ../mcp-server-rest-client/src/main/java
 compatibilityVersion: 15
+forcePredictableOperationId: true
 generateBatch: false
 generateGraphQL: false
 javaEEPackage: jakarta

--- a/modules/apps/mcp/mcp-server-rest-impl/rest-openapi.yaml
+++ b/modules/apps/mcp/mcp-server-rest-impl/rest-openapi.yaml
@@ -52,7 +52,7 @@ components:
             type: object
 info:
     description:
-        "Single entry point for an AI to discover, understand, and invoke any tool exposed by Liferay. When the user asks for something you do not already know how to do in Liferay, start with `getToolSets` to find a tool-set matching their intent, then `getToolSummaries` to find the right tool in it, then `getTool` to fetch the tool's input schema, then `invokeTool` with an input map matching that schema to execute it. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.mcp.server.rest.client', and version '1.0.2'."
+        "Single entry point for an AI to discover, understand, and invoke any tool exposed by Liferay. When the user asks for something you do not already know how to do in Liferay, start with `getToolSetsPage` to find a tool-set matching their intent, then `getToolSetToolSetNameToolSummariesPage` to find the right tool in it, then `getToolSetToolSetNameTool` to fetch the tool's input schema, then `postToolSetToolSetNameToolInvoke` with an input map matching that schema to execute it. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.mcp.server.rest.client', and version '1.0.2'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html
@@ -63,8 +63,8 @@ paths:
     "/tool-sets":
         get:
             description:
-                Use this whenever you do not know which tool-set can fulfill the user's request — it is the first thing to try. Returns every tool-set exposed by Liferay, each with a curated description. Pick the tool-set whose description matches the user's intent and pass its `name` to `getToolSummaries` to see what tools it offers.
-            operationId: getToolSets
+                Use this whenever you do not know which tool-set can fulfill the user's request — it is the first thing to try. Returns every tool-set exposed by Liferay, each with a curated description. Pick the tool-set whose description matches the user's intent and pass its `name` to `getToolSetToolSetNameToolSummariesPage` to see what tools it offers.
+            operationId: getToolSetsPage
             responses:
                 200:
                     content:
@@ -84,12 +84,12 @@ paths:
     "/tool-sets/{toolSetName}/tool-summaries":
         get:
             description:
-                Use this once you have identified a tool-set (via `getToolSets`) and need to find which of its tools matches the user's request. Returns every tool in the tool-set, each with a `name` and a description. Pick the tool whose description matches the user's intent and pass its `name` to `getTool` to see its input schema.
-            operationId: getToolSummaries
+                Use this once you have identified a tool-set (via `getToolSetsPage`) and need to find which of its tools matches the user's request. Returns every tool in the tool-set, each with a `name` and a description. Pick the tool whose description matches the user's intent and pass its `name` to `getToolSetToolSetNameTool` to see its input schema.
+            operationId: getToolSetToolSetNameToolSummariesPage
             parameters:
                 -   in: path
                     description:
-                        The tool-set name returned by `getToolSets`.
+                        The tool-set name returned by `getToolSetsPage`.
                     name: toolSetName
                     required: true
                     schema:
@@ -113,19 +113,19 @@ paths:
     "/tool-sets/{toolSetName}/tools/{toolName}":
         get:
             description:
-                Use this once you have identified a tool (via `getToolSummaries`) and need its input schema before invoking it. Returns the tool's `inputSchema`. Build an input map matching `inputSchema` and POST it to `invoke` under the same URL to execute the tool.
-            operationId: getTool
+                Use this once you have identified a tool (via `getToolSetToolSetNameToolSummariesPage`) and need its input schema before invoking it. Returns the tool's `inputSchema`. Build an input map matching `inputSchema` and POST it to `invoke` under the same URL to execute the tool.
+            operationId: getToolSetToolSetNameTool
             parameters:
                 -   in: path
                     description:
-                        The tool-set name returned by `getToolSets`.
+                        The tool-set name returned by `getToolSetsPage`.
                     name: toolSetName
                     required: true
                     schema:
                         type: string
                 -   in: path
                     description:
-                        The tool name returned by `getToolSummaries`.
+                        The tool name returned by `getToolSetToolSetNameToolSummariesPage`.
                     name: toolName
                     required: true
                     schema:
@@ -145,19 +145,19 @@ paths:
     "/tool-sets/{toolSetName}/tools/{toolName}/invoke":
         post:
             description:
-                Invokes a tool. ALWAYS call `getTool` first to fetch the tool's `inputSchema`, then build the request `body` to match it exactly. Skipping `getTool` leads to malformed input and avoidable failures. Returns the tool's response body unchanged.
-            operationId: invokeTool
+                Invokes a tool. ALWAYS call `getToolSetToolSetNameTool` first to fetch the tool's `inputSchema`, then build the request `body` to match it exactly. Skipping `getToolSetToolSetNameTool` leads to malformed input and avoidable failures. Returns the tool's response body unchanged.
+            operationId: postToolSetToolSetNameToolInvoke
             parameters:
                 -   in: path
                     description:
-                        The tool-set name returned by `getToolSets`.
+                        The tool-set name returned by `getToolSetsPage`.
                     name: toolSetName
                     required: true
                     schema:
                         type: string
                 -   in: path
                     description:
-                        The tool name returned by `getToolSummaries`.
+                        The tool name returned by `getToolSetToolSetNameToolSummariesPage`.
                     name: toolName
                     required: true
                     schema:

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/BaseToolResourceImpl.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/BaseToolResourceImpl.java
@@ -48,7 +48,7 @@ public abstract class BaseToolResourceImpl implements ToolResource {
 	 * curl -X 'GET' 'http://localhost:8080/o/mcp-server/v1.0/tool-sets/{toolSetName}/tools/{toolName}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
-		description = "Use this once you have identified a tool (via `getToolSummaries`) and need its input schema before invoking it. Returns the tool's `inputSchema`. Build an input map matching `inputSchema` and POST it to `invoke` under the same URL to execute the tool."
+		description = "Use this once you have identified a tool (via `getToolSetToolSetNameToolSummariesPage`) and need its input schema before invoking it. Returns the tool's `inputSchema`. Build an input map matching `inputSchema` and POST it to `invoke` under the same URL to execute the tool."
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -69,7 +69,7 @@ public abstract class BaseToolResourceImpl implements ToolResource {
 	@jakarta.ws.rs.Path("/tool-sets/{toolSetName}/tools/{toolName}")
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Tool getTool(
+	public Tool getToolSetToolSetNameTool(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("toolSetName")
@@ -89,8 +89,8 @@ public abstract class BaseToolResourceImpl implements ToolResource {
 	 * curl -X 'POST' 'http://localhost:8080/o/mcp-server/v1.0/tool-sets/{toolSetName}/tools/{toolName}/invoke'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
-		description = "Invokes a tool. ALWAYS call `getTool` first to fetch the tool's `inputSchema`, then build the request `body` to match it exactly. Skipping `getTool` leads to malformed input and avoidable failures. Returns the tool's response body unchanged.",
-		operationId = "invokeTool"
+		description = "Invokes a tool. ALWAYS call `getToolSetToolSetNameTool` first to fetch the tool's `inputSchema`, then build the request `body` to match it exactly. Skipping `getToolSetToolSetNameTool` leads to malformed input and avoidable failures. Returns the tool's response body unchanged.",
+		operationId = "postToolSetToolSetNameToolInvoke"
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -112,7 +112,7 @@ public abstract class BaseToolResourceImpl implements ToolResource {
 	@jakarta.ws.rs.POST
 	@jakarta.ws.rs.Produces("text/plain")
 	@Override
-	public Response invokeToolObject(
+	public Response postToolSetToolSetNameToolInvokeObject(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("toolSetName")
@@ -574,4 +574,4 @@ public abstract class BaseToolResourceImpl implements ToolResource {
 		LogFactoryUtil.getLog(BaseToolResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:341248448
+// LIFERAY-REST-BUILDER-HASH:-761566587

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/BaseToolSetResourceImpl.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/BaseToolSetResourceImpl.java
@@ -49,7 +49,7 @@ public abstract class BaseToolSetResourceImpl implements ToolSetResource {
 	 * curl -X 'GET' 'http://localhost:8080/o/mcp-server/v1.0/tool-sets'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
-		description = "Use this whenever you do not know which tool-set can fulfill the user's request — it is the first thing to try. Returns every tool-set exposed by Liferay, each with a curated description. Pick the tool-set whose description matches the user's intent and pass its `name` to `getToolSummaries` to see what tools it offers."
+		description = "Use this whenever you do not know which tool-set can fulfill the user's request — it is the first thing to try. Returns every tool-set exposed by Liferay, each with a curated description. Pick the tool-set whose description matches the user's intent and pass its `name` to `getToolSetToolSetNameToolSummariesPage` to see what tools it offers."
 	)
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "ToolSet")}
@@ -58,7 +58,7 @@ public abstract class BaseToolSetResourceImpl implements ToolSetResource {
 	@jakarta.ws.rs.Path("/tool-sets")
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<ToolSet> getToolSets() throws Exception {
+	public Page<ToolSet> getToolSetsPage() throws Exception {
 		return Page.of(Collections.emptyList());
 	}
 
@@ -507,4 +507,4 @@ public abstract class BaseToolSetResourceImpl implements ToolSetResource {
 		LogFactoryUtil.getLog(BaseToolSetResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:1633378965
+// LIFERAY-REST-BUILDER-HASH:-1998184160

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/BaseToolSummaryResourceImpl.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/BaseToolSummaryResourceImpl.java
@@ -50,7 +50,7 @@ public abstract class BaseToolSummaryResourceImpl
 	 * curl -X 'GET' 'http://localhost:8080/o/mcp-server/v1.0/tool-sets/{toolSetName}/tool-summaries'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
-		description = "Use this once you have identified a tool-set (via `getToolSets`) and need to find which of its tools matches the user's request. Returns every tool in the tool-set, each with a `name` and a description. Pick the tool whose description matches the user's intent and pass its `name` to `getTool` to see its input schema."
+		description = "Use this once you have identified a tool-set (via `getToolSetsPage`) and need to find which of its tools matches the user's request. Returns every tool in the tool-set, each with a `name` and a description. Pick the tool whose description matches the user's intent and pass its `name` to `getToolSetToolSetNameTool` to see its input schema."
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -67,7 +67,7 @@ public abstract class BaseToolSummaryResourceImpl
 	@jakarta.ws.rs.Path("/tool-sets/{toolSetName}/tool-summaries")
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<ToolSummary> getToolSummaries(
+	public Page<ToolSummary> getToolSetToolSetNameToolSummariesPage(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("toolSetName")
@@ -522,4 +522,4 @@ public abstract class BaseToolSummaryResourceImpl
 		LogFactoryUtil.getLog(BaseToolSummaryResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1545639353
+// LIFERAY-REST-BUILDER-HASH:-515175279

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Single entry point for an AI to discover, understand, and invoke any tool exposed by Liferay. When the user asks for something you do not already know how to do in Liferay, start with `getToolSets` to find a tool-set matching their intent, then `getToolSummaries` to find the right tool in it, then `getTool` to fetch the tool's input schema, then `invokeTool` with an input map matching that schema to execute it. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.mcp.server.rest.client', and version '1.0.2'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "MCP", version = "v1.0")
+	info = @Info(description = "Single entry point for an AI to discover, understand, and invoke any tool exposed by Liferay. When the user asks for something you do not already know how to do in Liferay, start with `getToolSetsPage` to find a tool-set matching their intent, then `getToolSetToolSetNameToolSummariesPage` to find the right tool in it, then `getToolSetToolSetNameTool` to fetch the tool's input schema, then `postToolSetToolSetNameToolInvoke` with an input map matching that schema to execute it. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.mcp.server.rest.client', and version '1.0.2'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "MCP", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {
@@ -96,4 +96,4 @@ public class OpenAPIResourceImpl {
 	};
 
 }
-// LIFERAY-REST-BUILDER-HASH:957208096
+// LIFERAY-REST-BUILDER-HASH:-1009237629

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/ToolResourceImpl.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/ToolResourceImpl.java
@@ -25,7 +25,7 @@ import org.osgi.service.component.annotations.ServiceScope;
 public class ToolResourceImpl extends BaseToolResourceImpl {
 
 	@Override
-	public Tool getTool(String toolSetName, String toolName) {
+	public Tool getToolSetToolSetNameTool(String toolSetName, String toolName) {
 		if (!FeatureFlagManagerUtil.isEnabled(
 				contextCompany.getCompanyId(), "LPD-63311")) {
 
@@ -37,7 +37,7 @@ public class ToolResourceImpl extends BaseToolResourceImpl {
 	}
 
 	@Override
-	public Response invokeToolObject(
+	public Response postToolSetToolSetNameToolInvokeObject(
 			String toolSetName, String toolName, Object object)
 		throws Exception {
 

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/ToolSetResourceImpl.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/ToolSetResourceImpl.java
@@ -24,7 +24,7 @@ import org.osgi.service.component.annotations.ServiceScope;
 public class ToolSetResourceImpl extends BaseToolSetResourceImpl {
 
 	@Override
-	public Page<ToolSet> getToolSets() {
+	public Page<ToolSet> getToolSetsPage() {
 		if (!FeatureFlagManagerUtil.isEnabled(
 				contextCompany.getCompanyId(), "LPD-63311")) {
 

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/ToolSummaryResourceImpl.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/ToolSummaryResourceImpl.java
@@ -24,7 +24,8 @@ import org.osgi.service.component.annotations.ServiceScope;
 public class ToolSummaryResourceImpl extends BaseToolSummaryResourceImpl {
 
 	@Override
-	public Page<ToolSummary> getToolSummaries(String toolSetName)
+	public Page<ToolSummary> getToolSetToolSetNameToolSummariesPage(
+			String toolSetName)
 		throws Exception {
 
 		if (!FeatureFlagManagerUtil.isEnabled(

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/ToolSetUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/ToolSetUtil.java
@@ -118,7 +118,7 @@ public class ToolSetUtil {
 		}
 
 		if (Objects.equals(toolSetName, "mcp-server-v1.0")) {
-			if (Objects.equals(toolName, "getTool")) {
+			if (Objects.equals(toolName, "getToolSetToolSetNameTool")) {
 				return _getResponse(
 					getTool(
 						httpServletRequest,
@@ -126,18 +126,20 @@ public class ToolSetUtil {
 						inputJSONObject.getString("toolSetName")));
 			}
 
-			if (Objects.equals(toolName, "getToolSets")) {
+			if (Objects.equals(toolName, "getToolSetsPage")) {
 				return _getResponse(getToolSetsPage());
 			}
 
-			if (Objects.equals(toolName, "getToolSummaries")) {
+			if (Objects.equals(
+					toolName, "getToolSetToolSetNameToolSummariesPage")) {
+
 				return _getResponse(
 					getToolSummariesPage(
 						httpServletRequest,
 						inputJSONObject.getString("toolSetName")));
 			}
 
-			if (Objects.equals(toolName, "invokeTool")) {
+			if (Objects.equals(toolName, "postToolSetToolSetNameToolInvoke")) {
 				return invokeTool(
 					httpServletRequest, inputJSONObject.opt("body"),
 					inputJSONObject.getString("toolName"),

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/resources/com/liferay/mcp/server/rest/internal/batch/03-object-entry.batch-engine-data.json
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/resources/com/liferay/mcp/server/rest/internal/batch/03-object-entry.batch-engine-data.json
@@ -16,7 +16,7 @@
 			"description": "Default MCP profile: the four mcp-server tools an AI orchestrates to use any Liferay tool (list tool-sets, list tools, fetch a tool's input schema, invoke).",
 			"externalReferenceCode": "L_MCP_SERVER_DEFAULT_PROFILE",
 			"name": "default",
-			"tools": "mcp-server-v1.0 getToolSets\nmcp-server-v1.0 getToolSummaries\nmcp-server-v1.0 getTool\nmcp-server-v1.0 invokeTool"
+			"tools": "mcp-server-v1.0 getToolSetsPage\nmcp-server-v1.0 getToolSetToolSetNameToolSummariesPage\nmcp-server-v1.0 getToolSetToolSetNameTool\nmcp-server-v1.0 postToolSetToolSetNameToolInvoke"
 		}
 	]
 }

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/servlet/test/MCPServerServletTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/servlet/test/MCPServerServletTest.java
@@ -165,7 +165,7 @@ public class MCPServerServletTest {
 
 		McpSchema.CallToolResult callToolResult = mcpSyncClient.callTool(
 			new McpSchema.CallToolRequest(
-				"invokeTool",
+				"postToolSetToolSetNameToolInvoke",
 				HashMapBuilder.<String, Object>put(
 					"body",
 					HashMapBuilder.<String, Object>put(
@@ -205,15 +205,18 @@ public class MCPServerServletTest {
 
 		Assert.assertEquals(tools.toString(), 4, tools.size());
 
-		_assertTool(tools.get(0), "getToolSets", "get_tool_sets.json");
+		_assertTool(tools.get(0), "getToolSetsPage", "get_tool_sets.json");
 		_assertTool(
-			tools.get(1), "getToolSummaries", "get_tool_summaries.json");
-		_assertTool(tools.get(2), "getTool", "get_tool.json");
-		_assertTool(tools.get(3), "invokeTool", "invoke_tool.json");
+			tools.get(1), "getToolSetToolSetNameToolSummariesPage",
+			"get_tool_summaries.json");
+		_assertTool(tools.get(2), "getToolSetToolSetNameTool", "get_tool.json");
+		_assertTool(
+			tools.get(3), "postToolSetToolSetNameToolInvoke",
+			"invoke_tool.json");
 
 		McpSchema.CallToolResult callToolResult = mcpSyncClient.callTool(
 			new McpSchema.CallToolRequest(
-				"getToolSets", Collections.emptyMap()));
+				"getToolSetsPage", Collections.emptyMap()));
 
 		List<McpSchema.Content> contents = callToolResult.content();
 
@@ -237,7 +240,7 @@ public class MCPServerServletTest {
 
 		callToolResult = mcpSyncClient.callTool(
 			new McpSchema.CallToolRequest(
-				"getToolSummaries",
+				"getToolSetToolSetNameToolSummariesPage",
 				HashMapBuilder.<String, Object>put(
 					"toolSetName", "mcp-server-profiles"
 				).build()));
@@ -263,7 +266,7 @@ public class MCPServerServletTest {
 
 		callToolResult = mcpSyncClient.callTool(
 			new McpSchema.CallToolRequest(
-				"getTool",
+				"getToolSetToolSetNameTool",
 				HashMapBuilder.<String, Object>put(
 					"toolName", "getMCPServerProfilesPage"
 				).put(
@@ -285,7 +288,7 @@ public class MCPServerServletTest {
 
 		callToolResult = mcpSyncClient.callTool(
 			new McpSchema.CallToolRequest(
-				"invokeTool",
+				"postToolSetToolSetNameToolInvoke",
 				HashMapBuilder.<String, Object>put(
 					"body", Collections.<String, Object>emptyMap()
 				).put(

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/resource/v1_0/test/BaseToolResourceTestCase.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/resource/v1_0/test/BaseToolResourceTestCase.java
@@ -181,12 +181,12 @@ public abstract class BaseToolResourceTestCase {
 	}
 
 	@Test
-	public void testGetTool() throws Exception {
+	public void testGetToolSetToolSetNameTool() throws Exception {
 		Assert.assertTrue(false);
 	}
 
 	@Test
-	public void testInvokeTool() throws Exception {
+	public void testPostToolSetToolSetNameToolInvoke() throws Exception {
 		Assert.assertTrue(false);
 	}
 
@@ -900,4 +900,4 @@ public abstract class BaseToolResourceTestCase {
 		_toolResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1431034240
+// LIFERAY-REST-BUILDER-HASH:-1507640032

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/resource/v1_0/test/BaseToolSetResourceTestCase.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/resource/v1_0/test/BaseToolSetResourceTestCase.java
@@ -181,26 +181,26 @@ public abstract class BaseToolSetResourceTestCase {
 	}
 
 	@Test
-	public void testGetToolSets() throws Exception {
-		Page<ToolSet> page = toolSetResource.getToolSets();
+	public void testGetToolSetsPage() throws Exception {
+		Page<ToolSet> page = toolSetResource.getToolSetsPage();
 
 		long totalCount = page.getTotalCount();
 
-		ToolSet toolSet1 = testGetToolSets_addToolSet(randomToolSet());
+		ToolSet toolSet1 = testGetToolSetsPage_addToolSet(randomToolSet());
 
-		ToolSet toolSet2 = testGetToolSets_addToolSet(randomToolSet());
+		ToolSet toolSet2 = testGetToolSetsPage_addToolSet(randomToolSet());
 
-		page = toolSetResource.getToolSets();
+		page = toolSetResource.getToolSetsPage();
 
 		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
 		assertContains(toolSet1, (List<ToolSet>)page.getItems());
 		assertContains(toolSet2, (List<ToolSet>)page.getItems());
-		assertValid(page, testGetToolSets_getExpectedActions());
+		assertValid(page, testGetToolSetsPage_getExpectedActions());
 	}
 
 	protected Map<String, Map<String, String>>
-			testGetToolSets_getExpectedActions()
+			testGetToolSetsPage_getExpectedActions()
 		throws Exception {
 
 		Map<String, Map<String, String>> expectedActions = new HashMap<>();
@@ -208,7 +208,7 @@ public abstract class BaseToolSetResourceTestCase {
 		return expectedActions;
 	}
 
-	protected ToolSet testGetToolSets_addToolSet(ToolSet toolSet)
+	protected ToolSet testGetToolSetsPage_addToolSet(ToolSet toolSet)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -907,4 +907,4 @@ public abstract class BaseToolSetResourceTestCase {
 		_toolSetResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1245916398
+// LIFERAY-REST-BUILDER-HASH:495507244

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/resource/v1_0/test/BaseToolSummaryResourceTestCase.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/resource/v1_0/test/BaseToolSummaryResourceTestCase.java
@@ -181,22 +181,25 @@ public abstract class BaseToolSummaryResourceTestCase {
 	}
 
 	@Test
-	public void testGetToolSummaries() throws Exception {
-		String toolSetName = testGetToolSummaries_getToolSetName();
+	public void testGetToolSetToolSetNameToolSummariesPage() throws Exception {
+		String toolSetName =
+			testGetToolSetToolSetNameToolSummariesPage_getToolSetName();
 		String irrelevantToolSetName =
-			testGetToolSummaries_getIrrelevantToolSetName();
+			testGetToolSetToolSetNameToolSummariesPage_getIrrelevantToolSetName();
 
-		Page<ToolSummary> page = toolSummaryResource.getToolSummaries(
-			toolSetName);
+		Page<ToolSummary> page =
+			toolSummaryResource.getToolSetToolSetNameToolSummariesPage(
+				toolSetName);
 
 		long totalCount = page.getTotalCount();
 
 		if (irrelevantToolSetName != null) {
 			ToolSummary irrelevantToolSummary =
-				testGetToolSummaries_addToolSummary(
+				testGetToolSetToolSetNameToolSummariesPage_addToolSummary(
 					irrelevantToolSetName, randomIrrelevantToolSummary());
 
-			page = toolSummaryResource.getToolSummaries(irrelevantToolSetName);
+			page = toolSummaryResource.getToolSetToolSetNameToolSummariesPage(
+				irrelevantToolSetName);
 
 			Assert.assertEquals(totalCount + 1, page.getTotalCount());
 
@@ -204,26 +207,34 @@ public abstract class BaseToolSummaryResourceTestCase {
 				irrelevantToolSummary, (List<ToolSummary>)page.getItems());
 			assertValid(
 				page,
-				testGetToolSummaries_getExpectedActions(irrelevantToolSetName));
+				testGetToolSetToolSetNameToolSummariesPage_getExpectedActions(
+					irrelevantToolSetName));
 		}
 
-		ToolSummary toolSummary1 = testGetToolSummaries_addToolSummary(
-			toolSetName, randomToolSummary());
+		ToolSummary toolSummary1 =
+			testGetToolSetToolSetNameToolSummariesPage_addToolSummary(
+				toolSetName, randomToolSummary());
 
-		ToolSummary toolSummary2 = testGetToolSummaries_addToolSummary(
-			toolSetName, randomToolSummary());
+		ToolSummary toolSummary2 =
+			testGetToolSetToolSetNameToolSummariesPage_addToolSummary(
+				toolSetName, randomToolSummary());
 
-		page = toolSummaryResource.getToolSummaries(toolSetName);
+		page = toolSummaryResource.getToolSetToolSetNameToolSummariesPage(
+			toolSetName);
 
 		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
 		assertContains(toolSummary1, (List<ToolSummary>)page.getItems());
 		assertContains(toolSummary2, (List<ToolSummary>)page.getItems());
-		assertValid(page, testGetToolSummaries_getExpectedActions(toolSetName));
+		assertValid(
+			page,
+			testGetToolSetToolSetNameToolSummariesPage_getExpectedActions(
+				toolSetName));
 	}
 
 	protected Map<String, Map<String, String>>
-			testGetToolSummaries_getExpectedActions(String toolSetName)
+			testGetToolSetToolSetNameToolSummariesPage_getExpectedActions(
+				String toolSetName)
 		throws Exception {
 
 		Map<String, Map<String, String>> expectedActions = new HashMap<>();
@@ -231,20 +242,24 @@ public abstract class BaseToolSummaryResourceTestCase {
 		return expectedActions;
 	}
 
-	protected ToolSummary testGetToolSummaries_addToolSummary(
-			String toolSetName, ToolSummary toolSummary)
+	protected ToolSummary
+			testGetToolSetToolSetNameToolSummariesPage_addToolSummary(
+				String toolSetName, ToolSummary toolSummary)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
 	}
 
-	protected String testGetToolSummaries_getToolSetName() throws Exception {
+	protected String testGetToolSetToolSetNameToolSummariesPage_getToolSetName()
+		throws Exception {
+
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
 	}
 
-	protected String testGetToolSummaries_getIrrelevantToolSetName()
+	protected String
+			testGetToolSetToolSetNameToolSummariesPage_getIrrelevantToolSetName()
 		throws Exception {
 
 		return null;
@@ -951,4 +966,4 @@ public abstract class BaseToolSummaryResourceTestCase {
 		_toolSummaryResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:206144530
+// LIFERAY-REST-BUILDER-HASH:1638616486

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/resource/v1_0/test/ToolResourceTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/resource/v1_0/test/ToolResourceTest.java
@@ -29,22 +29,23 @@ public class ToolResourceTest extends BaseToolResourceTestCase {
 
 	@Override
 	@Test
-	public void testGetTool() throws Exception {
-		Tool tool = toolResource.getTool("mcp-server-v1.0", "getToolSets");
+	public void testGetToolSetToolSetNameTool() throws Exception {
+		Tool tool = toolResource.getToolSetToolSetNameTool(
+			"mcp-server-v1.0", "getToolSetsPage");
 
-		Assert.assertEquals("getToolSets", tool.getName());
+		Assert.assertEquals("getToolSetsPage", tool.getName());
 		Assert.assertNotNull(tool.getInputSchema());
 	}
 
 	@Override
 	@Test
-	public void testInvokeTool() throws Exception {
+	public void testPostToolSetToolSetNameToolInvoke() throws Exception {
 		byte[] bytes = RandomTestUtil.randomBytes();
 		String fileName =
 			"mcp-upload-" + RandomTestUtil.randomString() + ".txt";
 
 		HttpInvoker.HttpResponse httpResponse =
-			toolResource.invokeToolHttpResponse(
+			toolResource.postToolSetToolSetNameToolInvokeHttpResponse(
 				"headless-delivery-v1.0", "postSiteDocument",
 				JSONUtil.put(
 					"file",
@@ -74,11 +75,12 @@ public class ToolResourceTest extends BaseToolResourceTestCase {
 			bytes.length, documentJSONObject.getInt("sizeInBytes"));
 		Assert.assertEquals(fileName, documentJSONObject.getString("title"));
 
-		httpResponse = toolResource.invokeToolHttpResponse(
-			"mcp-server-v1.0", "getToolSummaries",
-			JSONUtil.put(
-				"toolSetName", "mcp-server-v1.0"
-			).toString());
+		httpResponse =
+			toolResource.postToolSetToolSetNameToolInvokeHttpResponse(
+				"mcp-server-v1.0", "getToolSetToolSetNameToolSummariesPage",
+				JSONUtil.put(
+					"toolSetName", "mcp-server-v1.0"
+				).toString());
 
 		Assert.assertFalse(
 			JSONFactoryUtil.createJSONObject(

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/resource/v1_0/test/ToolSetResourceTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/resource/v1_0/test/ToolSetResourceTest.java
@@ -31,7 +31,7 @@ public class ToolSetResourceTest extends BaseToolSetResourceTestCase {
 
 	@Override
 	@Test
-	public void testGetToolSets() throws Exception {
+	public void testGetToolSetsPage() throws Exception {
 		_assertToolSet(
 			toolSet ->
 				Objects.equals(toolSet.getName(), "mcp-server-v1.0") &&
@@ -48,7 +48,7 @@ public class ToolSetResourceTest extends BaseToolSetResourceTestCase {
 	}
 
 	private void _assertToolSet(Predicate<ToolSet> predicate) throws Exception {
-		Page<ToolSet> toolSetsPage = toolSetResource.getToolSets();
+		Page<ToolSet> toolSetsPage = toolSetResource.getToolSetsPage();
 
 		Assert.assertTrue(
 			ListUtil.exists(

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/resource/v1_0/test/ToolSummaryResourceTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/resource/v1_0/test/ToolSummaryResourceTest.java
@@ -26,17 +26,23 @@ public class ToolSummaryResourceTest extends BaseToolSummaryResourceTestCase {
 
 	@Override
 	@Test
-	public void testGetToolSummaries() throws Exception {
-		Page<ToolSummary> page = toolSummaryResource.getToolSummaries(
-			"mcp-server-v1.0");
+	public void testGetToolSetToolSetNameToolSummariesPage() throws Exception {
+		Page<ToolSummary> page =
+			toolSummaryResource.getToolSetToolSetNameToolSummariesPage(
+				"mcp-server-v1.0");
 
 		List<String> names = TransformUtil.transform(
 			page.getItems(), ToolSummary::getName);
 
-		Assert.assertTrue(names.toString(), names.contains("getTool"));
-		Assert.assertTrue(names.toString(), names.contains("getToolSets"));
-		Assert.assertTrue(names.toString(), names.contains("getToolSummaries"));
-		Assert.assertTrue(names.toString(), names.contains("invokeTool"));
+		Assert.assertTrue(
+			names.toString(), names.contains("getToolSetToolSetNameTool"));
+		Assert.assertTrue(names.toString(), names.contains("getToolSetsPage"));
+		Assert.assertTrue(
+			names.toString(),
+			names.contains("getToolSetToolSetNameToolSummariesPage"));
+		Assert.assertTrue(
+			names.toString(),
+			names.contains("postToolSetToolSetNameToolInvoke"));
 	}
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89991

## What Is Being Fixed

The mcp-server-rest API kept the hand-written operation IDs from its OpenAPI document (`getToolSets`, `getToolSummaries`, `getTool`, `invokeTool`), which diverged from the predictable, method-and-path-derived naming every other Liferay REST API uses. Because the MCP server exposes its own REST operations as the bootstrap `mcp-server-v1.0` tool-set, those operation IDs are the tool names an AI sees, so the inconsistency was also visible to MCP clients.

## How It Is Being Fixed

Set `forcePredictableOperationId: true` in `rest-config.yaml` and regenerated the API, client, impl, and test scaffolding with REST Builder. This renames the four operations to their predictable forms (`getToolSetsPage`, `getToolSetToolSetNameToolSummariesPage`, `getToolSetToolSetNameTool`, `postToolSetToolSetNameToolInvoke`). Because the renamed operations are the tool names exposed by the self-referential `mcp-server-v1.0` tool-set, every usage was updated to match: the resource overrides, the `ToolSetUtil` dispatch that special-cases that tool-set, the default MCP profile seed data, the routing prose in the OpenAPI descriptions, and the unit and integration tests. A missing `jackson-annotations` dependency that prevented `OpenAPIUtilTest` from running was also declared, and the REST Builder rule now defaults new APIs to predictable operation IDs.

## Why Are There No Tests?

This is a no-behavior-change refactor: it only renames generated operation IDs and the code referencing them. The existing unit test (`OpenAPIUtilTest`) and integration tests (`ToolSetResourceTest`, `ToolResourceTest`, `ToolSummaryResourceTest`, `MCPServerServletTest`) were updated to the new names and all pass (3 unit + 22 integration).

## PR Check

**pr-check: PASS** — tested on `163aa868735165e64a82e310b9d641c721030f6a`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "163aa868735165e64a82e310b9d641c721030f6a"} -->