### PR TITLE
LPD-35240 Warn about removed SoyDataFactory methods

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -3667,6 +3667,22 @@
 	},
 	{
 		"classNames": [
+			"SoyDataFactory"
+		],
+		"from": "createSoyHTMLData(String paramName)",
+		"hasMessage": true,
+		"issueKey": "LPD-35240"
+	},
+	{
+		"classNames": [
+			"SoyDataFactory"
+		],
+		"from": "createSoyRawData(String paramName)",
+		"hasMessage": true,
+		"issueKey": "LPD-35240"
+	},
+	{
+		"classNames": [
 			"UpgradeProcess"
 		],
 		"classStructurePattern": true,

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_35240.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_35240.testjava
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_35240 {
+
+	public void method(String html) {
+		_soyDataFactory.createSoyHTMLData(html);
+		_soyDataFactory.createSoyHTMLData(null);
+
+		_soyDataFactory.createSoyRawData(html);
+		_soyDataFactory.createSoyRawData(null);
+	}
+
+	@Reference
+	private SoyDataFactory _soyDataFactory;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-35240

## What Is Being Fixed

The SoyDataFactory.createSoyHTMLData and createSoyRawData methods have been removed. Developers upgrading existing code get no automated signal pointing them to the removal, so calls to these methods surface only as raw compile errors without guidance.

## How It Is Being Fixed

Two entries are added to the source formatter's upgrade-catch-all-check replacements.json, one per removed method, so the formatter emits an upgrade warning referencing LPD-35240 whenever createSoyHTMLData(String) or createSoyRawData(String) is detected. A LPD_35240.testjava resource exercising both removed methods is added to cover the new warnings.

## PR Check

**pr-check: PASS** — tested on `71e54b8ef788de441734567d873efe0718084b9e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "71e54b8ef788de441734567d873efe0718084b9e"} -->