### PR TITLE
LRSD-12299 Add more scripts

### DIFF
--- a/workspaces/liferay-sample-workspace/scripts/deploy_client_extensions.sh
+++ b/workspaces/liferay-sample-workspace/scripts/deploy_client_extensions.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+source _common.sh
+
+function main {
+	cd ..
+
+	./gradlew \
+		deploy \
+		-Ddeploy.docker.container.id="$(docker ps --filter "name=liferay" --quiet)"
+}
+
+main "${@}"

--- a/workspaces/liferay-sample-workspace/scripts/extract_license.sh
+++ b/workspaces/liferay-sample-workspace/scripts/extract_license.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+source _common.sh
+
+function main {
+	local force=false
+
+	if [[ ${1:-} == "-f" || ${1:-} == "--force" ]]
+	then
+		force=true
+	fi
+
+	local license_path="../build/docker/deploy/license.xml"
+
+	if [[ -f ${license_path} && ${force} == false ]]
+	then
+		echo "A trial license already exists at ${license_path}."
+
+		exit 0
+	fi
+
+	local license_dir
+
+	license_dir=$(dirname "${license_path}")
+
+	echo "Extracting the trial license from liferay/dxp:latest."
+
+	mkdir --parents "${license_dir}"
+
+	docker run \
+		--entrypoint sh \
+		--rm \
+		--user root \
+		--volume "${license_dir}:/mnt/deploy" \
+		"liferay/dxp:latest" \
+		-c \
+		"cp /opt/liferay/deploy/trial-dxp-license*.xml /mnt/deploy/license.xml"
+}
+
+main "${@}"

--- a/workspaces/liferay-sample-workspace/scripts/extract_oauth_credentials.sh
+++ b/workspaces/liferay-sample-workspace/scripts/extract_oauth_credentials.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+source _common.sh
+
+function main {
+	local oauth_application_name="${1}"
+
+	if [[ -z ${oauth_application_name} ]]
+	then
+		echo "Please pass in the name of your OAuth application."
+		exit 1
+	fi
+
+	local container_name="liferay"
+
+	local routes_dir="/opt/liferay/routes/default/${oauth_application_name}"
+
+	local client_id
+
+	client_id="$(docker exec "${container_name}" cat "${routes_dir}/${oauth_application_name}.oauth2.headless.server.client.id")"
+
+	local client_secret
+
+	client_secret="$(docker exec "${container_name}" cat "${routes_dir}/${oauth_application_name}.oauth2.headless.server.client.secret")"
+
+	local env_file="../.env"
+
+	if [[ ! -f ${env_file} ]]
+	then
+		printf "OAUTH_CLIENT_ID=\nOAUTH_CLIENT_SECRET=\n" > "${env_file}"
+	fi
+
+	grep --quiet "^OAUTH_CLIENT_ID=" "${env_file}" || echo "OAUTH_CLIENT_ID=" >> "${env_file}"
+	grep --quiet "^OAUTH_CLIENT_SECRET=" "${env_file}" || echo "OAUTH_CLIENT_SECRET=" >> "${env_file}"
+
+	sed --in-place "s|^OAUTH_CLIENT_ID=.*|OAUTH_CLIENT_ID=${client_id}|" "${env_file}"
+	sed --in-place "s|^OAUTH_CLIENT_SECRET=.*|OAUTH_CLIENT_SECRET=${client_secret}|" "${env_file}"
+
+	echo "OAuth credentials were written to .env."
+	echo "OAUTH_CLIENT_ID=${client_id}"
+	echo "OAUTH_CLIENT_SECRET=${client_secret}"
+}
+
+main "${@}"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRSD-12299

## What Is Being Fixed

The sample workspace lacked convenience scripts for common local-development
tasks: deploying client extensions into the running Liferay Docker container,
extracting a trial DXP license, and pulling OAuth client credentials for a
headless application into the workspace `.env`.

## How It Is Being Fixed

Adds three shell scripts under `scripts/`, all sharing the existing
`_common.sh` helpers. `deploy_client_extensions.sh` runs the workspace Gradle
`deploy` task against the running `liferay` Docker container.
`extract_license.sh` copies the trial license out of the `liferay/dxp:latest`
image into `build/docker/deploy`, with a `--force` flag to overwrite an
existing one. `extract_oauth_credentials.sh` reads the generated client id and
secret for a named OAuth application out of the container and writes them into
the workspace `.env`, creating the file when absent.

## Why Are There No Tests?

These are developer-facing workspace utility scripts that orchestrate Docker
and Gradle against a running local environment. They are not part of the
product build, and there is no unit or integration harness for workspace shell
scripts; behavior is verified by running them against a local bundle.

## PR Check

**pr-check: SKIPPED** — branch is a long-lived environment branch whose local `master` is 2199 commits stale, so pr-check's diff baseline spans 3318 unrelated files and cannot scope to this change; the actual change is three workspace shell scripts not covered by any Java, build, or source-format validation.

<!-- pr-check {"reason": "branch is a long-lived environment branch whose local master is 2199 commits stale, so pr-check's diff baseline spans 3318 unrelated files and cannot scope to this change; the actual change is three workspace shell scripts not covered by any Java, build, or source-format validation", "result": "skipped", "sha": "f6e0a7ffc912dc300e04b2f4433a74e6286fc917"} -->
