### PR TITLE
LRSD-12299 Add more scripts

### DIFF
--- a/workspaces/liferay-sample-workspace/scripts/deploy_client_extensions.sh
+++ b/workspaces/liferay-sample-workspace/scripts/deploy_client_extensions.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+source _common.sh
+
+function main {
+	cd ..
+
+	./gradlew \
+		deploy \
+		-Ddeploy.docker.container.id="$(docker ps --filter "name=liferay" --quiet)"
+}
+
+main "${@}"

--- a/workspaces/liferay-sample-workspace/scripts/extract_license.sh
+++ b/workspaces/liferay-sample-workspace/scripts/extract_license.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+source _common.sh
+
+function main {
+	local force=false
+
+	if [[ ${1:-} == "-f" || ${1:-} == "--force" ]]
+	then
+		force=true
+	fi
+
+	local license_path="../build/docker/deploy/license.xml"
+
+	if [[ -f ${license_path} && ${force} == false ]]
+	then
+		echo "A trial license already exists at ${license_path}."
+
+		exit 0
+	fi
+
+	local license_dir
+
+	license_dir=$(dirname "${license_path}")
+
+	echo "Extracting the trial license from liferay/dxp:latest."
+
+	mkdir --parents "${license_dir}"
+
+	docker run \
+		--entrypoint sh \
+		--rm \
+		--user root \
+		--volume "${license_dir}:/mnt/deploy" \
+		"liferay/dxp:latest" \
+		-c \
+		"cp /opt/liferay/deploy/trial-dxp-license*.xml /mnt/deploy/license.xml"
+}
+
+main "${@}"

--- a/workspaces/liferay-sample-workspace/scripts/extract_oauth_credentials.sh
+++ b/workspaces/liferay-sample-workspace/scripts/extract_oauth_credentials.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+source _common.sh
+
+function main {
+	local oauth_application_name="${1:-}"
+
+	if [[ -z ${oauth_application_name} ]]
+	then
+		echo "Please pass in the name of your OAuth application."
+
+		exit 1
+	fi
+
+	local container_name="liferay"
+
+	local routes_dir="/opt/liferay/routes/default/${oauth_application_name}"
+
+	local client_id
+
+	client_id="$(docker exec "${container_name}" cat "${routes_dir}/${oauth_application_name}.oauth2.headless.server.client.id")"
+
+	local client_secret
+
+	client_secret="$(docker exec "${container_name}" cat "${routes_dir}/${oauth_application_name}.oauth2.headless.server.client.secret")"
+
+	local env_file="../.env"
+
+	if [[ ! -f ${env_file} ]]
+	then
+		printf "OAUTH_CLIENT_ID=\nOAUTH_CLIENT_SECRET=\n" > "${env_file}"
+	fi
+
+	grep --quiet "^OAUTH_CLIENT_ID=" "${env_file}" || echo "OAUTH_CLIENT_ID=" >> "${env_file}"
+	grep --quiet "^OAUTH_CLIENT_SECRET=" "${env_file}" || echo "OAUTH_CLIENT_SECRET=" >> "${env_file}"
+
+	sed --in-place "s|^OAUTH_CLIENT_ID=.*|OAUTH_CLIENT_ID=${client_id}|" "${env_file}"
+	sed --in-place "s|^OAUTH_CLIENT_SECRET=.*|OAUTH_CLIENT_SECRET=${client_secret}|" "${env_file}"
+
+	echo "OAuth credentials were written to .env."
+	echo "OAUTH_CLIENT_ID=${client_id}"
+	echo "OAUTH_CLIENT_SECRET=${client_secret}"
+}
+
+main "${@}"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRSD-12299

## What Is Being Fixed

The sample workspace lacked helper scripts for common local setup tasks: deploying client extensions to the running Liferay Docker container, extracting a trial license, and pulling OAuth client credentials into the workspace `.env` file.

## How It Is Being Fixed

Adds three scripts under `workspaces/liferay-sample-workspace/scripts`. `deploy_client_extensions.sh` runs the workspace deploy against the `liferay` container. `extract_license.sh` copies the trial license out of the `liferay/dxp` image. `extract_oauth_credentials.sh` reads an OAuth application's client id and secret from the container and writes them to the workspace `.env` file. Each sources `_common.sh` for fail-fast behavior, and the optional argument in `extract_oauth_credentials.sh` is defaulted (`${1:-}`) so the friendly usage error prints instead of tripping `nounset`.

## Why Are There No Tests?

These are sample-workspace helper scripts that orchestrate Docker and Gradle commands for local developer setup; they carry no unit-testable logic and are not part of a shippable module.

## PR Check

**pr-check: PASS** — tested on `4b4f9b2fd8508294c7b4d3a0788d520de97cde75`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "4b4f9b2fd8508294c7b4d3a0788d520de97cde75"} -->
