### PR TITLE
LPD-34692 Warn about removed MessageBus listener methods

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -3541,6 +3541,22 @@
 	},
 	{
 		"classNames": [
+			"MessageBus"
+		],
+		"from": "registerMessageListener(String paramName, MessageListener paramName)",
+		"hasMessage": true,
+		"issueKey": "LPD-34692"
+	},
+	{
+		"classNames": [
+			"MessageBus"
+		],
+		"from": "unregisterMessageListener(String paramName, MessageListener paramName)",
+		"hasMessage": true,
+		"issueKey": "LPD-34692"
+	},
+	{
+		"classNames": [
 			"MentionsUserFinder"
 		],
 		"classStructurePattern": true,

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_34692.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_34692.testjava
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_34692 {
+
+	public void method(
+		String destinationName, MessageListener messageListener) {
+
+		_messageBus.registerMessageListener(destinationName, messageListener);
+		_messageBus.registerMessageListener(null, null);
+
+		_messageBus.unregisterMessageListener(destinationName, messageListener);
+		_messageBus.unregisterMessageListener(null, null);
+	}
+
+	@Reference
+	private MessageBus _messageBus;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-34692

## What Is Being Fixed

The MessageBus.registerMessageListener and unregisterMessageListener methods have been removed. Developers upgrading existing code get no automated signal pointing them to the removal, so calls to these methods surface only as raw compile errors without guidance.

## How It Is Being Fixed

Two entries are added to the source formatter's upgrade-catch-all-check replacements.json, one per removed method, so the formatter emits an upgrade warning referencing LPD-34692 whenever registerMessageListener(String, MessageListener) or unregisterMessageListener(String, MessageListener) is detected. A LPD_34692.testjava resource exercising both removed methods is added to cover the new warnings.

## PR Check

**pr-check: PASS** — tested on `9fd9342982ef5339356de45365fc36b781859713`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "9fd9342982ef5339356de45365fc36b781859713"} -->