### PR TITLE
LPD-93305 Harden MCP tool invocation request body handling

### DIFF
--- a/modules/apps/mcp/mcp-server-rest-impl/build.gradle
+++ b/modules/apps/mcp/mcp-server-rest-impl/build.gradle
@@ -32,5 +32,6 @@ dependencies {
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")
+	testImplementation group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.18.6"
 	testImplementation group: "org.skyscreamer", name: "jsonassert", version: "1.5.0"
 }

--- a/modules/apps/mcp/mcp-server-rest-impl/rest-openapi.yaml
+++ b/modules/apps/mcp/mcp-server-rest-impl/rest-openapi.yaml
@@ -175,12 +175,7 @@ paths:
                                 Input map matching the tool's `inputSchema`.
                             type: object
                 description:
-                    "The complete input map for the target tool, matching the `inputSchema` that `getTool` returns for
-                    this `toolName`. Use that schema's properties exactly as named: when the `inputSchema` declares a
-                    `body` property, it holds the request payload and must stay nested under `body` here rather than be
-                    flattened into this map; pass any path or query parameters as siblings of `body`. For example, a
-                    tool whose `inputSchema` has `body` and `itemId` properties is invoked with `{\"body\": {...},
-                    \"itemId\": \"123\"}`."
+                    "The complete input map for the target tool, matching the `inputSchema` that `getTool` returns for this `toolName`. Use that schema's properties exactly as named: when the `inputSchema` declares a `body` property, it holds the request payload and must stay nested under `body` here rather than be flattened into this map; pass any path or query parameters as siblings of `body`. For example, a tool whose `inputSchema` has `body` and `itemId` properties is invoked with `{\"body\": {...}, \"itemId\": \"123\"}`."
                 required: false
             responses:
                 200:

--- a/modules/apps/mcp/mcp-server-rest-impl/rest-openapi.yaml
+++ b/modules/apps/mcp/mcp-server-rest-impl/rest-openapi.yaml
@@ -174,6 +174,13 @@ paths:
                             description:
                                 Input map matching the tool's `inputSchema`.
                             type: object
+                description:
+                    "The complete input map for the target tool, matching the `inputSchema` that `getTool` returns for
+                    this `toolName`. Use that schema's properties exactly as named: when the `inputSchema` declares a
+                    `body` property, it holds the request payload and must stay nested under `body` here rather than be
+                    flattened into this map; pass any path or query parameters as siblings of `body`. For example, a
+                    tool whose `inputSchema` has `body` and `itemId` properties is invoked with `{\"body\": {...},
+                    \"itemId\": \"123\"}`."
                 required: false
             responses:
                 200:

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/BaseToolResourceImpl.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/BaseToolResourceImpl.java
@@ -92,7 +92,8 @@ public abstract class BaseToolResourceImpl implements ToolResource {
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Invokes a tool. ALWAYS call `getToolSetToolSetNameTool` first to fetch the tool's `inputSchema`, then build the request `body` to match it exactly. Skipping `getToolSetToolSetNameTool` leads to malformed input and avoidable failures. Returns the tool's response body unchanged.",
-		operationId = "postToolSetToolSetNameToolInvoke"
+		operationId = "postToolSetToolSetNameToolInvoke",
+		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = Object.class)), description = "The complete input map for the target tool, matching the `inputSchema` that `getTool` returns for this `toolName`. Use that schema's properties exactly as named: when the `inputSchema` declares a `body` property, it holds the request payload and must stay nested under `body` here rather than be flattened into this map; pass any path or query parameters as siblings of `body`. For example, a tool whose `inputSchema` has `body` and `itemId` properties is invoked with `{\"body\": {...}, \"itemId\": \"123\"}`.")
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -578,4 +579,4 @@ public abstract class BaseToolResourceImpl implements ToolResource {
 		LogFactoryUtil.getLog(BaseToolResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:1426896571
+// LIFERAY-REST-BUILDER-HASH:-1744722583

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -905,8 +905,8 @@ public class OpenAPIUtil {
 			body = String.valueOf(bodyValue);
 		}
 
-		options.setBody(body, ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 		options.addHeader("Content-Type", ContentTypes.APPLICATION_JSON);
+		options.setBody(body, ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 	}
 
 	private static void _setMultipartBody(

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -67,9 +67,9 @@ public class OpenAPIUtil {
 					StringBundler.concat(
 						"The \"", toolName,
 						"\" tool requires the request payload nested under a ",
-						"\"body\" property; pass any path or query parameters ",
-						"as siblings of \"body\" rather than flattening the ",
-						"payload into the input map"));
+						"\"body\" property. Pass any path or query parameters as ",
+						"siblings of \"body\" rather than flattening the payload ",
+						"into the input map"));
 			}
 
 			Object bodyValue = inputJSONObject.opt("body");

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -72,7 +72,7 @@ public class OpenAPIUtil {
 						"into the input map"));
 			}
 
-			Object bodyValue = inputJSONObject.opt("body");
+			Object bodyValue = inputJSONObject.get("body");
 
 			String body = StringPool.BLANK;
 

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -891,7 +891,7 @@ public class OpenAPIUtil {
 					"\" tool requires the request payload nested under a ",
 					"\"body\" property. Pass any path or query parameters as ",
 					"siblings of \"body\" rather than flattening the payload ",
-					"into the input map"));
+					"into the input map."));
 		}
 
 		Object bodyValue = inputJSONObject.get("body");

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -544,12 +544,49 @@ public class OpenAPIUtil {
 					openAPIJSONObject);
 			}
 			else {
-				properties.put(
-					"body",
-					_resolveRefs(
+				JSONObject requestBodyJSONObject =
+					operationJSONObject.getJSONObject("requestBody");
+
+				Object bodySchema = null;
+
+				if (requestBodyJSONObject.getJSONObject("content") != null) {
+					bodySchema = _resolveRefs(
 						openAPIJSONObject,
 						_getBodySchemaJSONObject(operationJSONObject),
-						new HashSet<>()));
+						new HashSet<>());
+				}
+
+				if (!(bodySchema instanceof Map)) {
+					bodySchema = LinkedHashMapBuilder.<String, Object>put(
+						"type", "object"
+					).build();
+				}
+
+				String requestBodyDescription = requestBodyJSONObject.getString(
+					"description");
+
+				if (Validator.isNotNull(requestBodyDescription)) {
+					Map<String, Object> bodySchemaMap =
+						(Map<String, Object>)bodySchema;
+
+					Object schemaDescription = bodySchemaMap.get("description");
+
+					if (Validator.isNull(schemaDescription)) {
+						bodySchemaMap.put(
+							"description", requestBodyDescription);
+					}
+					else if (!Objects.equals(
+								schemaDescription, requestBodyDescription)) {
+
+						bodySchemaMap.put(
+							"description",
+							StringBundler.concat(
+								requestBodyDescription, StringPool.SPACE,
+								schemaDescription));
+					}
+				}
+
+				properties.put("body", bodySchema);
 
 				required.add("body");
 			}

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -61,10 +61,20 @@ public class OpenAPIUtil {
 			_setMultipartBody(
 				inputJSONObject, openAPIJSONObject, operation, options);
 		}
-		else if (inputJSONObject.has("body")) {
-			Object bodyValue = inputJSONObject.get("body");
+		else if (operation._operationJSONObject.has("requestBody")) {
+			if (!inputJSONObject.has("body")) {
+				throw new IllegalArgumentException(
+					StringBundler.concat(
+						"The \"", toolName,
+						"\" tool requires the request payload nested under a ",
+						"\"body\" property; pass any path or query parameters ",
+						"as siblings of \"body\" rather than flattening the ",
+						"payload into the input map"));
+			}
 
-			String body = null;
+			Object bodyValue = inputJSONObject.opt("body");
+
+			String body = StringPool.BLANK;
 
 			if (bodyValue instanceof JSONObject) {
 				body = bodyValue.toString();
@@ -73,12 +83,9 @@ public class OpenAPIUtil {
 				body = String.valueOf(bodyValue);
 			}
 
-			if (Validator.isNotNull(body)) {
-				options.setBody(
-					body, ContentTypes.APPLICATION_JSON, StringPool.UTF8);
-				options.addHeader(
-					"Content-Type", ContentTypes.APPLICATION_JSON);
-			}
+			options.setBody(
+				body, ContentTypes.APPLICATION_JSON, StringPool.UTF8);
+			options.addHeader("Content-Type", ContentTypes.APPLICATION_JSON);
 		}
 
 		return options;

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -62,30 +62,7 @@ public class OpenAPIUtil {
 				inputJSONObject, openAPIJSONObject, operation, options);
 		}
 		else if (operation._operationJSONObject.has("requestBody")) {
-			if (!inputJSONObject.has("body")) {
-				throw new IllegalArgumentException(
-					StringBundler.concat(
-						"The \"", toolName,
-						"\" tool requires the request payload nested under a ",
-						"\"body\" property. Pass any path or query parameters as ",
-						"siblings of \"body\" rather than flattening the payload ",
-						"into the input map"));
-			}
-
-			Object bodyValue = inputJSONObject.get("body");
-
-			String body = StringPool.BLANK;
-
-			if (bodyValue instanceof JSONObject) {
-				body = bodyValue.toString();
-			}
-			else if (bodyValue != null) {
-				body = String.valueOf(bodyValue);
-			}
-
-			options.setBody(
-				body, ContentTypes.APPLICATION_JSON, StringPool.UTF8);
-			options.addHeader("Content-Type", ContentTypes.APPLICATION_JSON);
+			_setBody(inputJSONObject, options, toolName);
 		}
 
 		return options;
@@ -902,6 +879,34 @@ public class OpenAPIUtil {
 		}
 
 		return value;
+	}
+
+	private static void _setBody(
+		JSONObject inputJSONObject, Http.Options options, String toolName) {
+
+		if (!inputJSONObject.has("body")) {
+			throw new IllegalArgumentException(
+				StringBundler.concat(
+					"The \"", toolName,
+					"\" tool requires the request payload nested under a ",
+					"\"body\" property. Pass any path or query parameters as ",
+					"siblings of \"body\" rather than flattening the payload ",
+					"into the input map"));
+		}
+
+		Object bodyValue = inputJSONObject.get("body");
+
+		String body = StringPool.BLANK;
+
+		if (bodyValue instanceof JSONObject) {
+			body = bodyValue.toString();
+		}
+		else if (bodyValue != null) {
+			body = String.valueOf(bodyValue);
+		}
+
+		options.setBody(body, ContentTypes.APPLICATION_JSON, StringPool.UTF8);
+		options.addHeader("Content-Type", ContentTypes.APPLICATION_JSON);
 	}
 
 	private static void _setMultipartBody(

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
@@ -244,31 +244,21 @@ public class OpenAPIUtilTest {
 
 	@Test
 	public void testGetToolMergesRequestBodyAndSchemaDescriptions() {
-		JSONObject openAPIJSONObject = JSONUtil.put(
-			"paths",
+		JSONObject openAPIJSONObject = _createOpenAPIJSONObject(
 			JSONUtil.put(
-				"/things",
+				"content",
 				JSONUtil.put(
-					"post",
+					"application/json",
 					JSONUtil.put(
-						"operationId", "postThing"
-					).put(
-						"requestBody",
+						"schema",
 						JSONUtil.put(
-							"content",
-							JSONUtil.put(
-								"application/json",
-								JSONUtil.put(
-									"schema",
-									JSONUtil.put(
-										"description", "A Thing resource."
-									).put(
-										"type", "object"
-									)))
+							"description", "A Thing resource."
 						).put(
-							"description", "The thing to create."
-						)
-					))));
+							"type", "object"
+						)))
+			).put(
+				"description", "The thing to create."
+			));
 
 		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
 
@@ -285,26 +275,15 @@ public class OpenAPIUtilTest {
 
 	@Test
 	public void testGetToolRequestBodyDescriptionIsSurfaced() {
-		JSONObject openAPIJSONObject = JSONUtil.put(
-			"paths",
+		JSONObject openAPIJSONObject = _createOpenAPIJSONObject(
 			JSONUtil.put(
-				"/things",
+				"content",
 				JSONUtil.put(
-					"post",
-					JSONUtil.put(
-						"operationId", "postThing"
-					).put(
-						"requestBody",
-						JSONUtil.put(
-							"content",
-							JSONUtil.put(
-								"application/json",
-								JSONUtil.put(
-									"schema", JSONUtil.put("type", "object")))
-						).put(
-							"description", "The thing to create."
-						)
-					))));
+					"application/json",
+					JSONUtil.put("schema", JSONUtil.put("type", "object")))
+			).put(
+				"description", "The thing to create."
+			));
 
 		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
 
@@ -320,18 +299,8 @@ public class OpenAPIUtilTest {
 
 	@Test
 	public void testGetToolRequestBodyWithoutContentDoesNotFail() {
-		JSONObject openAPIJSONObject = JSONUtil.put(
-			"paths",
-			JSONUtil.put(
-				"/things",
-				JSONUtil.put(
-					"post",
-					JSONUtil.put(
-						"operationId", "postThing"
-					).put(
-						"requestBody",
-						JSONUtil.put("description", "The thing to create.")
-					))));
+		JSONObject openAPIJSONObject = _createOpenAPIJSONObject(
+			JSONUtil.put("description", "The thing to create."));
 
 		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
 
@@ -401,6 +370,22 @@ public class OpenAPIUtilTest {
 
 		Assert.assertEquals(expectedDescription, toolSummary.getDescription());
 		Assert.assertEquals(expectedName, toolSummary.getName());
+	}
+
+	private JSONObject _createOpenAPIJSONObject(
+		JSONObject requestBodyJSONObject) {
+
+		return JSONUtil.put(
+			"paths",
+			JSONUtil.put(
+				"/things",
+				JSONUtil.put(
+					"post",
+					JSONUtil.put(
+						"operationId", "postThing"
+					).put(
+						"requestBody", requestBodyJSONObject
+					))));
 	}
 
 	private Map<String, ?> _getInputSchema(

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
@@ -94,6 +94,11 @@ public class OpenAPIUtilTest {
 				"itemId", "123"
 			),
 			"patchItem");
+		_testGetOptions(
+			"{}", "application/json", Http.Method.POST,
+			"http://localhost/test/v1.0/items",
+			JSONUtil.put("body", JSONFactoryUtil.createJSONObject()),
+			"postItem");
 
 		String fileContent = RandomTestUtil.randomString();
 		String fileName = RandomTestUtil.randomString();
@@ -166,10 +171,7 @@ public class OpenAPIUtilTest {
 		Assert.assertEquals("true", parts.get("boolean"));
 		Assert.assertEquals("1", parts.get("integer"));
 		Assert.assertEquals(fileContent, parts.get("string"));
-	}
 
-	@Test
-	public void testGetOptionsRequiresBodyForRequestBody() {
 		AssertUtils.assertFailure(
 			IllegalArgumentException.class,
 			StringBundler.concat(
@@ -180,22 +182,6 @@ public class OpenAPIUtilTest {
 			() -> OpenAPIUtil.getOptions(
 				"http://localhost/test", JSONUtil.put("string", "Test"),
 				_openAPIJSONObject, "postItem"));
-	}
-
-	@Test
-	public void testGetOptionsSetsJSONContentTypeForRequestBody() {
-		Http.Options options = OpenAPIUtil.getOptions(
-			"http://localhost/test",
-			JSONUtil.put("body", JSONFactoryUtil.createJSONObject()),
-			_openAPIJSONObject, "postItem");
-
-		Assert.assertEquals(
-			"application/json", options.getHeader("Content-Type"));
-
-		Http.Body body = options.getBody();
-
-		Assert.assertEquals("{}", body.getContent());
-		Assert.assertEquals("application/json", body.getContentType());
 	}
 
 	@Test
@@ -416,6 +402,8 @@ public class OpenAPIUtilTest {
 			Assert.assertNull(body);
 		}
 		else {
+			Assert.assertEquals(
+				expectedContentType, options.getHeader("Content-Type"));
 			Assert.assertEquals(expectedBody, body.getContent());
 			Assert.assertEquals(expectedContentType, body.getContentType());
 		}

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
@@ -178,7 +178,7 @@ public class OpenAPIUtilTest {
 				"The \"postItem\" tool requires the request payload nested ",
 				"under a \"body\" property. Pass any path or query parameters ",
 				"as siblings of \"body\" rather than flattening the payload ",
-				"into the input map"),
+				"into the input map."),
 			() -> OpenAPIUtil.getOptions(
 				"http://localhost/test", JSONUtil.put("string", "Test"),
 				_openAPIJSONObject, "postItem"));

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.mcp.server.rest.dto.v1_0.Tool;
 import com.liferay.mcp.server.rest.dto.v1_0.ToolSummary;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -165,6 +166,36 @@ public class OpenAPIUtilTest {
 		Assert.assertEquals("true", parts.get("boolean"));
 		Assert.assertEquals("1", parts.get("integer"));
 		Assert.assertEquals(fileContent, parts.get("string"));
+	}
+
+	@Test
+	public void testGetOptionsRequiresBodyForRequestBody() {
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			StringBundler.concat(
+				"The \"postItem\" tool requires the request payload nested ",
+				"under a \"body\" property; pass any path or query parameters ",
+				"as siblings of \"body\" rather than flattening the payload ",
+				"into the input map"),
+			() -> OpenAPIUtil.getOptions(
+				"http://localhost/test", JSONUtil.put("string", "Test"),
+				_openAPIJSONObject, "postItem"));
+	}
+
+	@Test
+	public void testGetOptionsSetsJSONContentTypeForRequestBody() {
+		Http.Options options = OpenAPIUtil.getOptions(
+			"http://localhost/test",
+			JSONUtil.put("body", JSONFactoryUtil.createJSONObject()),
+			_openAPIJSONObject, "postItem");
+
+		Http.Body body = options.getBody();
+
+		Assert.assertEquals("{}", body.getContent());
+		Assert.assertEquals("application/json", body.getContentType());
+
+		Assert.assertEquals(
+			"application/json", options.getHeader("Content-Type"));
 	}
 
 	@Test

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
@@ -180,7 +180,10 @@ public class OpenAPIUtilTest {
 				"as siblings of \"body\" rather than flattening the payload ",
 				"into the input map."),
 			() -> OpenAPIUtil.getOptions(
-				"http://localhost/test", JSONUtil.put("string", "Test"),
+				"http://localhost/test",
+				JSONUtil.put(
+					RandomTestUtil.randomString(),
+					RandomTestUtil.randomString()),
 				_openAPIJSONObject, "postItem"));
 	}
 

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
@@ -241,7 +241,7 @@ public class OpenAPIUtilTest {
 					JSONUtil.put(
 						"schema",
 						JSONUtil.put(
-							"description", "A Thing resource."
+							"description", _SCHEMA_DESCRIPTION
 						).put(
 							"type", "object"
 						)))
@@ -258,7 +258,7 @@ public class OpenAPIUtilTest {
 		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
 
 		Assert.assertEquals(
-			"The thing to create. A Thing resource.",
+			_REQUEST_BODY_DESCRIPTION + " " + _SCHEMA_DESCRIPTION,
 			bodySchema.get("description"));
 	}
 
@@ -405,10 +405,10 @@ public class OpenAPIUtilTest {
 			Assert.assertNull(body);
 		}
 		else {
-			Assert.assertEquals(
-				expectedContentType, options.getHeader("Content-Type"));
 			Assert.assertEquals(expectedBody, body.getContent());
 			Assert.assertEquals(expectedContentType, body.getContentType());
+			Assert.assertEquals(
+				expectedContentType, options.getHeader("Content-Type"));
 		}
 
 		Assert.assertNull(options.getFileParts());
@@ -438,6 +438,8 @@ public class OpenAPIUtilTest {
 
 	private static final String _REQUEST_BODY_DESCRIPTION =
 		"The thing to create.";
+
+	private static final String _SCHEMA_DESCRIPTION = "A Thing resource.";
 
 	private JSONObject _openAPIJSONObject;
 

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
@@ -180,9 +180,6 @@ public class OpenAPIUtilTest {
 				JSONFactoryUtil.createJSONObject(),
 				RandomTestUtil.randomString()));
 		AssertUtils.assertFailure(
-			IllegalArgumentException.class, "Request body has no \"content\"",
-			() -> _getInputSchema(_openAPIJSONObject, "postNoContent"));
-		AssertUtils.assertFailure(
 			IllegalArgumentException.class, "Request body has no content",
 			() -> _getInputSchema(_openAPIJSONObject, "postEmptyContent"));
 		AssertUtils.assertFailure(
@@ -212,6 +209,110 @@ public class OpenAPIUtilTest {
 		_testGetTool(
 			"PUT /v1.0/items/{itemId}", "put_test_v1.0_items_itemId.json",
 			"putItem");
+	}
+
+	@Test
+	public void testGetToolMergesRequestBodyAndSchemaDescriptions() {
+		JSONObject openAPIJSONObject = JSONUtil.put(
+			"paths",
+			JSONUtil.put(
+				"/things",
+				JSONUtil.put(
+					"post",
+					JSONUtil.put(
+						"operationId", "postThing"
+					).put(
+						"requestBody",
+						JSONUtil.put(
+							"content",
+							JSONUtil.put(
+								"application/json",
+								JSONUtil.put(
+									"schema",
+									JSONUtil.put(
+										"description", "A Thing resource."
+									).put(
+										"type", "object"
+									)))
+						).put(
+							"description", "The thing to create."
+						)
+					))));
+
+		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
+
+		Map<String, ?> inputSchema = tool.getInputSchema();
+
+		Map<?, ?> properties = (Map<?, ?>)inputSchema.get("properties");
+
+		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
+
+		Assert.assertEquals(
+			"The thing to create. A Thing resource.",
+			bodySchema.get("description"));
+	}
+
+	@Test
+	public void testGetToolRequestBodyDescriptionIsSurfaced() {
+		JSONObject openAPIJSONObject = JSONUtil.put(
+			"paths",
+			JSONUtil.put(
+				"/things",
+				JSONUtil.put(
+					"post",
+					JSONUtil.put(
+						"operationId", "postThing"
+					).put(
+						"requestBody",
+						JSONUtil.put(
+							"content",
+							JSONUtil.put(
+								"application/json",
+								JSONUtil.put(
+									"schema", JSONUtil.put("type", "object")))
+						).put(
+							"description", "The thing to create."
+						)
+					))));
+
+		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
+
+		Map<String, ?> inputSchema = tool.getInputSchema();
+
+		Map<?, ?> properties = (Map<?, ?>)inputSchema.get("properties");
+
+		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
+
+		Assert.assertEquals(
+			"The thing to create.", bodySchema.get("description"));
+	}
+
+	@Test
+	public void testGetToolRequestBodyWithoutContentDoesNotFail() {
+		JSONObject openAPIJSONObject = JSONUtil.put(
+			"paths",
+			JSONUtil.put(
+				"/things",
+				JSONUtil.put(
+					"post",
+					JSONUtil.put(
+						"operationId", "postThing"
+					).put(
+						"requestBody",
+						JSONUtil.put("description", "The thing to create.")
+					))));
+
+		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
+
+		Map<String, ?> inputSchema = tool.getInputSchema();
+
+		Map<?, ?> properties = (Map<?, ?>)inputSchema.get("properties");
+
+		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
+
+		Assert.assertEquals("object", bodySchema.get("type"));
+		Assert.assertEquals(
+			"The thing to create.", bodySchema.get("description"));
 	}
 
 	@Test

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
@@ -189,13 +189,13 @@ public class OpenAPIUtilTest {
 			JSONUtil.put("body", JSONFactoryUtil.createJSONObject()),
 			_openAPIJSONObject, "postItem");
 
+		Assert.assertEquals(
+			"application/json", options.getHeader("Content-Type"));
+
 		Http.Body body = options.getBody();
 
 		Assert.assertEquals("{}", body.getContent());
 		Assert.assertEquals("application/json", body.getContentType());
-
-		Assert.assertEquals(
-			"application/json", options.getHeader("Content-Type"));
 	}
 
 	@Test

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
@@ -174,7 +174,7 @@ public class OpenAPIUtilTest {
 			IllegalArgumentException.class,
 			StringBundler.concat(
 				"The \"postItem\" tool requires the request payload nested ",
-				"under a \"body\" property; pass any path or query parameters ",
+				"under a \"body\" property. Pass any path or query parameters ",
 				"as siblings of \"body\" rather than flattening the payload ",
 				"into the input map"),
 			() -> OpenAPIUtil.getOptions(

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
@@ -246,7 +246,7 @@ public class OpenAPIUtilTest {
 							"type", "object"
 						)))
 			).put(
-				"description", "The thing to create."
+				"description", _REQUEST_BODY_DESCRIPTION
 			));
 
 		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
@@ -271,7 +271,7 @@ public class OpenAPIUtilTest {
 					"application/json",
 					JSONUtil.put("schema", JSONUtil.put("type", "object")))
 			).put(
-				"description", "The thing to create."
+				"description", _REQUEST_BODY_DESCRIPTION
 			));
 
 		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
@@ -283,13 +283,13 @@ public class OpenAPIUtilTest {
 		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
 
 		Assert.assertEquals(
-			"The thing to create.", bodySchema.get("description"));
+			_REQUEST_BODY_DESCRIPTION, bodySchema.get("description"));
 	}
 
 	@Test
 	public void testGetToolRequestBodyWithoutContentDoesNotFail() {
 		JSONObject openAPIJSONObject = _createOpenAPIJSONObject(
-			JSONUtil.put("description", "The thing to create."));
+			JSONUtil.put("description", _REQUEST_BODY_DESCRIPTION));
 
 		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
 
@@ -301,7 +301,7 @@ public class OpenAPIUtilTest {
 
 		Assert.assertEquals("object", bodySchema.get("type"));
 		Assert.assertEquals(
-			"The thing to create.", bodySchema.get("description"));
+			_REQUEST_BODY_DESCRIPTION, bodySchema.get("description"));
 	}
 
 	@Test
@@ -435,6 +435,9 @@ public class OpenAPIUtilTest {
 			),
 			true);
 	}
+
+	private static final String _REQUEST_BODY_DESCRIPTION =
+		"The thing to create.";
 
 	private JSONObject _openAPIJSONObject;
 


### PR DESCRIPTION
@albertojml
@liferay-headless

Original pull request comment:
https://liferay.atlassian.net/browse/LPD-93300

**What is being fixed:** When an AI agent invokes a Liferay MCP tool via POST /o/mcp-server/v1.0/tool-sets/{toolSetName}/tools/{toolName}/invoke, it must build the input map to match the tool's inputSchema: the request payload has to stay nested under a "body" property, with path/query parameters as siblings. Agents were not reliably understanding the full structure of the input and frequently flattened the payload into the top-level map. In that case the outgoing request carried no body and no application/json Content-Type, so the underlying JAX-RS endpoint rejected it with an unhelpful 415 instead of a usable error.

**How it is being fixed:** The request body description is surfaced to MCP agents so they understand what the body must contain. The invoke implementation now keys off the operation's request body and fails fast with actionable guidance — nest the payload under "body", pass path/query parameters as siblings — when "body" is missing, and always sets the Content-Type for request-body operations so the silent 415 can no longer be reached.

**Note:** Rebased on the latest master; the REST Builder requestBody.description dependency has since landed, so the diff is now self-contained across the five files touched here.

---

Applied the changes suggested in the review (#176372).