### PR TITLE
LPD-88506 Avoid NPE in asset entry search when the sort is null

### DIFF
--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -1107,7 +1107,7 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 		return buildSearchContext(
 			companyId, groupIds, userId, classTypeId, assetCategoryIds,
 			assetTagNames, showNonindexable, statuses, andSearch, start, end,
-			(sort == null) ? null : new Sort[] {sort});
+			(sort == null) ? new Sort[0] : new Sort[] {sort});
 	}
 
 	protected SearchContext buildSearchContext(


### PR DESCRIPTION
Backport of master commit brianchandotcom/liferay-portal@1713da24e5404d32b0cb4e3dba783cfff29bdd31 (LPD-88506) to `release-7.4.13.150`.

Fixes the release test failure tracked in LPD-94399: creating or listing tags in CMS throws a NullPointerException in `AssetEntryLocalServiceImpl._hasScoreSort` because the keyword usage count search builds a `SearchContext` with `setSorts(null)`. The one-line change passes `new Sort[0]` instead of `null` so the score-sort check iterates an empty array instead of NPEing.

Verified locally on a `release-7.4.13.150` bundle: POST `/o/headless-admin-taxonomy/v1.0/sites/{id}/keywords` went from HTTP 500 to HTTP 200 with `keywordUsageCount` serialized.

(cherry picked from commit 1713da24e5404d32b0cb4e3dba783cfff29bdd31)