### PR TITLE
LPD-93701 Drain the result set in the progress tracker concurrency test

### DIFF
--- a/portal-kernel/test/unit/com/liferay/portal/kernel/upgrade/recorder/UpgradeLogProgressTrackerTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/upgrade/recorder/UpgradeLogProgressTrackerTest.java
@@ -427,13 +427,7 @@ public class UpgradeLogProgressTrackerTest {
 				tasks.add(
 					() -> {
 						for (int j = 0; j < _ITERATIONS_PER_THREAD; j++) {
-							ResultSet resultSet = Mockito.mock(ResultSet.class);
-
-							Mockito.when(
-								resultSet.next()
-							).thenReturn(
-								true, false
-							);
+							ResultSet resultSet = _mockSingleRowResultSet();
 
 							ResultSet wrappedResultSet = _wrapResultSet(
 								resultSet, _UPGRADE_PROCESS_CLASS_NAME);
@@ -1694,6 +1688,18 @@ public class UpgradeLogProgressTrackerTest {
 			resultSet.next()
 		).thenReturn(
 			true
+		);
+
+		return resultSet;
+	}
+
+	private ResultSet _mockSingleRowResultSet() throws Exception {
+		ResultSet resultSet = Mockito.mock(ResultSet.class);
+
+		Mockito.when(
+			resultSet.next()
+		).thenReturn(
+			true, false
 		);
 
 		return resultSet;

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/upgrade/recorder/UpgradeLogProgressTrackerTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/upgrade/recorder/UpgradeLogProgressTrackerTest.java
@@ -427,12 +427,22 @@ public class UpgradeLogProgressTrackerTest {
 				tasks.add(
 					() -> {
 						for (int j = 0; j < _ITERATIONS_PER_THREAD; j++) {
-							ResultSet resultSet = _mockResultSet();
+							ResultSet resultSet = Mockito.mock(ResultSet.class);
+
+							Mockito.when(
+								resultSet.next()
+							).thenReturn(
+								true, false
+							);
 
 							ResultSet wrappedResultSet = _wrapResultSet(
 								resultSet, _UPGRADE_PROCESS_CLASS_NAME);
 
-							wrappedResultSet.next();
+							_resetLogTime(wrappedResultSet);
+
+							Assert.assertTrue(wrappedResultSet.next());
+							Assert.assertFalse(wrappedResultSet.next());
+
 							wrappedResultSet.close();
 						}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93701

## What Is Being Fixed

`testConcurrentResultSetIterationDoesNotCorruptProgresses` in `UpgradeLogProgressTrackerTest` fails intermittently with an AssertionFailedError: the progress map is sometimes not empty after all threads finish. The test runs with a one millisecond log interval and a mock whose `next()` always returns true, so the cursor is never drained. Each iteration stamps the log time in the handler constructor and then calls `next()` once. When more than one millisecond elapses before that call on a loaded CI machine, `_captureProgress()` adds an entry to the map, and because the entry is only removed when `next()` returns false, `close()` leaves it stranded. The assertion then fails non-deterministically.

## How It Is Being Fixed

The first commit makes the iteration deterministic without changing production code. The mock now returns true and then false, the body resets the log time to force a capture, and two assertions drain the cursor to the end of the result set. Each iteration therefore performs a put followed by a remove through the real code path, so the map ends empty regardless of timing while the test still exercises concurrent puts and removes on the shared map.

The second commit addresses the review comment on the forwarded pull request (https://github.com/brianchandotcom/liferay-portal/pull/176479#issuecomment-4679287915). That comment noted the first commit created the result set mock inline with `Mockito.mock(ResultSet.class)` and `Mockito.when(...).thenReturn(true, false)`, diverging from the established `_mockResultSet()` helper used elsewhere in the class, and suggested either a `_mockResultSet(true, false)` overload or a new `_mockExhaustibleResultSet()` helper. The mock setup is now extracted into a sibling helper that mirrors `_mockResultSet()`, and the concurrency test calls it.

The helper is named `_mockSingleRowResultSet()` rather than the suggested `_mockExhaustibleResultSet()`. The word "exhaustible" does not appear anywhere in the codebase, whereas naming a result set by its row content is the established convention (`emptyResultSet` is used in 15 places). `_mockSingleRowResultSet` follows that convention and states the behavior precisely: one row, then end of set. A dedicated helper is used instead of the overload because a clean varargs overload would require `OngoingStubbing`, which also has no precedent in the codebase.

## PR Check

**pr-check: PASS** — tested on `2d6e6a16a93902a504a45229631e485a4fe52295`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Java Unit Tests | PASS |
| Full Portal Build | SKIPPED (not applicable to a test-only change) |

<!-- pr-check {"result": "success", "sha": "2d6e6a16a93902a504a45229631e485a4fe52295"} -->
