### PR TITLE
LPD-92575 baseLine

### DIFF
--- a/modules/apps/export-import/export-import-api/bnd.bnd
+++ b/modules/apps/export-import/export-import-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Export Import API
 Bundle-SymbolicName: com.liferay.exportimport.api
-Bundle-Version: 17.1.1
+Bundle-Version: 17.2.0
 Export-Package:\
 	com.liferay.exportimport.attachment,\
 	com.liferay.exportimport.configuration,\

--- a/modules/apps/export-import/export-import-api/src/main/resources/com/liferay/exportimport/vulcan/batch/engine/packageinfo
+++ b/modules/apps/export-import/export-import-api/src/main/resources/com/liferay/exportimport/vulcan/batch/engine/packageinfo
@@ -1,1 +1,1 @@
-version 8.1.0
+version 8.2.0


### PR DESCRIPTION
Semantic version increase for the `com.liferay.exportimport.vulcan.batch.engine` package.

liferay-headless/liferay-portal#3849 (LPD-92575) added the `PORTLET` constant to the `ExportImportVulcanBatchEngineTaskItemDelegate.Scope` enum without the corresponding semantic version increase, so `gw baseline` now fails on master for `export-import-api`. This raises the package to 8.2.0 and the bundle to 17.2.0.

https://liferay.atlassian.net/browse/LPD-92575