### PR TITLE
LPD-64610 Match the Users portlet event name by namespace prefix

### DIFF
--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/item/selector/DepotGroupItemSelectorView.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/item/selector/DepotGroupItemSelectorView.java
@@ -251,8 +251,9 @@ public class DepotGroupItemSelectorView
 				String itemSelectedEventName = ParamUtil.getString(
 					portletRequest, "itemSelectedEventName");
 
-				if (itemSelectedEventName.contains(
-						UsersAdminPortletKeys.USERS_ADMIN)) {
+				if (itemSelectedEventName.startsWith(
+						_portal.getPortletNamespace(
+							UsersAdminPortletKeys.USERS_ADMIN))) {
 
 					ctCollectionId =
 						CTCollectionThreadLocal.CT_COLLECTION_ID_PRODUCTION;

--- a/modules/apps/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/display/context/SelectRoleManagementToolbarDisplayContext.java
+++ b/modules/apps/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/display/context/SelectRoleManagementToolbarDisplayContext.java
@@ -145,7 +145,9 @@ public class SelectRoleManagementToolbarDisplayContext {
 		long ctCollectionId = CTCollectionThreadLocal.getCTCollectionId();
 
 		if ((_eventName != null) &&
-			_eventName.contains(UsersAdminPortletKeys.USERS_ADMIN)) {
+			_eventName.startsWith(
+				PortalUtil.getPortletNamespace(
+					UsersAdminPortletKeys.USERS_ADMIN))) {
 
 			ctCollectionId =
 				CTCollectionThreadLocal.CT_COLLECTION_ID_PRODUCTION;

--- a/modules/apps/site/site-item-selector-web/src/main/java/com/liferay/site/item/selector/web/internal/display/context/MySitesItemSelectorViewDisplayContext.java
+++ b/modules/apps/site/site-item-selector-web/src/main/java/com/liferay/site/item/selector/web/internal/display/context/MySitesItemSelectorViewDisplayContext.java
@@ -81,7 +81,9 @@ public class MySitesItemSelectorViewDisplayContext
 		String itemSelectedEventName = getItemSelectedEventName();
 
 		if ((itemSelectedEventName != null) &&
-			itemSelectedEventName.contains(UsersAdminPortletKeys.USERS_ADMIN)) {
+			itemSelectedEventName.startsWith(
+				PortalUtil.getPortletNamespace(
+					UsersAdminPortletKeys.USERS_ADMIN))) {
 
 			ctCollectionId =
 				CTCollectionThreadLocal.CT_COLLECTION_ID_PRODUCTION;

--- a/modules/apps/user-groups-admin/user-groups-admin-item-selector-web/src/main/java/com/liferay/user/groups/admin/item/selector/web/internal/display/context/UserGroupItemSelectorViewDisplayContext.java
+++ b/modules/apps/user-groups-admin/user-groups-admin-item-selector-web/src/main/java/com/liferay/user/groups/admin/item/selector/web/internal/display/context/UserGroupItemSelectorViewDisplayContext.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.service.UserGroupLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portlet.usersadmin.util.UsersAdminUtil;
 import com.liferay.user.groups.admin.item.selector.UserGroupItemSelectorCriterion;
@@ -94,7 +95,10 @@ public class UserGroupItemSelectorViewDisplayContext {
 		String itemSelectedEventName = ParamUtil.getString(
 			_renderRequest, "itemSelectedEventName");
 
-		if (itemSelectedEventName.contains(UsersAdminPortletKeys.USERS_ADMIN)) {
+		if (itemSelectedEventName.startsWith(
+				PortalUtil.getPortletNamespace(
+					UsersAdminPortletKeys.USERS_ADMIN))) {
+
 			ctCollectionId =
 				CTCollectionThreadLocal.CT_COLLECTION_ID_PRODUCTION;
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-64610

## What Is Being Fixed

Follow-up to the LPD-64610 fix (already merged) that excludes publication scoped entities from the user membership selectors. The four selectors now detect the Users portlet by testing whether the item selected event name starts with the portlet namespace.

## PR Check

**pr-check: PASS** — tested on `77bb0cf8a16fe8c75c0f62d297a1d4fb948307f2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "77bb0cf8a16fe8c75c0f62d297a1d4fb948307f2"} -->