### PR TITLE
LPD-94196 Return false if release has already been verified

### DIFF
--- a/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
+++ b/modules/apps/portal/portal-verify-extender/src/main/java/com/liferay/portal/verify/extender/internal/osgi/commands/VerifyProcessTrackerOSGiCommands.java
@@ -376,6 +376,10 @@ public class VerifyProcessTrackerOSGiCommands {
 			return true;
 		}
 
+		if (release.isVerified()) {
+			return false;
+		}
+
 		try {
 			Collection<ServiceReference<Release>> releases =
 				bundleContext.getServiceReferences(

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/VerifyProcessTrackerOSGiCommandsTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/VerifyProcessTrackerOSGiCommandsTest.java
@@ -216,6 +216,27 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 	}
 
 	@Test
+	public void testRegisterInitialDeploymentVerifyProcessTwiceWithInitialRelease() {
+		_initialDeployment = true;
+
+		try (SafeCloseable safeCloseable1 = _publishInitialRelease()) {
+			try (SafeCloseable safeCloseable2 = _registerVerifyProcess(
+					true, false)) {
+
+				_assertVerify(true);
+			}
+
+			_verifyProcessRun = false;
+
+			try (SafeCloseable safeCloseable3 = _registerVerifyProcess(
+					true, false)) {
+
+				_assertVerify(false);
+			}
+		}
+	}
+
+	@Test
 	public void testRegisterNewVerifyProcessDuringUpgradePortal() {
 		try (SafeCloseable safeCloseable1 = _upgradePortal(false);
 			SafeCloseable safeCloseable2 = _registerVerifyProcess(
@@ -359,6 +380,28 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 				).build());
 
 		return upgradeStepServiceRegistration::unregister;
+	}
+
+	private SafeCloseable _publishInitialRelease() {
+		Release release = _releaseLocalService.createRelease(
+			_counterLocalService.increment());
+
+		release.setServletContextName(_symbolicName);
+		release.setVerified(false);
+
+		release = _releaseLocalService.updateRelease(release);
+
+		ServiceRegistration<Release> releaseServiceRegistration =
+			_bundleContext.registerService(
+				Release.class, release,
+				HashMapDictionaryBuilder.<String, Object>put(
+					"release.bundle.symbolic.name",
+					release.getBundleSymbolicName()
+				).put(
+					"release.initial", true
+				).build());
+
+		return releaseServiceRegistration::unregister;
 	}
 
 	private SafeCloseable _registerVerifyProcess(

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/VerifyProcessTrackerOSGiCommandsTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/VerifyProcessTrackerOSGiCommandsTest.java
@@ -71,6 +71,10 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 			_runOnPortalUpgradeVerifiers);
 		StartupHelperUtil.setUpgrading(_upgrading);
 
+		if (_serviceRegistration != null) {
+			_serviceRegistration.unregister();
+		}
+
 		Release release = _releaseLocalService.fetchRelease(_symbolicName);
 
 		if (release != null) {
@@ -219,20 +223,34 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 	public void testRegisterInitialDeploymentVerifyProcessTwiceWithInitialRelease() {
 		_initialDeployment = true;
 
-		try (SafeCloseable safeCloseable1 = _publishInitialRelease()) {
-			try (SafeCloseable safeCloseable2 = _registerVerifyProcess(
-					true, false)) {
+		Release release = _releaseLocalService.createRelease(
+			_counterLocalService.increment());
 
-				_assertVerify(true);
-			}
+		release.setServletContextName(_symbolicName);
+		release.setVerified(false);
 
-			_verifyProcessRun = false;
+		release = _releaseLocalService.updateRelease(release);
 
-			try (SafeCloseable safeCloseable3 = _registerVerifyProcess(
-					true, false)) {
+		_serviceRegistration = _bundleContext.registerService(
+			Release.class, release,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"release.bundle.symbolic.name", release.getBundleSymbolicName()
+			).put(
+				"release.initial", true
+			).build());
 
-				_assertVerify(false);
-			}
+		try (SafeCloseable safeCloseable = _registerVerifyProcess(
+				true, false)) {
+
+			_assertVerify(true);
+		}
+
+		_verifyProcessRun = false;
+
+		try (SafeCloseable safeCloseable = _registerVerifyProcess(
+				true, false)) {
+
+			_assertVerify(false);
 		}
 	}
 
@@ -382,28 +400,6 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 		return upgradeStepServiceRegistration::unregister;
 	}
 
-	private SafeCloseable _publishInitialRelease() {
-		Release release = _releaseLocalService.createRelease(
-			_counterLocalService.increment());
-
-		release.setServletContextName(_symbolicName);
-		release.setVerified(false);
-
-		release = _releaseLocalService.updateRelease(release);
-
-		ServiceRegistration<Release> releaseServiceRegistration =
-			_bundleContext.registerService(
-				Release.class, release,
-				HashMapDictionaryBuilder.<String, Object>put(
-					"release.bundle.symbolic.name",
-					release.getBundleSymbolicName()
-				).put(
-					"release.initial", true
-				).build());
-
-		return releaseServiceRegistration::unregister;
-	}
-
 	private SafeCloseable _registerVerifyProcess(
 		boolean initialDeployment, boolean runOnPortalUpgrade) {
 
@@ -464,6 +460,7 @@ public class VerifyProcessTrackerOSGiCommandsTest {
 	@Inject
 	private ReleaseLocalService _releaseLocalService;
 
+	private ServiceRegistration<Release> _serviceRegistration;
 	private final VerifyProcessTest _verifyProcess = new VerifyProcessTest();
 	private boolean _verifyProcessRun;
 


### PR DESCRIPTION
**Previous PR:** https://github.com/brianchandotcom/liferay-portal/pull/176476#issuecomment-4680422563

> @ericyanLr
> 
> _publishInitialRelease
> 
> is only used once

New Changes: Added SF commit

----

https://liferay.atlassian.net/browse/LPD-94196

## What Is Being Fixed

`SXPServiceVerifyProcess` re-executes on every restart of `search-experiences-service` against a fresh
database, even after the verify process has already completed successfully. The same pattern affects
any Liferay-Service module that registers a `VerifyProcess` with `initial.deployment=true`.

`ReleaseManagerImpl` publishes a `Release` OSGi service with `release.initial=true` at schema
creation, and `VerifyProcessTrackerOSGiCommands._isInitialDeployment` checks for that property to
determine whether an `initial.deployment=true` verify process should run. The property remains in
place until Liferay is restarted, so the method keeps returning true on each module restart.

On portal startup, `ReleasePublisher.activate` republishes existing releases with 
`release.initial=false`, which is why a full Liferay restart resolves the symptom.

## How It Is Being Fixed

`_isInitialDeployment` now returns false if the release has already been verified. The release's
verified state accurately tracks whether the initial verify completed, so a verified release is
reliably treated as past initial deployment.

An integration test in `VerifyProcessTrackerOSGiCommandsTest` reproduces the bug by publishing
`release.initial=true` manually and re-registering the verify process twice — it asserts the verify
process runs on first registration and does not re-run on the second.

## PR Check

**pr-check: PASS** — tested on `10c8c321609c2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "10c8c321609c252d5a7edece9736d74609999047"} -->