### PR TITLE
LPD-93340 Deploy latest builder jar in build-rests and build-services

### DIFF
--- a/portal-impl/build.xml
+++ b/portal-impl/build.xml
@@ -237,6 +237,13 @@
 	</target>
 
 	<target name="build-rests">
+		<if>
+			<available file="${project.dir}/modules/util/portal-tools-rest-builder" />
+			<then>
+				<gradle-execute dir="${project.dir}/modules/util/portal-tools-rest-builder" task="deploy" />
+			</then>
+		</if>
+
 		<tstamp>
 			<format pattern="yyyyMMddkkmmssSSS" property="build.rests.tstamp.value" />
 		</tstamp>
@@ -381,6 +388,13 @@
 	</target>
 
 	<target name="build-services">
+		<if>
+			<available file="${project.dir}/modules/util/portal-tools-service-builder" />
+			<then>
+				<gradle-execute dir="${project.dir}/modules/util/portal-tools-service-builder" task="deploy" />
+			</then>
+		</if>
+
 		<build-service
 			hbm.file="counter-hbm.xml"
 			service.file="${basedir}/src/com/liferay/counter/service.xml"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93340

## What Is Being Fixed

Running `ant build-rests` or `ant build-services` locally never rebuilt or redeployed the REST Builder or Service Builder tool, so they ran against whatever jar happened to be sitting in `tools/sdk/dependencies`, which could be stale. CI deploys the tool first through `build-test-batch.xml`, so sources generated locally could diverge from what CI produces — the mismatch hit when sending REST Builder corrections.

## How It Is Being Fixed

Each of the `build-rests` and `build-services` targets now deploys its tool module first (`modules/util/portal-tools-rest-builder` / `portal-tools-service-builder`) before invoking the builder, mirroring CI's `deploy-and-execute-rest-builder-or-service-builder-ant-target` macro. The deploy is guarded by an `<available>` check so trimmed checkouts without the tool module fall back to the previously deployed jar. Unlike CI it does not pass `clean`, so it relies on Gradle's incremental build: an unchanged tool source is up-to-date and skips recompilation, while a changed tool source recompiles and redeploys before generating. This keeps locally generated sources consistent with CI without sacrificing local caching.

## Why Are There No Tests?

This is a build infrastructure change to Ant targets in portal-impl/build.xml. The behavior is not unit/integration testable; it was verified manually by running ant build-rests and build-services and confirming the builder jar is deployed and the build is cached on reruns.

## PR Check

**pr-check: PASS** — tested on `321f2c63db79d7fda9fb6ae0ae2a1c41e8d18dcf`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |

Source Format was re-run on this commit. Full Portal Build (`ant all`) passed on the immediately prior commit `5ee2220`; the only delta is the path-expression form in `build.xml` (`${basedir}/..` normalized to `${project.dir}`), which resolves to the same directories and is not exercised by `ant all`. The `build-rests` and `build-services` targets were re-verified manually on this commit.

<!-- pr-check {"result": "success", "sha": "321f2c63db79d7fda9fb6ae0ae2a1c41e8d18dcf"} -->