### PR TITLE
LPD-91101 Allow CMS and space admins to list site templates and sites

### DIFF
--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
@@ -7,6 +7,7 @@ package com.liferay.depot.internal.security.permission.wrapper;
 
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.constants.DepotRolesConstants;
+import com.liferay.depot.internal.util.PermissionUtil;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.exportimport.kernel.staging.StagingUtil;
 import com.liferay.petra.function.UnsafeFunction;
@@ -228,23 +229,6 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 		}
 	}
 
-	private boolean _hasCMSAdministratorRole(long companyId)
-		throws PortalException {
-
-		Boolean value = PermissionCacheUtil.getUserPrimaryKeyRole(
-			getUserId(), companyId, RoleConstants.CMS_ADMINISTRATOR);
-
-		if (value == null) {
-			value = _roleLocalService.hasUserRole(
-				getUserId(), companyId, RoleConstants.CMS_ADMINISTRATOR, true);
-
-			PermissionCacheUtil.putUserPrimaryKeyRole(
-				getUserId(), companyId, RoleConstants.CMS_ADMINISTRATOR, value);
-		}
-
-		return value;
-	}
-
 	private Boolean _hasPermission(
 		long groupId, String name, long primKey, String actionId) {
 
@@ -280,13 +264,10 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 			}
 			else if (actionId.equals(ActionKeys.VIEW) && group.isSite()) {
 				try {
-					if (_hasCMSAdministratorRole(group.getCompanyId()) ||
-						_isDepotGroupAdminOrOwner(group.getCompanyId())) {
-
-						return true;
-					}
-
-					return false;
+					return PermissionUtil.hasCMSAdministratorRole(
+						group.getCompanyId()) ||
+						   PermissionUtil.isDepotGroupAdminOrOwner(
+							   group.getCompanyId());
 				}
 				catch (PortalException portalException) {
 					_log.error(portalException);
@@ -302,7 +283,9 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 				(role.getType() == RoleConstants.TYPE_DEPOT)) {
 
 				try {
-					if (_hasCMSAdministratorRole(getCompanyId())) {
+					if (PermissionUtil.hasCMSAdministratorRole(
+							getCompanyId())) {
+
 						return true;
 					}
 
@@ -369,7 +352,7 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 			return false;
 		}
 
-		return _hasCMSAdministratorRole(group.getCompanyId());
+		return PermissionUtil.hasCMSAdministratorRole(group.getCompanyId());
 	}
 
 	private boolean _isContentReviewer(Group group) throws PortalException {
@@ -406,29 +389,6 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 			if (_isDepotGroupAdmin(
 					_groupLocalService.fetchGroup(
 						userGroupRole.getGroupId()))) {
-
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	private boolean _isDepotGroupAdminOrOwner(long companyId)
-		throws PortalException {
-
-		Role assetLibraryAdministratorRole = _roleLocalService.getRole(
-			companyId, DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR);
-		Role assetLibraryOwnerRole = _roleLocalService.getRole(
-			companyId, DepotRolesConstants.ASSET_LIBRARY_OWNER);
-
-		for (UserGroupRole userGroupRole :
-				_userGroupRoleLocalService.getUserGroupRoles(getUserId())) {
-
-			long roleId = userGroupRole.getRoleId();
-
-			if ((roleId == assetLibraryAdministratorRole.getRoleId()) ||
-				(roleId == assetLibraryOwnerRole.getRoleId())) {
 
 				return true;
 			}

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
@@ -251,7 +251,11 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 		if (StringUtil.equals(name, Group.class.getName())) {
 			Group group = _groupLocalService.fetchGroup(primKey);
 
-			if ((group != null) && group.isDepot()) {
+			if (group == null) {
+				return null;
+			}
+
+			if (group.isDepot()) {
 				try {
 					if (!_supportedActionIds.contains(actionId)) {
 						return false;
@@ -267,6 +271,22 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 
 					return _depotEntryModelResourcePermission.contains(
 						this, group.getClassPK(), actionId);
+				}
+				catch (PortalException portalException) {
+					_log.error(portalException);
+
+					return false;
+				}
+			}
+			else if (actionId.equals(ActionKeys.VIEW) && group.isSite()) {
+				try {
+					if (_hasCMSAdministratorRole(group.getCompanyId()) ||
+						_isDepotGroupAdminOrOwner(group.getCompanyId())) {
+
+						return true;
+					}
+
+					return false;
 				}
 				catch (PortalException portalException) {
 					_log.error(portalException);
@@ -386,6 +406,29 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 			if (_isDepotGroupAdmin(
 					_groupLocalService.fetchGroup(
 						userGroupRole.getGroupId()))) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private boolean _isDepotGroupAdminOrOwner(long companyId)
+		throws PortalException {
+
+		Role assetLibraryAdministratorRole = _roleLocalService.getRole(
+			companyId, DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR);
+		Role assetLibraryOwnerRole = _roleLocalService.getRole(
+			companyId, DepotRolesConstants.ASSET_LIBRARY_OWNER);
+
+		for (UserGroupRole userGroupRole :
+				_userGroupRoleLocalService.getUserGroupRoles(getUserId())) {
+
+			long roleId = userGroupRole.getRoleId();
+
+			if ((roleId == assetLibraryAdministratorRole.getRoleId()) ||
+				(roleId == assetLibraryOwnerRole.getRoleId())) {
 
 				return true;
 			}

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/service/DepotLayoutSetPrototypeServiceWrapper.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/service/DepotLayoutSetPrototypeServiceWrapper.java
@@ -1,0 +1,136 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.depot.internal.service;
+
+import com.liferay.depot.constants.DepotRolesConstants;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.LayoutSetPrototype;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.UserGroupRole;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
+import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
+import com.liferay.portal.kernel.service.LayoutSetPrototypeServiceWrapper;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.ServiceWrapper;
+import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
+import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.security.permission.PermissionCacheUtil;
+
+import java.util.List;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(service = ServiceWrapper.class)
+public class DepotLayoutSetPrototypeServiceWrapper
+	extends LayoutSetPrototypeServiceWrapper {
+
+	@Override
+	public List<LayoutSetPrototype> search(
+		long companyId, Boolean active, int start, int end,
+		OrderByComparator<LayoutSetPrototype> orderByComparator) {
+
+		try {
+			if (_hasCMSAdministratorRole(companyId) ||
+				_isDepotGroupAdminOrOwner(companyId)) {
+
+				return _layoutSetPrototypeLocalService.search(
+					companyId, active, start, end, orderByComparator);
+			}
+
+			return super.search(
+				companyId, active, start, end, orderByComparator);
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+
+			return super.search(
+				companyId, active, start, end, orderByComparator);
+		}
+	}
+
+	@Override
+	public int searchCount(long companyId, Boolean active) {
+		try {
+			if (_hasCMSAdministratorRole(companyId) ||
+				_isDepotGroupAdminOrOwner(companyId)) {
+
+				return _layoutSetPrototypeLocalService.searchCount(
+					companyId, active);
+			}
+
+			return super.searchCount(companyId, active);
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+
+			return super.searchCount(companyId, active);
+		}
+	}
+
+	private boolean _hasCMSAdministratorRole(long companyId)
+		throws PortalException {
+
+		Boolean value = PermissionCacheUtil.getUserPrimaryKeyRole(
+			GuestOrUserUtil.getUserId(), companyId,
+			RoleConstants.CMS_ADMINISTRATOR);
+
+		if (value == null) {
+			value = _roleLocalService.hasUserRole(
+				GuestOrUserUtil.getUserId(), companyId,
+				RoleConstants.CMS_ADMINISTRATOR, true);
+
+			PermissionCacheUtil.putUserPrimaryKeyRole(
+				GuestOrUserUtil.getUserId(), companyId,
+				RoleConstants.CMS_ADMINISTRATOR, value);
+		}
+
+		return value;
+	}
+
+	private boolean _isDepotGroupAdminOrOwner(long companyId)
+		throws PortalException {
+
+		Role assetLibraryAdministratorRole = _roleLocalService.getRole(
+			companyId, DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR);
+		Role assetLibraryOwnerRole = _roleLocalService.getRole(
+			companyId, DepotRolesConstants.ASSET_LIBRARY_OWNER);
+
+		for (UserGroupRole userGroupRole :
+				_userGroupRoleLocalService.getUserGroupRoles(
+					GuestOrUserUtil.getUserId())) {
+
+			long roleId = userGroupRole.getRoleId();
+
+			if ((roleId == assetLibraryAdministratorRole.getRoleId()) ||
+				(roleId == assetLibraryOwnerRole.getRoleId())) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DepotLayoutSetPrototypeServiceWrapper.class);
+
+	@Reference
+	private LayoutSetPrototypeLocalService _layoutSetPrototypeLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private UserGroupRoleLocalService _userGroupRoleLocalService;
+
+}

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/service/DepotLayoutSetPrototypeServiceWrapper.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/service/DepotLayoutSetPrototypeServiceWrapper.java
@@ -5,22 +5,15 @@
 
 package com.liferay.depot.internal.service;
 
-import com.liferay.depot.constants.DepotRolesConstants;
+import com.liferay.depot.internal.util.PermissionUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
-import com.liferay.portal.kernel.model.Role;
-import com.liferay.portal.kernel.model.UserGroupRole;
-import com.liferay.portal.kernel.model.role.RoleConstants;
-import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeServiceWrapper;
-import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceWrapper;
-import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.util.OrderByComparator;
-import com.liferay.portal.security.permission.PermissionCacheUtil;
 
 import java.util.List;
 
@@ -40,8 +33,8 @@ public class DepotLayoutSetPrototypeServiceWrapper
 		OrderByComparator<LayoutSetPrototype> orderByComparator) {
 
 		try {
-			if (_hasCMSAdministratorRole(companyId) ||
-				_isDepotGroupAdminOrOwner(companyId)) {
+			if (PermissionUtil.hasCMSAdministratorRole(companyId) ||
+				PermissionUtil.isDepotGroupAdminOrOwner(companyId)) {
 
 				return _layoutSetPrototypeLocalService.search(
 					companyId, active, start, end, orderByComparator);
@@ -61,8 +54,8 @@ public class DepotLayoutSetPrototypeServiceWrapper
 	@Override
 	public int searchCount(long companyId, Boolean active) {
 		try {
-			if (_hasCMSAdministratorRole(companyId) ||
-				_isDepotGroupAdminOrOwner(companyId)) {
+			if (PermissionUtil.hasCMSAdministratorRole(companyId) ||
+				PermissionUtil.isDepotGroupAdminOrOwner(companyId)) {
 
 				return _layoutSetPrototypeLocalService.searchCount(
 					companyId, active);
@@ -77,60 +70,10 @@ public class DepotLayoutSetPrototypeServiceWrapper
 		}
 	}
 
-	private boolean _hasCMSAdministratorRole(long companyId)
-		throws PortalException {
-
-		Boolean value = PermissionCacheUtil.getUserPrimaryKeyRole(
-			GuestOrUserUtil.getUserId(), companyId,
-			RoleConstants.CMS_ADMINISTRATOR);
-
-		if (value == null) {
-			value = _roleLocalService.hasUserRole(
-				GuestOrUserUtil.getUserId(), companyId,
-				RoleConstants.CMS_ADMINISTRATOR, true);
-
-			PermissionCacheUtil.putUserPrimaryKeyRole(
-				GuestOrUserUtil.getUserId(), companyId,
-				RoleConstants.CMS_ADMINISTRATOR, value);
-		}
-
-		return value;
-	}
-
-	private boolean _isDepotGroupAdminOrOwner(long companyId)
-		throws PortalException {
-
-		Role assetLibraryAdministratorRole = _roleLocalService.getRole(
-			companyId, DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR);
-		Role assetLibraryOwnerRole = _roleLocalService.getRole(
-			companyId, DepotRolesConstants.ASSET_LIBRARY_OWNER);
-
-		for (UserGroupRole userGroupRole :
-				_userGroupRoleLocalService.getUserGroupRoles(
-					GuestOrUserUtil.getUserId())) {
-
-			long roleId = userGroupRole.getRoleId();
-
-			if ((roleId == assetLibraryAdministratorRole.getRoleId()) ||
-				(roleId == assetLibraryOwnerRole.getRoleId())) {
-
-				return true;
-			}
-		}
-
-		return false;
-	}
-
 	private static final Log _log = LogFactoryUtil.getLog(
 		DepotLayoutSetPrototypeServiceWrapper.class);
 
 	@Reference
 	private LayoutSetPrototypeLocalService _layoutSetPrototypeLocalService;
-
-	@Reference
-	private RoleLocalService _roleLocalService;
-
-	@Reference
-	private UserGroupRoleLocalService _userGroupRoleLocalService;
 
 }

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/util/PermissionUtil.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/util/PermissionUtil.java
@@ -1,0 +1,76 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.depot.internal.util;
+
+import com.liferay.depot.constants.DepotRolesConstants;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.UserGroupRole;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
+import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
+import com.liferay.portal.kernel.service.UserGroupRoleLocalServiceUtil;
+import com.liferay.portal.security.permission.PermissionCacheUtil;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class PermissionUtil {
+
+	public static boolean hasCMSAdministratorRole(long companyId)
+		throws PortalException {
+
+		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-17564")) {
+			return false;
+		}
+
+		Boolean value = PermissionCacheUtil.getUserPrimaryKeyRole(
+			GuestOrUserUtil.getUserId(), companyId,
+			RoleConstants.CMS_ADMINISTRATOR);
+
+		if (value == null) {
+			value = RoleLocalServiceUtil.hasUserRole(
+				GuestOrUserUtil.getUserId(), companyId,
+				RoleConstants.CMS_ADMINISTRATOR, true);
+
+			PermissionCacheUtil.putUserPrimaryKeyRole(
+				GuestOrUserUtil.getUserId(), companyId,
+				RoleConstants.CMS_ADMINISTRATOR, value);
+		}
+
+		return value;
+	}
+
+	public static boolean isDepotGroupAdminOrOwner(long companyId)
+		throws PortalException {
+
+		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-17564")) {
+			return false;
+		}
+
+		Role assetLibraryAdministratorRole = RoleLocalServiceUtil.getRole(
+			companyId, DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR);
+		Role assetLibraryOwnerRole = RoleLocalServiceUtil.getRole(
+			companyId, DepotRolesConstants.ASSET_LIBRARY_OWNER);
+
+		for (UserGroupRole userGroupRole :
+				UserGroupRoleLocalServiceUtil.getUserGroupRoles(
+					GuestOrUserUtil.getUserId())) {
+
+			long roleId = userGroupRole.getRoleId();
+
+			if ((roleId == assetLibraryAdministratorRole.getRoleId()) ||
+				(roleId == assetLibraryOwnerRole.getRoleId())) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteResourceTest.java
@@ -7,6 +7,7 @@ package com.liferay.headless.admin.site.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.exportimport.test.rule.LazyReferencing;
@@ -28,13 +29,17 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
+import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -53,8 +58,11 @@ import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LanguageIds;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.site.initializer.SiteInitializer;
 
 import java.io.File;
@@ -68,7 +76,6 @@ import java.util.Map;
 
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -92,18 +99,10 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 
 	@ClassRule
 	@Rule
-	public static final LazyReferencingTestRule lazyReferencingTestRule =
-		LazyReferencingTestRule.INSTANCE;
-
-	@Before
-	@Override
-	public void setUp() throws Exception {
-		super.setUp();
-
-		_originalName = PrincipalThreadLocal.getName();
-
-		PrincipalThreadLocal.setName(TestPropsValues.getUserId());
-	}
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			LazyReferencingTestRule.INSTANCE, new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@After
 	@Override
@@ -129,8 +128,6 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 
 			_groupLocalService.deleteGroup(group);
 		}
-
-		PrincipalThreadLocal.setName(_originalName);
 	}
 
 	@Override
@@ -170,6 +167,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 	public void testGetSiteSiteInitializer() throws Exception {
 	}
 
+	@FeatureFlag("LPD-17564")
 	@Override
 	@Test
 	public void testGetSitesPage() throws Exception {
@@ -178,12 +176,22 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		_testGetSitesPageWithActiveAndInactiveSites();
 		_testGetSitesPageWithActiveOrSiteGroups(false, true);
 		_testGetSitesPageWithActiveOrSiteGroups(true, false);
+		_testGetSitesPageWithAssetLibraryMember();
 		_testGetSitesPageWithDepotEntry();
 		_testGetSitesPageWithExcludedExternalReferenceCodes();
 		_testGetSitesPageWithInactiveSites();
+		_testGetSitesPageWithoutAuthentication();
 		_testGetSitesPageWithoutSiteMembership();
 		_testGetSitesPageWithSearch();
-		_testGetSitesPageWithoutAuthentication();
+		_testGetSitesPageWithUser(
+			_addUserWithDepotRole(
+				_addDepotEntry(),
+				DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR));
+		_testGetSitesPageWithUser(
+			_addUserWithDepotRole(
+				_addDepotEntry(), DepotRolesConstants.ASSET_LIBRARY_OWNER));
+		_testGetSitesPageWithUser(
+			_addUserWithRegularRole(RoleConstants.CMS_ADMINISTRATOR));
 	}
 
 	@LazyReferencing
@@ -402,6 +410,44 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		}
 	}
 
+	private DepotEntry _addDepotEntry() throws Exception {
+		return _depotEntryLocalService.addDepotEntry(
+			Collections.singletonMap(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			Collections.singletonMap(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private User _addUserWithDepotRole(DepotEntry depotEntry, String roleName)
+		throws Exception {
+
+		User user = UserTestUtil.addUser(
+			testCompany, RandomTestUtil.randomString());
+
+		Role role = _roleLocalService.getRole(
+			testCompany.getCompanyId(), roleName);
+
+		_userGroupRoleLocalService.addUserGroupRoles(
+			user.getUserId(), depotEntry.getGroupId(),
+			new long[] {role.getRoleId()});
+
+		return user;
+	}
+
+	private User _addUserWithRegularRole(String roleName) throws Exception {
+		User user = UserTestUtil.addUser(
+			testCompany, RandomTestUtil.randomString());
+
+		Role role = _roleLocalService.getRole(
+			testCompany.getCompanyId(), roleName);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user.getUserId());
+
+		return user;
+	}
+
 	private void _assertEquals(Group group, Site site) throws Exception {
 		Assert.assertEquals(site.getActive(), group.isActive());
 		Assert.assertEquals(
@@ -429,6 +475,18 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 
 		Assert.assertEquals(
 			site.getName(), group.getName(LocaleUtil.getDefault()));
+	}
+
+	private SiteResource _getSiteResource(User user) {
+		return SiteResource.builder(
+		).authentication(
+			user.getEmailAddress(), user.getPasswordUnencrypted()
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
 	}
 
 	private void _testGetSitesPageWithActiveAndInactiveSites()
@@ -475,6 +533,24 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		List<Site> existingItems = (List<Site>)sitesPage.getItems();
 
 		Assert.assertEquals(originalItems, existingItems);
+	}
+
+	private void _testGetSitesPageWithAssetLibraryMember() throws Exception {
+		SiteResource siteResource = _getSiteResource(
+			_addUserWithDepotRole(
+				_addDepotEntry(), DepotRolesConstants.ASSET_LIBRARY_MEMBER));
+
+		Page<Site> sitesPage1 = siteResource.getSitesPage(
+			null, null, null, Pagination.of(1, 1));
+
+		long totalCount = sitesPage1.getTotalCount();
+
+		_testPostSite_addSite(randomSite());
+
+		Page<Site> sitesPage2 = siteResource.getSitesPage(
+			null, null, null, Pagination.of(1, 1));
+
+		Assert.assertEquals(totalCount, sitesPage2.getTotalCount());
 	}
 
 	private void _testGetSitesPageWithDepotEntry() throws Exception {
@@ -624,6 +700,17 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		Assert.assertEquals(items.toString(), 1, items.size());
 
 		assertEquals(postSite, items.get(0));
+	}
+
+	private void _testGetSitesPageWithUser(User user) throws Exception {
+		Site site = _testPostSite_addSite(randomSite());
+
+		SiteResource siteResource = _getSiteResource(user);
+
+		Page<Site> sitesPage = siteResource.getSitesPage(
+			null, null, null, Pagination.of(1, 500));
+
+		assertContains(site, (List<Site>)sitesPage.getItems());
 	}
 
 	private void _testGetSiteWithDollar() throws Exception {
@@ -1685,8 +1772,13 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 	@Inject
 	private LayoutSetPrototypeLocalService _layoutSetPrototypeLocalService;
 
-	private String _originalName;
+	@Inject
+	private RoleLocalService _roleLocalService;
+
 	private final List<Site> _sites = new ArrayList<>();
+
+	@Inject
+	private UserGroupRoleLocalService _userGroupRoleLocalService;
 
 	@Inject
 	private UserLocalService _userLocalService;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteTemplateResourceTest.java
@@ -6,24 +6,46 @@
 package com.liferay.headless.admin.site.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.constants.DepotRolesConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.headless.admin.site.client.dto.v1_0.SiteTemplate;
 import com.liferay.headless.admin.site.client.pagination.Page;
 import com.liferay.headless.admin.site.client.pagination.Pagination;
+import com.liferay.headless.admin.site.client.resource.v1_0.SiteTemplateResource;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
 import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -33,16 +55,34 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class SiteTemplateResourceTest extends BaseSiteTemplateResourceTestCase {
 
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@FeatureFlag("LPD-17564")
 	@Override
 	@Test
 	public void testGetSiteTemplatesPage() throws Exception {
 		super.testGetSiteTemplatesPage();
 
+		_testGetSiteTemplatesPageWithAssetLibraryMember();
 		_testGetSiteTemplatesPageWithExcludedSiteExternalReferenceCodes();
+		_testGetSiteTemplatesPageWithUser(
+			_addUserWithDepotRole(
+				_addDepotEntry(),
+				DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR));
+		_testGetSiteTemplatesPageWithUser(
+			_addUserWithDepotRole(
+				_addDepotEntry(), DepotRolesConstants.ASSET_LIBRARY_OWNER));
+		_testGetSiteTemplatesPageWithUser(
+			_addUserWithRegularRole(RoleConstants.CMS_ADMINISTRATOR));
 	}
 
 	@Override
-	protected SiteTemplate randomSiteTemplate() throws Exception {
+	protected SiteTemplate randomSiteTemplate() {
 		return new SiteTemplate() {
 			{
 				active = RandomTestUtil.randomBoolean();
@@ -92,6 +132,76 @@ public class SiteTemplateResourceTest extends BaseSiteTemplateResourceTestCase {
 			siteTemplate.getPagesUpdateable(), new ServiceContext());
 
 		return siteTemplate;
+	}
+
+	private DepotEntry _addDepotEntry() throws Exception {
+		return _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private User _addUserWithDepotRole(DepotEntry depotEntry, String roleName)
+		throws Exception {
+
+		User user = UserTestUtil.addUser(
+			testCompany, RandomTestUtil.randomString());
+
+		Role role = _roleLocalService.getRole(
+			testCompany.getCompanyId(), roleName);
+
+		_userGroupRoleLocalService.addUserGroupRoles(
+			user.getUserId(), depotEntry.getGroupId(),
+			new long[] {role.getRoleId()});
+
+		return user;
+	}
+
+	private User _addUserWithRegularRole(String roleName) throws Exception {
+		User user = UserTestUtil.addUser(
+			testCompany, RandomTestUtil.randomString());
+
+		Role role = _roleLocalService.getRole(
+			testCompany.getCompanyId(), roleName);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user.getUserId());
+
+		return user;
+	}
+
+	private SiteTemplateResource _getSiteTemplateResource(User user) {
+		return SiteTemplateResource.builder(
+		).authentication(
+			user.getEmailAddress(), user.getPasswordUnencrypted()
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	private void _testGetSiteTemplatesPageWithAssetLibraryMember()
+		throws Exception {
+
+		testGetSiteTemplatesPage_addSiteTemplate(randomSiteTemplate());
+
+		SiteTemplateResource siteTemplateResource = _getSiteTemplateResource(
+			_addUserWithDepotRole(
+				_addDepotEntry(), DepotRolesConstants.ASSET_LIBRARY_MEMBER));
+
+		Page<SiteTemplate> siteTemplatesPage =
+			siteTemplateResource.getSiteTemplatesPage(
+				null, null, Pagination.of(1, 500));
+
+		Collection<SiteTemplate> siteTemplates = siteTemplatesPage.getItems();
+
+		Assert.assertTrue(siteTemplates.isEmpty());
 	}
 
 	private void _testGetSiteTemplatesPageWithExcludedSiteExternalReferenceCodes()
@@ -158,7 +268,34 @@ public class SiteTemplateResourceTest extends BaseSiteTemplateResourceTestCase {
 		Assert.assertTrue(includedSiteTemplateFound);
 	}
 
+	private void _testGetSiteTemplatesPageWithUser(User user) throws Exception {
+		SiteTemplate siteTemplate = testGetSiteTemplatesPage_addSiteTemplate(
+			randomSiteTemplate());
+
+		SiteTemplateResource siteTemplateResource = _getSiteTemplateResource(
+			user);
+
+		Page<SiteTemplate> siteTemplatesPage =
+			siteTemplateResource.getSiteTemplatesPage(
+				null, null, Pagination.of(1, 500));
+
+		assertContains(
+			siteTemplate, (List<SiteTemplate>)siteTemplatesPage.getItems());
+	}
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
 	@Inject
 	private LayoutSetPrototypeLocalService _layoutSetPrototypeLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@Inject
+	private UserGroupRoleLocalService _userGroupRoleLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 }


### PR DESCRIPTION
> [!NOTE]
> Followup to https://github.com/brianchandotcom/liferay-portal/pull/176577

https://liferay.atlassian.net/browse/LPD-91101

## What Is Being Fixed

CMS Administrators and asset library (space) Administrators and Owners could not connect site templates to spaces because neither the site templates nor the sites were listed for them.

## How It Is Being Fixed

Site template listings are filtered by inline permission SQL on LayoutSetPrototype, which resolves only the user's company-scoped roles, so a depot-scoped asset library role can never satisfy it. A new DepotLayoutSetPrototypeServiceWrapper in depot-service delegates the search to the unfiltered local service for CMS administrators and asset library administrators and owners, keeping the default permission-filtered behavior for everyone else. Site listings route through the permission checker, so DepotPermissionCheckerWrapper now grants VIEW on any site to the same administrators, detecting depot administrators and owners by their user group roles rather than by depot membership.

## PR Check

**pr-check: PASS** — tested on `020cde1a583df50a6313b4eae000cf201545e1f2`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "020cde1a583df50a6313b4eae000cf201545e1f2"} -->