### PR TITLE
LPD-90025 Fix compilation error

### DIFF
--- a/modules/apps/layout/layout-content-test/src/testIntegration/java/com/liferay/layout/content/service/test/LayoutContentVersionLocalServiceTest.java
+++ b/modules/apps/layout/layout-content-test/src/testIntegration/java/com/liferay/layout/content/service/test/LayoutContentVersionLocalServiceTest.java
@@ -176,9 +176,7 @@ public class LayoutContentVersionLocalServiceTest {
 		catch (RequiredLayoutContentVersionException
 					requiredLayoutContentVersionException) {
 
-			if (_log.isDebugEnabled()) {
-				_log.debug(requiredLayoutContentVersionException);
-			}
+			Assert.assertNotNull(requiredLayoutContentVersionException);
 		}
 
 		Assert.assertNotNull(


### PR DESCRIPTION
A leftover `_log.debug(...)` block inside the `catch (RequiredLayoutContentVersionException ...)` in `testDeleteLayoutContentVersion` was missed in the cleanup commit "Matches our other patterns" (d0982f9bcc8e0). The `_log` field and its imports were removed, but this catch still referenced `_log`, breaking `:apps:layout:layout-content-test:compileTestIntegrationJava` on master.

This applies the same `Assert.assertNotNull(...)` pattern to that block.

Jira: https://liferay.atlassian.net/browse/LPD-90025
