### PR TITLE
LPD-93976 Avoid quadratic reindexing on web content expiration

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -1556,12 +1556,34 @@ public class JournalArticleLocalServiceImpl
 				groupId, articleId, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
 				ArticleVersionComparator.getInstance(true));
 
-			for (JournalArticle article : articles) {
-				if (!article.isExpired()) {
-					journalArticleLocalService.expireArticle(
-						userId, groupId, article.getArticleId(),
-						article.getVersion(), articleURL, serviceContext);
+			boolean expired = false;
+			boolean indexingEnabled = serviceContext.isIndexingEnabled();
+
+			try {
+				serviceContext.setIndexingEnabled(false);
+
+				for (JournalArticle article : articles) {
+					if (!article.isExpired()) {
+						journalArticleLocalService.expireArticle(
+							userId, groupId, article.getArticleId(),
+							article.getVersion(), articleURL, serviceContext);
+
+						expired = true;
+					}
 				}
+			}
+			finally {
+				serviceContext.setIndexingEnabled(indexingEnabled);
+			}
+
+			if (expired && serviceContext.isIndexingEnabled()) {
+				Indexer<JournalArticle> indexer =
+					IndexerRegistryUtil.nullSafeGetIndexer(
+						JournalArticle.class);
+
+				indexer.reindex(
+					getLatestArticle(
+						groupId, articleId, WorkflowConstants.STATUS_ANY));
 			}
 		}
 		else {

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleIndexVersionsTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleIndexVersionsTest.java
@@ -111,14 +111,14 @@ public class JournalArticleIndexVersionsTest {
 
 		assertSearchCount(1, true);
 
-		JournalArticle updateArticle = JournalTestUtil.updateArticle(
+		JournalArticle updatedArticle = JournalTestUtil.updateArticle(
 			article, article.getTitleMap(), article.getContent(), true, true,
 			ServiceContextTestUtil.getServiceContext());
 
 		assertSearchCount(1, true);
 
 		_journalArticleLocalService.deleteArticle(
-			_group.getGroupId(), updateArticle.getArticleId(),
+			_group.getGroupId(), updatedArticle.getArticleId(),
 			ServiceContextTestUtil.getServiceContext());
 
 		assertSearchCount(0, true);
@@ -137,14 +137,14 @@ public class JournalArticleIndexVersionsTest {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext();
 
-		JournalArticle updateArticle = JournalTestUtil.updateArticle(
+		JournalArticle updatedArticle = JournalTestUtil.updateArticle(
 			article, article.getTitleMap(), article.getContent(), true, true,
 			serviceContext);
 
 		assertSearchCount(1, true);
 
 		_journalArticleLocalService.deleteArticle(
-			updateArticle, updateArticle.getUrlTitle(), serviceContext);
+			updatedArticle, updatedArticle.getUrlTitle(), serviceContext);
 
 		assertSearchArticle(1, article);
 	}
@@ -161,13 +161,13 @@ public class JournalArticleIndexVersionsTest {
 
 		assertSearchCount(1, true);
 
-		JournalArticle updateArticle = JournalTestUtil.updateArticle(
+		JournalArticle updatedArticle = JournalTestUtil.updateArticle(
 			article, article.getTitleMap(), article.getContent(), true, true,
 			ServiceContextTestUtil.getServiceContext());
 
 		assertSearchCount(1, true);
 
-		JournalTestUtil.expireArticle(_group.getGroupId(), updateArticle);
+		JournalTestUtil.expireArticle(_group.getGroupId(), updatedArticle);
 
 		assertSearchCount(0, true);
 		assertSearchCount(1, false);
@@ -260,14 +260,14 @@ public class JournalArticleIndexVersionsTest {
 
 		assertSearchCount(1, true);
 
-		JournalArticle updateArticle = JournalTestUtil.updateArticle(
+		JournalArticle updatedArticle = JournalTestUtil.updateArticle(
 			article, article.getTitleMap(), article.getContent(), true, true,
 			ServiceContextTestUtil.getServiceContext());
 
 		assertSearchCount(1, true);
 
 		JournalTestUtil.expireArticle(
-			_group.getGroupId(), updateArticle, updateArticle.getVersion());
+			_group.getGroupId(), updatedArticle, updatedArticle.getVersion());
 
 		assertSearchArticle(1, article);
 	}

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleIndexVersionsTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleIndexVersionsTest.java
@@ -164,6 +164,43 @@ public class JournalArticleIndexVersionsTest {
 	}
 
 	@Test
+	public void testExpireAllArticleVersionsWhenIndexAllArticleVersionsEnabled()
+		throws Exception {
+
+		_enableIndexAllArticleVersions();
+
+		assertSearchCount(0, true);
+		assertSearchCount(0, false);
+
+		JournalArticle article = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		JournalArticle updatedArticle = JournalTestUtil.updateArticle(
+			article, article.getTitleMap(), article.getContent(), true, true,
+			ServiceContextTestUtil.getServiceContext());
+
+		updatedArticle = JournalTestUtil.updateArticle(
+			updatedArticle, updatedArticle.getTitleMap(),
+			updatedArticle.getContent(), true, true,
+			ServiceContextTestUtil.getServiceContext());
+
+		// All three versions are indexed: the head search returns only the
+		// latest version while the non-head search returns every version
+
+		assertSearchCount(1, true);
+		assertSearchCount(3, false);
+
+		JournalTestUtil.expireArticle(_group.getGroupId(), updatedArticle);
+
+		// Expiring all versions reindexes the article once, but every version
+		// document remains indexed (LPD-93976)
+
+		assertSearchCount(0, true);
+		assertSearchCount(3, false);
+	}
+
+	@Test
 	public void testExpireArticleVersion() throws Exception {
 		assertSearchCount(0, true);
 
@@ -267,6 +304,20 @@ public class JournalArticleIndexVersionsTest {
 			searchResponse.getRequestString() + "->" +
 				searchResponse.getDocuments(),
 			expectedCount, searchResponse.getCount());
+	}
+
+	private void _enableIndexAllArticleVersions() throws Exception {
+		PortalPreferences portalPreferences =
+			_portletPreferencesFactory.getPortalPreferences(
+				TestPropsValues.getUserId(), true);
+
+		portalPreferences.setValue(
+			"", "indexAllArticleVersionsEnabled", "true");
+
+		_portalPreferencesLocalService.updatePreferences(
+			TestPropsValues.getCompanyId(),
+			PortletKeys.PREFS_OWNER_TYPE_COMPANY,
+			PortletPreferencesFactoryUtil.toXML(portalPreferences));
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleIndexVersionsTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleIndexVersionsTest.java
@@ -15,9 +15,12 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactory;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
+import com.liferay.portal.kernel.search.BaseIndexerPostProcessor;
+import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerPostProcessor;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
@@ -28,6 +31,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
@@ -39,6 +43,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -47,6 +52,11 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
 
 /**
  * @author Eudaldo Alonso
@@ -161,6 +171,46 @@ public class JournalArticleIndexVersionsTest {
 
 		assertSearchCount(0, true);
 		assertSearchCount(1, false);
+	}
+
+	@Test
+	public void testExpireAllArticleVersionsReindexesArticleOnce()
+		throws Exception {
+
+		_enableIndexAllArticleVersions();
+
+		JournalArticle article = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		JournalArticle updatedArticle = JournalTestUtil.updateArticle(
+			article, article.getTitleMap(), article.getContent(), true, true,
+			ServiceContextTestUtil.getServiceContext());
+
+		updatedArticle = JournalTestUtil.updateArticle(
+			updatedArticle, updatedArticle.getTitleMap(),
+			updatedArticle.getContent(), true, true,
+			ServiceContextTestUtil.getServiceContext());
+
+		AtomicInteger documentBuildCount = new AtomicInteger();
+
+		ServiceRegistration<IndexerPostProcessor> serviceRegistration =
+			_registerDocumentBuildCounter(documentBuildCount);
+
+		try {
+			JournalTestUtil.expireArticle(_group.getGroupId(), updatedArticle);
+		}
+		finally {
+			serviceRegistration.unregister();
+		}
+
+		// Reindexing the article rebuilds every version document once, so a
+		// single reindex of these three versions builds three documents.
+		// Before LPD-93976 the bulk expiration reindexed the article once per
+		// version, so the document build count grew with the square of the
+		// version count (nine builds for three versions).
+
+		Assert.assertEquals(3, documentBuildCount.get());
 	}
 
 	@Test
@@ -318,6 +368,33 @@ public class JournalArticleIndexVersionsTest {
 			TestPropsValues.getCompanyId(),
 			PortletKeys.PREFS_OWNER_TYPE_COMPANY,
 			PortletPreferencesFactoryUtil.toXML(portalPreferences));
+	}
+
+	private ServiceRegistration<IndexerPostProcessor>
+		_registerDocumentBuildCounter(AtomicInteger documentBuildCount) {
+
+		Indexer<JournalArticle> indexer = _indexerRegistry.getIndexer(
+			JournalArticle.class);
+
+		Bundle bundle = FrameworkUtil.getBundle(
+			JournalArticleIndexVersionsTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		return bundleContext.registerService(
+			IndexerPostProcessor.class,
+			new BaseIndexerPostProcessor() {
+
+				@Override
+				public void postProcessDocument(
+					Document document, Object object) {
+
+					documentBuildCount.incrementAndGet();
+				}
+
+			},
+			MapUtil.singletonDictionary(
+				"indexer.class.name", indexer.getClassName()));
 	}
 
 	@DeleteAfterTestRun


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93976

## What Is Being Fixed

Expiring web content that has many versions was extremely slow. When all versions are expired in bulk, each version was reindexed individually, so the indexing work grew with the square of the version count.

## How It Is Being Fixed

The bulk expiration path in JournalArticleLocalServiceImpl.expireArticle now disables indexing while it expires each version, then performs a single reindex of the latest article once all versions are expired. This collapses the per-version reindexing into one operation. Integration tests assert that expiring all versions reindexes the article exactly once and that every version stays indexed when indexing all article versions is enabled. A follow-up commit renames the updateArticle locals to updatedArticle so the test file uses one consistent name.

## PR Check

**pr-check: PASS** — tested on `f5fe7b5d6f3ae6fd568685b026d2a18b3beff301`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "f5fe7b5d6f3ae6fd568685b026d2a18b3beff301"} -->