### PR TITLE
Lpd 93300 harden mcp body

### DIFF
--- a/modules/apps/mcp/mcp-server-rest-impl/build.gradle
+++ b/modules/apps/mcp/mcp-server-rest-impl/build.gradle
@@ -32,5 +32,6 @@ dependencies {
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")
+	testImplementation group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.18.6"
 	testImplementation group: "org.skyscreamer", name: "jsonassert", version: "1.5.0"
 }

--- a/modules/apps/mcp/mcp-server-rest-impl/rest-openapi.yaml
+++ b/modules/apps/mcp/mcp-server-rest-impl/rest-openapi.yaml
@@ -175,12 +175,7 @@ paths:
                                 Input map matching the tool's `inputSchema`.
                             type: object
                 description:
-                    "The complete input map for the target tool, matching the `inputSchema` that `getTool` returns for
-                    this `toolName`. Use that schema's properties exactly as named: when the `inputSchema` declares a
-                    `body` property, it holds the request payload and must stay nested under `body` here rather than be
-                    flattened into this map; pass any path or query parameters as siblings of `body`. For example, a
-                    tool whose `inputSchema` has `body` and `itemId` properties is invoked with `{\"body\": {...},
-                    \"itemId\": \"123\"}`."
+                    "The complete input map for the target tool, matching the `inputSchema` that `getTool` returns for this `toolName`. Use that schema's properties exactly as named: when the `inputSchema` declares a `body` property, it holds the request payload and must stay nested under `body` here rather than be flattened into this map; pass any path or query parameters as siblings of `body`. For example, a tool whose `inputSchema` has `body` and `itemId` properties is invoked with `{\"body\": {...}, \"itemId\": \"123\"}`."
                 required: false
             responses:
                 200:

--- a/modules/apps/mcp/mcp-server-rest-impl/rest-openapi.yaml
+++ b/modules/apps/mcp/mcp-server-rest-impl/rest-openapi.yaml
@@ -174,6 +174,13 @@ paths:
                             description:
                                 Input map matching the tool's `inputSchema`.
                             type: object
+                description:
+                    "The complete input map for the target tool, matching the `inputSchema` that `getTool` returns for
+                    this `toolName`. Use that schema's properties exactly as named: when the `inputSchema` declares a
+                    `body` property, it holds the request payload and must stay nested under `body` here rather than be
+                    flattened into this map; pass any path or query parameters as siblings of `body`. For example, a
+                    tool whose `inputSchema` has `body` and `itemId` properties is invoked with `{\"body\": {...},
+                    \"itemId\": \"123\"}`."
                 required: false
             responses:
                 200:

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/BaseToolResourceImpl.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/BaseToolResourceImpl.java
@@ -92,7 +92,8 @@ public abstract class BaseToolResourceImpl implements ToolResource {
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Invokes a tool. ALWAYS call `getToolSetToolSetNameTool` first to fetch the tool's `inputSchema`, then build the request `body` to match it exactly. Skipping `getToolSetToolSetNameTool` leads to malformed input and avoidable failures. Returns the tool's response body unchanged.",
-		operationId = "postToolSetToolSetNameToolInvoke"
+		operationId = "postToolSetToolSetNameToolInvoke",
+		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = Object.class)), description = "The complete input map for the target tool, matching the `inputSchema` that `getTool` returns for this `toolName`. Use that schema's properties exactly as named: when the `inputSchema` declares a `body` property, it holds the request payload and must stay nested under `body` here rather than be flattened into this map; pass any path or query parameters as siblings of `body`. For example, a tool whose `inputSchema` has `body` and `itemId` properties is invoked with `{\"body\": {...}, \"itemId\": \"123\"}`.")
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -578,4 +579,4 @@ public abstract class BaseToolResourceImpl implements ToolResource {
 		LogFactoryUtil.getLog(BaseToolResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:1426896571
+// LIFERAY-REST-BUILDER-HASH:-1744722583

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -894,18 +894,19 @@ public class OpenAPIUtil {
 					"into the input map."));
 		}
 
-		Object bodyValue = inputJSONObject.get("body");
+		options.addHeader("Content-Type", ContentTypes.APPLICATION_JSON);
 
 		String body = StringPool.BLANK;
 
-		if (bodyValue instanceof JSONObject) {
-			body = bodyValue.toString();
+		Object bodyObject = inputJSONObject.get("body");
+
+		if (bodyObject instanceof JSONObject) {
+			body = bodyObject.toString();
 		}
-		else if (bodyValue != null) {
-			body = String.valueOf(bodyValue);
+		else if (bodyObject != null) {
+			body = String.valueOf(bodyObject);
 		}
 
-		options.addHeader("Content-Type", ContentTypes.APPLICATION_JSON);
 		options.setBody(body, ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 	}
 

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -61,24 +61,8 @@ public class OpenAPIUtil {
 			_setMultipartBody(
 				inputJSONObject, openAPIJSONObject, operation, options);
 		}
-		else if (inputJSONObject.has("body")) {
-			Object bodyValue = inputJSONObject.get("body");
-
-			String body = null;
-
-			if (bodyValue instanceof JSONObject) {
-				body = bodyValue.toString();
-			}
-			else if (bodyValue != null) {
-				body = String.valueOf(bodyValue);
-			}
-
-			if (Validator.isNotNull(body)) {
-				options.setBody(
-					body, ContentTypes.APPLICATION_JSON, StringPool.UTF8);
-				options.addHeader(
-					"Content-Type", ContentTypes.APPLICATION_JSON);
-			}
+		else if (operation._operationJSONObject.has("requestBody")) {
+			_setBody(inputJSONObject, options, toolName);
 		}
 
 		return options;
@@ -895,6 +879,34 @@ public class OpenAPIUtil {
 		}
 
 		return value;
+	}
+
+	private static void _setBody(
+		JSONObject inputJSONObject, Http.Options options, String toolName) {
+
+		if (!inputJSONObject.has("body")) {
+			throw new IllegalArgumentException(
+				StringBundler.concat(
+					"The \"", toolName,
+					"\" tool requires the request payload nested under a ",
+					"\"body\" property. Pass any path or query parameters as ",
+					"siblings of \"body\" rather than flattening the payload ",
+					"into the input map."));
+		}
+
+		Object bodyValue = inputJSONObject.get("body");
+
+		String body = StringPool.BLANK;
+
+		if (bodyValue instanceof JSONObject) {
+			body = bodyValue.toString();
+		}
+		else if (bodyValue != null) {
+			body = String.valueOf(bodyValue);
+		}
+
+		options.addHeader("Content-Type", ContentTypes.APPLICATION_JSON);
+		options.setBody(body, ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 	}
 
 	private static void _setMultipartBody(

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -544,12 +544,49 @@ public class OpenAPIUtil {
 					openAPIJSONObject);
 			}
 			else {
-				properties.put(
-					"body",
-					_resolveRefs(
+				JSONObject requestBodyJSONObject =
+					operationJSONObject.getJSONObject("requestBody");
+
+				Object bodySchema = null;
+
+				if (requestBodyJSONObject.getJSONObject("content") != null) {
+					bodySchema = _resolveRefs(
 						openAPIJSONObject,
 						_getBodySchemaJSONObject(operationJSONObject),
-						new HashSet<>()));
+						new HashSet<>());
+				}
+
+				if (!(bodySchema instanceof Map)) {
+					bodySchema = LinkedHashMapBuilder.<String, Object>put(
+						"type", "object"
+					).build();
+				}
+
+				String requestBodyDescription = requestBodyJSONObject.getString(
+					"description");
+
+				if (Validator.isNotNull(requestBodyDescription)) {
+					Map<String, Object> bodySchemaMap =
+						(Map<String, Object>)bodySchema;
+
+					Object schemaDescription = bodySchemaMap.get("description");
+
+					if (Validator.isNull(schemaDescription)) {
+						bodySchemaMap.put(
+							"description", requestBodyDescription);
+					}
+					else if (!Objects.equals(
+								schemaDescription, requestBodyDescription)) {
+
+						bodySchemaMap.put(
+							"description",
+							StringBundler.concat(
+								requestBodyDescription, StringPool.SPACE,
+								schemaDescription));
+					}
+				}
+
+				properties.put("body", bodySchema);
 
 				required.add("body");
 			}

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.mcp.server.rest.dto.v1_0.Tool;
 import com.liferay.mcp.server.rest.dto.v1_0.ToolSummary;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -93,6 +94,11 @@ public class OpenAPIUtilTest {
 				"itemId", "123"
 			),
 			"patchItem");
+		_testGetOptions(
+			"{}", "application/json", Http.Method.POST,
+			"http://localhost/test/v1.0/items",
+			JSONUtil.put("body", JSONFactoryUtil.createJSONObject()),
+			"postItem");
 
 		String fileContent = RandomTestUtil.randomString();
 		String fileName = RandomTestUtil.randomString();
@@ -165,6 +171,20 @@ public class OpenAPIUtilTest {
 		Assert.assertEquals("true", parts.get("boolean"));
 		Assert.assertEquals("1", parts.get("integer"));
 		Assert.assertEquals(fileContent, parts.get("string"));
+
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			StringBundler.concat(
+				"The \"postItem\" tool requires the request payload nested ",
+				"under a \"body\" property. Pass any path or query parameters ",
+				"as siblings of \"body\" rather than flattening the payload ",
+				"into the input map."),
+			() -> OpenAPIUtil.getOptions(
+				"http://localhost/test",
+				JSONUtil.put(
+					RandomTestUtil.randomString(),
+					RandomTestUtil.randomString()),
+				_openAPIJSONObject, "postItem"));
 	}
 
 	@Test
@@ -213,31 +233,21 @@ public class OpenAPIUtilTest {
 
 	@Test
 	public void testGetToolMergesRequestBodyAndSchemaDescriptions() {
-		JSONObject openAPIJSONObject = JSONUtil.put(
-			"paths",
+		JSONObject openAPIJSONObject = _createOpenAPIJSONObject(
 			JSONUtil.put(
-				"/things",
+				"content",
 				JSONUtil.put(
-					"post",
+					"application/json",
 					JSONUtil.put(
-						"operationId", "postThing"
-					).put(
-						"requestBody",
+						"schema",
 						JSONUtil.put(
-							"content",
-							JSONUtil.put(
-								"application/json",
-								JSONUtil.put(
-									"schema",
-									JSONUtil.put(
-										"description", "A Thing resource."
-									).put(
-										"type", "object"
-									)))
+							"description", _SCHEMA_DESCRIPTION
 						).put(
-							"description", "The thing to create."
-						)
-					))));
+							"type", "object"
+						)))
+			).put(
+				"description", _REQUEST_BODY_DESCRIPTION
+			));
 
 		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
 
@@ -248,32 +258,21 @@ public class OpenAPIUtilTest {
 		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
 
 		Assert.assertEquals(
-			"The thing to create. A Thing resource.",
+			_REQUEST_BODY_DESCRIPTION + " " + _SCHEMA_DESCRIPTION,
 			bodySchema.get("description"));
 	}
 
 	@Test
 	public void testGetToolRequestBodyDescriptionIsSurfaced() {
-		JSONObject openAPIJSONObject = JSONUtil.put(
-			"paths",
+		JSONObject openAPIJSONObject = _createOpenAPIJSONObject(
 			JSONUtil.put(
-				"/things",
+				"content",
 				JSONUtil.put(
-					"post",
-					JSONUtil.put(
-						"operationId", "postThing"
-					).put(
-						"requestBody",
-						JSONUtil.put(
-							"content",
-							JSONUtil.put(
-								"application/json",
-								JSONUtil.put(
-									"schema", JSONUtil.put("type", "object")))
-						).put(
-							"description", "The thing to create."
-						)
-					))));
+					"application/json",
+					JSONUtil.put("schema", JSONUtil.put("type", "object")))
+			).put(
+				"description", _REQUEST_BODY_DESCRIPTION
+			));
 
 		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
 
@@ -284,23 +283,13 @@ public class OpenAPIUtilTest {
 		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
 
 		Assert.assertEquals(
-			"The thing to create.", bodySchema.get("description"));
+			_REQUEST_BODY_DESCRIPTION, bodySchema.get("description"));
 	}
 
 	@Test
 	public void testGetToolRequestBodyWithoutContentDoesNotFail() {
-		JSONObject openAPIJSONObject = JSONUtil.put(
-			"paths",
-			JSONUtil.put(
-				"/things",
-				JSONUtil.put(
-					"post",
-					JSONUtil.put(
-						"operationId", "postThing"
-					).put(
-						"requestBody",
-						JSONUtil.put("description", "The thing to create.")
-					))));
+		JSONObject openAPIJSONObject = _createOpenAPIJSONObject(
+			JSONUtil.put("description", _REQUEST_BODY_DESCRIPTION));
 
 		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
 
@@ -310,9 +299,9 @@ public class OpenAPIUtilTest {
 
 		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
 
-		Assert.assertEquals("object", bodySchema.get("type"));
 		Assert.assertEquals(
-			"The thing to create.", bodySchema.get("description"));
+			_REQUEST_BODY_DESCRIPTION, bodySchema.get("description"));
+		Assert.assertEquals("object", bodySchema.get("type"));
 	}
 
 	@Test
@@ -322,31 +311,31 @@ public class OpenAPIUtilTest {
 
 		Assert.assertEquals(toolSummaries.toString(), 12, toolSummaries.size());
 		_assertToolSummary(
-			toolSummaries.get(0), "This is the description", "getItem");
+			"This is the description", "getItem", toolSummaries.get(0));
 		_assertToolSummary(
-			toolSummaries.get(1), "PATCH /v1.0/items/{itemId}", "patchItem");
+			"PATCH /v1.0/items/{itemId}", "patchItem", toolSummaries.get(1));
 		_assertToolSummary(
-			toolSummaries.get(2), "PUT /v1.0/items/{itemId}", "putItem");
+			"PUT /v1.0/items/{itemId}", "putItem", toolSummaries.get(2));
 		_assertToolSummary(
-			toolSummaries.get(3), "POST /v1.0/binaries", "postBinary");
+			"POST /v1.0/binaries", "postBinary", toolSummaries.get(3));
 		_assertToolSummary(
-			toolSummaries.get(4), "POST /v1.0/empty-content",
-			"postEmptyContent");
+			"POST /v1.0/empty-content", "postEmptyContent",
+			toolSummaries.get(4));
 		_assertToolSummary(
-			toolSummaries.get(5), "POST /v1.0/no-content", "postNoContent");
+			"POST /v1.0/no-content", "postNoContent", toolSummaries.get(5));
 		_assertToolSummary(
-			toolSummaries.get(6), "POST /v1.0/parents", "postParent");
+			"POST /v1.0/parents", "postParent", toolSummaries.get(6));
 		_assertToolSummary(
-			toolSummaries.get(7), "POST /v1.0/uploads", "postUpload");
+			"POST /v1.0/uploads", "postUpload", toolSummaries.get(7));
 		_assertToolSummary(
-			toolSummaries.get(8),
-			"This is the summary. This is the description", "getItems");
+			"This is the summary. This is the description", "getItems",
+			toolSummaries.get(8));
 		_assertToolSummary(
-			toolSummaries.get(9), "POST /v1.0/items", "postItem");
+			"POST /v1.0/items", "postItem", toolSummaries.get(9));
 		_assertToolSummary(
-			toolSummaries.get(10), "POST /v1.0/no-schema", "postNoSchema");
+			"POST /v1.0/no-schema", "postNoSchema", toolSummaries.get(10));
 		_assertToolSummary(
-			toolSummaries.get(11), "This is the summary", "getItemsPage");
+			"This is the summary", "getItemsPage", toolSummaries.get(11));
 
 		AssertUtils.assertFailure(
 			IllegalArgumentException.class,
@@ -365,11 +354,27 @@ public class OpenAPIUtilTest {
 	}
 
 	private void _assertToolSummary(
-		ToolSummary toolSummary, String expectedDescription,
-		String expectedName) {
+		String expectedDescription, String expectedName,
+		ToolSummary toolSummary) {
 
 		Assert.assertEquals(expectedDescription, toolSummary.getDescription());
 		Assert.assertEquals(expectedName, toolSummary.getName());
+	}
+
+	private JSONObject _createOpenAPIJSONObject(
+		JSONObject requestBodyJSONObject) {
+
+		return JSONUtil.put(
+			"paths",
+			JSONUtil.put(
+				"/things",
+				JSONUtil.put(
+					"post",
+					JSONUtil.put(
+						"operationId", "postThing"
+					).put(
+						"requestBody", requestBodyJSONObject
+					))));
 	}
 
 	private Map<String, ?> _getInputSchema(
@@ -402,6 +407,8 @@ public class OpenAPIUtilTest {
 		else {
 			Assert.assertEquals(expectedBody, body.getContent());
 			Assert.assertEquals(expectedContentType, body.getContentType());
+			Assert.assertEquals(
+				expectedContentType, options.getHeader("Content-Type"));
 		}
 
 		Assert.assertNull(options.getFileParts());
@@ -428,6 +435,11 @@ public class OpenAPIUtilTest {
 			),
 			true);
 	}
+
+	private static final String _REQUEST_BODY_DESCRIPTION =
+		"The thing to create.";
+
+	private static final String _SCHEMA_DESCRIPTION = "A Thing resource.";
 
 	private JSONObject _openAPIJSONObject;
 

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
@@ -180,9 +180,6 @@ public class OpenAPIUtilTest {
 				JSONFactoryUtil.createJSONObject(),
 				RandomTestUtil.randomString()));
 		AssertUtils.assertFailure(
-			IllegalArgumentException.class, "Request body has no \"content\"",
-			() -> _getInputSchema(_openAPIJSONObject, "postNoContent"));
-		AssertUtils.assertFailure(
 			IllegalArgumentException.class, "Request body has no content",
 			() -> _getInputSchema(_openAPIJSONObject, "postEmptyContent"));
 		AssertUtils.assertFailure(
@@ -212,6 +209,110 @@ public class OpenAPIUtilTest {
 		_testGetTool(
 			"PUT /v1.0/items/{itemId}", "put_test_v1.0_items_itemId.json",
 			"putItem");
+	}
+
+	@Test
+	public void testGetToolMergesRequestBodyAndSchemaDescriptions() {
+		JSONObject openAPIJSONObject = JSONUtil.put(
+			"paths",
+			JSONUtil.put(
+				"/things",
+				JSONUtil.put(
+					"post",
+					JSONUtil.put(
+						"operationId", "postThing"
+					).put(
+						"requestBody",
+						JSONUtil.put(
+							"content",
+							JSONUtil.put(
+								"application/json",
+								JSONUtil.put(
+									"schema",
+									JSONUtil.put(
+										"description", "A Thing resource."
+									).put(
+										"type", "object"
+									)))
+						).put(
+							"description", "The thing to create."
+						)
+					))));
+
+		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
+
+		Map<String, ?> inputSchema = tool.getInputSchema();
+
+		Map<?, ?> properties = (Map<?, ?>)inputSchema.get("properties");
+
+		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
+
+		Assert.assertEquals(
+			"The thing to create. A Thing resource.",
+			bodySchema.get("description"));
+	}
+
+	@Test
+	public void testGetToolRequestBodyDescriptionIsSurfaced() {
+		JSONObject openAPIJSONObject = JSONUtil.put(
+			"paths",
+			JSONUtil.put(
+				"/things",
+				JSONUtil.put(
+					"post",
+					JSONUtil.put(
+						"operationId", "postThing"
+					).put(
+						"requestBody",
+						JSONUtil.put(
+							"content",
+							JSONUtil.put(
+								"application/json",
+								JSONUtil.put(
+									"schema", JSONUtil.put("type", "object")))
+						).put(
+							"description", "The thing to create."
+						)
+					))));
+
+		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
+
+		Map<String, ?> inputSchema = tool.getInputSchema();
+
+		Map<?, ?> properties = (Map<?, ?>)inputSchema.get("properties");
+
+		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
+
+		Assert.assertEquals(
+			"The thing to create.", bodySchema.get("description"));
+	}
+
+	@Test
+	public void testGetToolRequestBodyWithoutContentDoesNotFail() {
+		JSONObject openAPIJSONObject = JSONUtil.put(
+			"paths",
+			JSONUtil.put(
+				"/things",
+				JSONUtil.put(
+					"post",
+					JSONUtil.put(
+						"operationId", "postThing"
+					).put(
+						"requestBody",
+						JSONUtil.put("description", "The thing to create.")
+					))));
+
+		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
+
+		Map<String, ?> inputSchema = tool.getInputSchema();
+
+		Map<?, ?> properties = (Map<?, ?>)inputSchema.get("properties");
+
+		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
+
+		Assert.assertEquals("object", bodySchema.get("type"));
+		Assert.assertEquals(
+			"The thing to create.", bodySchema.get("description"));
 	}
 
 	@Test


### PR DESCRIPTION
Resent after https://github.com/brianchandotcom/liferay-portal/pull/176459#issuecomment-4682060889

@brianchandotcom the reasoning why I believe is not inconsistent is because  the value under "body" is the body's schema (type/description map), not the payload — see OpenAPIUtil.java:573. Naming it body would wrongly imply a payload.

If you still believe it would be better using "body" just let me know. Thanks.