### PR TITLE
LPD-94235 Fix the deprecation badge styling and feature flag state

### DIFF
--- a/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/js/ScopeDropdown.tsx
+++ b/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/js/ScopeDropdown.tsx
@@ -51,7 +51,7 @@ export default function ScopeDropdown({
 						<ClayBadge
 							className="c-ml-2 text-uppercase"
 							displayType="warning"
-							label="deprecated"
+							label={Liferay.Language.get('deprecated')}
 							translucent
 						/>
 					)}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
@@ -29,6 +29,7 @@ const Item = ({item, onClick}) => {
 					{unescapeHTML(item.label)}
 
 					<ClayBadge
+						className="text-uppercase"
 						displayType="warning"
 						label={Liferay.Language.get('deprecated')}
 						translucent

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
@@ -1593,8 +1593,9 @@ public class LayoutsAdminDisplayContext {
 					verticalNavItem.setLabel(name);
 				}
 			).add(
-				() -> FeatureFlagManagerUtil.isEnabled(
-					themeDisplay.getCompanyId(), "LPD-76864"),
+				() ->
+					selectLayoutPageTemplateEntryDisplayContext.
+						isShowGlobalTemplates(),
 				verticalNavItem -> {
 					verticalNavItem.setActive(
 						selectLayoutPageTemplateEntryDisplayContext.

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/SelectLayoutPageTemplateEntryDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/SelectLayoutPageTemplateEntryDisplayContext.java
@@ -278,6 +278,12 @@ public class SelectLayoutPageTemplateEntryDisplayContext {
 		_selectedTab = ParamUtil.getString(
 			_httpServletRequest, "selectedTab", "basic-templates");
 
+		if (Objects.equals(_selectedTab, "global-templates") &&
+			!isShowGlobalTemplates()) {
+
+			_selectedTab = "basic-templates";
+		}
+
 		return _selectedTab;
 	}
 
@@ -362,6 +368,16 @@ public class SelectLayoutPageTemplateEntryDisplayContext {
 		}
 
 		return true;
+	}
+
+	public boolean isShowGlobalTemplates() {
+		if (_isWidgetPageFeatureFlagEnabled() &&
+			(getGlobalLayoutPageTemplateEntriesCount() > 0)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private String _getLayoutPageTemplateEntryAddLayoutURL(

--- a/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContextTest.java
+++ b/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContextTest.java
@@ -218,7 +218,7 @@ public class LayoutsAdminDisplayContextTest {
 							Mockito.anyLong(), Mockito.anyLong(),
 							Mockito.anyInt())
 			).thenReturn(
-				1
+				RandomTestUtil.randomInt()
 			);
 
 			layoutPageTemplateEntryServiceUtilMockedStatic.when(
@@ -230,39 +230,17 @@ public class LayoutsAdminDisplayContextTest {
 							Mockito.eq(
 								LayoutPageTemplateEntryTypeConstants.BASIC))
 			).thenReturn(
-				1
+				RandomTestUtil.randomInt()
 			);
 
-			for (boolean featureFlagEnabled : new boolean[] {false, true}) {
-				try (MockedStatic<FeatureFlagManagerUtil>
-						featureFlagManagerUtilMockedStatic = Mockito.mockStatic(
-							FeatureFlagManagerUtil.class)) {
-
-					featureFlagManagerUtilMockedStatic.when(
-						() -> FeatureFlagManagerUtil.isEnabled(
-							Mockito.anyLong(), Mockito.eq("LPD-76864"))
-					).thenReturn(
-						featureFlagEnabled
-					);
-
-					VerticalNavItemList verticalNavItemList =
-						layoutsAdminDisplayContext.getVerticalNavItemList(
-							Mockito.mock(
-								SelectLayoutPageTemplateEntryDisplayContext.
-									class));
-
-					if (featureFlagEnabled) {
-						Assert.assertEquals(
-							verticalNavItemList.toString(), 4,
-							verticalNavItemList.size());
-					}
-					else {
-						Assert.assertEquals(
-							verticalNavItemList.toString(), 2,
-							verticalNavItemList.size());
-					}
-				}
-			}
+			_testGetVerticalNavItemList(
+				2, false, layoutsAdminDisplayContext, false);
+			_testGetVerticalNavItemList(
+				3, false, layoutsAdminDisplayContext, true);
+			_testGetVerticalNavItemList(
+				3, true, layoutsAdminDisplayContext, false);
+			_testGetVerticalNavItemList(
+				4, true, layoutsAdminDisplayContext, true);
 		}
 	}
 
@@ -455,6 +433,42 @@ public class LayoutsAdminDisplayContextTest {
 		);
 
 		portalUtil.setPortal(_portal);
+	}
+
+	private void _testGetVerticalNavItemList(
+		int expectedVerticalNavItemsCount, boolean featureFlagEnabled,
+		LayoutsAdminDisplayContext layoutsAdminDisplayContext,
+		boolean showGlobalTemplates) {
+
+		SelectLayoutPageTemplateEntryDisplayContext
+			selectLayoutPageTemplateEntryDisplayContext = Mockito.mock(
+				SelectLayoutPageTemplateEntryDisplayContext.class);
+
+		Mockito.when(
+			selectLayoutPageTemplateEntryDisplayContext.isShowGlobalTemplates()
+		).thenReturn(
+			showGlobalTemplates
+		);
+
+		try (MockedStatic<FeatureFlagManagerUtil>
+				featureFlagManagerUtilMockedStatic = Mockito.mockStatic(
+					FeatureFlagManagerUtil.class)) {
+
+			featureFlagManagerUtilMockedStatic.when(
+				() -> FeatureFlagManagerUtil.isEnabled(
+					Mockito.anyLong(), Mockito.eq("LPD-76864"))
+			).thenReturn(
+				featureFlagEnabled
+			);
+
+			VerticalNavItemList verticalNavItemList =
+				layoutsAdminDisplayContext.getVerticalNavItemList(
+					selectLayoutPageTemplateEntryDisplayContext);
+
+			Assert.assertEquals(
+				verticalNavItemList.toString(), expectedVerticalNavItemsCount,
+				verticalNavItemList.size());
+		}
 	}
 
 	private static final Group _group = Mockito.mock(Group.class);

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/LayoutPageTemplatesAdminDisplayContext.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/LayoutPageTemplatesAdminDisplayContext.java
@@ -8,6 +8,9 @@ package com.liferay.layout.page.template.admin.web.internal.display.context;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemListBuilder;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryServiceUtil;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
@@ -121,6 +124,25 @@ public class LayoutPageTemplatesAdminDisplayContext {
 			_liferayPortletRequest, "tabs1", "master-layouts");
 
 		return _tabs1;
+	}
+
+	public boolean isShowWidgetPageTemplates() {
+		int layoutPageTemplateEntriesCountByType =
+			LayoutPageTemplateEntryServiceUtil.
+				getLayoutPageTemplateEntriesCountByType(
+					_themeDisplay.getScopeGroupId(),
+					LayoutPageTemplateConstants.
+						PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
+					LayoutPageTemplateEntryTypeConstants.WIDGET_PAGE);
+
+		if (FeatureFlagManagerUtil.isEnabled(
+				_themeDisplay.getCompanyId(), "LPD-76864") ||
+			(layoutPageTemplateEntriesCountByType > 0)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private final HttpServletRequest _httpServletRequest;

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -18,7 +18,7 @@ Group scopeGroup = themeDisplay.getScopeGroup();
 	<c:when test='<%= Objects.equals(layoutPageTemplatesAdminDisplayContext.getTabs1(), "master-layouts") %>'>
 		<liferay-util:include page="/view_master_layouts.jsp" servletContext="<%= application %>" />
 	</c:when>
-	<c:when test='<%= Objects.equals(layoutPageTemplatesAdminDisplayContext.getTabs1(), "page-templates") && scopeGroup.isCompany() %>'>
+	<c:when test='<%= Objects.equals(layoutPageTemplatesAdminDisplayContext.getTabs1(), "page-templates") && scopeGroup.isCompany() && layoutPageTemplatesAdminDisplayContext.isShowWidgetPageTemplates() %>'>
 		<liferay-util:include page="/view_layout_prototypes.jsp" servletContext="<%= application %>" />
 	</c:when>
 	<c:when test='<%= Objects.equals(layoutPageTemplatesAdminDisplayContext.getTabs1(), "page-templates") && !scopeGroup.isCompany() %>'>

--- a/modules/apps/layout/layout-page-template-admin-web/src/test/java/com/liferay/layout/page/template/admin/web/internal/display/context/LayoutPageTemplatesAdminDisplayContextTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/test/java/com/liferay/layout/page/template/admin/web/internal/display/context/LayoutPageTemplatesAdminDisplayContextTest.java
@@ -6,6 +6,10 @@
 package com.liferay.layout.page.template.admin.web.internal.display.context;
 
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryServiceUtil;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -13,6 +17,7 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletURL;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -139,6 +144,13 @@ public class LayoutPageTemplatesAdminDisplayContextTest {
 			navigationItems.toString(), 0, navigationItems.size());
 	}
 
+	@Test
+	public void testIsShowWidgetPageTemplates() {
+		_testIsShowWidgetPageTemplates(false, 0, false);
+		_testIsShowWidgetPageTemplates(false, RandomTestUtil.randomInt(), true);
+		_testIsShowWidgetPageTemplates(true, 0, true);
+	}
+
 	private void _setUpGroup(boolean company) {
 		Mockito.when(
 			_group.isCompany()
@@ -230,6 +242,52 @@ public class LayoutPageTemplatesAdminDisplayContextTest {
 		).thenReturn(
 			_group
 		);
+	}
+
+	private void _testIsShowWidgetPageTemplates(
+		boolean featureFlagEnabled, int layoutPageTemplateEntriesCountByType,
+		boolean expectedIsShowWidgetPageTemplates) {
+
+		try (MockedStatic<FeatureFlagManagerUtil>
+				featureFlagManagerUtilMockedStatic = Mockito.mockStatic(
+					FeatureFlagManagerUtil.class);
+			MockedStatic<LayoutPageTemplateEntryServiceUtil>
+				layoutPageTemplateEntryServiceUtilMockedStatic =
+					Mockito.mockStatic(
+						LayoutPageTemplateEntryServiceUtil.class)) {
+
+			featureFlagManagerUtilMockedStatic.when(
+				() -> FeatureFlagManagerUtil.isEnabled(
+					Mockito.anyLong(), Mockito.eq("LPD-76864"))
+			).thenReturn(
+				featureFlagEnabled
+			);
+
+			layoutPageTemplateEntryServiceUtilMockedStatic.when(
+				() ->
+					LayoutPageTemplateEntryServiceUtil.
+						getLayoutPageTemplateEntriesCountByType(
+							Mockito.anyLong(),
+							Mockito.eq(
+								LayoutPageTemplateConstants.
+									PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT),
+							Mockito.eq(
+								LayoutPageTemplateEntryTypeConstants.
+									WIDGET_PAGE))
+			).thenReturn(
+				layoutPageTemplateEntriesCountByType
+			);
+
+			LayoutPageTemplatesAdminDisplayContext
+				layoutPageTemplatesAdminDisplayContext =
+					new LayoutPageTemplatesAdminDisplayContext(
+						_liferayPortletRequest, _liferayPortletResponse);
+
+			Assert.assertEquals(
+				expectedIsShowWidgetPageTemplates,
+				layoutPageTemplatesAdminDisplayContext.
+					isShowWidgetPageTemplates());
+		}
 	}
 
 	private final Group _group = Mockito.mock(Group.class);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94235

Previous pull: https://github.com/brianchandotcom/liferay-portal/pull/176609

## What Is Being Fixed

The Widget Page Template deprecation badge rendered with incorrect styling and showed regardless of the LPD-76864 feature flag or whether any widget page template entries exist, and the deprecated Widget Page Template panels stayed visible when they should be hidden.

## How It Is Being Fixed

Hide the deprecated Widget Page Template panels and gate their visibility on the LPD-76864 feature flag or the presence of existing widget page template entries (isShowWidgetPageTemplates). Uppercase and localize the deprecated badge label. Unit tests cover the panel-visibility logic.

Addresses review feedback: sorted the _testGetVerticalNavItemList parameter order and the test call order (plus the earlier count variable name layoutPageTemplateEntriesCountByType).

## PR Check

**pr-check: PASS** — tested on `45625c1f4aabcac6a1b6e071a7e943359b294ec8`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "45625c1f4aabcac6a1b6e071a7e943359b294ec8"} -->
