### PR TITLE
LPD-93831 Limit orphan ResourcePermission cleanup to individual scope

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/JournalDataCleanupPreupgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/JournalDataCleanupPreupgradeProcessTest.java
@@ -29,8 +29,7 @@ import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
-import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
-import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -133,18 +132,18 @@ public class JournalDataCleanupPreupgradeProcessTest
 	public void testUpgradeJournalArticleResourcePermissionScopeCheck()
 		throws Exception {
 
+		Role role = _roleLocalService.getRole(
+			TestPropsValues.getCompanyId(), "Owner");
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			TestPropsValues.getCompanyId(), JournalArticle.class.getName(),
+			ResourceConstants.SCOPE_GROUP, String.valueOf(_group.getGroupId()),
+			role.getRoleId(), new String[] {ActionKeys.VIEW});
+
 		JournalArticle journalArticle = JournalTestUtil.addArticle(
 			_group.getGroupId(),
 			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			Collections.emptyMap());
-
-		Role role = RoleLocalServiceUtil.getRole(
-			TestPropsValues.getCompanyId(), "Owner");
-
-		ResourcePermissionLocalServiceUtil.setResourcePermissions(
-			TestPropsValues.getCompanyId(), JournalArticle.class.getName(),
-			ResourceConstants.SCOPE_GROUP, String.valueOf(_group.getGroupId()),
-			role.getRoleId(), new String[] {ActionKeys.VIEW});
 
 		runSQL(
 			"delete from JournalArticle where articleId = '" +
@@ -212,5 +211,8 @@ public class JournalDataCleanupPreupgradeProcessTest
 
 	@Inject
 	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
 
 }

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/JournalDataCleanupPreupgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/JournalDataCleanupPreupgradeProcessTest.java
@@ -16,14 +16,22 @@ import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalFeed;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.cache.CacheRegistryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.ClassName;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
+import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -38,6 +46,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -61,10 +70,15 @@ public class JournalDataCleanupPreupgradeProcessTest
 	public void setUp() throws Exception {
 		_classNames = _classNameLocalService.getClassNames(
 			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+		_group = GroupTestUtil.addGroup();
 	}
 
 	@After
 	public void tearDown() throws Exception {
+		if (_group != null) {
+			_groupLocalService.deleteGroup(_group);
+		}
+
 		List<ClassName> classNames = ListUtil.remove(
 			_classNameLocalService.getClassNames(
 				QueryUtil.ALL_POS, QueryUtil.ALL_POS),
@@ -77,17 +91,16 @@ public class JournalDataCleanupPreupgradeProcessTest
 
 	@Test
 	public void testUpgrade() throws Exception {
-		Group group = GroupTestUtil.addGroup();
-
 		JournalArticle journalArticle = JournalTestUtil.addArticle(
-			group.getGroupId(), JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			Collections.emptyMap());
 
-		Layout layout = LayoutTestUtil.addTypeContentLayout(group);
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
 
 		JournalFeed journalFeed = JournalTestUtil.addFeed(
-			group.getGroupId(), layout.getPlid(), RandomTestUtil.randomString(),
-			journalArticle.getDDMStructureId(),
+			_group.getGroupId(), layout.getPlid(),
+			RandomTestUtil.randomString(), journalArticle.getDDMStructureId(),
 			journalArticle.getDDMTemplateKey(),
 			journalArticle.getDDMTemplateKey());
 
@@ -103,16 +116,7 @@ public class JournalDataCleanupPreupgradeProcessTest
 		_ddmTemplateLocalService.deleteTemplate(
 			journalArticle.getDDMTemplate());
 
-		DDMStructure ddmStructure = journalArticle.getDDMStructure();
-
-		DDMStructureVersion ddmStructureVersion =
-			ddmStructure.getStructureVersion();
-
-		_ddmFieldLocalService.deleteDDMFields(
-			ddmStructureVersion.getStructureId());
-
-		_ddmStructureLocalService.deleteStructure(
-			journalArticle.getDDMStructure());
+		_deleteDDMStructure(journalArticle);
 
 		String originalName = PrincipalThreadLocal.getName();
 
@@ -124,8 +128,75 @@ public class JournalDataCleanupPreupgradeProcessTest
 		finally {
 			PrincipalThreadLocal.setName(originalName);
 		}
+	}
 
-		_groupLocalService.deleteGroup(group);
+	@Test
+	public void testUpgradeJournalArticleResourcePermissionScopeCheck()
+		throws Exception {
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			Collections.emptyMap());
+
+		long companyId = TestPropsValues.getCompanyId();
+
+		Role role = RoleLocalServiceUtil.getRole(companyId, "Owner");
+
+		long roleId = role.getRoleId();
+
+		ResourcePermissionLocalServiceUtil.setResourcePermissions(
+			companyId, JournalArticle.class.getName(),
+			ResourceConstants.SCOPE_GROUP, String.valueOf(_group.getGroupId()),
+			roleId, new String[] {ActionKeys.VIEW});
+
+		runSQL(
+			"delete from JournalArticle where articleId = '" +
+				journalArticle.getArticleId() + "'");
+
+		upgrade();
+
+		CacheRegistryUtil.clear();
+
+		Assert.assertFalse(
+			_resourcePermissionLocalService.hasResourcePermission(
+				companyId, JournalArticle.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(journalArticle.getResourcePrimKey()),
+				roleId, ActionKeys.VIEW));
+
+		Assert.assertTrue(
+			_resourcePermissionLocalService.hasResourcePermission(
+				companyId, JournalArticle.class.getName(),
+				ResourceConstants.SCOPE_GROUP,
+				String.valueOf(_group.getGroupId()), roleId,
+				ActionKeys.VIEW));
+
+		runSQL(
+			StringBundler.concat(
+				"delete from ResourcePermission where name = '",
+				JournalArticle.class.getName(), "' and scope = ",
+				ResourceConstants.SCOPE_GROUP, " and primKey = '",
+				_group.getGroupId(), "'"));
+
+		_ddmTemplateLocalService.deleteTemplate(
+			journalArticle.getDDMTemplate());
+
+		_deleteDDMStructure(journalArticle);
+	}
+
+	private void _deleteDDMStructure(JournalArticle journalArticle)
+		throws Exception {
+
+		DDMStructure ddmStructure = journalArticle.getDDMStructure();
+
+		DDMStructureVersion ddmStructureVersion =
+			ddmStructure.getStructureVersion();
+
+		_ddmFieldLocalService.deleteDDMFields(
+			ddmStructureVersion.getStructureId());
+
+		_ddmStructureLocalService.deleteStructure(ddmStructure);
 	}
 
 	@Inject
@@ -142,10 +213,15 @@ public class JournalDataCleanupPreupgradeProcessTest
 	@Inject
 	private DDMTemplateLocalService _ddmTemplateLocalService;
 
+	private Group _group;
+
 	@Inject
 	private GroupLocalService _groupLocalService;
 
 	@Inject
 	private LayoutLocalService _layoutLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
 
 }

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/JournalDataCleanupPreupgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/JournalDataCleanupPreupgradeProcessTest.java
@@ -16,7 +16,6 @@ import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalFeed;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.cache.CacheRegistryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.ClassName;
@@ -171,13 +170,6 @@ public class JournalDataCleanupPreupgradeProcessTest
 				ResourceConstants.SCOPE_GROUP,
 				String.valueOf(_group.getGroupId()), roleId,
 				ActionKeys.VIEW));
-
-		runSQL(
-			StringBundler.concat(
-				"delete from ResourcePermission where name = '",
-				JournalArticle.class.getName(), "' and scope = ",
-				ResourceConstants.SCOPE_GROUP, " and primKey = '",
-				_group.getGroupId(), "'"));
 
 		_ddmTemplateLocalService.deleteTemplate(
 			journalArticle.getDDMTemplate());

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/JournalDataCleanupPreupgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/JournalDataCleanupPreupgradeProcessTest.java
@@ -138,16 +138,13 @@ public class JournalDataCleanupPreupgradeProcessTest
 			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			Collections.emptyMap());
 
-		long companyId = TestPropsValues.getCompanyId();
-
-		Role role = RoleLocalServiceUtil.getRole(companyId, "Owner");
-
-		long roleId = role.getRoleId();
+		Role role = RoleLocalServiceUtil.getRole(
+			TestPropsValues.getCompanyId(), "Owner");
 
 		ResourcePermissionLocalServiceUtil.setResourcePermissions(
-			companyId, JournalArticle.class.getName(),
+			TestPropsValues.getCompanyId(), JournalArticle.class.getName(),
 			ResourceConstants.SCOPE_GROUP, String.valueOf(_group.getGroupId()),
-			roleId, new String[] {ActionKeys.VIEW});
+			role.getRoleId(), new String[] {ActionKeys.VIEW});
 
 		runSQL(
 			"delete from JournalArticle where articleId = '" +
@@ -159,16 +156,16 @@ public class JournalDataCleanupPreupgradeProcessTest
 
 		Assert.assertFalse(
 			_resourcePermissionLocalService.hasResourcePermission(
-				companyId, JournalArticle.class.getName(),
+				TestPropsValues.getCompanyId(), JournalArticle.class.getName(),
 				ResourceConstants.SCOPE_INDIVIDUAL,
 				String.valueOf(journalArticle.getResourcePrimKey()),
-				roleId, ActionKeys.VIEW));
+				role.getRoleId(), ActionKeys.VIEW));
 
 		Assert.assertTrue(
 			_resourcePermissionLocalService.hasResourcePermission(
-				companyId, JournalArticle.class.getName(),
+				TestPropsValues.getCompanyId(), JournalArticle.class.getName(),
 				ResourceConstants.SCOPE_GROUP,
-				String.valueOf(_group.getGroupId()), roleId,
+				String.valueOf(_group.getGroupId()), role.getRoleId(),
 				ActionKeys.VIEW));
 
 		_ddmTemplateLocalService.deleteTemplate(

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DLFileEntryDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DLFileEntryDataCleanupPreupgradeProcess.java
@@ -14,6 +14,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.upgrade.data.cleanup.DataCleanupPreupgradeProcess;
 import com.liferay.portal.kernel.upgrade.data.cleanup.FilterableAllTablesOrphanReferencesDataCleanupPreupgradeProcess;
@@ -103,7 +104,9 @@ public class DLFileEntryDataCleanupPreupgradeProcess
 				null,
 				StringBundler.concat(
 					"[$SOURCE_TABLE_ALIAS$].name = '",
-					DLFileEntry.class.getName(), "'"),
+					DLFileEntry.class.getName(),
+					"' and [$SOURCE_TABLE_ALIAS$].scope = ",
+					ResourceConstants.SCOPE_INDIVIDUAL),
 				"primKeyId", "ResourcePermission", "fileEntryId",
 				"DLFileEntry"));
 	}
@@ -210,7 +213,9 @@ public class DLFileEntryDataCleanupPreupgradeProcess
 				null,
 				StringBundler.concat(
 					"[$SOURCE_TABLE_ALIAS$].name = '",
-					DLFileShortcut.class.getName(), "'"),
+					DLFileShortcut.class.getName(),
+					"' and [$SOURCE_TABLE_ALIAS$].scope = ",
+					ResourceConstants.SCOPE_INDIVIDUAL),
 				"primKeyId", "ResourcePermission", "fileShortcutId",
 				"DLFileShortcut"));
 	}

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/JournalDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/JournalDataCleanupPreupgradeProcess.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.upgrade.data.cleanup;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.upgrade.data.cleanup.DataCleanupPreupgradeProcess;
 import com.liferay.portal.kernel.upgrade.data.cleanup.FilterableAllTablesOrphanReferencesDataCleanupPreupgradeProcess;
 import com.liferay.portal.kernel.upgrade.data.cleanup.TableOrphanReferencesDataCleanupPreupgradeProcess;
@@ -45,15 +46,21 @@ public class JournalDataCleanupPreupgradeProcess
 		upgrade(
 			new TableOrphanReferencesDataCleanupPreupgradeProcess(
 				null,
-				"[$SOURCE_TABLE_ALIAS$].name = 'com.liferay.journal.model." +
-					"JournalArticle'",
+				StringBundler.concat(
+					"[$SOURCE_TABLE_ALIAS$].scope = ",
+					ResourceConstants.SCOPE_INDIVIDUAL,
+					" and [$SOURCE_TABLE_ALIAS$].name = ",
+					"'com.liferay.journal.model.JournalArticle'"),
 				"primKeyId", "ResourcePermission", "resourcePrimKey",
 				"JournalArticle"));
 		upgrade(
 			new TableOrphanReferencesDataCleanupPreupgradeProcess(
 				null,
-				"[$SOURCE_TABLE_ALIAS$].name = 'com.liferay.journal.model." +
-					"JournalFeed'",
+				StringBundler.concat(
+					"[$SOURCE_TABLE_ALIAS$].scope = ",
+					ResourceConstants.SCOPE_INDIVIDUAL,
+					" and [$SOURCE_TABLE_ALIAS$].name = ",
+					"'com.liferay.journal.model.JournalFeed'"),
 				"primKeyId", "ResourcePermission", "id_", "JournalFeed"));
 	}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/JournalDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/JournalDataCleanupPreupgradeProcess.java
@@ -47,20 +47,20 @@ public class JournalDataCleanupPreupgradeProcess
 			new TableOrphanReferencesDataCleanupPreupgradeProcess(
 				null,
 				StringBundler.concat(
+					"[$SOURCE_TABLE_ALIAS$].name = ",
+					"'com.liferay.journal.model.JournalArticle' and ",
 					"[$SOURCE_TABLE_ALIAS$].scope = ",
-					ResourceConstants.SCOPE_INDIVIDUAL,
-					" and [$SOURCE_TABLE_ALIAS$].name = ",
-					"'com.liferay.journal.model.JournalArticle'"),
+					ResourceConstants.SCOPE_INDIVIDUAL),
 				"primKeyId", "ResourcePermission", "resourcePrimKey",
 				"JournalArticle"));
 		upgrade(
 			new TableOrphanReferencesDataCleanupPreupgradeProcess(
 				null,
 				StringBundler.concat(
+					"[$SOURCE_TABLE_ALIAS$].name = ",
+					"'com.liferay.journal.model.JournalFeed' and ",
 					"[$SOURCE_TABLE_ALIAS$].scope = ",
-					ResourceConstants.SCOPE_INDIVIDUAL,
-					" and [$SOURCE_TABLE_ALIAS$].name = ",
-					"'com.liferay.journal.model.JournalFeed'"),
+					ResourceConstants.SCOPE_INDIVIDUAL),
 				"primKeyId", "ResourcePermission", "id_", "JournalFeed"));
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93831

## What Is Being Fixed

The pre-upgrade orphan ResourcePermission cleanup matched rows by `name` alone. For JournalArticle, JournalFeed, DLFileEntry, and DLFileShortcut this also matched company- and group-scoped (General Permissions) rows, so the cleanup deleted permissions that were not orphaned. After the upgrade, web content articles were left missing permissions.

## How It Is Being Fixed

The cleanup now restricts the orphan match to individual-scope rows by adding `scope = SCOPE_INDIVIDUAL` to the WHERE clause for each of the four entities, leaving company- and group-scoped permissions untouched. A new integration test verifies that an individual-scope permission for a deleted article is removed while the group-scope permission is preserved.

## PR Check

**pr-check: SKIPPED** — Full build was done manually.

<!-- pr-check {"reason": "Full build was done manually.", "result": "skipped", "sha": "9cefe8f6b275764ad99f56f468319b33772bb054"} -->
