### PR TITLE
LPD-94235 Fix the deprecation badge styling and feature flag state

### DIFF
--- a/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/js/ScopeDropdown.tsx
+++ b/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/js/ScopeDropdown.tsx
@@ -51,7 +51,7 @@ export default function ScopeDropdown({
 						<ClayBadge
 							className="c-ml-2 text-uppercase"
 							displayType="warning"
-							label="deprecated"
+							label={Liferay.Language.get('deprecated')}
 							translucent
 						/>
 					)}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
@@ -29,6 +29,7 @@ const Item = ({item, onClick}) => {
 					{unescapeHTML(item.label)}
 
 					<ClayBadge
+						className="text-uppercase"
 						displayType="warning"
 						label={Liferay.Language.get('deprecated')}
 						translucent

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
@@ -1593,8 +1593,9 @@ public class LayoutsAdminDisplayContext {
 					verticalNavItem.setLabel(name);
 				}
 			).add(
-				() -> FeatureFlagManagerUtil.isEnabled(
-					themeDisplay.getCompanyId(), "LPD-76864"),
+				() ->
+					selectLayoutPageTemplateEntryDisplayContext.
+						isShowGlobalTemplates(),
 				verticalNavItem -> {
 					verticalNavItem.setActive(
 						selectLayoutPageTemplateEntryDisplayContext.

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/SelectLayoutPageTemplateEntryDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/SelectLayoutPageTemplateEntryDisplayContext.java
@@ -278,6 +278,12 @@ public class SelectLayoutPageTemplateEntryDisplayContext {
 		_selectedTab = ParamUtil.getString(
 			_httpServletRequest, "selectedTab", "basic-templates");
 
+		if (Objects.equals(_selectedTab, "global-templates") &&
+			!isShowGlobalTemplates()) {
+
+			_selectedTab = "basic-templates";
+		}
+
 		return _selectedTab;
 	}
 
@@ -362,6 +368,16 @@ public class SelectLayoutPageTemplateEntryDisplayContext {
 		}
 
 		return true;
+	}
+
+	public boolean isShowGlobalTemplates() {
+		if (_isWidgetPageFeatureFlagEnabled() &&
+			(getGlobalLayoutPageTemplateEntriesCount() > 0)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private String _getLayoutPageTemplateEntryAddLayoutURL(

--- a/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContextTest.java
+++ b/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContextTest.java
@@ -218,7 +218,7 @@ public class LayoutsAdminDisplayContextTest {
 							Mockito.anyLong(), Mockito.anyLong(),
 							Mockito.anyInt())
 			).thenReturn(
-				1
+				RandomTestUtil.randomInt()
 			);
 
 			layoutPageTemplateEntryServiceUtilMockedStatic.when(
@@ -230,39 +230,17 @@ public class LayoutsAdminDisplayContextTest {
 							Mockito.eq(
 								LayoutPageTemplateEntryTypeConstants.BASIC))
 			).thenReturn(
-				1
+				RandomTestUtil.randomInt()
 			);
 
-			for (boolean featureFlagEnabled : new boolean[] {false, true}) {
-				try (MockedStatic<FeatureFlagManagerUtil>
-						featureFlagManagerUtilMockedStatic = Mockito.mockStatic(
-							FeatureFlagManagerUtil.class)) {
-
-					featureFlagManagerUtilMockedStatic.when(
-						() -> FeatureFlagManagerUtil.isEnabled(
-							Mockito.anyLong(), Mockito.eq("LPD-76864"))
-					).thenReturn(
-						featureFlagEnabled
-					);
-
-					VerticalNavItemList verticalNavItemList =
-						layoutsAdminDisplayContext.getVerticalNavItemList(
-							Mockito.mock(
-								SelectLayoutPageTemplateEntryDisplayContext.
-									class));
-
-					if (featureFlagEnabled) {
-						Assert.assertEquals(
-							verticalNavItemList.toString(), 4,
-							verticalNavItemList.size());
-					}
-					else {
-						Assert.assertEquals(
-							verticalNavItemList.toString(), 2,
-							verticalNavItemList.size());
-					}
-				}
-			}
+			_testGetVerticalNavItemList(
+				2, false, layoutsAdminDisplayContext, false);
+			_testGetVerticalNavItemList(
+				3, false, layoutsAdminDisplayContext, true);
+			_testGetVerticalNavItemList(
+				3, true, layoutsAdminDisplayContext, false);
+			_testGetVerticalNavItemList(
+				4, true, layoutsAdminDisplayContext, true);
 		}
 	}
 
@@ -455,6 +433,42 @@ public class LayoutsAdminDisplayContextTest {
 		);
 
 		portalUtil.setPortal(_portal);
+	}
+
+	private void _testGetVerticalNavItemList(
+		int expectedVerticalNavItemsCount, boolean featureFlagEnabled,
+		LayoutsAdminDisplayContext layoutsAdminDisplayContext,
+		boolean showGlobalTemplates) {
+
+		SelectLayoutPageTemplateEntryDisplayContext
+			selectLayoutPageTemplateEntryDisplayContext = Mockito.mock(
+				SelectLayoutPageTemplateEntryDisplayContext.class);
+
+		Mockito.when(
+			selectLayoutPageTemplateEntryDisplayContext.isShowGlobalTemplates()
+		).thenReturn(
+			showGlobalTemplates
+		);
+
+		try (MockedStatic<FeatureFlagManagerUtil>
+				featureFlagManagerUtilMockedStatic = Mockito.mockStatic(
+					FeatureFlagManagerUtil.class)) {
+
+			featureFlagManagerUtilMockedStatic.when(
+				() -> FeatureFlagManagerUtil.isEnabled(
+					Mockito.anyLong(), Mockito.eq("LPD-76864"))
+			).thenReturn(
+				featureFlagEnabled
+			);
+
+			VerticalNavItemList verticalNavItemList =
+				layoutsAdminDisplayContext.getVerticalNavItemList(
+					selectLayoutPageTemplateEntryDisplayContext);
+
+			Assert.assertEquals(
+				verticalNavItemList.toString(), expectedVerticalNavItemsCount,
+				verticalNavItemList.size());
+		}
 	}
 
 	private static final Group _group = Mockito.mock(Group.class);

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/LayoutPageTemplatesAdminDisplayContext.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/LayoutPageTemplatesAdminDisplayContext.java
@@ -8,6 +8,9 @@ package com.liferay.layout.page.template.admin.web.internal.display.context;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemListBuilder;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryServiceUtil;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
@@ -121,6 +124,25 @@ public class LayoutPageTemplatesAdminDisplayContext {
 			_liferayPortletRequest, "tabs1", "master-layouts");
 
 		return _tabs1;
+	}
+
+	public boolean isShowPageTemplates() {
+		int layoutPageTemplateEntriesCountByType =
+			LayoutPageTemplateEntryServiceUtil.
+				getLayoutPageTemplateEntriesCountByType(
+					_themeDisplay.getScopeGroupId(),
+					LayoutPageTemplateConstants.
+						PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
+					LayoutPageTemplateEntryTypeConstants.WIDGET_PAGE);
+
+		if (FeatureFlagManagerUtil.isEnabled(
+				_themeDisplay.getCompanyId(), "LPD-76864") ||
+			(layoutPageTemplateEntriesCountByType > 0)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private final HttpServletRequest _httpServletRequest;

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -18,7 +18,7 @@ Group scopeGroup = themeDisplay.getScopeGroup();
 	<c:when test='<%= Objects.equals(layoutPageTemplatesAdminDisplayContext.getTabs1(), "master-layouts") %>'>
 		<liferay-util:include page="/view_master_layouts.jsp" servletContext="<%= application %>" />
 	</c:when>
-	<c:when test='<%= Objects.equals(layoutPageTemplatesAdminDisplayContext.getTabs1(), "page-templates") && scopeGroup.isCompany() %>'>
+	<c:when test='<%= Objects.equals(layoutPageTemplatesAdminDisplayContext.getTabs1(), "page-templates") && scopeGroup.isCompany() && layoutPageTemplatesAdminDisplayContext.isShowPageTemplates() %>'>
 		<liferay-util:include page="/view_layout_prototypes.jsp" servletContext="<%= application %>" />
 	</c:when>
 	<c:when test='<%= Objects.equals(layoutPageTemplatesAdminDisplayContext.getTabs1(), "page-templates") && !scopeGroup.isCompany() %>'>

--- a/modules/apps/layout/layout-page-template-admin-web/src/test/java/com/liferay/layout/page/template/admin/web/internal/display/context/LayoutPageTemplatesAdminDisplayContextTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/test/java/com/liferay/layout/page/template/admin/web/internal/display/context/LayoutPageTemplatesAdminDisplayContextTest.java
@@ -6,6 +6,10 @@
 package com.liferay.layout.page.template.admin.web.internal.display.context;
 
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryServiceUtil;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -13,6 +17,7 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletURL;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -139,6 +144,13 @@ public class LayoutPageTemplatesAdminDisplayContextTest {
 			navigationItems.toString(), 0, navigationItems.size());
 	}
 
+	@Test
+	public void testIsShowPageTemplates() {
+		_testIsShowPageTemplates(false, 0, false);
+		_testIsShowPageTemplates(false, RandomTestUtil.randomInt(), true);
+		_testIsShowPageTemplates(true, RandomTestUtil.randomInt(), true);
+	}
+
 	private void _setUpGroup(boolean company) {
 		Mockito.when(
 			_group.isCompany()
@@ -230,6 +242,51 @@ public class LayoutPageTemplatesAdminDisplayContextTest {
 		).thenReturn(
 			_group
 		);
+	}
+
+	private void _testIsShowPageTemplates(
+		boolean featureFlagEnabled, int layoutPageTemplateEntriesCountByType,
+		boolean showPageTemplates) {
+
+		try (MockedStatic<FeatureFlagManagerUtil>
+				featureFlagManagerUtilMockedStatic = Mockito.mockStatic(
+					FeatureFlagManagerUtil.class);
+			MockedStatic<LayoutPageTemplateEntryServiceUtil>
+				layoutPageTemplateEntryServiceUtilMockedStatic =
+					Mockito.mockStatic(
+						LayoutPageTemplateEntryServiceUtil.class)) {
+
+			featureFlagManagerUtilMockedStatic.when(
+				() -> FeatureFlagManagerUtil.isEnabled(
+					Mockito.anyLong(), Mockito.eq("LPD-76864"))
+			).thenReturn(
+				featureFlagEnabled
+			);
+
+			layoutPageTemplateEntryServiceUtilMockedStatic.when(
+				() ->
+					LayoutPageTemplateEntryServiceUtil.
+						getLayoutPageTemplateEntriesCountByType(
+							Mockito.anyLong(),
+							Mockito.eq(
+								LayoutPageTemplateConstants.
+									PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT),
+							Mockito.eq(
+								LayoutPageTemplateEntryTypeConstants.
+									WIDGET_PAGE))
+			).thenReturn(
+				layoutPageTemplateEntriesCountByType
+			);
+
+			LayoutPageTemplatesAdminDisplayContext
+				layoutPageTemplatesAdminDisplayContext =
+					new LayoutPageTemplatesAdminDisplayContext(
+						_liferayPortletRequest, _liferayPortletResponse);
+
+			Assert.assertEquals(
+				showPageTemplates,
+				layoutPageTemplatesAdminDisplayContext.isShowPageTemplates());
+		}
 	}
 
 	private final Group _group = Mockito.mock(Group.class);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94235

Previous pull: https://github.com/brianchandotcom/liferay-portal/pull/176641

## What Is Being Fixed

The deprecated Widget Page section (company scope, the "page-templates" tab, backed by LayoutPrototype) had two defects: the deprecation badge rendered with incorrect styling (lowercase plain orange text instead of the Lexicon deprecated badge), and the section showed regardless of the LPD-76864 feature flag state.

## How It Is Being Fixed

Gate the section visibility on the LPD-76864 feature flag or the presence of existing WIDGET_PAGE entries, and uppercase and localize the deprecated badge label. Unit tests cover the visibility logic.

## Naming (Response to Review)

In https://github.com/brianchandotcom/liferay-portal/pull/176641#issuecomment-4701468915 you flagged that this path mixes interchangeable terms. They are all pre-existing in the module, not coined here:

- `LayoutPageTemplateEntryTypeConstants.WIDGET_PAGE` -> label "Widget Page" (`layout.types.portlet`).
- `widget-page-templates` -> "Widget Page Templates" (`Language.properties` 23677-23678), the section label used by `LayoutPageTemplatesPanelApp`, the portlet title, the vertical cards, the dropdown items, and the management toolbar.
- `"page-templates"` -> the `getTabs1()` tab token.
- `view_layout_prototypes.jsp` / `LayoutPrototype` -> the model the section lists.

At company scope `getTabs1()` always returns `"page-templates"`, and that tab resolves only to `view_layout_prototypes.jsp`, so a company-scope "page template" is always a Widget Page Template. Because the terms collapse to one concept here, this PR drops the newly introduced "Widget Page Template" wording and reuses the existing `"page-templates"` token: `isShowWidgetPageTemplates()` -> `isShowPageTemplates()`.

## PR Check

Behavior-preserving rename on top of 176641 (full pr-check PASS on `f7d9c219a88d1f0f6d841200d0cf854130c454fa`). Re-validated on this head:

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| JSP Compile | PASS |
| Java Unit Tests (LayoutPageTemplatesAdminDisplayContextTest) | PASS |

<!-- pr-check {"result": "success", "sha": "29ea680d94a282881dc7e5220d456dd08acae78d"} -->

Thanks for reviewing! 