### PR TITLE
LPD-93305 Harden MCP tool invocation request body handling

### DIFF
--- a/modules/apps/mcp/mcp-server-rest-impl/rest-openapi.yaml
+++ b/modules/apps/mcp/mcp-server-rest-impl/rest-openapi.yaml
@@ -175,12 +175,7 @@ paths:
                                 Input map matching the tool's `inputSchema`.
                             type: object
                 description:
-                    "The complete input map for the target tool, matching the `inputSchema` that `getTool` returns for
-                    this `toolName`. Use that schema's properties exactly as named: when the `inputSchema` declares a
-                    `body` property, it holds the request payload and must stay nested under `body` here rather than be
-                    flattened into this map; pass any path or query parameters as siblings of `body`. For example, a
-                    tool whose `inputSchema` has `body` and `itemId` properties is invoked with `{\"body\": {...},
-                    \"itemId\": \"123\"}`."
+                    "The complete input map for the target tool, matching the `inputSchema` that `getTool` returns for this `toolName`. Use that schema's properties exactly as named: when the `inputSchema` declares a `body` property, it holds the request payload and must stay nested under `body` here rather than be flattened into this map; pass any path or query parameters as siblings of `body`. For example, a tool whose `inputSchema` has `body` and `itemId` properties is invoked with `{\"body\": {...}, \"itemId\": \"123\"}`."
                 required: false
             responses:
                 200:

--- a/modules/apps/mcp/mcp-server-rest-impl/rest-openapi.yaml
+++ b/modules/apps/mcp/mcp-server-rest-impl/rest-openapi.yaml
@@ -174,6 +174,13 @@ paths:
                             description:
                                 Input map matching the tool's `inputSchema`.
                             type: object
+                description:
+                    "The complete input map for the target tool, matching the `inputSchema` that `getTool` returns for
+                    this `toolName`. Use that schema's properties exactly as named: when the `inputSchema` declares a
+                    `body` property, it holds the request payload and must stay nested under `body` here rather than be
+                    flattened into this map; pass any path or query parameters as siblings of `body`. For example, a
+                    tool whose `inputSchema` has `body` and `itemId` properties is invoked with `{\"body\": {...},
+                    \"itemId\": \"123\"}`."
                 required: false
             responses:
                 200:

--- a/modules/apps/mcp/mcp-server-rest-impl/rest-openapi.yaml
+++ b/modules/apps/mcp/mcp-server-rest-impl/rest-openapi.yaml
@@ -175,7 +175,7 @@ paths:
                                 Input map matching the tool's `inputSchema`.
                             type: object
                 description:
-                    "The complete input map for the target tool, matching the `inputSchema` that `getTool` returns for this `toolName`. Use that schema's properties exactly as named: when the `inputSchema` declares a `body` property, it holds the request payload and must stay nested under `body` here rather than be flattened into this map; pass any path or query parameters as siblings of `body`. For example, a tool whose `inputSchema` has `body` and `itemId` properties is invoked with `{\"body\": {...}, \"itemId\": \"123\"}`."
+                    "The complete input map for the target tool, matching the `inputSchema` that `getToolSetToolSetNameTool` returns for this `toolName`. Use that schema's properties exactly as named: when the `inputSchema` declares a `body` property, it holds the request payload and must stay nested under `body` here rather than be flattened into this map; pass any path or query parameters as siblings of `body`. For example, a tool whose `inputSchema` has `body` and `itemId` properties is invoked with `{\"body\": {...}, \"itemId\": \"123\"}`."
                 required: false
             responses:
                 200:

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/BaseToolResourceImpl.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/BaseToolResourceImpl.java
@@ -92,7 +92,8 @@ public abstract class BaseToolResourceImpl implements ToolResource {
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Invokes a tool. ALWAYS call `getToolSetToolSetNameTool` first to fetch the tool's `inputSchema`, then build the request `body` to match it exactly. Skipping `getToolSetToolSetNameTool` leads to malformed input and avoidable failures. Returns the tool's response body unchanged.",
-		operationId = "postToolSetToolSetNameToolInvoke"
+		operationId = "postToolSetToolSetNameToolInvoke",
+		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = Object.class)), description = "The complete input map for the target tool, matching the `inputSchema` that `getTool` returns for this `toolName`. Use that schema's properties exactly as named: when the `inputSchema` declares a `body` property, it holds the request payload and must stay nested under `body` here rather than be flattened into this map; pass any path or query parameters as siblings of `body`. For example, a tool whose `inputSchema` has `body` and `itemId` properties is invoked with `{\"body\": {...}, \"itemId\": \"123\"}`.")
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -578,4 +579,4 @@ public abstract class BaseToolResourceImpl implements ToolResource {
 		LogFactoryUtil.getLog(BaseToolResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:1426896571
+// LIFERAY-REST-BUILDER-HASH:-1744722583

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/BaseToolResourceImpl.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/BaseToolResourceImpl.java
@@ -93,7 +93,7 @@ public abstract class BaseToolResourceImpl implements ToolResource {
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Invokes a tool. ALWAYS call `getToolSetToolSetNameTool` first to fetch the tool's `inputSchema`, then build the request `body` to match it exactly. Skipping `getToolSetToolSetNameTool` leads to malformed input and avoidable failures. Returns the tool's response body unchanged.",
 		operationId = "postToolSetToolSetNameToolInvoke",
-		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = Object.class)), description = "The complete input map for the target tool, matching the `inputSchema` that `getTool` returns for this `toolName`. Use that schema's properties exactly as named: when the `inputSchema` declares a `body` property, it holds the request payload and must stay nested under `body` here rather than be flattened into this map; pass any path or query parameters as siblings of `body`. For example, a tool whose `inputSchema` has `body` and `itemId` properties is invoked with `{\"body\": {...}, \"itemId\": \"123\"}`.")
+		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = Object.class)), description = "The complete input map for the target tool, matching the `inputSchema` that `getToolSetToolSetNameTool` returns for this `toolName`. Use that schema's properties exactly as named: when the `inputSchema` declares a `body` property, it holds the request payload and must stay nested under `body` here rather than be flattened into this map; pass any path or query parameters as siblings of `body`. For example, a tool whose `inputSchema` has `body` and `itemId` properties is invoked with `{\"body\": {...}, \"itemId\": \"123\"}`.")
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -579,4 +579,4 @@ public abstract class BaseToolResourceImpl implements ToolResource {
 		LogFactoryUtil.getLog(BaseToolResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1744722583
+// LIFERAY-REST-BUILDER-HASH:-1516858284

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -894,18 +894,19 @@ public class OpenAPIUtil {
 					"into the input map."));
 		}
 
-		Object bodyValue = inputJSONObject.get("body");
+		options.addHeader("Content-Type", ContentTypes.APPLICATION_JSON);
 
 		String body = StringPool.BLANK;
 
-		if (bodyValue instanceof JSONObject) {
-			body = bodyValue.toString();
+		Object bodyObject = inputJSONObject.get("body");
+
+		if (bodyObject instanceof JSONObject) {
+			body = bodyObject.toString();
 		}
-		else if (bodyValue != null) {
-			body = String.valueOf(bodyValue);
+		else if (bodyObject != null) {
+			body = String.valueOf(bodyObject);
 		}
 
-		options.addHeader("Content-Type", ContentTypes.APPLICATION_JSON);
 		options.setBody(body, ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 	}
 

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -7,12 +7,14 @@ package com.liferay.mcp.server.rest.internal.util;
 
 import com.liferay.mcp.server.rest.dto.v1_0.Tool;
 import com.liferay.mcp.server.rest.dto.v1_0.ToolSummary;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
@@ -110,14 +112,17 @@ public class OpenAPIUtil {
 					continue;
 				}
 
-				ToolSummary toolSummary = new ToolSummary();
-
-				toolSummary.setDescription(
-					() -> _getDescription(method, operationJSONObject, path));
-				toolSummary.setName(
-					() -> operationJSONObject.getString("operationId"));
-
-				toolSummaries.add(toolSummary);
+				toolSummaries.add(
+					new ToolSummary() {
+						{
+							setDescription(
+								() -> _getDescription(
+									method, operationJSONObject, path));
+							setName(
+								() -> operationJSONObject.getString(
+									"operationId"));
+						}
+					});
 			}
 		}
 
@@ -126,76 +131,71 @@ public class OpenAPIUtil {
 
 	private static void _addMultipartParts(
 		JSONObject operationJSONObject, Map<String, Object> properties,
-		List<Object> required, JSONObject openAPIJSONObject) {
+		List<String> requiredPropertyNames, JSONObject openAPIJSONObject) {
 
-		Map<String, Object> bodySchemaMap = (Map<String, Object>)_resolveRefs(
-			openAPIJSONObject, _getBodySchemaJSONObject(operationJSONObject),
-			new HashSet<>());
+		Map<String, Object> bodySchemaMap =
+			(Map<String, Object>)_getSchemaObject(
+				openAPIJSONObject,
+				_getBodySchemaJSONObject(operationJSONObject), new HashSet<>());
 
-		Map<String, Object> partProperties =
+		Map<String, Object> bodyProperties =
 			(Map<String, Object>)bodySchemaMap.get("properties");
 
-		if (partProperties == null) {
+		if (bodyProperties == null) {
 			return;
 		}
 
-		for (Map.Entry<String, Object> entry : partProperties.entrySet()) {
-			String partName = entry.getKey();
-			Map<String, Object> partSchema =
+		for (Map.Entry<String, Object> entry : bodyProperties.entrySet()) {
+			Map<String, Object> propertySchemaMap =
 				(Map<String, Object>)entry.getValue();
 
-			if (_isBinaryPartSchema(partSchema)) {
-				properties.put(partName, _buildBinaryPartEnvelope(partSchema));
-			}
-			else {
-				properties.put(partName, partSchema);
-			}
+			properties.put(
+				entry.getKey(),
+				_isBinary(propertySchemaMap) ?
+					_getBinarySchemaMap(propertySchemaMap) : propertySchemaMap);
 		}
 
-		List<Object> bodySchemaRequired = (List<Object>)bodySchemaMap.get(
-			"required");
-
-		if (bodySchemaRequired != null) {
-			required.addAll(bodySchemaRequired);
-		}
+		requiredPropertyNames.addAll(
+			TransformUtil.transform(
+				(List<Object>)bodySchemaMap.get("required"), String::valueOf));
 	}
 
 	private static void _addParameter(
-		JSONObject parameterJSONObject, Set<String> processedParameterNames,
-		Map<String, Object> properties, List<Object> required) {
+		JSONObject parameterJSONObject, Map<String, Object> properties,
+		List<String> requiredPropertyNames, Set<String> visitedParameterNames) {
 
 		String name = parameterJSONObject.getString("name");
 
 		if (_vulcanFieldSelectionParameterNames.contains(name) ||
-			!processedParameterNames.add(name)) {
+			!visitedParameterNames.add(name)) {
 
 			return;
 		}
 
-		Map<String, Object> property = new LinkedHashMap<>();
+		Map<String, Object> parameterProperties = new LinkedHashMap<>();
 
 		JSONObject parameterSchemaJSONObject =
 			parameterJSONObject.getJSONObject("schema");
 
 		for (String key : parameterSchemaJSONObject.keySet()) {
-			property.put(key, parameterSchemaJSONObject.get(key));
+			parameterProperties.put(key, parameterSchemaJSONObject.get(key));
 		}
 
 		if (parameterJSONObject.has("description")) {
-			property.put(
+			parameterProperties.put(
 				"description", parameterJSONObject.getString("description"));
 		}
 
-		properties.put(name, property);
+		properties.put(name, parameterProperties);
 
 		if (Objects.equals(parameterJSONObject.getString("in"), "path")) {
-			required.add(name);
+			requiredPropertyNames.add(name);
 		}
 	}
 
 	private static void _addParameters(
-		JSONArray parametersJSONArray, Set<String> processedParameterNames,
-		Map<String, Object> properties, List<Object> required) {
+		JSONArray parametersJSONArray, Map<String, Object> properties,
+		List<String> requiredPropertyNames, Set<String> visitedParameterNames) {
 
 		if (parametersJSONArray == null) {
 			return;
@@ -203,13 +203,13 @@ public class OpenAPIUtil {
 
 		for (int i = 0; i < parametersJSONArray.length(); i++) {
 			_addParameter(
-				parametersJSONArray.getJSONObject(i), processedParameterNames,
-				properties, required);
+				parametersJSONArray.getJSONObject(i), properties,
+				requiredPropertyNames, visitedParameterNames);
 		}
 	}
 
 	private static void _appendQueryParameter(
-		String name, StringBundler queryStringSB, Object value) {
+		String name, StringBundler sb, Object value) {
 
 		if (value == null) {
 			return;
@@ -221,30 +221,106 @@ public class OpenAPIUtil {
 			return;
 		}
 
-		if (queryStringSB.length() > 0) {
-			queryStringSB.append(CharPool.AMPERSAND);
+		if (sb.length() > 0) {
+			sb.append(CharPool.AMPERSAND);
 		}
 
-		queryStringSB.append(URLCodec.encodeURL(name));
-		queryStringSB.append(CharPool.EQUAL);
-		queryStringSB.append(URLCodec.encodeURL(stringValue));
+		sb.append(URLCodec.encodeURL(name));
+		sb.append(CharPool.EQUAL);
+		sb.append(URLCodec.encodeURL(stringValue));
 	}
 
-	private static Map<String, Object> _buildBinaryPartEnvelope(
-		Map<String, Object> partSchema) {
+	private static Map<String, Object> _getAllOfSchemaMap(
+		JSONObject jsonObject, JSONObject openAPIJSONObject,
+		Set<String> visitedRefs) {
 
-		String description = (String)partSchema.get("description");
+		Map<String, Object> allOfSchemaMap = new LinkedHashMap<>();
+		Map<String, Object> properties = new LinkedHashMap<>();
+		Set<String> requiredPropertyNames = new HashSet<>();
 
-		String envelopeDescription =
-			"Provide as an object with `data` (base64-encoded bytes), and " +
-				"optional `filename` and `contentType`.";
+		for (String key : jsonObject.keySet()) {
+			if (key.equals("allOf") || _excludedSchemaKeys.contains(key) ||
+				key.startsWith("x-")) {
 
-		if (Validator.isNotNull(description)) {
-			envelopeDescription = description + ". " + envelopeDescription;
+				continue;
+			}
+
+			allOfSchemaMap.put(
+				key,
+				_getSchemaObject(
+					openAPIJSONObject, jsonObject.get(key), visitedRefs));
 		}
 
+		JSONArray allOfJSONArray = jsonObject.getJSONArray("allOf");
+
+		for (int i = 0; i < allOfJSONArray.length(); i++) {
+			Object schemaObject = _getSchemaObject(
+				openAPIJSONObject, allOfJSONArray.getJSONObject(i),
+				visitedRefs);
+
+			if (!(schemaObject instanceof Map)) {
+				continue;
+			}
+
+			Map<String, Object> schemaMap = (Map<String, Object>)schemaObject;
+
+			Map<String, Object> schemaProperties =
+				(Map<String, Object>)schemaMap.get("properties");
+
+			if (schemaProperties != null) {
+				properties.putAll(schemaProperties);
+			}
+
+			requiredPropertyNames.addAll(
+				TransformUtil.transform(
+					(List<Object>)schemaMap.get("required"), String::valueOf));
+
+			for (Map.Entry<String, Object> entry : schemaMap.entrySet()) {
+				String key = entry.getKey();
+
+				if (allOfSchemaMap.containsKey(key) ||
+					key.equals("properties") || key.equals("required")) {
+
+					continue;
+				}
+
+				allOfSchemaMap.put(key, entry.getValue());
+			}
+		}
+
+		if (!properties.isEmpty()) {
+			allOfSchemaMap.put("properties", properties);
+		}
+
+		if (!requiredPropertyNames.isEmpty()) {
+			allOfSchemaMap.put("required", List.copyOf(requiredPropertyNames));
+		}
+
+		if (!allOfSchemaMap.containsKey("type")) {
+			allOfSchemaMap.put("type", "object");
+		}
+
+		return allOfSchemaMap;
+	}
+
+	private static Map<String, Object> _getBinarySchemaMap(
+		Map<String, Object> schemaMap) {
+
 		return HashMapBuilder.<String, Object>put(
-			"description", envelopeDescription
+			"description",
+			() -> {
+				String extraDescription =
+					"Provide as an object with `data` (base64-encoded bytes)" +
+						", and optional `filename` and `contentType`.";
+
+				String description = (String)schemaMap.get("description");
+
+				if (Validator.isNotNull(description)) {
+					return description + ". " + extraDescription;
+				}
+
+				return extraDescription;
+			}
 		).put(
 			"properties",
 			HashMapBuilder.<String, Object>put(
@@ -273,136 +349,6 @@ public class OpenAPIUtil {
 			"required", Arrays.asList("data")
 		).put(
 			"type", "object"
-		).build();
-	}
-
-	private static Map<String, Object> _collectMatchingParameters(
-		JSONObject inputJSONObject, Operation operation, String filterIn) {
-
-		Map<String, Object> matchingParameters = new LinkedHashMap<>();
-
-		for (JSONArray parametersJSONArray :
-				Arrays.asList(
-					operation._operationJSONObject.getJSONArray("parameters"),
-					operation._pathParametersJSONArray)) {
-
-			if (parametersJSONArray == null) {
-				continue;
-			}
-
-			for (int i = 0; i < parametersJSONArray.length(); i++) {
-				JSONObject parameterJSONObject =
-					parametersJSONArray.getJSONObject(i);
-
-				if (!Objects.equals(
-						parameterJSONObject.getString("in"), filterIn)) {
-
-					continue;
-				}
-
-				String name = parameterJSONObject.getString("name");
-
-				if (matchingParameters.containsKey(name) ||
-					!inputJSONObject.has(name)) {
-
-					continue;
-				}
-
-				Object value = inputJSONObject.get(name);
-
-				if (value == null) {
-					continue;
-				}
-
-				matchingParameters.put(name, value);
-			}
-		}
-
-		return matchingParameters;
-	}
-
-	private static Map<String, Object> _expandDiscriminator(
-		JSONObject baseJSONObject, String baseRef, JSONObject openAPIJSONObject,
-		Set<String> visitedRefs) {
-
-		List<Object> oneOfList = new ArrayList<>();
-
-		JSONObject componentsJSONObject = openAPIJSONObject.getJSONObject(
-			"components");
-
-		JSONObject schemasJSONObject = (componentsJSONObject != null) ?
-			componentsJSONObject.getJSONObject("schemas") : null;
-
-		if (schemasJSONObject != null) {
-			for (String schemaName : schemasJSONObject.keySet()) {
-				JSONObject candidateJSONObject =
-					schemasJSONObject.getJSONObject(schemaName);
-
-				JSONArray allOfJSONArray = candidateJSONObject.getJSONArray(
-					"allOf");
-
-				if (allOfJSONArray == null) {
-					continue;
-				}
-
-				boolean extendsBase = false;
-
-				for (int i = 0; i < allOfJSONArray.length(); i++) {
-					JSONObject memberJSONObject = allOfJSONArray.getJSONObject(
-						i);
-
-					if (memberJSONObject == null) {
-						continue;
-					}
-
-					if (baseRef.equals(memberJSONObject.getString("$ref"))) {
-						extendsBase = true;
-
-						break;
-					}
-				}
-
-				if (!extendsBase) {
-					continue;
-				}
-
-				String subtypeRef = "#/components/schemas/" + schemaName;
-
-				if (visitedRefs.contains(subtypeRef)) {
-					continue;
-				}
-
-				Set<String> subtypeVisitedRefs = new HashSet<>(visitedRefs);
-
-				subtypeVisitedRefs.add(subtypeRef);
-
-				oneOfList.add(
-					_resolveRefs(
-						openAPIJSONObject, candidateJSONObject,
-						subtypeVisitedRefs));
-			}
-		}
-
-		if (oneOfList.isEmpty()) {
-			Map<String, Object> resolvedMap = new LinkedHashMap<>();
-
-			for (String key : baseJSONObject.keySet()) {
-				if (_excludedSchemaKeys.contains(key) || key.startsWith("x-")) {
-					continue;
-				}
-
-				resolvedMap.put(
-					key,
-					_resolveRefs(
-						openAPIJSONObject, baseJSONObject.get(key),
-						visitedRefs));
-			}
-
-			return resolvedMap;
-		}
-
-		return LinkedHashMapBuilder.<String, Object>put(
-			"oneOf", oneOfList
 		).build();
 	}
 
@@ -474,41 +420,41 @@ public class OpenAPIUtil {
 	private static Http.FilePart _getFilePart(String name, Object value) {
 		String fileName = name;
 		String contentType = ContentTypes.APPLICATION_OCTET_STREAM;
-		String base64Data;
+		String data;
 
-		JSONObject envelopeJSONObject = null;
+		JSONObject jsonObject = null;
 
 		if (value instanceof JSONObject) {
-			envelopeJSONObject = (JSONObject)value;
+			jsonObject = (JSONObject)value;
 		}
 		else if (value instanceof Map) {
-			envelopeJSONObject = JSONFactoryUtil.createJSONObject(
+			jsonObject = JSONFactoryUtil.createJSONObject(
 				(Map<String, ?>)value);
 		}
 
-		if (envelopeJSONObject != null) {
-			if (envelopeJSONObject.has("filename")) {
-				fileName = envelopeJSONObject.getString("filename");
+		if (jsonObject != null) {
+			if (jsonObject.has("filename")) {
+				fileName = jsonObject.getString("filename");
 			}
 
-			if (envelopeJSONObject.has("contentType")) {
-				contentType = envelopeJSONObject.getString("contentType");
+			if (jsonObject.has("contentType")) {
+				contentType = jsonObject.getString("contentType");
 			}
 
-			base64Data = envelopeJSONObject.getString("data");
+			data = jsonObject.getString("data");
 		}
 		else {
-			base64Data = String.valueOf(value);
+			data = String.valueOf(value);
 		}
 
-		if (Validator.isNull(base64Data)) {
+		if (Validator.isNull(data)) {
 			throw new IllegalArgumentException(
 				"Multipart part \"" + name + "\" has no \"data\"");
 		}
 
 		Base64.Decoder decoder = Base64.getDecoder();
 
-		byte[] bytes = decoder.decode(base64Data);
+		byte[] bytes = decoder.decode(data);
 
 		return new Http.FilePart(
 			name, fileName, bytes, contentType, StringPool.UTF8);
@@ -519,12 +465,12 @@ public class OpenAPIUtil {
 		JSONArray pathParametersJSONArray) {
 
 		Map<String, Object> properties = new LinkedHashMap<>();
-		List<Object> required = new ArrayList<>();
+		List<String> requiredPropertyNames = new ArrayList<>();
 
 		if (operationJSONObject.has("requestBody")) {
 			if (_isMultipartRequest(operationJSONObject)) {
 				_addMultipartParts(
-					operationJSONObject, properties, required,
+					operationJSONObject, properties, requiredPropertyNames,
 					openAPIJSONObject);
 			}
 			else {
@@ -534,13 +480,13 @@ public class OpenAPIUtil {
 				Map<String, Object> bodySchemaMap = null;
 
 				if (requestBodyJSONObject.getJSONObject("content") != null) {
-					Object resolvedObject = _resolveRefs(
+					Object bodySchemaObject = _getSchemaObject(
 						openAPIJSONObject,
 						_getBodySchemaJSONObject(operationJSONObject),
 						new HashSet<>());
 
-					if (resolvedObject instanceof Map) {
-						bodySchemaMap = (Map<String, Object>)resolvedObject;
+					if (bodySchemaObject instanceof Map) {
+						bodySchemaMap = (Map<String, Object>)bodySchemaObject;
 					}
 				}
 
@@ -554,46 +500,125 @@ public class OpenAPIUtil {
 					"description");
 
 				if (Validator.isNotNull(requestBodyDescription)) {
-					Object bodySchemaDescription = bodySchemaMap.get(
-						"description");
+					Object bodyDescription = bodySchemaMap.get("description");
 
-					if (Validator.isNull(bodySchemaDescription)) {
+					if (Validator.isNull(bodyDescription)) {
 						bodySchemaMap.put(
 							"description", requestBodyDescription);
 					}
 					else if (!Objects.equals(
-								bodySchemaDescription,
-								requestBodyDescription)) {
+								bodyDescription, requestBodyDescription)) {
 
 						bodySchemaMap.put(
 							"description",
 							StringBundler.concat(
 								requestBodyDescription, StringPool.SPACE,
-								bodySchemaDescription));
+								bodyDescription));
 					}
 				}
 
 				properties.put("body", bodySchemaMap);
 
-				required.add("body");
+				requiredPropertyNames.add("body");
 			}
 		}
 
-		Set<String> processedParameterNames = new HashSet<>();
+		Set<String> visitedParameterNames = new HashSet<>();
 
 		_addParameters(
-			operationJSONObject.getJSONArray("parameters"),
-			processedParameterNames, properties, required);
+			operationJSONObject.getJSONArray("parameters"), properties,
+			requiredPropertyNames, visitedParameterNames);
 		_addParameters(
-			pathParametersJSONArray, processedParameterNames, properties,
-			required);
+			pathParametersJSONArray, properties, requiredPropertyNames,
+			visitedParameterNames);
 
 		return LinkedHashMapBuilder.<String, Object>put(
 			"properties", properties
 		).put(
-			"required", required
+			"required", requiredPropertyNames
 		).put(
 			"type", "object"
+		).build();
+	}
+
+	private static Map<String, Object> _getOneOfSchemaMap(
+		JSONObject jsonObject, JSONObject openAPIJSONObject, String ref,
+		Set<String> visitedRefs) {
+
+		List<Object> oneOfSchemaObjects = new ArrayList<>();
+
+		JSONObject schemasJSONObject = JSONUtil.getValueAsJSONObject(
+			openAPIJSONObject, "JSONObject/components", "JSONObject/schemas");
+
+		if (schemasJSONObject != null) {
+			for (String schemaName : schemasJSONObject.keySet()) {
+				JSONObject schemaJSONObject = schemasJSONObject.getJSONObject(
+					schemaName);
+
+				JSONArray allOfJSONArray = schemaJSONObject.getJSONArray(
+					"allOf");
+
+				if (allOfJSONArray == null) {
+					continue;
+				}
+
+				boolean extendsBase = false;
+
+				for (int i = 0; i < allOfJSONArray.length(); i++) {
+					JSONObject memberJSONObject = allOfJSONArray.getJSONObject(
+						i);
+
+					if (memberJSONObject == null) {
+						continue;
+					}
+
+					if (ref.equals(memberJSONObject.getString("$ref"))) {
+						extendsBase = true;
+
+						break;
+					}
+				}
+
+				if (!extendsBase) {
+					continue;
+				}
+
+				String subtypeRef = "#/components/schemas/" + schemaName;
+
+				if (visitedRefs.contains(subtypeRef)) {
+					continue;
+				}
+
+				Set<String> subtypeVisitedRefs = new HashSet<>(visitedRefs);
+
+				subtypeVisitedRefs.add(subtypeRef);
+
+				oneOfSchemaObjects.add(
+					_getSchemaObject(
+						openAPIJSONObject, schemaJSONObject,
+						subtypeVisitedRefs));
+			}
+		}
+
+		if (oneOfSchemaObjects.isEmpty()) {
+			Map<String, Object> schemaMap = new LinkedHashMap<>();
+
+			for (String key : jsonObject.keySet()) {
+				if (_excludedSchemaKeys.contains(key) || key.startsWith("x-")) {
+					continue;
+				}
+
+				schemaMap.put(
+					key,
+					_getSchemaObject(
+						openAPIJSONObject, jsonObject.get(key), visitedRefs));
+			}
+
+			return schemaMap;
+		}
+
+		return LinkedHashMapBuilder.<String, Object>put(
+			"oneOf", oneOfSchemaObjects
 		).build();
 	}
 
@@ -608,11 +633,11 @@ public class OpenAPIUtil {
 		}
 
 		for (String path : pathsJSONObject.keySet()) {
-			JSONObject pathItemJSONObject = pathsJSONObject.getJSONObject(path);
+			JSONObject pathJSONObject = pathsJSONObject.getJSONObject(path);
 
 			for (String method : _METHODS) {
-				JSONObject operationJSONObject =
-					pathItemJSONObject.getJSONObject(method);
+				JSONObject operationJSONObject = pathJSONObject.getJSONObject(
+					method);
 
 				if ((operationJSONObject == null) ||
 					!toolName.equals(
@@ -623,12 +648,55 @@ public class OpenAPIUtil {
 
 				return new Operation(
 					method, operationJSONObject, path,
-					pathItemJSONObject.getJSONArray("parameters"));
+					pathJSONObject.getJSONArray("parameters"));
 			}
 		}
 
 		throw new IllegalArgumentException(
 			"OpenAPI document has no tool with name \"" + toolName + "\"");
+	}
+
+	private static Map<String, Object> _getParameterSchemaObjects(
+		String in, JSONObject inputJSONObject, Operation operation) {
+
+		Map<String, Object> parameterSchemaObjects = new LinkedHashMap<>();
+
+		for (JSONArray parametersJSONArray :
+				Arrays.asList(
+					operation._operationJSONObject.getJSONArray("parameters"),
+					operation._pathParametersJSONArray)) {
+
+			if (parametersJSONArray == null) {
+				continue;
+			}
+
+			for (int i = 0; i < parametersJSONArray.length(); i++) {
+				JSONObject parameterJSONObject =
+					parametersJSONArray.getJSONObject(i);
+
+				if (!Objects.equals(parameterJSONObject.getString("in"), in)) {
+					continue;
+				}
+
+				String name = parameterJSONObject.getString("name");
+
+				if (parameterSchemaObjects.containsKey(name) ||
+					!inputJSONObject.has(name)) {
+
+					continue;
+				}
+
+				Object value = inputJSONObject.get(name);
+
+				if (value == null) {
+					continue;
+				}
+
+				parameterSchemaObjects.put(name, value);
+			}
+		}
+
+		return parameterSchemaObjects;
 	}
 
 	private static String _getPart(Object value) {
@@ -654,12 +722,14 @@ public class OpenAPIUtil {
 	private static String _getPath(
 		JSONObject inputJSONObject, Operation operation) {
 
-		Map<String, Object> pathParameters = _collectMatchingParameters(
-			inputJSONObject, operation, "path");
+		Map<String, Object> parameterSchemaObjects = _getParameterSchemaObjects(
+			"path", inputJSONObject, operation);
 
 		String path = operation._path;
 
-		for (Map.Entry<String, Object> entry : pathParameters.entrySet()) {
+		for (Map.Entry<String, Object> entry :
+				parameterSchemaObjects.entrySet()) {
+
 			path = StringUtil.replace(
 				path, "{" + entry.getKey() + "}",
 				URLCodec.encodeURL(String.valueOf(entry.getValue())));
@@ -673,10 +743,12 @@ public class OpenAPIUtil {
 
 		StringBundler sb = new StringBundler();
 
-		Map<String, Object> queryParameters = _collectMatchingParameters(
-			inputJSONObject, operation, "query");
+		Map<String, Object> parameterSchemaObjects = _getParameterSchemaObjects(
+			"query", inputJSONObject, operation);
 
-		for (Map.Entry<String, Object> entry : queryParameters.entrySet()) {
+		for (Map.Entry<String, Object> entry :
+				parameterSchemaObjects.entrySet()) {
+
 			String name = entry.getKey();
 
 			if (_vulcanFieldSelectionParameterNames.contains(name)) {
@@ -693,128 +765,19 @@ public class OpenAPIUtil {
 		return sb.toString();
 	}
 
-	private static boolean _isBinaryPartSchema(Map<String, Object> partSchema) {
-		if (partSchema == null) {
-			return false;
-		}
-
-		return Objects.equals(partSchema.get("format"), "binary");
-	}
-
-	private static boolean _isMultipartRequest(JSONObject operationJSONObject) {
-		JSONObject requestBodyJSONObject = operationJSONObject.getJSONObject(
-			"requestBody");
-
-		if (requestBodyJSONObject == null) {
-			return false;
-		}
-
-		JSONObject contentJSONObject = requestBodyJSONObject.getJSONObject(
-			"content");
-
-		if ((contentJSONObject == null) ||
-			contentJSONObject.has("application/json")) {
-
-			return false;
-		}
-
-		return contentJSONObject.has("multipart/form-data");
-	}
-
-	private static Map<String, Object> _mergeAllOf(
-		JSONObject jsonObject, JSONObject openAPIJSONObject,
-		Set<String> visitedRefs) {
-
-		Map<String, Object> mergedMap = new LinkedHashMap<>();
-		Map<String, Object> mergedProperties = new LinkedHashMap<>();
-		List<Object> mergedRequired = new ArrayList<>();
-		Set<String> mergedRequiredSet = new HashSet<>();
-
-		for (String key : jsonObject.keySet()) {
-			if (key.equals("allOf") || _excludedSchemaKeys.contains(key) ||
-				key.startsWith("x-")) {
-
-				continue;
-			}
-
-			mergedMap.put(
-				key,
-				_resolveRefs(
-					openAPIJSONObject, jsonObject.get(key), visitedRefs));
-		}
-
-		JSONArray allOfJSONArray = jsonObject.getJSONArray("allOf");
-
-		for (int i = 0; i < allOfJSONArray.length(); i++) {
-			Object resolvedObject = _resolveRefs(
-				openAPIJSONObject, allOfJSONArray.getJSONObject(i),
-				visitedRefs);
-
-			if (!(resolvedObject instanceof Map)) {
-				continue;
-			}
-
-			Map<String, Object> memberMap = (Map<String, Object>)resolvedObject;
-
-			Map<String, Object> memberProperties =
-				(Map<String, Object>)memberMap.get("properties");
-
-			if (memberProperties != null) {
-				mergedProperties.putAll(memberProperties);
-			}
-
-			List<Object> memberRequired = (List<Object>)memberMap.get(
-				"required");
-
-			if (memberRequired != null) {
-				for (Object name : memberRequired) {
-					if (mergedRequiredSet.add(String.valueOf(name))) {
-						mergedRequired.add(name);
-					}
-				}
-			}
-
-			for (Map.Entry<String, Object> entry : memberMap.entrySet()) {
-				String key = entry.getKey();
-
-				if (mergedMap.containsKey(key) || key.equals("properties") ||
-					key.equals("required")) {
-
-					continue;
-				}
-
-				mergedMap.put(key, entry.getValue());
-			}
-		}
-
-		if (!mergedProperties.isEmpty()) {
-			mergedMap.put("properties", mergedProperties);
-		}
-
-		if (!mergedRequired.isEmpty()) {
-			mergedMap.put("required", mergedRequired);
-		}
-
-		if (!mergedMap.containsKey("type")) {
-			mergedMap.put("type", "object");
-		}
-
-		return mergedMap;
-	}
-
-	private static JSONObject _resolveRef(
+	private static JSONObject _getRefJSONObject(
 		String ref, JSONObject openAPIJSONObject) {
 
-		JSONObject currentJSONObject = openAPIJSONObject;
+		JSONObject refJSONObject = openAPIJSONObject;
 
 		for (String part : StringUtil.split(ref.substring(2), CharPool.SLASH)) {
-			currentJSONObject = currentJSONObject.getJSONObject(part);
+			refJSONObject = refJSONObject.getJSONObject(part);
 		}
 
-		return currentJSONObject;
+		return refJSONObject;
 	}
 
-	private static Object _resolveRefs(
+	private static Object _getSchemaObject(
 		JSONObject openAPIJSONObject, Object value, Set<String> visitedRefs) {
 
 		if (value instanceof JSONObject) {
@@ -829,59 +792,74 @@ public class OpenAPIUtil {
 					).build();
 				}
 
-				JSONObject referencedJSONObject = _resolveRef(
+				JSONObject refJSONObject = _getRefJSONObject(
 					ref, openAPIJSONObject);
 
 				Set<String> currentVisitedRefs = new HashSet<>(visitedRefs);
 
 				currentVisitedRefs.add(ref);
 
-				if (referencedJSONObject.has("discriminator")) {
-					return _expandDiscriminator(
-						referencedJSONObject, ref, openAPIJSONObject,
+				if (refJSONObject.has("discriminator")) {
+					return _getOneOfSchemaMap(
+						refJSONObject, openAPIJSONObject, ref,
 						currentVisitedRefs);
 				}
 
-				return _resolveRefs(
-					openAPIJSONObject, referencedJSONObject,
-					currentVisitedRefs);
+				return _getSchemaObject(
+					openAPIJSONObject, refJSONObject, currentVisitedRefs);
 			}
 
 			if (jsonObject.has("allOf")) {
-				return _mergeAllOf(jsonObject, openAPIJSONObject, visitedRefs);
+				return _getAllOfSchemaMap(
+					jsonObject, openAPIJSONObject, visitedRefs);
 			}
 
-			Map<String, Object> resolvedMap = new LinkedHashMap<>();
+			Map<String, Object> schemaMap = new LinkedHashMap<>();
 
 			for (String key : jsonObject.keySet()) {
 				if (_excludedSchemaKeys.contains(key) || key.startsWith("x-")) {
 					continue;
 				}
 
-				resolvedMap.put(
+				schemaMap.put(
 					key,
-					_resolveRefs(
+					_getSchemaObject(
 						openAPIJSONObject, jsonObject.get(key), visitedRefs));
 			}
 
-			return resolvedMap;
+			return schemaMap;
 		}
 
-		if (value instanceof JSONArray) {
-			JSONArray jsonArray = (JSONArray)value;
-
-			List<Object> resolvedList = new ArrayList<>();
-
-			for (int i = 0; i < jsonArray.length(); i++) {
-				resolvedList.add(
-					_resolveRefs(
-						openAPIJSONObject, jsonArray.get(i), visitedRefs));
-			}
-
-			return resolvedList;
+		if (value instanceof JSONArray jsonArray) {
+			return TransformUtil.transform(
+				JSONUtil.toObjectList(jsonArray),
+				object -> _getSchemaObject(
+					openAPIJSONObject, object, visitedRefs));
 		}
 
 		return value;
+	}
+
+	private static boolean _isBinary(Map<String, Object> schemaMap) {
+		if (schemaMap == null) {
+			return false;
+		}
+
+		return Objects.equals(schemaMap.get("format"), "binary");
+	}
+
+	private static boolean _isMultipartRequest(JSONObject operationJSONObject) {
+		JSONObject contentJSONObject = JSONUtil.getValueAsJSONObject(
+			operationJSONObject, "JSONObject/requestBody",
+			"JSONObject/content");
+
+		if ((contentJSONObject == null) ||
+			contentJSONObject.has("application/json")) {
+
+			return false;
+		}
+
+		return contentJSONObject.has("multipart/form-data");
 	}
 
 	private static void _setBody(
@@ -917,10 +895,11 @@ public class OpenAPIUtil {
 		JSONObject inputJSONObject, JSONObject openAPIJSONObject,
 		Operation operation, Http.Options options) {
 
-		Map<String, Object> bodySchemaMap = (Map<String, Object>)_resolveRefs(
-			openAPIJSONObject,
-			_getBodySchemaJSONObject(operation._operationJSONObject),
-			new HashSet<>());
+		Map<String, Object> bodySchemaMap =
+			(Map<String, Object>)_getSchemaObject(
+				openAPIJSONObject,
+				_getBodySchemaJSONObject(operation._operationJSONObject),
+				new HashSet<>());
 
 		Map<String, Object> partProperties =
 			(Map<String, Object>)bodySchemaMap.get("properties");

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -61,24 +61,8 @@ public class OpenAPIUtil {
 			_setMultipartBody(
 				inputJSONObject, openAPIJSONObject, operation, options);
 		}
-		else if (inputJSONObject.has("body")) {
-			Object bodyValue = inputJSONObject.get("body");
-
-			String body = null;
-
-			if (bodyValue instanceof JSONObject) {
-				body = bodyValue.toString();
-			}
-			else if (bodyValue != null) {
-				body = String.valueOf(bodyValue);
-			}
-
-			if (Validator.isNotNull(body)) {
-				options.setBody(
-					body, ContentTypes.APPLICATION_JSON, StringPool.UTF8);
-				options.addHeader(
-					"Content-Type", ContentTypes.APPLICATION_JSON);
-			}
+		else if (operation._operationJSONObject.has("requestBody")) {
+			_setBody(inputJSONObject, options, toolName);
 		}
 
 		return options;
@@ -895,6 +879,34 @@ public class OpenAPIUtil {
 		}
 
 		return value;
+	}
+
+	private static void _setBody(
+		JSONObject inputJSONObject, Http.Options options, String toolName) {
+
+		if (!inputJSONObject.has("body")) {
+			throw new IllegalArgumentException(
+				StringBundler.concat(
+					"The \"", toolName,
+					"\" tool requires the request payload nested under a ",
+					"\"body\" property. Pass any path or query parameters as ",
+					"siblings of \"body\" rather than flattening the payload ",
+					"into the input map."));
+		}
+
+		Object bodyValue = inputJSONObject.get("body");
+
+		String body = StringPool.BLANK;
+
+		if (bodyValue instanceof JSONObject) {
+			body = bodyValue.toString();
+		}
+		else if (bodyValue != null) {
+			body = String.valueOf(bodyValue);
+		}
+
+		options.addHeader("Content-Type", ContentTypes.APPLICATION_JSON);
+		options.setBody(body, ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 	}
 
 	private static void _setMultipartBody(

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -128,12 +128,12 @@ public class OpenAPIUtil {
 		JSONObject operationJSONObject, Map<String, Object> properties,
 		List<Object> required, JSONObject openAPIJSONObject) {
 
-		Map<String, Object> resolvedSchema = (Map<String, Object>)_resolveRefs(
+		Map<String, Object> bodySchemaMap = (Map<String, Object>)_resolveRefs(
 			openAPIJSONObject, _getBodySchemaJSONObject(operationJSONObject),
 			new HashSet<>());
 
 		Map<String, Object> partProperties =
-			(Map<String, Object>)resolvedSchema.get("properties");
+			(Map<String, Object>)bodySchemaMap.get("properties");
 
 		if (partProperties == null) {
 			return;
@@ -152,11 +152,11 @@ public class OpenAPIUtil {
 			}
 		}
 
-		List<Object> schemaRequired = (List<Object>)resolvedSchema.get(
+		List<Object> bodySchemaRequired = (List<Object>)bodySchemaMap.get(
 			"required");
 
-		if (schemaRequired != null) {
-			required.addAll(schemaRequired);
+		if (bodySchemaRequired != null) {
+			required.addAll(bodySchemaRequired);
 		}
 	}
 
@@ -174,11 +174,11 @@ public class OpenAPIUtil {
 
 		Map<String, Object> property = new LinkedHashMap<>();
 
-		JSONObject schemaJSONObject = parameterJSONObject.getJSONObject(
-			"schema");
+		JSONObject parameterSchemaJSONObject =
+			parameterJSONObject.getJSONObject("schema");
 
-		for (String key : schemaJSONObject.keySet()) {
-			property.put(key, schemaJSONObject.get(key));
+		for (String key : parameterSchemaJSONObject.keySet()) {
+			property.put(key, parameterSchemaJSONObject.get(key));
 		}
 
 		if (parameterJSONObject.has("description")) {
@@ -438,15 +438,15 @@ public class OpenAPIUtil {
 			throw new IllegalArgumentException("Request body has no content");
 		}
 
-		JSONObject schemaJSONObject = mediaTypeJSONObject.getJSONObject(
+		JSONObject bodySchemaJSONObject = mediaTypeJSONObject.getJSONObject(
 			"schema");
 
-		if (schemaJSONObject == null) {
+		if (bodySchemaJSONObject == null) {
 			throw new IllegalArgumentException(
 				"Request body content has no \"schema\"");
 		}
 
-		return schemaJSONObject;
+		return bodySchemaJSONObject;
 	}
 
 	private static String _getDescription(
@@ -531,17 +531,21 @@ public class OpenAPIUtil {
 				JSONObject requestBodyJSONObject =
 					operationJSONObject.getJSONObject("requestBody");
 
-				Object bodySchema = null;
+				Map<String, Object> bodySchemaMap = null;
 
 				if (requestBodyJSONObject.getJSONObject("content") != null) {
-					bodySchema = _resolveRefs(
+					Object resolvedObject = _resolveRefs(
 						openAPIJSONObject,
 						_getBodySchemaJSONObject(operationJSONObject),
 						new HashSet<>());
+
+					if (resolvedObject instanceof Map) {
+						bodySchemaMap = (Map<String, Object>)resolvedObject;
+					}
 				}
 
-				if (!(bodySchema instanceof Map)) {
-					bodySchema = LinkedHashMapBuilder.<String, Object>put(
+				if (bodySchemaMap == null) {
+					bodySchemaMap = LinkedHashMapBuilder.<String, Object>put(
 						"type", "object"
 					).build();
 				}
@@ -550,27 +554,26 @@ public class OpenAPIUtil {
 					"description");
 
 				if (Validator.isNotNull(requestBodyDescription)) {
-					Map<String, Object> bodySchemaMap =
-						(Map<String, Object>)bodySchema;
+					Object bodySchemaDescription = bodySchemaMap.get(
+						"description");
 
-					Object schemaDescription = bodySchemaMap.get("description");
-
-					if (Validator.isNull(schemaDescription)) {
+					if (Validator.isNull(bodySchemaDescription)) {
 						bodySchemaMap.put(
 							"description", requestBodyDescription);
 					}
 					else if (!Objects.equals(
-								schemaDescription, requestBodyDescription)) {
+								bodySchemaDescription,
+								requestBodyDescription)) {
 
 						bodySchemaMap.put(
 							"description",
 							StringBundler.concat(
 								requestBodyDescription, StringPool.SPACE,
-								schemaDescription));
+								bodySchemaDescription));
 					}
 				}
 
-				properties.put("body", bodySchema);
+				properties.put("body", bodySchemaMap);
 
 				required.add("body");
 			}
@@ -914,13 +917,13 @@ public class OpenAPIUtil {
 		JSONObject inputJSONObject, JSONObject openAPIJSONObject,
 		Operation operation, Http.Options options) {
 
-		Map<String, Object> bodySchema = (Map<String, Object>)_resolveRefs(
+		Map<String, Object> bodySchemaMap = (Map<String, Object>)_resolveRefs(
 			openAPIJSONObject,
 			_getBodySchemaJSONObject(operation._operationJSONObject),
 			new HashSet<>());
 
 		Map<String, Object> partProperties =
-			(Map<String, Object>)bodySchema.get("properties");
+			(Map<String, Object>)bodySchemaMap.get("properties");
 
 		if (partProperties == null) {
 			return;

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -544,12 +544,49 @@ public class OpenAPIUtil {
 					openAPIJSONObject);
 			}
 			else {
-				properties.put(
-					"body",
-					_resolveRefs(
+				JSONObject requestBodyJSONObject =
+					operationJSONObject.getJSONObject("requestBody");
+
+				Object bodySchema = null;
+
+				if (requestBodyJSONObject.getJSONObject("content") != null) {
+					bodySchema = _resolveRefs(
 						openAPIJSONObject,
 						_getBodySchemaJSONObject(operationJSONObject),
-						new HashSet<>()));
+						new HashSet<>());
+				}
+
+				if (!(bodySchema instanceof Map)) {
+					bodySchema = LinkedHashMapBuilder.<String, Object>put(
+						"type", "object"
+					).build();
+				}
+
+				String requestBodyDescription = requestBodyJSONObject.getString(
+					"description");
+
+				if (Validator.isNotNull(requestBodyDescription)) {
+					Map<String, Object> bodySchemaMap =
+						(Map<String, Object>)bodySchema;
+
+					Object schemaDescription = bodySchemaMap.get("description");
+
+					if (Validator.isNull(schemaDescription)) {
+						bodySchemaMap.put(
+							"description", requestBodyDescription);
+					}
+					else if (!Objects.equals(
+								schemaDescription, requestBodyDescription)) {
+
+						bodySchemaMap.put(
+							"description",
+							StringBundler.concat(
+								requestBodyDescription, StringPool.SPACE,
+								schemaDescription));
+					}
+				}
+
+				properties.put("body", bodySchema);
 
 				required.add("body");
 			}

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.mcp.server.rest.dto.v1_0.Tool;
 import com.liferay.mcp.server.rest.dto.v1_0.ToolSummary;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -93,6 +94,11 @@ public class OpenAPIUtilTest {
 				"itemId", "123"
 			),
 			"patchItem");
+		_testGetOptions(
+			"{}", "application/json", Http.Method.POST,
+			"http://localhost/test/v1.0/items",
+			JSONUtil.put("body", JSONFactoryUtil.createJSONObject()),
+			"postItem");
 
 		String fileContent = RandomTestUtil.randomString();
 		String fileName = RandomTestUtil.randomString();
@@ -165,6 +171,20 @@ public class OpenAPIUtilTest {
 		Assert.assertEquals("true", parts.get("boolean"));
 		Assert.assertEquals("1", parts.get("integer"));
 		Assert.assertEquals(fileContent, parts.get("string"));
+
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			StringBundler.concat(
+				"The \"postItem\" tool requires the request payload nested ",
+				"under a \"body\" property. Pass any path or query parameters ",
+				"as siblings of \"body\" rather than flattening the payload ",
+				"into the input map."),
+			() -> OpenAPIUtil.getOptions(
+				"http://localhost/test",
+				JSONUtil.put(
+					RandomTestUtil.randomString(),
+					RandomTestUtil.randomString()),
+				_openAPIJSONObject, "postItem"));
 	}
 
 	@Test
@@ -213,31 +233,21 @@ public class OpenAPIUtilTest {
 
 	@Test
 	public void testGetToolMergesRequestBodyAndSchemaDescriptions() {
-		JSONObject openAPIJSONObject = JSONUtil.put(
-			"paths",
+		JSONObject openAPIJSONObject = _createOpenAPIJSONObject(
 			JSONUtil.put(
-				"/things",
+				"content",
 				JSONUtil.put(
-					"post",
+					"application/json",
 					JSONUtil.put(
-						"operationId", "postThing"
-					).put(
-						"requestBody",
+						"schema",
 						JSONUtil.put(
-							"content",
-							JSONUtil.put(
-								"application/json",
-								JSONUtil.put(
-									"schema",
-									JSONUtil.put(
-										"description", "A Thing resource."
-									).put(
-										"type", "object"
-									)))
+							"description", _SCHEMA_DESCRIPTION
 						).put(
-							"description", "The thing to create."
-						)
-					))));
+							"type", "object"
+						)))
+			).put(
+				"description", _REQUEST_BODY_DESCRIPTION
+			));
 
 		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
 
@@ -248,32 +258,21 @@ public class OpenAPIUtilTest {
 		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
 
 		Assert.assertEquals(
-			"The thing to create. A Thing resource.",
+			_REQUEST_BODY_DESCRIPTION + " " + _SCHEMA_DESCRIPTION,
 			bodySchema.get("description"));
 	}
 
 	@Test
 	public void testGetToolRequestBodyDescriptionIsSurfaced() {
-		JSONObject openAPIJSONObject = JSONUtil.put(
-			"paths",
+		JSONObject openAPIJSONObject = _createOpenAPIJSONObject(
 			JSONUtil.put(
-				"/things",
+				"content",
 				JSONUtil.put(
-					"post",
-					JSONUtil.put(
-						"operationId", "postThing"
-					).put(
-						"requestBody",
-						JSONUtil.put(
-							"content",
-							JSONUtil.put(
-								"application/json",
-								JSONUtil.put(
-									"schema", JSONUtil.put("type", "object")))
-						).put(
-							"description", "The thing to create."
-						)
-					))));
+					"application/json",
+					JSONUtil.put("schema", JSONUtil.put("type", "object")))
+			).put(
+				"description", _REQUEST_BODY_DESCRIPTION
+			));
 
 		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
 
@@ -284,23 +283,13 @@ public class OpenAPIUtilTest {
 		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
 
 		Assert.assertEquals(
-			"The thing to create.", bodySchema.get("description"));
+			_REQUEST_BODY_DESCRIPTION, bodySchema.get("description"));
 	}
 
 	@Test
 	public void testGetToolRequestBodyWithoutContentDoesNotFail() {
-		JSONObject openAPIJSONObject = JSONUtil.put(
-			"paths",
-			JSONUtil.put(
-				"/things",
-				JSONUtil.put(
-					"post",
-					JSONUtil.put(
-						"operationId", "postThing"
-					).put(
-						"requestBody",
-						JSONUtil.put("description", "The thing to create.")
-					))));
+		JSONObject openAPIJSONObject = _createOpenAPIJSONObject(
+			JSONUtil.put("description", _REQUEST_BODY_DESCRIPTION));
 
 		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
 
@@ -310,9 +299,9 @@ public class OpenAPIUtilTest {
 
 		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
 
-		Assert.assertEquals("object", bodySchema.get("type"));
 		Assert.assertEquals(
-			"The thing to create.", bodySchema.get("description"));
+			_REQUEST_BODY_DESCRIPTION, bodySchema.get("description"));
+		Assert.assertEquals("object", bodySchema.get("type"));
 	}
 
 	@Test
@@ -322,31 +311,31 @@ public class OpenAPIUtilTest {
 
 		Assert.assertEquals(toolSummaries.toString(), 12, toolSummaries.size());
 		_assertToolSummary(
-			toolSummaries.get(0), "This is the description", "getItem");
+			"This is the description", "getItem", toolSummaries.get(0));
 		_assertToolSummary(
-			toolSummaries.get(1), "PATCH /v1.0/items/{itemId}", "patchItem");
+			"PATCH /v1.0/items/{itemId}", "patchItem", toolSummaries.get(1));
 		_assertToolSummary(
-			toolSummaries.get(2), "PUT /v1.0/items/{itemId}", "putItem");
+			"PUT /v1.0/items/{itemId}", "putItem", toolSummaries.get(2));
 		_assertToolSummary(
-			toolSummaries.get(3), "POST /v1.0/binaries", "postBinary");
+			"POST /v1.0/binaries", "postBinary", toolSummaries.get(3));
 		_assertToolSummary(
-			toolSummaries.get(4), "POST /v1.0/empty-content",
-			"postEmptyContent");
+			"POST /v1.0/empty-content", "postEmptyContent",
+			toolSummaries.get(4));
 		_assertToolSummary(
-			toolSummaries.get(5), "POST /v1.0/no-content", "postNoContent");
+			"POST /v1.0/no-content", "postNoContent", toolSummaries.get(5));
 		_assertToolSummary(
-			toolSummaries.get(6), "POST /v1.0/parents", "postParent");
+			"POST /v1.0/parents", "postParent", toolSummaries.get(6));
 		_assertToolSummary(
-			toolSummaries.get(7), "POST /v1.0/uploads", "postUpload");
+			"POST /v1.0/uploads", "postUpload", toolSummaries.get(7));
 		_assertToolSummary(
-			toolSummaries.get(8),
-			"This is the summary. This is the description", "getItems");
+			"This is the summary. This is the description", "getItems",
+			toolSummaries.get(8));
 		_assertToolSummary(
-			toolSummaries.get(9), "POST /v1.0/items", "postItem");
+			"POST /v1.0/items", "postItem", toolSummaries.get(9));
 		_assertToolSummary(
-			toolSummaries.get(10), "POST /v1.0/no-schema", "postNoSchema");
+			"POST /v1.0/no-schema", "postNoSchema", toolSummaries.get(10));
 		_assertToolSummary(
-			toolSummaries.get(11), "This is the summary", "getItemsPage");
+			"This is the summary", "getItemsPage", toolSummaries.get(11));
 
 		AssertUtils.assertFailure(
 			IllegalArgumentException.class,
@@ -365,11 +354,27 @@ public class OpenAPIUtilTest {
 	}
 
 	private void _assertToolSummary(
-		ToolSummary toolSummary, String expectedDescription,
-		String expectedName) {
+		String expectedDescription, String expectedName,
+		ToolSummary toolSummary) {
 
 		Assert.assertEquals(expectedDescription, toolSummary.getDescription());
 		Assert.assertEquals(expectedName, toolSummary.getName());
+	}
+
+	private JSONObject _createOpenAPIJSONObject(
+		JSONObject requestBodyJSONObject) {
+
+		return JSONUtil.put(
+			"paths",
+			JSONUtil.put(
+				"/things",
+				JSONUtil.put(
+					"post",
+					JSONUtil.put(
+						"operationId", "postThing"
+					).put(
+						"requestBody", requestBodyJSONObject
+					))));
 	}
 
 	private Map<String, ?> _getInputSchema(
@@ -402,6 +407,8 @@ public class OpenAPIUtilTest {
 		else {
 			Assert.assertEquals(expectedBody, body.getContent());
 			Assert.assertEquals(expectedContentType, body.getContentType());
+			Assert.assertEquals(
+				expectedContentType, options.getHeader("Content-Type"));
 		}
 
 		Assert.assertNull(options.getFileParts());
@@ -428,6 +435,11 @@ public class OpenAPIUtilTest {
 			),
 			true);
 	}
+
+	private static final String _REQUEST_BODY_DESCRIPTION =
+		"The thing to create.";
+
+	private static final String _SCHEMA_DESCRIPTION = "A Thing resource.";
 
 	private JSONObject _openAPIJSONObject;
 

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
@@ -221,9 +221,18 @@ public class OpenAPIUtilTest {
 			"POST /v1.0/binaries", "post_test_v1.0_binaries.json",
 			"postBinary");
 		_testGetTool(
+			"POST /v1.0/described", "post_test_v1.0_described.json",
+			"postDescribed");
+		_testGetTool(
 			"POST /v1.0/items", "post_test_v1.0_items.json", "postItem");
 		_testGetTool(
+			"POST /v1.0/no-content", "post_test_v1.0_no-content.json",
+			"postNoContent");
+		_testGetTool(
 			"POST /v1.0/parents", "post_test_v1.0_parents.json", "postParent");
+		_testGetTool(
+			"POST /v1.0/undescribed", "post_test_v1.0_undescribed.json",
+			"postUndescribed");
 		_testGetTool(
 			"POST /v1.0/uploads", "post_test_v1.0_uploads.json", "postUpload");
 		_testGetTool(
@@ -232,110 +241,41 @@ public class OpenAPIUtilTest {
 	}
 
 	@Test
-	public void testGetToolMergesRequestBodyAndSchemaDescriptions() {
-		JSONObject openAPIJSONObject = _createOpenAPIJSONObject(
-			JSONUtil.put(
-				"content",
-				JSONUtil.put(
-					"application/json",
-					JSONUtil.put(
-						"schema",
-						JSONUtil.put(
-							"description", _SCHEMA_DESCRIPTION
-						).put(
-							"type", "object"
-						)))
-			).put(
-				"description", _REQUEST_BODY_DESCRIPTION
-			));
-
-		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
-
-		Map<String, ?> inputSchema = tool.getInputSchema();
-
-		Map<?, ?> properties = (Map<?, ?>)inputSchema.get("properties");
-
-		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
-
-		Assert.assertEquals(
-			_REQUEST_BODY_DESCRIPTION + " " + _SCHEMA_DESCRIPTION,
-			bodySchema.get("description"));
-	}
-
-	@Test
-	public void testGetToolRequestBodyDescriptionIsSurfaced() {
-		JSONObject openAPIJSONObject = _createOpenAPIJSONObject(
-			JSONUtil.put(
-				"content",
-				JSONUtil.put(
-					"application/json",
-					JSONUtil.put("schema", JSONUtil.put("type", "object")))
-			).put(
-				"description", _REQUEST_BODY_DESCRIPTION
-			));
-
-		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
-
-		Map<String, ?> inputSchema = tool.getInputSchema();
-
-		Map<?, ?> properties = (Map<?, ?>)inputSchema.get("properties");
-
-		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
-
-		Assert.assertEquals(
-			_REQUEST_BODY_DESCRIPTION, bodySchema.get("description"));
-	}
-
-	@Test
-	public void testGetToolRequestBodyWithoutContentDoesNotFail() {
-		JSONObject openAPIJSONObject = _createOpenAPIJSONObject(
-			JSONUtil.put("description", _REQUEST_BODY_DESCRIPTION));
-
-		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
-
-		Map<String, ?> inputSchema = tool.getInputSchema();
-
-		Map<?, ?> properties = (Map<?, ?>)inputSchema.get("properties");
-
-		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
-
-		Assert.assertEquals(
-			_REQUEST_BODY_DESCRIPTION, bodySchema.get("description"));
-		Assert.assertEquals("object", bodySchema.get("type"));
-	}
-
-	@Test
 	public void testGetToolSummaries() {
 		List<ToolSummary> toolSummaries = OpenAPIUtil.getToolSummaries(
 			_openAPIJSONObject);
 
-		Assert.assertEquals(toolSummaries.toString(), 12, toolSummaries.size());
+		Assert.assertEquals(toolSummaries.toString(), 14, toolSummaries.size());
 		_assertToolSummary(
-			"This is the description", "getItem", toolSummaries.get(0));
+			"POST /v1.0/described", "postDescribed", toolSummaries.get(0));
 		_assertToolSummary(
-			"PATCH /v1.0/items/{itemId}", "patchItem", toolSummaries.get(1));
+			"POST /v1.0/undescribed", "postUndescribed", toolSummaries.get(1));
 		_assertToolSummary(
-			"PUT /v1.0/items/{itemId}", "putItem", toolSummaries.get(2));
+			"This is the description", "getItem", toolSummaries.get(2));
 		_assertToolSummary(
-			"POST /v1.0/binaries", "postBinary", toolSummaries.get(3));
+			"PATCH /v1.0/items/{itemId}", "patchItem", toolSummaries.get(3));
+		_assertToolSummary(
+			"PUT /v1.0/items/{itemId}", "putItem", toolSummaries.get(4));
+		_assertToolSummary(
+			"POST /v1.0/binaries", "postBinary", toolSummaries.get(5));
 		_assertToolSummary(
 			"POST /v1.0/empty-content", "postEmptyContent",
-			toolSummaries.get(4));
+			toolSummaries.get(6));
 		_assertToolSummary(
-			"POST /v1.0/no-content", "postNoContent", toolSummaries.get(5));
+			"POST /v1.0/no-content", "postNoContent", toolSummaries.get(7));
 		_assertToolSummary(
-			"POST /v1.0/parents", "postParent", toolSummaries.get(6));
+			"POST /v1.0/parents", "postParent", toolSummaries.get(8));
 		_assertToolSummary(
-			"POST /v1.0/uploads", "postUpload", toolSummaries.get(7));
+			"POST /v1.0/uploads", "postUpload", toolSummaries.get(9));
 		_assertToolSummary(
 			"This is the summary. This is the description", "getItems",
-			toolSummaries.get(8));
+			toolSummaries.get(10));
 		_assertToolSummary(
-			"POST /v1.0/items", "postItem", toolSummaries.get(9));
+			"POST /v1.0/items", "postItem", toolSummaries.get(11));
 		_assertToolSummary(
-			"POST /v1.0/no-schema", "postNoSchema", toolSummaries.get(10));
+			"POST /v1.0/no-schema", "postNoSchema", toolSummaries.get(12));
 		_assertToolSummary(
-			"This is the summary", "getItemsPage", toolSummaries.get(11));
+			"This is the summary", "getItemsPage", toolSummaries.get(13));
 
 		AssertUtils.assertFailure(
 			IllegalArgumentException.class,
@@ -359,22 +299,6 @@ public class OpenAPIUtilTest {
 
 		Assert.assertEquals(expectedDescription, toolSummary.getDescription());
 		Assert.assertEquals(expectedName, toolSummary.getName());
-	}
-
-	private JSONObject _createOpenAPIJSONObject(
-		JSONObject requestBodyJSONObject) {
-
-		return JSONUtil.put(
-			"paths",
-			JSONUtil.put(
-				"/things",
-				JSONUtil.put(
-					"post",
-					JSONUtil.put(
-						"operationId", "postThing"
-					).put(
-						"requestBody", requestBodyJSONObject
-					))));
 	}
 
 	private Map<String, ?> _getInputSchema(
@@ -435,11 +359,6 @@ public class OpenAPIUtilTest {
 			),
 			true);
 	}
-
-	private static final String _REQUEST_BODY_DESCRIPTION =
-		"The thing to create.";
-
-	private static final String _SCHEMA_DESCRIPTION = "A Thing resource.";
 
 	private JSONObject _openAPIJSONObject;
 

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
@@ -180,9 +180,6 @@ public class OpenAPIUtilTest {
 				JSONFactoryUtil.createJSONObject(),
 				RandomTestUtil.randomString()));
 		AssertUtils.assertFailure(
-			IllegalArgumentException.class, "Request body has no \"content\"",
-			() -> _getInputSchema(_openAPIJSONObject, "postNoContent"));
-		AssertUtils.assertFailure(
 			IllegalArgumentException.class, "Request body has no content",
 			() -> _getInputSchema(_openAPIJSONObject, "postEmptyContent"));
 		AssertUtils.assertFailure(
@@ -212,6 +209,110 @@ public class OpenAPIUtilTest {
 		_testGetTool(
 			"PUT /v1.0/items/{itemId}", "put_test_v1.0_items_itemId.json",
 			"putItem");
+	}
+
+	@Test
+	public void testGetToolMergesRequestBodyAndSchemaDescriptions() {
+		JSONObject openAPIJSONObject = JSONUtil.put(
+			"paths",
+			JSONUtil.put(
+				"/things",
+				JSONUtil.put(
+					"post",
+					JSONUtil.put(
+						"operationId", "postThing"
+					).put(
+						"requestBody",
+						JSONUtil.put(
+							"content",
+							JSONUtil.put(
+								"application/json",
+								JSONUtil.put(
+									"schema",
+									JSONUtil.put(
+										"description", "A Thing resource."
+									).put(
+										"type", "object"
+									)))
+						).put(
+							"description", "The thing to create."
+						)
+					))));
+
+		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
+
+		Map<String, ?> inputSchema = tool.getInputSchema();
+
+		Map<?, ?> properties = (Map<?, ?>)inputSchema.get("properties");
+
+		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
+
+		Assert.assertEquals(
+			"The thing to create. A Thing resource.",
+			bodySchema.get("description"));
+	}
+
+	@Test
+	public void testGetToolRequestBodyDescriptionIsSurfaced() {
+		JSONObject openAPIJSONObject = JSONUtil.put(
+			"paths",
+			JSONUtil.put(
+				"/things",
+				JSONUtil.put(
+					"post",
+					JSONUtil.put(
+						"operationId", "postThing"
+					).put(
+						"requestBody",
+						JSONUtil.put(
+							"content",
+							JSONUtil.put(
+								"application/json",
+								JSONUtil.put(
+									"schema", JSONUtil.put("type", "object")))
+						).put(
+							"description", "The thing to create."
+						)
+					))));
+
+		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
+
+		Map<String, ?> inputSchema = tool.getInputSchema();
+
+		Map<?, ?> properties = (Map<?, ?>)inputSchema.get("properties");
+
+		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
+
+		Assert.assertEquals(
+			"The thing to create.", bodySchema.get("description"));
+	}
+
+	@Test
+	public void testGetToolRequestBodyWithoutContentDoesNotFail() {
+		JSONObject openAPIJSONObject = JSONUtil.put(
+			"paths",
+			JSONUtil.put(
+				"/things",
+				JSONUtil.put(
+					"post",
+					JSONUtil.put(
+						"operationId", "postThing"
+					).put(
+						"requestBody",
+						JSONUtil.put("description", "The thing to create.")
+					))));
+
+		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
+
+		Map<String, ?> inputSchema = tool.getInputSchema();
+
+		Map<?, ?> properties = (Map<?, ?>)inputSchema.get("properties");
+
+		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
+
+		Assert.assertEquals("object", bodySchema.get("type"));
+		Assert.assertEquals(
+			"The thing to create.", bodySchema.get("description"));
 	}
 
 	@Test

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/openapi.json
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/openapi.json
@@ -130,6 +130,22 @@
 				}
 			}
 		},
+		"/v1.0/described": {
+			"post": {
+				"operationId": "postDescribed",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"description": "This is the schema description",
+								"type": "object"
+							}
+						}
+					},
+					"description": "This is the request body description"
+				}
+			}
+		},
 		"/v1.0/empty-content": {
 			"post": {
 				"operationId": "postEmptyContent",
@@ -282,6 +298,7 @@
 			"post": {
 				"operationId": "postNoContent",
 				"requestBody": {
+					"description": "This is the request body description"
 				}
 			}
 		},
@@ -307,6 +324,21 @@
 							}
 						}
 					}
+				}
+			}
+		},
+		"/v1.0/undescribed": {
+			"post": {
+				"operationId": "postUndescribed",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object"
+							}
+						}
+					},
+					"description": "This is the request body description"
 				}
 			}
 		},

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/post_test_v1.0_described.json
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/post_test_v1.0_described.json
@@ -1,0 +1,12 @@
+{
+	"properties": {
+		"body": {
+			"description": "This is the request body description This is the schema description",
+			"type": "object"
+		}
+	},
+	"required": [
+		"body"
+	],
+	"type": "object"
+}

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/post_test_v1.0_no-content.json
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/post_test_v1.0_no-content.json
@@ -1,0 +1,12 @@
+{
+	"properties": {
+		"body": {
+			"description": "This is the request body description",
+			"type": "object"
+		}
+	},
+	"required": [
+		"body"
+	],
+	"type": "object"
+}

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/post_test_v1.0_undescribed.json
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/post_test_v1.0_undescribed.json
@@ -1,0 +1,12 @@
+{
+	"properties": {
+		"body": {
+			"description": "This is the request body description",
+			"type": "object"
+		}
+	},
+	"required": [
+		"body"
+	],
+	"type": "object"
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93305

## What Is Being Fixed

When AI agents invoke a Liferay MCP tool through the `postToolSetToolSetNameToolInvoke` operation, they were getting the request-body structure wrong — either flattening the tool's payload directly into the input map instead of nesting it under `body`, or omitting the body entirely. The server forwarded the malformed or empty request to the underlying REST endpoint, producing confusing downstream failures that were hard to trace back to the input shape.

## How It Is Being Fixed

The invoke operation now documents the expected input shape: a new request-body description (in both `rest-openapi.yaml` and the generated `@RequestBody` annotation) explains that the payload must stay nested under a `body` property, with path and query parameters passed as siblings, e.g. `{"body": {...}, "itemId": "123"}`. This surfaces to MCP agents so they build correct input.

`OpenAPIUtil` was restructured so body handling triggers whenever the operation declares a `requestBody`, rather than only when the input happens to contain a `body` key. When the body is missing it now throws an `IllegalArgumentException` with an actionable message telling the agent to nest the payload under `body`, instead of silently sending an empty request. A new `_setBody` helper centralizes this and always sets the `Content-Type` header. The util's schema-handling internals were also renamed so each schema concept carries a single consistent name.

Test coverage was added in `OpenAPIUtilTest` with new dependency fixtures following the existing test patterns.

## PR Check

**pr-check: PASS** — tested on `99daeac9afdcdf28e7b5a766f7f2568729436d32`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Cross-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "99daeac9afdcdf28e7b5a766f7f2568729436d32"} -->