### PR TITLE
LPD-93513 LPD-94257 Exclude marketplace fragments from batch export

### DIFF
--- a/modules/apps/fragment/fragment-api/bnd.bnd
+++ b/modules/apps/fragment/fragment-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Fragment API
 Bundle-SymbolicName: com.liferay.fragment.api
-Bundle-Version: 62.0.1
+Bundle-Version: 62.1.0
 Export-Package:\
 	com.liferay.fragment.cache,\
 	com.liferay.fragment.configuration,\

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/constants/FragmentCollectionField.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/constants/FragmentCollectionField.java
@@ -1,0 +1,15 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.constants;
+
+/**
+ * @author Rubén Pulido
+ */
+public class FragmentCollectionField {
+
+	public static final String MARKETPLACE = "marketplace";
+
+}

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/constants/FragmentEntryField.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/constants/FragmentEntryField.java
@@ -12,6 +12,8 @@ public class FragmentEntryField {
 
 	public static final String FRAGMENT_COLLECTION_ID = "fragmentCollectionId";
 
+	public static final String HEAD = "head";
+
 	public static final String HEAD_LISTABLE = "headListable";
 
 	public static final String MARKETPLACE = "marketplace";

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/constants/FragmentEntryField.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/constants/FragmentEntryField.java
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.constants;
+
+/**
+ * @author Rubén Pulido
+ */
+public class FragmentEntryField {
+
+	public static final String DRAFT_ONLY_OR_PUBLISHED = "draftOnlyOrPublished";
+
+	public static final String FRAGMENT_COLLECTION_ID = "fragmentCollectionId";
+
+	public static final String MARKETPLACE = "marketplace";
+
+}

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/constants/FragmentEntryField.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/constants/FragmentEntryField.java
@@ -10,9 +10,9 @@ package com.liferay.fragment.constants;
  */
 public class FragmentEntryField {
 
-	public static final String DRAFT_ONLY_OR_PUBLISHED = "draftOnlyOrPublished";
-
 	public static final String FRAGMENT_COLLECTION_ID = "fragmentCollectionId";
+
+	public static final String HEAD_LISTABLE = "headListable";
 
 	public static final String MARKETPLACE = "marketplace";
 

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalService.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalService.java
@@ -435,6 +435,7 @@ public interface FragmentEntryLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<FragmentEntryVersion> getVersions(FragmentEntry fragmentEntry);
 
+	@Indexable(type = IndexableType.REINDEX)
 	public FragmentEntry moveFragmentEntry(
 			long fragmentEntryId, long fragmentCollectionId)
 		throws PortalException;
@@ -512,4 +513,4 @@ public interface FragmentEntryLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2100304562
+// LIFERAY-SERVICE-BUILDER-HASH:-895421038

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalService.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalService.java
@@ -81,6 +81,7 @@ public interface FragmentEntryLocalService
 	@Indexable(type = IndexableType.REINDEX)
 	public FragmentEntry addFragmentEntry(FragmentEntry fragmentEntry);
 
+	@Indexable(type = IndexableType.REINDEX)
 	public FragmentEntry addFragmentEntry(
 			String externalReferenceCode, long userId, long groupId,
 			long fragmentCollectionId, String fragmentEntryKey, String name,
@@ -96,6 +97,7 @@ public interface FragmentEntryLocalService
 			FragmentEntry publishedFragmentEntry, int version)
 		throws PortalException;
 
+	@Indexable(type = IndexableType.REINDEX)
 	public FragmentEntry copyFragmentEntry(
 			long userId, long groupId, long sourceFragmentEntryId,
 			long fragmentCollectionId, ServiceContext serviceContext)
@@ -159,6 +161,7 @@ public interface FragmentEntryLocalService
 	public FragmentEntry deleteFragmentEntry(long fragmentEntryId)
 		throws PortalException;
 
+	@Indexable(type = IndexableType.DELETE)
 	public FragmentEntry deleteFragmentEntry(
 			String externalReferenceCode, long groupId)
 		throws PortalException;
@@ -471,14 +474,17 @@ public interface FragmentEntryLocalService
 	public FragmentEntry updateFragmentEntry(FragmentEntry draftFragmentEntry)
 		throws PortalException;
 
+	@Indexable(type = IndexableType.REINDEX)
 	public FragmentEntry updateFragmentEntry(
 			long fragmentEntryId, boolean cacheable)
 		throws PortalException;
 
+	@Indexable(type = IndexableType.REINDEX)
 	public FragmentEntry updateFragmentEntry(
 			long fragmentEntryId, long previewFileEntryId)
 		throws PortalException;
 
+	@Indexable(type = IndexableType.REINDEX)
 	public FragmentEntry updateFragmentEntry(
 			long userId, long fragmentEntryId, long fragmentCollectionId,
 			String name, String css, String html, String js, boolean cacheable,
@@ -486,6 +492,7 @@ public interface FragmentEntryLocalService
 			boolean readOnly, String typeOptions, int status)
 		throws PortalException;
 
+	@Indexable(type = IndexableType.REINDEX)
 	public FragmentEntry updateFragmentEntry(long fragmentEntryId, String name)
 		throws PortalException;
 
@@ -505,4 +512,4 @@ public interface FragmentEntryLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1870565390
+// LIFERAY-SERVICE-BUILDER-HASH:2100304562

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/constants/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/constants/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.1.0

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/service/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/service/packageinfo
@@ -1,1 +1,1 @@
-version 17.0.0
+version 17.0.1

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/search/FragmentEntryModelSearchConfigurator.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/search/FragmentEntryModelSearchConfigurator.java
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.internal.search;
+
+import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.service.FragmentEntryLocalService;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.search.spi.model.index.contributor.ModelIndexerWriterContributor;
+import com.liferay.portal.search.spi.model.registrar.ModelSearchConfigurator;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Rubén Pulido
+ */
+@Component(service = ModelSearchConfigurator.class)
+public class FragmentEntryModelSearchConfigurator
+	implements ModelSearchConfigurator<FragmentEntry> {
+
+	@Override
+	public String getClassName() {
+		return FragmentEntry.class.getName();
+	}
+
+	@Override
+	public String[] getDefaultSelectedFieldNames() {
+		return new String[] {
+			Field.COMPANY_ID, Field.ENTRY_CLASS_NAME, Field.ENTRY_CLASS_PK,
+			Field.UID
+		};
+	}
+
+	@Override
+	public ModelIndexerWriterContributor<FragmentEntry>
+		getModelIndexerWriterContributor() {
+
+		return _modelIndexWriterContributor;
+	}
+
+	@Activate
+	protected void activate() {
+		_modelIndexWriterContributor = new ModelIndexerWriterContributor<>(
+			_fragmentEntryLocalService::getIndexableActionableDynamicQuery);
+	}
+
+	@Reference
+	private FragmentEntryLocalService _fragmentEntryLocalService;
+
+	private ModelIndexerWriterContributor<FragmentEntry>
+		_modelIndexWriterContributor;
+
+}

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/search/spi/model/index/contributor/FragmentCollectionModelDocumentContributor.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/search/spi/model/index/contributor/FragmentCollectionModelDocumentContributor.java
@@ -5,6 +5,7 @@
 
 package com.liferay.fragment.internal.search.spi.model.index.contributor;
 
+import com.liferay.fragment.constants.FragmentCollectionField;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
@@ -29,7 +30,9 @@ public class FragmentCollectionModelDocumentContributor
 		document.addText(
 			Field.DESCRIPTION, fragmentCollection.getDescription());
 		document.addText(Field.NAME, fragmentCollection.getName());
-		document.addKeyword("marketplace", fragmentCollection.isMarketplace());
+		document.addKeyword(
+			FragmentCollectionField.MARKETPLACE,
+			fragmentCollection.isMarketplace());
 	}
 
 }

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/search/spi/model/index/contributor/FragmentEntryModelDocumentContributor.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/search/spi/model/index/contributor/FragmentEntryModelDocumentContributor.java
@@ -1,0 +1,40 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.internal.search.spi.model.index.contributor;
+
+import com.liferay.fragment.constants.FragmentEntryField;
+import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Rubén Pulido
+ */
+@Component(
+	property = "indexer.class.name=com.liferay.fragment.model.FragmentEntry",
+	service = ModelDocumentContributor.class
+)
+public class FragmentEntryModelDocumentContributor
+	implements ModelDocumentContributor<FragmentEntry> {
+
+	@Override
+	public void contribute(Document document, FragmentEntry fragmentEntry) {
+		document.addText(Field.NAME, fragmentEntry.getName());
+		document.addKeyword(
+			FragmentEntryField.DRAFT_ONLY_OR_PUBLISHED,
+			fragmentEntry.isHead() ||
+			(fragmentEntry.getHeadId() == fragmentEntry.getFragmentEntryId()));
+		document.addKeyword(
+			FragmentEntryField.FRAGMENT_COLLECTION_ID,
+			fragmentEntry.getFragmentCollectionId());
+		document.addKeyword(
+			FragmentEntryField.MARKETPLACE, fragmentEntry.isMarketplace());
+	}
+
+}

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/search/spi/model/index/contributor/FragmentEntryModelDocumentContributor.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/search/spi/model/index/contributor/FragmentEntryModelDocumentContributor.java
@@ -29,6 +29,7 @@ public class FragmentEntryModelDocumentContributor
 		document.addKeyword(
 			FragmentEntryField.FRAGMENT_COLLECTION_ID,
 			fragmentEntry.getFragmentCollectionId());
+		document.addKeyword(FragmentEntryField.HEAD, fragmentEntry.isHead());
 		document.addKeyword(
 			FragmentEntryField.HEAD_LISTABLE,
 			fragmentEntry.isHead() ||

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/search/spi/model/index/contributor/FragmentEntryModelDocumentContributor.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/search/spi/model/index/contributor/FragmentEntryModelDocumentContributor.java
@@ -27,12 +27,12 @@ public class FragmentEntryModelDocumentContributor
 	public void contribute(Document document, FragmentEntry fragmentEntry) {
 		document.addText(Field.NAME, fragmentEntry.getName());
 		document.addKeyword(
-			FragmentEntryField.DRAFT_ONLY_OR_PUBLISHED,
-			fragmentEntry.isHead() ||
-			(fragmentEntry.getHeadId() == fragmentEntry.getFragmentEntryId()));
-		document.addKeyword(
 			FragmentEntryField.FRAGMENT_COLLECTION_ID,
 			fragmentEntry.getFragmentCollectionId());
+		document.addKeyword(
+			FragmentEntryField.HEAD_LISTABLE,
+			fragmentEntry.isHead() ||
+			(fragmentEntry.getHeadId() == fragmentEntry.getFragmentEntryId()));
 		document.addKeyword(
 			FragmentEntryField.MARKETPLACE, fragmentEntry.isMarketplace());
 	}

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/search/spi/model/query/contributor/FragmentEntryKeywordQueryContributor.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/search/spi/model/query/contributor/FragmentEntryKeywordQueryContributor.java
@@ -1,0 +1,40 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.internal.search.spi.model.query.contributor;
+
+import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.search.query.QueryHelper;
+import com.liferay.portal.search.spi.model.query.contributor.KeywordQueryContributor;
+import com.liferay.portal.search.spi.model.query.contributor.helper.KeywordQueryContributorHelper;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Rubén Pulido
+ */
+@Component(
+	property = "indexer.class.name=com.liferay.fragment.model.FragmentEntry",
+	service = KeywordQueryContributor.class
+)
+public class FragmentEntryKeywordQueryContributor
+	implements KeywordQueryContributor {
+
+	@Override
+	public void contribute(
+		String keywords, BooleanQuery booleanQuery,
+		KeywordQueryContributorHelper keywordQueryContributorHelper) {
+
+		_queryHelper.addSearchTerm(
+			booleanQuery, keywordQueryContributorHelper.getSearchContext(),
+			Field.NAME, false);
+	}
+
+	@Reference
+	private QueryHelper _queryHelper;
+
+}

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/search/spi/model/query/contributor/FragmentEntryModelPreFilterContributor.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/search/spi/model/query/contributor/FragmentEntryModelPreFilterContributor.java
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.internal.search.spi.model.query.contributor;
+
+import com.liferay.fragment.constants.FragmentEntryField;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.search.spi.model.query.contributor.ModelPreFilterContributor;
+import com.liferay.portal.search.spi.model.registrar.ModelSearchSettings;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Javier Moral
+ */
+@Component(
+	property = "indexer.class.name=com.liferay.fragment.model.FragmentEntry",
+	service = ModelPreFilterContributor.class
+)
+public class FragmentEntryModelPreFilterContributor
+	implements ModelPreFilterContributor {
+
+	@Override
+	public void contribute(
+		BooleanFilter booleanFilter, ModelSearchSettings modelSearchSettings,
+		SearchContext searchContext) {
+
+		boolean head = GetterUtil.getBoolean(
+			searchContext.getAttribute(FragmentEntryField.HEAD), Boolean.TRUE);
+		boolean headListable = GetterUtil.getBoolean(
+			searchContext.getAttribute(FragmentEntryField.HEAD_LISTABLE));
+
+		if (headListable) {
+			booleanFilter.addRequiredTerm(
+				FragmentEntryField.HEAD_LISTABLE, true);
+		}
+		else if (head) {
+			booleanFilter.addRequiredTerm(FragmentEntryField.HEAD, true);
+		}
+
+		long fragmentCollectionId = GetterUtil.getLong(
+			searchContext.getAttribute(
+				FragmentEntryField.FRAGMENT_COLLECTION_ID));
+
+		if (fragmentCollectionId > 0) {
+			booleanFilter.addRequiredTerm(
+				FragmentEntryField.FRAGMENT_COLLECTION_ID,
+				fragmentCollectionId);
+		}
+	}
+
+}

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
@@ -369,8 +369,14 @@ public class FragmentEntryLocalServiceImpl
 			String externalReferenceCode, long groupId)
 		throws PortalException {
 
-		FragmentEntry fragmentEntry = fragmentEntryPersistence.findByERC_G_Head(
-			externalReferenceCode, groupId, true);
+		FragmentEntry fragmentEntry =
+			fragmentEntryPersistence.fetchByERC_G_Head(
+				externalReferenceCode, groupId, true);
+
+		if (fragmentEntry == null) {
+			fragmentEntry = fragmentEntryPersistence.findByERC_G_Head(
+				externalReferenceCode, groupId, false);
+		}
 
 		return fragmentEntryLocalService.deleteFragmentEntry(fragmentEntry);
 	}

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
@@ -586,6 +586,7 @@ public class FragmentEntryLocalServiceImpl
 		}
 	}
 
+	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public FragmentEntry moveFragmentEntry(
 			long fragmentEntryId, long fragmentCollectionId)

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
@@ -46,6 +46,8 @@ import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.search.Indexable;
+import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -82,6 +84,7 @@ import org.osgi.service.component.annotations.Reference;
 public class FragmentEntryLocalServiceImpl
 	extends FragmentEntryLocalServiceBaseImpl {
 
+	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public FragmentEntry addFragmentEntry(
 			String externalReferenceCode, long userId, long groupId,
@@ -166,6 +169,7 @@ public class FragmentEntryLocalServiceImpl
 		return updatedDraftFragmentEntry;
 	}
 
+	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public FragmentEntry copyFragmentEntry(
 			long userId, long groupId, long sourceFragmentEntryId,
@@ -299,6 +303,7 @@ public class FragmentEntryLocalServiceImpl
 		return draftFragmentEntry;
 	}
 
+	@Indexable(type = IndexableType.DELETE)
 	@Override
 	@SystemEvent(type = SystemEventConstants.TYPE_DELETE)
 	public FragmentEntry deleteFragmentEntry(FragmentEntry fragmentEntry)
@@ -349,6 +354,7 @@ public class FragmentEntryLocalServiceImpl
 		return delete(fragmentEntry);
 	}
 
+	@Indexable(type = IndexableType.DELETE)
 	@Override
 	public FragmentEntry deleteFragmentEntry(long fragmentEntryId)
 		throws PortalException {
@@ -357,6 +363,7 @@ public class FragmentEntryLocalServiceImpl
 			getFragmentEntry(fragmentEntryId));
 	}
 
+	@Indexable(type = IndexableType.DELETE)
 	@Override
 	public FragmentEntry deleteFragmentEntry(
 			String externalReferenceCode, long groupId)
@@ -596,6 +603,7 @@ public class FragmentEntryLocalServiceImpl
 		return fragmentEntryPersistence.update(fragmentEntry);
 	}
 
+	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public FragmentEntry publishDraft(FragmentEntry draftFragmentEntry)
 		throws PortalException {
@@ -613,6 +621,7 @@ public class FragmentEntryLocalServiceImpl
 		return _publishDraft(draftFragmentEntry);
 	}
 
+	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public FragmentEntry updateFragmentEntry(FragmentEntry fragmentEntry)
 		throws PortalException {
@@ -641,6 +650,7 @@ public class FragmentEntryLocalServiceImpl
 		return publishDraft(updatedDraftFragmentEntry);
 	}
 
+	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public FragmentEntry updateFragmentEntry(
 			long fragmentEntryId, boolean cacheable)
@@ -654,6 +664,7 @@ public class FragmentEntryLocalServiceImpl
 		return fragmentEntryPersistence.update(fragmentEntry);
 	}
 
+	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public FragmentEntry updateFragmentEntry(
 			long fragmentEntryId, long previewFileEntryId)
@@ -676,6 +687,7 @@ public class FragmentEntryLocalServiceImpl
 		return fragmentEntry;
 	}
 
+	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public FragmentEntry updateFragmentEntry(
 			long userId, long fragmentEntryId, long fragmentCollectionId,
@@ -734,6 +746,7 @@ public class FragmentEntryLocalServiceImpl
 		return _publishDraft(fragmentEntry);
 	}
 
+	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public FragmentEntry updateFragmentEntry(long fragmentEntryId, String name)
 		throws PortalException {

--- a/modules/apps/fragment/fragment-test/build.gradle
+++ b/modules/apps/fragment/fragment-test/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-api")
+	testIntegrationImplementation project(":apps:portal-search:portal-search-spi")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationImplementation project(":apps:portal:portal-db-partition-test-util")

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/search/test/FragmentEntryIndexerReindexTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/search/test/FragmentEntryIndexerReindexTest.java
@@ -69,13 +69,15 @@ public class FragmentEntryIndexerReindexTest {
 			WorkflowConstants.STATUS_DRAFT);
 
 		_assertFieldValues(
-			true, fragmentEntry.isMarketplace(), fragmentEntry.getName());
+			fragmentEntry.isHead(), true, fragmentEntry.isMarketplace(),
+			fragmentEntry.getName());
 
 		fragmentEntry = _fragmentEntryLocalService.updateFragmentEntry(
 			fragmentEntry.getFragmentEntryId(), RandomTestUtil.randomString());
 
 		_assertFieldValues(
-			true, fragmentEntry.isMarketplace(), fragmentEntry.getName());
+			fragmentEntry.isHead(), true, fragmentEntry.isMarketplace(),
+			fragmentEntry.getName());
 
 		_deleteDocument(
 			fragmentEntry.getCompanyId(), uidFactory.getUID(fragmentEntry));
@@ -85,12 +87,14 @@ public class FragmentEntryIndexerReindexTest {
 		_reindex(fragmentEntry);
 
 		_assertFieldValues(
-			true, fragmentEntry.isMarketplace(), fragmentEntry.getName());
+			fragmentEntry.isHead(), true, fragmentEntry.isMarketplace(),
+			fragmentEntry.getName());
 
 		_reindex();
 
 		_assertFieldValues(
-			true, fragmentEntry.isMarketplace(), fragmentEntry.getName());
+			fragmentEntry.isHead(), true, fragmentEntry.isMarketplace(),
+			fragmentEntry.getName());
 
 		_fragmentEntryLocalService.deleteFragmentEntry(fragmentEntry);
 
@@ -99,7 +103,8 @@ public class FragmentEntryIndexerReindexTest {
 		fragmentEntry = _addFragmentEntry(WorkflowConstants.STATUS_APPROVED);
 
 		_assertFieldValues(
-			true, fragmentEntry.isMarketplace(), fragmentEntry.getName());
+			fragmentEntry.isHead(), true, fragmentEntry.isMarketplace(),
+			fragmentEntry.getName());
 
 		FragmentEntry draftFragmentEntry = _fragmentEntryLocalService.getDraft(
 			fragmentEntry.getFragmentEntryId());
@@ -109,10 +114,11 @@ public class FragmentEntryIndexerReindexTest {
 			RandomTestUtil.randomString());
 
 		_assertFieldValues(
-			true, fragmentEntry.isMarketplace(), fragmentEntry.getName());
+			fragmentEntry.isHead(), true, fragmentEntry.isMarketplace(),
+			fragmentEntry.getName());
 		_assertFieldValues(
-			false, draftFragmentEntry.isMarketplace(),
-			draftFragmentEntry.getName());
+			draftFragmentEntry.isHead(), false,
+			draftFragmentEntry.isMarketplace(), draftFragmentEntry.getName());
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
@@ -171,7 +177,8 @@ public class FragmentEntryIndexerReindexTest {
 	}
 
 	private void _assertFieldValues(
-			boolean headListable, boolean marketplace, String name)
+			boolean head, boolean headListable, boolean marketplace,
+			String name)
 		throws Exception {
 
 		_assertFieldValue(Field.NAME, name, name);
@@ -179,6 +186,7 @@ public class FragmentEntryIndexerReindexTest {
 			FragmentEntryField.FRAGMENT_COLLECTION_ID,
 			String.valueOf(_fragmentCollection.getFragmentCollectionId()),
 			name);
+		_assertFieldValue(FragmentEntryField.HEAD, String.valueOf(head), name);
 		_assertFieldValue(
 			FragmentEntryField.HEAD_LISTABLE, String.valueOf(headListable),
 			name);
@@ -216,6 +224,9 @@ public class FragmentEntryIndexerReindexTest {
 				FragmentEntry.class
 			).queryString(
 				queryString
+			).withSearchContext(
+				searchContext -> searchContext.setAttribute(
+					FragmentEntryField.HEAD, Boolean.FALSE)
 			).build());
 	}
 

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/search/test/FragmentEntryIndexerReindexTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/search/test/FragmentEntryIndexerReindexTest.java
@@ -171,16 +171,16 @@ public class FragmentEntryIndexerReindexTest {
 	}
 
 	private void _assertFieldValues(
-			boolean draftOnlyOrPublished, boolean marketplace, String name)
+			boolean headListable, boolean marketplace, String name)
 		throws Exception {
 
 		_assertFieldValue(Field.NAME, name, name);
 		_assertFieldValue(
-			FragmentEntryField.DRAFT_ONLY_OR_PUBLISHED,
-			String.valueOf(draftOnlyOrPublished), name);
-		_assertFieldValue(
 			FragmentEntryField.FRAGMENT_COLLECTION_ID,
 			String.valueOf(_fragmentCollection.getFragmentCollectionId()),
+			name);
+		_assertFieldValue(
+			FragmentEntryField.HEAD_LISTABLE, String.valueOf(headListable),
 			name);
 		_assertFieldValue(
 			FragmentEntryField.MARKETPLACE, String.valueOf(marketplace), name);

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/search/test/FragmentEntryIndexerReindexTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/search/test/FragmentEntryIndexerReindexTest.java
@@ -113,6 +113,25 @@ public class FragmentEntryIndexerReindexTest {
 		_assertFieldValues(
 			false, draftFragmentEntry.isMarketplace(),
 			draftFragmentEntry.getName());
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				TestPropsValues.getGroupId());
+
+		FragmentCollection fragmentCollection =
+			_fragmentCollectionLocalService.addFragmentCollection(
+				null, serviceContext.getUserId(), TestPropsValues.getGroupId(),
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				serviceContext);
+
+		fragmentEntry = _fragmentEntryLocalService.moveFragmentEntry(
+			fragmentEntry.getFragmentEntryId(),
+			fragmentCollection.getFragmentCollectionId());
+
+		_assertFieldValue(
+			FragmentEntryField.FRAGMENT_COLLECTION_ID,
+			String.valueOf(fragmentCollection.getFragmentCollectionId()),
+			fragmentEntry.getName());
 	}
 
 	@Rule

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/search/test/FragmentEntryIndexerReindexTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/search/test/FragmentEntryIndexerReindexTest.java
@@ -138,6 +138,20 @@ public class FragmentEntryIndexerReindexTest {
 			FragmentEntryField.FRAGMENT_COLLECTION_ID,
 			String.valueOf(fragmentCollection.getFragmentCollectionId()),
 			fragmentEntry.getName());
+
+		fragmentEntry = _addFragmentEntry(WorkflowConstants.STATUS_APPROVED);
+
+		FragmentEntry copyFragmentEntry =
+			_fragmentEntryLocalService.copyFragmentEntry(
+				serviceContext.getUserId(), TestPropsValues.getGroupId(),
+				fragmentEntry.getFragmentEntryId(),
+				_fragmentCollection.getFragmentCollectionId(), serviceContext);
+
+		_fragmentEntryLocalService.deleteFragmentEntry(fragmentEntry);
+
+		_assertFieldValues(
+			copyFragmentEntry.isHead(), true, copyFragmentEntry.isMarketplace(),
+			copyFragmentEntry.getName());
 	}
 
 	@Rule

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/search/test/FragmentEntryIndexerReindexTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/search/test/FragmentEntryIndexerReindexTest.java
@@ -1,0 +1,217 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.fragment.constants.FragmentConstants;
+import com.liferay.fragment.constants.FragmentEntryField;
+import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.service.FragmentCollectionLocalService;
+import com.liferay.fragment.service.FragmentEntryLocalService;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.IndexWriterHelper;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.search.model.uid.UIDFactory;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.SearchResponse;
+import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.portal.search.test.rule.SearchTestRule;
+import com.liferay.portal.search.test.util.FieldValuesAssert;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Rubén Pulido
+ */
+@RunWith(Arquillian.class)
+public class FragmentEntryIndexerReindexTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				TestPropsValues.getGroupId());
+
+		_fragmentCollection =
+			_fragmentCollectionLocalService.addFragmentCollection(
+				null, serviceContext.getUserId(), TestPropsValues.getGroupId(),
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				serviceContext);
+	}
+
+	@Test
+	public void testReindex() throws Exception {
+		FragmentEntry fragmentEntry = _addFragmentEntry(
+			WorkflowConstants.STATUS_DRAFT);
+
+		_assertFieldValues(
+			true, fragmentEntry.isMarketplace(), fragmentEntry.getName());
+
+		fragmentEntry = _fragmentEntryLocalService.updateFragmentEntry(
+			fragmentEntry.getFragmentEntryId(), RandomTestUtil.randomString());
+
+		_assertFieldValues(
+			true, fragmentEntry.isMarketplace(), fragmentEntry.getName());
+
+		_deleteDocument(
+			fragmentEntry.getCompanyId(), uidFactory.getUID(fragmentEntry));
+
+		_assertNoFieldValues(fragmentEntry.getName());
+
+		_reindex(fragmentEntry);
+
+		_assertFieldValues(
+			true, fragmentEntry.isMarketplace(), fragmentEntry.getName());
+
+		_reindex();
+
+		_assertFieldValues(
+			true, fragmentEntry.isMarketplace(), fragmentEntry.getName());
+
+		_fragmentEntryLocalService.deleteFragmentEntry(fragmentEntry);
+
+		_assertNoFieldValues(fragmentEntry.getName());
+
+		fragmentEntry = _addFragmentEntry(WorkflowConstants.STATUS_APPROVED);
+
+		_assertFieldValues(
+			true, fragmentEntry.isMarketplace(), fragmentEntry.getName());
+
+		FragmentEntry draftFragmentEntry = _fragmentEntryLocalService.getDraft(
+			fragmentEntry.getFragmentEntryId());
+
+		draftFragmentEntry = _fragmentEntryLocalService.updateFragmentEntry(
+			draftFragmentEntry.getFragmentEntryId(),
+			RandomTestUtil.randomString());
+
+		_assertFieldValues(
+			true, fragmentEntry.isMarketplace(), fragmentEntry.getName());
+		_assertFieldValues(
+			false, draftFragmentEntry.isMarketplace(),
+			draftFragmentEntry.getName());
+	}
+
+	@Rule
+	public SearchTestRule searchTestRule = new SearchTestRule();
+
+	@Inject(
+		filter = "indexer.class.name=com.liferay.fragment.model.FragmentEntry"
+	)
+	protected Indexer<FragmentEntry> indexer;
+
+	@Inject
+	protected IndexWriterHelper indexWriterHelper;
+
+	@Inject
+	protected UIDFactory uidFactory;
+
+	private FragmentEntry _addFragmentEntry(int status) throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				TestPropsValues.getGroupId());
+
+		return _fragmentEntryLocalService.addFragmentEntry(
+			null, serviceContext.getUserId(), TestPropsValues.getGroupId(),
+			_fragmentCollection.getFragmentCollectionId(), null,
+			RandomTestUtil.randomString(), StringPool.BLANK, "<div></div>",
+			StringPool.BLANK, false, StringPool.BLANK, StringPool.BLANK, 0,
+			false, false, FragmentConstants.TYPE_COMPONENT, null, status,
+			serviceContext);
+	}
+
+	private void _assertFieldValue(
+			String fieldName, String fieldValue, String queryString)
+		throws Exception {
+
+		FieldValuesAssert.assertFieldValue(
+			fieldName, fieldValue, _search(queryString));
+	}
+
+	private void _assertFieldValues(
+			boolean draftOnlyOrPublished, boolean marketplace, String name)
+		throws Exception {
+
+		_assertFieldValue(Field.NAME, name, name);
+		_assertFieldValue(
+			FragmentEntryField.DRAFT_ONLY_OR_PUBLISHED,
+			String.valueOf(draftOnlyOrPublished), name);
+		_assertFieldValue(
+			FragmentEntryField.FRAGMENT_COLLECTION_ID,
+			String.valueOf(_fragmentCollection.getFragmentCollectionId()),
+			name);
+		_assertFieldValue(
+			FragmentEntryField.MARKETPLACE, String.valueOf(marketplace), name);
+	}
+
+	private void _assertNoFieldValues(String queryString) throws Exception {
+		FieldValuesAssert.assertFieldValues(
+			Collections.emptyMap(), _search(queryString));
+	}
+
+	private void _deleteDocument(long companyId, String uid) throws Exception {
+		indexWriterHelper.deleteDocument(companyId, uid, true);
+	}
+
+	private void _reindex() throws Exception {
+		indexer.reindexCompany(TestPropsValues.getCompanyId());
+	}
+
+	private void _reindex(FragmentEntry fragmentEntry) throws Exception {
+		indexer.reindex(fragmentEntry);
+	}
+
+	private SearchResponse _search(String queryString) throws Exception {
+		return _searcher.search(
+			_searchRequestBuilderFactory.builder(
+			).companyId(
+				TestPropsValues.getCompanyId()
+			).groupIds(
+				TestPropsValues.getGroupId()
+			).fields(
+				StringPool.STAR
+			).modelIndexerClasses(
+				FragmentEntry.class
+			).queryString(
+				queryString
+			).build());
+	}
+
+	private FragmentCollection _fragmentCollection;
+
+	@Inject
+	private FragmentCollectionLocalService _fragmentCollectionLocalService;
+
+	@Inject
+	private FragmentEntryLocalService _fragmentEntryLocalService;
+
+	@Inject
+	private Searcher _searcher;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
+
+}

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/search/test/FragmentEntryModelPreFilterContributorTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/search/test/FragmentEntryModelPreFilterContributorTest.java
@@ -1,0 +1,117 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.fragment.constants.FragmentEntryField;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
+import com.liferay.portal.search.spi.model.query.contributor.ModelPreFilterContributor;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Javier Moral
+ */
+@RunWith(Arquillian.class)
+public class FragmentEntryModelPreFilterContributorTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testContribute() throws Exception {
+		SearchContext searchContext = SearchContextTestUtil.getSearchContext(
+			_group.getGroupId());
+
+		BooleanFilter booleanFilter = new BooleanFilter();
+
+		_fragmentEntryModelPreFilterContributor.contribute(
+			booleanFilter, null, searchContext);
+
+		String booleanFilterString = booleanFilter.toString();
+
+		Assert.assertFalse(
+			booleanFilterString,
+			booleanFilterString.contains(FragmentEntryField.HEAD_LISTABLE));
+		Assert.assertTrue(
+			booleanFilterString,
+			booleanFilterString.contains(FragmentEntryField.HEAD));
+
+		searchContext.setAttribute(
+			FragmentEntryField.HEAD_LISTABLE, Boolean.TRUE);
+
+		booleanFilter = new BooleanFilter();
+
+		_fragmentEntryModelPreFilterContributor.contribute(
+			booleanFilter, null, searchContext);
+
+		booleanFilterString = booleanFilter.toString();
+
+		Assert.assertTrue(
+			booleanFilterString,
+			booleanFilterString.contains(FragmentEntryField.HEAD_LISTABLE));
+
+		searchContext.setAttribute(FragmentEntryField.HEAD, Boolean.FALSE);
+		searchContext.setAttribute(
+			FragmentEntryField.HEAD_LISTABLE, Boolean.FALSE);
+
+		booleanFilter = new BooleanFilter();
+
+		_fragmentEntryModelPreFilterContributor.contribute(
+			booleanFilter, null, searchContext);
+
+		booleanFilterString = booleanFilter.toString();
+
+		Assert.assertFalse(
+			booleanFilterString,
+			booleanFilterString.contains(FragmentEntryField.HEAD));
+
+		searchContext.setAttribute(
+			FragmentEntryField.FRAGMENT_COLLECTION_ID,
+			RandomTestUtil.randomLong());
+
+		booleanFilter = new BooleanFilter();
+
+		_fragmentEntryModelPreFilterContributor.contribute(
+			booleanFilter, null, searchContext);
+
+		booleanFilterString = booleanFilter.toString();
+
+		Assert.assertTrue(
+			booleanFilterString,
+			booleanFilterString.contains(
+				FragmentEntryField.FRAGMENT_COLLECTION_ID));
+	}
+
+	@Inject(
+		filter = "indexer.class.name=com.liferay.fragment.model.FragmentEntry"
+	)
+	private ModelPreFilterContributor _fragmentEntryModelPreFilterContributor;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+}

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLocalServiceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLocalServiceTest.java
@@ -8,6 +8,7 @@ package com.liferay.fragment.service.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.exception.DuplicateFragmentEntryExternalReferenceCodeException;
+import com.liferay.fragment.exception.NoSuchEntryException;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.service.FragmentEntryLocalService;
@@ -646,6 +647,14 @@ public class FragmentEntryLocalServiceTest {
 		Assert.assertNull(
 			_fragmentEntryLocalService.fetchFragmentEntry(
 				fragmentEntry.getFragmentEntryId()));
+	}
+
+	@Test(expected = NoSuchEntryException.class)
+	public void testDeleteNonexistentFragmentEntryByExternalReferenceCode()
+		throws Exception {
+
+		_fragmentEntryLocalService.deleteFragmentEntry(
+			RandomTestUtil.randomString(), _group.getGroupId());
 	}
 
 	@Test

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLocalServiceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLocalServiceTest.java
@@ -552,7 +552,20 @@ public class FragmentEntryLocalServiceTest {
 	}
 
 	@Test
-	public void testDeleteApprovedAndDraftFragmentEntryByExternalReferenceCode()
+	public void testDeleteFragmentEntry() throws Exception {
+		FragmentEntry fragmentEntry = FragmentEntryTestUtil.addFragmentEntry(
+			_fragmentCollection.getFragmentCollectionId());
+
+		_fragmentEntryLocalService.deleteFragmentEntry(
+			fragmentEntry.getFragmentEntryId());
+
+		Assert.assertNull(
+			_fragmentEntryLocalService.fetchFragmentEntry(
+				fragmentEntry.getFragmentEntryId()));
+	}
+
+	@Test
+	public void testDeleteFragmentEntryApprovedAndDraftByExternalReferenceCode()
 		throws Exception {
 
 		FragmentEntry fragmentEntry =
@@ -574,37 +587,6 @@ public class FragmentEntryLocalServiceTest {
 		Assert.assertNull(
 			_fragmentEntryLocalService.fetchFragmentEntry(
 				draftFragmentEntry.getFragmentEntryId()));
-	}
-
-	@Test
-	public void testDeleteDraftFragmentEntryByExternalReferenceCode()
-		throws Exception {
-
-		FragmentEntry fragmentEntry =
-			FragmentEntryTestUtil.addFragmentEntryByStatus(
-				_fragmentCollection.getFragmentCollectionId(),
-				WorkflowConstants.STATUS_DRAFT);
-
-		_fragmentEntryLocalService.deleteFragmentEntry(
-			fragmentEntry.getExternalReferenceCode(),
-			fragmentEntry.getGroupId());
-
-		Assert.assertNull(
-			_fragmentEntryLocalService.fetchFragmentEntry(
-				fragmentEntry.getFragmentEntryId()));
-	}
-
-	@Test
-	public void testDeleteFragmentEntry() throws Exception {
-		FragmentEntry fragmentEntry = FragmentEntryTestUtil.addFragmentEntry(
-			_fragmentCollection.getFragmentCollectionId());
-
-		_fragmentEntryLocalService.deleteFragmentEntry(
-			fragmentEntry.getFragmentEntryId());
-
-		Assert.assertNull(
-			_fragmentEntryLocalService.fetchFragmentEntry(
-				fragmentEntry.getFragmentEntryId()));
 	}
 
 	@Test
@@ -633,8 +615,26 @@ public class FragmentEntryLocalServiceTest {
 				fragmentEntry.getFragmentEntryId()));
 	}
 
+	@Test
+	public void testDeleteFragmentEntryDraftByExternalReferenceCode()
+		throws Exception {
+
+		FragmentEntry fragmentEntry =
+			FragmentEntryTestUtil.addFragmentEntryByStatus(
+				_fragmentCollection.getFragmentCollectionId(),
+				WorkflowConstants.STATUS_DRAFT);
+
+		_fragmentEntryLocalService.deleteFragmentEntry(
+			fragmentEntry.getExternalReferenceCode(),
+			fragmentEntry.getGroupId());
+
+		Assert.assertNull(
+			_fragmentEntryLocalService.fetchFragmentEntry(
+				fragmentEntry.getFragmentEntryId()));
+	}
+
 	@Test(expected = NoSuchEntryException.class)
-	public void testDeleteNonexistentFragmentEntryByExternalReferenceCode()
+	public void testDeleteFragmentEntryNonexistentByExternalReferenceCode()
 		throws Exception {
 
 		_fragmentEntryLocalService.deleteFragmentEntry(

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLocalServiceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLocalServiceTest.java
@@ -556,17 +556,9 @@ public class FragmentEntryLocalServiceTest {
 		throws Exception {
 
 		FragmentEntry fragmentEntry =
-			_fragmentEntryLocalService.addFragmentEntry(
-				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
-				_group.getGroupId(),
+			FragmentEntryTestUtil.addFragmentEntryByStatus(
 				_fragmentCollection.getFragmentCollectionId(),
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), false, StringPool.BLANK, null, 0,
-				false, false, FragmentConstants.TYPE_COMPONENT, null,
-				WorkflowConstants.STATUS_APPROVED,
-				ServiceContextTestUtil.getServiceContext(
-					_group.getGroupId(), TestPropsValues.getUserId()));
+				WorkflowConstants.STATUS_APPROVED);
 
 		FragmentEntry draftFragmentEntry = _fragmentEntryLocalService.getDraft(
 			fragmentEntry.getFragmentEntryId());
@@ -589,17 +581,9 @@ public class FragmentEntryLocalServiceTest {
 		throws Exception {
 
 		FragmentEntry fragmentEntry =
-			_fragmentEntryLocalService.addFragmentEntry(
-				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
-				_group.getGroupId(),
+			FragmentEntryTestUtil.addFragmentEntryByStatus(
 				_fragmentCollection.getFragmentCollectionId(),
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), false, StringPool.BLANK, null, 0,
-				false, false, FragmentConstants.TYPE_COMPONENT, null,
-				WorkflowConstants.STATUS_DRAFT,
-				ServiceContextTestUtil.getServiceContext(
-					_group.getGroupId(), TestPropsValues.getUserId()));
+				WorkflowConstants.STATUS_DRAFT);
 
 		_fragmentEntryLocalService.deleteFragmentEntry(
 			fragmentEntry.getExternalReferenceCode(),

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLocalServiceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLocalServiceTest.java
@@ -551,6 +551,65 @@ public class FragmentEntryLocalServiceTest {
 	}
 
 	@Test
+	public void testDeleteApprovedAndDraftFragmentEntryByExternalReferenceCode()
+		throws Exception {
+
+		FragmentEntry fragmentEntry =
+			_fragmentEntryLocalService.addFragmentEntry(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				_group.getGroupId(),
+				_fragmentCollection.getFragmentCollectionId(),
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(), false, StringPool.BLANK, null, 0,
+				false, false, FragmentConstants.TYPE_COMPONENT, null,
+				WorkflowConstants.STATUS_APPROVED,
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId()));
+
+		FragmentEntry draftFragmentEntry = _fragmentEntryLocalService.getDraft(
+			fragmentEntry.getFragmentEntryId());
+
+		_fragmentEntryLocalService.deleteFragmentEntry(
+			fragmentEntry.getExternalReferenceCode(),
+			fragmentEntry.getGroupId());
+
+		Assert.assertNull(
+			_fragmentEntryLocalService.fetchFragmentEntry(
+				fragmentEntry.getFragmentEntryId()));
+
+		Assert.assertNull(
+			_fragmentEntryLocalService.fetchFragmentEntry(
+				draftFragmentEntry.getFragmentEntryId()));
+	}
+
+	@Test
+	public void testDeleteDraftFragmentEntryByExternalReferenceCode()
+		throws Exception {
+
+		FragmentEntry fragmentEntry =
+			_fragmentEntryLocalService.addFragmentEntry(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				_group.getGroupId(),
+				_fragmentCollection.getFragmentCollectionId(),
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(), false, StringPool.BLANK, null, 0,
+				false, false, FragmentConstants.TYPE_COMPONENT, null,
+				WorkflowConstants.STATUS_DRAFT,
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId()));
+
+		_fragmentEntryLocalService.deleteFragmentEntry(
+			fragmentEntry.getExternalReferenceCode(),
+			fragmentEntry.getGroupId());
+
+		Assert.assertNull(
+			_fragmentEntryLocalService.fetchFragmentEntry(
+				fragmentEntry.getFragmentEntryId()));
+	}
+
+	@Test
 	public void testDeleteFragmentEntry() throws Exception {
 		FragmentEntry fragmentEntry = FragmentEntryTestUtil.addFragmentEntry(
 			_fragmentCollection.getFragmentCollectionId());

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-api/bnd.bnd
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Admin Fragment API
 Bundle-SymbolicName: com.liferay.headless.admin.fragment.api
-Bundle-Version: 2.0.1
+Bundle-Version: 2.1.0
 Export-Package:\
 	com.liferay.headless.admin.fragment.dto.v1_0,\
 	com.liferay.headless.admin.fragment.resource.v1_0

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-api/src/main/java/com/liferay/headless/admin/fragment/resource/v1_0/FragmentResource.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-api/src/main/java/com/liferay/headless/admin/fragment/resource/v1_0/FragmentResource.java
@@ -61,6 +61,12 @@ public interface FragmentResource {
 			String fragmentSetExternalReferenceCode, Pagination pagination)
 		throws Exception;
 
+	public Page<Fragment> getSiteFragmentsPage(
+			String siteExternalReferenceCode,
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			Pagination pagination)
+		throws Exception;
+
 	public Fragment postSiteFragment(
 			String siteExternalReferenceCode, Fragment fragment)
 		throws Exception;
@@ -72,6 +78,12 @@ public interface FragmentResource {
 	public Fragment postSiteFragmentSetFragment(
 			String siteExternalReferenceCode,
 			String fragmentSetExternalReferenceCode, Fragment fragment)
+		throws Exception;
+
+	public Response postSiteFragmentsPageExportBatch(
+			String siteExternalReferenceCode,
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			String callbackURL, String contentType, String fieldNames)
 		throws Exception;
 
 	public Fragment putSiteFragment(
@@ -175,4 +187,4 @@ public interface FragmentResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1350158393
+// LIFERAY-REST-BUILDER-HASH:1063955899

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-api/src/main/resources/com/liferay/headless/admin/fragment/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-api/src/main/resources/com/liferay/headless/admin/fragment/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-client/src/main/java/com/liferay/headless/admin/fragment/client/resource/v1_0/FragmentResource.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-client/src/main/java/com/liferay/headless/admin/fragment/client/resource/v1_0/FragmentResource.java
@@ -64,6 +64,16 @@ public interface FragmentResource {
 			String fragmentSetExternalReferenceCode, Pagination pagination)
 		throws Exception;
 
+	public Page<Fragment> getSiteFragmentsPage(
+			String siteExternalReferenceCode, String filterString,
+			Pagination pagination)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getSiteFragmentsPageHttpResponse(
+			String siteExternalReferenceCode, String filterString,
+			Pagination pagination)
+		throws Exception;
+
 	public Fragment postSiteFragment(
 			String siteExternalReferenceCode, Fragment fragment)
 		throws Exception;
@@ -88,6 +98,17 @@ public interface FragmentResource {
 	public HttpInvoker.HttpResponse postSiteFragmentSetFragmentHttpResponse(
 			String siteExternalReferenceCode,
 			String fragmentSetExternalReferenceCode, Fragment fragment)
+		throws Exception;
+
+	public void postSiteFragmentsPageExportBatch(
+			String siteExternalReferenceCode, String filterString,
+			String callbackURL, String contentType, String fieldNames)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			postSiteFragmentsPageExportBatchHttpResponse(
+				String siteExternalReferenceCode, String filterString,
+				String callbackURL, String contentType, String fieldNames)
 		throws Exception;
 
 	public Fragment putSiteFragment(
@@ -554,6 +575,127 @@ public interface FragmentResource {
 			return httpInvoker.invoke();
 		}
 
+		public Page<Fragment> getSiteFragmentsPage(
+				String siteExternalReferenceCode, String filterString,
+				Pagination pagination)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getSiteFragmentsPageHttpResponse(
+					siteExternalReferenceCode, filterString, pagination);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, FragmentSerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse getSiteFragmentsPageHttpResponse(
+				String siteExternalReferenceCode, String filterString,
+				Pagination pagination)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (filterString != null) {
+				httpInvoker.parameter("filter", filterString);
+			}
+
+			if (pagination != null) {
+				httpInvoker.parameter(
+					"page", String.valueOf(pagination.getPage()));
+				httpInvoker.parameter(
+					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-admin-fragment/v1.0/sites/{siteExternalReferenceCode}/fragments");
+
+			httpInvoker.path(
+				"siteExternalReferenceCode", siteExternalReferenceCode);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
 		public Fragment postSiteFragment(
 				String siteExternalReferenceCode, Fragment fragment)
 			throws Exception {
@@ -886,6 +1028,127 @@ public interface FragmentResource {
 			return httpInvoker.invoke();
 		}
 
+		public void postSiteFragmentsPageExportBatch(
+				String siteExternalReferenceCode, String filterString,
+				String callbackURL, String contentType, String fieldNames)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postSiteFragmentsPageExportBatchHttpResponse(
+					siteExternalReferenceCode, filterString, callbackURL,
+					contentType, fieldNames);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				postSiteFragmentsPageExportBatchHttpResponse(
+					String siteExternalReferenceCode, String filterString,
+					String callbackURL, String contentType, String fieldNames)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body("[]", "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (filterString != null) {
+				httpInvoker.parameter("filter", filterString);
+			}
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			if (contentType != null) {
+				httpInvoker.parameter(
+					"contentType", String.valueOf(contentType));
+			}
+
+			if (fieldNames != null) {
+				httpInvoker.parameter("fieldNames", String.valueOf(fieldNames));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-admin-fragment/v1.0/sites/{siteExternalReferenceCode}/fragments/export-batch");
+
+			httpInvoker.path(
+				"siteExternalReferenceCode", siteExternalReferenceCode);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
 		public Fragment putSiteFragment(
 				String siteExternalReferenceCode,
 				String fragmentExternalReferenceCode, Fragment fragment)
@@ -1012,4 +1275,4 @@ public interface FragmentResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-107808666
+// LIFERAY-REST-BUILDER-HASH:-1283746489

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/rest-openapi.yaml
@@ -392,6 +392,50 @@ paths:
                                 $ref: "#/components/schemas/Fragment"
             tags: ["Fragment"]
     "/sites/{siteExternalReferenceCode}/fragments":
+        get:
+            description:
+                Retrieves the fragments of a site.
+            operationId: getSiteFragmentsPage
+            parameters:
+                -   in: path
+                    name: siteExternalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: query
+                    name: fields
+                    schema:
+                        type: string
+                -   in: query
+                    name: filter
+                    schema:
+                        type: string
+                -   in: query
+                    name: page
+                    schema:
+                        type: integer
+                -   in: query
+                    name: pageSize
+                    schema:
+                        type: integer
+                -   in: query
+                    name: restrictFields
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/Fragment"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/Fragment"
+                                type: array
+            tags: ["Fragment"]
         post:
             description:
                 Adds a new fragment to a site.

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/dto/v1_0/converter/FragmentDTOConverter.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/dto/v1_0/converter/FragmentDTOConverter.java
@@ -152,15 +152,20 @@ public class FragmentDTOConverter
 		FragmentEntry fragmentEntry,
 		FragmentVersion.Status fragmentVersionStatus) {
 
-		return new FragmentVersion() {
+		FragmentVersion fragmentVersion = new FragmentVersion() {
 			{
-				setConfiguration(fragmentEntry::getConfiguration);
-				setCss(fragmentEntry::getCss);
-				setHtml(fragmentEntry::getHtml);
-				setJs(fragmentEntry::getJs);
 				setStatus(() -> fragmentVersionStatus);
 			}
 		};
+
+		if (!fragmentEntry.isMarketplace()) {
+			fragmentVersion.setConfiguration(fragmentEntry::getConfiguration);
+			fragmentVersion.setCss(fragmentEntry::getCss);
+			fragmentVersion.setHtml(fragmentEntry::getHtml);
+			fragmentVersion.setJs(fragmentEntry::getJs);
+		}
+
+		return fragmentVersion;
 	}
 
 	@Reference

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/dto/v1_0/converter/FragmentDTOConverter.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/dto/v1_0/converter/FragmentDTOConverter.java
@@ -48,10 +48,10 @@ public class FragmentDTOConverter
 	public Fragment toDTO(
 		DTOConverterContext dtoConverterContext, FragmentEntry fragmentEntry) {
 
-		FragmentEntry draftOnlyOrPublishedFragmentEntry =
-			_fetchDraftOnlyOrPublishedFragmentEntry(fragmentEntry);
+		FragmentEntry headListableFragmentEntry =
+			_fetchHeadListableFragmentEntry(fragmentEntry);
 
-		if (draftOnlyOrPublishedFragmentEntry == null) {
+		if (headListableFragmentEntry == null) {
 			throw new IllegalStateException(
 				StringBundler.concat(
 					"Fragment entry draft with ID ",
@@ -59,10 +59,10 @@ public class FragmentDTOConverter
 					fragmentEntry.getHeadId(), " that no longer exists"));
 		}
 
-		return _toFragment(draftOnlyOrPublishedFragmentEntry);
+		return _toFragment(headListableFragmentEntry);
 	}
 
-	private FragmentEntry _fetchDraftOnlyOrPublishedFragmentEntry(
+	private FragmentEntry _fetchHeadListableFragmentEntry(
 		FragmentEntry fragmentEntry) {
 
 		if (fragmentEntry.isHead()) {

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/odata/entity/v1_0/FragmentEntityModel.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/odata/entity/v1_0/FragmentEntityModel.java
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.fragment.internal.odata.entity.v1_0;
+
+import com.liferay.fragment.constants.FragmentEntryField;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.odata.entity.BooleanEntityField;
+import com.liferay.portal.odata.entity.DateTimeEntityField;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+
+import java.util.Map;
+
+/**
+ * @author Rubén Pulido
+ */
+public class FragmentEntityModel implements EntityModel {
+
+	public FragmentEntityModel() {
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
+			new BooleanEntityField(
+				"marketplace", locale -> FragmentEntryField.MARKETPLACE),
+			new DateTimeEntityField(
+				"dateCreated",
+				locale -> Field.getSortableFieldName(Field.CREATE_DATE),
+				locale -> Field.CREATE_DATE),
+			new DateTimeEntityField(
+				"dateModified",
+				locale -> Field.getSortableFieldName(Field.MODIFIED_DATE),
+				locale -> Field.MODIFIED_DATE));
+	}
+
+	@Override
+	public Map<String, EntityField> getEntityFieldsMap() {
+		return _entityFieldsMap;
+	}
+
+	private final Map<String, EntityField> _entityFieldsMap;
+
+}

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/odata/entity/v1_0/FragmentSetEntityModel.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/odata/entity/v1_0/FragmentSetEntityModel.java
@@ -5,6 +5,7 @@
 
 package com.liferay.headless.admin.fragment.internal.odata.entity.v1_0;
 
+import com.liferay.fragment.constants.FragmentCollectionField;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.odata.entity.BooleanEntityField;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
@@ -20,7 +21,8 @@ public class FragmentSetEntityModel implements EntityModel {
 
 	public FragmentSetEntityModel() {
 		_entityFieldsMap = EntityModel.toEntityFieldsMap(
-			new BooleanEntityField("marketplace", locale -> "marketplace"),
+			new BooleanEntityField(
+				"marketplace", locale -> FragmentCollectionField.MARKETPLACE),
 			new DateTimeEntityField(
 				"dateCreated",
 				locale -> Field.getSortableFieldName(Field.CREATE_DATE),

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/BaseFragmentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/BaseFragmentResourceImpl.java
@@ -224,6 +224,62 @@ public abstract class BaseFragmentResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-admin-fragment/v1.0/sites/{siteExternalReferenceCode}/fragments'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves the fragments of a site."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "siteExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "filter"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "restrictFields"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Fragment")}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path("/sites/{siteExternalReferenceCode}/fragments")
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<Fragment> getSiteFragmentsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
+			String siteExternalReferenceCode,
+			@jakarta.ws.rs.core.Context
+				com.liferay.portal.kernel.search.filter.Filter filter,
+			@jakarta.ws.rs.core.Context Pagination pagination)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-fragment/v1.0/sites/{siteExternalReferenceCode}/fragments' -d $'{"cacheable": ___, "dateCreated": ___, "dateModified": ___, "externalReferenceCode": ___, "fragmentSet": ___, "fragmentVersions": ___, "icon": ___, "key": ___, "marketplace": ___, "name": ___, "readOnly": ___, "thumbnailURLReference": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
@@ -351,6 +407,82 @@ public abstract class BaseFragmentResourceImpl
 		throws Exception {
 
 		return new Fragment();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-fragment/v1.0/sites/{siteExternalReferenceCode}/fragments/export-batch'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "siteExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "filter"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "callbackURL"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "contentType"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fieldNames"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Fragment")}
+	)
+	@jakarta.ws.rs.Consumes("application/json")
+	@jakarta.ws.rs.Path(
+		"/sites/{siteExternalReferenceCode}/fragments/export-batch"
+	)
+	@jakarta.ws.rs.POST
+	@jakarta.ws.rs.Produces("application/json")
+	@Override
+	public Response postSiteFragmentsPageExportBatch(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
+			String siteExternalReferenceCode,
+			@jakarta.ws.rs.core.Context
+				com.liferay.portal.kernel.search.filter.Filter filter,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("callbackURL")
+			String callbackURL,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.DefaultValue("JSON")
+			@jakarta.ws.rs.QueryParam("contentType")
+			String contentType,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("fieldNames")
+			String fieldNames)
+		throws Exception {
+
+		vulcanBatchEngineExportTaskResource.setContextAcceptLanguage(
+			contextAcceptLanguage);
+		vulcanBatchEngineExportTaskResource.setContextCompany(contextCompany);
+		vulcanBatchEngineExportTaskResource.setContextHttpServletRequest(
+			contextHttpServletRequest);
+		vulcanBatchEngineExportTaskResource.setContextUriInfo(contextUriInfo);
+		vulcanBatchEngineExportTaskResource.setContextUser(contextUser);
+		vulcanBatchEngineExportTaskResource.setGroupLocalService(
+			groupLocalService);
+
+		Response.ResponseBuilder responseBuilder = Response.accepted();
+
+		return responseBuilder.entity(
+			vulcanBatchEngineExportTaskResource.postExportTask(
+				Fragment.class.getName(), callbackURL, contentType, fieldNames)
+		).build();
 	}
 
 	/**
@@ -542,8 +674,15 @@ public abstract class BaseFragmentResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
+		if (parameters.containsKey("siteExternalReferenceCode")) {
+			return getSiteFragmentsPage(
+				(String)parameters.get("siteExternalReferenceCode"), filter,
+				pagination);
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be specified: [siteExternalReferenceCode]");
+		}
 	}
 
 	@Override
@@ -1147,4 +1286,4 @@ public abstract class BaseFragmentResourceImpl
 		LogFactoryUtil.getLog(BaseFragmentResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-776860739
+// LIFERAY-REST-BUILDER-HASH:-1164969154

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentResourceImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.admin.fragment.internal.resource.v1_0;
 
 import com.liferay.fragment.constants.FragmentConstants;
+import com.liferay.fragment.constants.FragmentEntryField;
 import com.liferay.fragment.constants.FragmentPortletKeys;
 import com.liferay.fragment.exception.RequiredFragmentEntryVersionException;
 import com.liferay.fragment.exception.UnsupportedUnpublishFragmentEntryOperationException;
@@ -18,6 +19,7 @@ import com.liferay.fragment.service.FragmentEntryService;
 import com.liferay.headless.admin.fragment.dto.v1_0.Fragment;
 import com.liferay.headless.admin.fragment.dto.v1_0.FragmentSet;
 import com.liferay.headless.admin.fragment.dto.v1_0.FragmentVersion;
+import com.liferay.headless.admin.fragment.internal.odata.entity.v1_0.FragmentEntityModel;
 import com.liferay.headless.admin.fragment.internal.resource.v1_0.util.FragmentSetUtil;
 import com.liferay.headless.admin.fragment.internal.resource.v1_0.util.ServiceContextUtil;
 import com.liferay.headless.admin.fragment.internal.util.EnabledUtil;
@@ -29,15 +31,24 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.util.SearchUtil;
+
+import jakarta.ws.rs.core.MultivaluedMap;
+
+import java.util.Collections;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -65,6 +76,11 @@ public class FragmentResourceImpl extends BaseFragmentResourceImpl {
 			GroupUtil.getStagingAwareGroupId(
 				true, contextCompany.getCompanyId(),
 				siteExternalReferenceCode));
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
+		return _entityModel;
 	}
 
 	@Override
@@ -137,6 +153,22 @@ public class FragmentResourceImpl extends BaseFragmentResourceImpl {
 				getFragmentCompositionsAndFragmentEntriesCount(
 					groupId, fragmentCollection.getFragmentCollectionId(),
 					WorkflowConstants.STATUS_ANY));
+	}
+
+	@Override
+	public Page<Fragment> getSiteFragmentsPage(
+			String siteExternalReferenceCode, Filter filter,
+			Pagination pagination)
+		throws Exception {
+
+		EnabledUtil.checkEnabled(contextCompany);
+
+		return _getFragmentsPage(
+			filter, 0,
+			GroupUtil.getGroupId(
+				true, true, contextCompany.getCompanyId(),
+				siteExternalReferenceCode),
+			pagination);
 	}
 
 	@Override
@@ -282,6 +314,47 @@ public class FragmentResourceImpl extends BaseFragmentResourceImpl {
 		}
 
 		return _toFragment(fragmentEntry);
+	}
+
+	private Page<Fragment> _getFragmentsPage(
+			Filter filter, long fragmentCollectionId, long groupId,
+			Pagination pagination)
+		throws Exception {
+
+		return SearchUtil.search(
+			Collections.emptyMap(),
+			booleanQuery -> {
+				BooleanFilter booleanFilter =
+					booleanQuery.getPreBooleanFilter();
+
+				booleanFilter.addRequiredTerm(
+					FragmentEntryField.DRAFT_ONLY_OR_PUBLISHED, true);
+
+				if (fragmentCollectionId > 0) {
+					booleanFilter.addRequiredTerm(
+						FragmentEntryField.FRAGMENT_COLLECTION_ID,
+						fragmentCollectionId);
+				}
+			},
+			filter, FragmentEntry.class.getName(), null, pagination,
+			queryConfig -> queryConfig.setSelectedFieldNames(
+				Field.ENTRY_CLASS_PK),
+			searchContext -> {
+				searchContext.setCompanyId(contextCompany.getCompanyId());
+				searchContext.setGroupIds(new long[] {groupId});
+			},
+			null,
+			document -> {
+				FragmentEntry fragmentEntry =
+					_fragmentEntryService.fetchFragmentEntry(
+						GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK)));
+
+				if (fragmentEntry == null) {
+					return null;
+				}
+
+				return _toFragment(fragmentEntry);
+			});
 	}
 
 	private FragmentVersion _getFragmentVersion(
@@ -465,6 +538,8 @@ public class FragmentResourceImpl extends BaseFragmentResourceImpl {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		FragmentResourceImpl.class);
+
+	private static final EntityModel _entityModel = new FragmentEntityModel();
 
 	@Reference
 	private DTOConverterRegistry _dtoConverterRegistry;

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentResourceImpl.java
@@ -32,7 +32,6 @@ import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -46,13 +45,9 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.SearchUtil;
 
-import jakarta.ws.rs.NotSupportedException;
 import jakarta.ws.rs.core.MultivaluedMap;
 
-import java.io.Serializable;
-
 import java.util.Collections;
-import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -233,28 +228,6 @@ public class FragmentResourceImpl extends BaseFragmentResourceImpl {
 				_getOrAddFragmentCollection(fragment.getFragmentSet(), groupId),
 				groupId);
 		}
-	}
-
-	@Override
-	public Page<Fragment> read(
-			Filter filter, Pagination pagination, Sort[] sorts,
-			Map<String, Serializable> parameters, String search)
-		throws Exception {
-
-		EnabledUtil.checkEnabled(contextCompany);
-
-		if (!parameters.containsKey("siteExternalReferenceCode")) {
-			throw new NotSupportedException(
-				"One of the following parameters must be specified: " +
-					"[siteExternalReferenceCode]");
-		}
-
-		return _getFragmentsPage(
-			filter, 0,
-			GroupUtil.getGroupId(
-				true, true, contextCompany.getCompanyId(),
-				(String)parameters.get("siteExternalReferenceCode")),
-			pagination);
 	}
 
 	private Fragment _addFragmentEntry(

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentResourceImpl.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -46,9 +47,13 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.SearchUtil;
 
+import jakarta.ws.rs.NotSupportedException;
 import jakarta.ws.rs.core.MultivaluedMap;
 
+import java.io.Serializable;
+
 import java.util.Collections;
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -229,6 +234,28 @@ public class FragmentResourceImpl extends BaseFragmentResourceImpl {
 				_getOrAddFragmentCollection(fragment.getFragmentSet(), groupId),
 				groupId);
 		}
+	}
+
+	@Override
+	public Page<Fragment> read(
+			Filter filter, Pagination pagination, Sort[] sorts,
+			Map<String, Serializable> parameters, String search)
+		throws Exception {
+
+		EnabledUtil.checkEnabled(contextCompany);
+
+		if (!parameters.containsKey("siteExternalReferenceCode")) {
+			throw new NotSupportedException(
+				"One of the following parameters must be specified: " +
+					"[siteExternalReferenceCode]");
+		}
+
+		return _getFragmentsPage(
+			filter, 0,
+			GroupUtil.getGroupId(
+				true, true, contextCompany.getCompanyId(),
+				(String)parameters.get("siteExternalReferenceCode")),
+			pagination);
 	}
 
 	private Fragment _addFragmentEntry(

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentResourceImpl.java
@@ -33,7 +33,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Sort;
-import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -335,23 +334,16 @@ public class FragmentResourceImpl extends BaseFragmentResourceImpl {
 
 		return SearchUtil.search(
 			Collections.emptyMap(),
-			booleanQuery -> {
-				BooleanFilter booleanFilter =
-					booleanQuery.getPreBooleanFilter();
-
-				booleanFilter.addRequiredTerm(
-					FragmentEntryField.HEAD_LISTABLE, true);
-
-				if (fragmentCollectionId > 0) {
-					booleanFilter.addRequiredTerm(
-						FragmentEntryField.FRAGMENT_COLLECTION_ID,
-						fragmentCollectionId);
-				}
-			},
-			filter, FragmentEntry.class.getName(), null, pagination,
+			booleanQuery -> booleanQuery.getPreBooleanFilter(), filter,
+			FragmentEntry.class.getName(), null, pagination,
 			queryConfig -> queryConfig.setSelectedFieldNames(
 				Field.ENTRY_CLASS_PK),
 			searchContext -> {
+				searchContext.setAttribute(
+					FragmentEntryField.FRAGMENT_COLLECTION_ID,
+					fragmentCollectionId);
+				searchContext.setAttribute(
+					FragmentEntryField.HEAD_LISTABLE, Boolean.TRUE);
 				searchContext.setCompanyId(contextCompany.getCompanyId());
 				searchContext.setGroupIds(new long[] {groupId});
 			},

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentResourceImpl.java
@@ -340,7 +340,7 @@ public class FragmentResourceImpl extends BaseFragmentResourceImpl {
 					booleanQuery.getPreBooleanFilter();
 
 				booleanFilter.addRequiredTerm(
-					FragmentEntryField.DRAFT_ONLY_OR_PUBLISHED, true);
+					FragmentEntryField.HEAD_LISTABLE, true);
 
 				if (fragmentCollectionId > 0) {
 					booleanFilter.addRequiredTerm(

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentResourceImpl.java
@@ -135,24 +135,9 @@ public class FragmentResourceImpl extends BaseFragmentResourceImpl {
 				getFragmentCollectionByExternalReferenceCode(
 					fragmentSetExternalReferenceCode, groupId);
 
-		return Page.of(
-			transform(
-				_fragmentEntryService.getFragmentCompositionsAndFragmentEntries(
-					groupId, fragmentCollection.getFragmentCollectionId(),
-					WorkflowConstants.STATUS_ANY, pagination.getStartPosition(),
-					pagination.getEndPosition(), null),
-				object -> {
-					if (object instanceof FragmentEntry) {
-						return _toFragment((FragmentEntry)object);
-					}
-
-					return null;
-				}),
-			pagination,
-			_fragmentEntryService.
-				getFragmentCompositionsAndFragmentEntriesCount(
-					groupId, fragmentCollection.getFragmentCollectionId(),
-					WorkflowConstants.STATUS_ANY));
+		return _getFragmentsPage(
+			null, fragmentCollection.getFragmentCollectionId(), groupId,
+			pagination);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentSetResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentSetResourceImpl.java
@@ -103,9 +103,17 @@ public class FragmentSetResourceImpl extends BaseFragmentSetResourceImpl {
 				searchContext.setGroupIds(new long[] {groupId});
 			},
 			null,
-			document -> _toFragmentSet(
-				_fragmentCollectionService.fetchFragmentCollection(
-					GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK)))));
+			document -> {
+				FragmentCollection fragmentCollection =
+					_fragmentCollectionService.fetchFragmentCollection(
+						GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK)));
+
+				if (fragmentCollection == null) {
+					return null;
+				}
+
+				return _toFragmentSet(fragmentCollection);
+			});
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/fragment.properties
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/fragment.properties
@@ -5,7 +5,7 @@
 api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.admin.fragment.dto.v1_0.Fragment
 batch.engine.task.item.delegate=true
-batch.planner.export.enabled=false
+batch.planner.export.enabled=true
 batch.planner.import.enabled=true
 entity.class.name=com.liferay.headless.admin.fragment.dto.v1_0.Fragment
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.Fragment)

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/BaseFragmentResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/BaseFragmentResourceTestCase.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.search.test.rule.SearchTestRule;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
@@ -465,6 +466,270 @@ public abstract class BaseFragmentResourceTestCase {
 	}
 
 	@Test
+	public void testGetSiteFragmentsPage() throws Exception {
+		String siteExternalReferenceCode =
+			testGetSiteFragmentsPage_getSiteExternalReferenceCode();
+		String irrelevantSiteExternalReferenceCode =
+			testGetSiteFragmentsPage_getIrrelevantSiteExternalReferenceCode();
+
+		Page<Fragment> page = fragmentResource.getSiteFragmentsPage(
+			siteExternalReferenceCode, null, Pagination.of(1, 10));
+
+		long totalCount = page.getTotalCount();
+
+		if (irrelevantSiteExternalReferenceCode != null) {
+			Fragment irrelevantFragment = testGetSiteFragmentsPage_addFragment(
+				irrelevantSiteExternalReferenceCode,
+				randomIrrelevantFragment());
+
+			page = fragmentResource.getSiteFragmentsPage(
+				irrelevantSiteExternalReferenceCode, null,
+				Pagination.of(1, (int)totalCount + 1));
+
+			Assert.assertEquals(totalCount + 1, page.getTotalCount());
+
+			assertContains(irrelevantFragment, (List<Fragment>)page.getItems());
+			assertValid(
+				page,
+				testGetSiteFragmentsPage_getExpectedActions(
+					irrelevantSiteExternalReferenceCode));
+		}
+
+		Fragment fragment1 = testGetSiteFragmentsPage_addFragment(
+			siteExternalReferenceCode, randomFragment());
+
+		Fragment fragment2 = testGetSiteFragmentsPage_addFragment(
+			siteExternalReferenceCode, randomFragment());
+
+		page = fragmentResource.getSiteFragmentsPage(
+			siteExternalReferenceCode, null, Pagination.of(1, 10));
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(fragment1, (List<Fragment>)page.getItems());
+		assertContains(fragment2, (List<Fragment>)page.getItems());
+		assertValid(
+			page,
+			testGetSiteFragmentsPage_getExpectedActions(
+				siteExternalReferenceCode));
+	}
+
+	protected Map<String, Map<String, String>>
+			testGetSiteFragmentsPage_getExpectedActions(
+				String siteExternalReferenceCode)
+		throws Exception {
+
+		Map<String, Map<String, String>> expectedActions = new HashMap<>();
+
+		Map createBatchAction = new HashMap<>();
+		createBatchAction.put("method", "POST");
+		createBatchAction.put(
+			"href",
+			("http://localhost:" + PortalUtil.getPortalServerPort(false) +
+				"/o/headless-admin-fragment/v1.0/sites/{siteExternalReferenceCode}/fragments/batch").
+					replace(
+						"{siteExternalReferenceCode}",
+						String.valueOf(siteExternalReferenceCode)));
+
+		expectedActions.put("createBatch", createBatchAction);
+
+		return expectedActions;
+	}
+
+	@Test
+	public void testGetSiteFragmentsPageWithFilterDateTimeEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DATE_TIME);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		String siteExternalReferenceCode =
+			testGetSiteFragmentsPage_getSiteExternalReferenceCode();
+
+		Fragment fragment1 = randomFragment();
+
+		fragment1 = testGetSiteFragmentsPage_addFragment(
+			siteExternalReferenceCode, fragment1);
+
+		for (EntityField entityField : entityFields) {
+			Page<Fragment> page = fragmentResource.getSiteFragmentsPage(
+				siteExternalReferenceCode,
+				getFilterString(entityField, "between", fragment1),
+				Pagination.of(1, 2));
+
+			assertEquals(
+				Collections.singletonList(fragment1),
+				(List<Fragment>)page.getItems());
+		}
+	}
+
+	@Test
+	public void testGetSiteFragmentsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		testGetSiteFragmentsPageWithFilter("eq", EntityField.Type.DOUBLE);
+	}
+
+	@Test
+	public void testGetSiteFragmentsPageWithFilterStringContains()
+		throws Exception {
+
+		testGetSiteFragmentsPageWithFilter("contains", EntityField.Type.STRING);
+	}
+
+	@Test
+	public void testGetSiteFragmentsPageWithFilterStringEquals()
+		throws Exception {
+
+		testGetSiteFragmentsPageWithFilter("eq", EntityField.Type.STRING);
+	}
+
+	@Test
+	public void testGetSiteFragmentsPageWithFilterStringStartsWith()
+		throws Exception {
+
+		testGetSiteFragmentsPageWithFilter(
+			"startswith", EntityField.Type.STRING);
+	}
+
+	protected void testGetSiteFragmentsPageWithFilter(
+			String operator, EntityField.Type type)
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(type);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		String siteExternalReferenceCode =
+			testGetSiteFragmentsPage_getSiteExternalReferenceCode();
+
+		Fragment fragment1 = testGetSiteFragmentsPage_addFragment(
+			siteExternalReferenceCode, randomFragment());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Fragment fragment2 = testGetSiteFragmentsPage_addFragment(
+			siteExternalReferenceCode, randomFragment());
+
+		for (EntityField entityField : entityFields) {
+			Page<Fragment> page = fragmentResource.getSiteFragmentsPage(
+				siteExternalReferenceCode,
+				getFilterString(entityField, operator, fragment1),
+				Pagination.of(1, 2));
+
+			assertEquals(
+				Collections.singletonList(fragment1),
+				(List<Fragment>)page.getItems());
+		}
+	}
+
+	@Test
+	public void testGetSiteFragmentsPageWithPagination() throws Exception {
+		String siteExternalReferenceCode =
+			testGetSiteFragmentsPage_getSiteExternalReferenceCode();
+
+		Page<Fragment> fragmentsPage = fragmentResource.getSiteFragmentsPage(
+			siteExternalReferenceCode, null, null);
+
+		int totalCount = GetterUtil.getInteger(fragmentsPage.getTotalCount());
+
+		Fragment fragment1 = testGetSiteFragmentsPage_addFragment(
+			siteExternalReferenceCode, randomFragment());
+
+		Fragment fragment2 = testGetSiteFragmentsPage_addFragment(
+			siteExternalReferenceCode, randomFragment());
+
+		Fragment fragment3 = testGetSiteFragmentsPage_addFragment(
+			siteExternalReferenceCode, randomFragment());
+
+		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
+
+		int pageSizeLimit = 500;
+
+		if (totalCount >= (pageSizeLimit - 2)) {
+			Page<Fragment> page1 = fragmentResource.getSiteFragmentsPage(
+				siteExternalReferenceCode, null,
+				Pagination.of(
+					(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
+					pageSizeLimit));
+
+			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
+
+			assertContains(fragment1, (List<Fragment>)page1.getItems());
+
+			Page<Fragment> page2 = fragmentResource.getSiteFragmentsPage(
+				siteExternalReferenceCode, null,
+				Pagination.of(
+					(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
+					pageSizeLimit));
+
+			assertContains(fragment2, (List<Fragment>)page2.getItems());
+
+			Page<Fragment> page3 = fragmentResource.getSiteFragmentsPage(
+				siteExternalReferenceCode, null,
+				Pagination.of(
+					(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
+					pageSizeLimit));
+
+			assertContains(fragment3, (List<Fragment>)page3.getItems());
+		}
+		else {
+			Page<Fragment> page1 = fragmentResource.getSiteFragmentsPage(
+				siteExternalReferenceCode, null,
+				Pagination.of(1, totalCount + 2));
+
+			List<Fragment> fragments1 = (List<Fragment>)page1.getItems();
+
+			Assert.assertEquals(
+				fragments1.toString(), totalCount + 2, fragments1.size());
+
+			Page<Fragment> page2 = fragmentResource.getSiteFragmentsPage(
+				siteExternalReferenceCode, null,
+				Pagination.of(2, totalCount + 2));
+
+			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+			List<Fragment> fragments2 = (List<Fragment>)page2.getItems();
+
+			Assert.assertEquals(fragments2.toString(), 1, fragments2.size());
+
+			Page<Fragment> page3 = fragmentResource.getSiteFragmentsPage(
+				siteExternalReferenceCode, null,
+				Pagination.of(1, (int)totalCount + 3));
+
+			assertContains(fragment1, (List<Fragment>)page3.getItems());
+			assertContains(fragment2, (List<Fragment>)page3.getItems());
+			assertContains(fragment3, (List<Fragment>)page3.getItems());
+		}
+	}
+
+	protected Fragment testGetSiteFragmentsPage_addFragment(
+			String siteExternalReferenceCode, Fragment fragment)
+		throws Exception {
+
+		return fragmentResource.postSiteFragment(
+			siteExternalReferenceCode, fragment);
+	}
+
+	protected String testGetSiteFragmentsPage_getSiteExternalReferenceCode()
+		throws Exception {
+
+		return testGroup.getExternalReferenceCode();
+	}
+
+	protected String
+			testGetSiteFragmentsPage_getIrrelevantSiteExternalReferenceCode()
+		throws Exception {
+
+		return irrelevantGroup.getExternalReferenceCode();
+	}
+
+	@Test
 	public void testPostSiteFragment() throws Exception {
 		Fragment randomFragment = randomFragment();
 
@@ -593,6 +858,9 @@ public abstract class BaseFragmentResourceTestCase {
 
 		return testGroup.getExternalReferenceCode();
 	}
+
+	@Rule
+	public SearchTestRule searchTestRule = new SearchTestRule();
 
 	protected void assertContains(Fragment fragment, List<Fragment> fragments) {
 		boolean contains = false;
@@ -1733,4 +2001,4 @@ public abstract class BaseFragmentResourceTestCase {
 		_fragmentResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:15180889
+// LIFERAY-REST-BUILDER-HASH:-1931625404

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
@@ -1007,30 +1007,34 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 	private void _testGetSiteFragmentSetFragmentsPageWithStatus()
 		throws Exception {
 
+		FragmentCollection fragmentCollection = _addFragmentCollection();
+
 		Fragment approvedAndDraftFragment = _postSiteFragmentSetFragment(
-			_randomFragment(true, true));
+			_randomFragment(true, true, fragmentCollection),
+			fragmentCollection.getExternalReferenceCode());
 		Fragment approvedFragment = _postSiteFragmentSetFragment(
-			_randomFragment(true, false));
+			_randomFragment(true, false, fragmentCollection),
+			fragmentCollection.getExternalReferenceCode());
 		Fragment draftFragment = _postSiteFragmentSetFragment(
-			_randomFragment(false, true));
+			_randomFragment(false, true, fragmentCollection),
+			fragmentCollection.getExternalReferenceCode());
 
 		FragmentCollection irrelevantFragmentCollection =
 			_addFragmentCollection();
 
-		Fragment irrelevantApprovedAndDraftFragment =
-			_postSiteFragmentSetFragment(
-				_randomFragment(true, true, irrelevantFragmentCollection),
-				irrelevantFragmentCollection.getExternalReferenceCode());
-		Fragment irrelevantApprovedFragment = _postSiteFragmentSetFragment(
+		_postSiteFragmentSetFragment(
+			_randomFragment(true, true, irrelevantFragmentCollection),
+			irrelevantFragmentCollection.getExternalReferenceCode());
+		_postSiteFragmentSetFragment(
 			_randomFragment(true, false, irrelevantFragmentCollection),
 			irrelevantFragmentCollection.getExternalReferenceCode());
-		Fragment irrelevantDraftFragment = _postSiteFragmentSetFragment(
+		_postSiteFragmentSetFragment(
 			_randomFragment(false, true, irrelevantFragmentCollection),
 			irrelevantFragmentCollection.getExternalReferenceCode());
 
 		Page<Fragment> page = fragmentResource.getSiteFragmentSetFragmentsPage(
 			testGroup.getExternalReferenceCode(),
-			_fragmentCollection.getExternalReferenceCode(),
+			fragmentCollection.getExternalReferenceCode(),
 			Pagination.of(1, 10));
 
 		List<Fragment> items = (List<Fragment>)page.getItems();
@@ -1038,9 +1042,7 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		assertContains(approvedAndDraftFragment, items);
 		assertContains(approvedFragment, items);
 		assertContains(draftFragment, items);
-		assertNotContains(irrelevantApprovedAndDraftFragment, items);
-		assertNotContains(irrelevantApprovedFragment, items);
-		assertNotContains(irrelevantDraftFragment, items);
+		Assert.assertEquals(items.toString(), 3, items.size());
 	}
 
 	private void _testGetSiteFragmentsPageWithFilter() throws Exception {

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
@@ -25,8 +25,11 @@ import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.io.StreamUtil;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
@@ -34,17 +37,25 @@ import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.test.util.IdempotentRetryAssert;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -67,6 +78,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.zip.ZipInputStream;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -134,6 +146,14 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		super.setUp();
 
 		_fragmentCollection = _addFragmentCollection();
+	}
+
+	@Override
+	@Test
+	public void testBatchEngineDeleteImportTask() throws Exception {
+		super.testBatchEngineDeleteImportTask();
+
+		_testBatchEngineDeleteImportTask();
 	}
 
 	@Override
@@ -232,6 +252,7 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 		_testPostSiteFragmentApproved();
 		_testPostSiteFragmentApprovedAndDraft();
+		_testPostSiteFragmentBatch();
 		_testPostSiteFragmentDraft();
 		_testPostSiteFragmentDuplicateKeyProblemException();
 		_testPostSiteFragmentEmpty();
@@ -273,6 +294,7 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 	@Override
 	@Test
 	public void testPutSiteFragment() throws Exception {
+		_testPutSiteFragmentBatch();
 		_testPutSiteFragmentCreateApproved();
 		_testPutSiteFragmentCreateApprovedAndDraft();
 		_testPutSiteFragmentCreateDraft();
@@ -479,6 +501,16 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 			false);
 	}
 
+	private void _assertFragmentEntry(Fragment fragment, Group group)
+		throws Exception {
+
+		FragmentEntry fragmentEntry =
+			_fragmentEntryLocalService.getFragmentEntryByExternalReferenceCode(
+				fragment.getExternalReferenceCode(), group.getGroupId());
+
+		Assert.assertEquals(fragment.getName(), fragmentEntry.getName());
+	}
+
 	private void _assertFragmentSet(
 		FragmentCollection expectedFragmentCollection,
 		FragmentSet fragmentSet) {
@@ -607,6 +639,38 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		String contentType = httpURLConnection.getContentType();
 
 		Assert.assertTrue(contentType.startsWith("image/"));
+	}
+
+	private String _exportFragmentsToJSON(String siteExternalReferenceCode)
+		throws Exception {
+
+		JSONObject exportTaskJSONObject = _waitForExportFinish(
+			"COMPLETED",
+			HTTPTestUtil.invokeToJSONObject(
+				null,
+				"headless-admin-fragment/v1.0/sites/" +
+					siteExternalReferenceCode +
+						"/fragments/export-batch?contentType=JSON",
+				Http.Method.POST));
+
+		try (InputStream inputStream = HTTPTestUtil.invokeToInputStream(
+				null,
+				StringBundler.concat(
+					"headless-batch-engine/v1.0/export-task",
+					"/by-external-reference-code/",
+					exportTaskJSONObject.getString("externalReferenceCode"),
+					"/content"),
+				HashMapBuilder.put(
+					HttpHeaders.ACCEPT, ContentTypes.APPLICATION_OCTET_STREAM
+				).build(),
+				Http.Method.GET)) {
+
+			ZipInputStream zipInputStream = new ZipInputStream(inputStream);
+
+			zipInputStream.getNextEntry();
+
+			return StringUtil.read(zipInputStream);
+		}
 	}
 
 	private FragmentResource _getFragmentResource(String nestedFields)
@@ -818,6 +882,39 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		fragmentSet.setName(RandomTestUtil.randomString());
 
 		return fragmentSet;
+	}
+
+	private void _testBatchEngineDeleteImportTask() throws Exception {
+		Fragment fragment1 = _postSiteFragmentSetFragment(randomFragment());
+		Fragment fragment2 = _postSiteFragmentSetFragment(randomFragment());
+
+		try (SafeCloseable safeCloseable =
+				LazyReferencingTestUtil.setLazyReferencingWithSafeCloseable(
+					true)) {
+
+			waitForFinish(
+				"COMPLETED",
+				HTTPTestUtil.invokeToJSONObject(
+					_exportFragmentsToJSON(
+						testGroup.getExternalReferenceCode()),
+					"headless-admin-fragment/v1.0/sites/" +
+						irrelevantGroup.getExternalReferenceCode() +
+							"/fragments/batch?createStrategy=INSERT",
+					Http.Method.POST));
+		}
+
+		testBatchEngineDeleteImportTask_deleteFragment(
+			200, fragment2.getExternalReferenceCode(),
+			"siteExternalReferenceCode",
+			irrelevantGroup.getExternalReferenceCode());
+
+		_assertFragmentEntry(fragment1, irrelevantGroup);
+
+		Assert.assertNull(
+			_fragmentEntryLocalService.
+				fetchFragmentEntryByExternalReferenceCode(
+					fragment2.getExternalReferenceCode(),
+					irrelevantGroup.getGroupId()));
 	}
 
 	private void _testGetSiteFragment(boolean approved, boolean draft)
@@ -1053,6 +1150,101 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 	private void _testPostSiteFragmentApprovedAndDraft() throws Exception {
 		_testPostFragmentApprovedAndDraft(this::_postSiteFragment);
+	}
+
+	private void _testPostSiteFragmentBatch() throws Exception {
+		Fragment fragment1 = _postSiteFragmentSetFragment(randomFragment());
+		Fragment fragment2 = _postSiteFragmentSetFragment(randomFragment());
+
+		String json = _exportFragmentsToJSON(
+			testGroup.getExternalReferenceCode());
+
+		Assert.assertNull(
+			_fragmentCollectionLocalService.
+				fetchFragmentCollectionByExternalReferenceCode(
+					_fragmentCollection.getExternalReferenceCode(),
+					irrelevantGroup.getGroupId()));
+		Assert.assertNull(
+			_fragmentEntryLocalService.
+				fetchFragmentEntryByExternalReferenceCode(
+					fragment1.getExternalReferenceCode(),
+					irrelevantGroup.getGroupId()));
+		Assert.assertNull(
+			_fragmentEntryLocalService.
+				fetchFragmentEntryByExternalReferenceCode(
+					fragment2.getExternalReferenceCode(),
+					irrelevantGroup.getGroupId()));
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.batch.engine.internal." +
+					"BatchEngineImportTaskExecutorImpl",
+				LoggerTestUtil.ERROR)) {
+
+			waitForFinish(
+				"FAILED",
+				HTTPTestUtil.invokeToJSONObject(
+					json,
+					"headless-admin-fragment/v1.0/sites/" +
+						irrelevantGroup.getExternalReferenceCode() +
+							"/fragments/batch?createStrategy=INSERT",
+					Http.Method.POST));
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertFalse(logEntries.toString(), logEntries.isEmpty());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Throwable throwable = logEntry.getThrowable();
+
+			Assert.assertTrue(
+				String.valueOf(throwable),
+				throwable instanceof IllegalArgumentException);
+			Assert.assertEquals(
+				_language.format(
+					LocaleUtil.getDefault(),
+					"no-fragment-set-was-found-with-external-reference-code-x",
+					_fragmentCollection.getExternalReferenceCode()),
+				throwable.getMessage());
+		}
+
+		Assert.assertNull(
+			_fragmentCollectionLocalService.
+				fetchFragmentCollectionByExternalReferenceCode(
+					_fragmentCollection.getExternalReferenceCode(),
+					irrelevantGroup.getGroupId()));
+		Assert.assertNull(
+			_fragmentEntryLocalService.
+				fetchFragmentEntryByExternalReferenceCode(
+					fragment1.getExternalReferenceCode(),
+					irrelevantGroup.getGroupId()));
+		Assert.assertNull(
+			_fragmentEntryLocalService.
+				fetchFragmentEntryByExternalReferenceCode(
+					fragment2.getExternalReferenceCode(),
+					irrelevantGroup.getGroupId()));
+
+		try (SafeCloseable safeCloseable =
+				LazyReferencingTestUtil.setLazyReferencingWithSafeCloseable(
+					true)) {
+
+			waitForFinish(
+				"COMPLETED",
+				HTTPTestUtil.invokeToJSONObject(
+					json,
+					"headless-admin-fragment/v1.0/sites/" +
+						irrelevantGroup.getExternalReferenceCode() +
+							"/fragments/batch?createStrategy=INSERT",
+					Http.Method.POST));
+		}
+
+		Assert.assertNotNull(
+			_fragmentCollectionLocalService.
+				fetchFragmentCollectionByExternalReferenceCode(
+					_fragmentCollection.getExternalReferenceCode(),
+					irrelevantGroup.getGroupId()));
+		_assertFragmentEntry(fragment1, irrelevantGroup);
+		_assertFragmentEntry(fragment2, irrelevantGroup);
 	}
 
 	private void _testPostSiteFragmentDraft() throws Exception {
@@ -1436,6 +1628,57 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 		assertEquals(fragment, getFragment);
 		assertValid(getFragment);
+	}
+
+	private void _testPutSiteFragmentBatch() throws Exception {
+		Fragment fragment1 = _postSiteFragmentSetFragment(randomFragment());
+		Fragment fragment2 = _postSiteFragmentSetFragment(randomFragment());
+
+		try (SafeCloseable safeCloseable =
+				LazyReferencingTestUtil.setLazyReferencingWithSafeCloseable(
+					true)) {
+
+			waitForFinish(
+				"COMPLETED",
+				HTTPTestUtil.invokeToJSONObject(
+					_exportFragmentsToJSON(
+						testGroup.getExternalReferenceCode()),
+					"headless-admin-fragment/v1.0/sites/" +
+						irrelevantGroup.getExternalReferenceCode() +
+							"/fragments/batch?createStrategy=INSERT",
+					Http.Method.POST));
+		}
+
+		Fragment putFragment = fragmentResource.putSiteFragment(
+			testGroup.getExternalReferenceCode(),
+			fragment2.getExternalReferenceCode(),
+			_randomFragment(
+				true, true, fragment2.getExternalReferenceCode(), null));
+
+		try (SafeCloseable safeCloseable =
+				LazyReferencingTestUtil.setLazyReferencingWithSafeCloseable(
+					true)) {
+
+			waitForFinish(
+				"COMPLETED",
+				HTTPTestUtil.invokeToJSONObject(
+					_exportFragmentsToJSON(
+						testGroup.getExternalReferenceCode()),
+					"headless-admin-fragment/v1.0/sites/" +
+						irrelevantGroup.getExternalReferenceCode() +
+							"/fragments/batch?createStrategy=UPSERT",
+					Http.Method.POST));
+		}
+
+		_assertFragmentEntry(fragment1, irrelevantGroup);
+
+		FragmentEntry fragmentEntry =
+			_fragmentEntryLocalService.
+				fetchFragmentEntryByExternalReferenceCode(
+					putFragment.getExternalReferenceCode(),
+					irrelevantGroup.getGroupId());
+
+		Assert.assertEquals(putFragment.getName(), fragmentEntry.getName());
 	}
 
 	private void _testPutSiteFragmentCreateApproved() throws Exception {
@@ -2032,6 +2275,47 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 			}
 		};
 	}
+
+	private JSONObject _waitForExportFinish(
+			String expectedExecuteStatus, JSONObject jsonObject)
+		throws Exception {
+
+		String externalReferenceCode = jsonObject.getString(
+			"externalReferenceCode");
+
+		long time = System.currentTimeMillis() + _EXPORT_TIMEOUT;
+
+		while (true) {
+			jsonObject = HTTPTestUtil.invokeToJSONObject(
+				null,
+				"headless-batch-engine/v1.0/export-task" +
+					"/by-external-reference-code/" + externalReferenceCode,
+				Http.Method.GET);
+
+			String executeStatus = jsonObject.getString("executeStatus");
+
+			if (StringUtil.equals(executeStatus, "COMPLETED") ||
+				StringUtil.equals(executeStatus, "FAILED")) {
+
+				Assert.assertEquals(expectedExecuteStatus, executeStatus);
+
+				return jsonObject;
+			}
+
+			if (System.currentTimeMillis() > time) {
+				throw new AssertionError(
+					StringBundler.concat(
+						"Export task ", externalReferenceCode,
+						" did not finish within ", _EXPORT_TIMEOUT, " ms"));
+			}
+
+			Thread.sleep(_EXPORT_POLL_INTERVAL);
+		}
+	}
+
+	private static final long _EXPORT_POLL_INTERVAL = 500;
+
+	private static final long _EXPORT_TIMEOUT = 60000;
 
 	private static HttpServer _httpServer;
 	private static String _thumbnail1Base64;

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -52,6 +53,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.search.test.util.IdempotentRetryAssert;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
@@ -74,6 +76,8 @@ import java.net.InetSocketAddress;
 import java.net.URL;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -328,6 +332,7 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 					}
 				}
 			});
+		fragment.setMarketplace(false);
 
 		return fragment;
 	}
@@ -450,6 +455,41 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 			clazz.getResourceAsStream("dependencies/" + fileName),
 			RandomTestUtil.randomString() + ".png", ContentTypes.IMAGE_PNG,
 			false);
+	}
+
+	private void _assertExportImportFragments(
+			List<Fragment> expectedFragments, String filterString,
+			List<Fragment> notExpectedFragments)
+		throws Exception {
+
+		Group group = GroupTestUtil.addGroup();
+
+		try (SafeCloseable safeCloseable =
+				LazyReferencingTestUtil.setLazyReferencingWithSafeCloseable(
+					true)) {
+
+			waitForFinish(
+				"COMPLETED",
+				HTTPTestUtil.invokeToJSONObject(
+					_exportFragmentsToJSON(
+						filterString, testGroup.getExternalReferenceCode()),
+					"headless-admin-fragment/v1.0/sites/" +
+						group.getExternalReferenceCode() +
+							"/fragments/batch?createStrategy=INSERT",
+					Http.Method.POST));
+		}
+
+		for (Fragment fragment : expectedFragments) {
+			_assertFragmentEntry(fragment, group);
+		}
+
+		for (Fragment fragment : notExpectedFragments) {
+			Assert.assertNull(
+				_fragmentEntryLocalService.
+					fetchFragmentEntryByExternalReferenceCode(
+						fragment.getExternalReferenceCode(),
+						group.getGroupId()));
+		}
 	}
 
 	private void _assertFragmentEntry(Fragment fragment, Group group)
@@ -595,14 +635,25 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 	private String _exportFragmentsToJSON(String siteExternalReferenceCode)
 		throws Exception {
 
+		return _exportFragmentsToJSON(null, siteExternalReferenceCode);
+	}
+
+	private String _exportFragmentsToJSON(
+			String filterString, String siteExternalReferenceCode)
+		throws Exception {
+
+		String endpoint = StringBundler.concat(
+			"headless-admin-fragment/v1.0/sites/", siteExternalReferenceCode,
+			"/fragments/export-batch?contentType=JSON");
+
+		if (filterString != null) {
+			endpoint = StringBundler.concat(
+				endpoint, "&filter=", URLCodec.encodeURL(filterString));
+		}
+
 		JSONObject exportTaskJSONObject = _waitForExportFinish(
 			"COMPLETED",
-			HTTPTestUtil.invokeToJSONObject(
-				null,
-				"headless-admin-fragment/v1.0/sites/" +
-					siteExternalReferenceCode +
-						"/fragments/export-batch?contentType=JSON",
-				Http.Method.POST));
+			HTTPTestUtil.invokeToJSONObject(null, endpoint, Http.Method.POST));
 
 		try (InputStream inputStream = HTTPTestUtil.invokeToInputStream(
 				null,
@@ -835,6 +886,14 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		return fragmentSet;
 	}
 
+	private Fragment _randomMarketPlaceFragment() throws Exception {
+		Fragment fragment = randomFragment();
+
+		fragment.setMarketplace(true);
+
+		return fragment;
+	}
+
 	private void _testBatchEngineDeleteImportTask() throws Exception {
 		Fragment fragment1 = _postSiteFragmentSetFragment(randomFragment());
 		Fragment fragment2 = _postSiteFragmentSetFragment(randomFragment());
@@ -985,16 +1044,12 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 	}
 
 	private void _testGetSiteFragmentsPageWithFilter() throws Exception {
-		Fragment marketplaceFragment = randomFragment();
-
-		marketplaceFragment.setMarketplace(true);
+		Fragment marketplaceFragment = _randomMarketPlaceFragment();
 
 		marketplaceFragment = testGetSiteFragmentsPage_addFragment(
 			testGroup.getExternalReferenceCode(), marketplaceFragment);
 
 		Fragment nonmarketplaceFragment = randomFragment();
-
-		nonmarketplaceFragment.setMarketplace(false);
 
 		nonmarketplaceFragment = testGetSiteFragmentsPage_addFragment(
 			testGroup.getExternalReferenceCode(), nonmarketplaceFragment);
@@ -1177,11 +1232,15 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 	}
 
 	private void _testPostSiteFragmentBatch() throws Exception {
+		_testPostSiteFragmentBatchWithLazyReferencingDisabled();
+		_testPostSiteFragmentBatchWithLazyReferencingEnabled();
+	}
+
+	private void _testPostSiteFragmentBatchWithLazyReferencingDisabled()
+		throws Exception {
+
 		Fragment fragment1 = _postSiteFragmentSetFragment(randomFragment());
 		Fragment fragment2 = _postSiteFragmentSetFragment(randomFragment());
-
-		String json = _exportFragmentsToJSON(
-			testGroup.getExternalReferenceCode());
 
 		Assert.assertNull(
 			_fragmentCollectionLocalService.
@@ -1207,7 +1266,8 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 			waitForFinish(
 				"FAILED",
 				HTTPTestUtil.invokeToJSONObject(
-					json,
+					_exportFragmentsToJSON(
+						testGroup.getExternalReferenceCode()),
 					"headless-admin-fragment/v1.0/sites/" +
 						irrelevantGroup.getExternalReferenceCode() +
 							"/fragments/batch?createStrategy=INSERT",
@@ -1247,28 +1307,31 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 				fetchFragmentEntryByExternalReferenceCode(
 					fragment2.getExternalReferenceCode(),
 					irrelevantGroup.getGroupId()));
+	}
 
-		try (SafeCloseable safeCloseable =
-				LazyReferencingTestUtil.setLazyReferencingWithSafeCloseable(
-					true)) {
+	private void _testPostSiteFragmentBatchWithLazyReferencingEnabled()
+		throws Exception {
 
-			waitForFinish(
-				"COMPLETED",
-				HTTPTestUtil.invokeToJSONObject(
-					json,
-					"headless-admin-fragment/v1.0/sites/" +
-						irrelevantGroup.getExternalReferenceCode() +
-							"/fragments/batch?createStrategy=INSERT",
-					Http.Method.POST));
-		}
+		Fragment marketplaceFragment = _randomMarketPlaceFragment();
 
-		Assert.assertNotNull(
-			_fragmentCollectionLocalService.
-				fetchFragmentCollectionByExternalReferenceCode(
-					_fragmentCollection.getExternalReferenceCode(),
-					irrelevantGroup.getGroupId()));
-		_assertFragmentEntry(fragment1, irrelevantGroup);
-		_assertFragmentEntry(fragment2, irrelevantGroup);
+		marketplaceFragment = _postSiteFragmentSetFragment(marketplaceFragment);
+
+		Fragment nonmarketplaceFragment = randomFragment();
+
+		nonmarketplaceFragment = _postSiteFragmentSetFragment(
+			nonmarketplaceFragment);
+
+		_assertExportImportFragments(
+			Arrays.asList(marketplaceFragment, nonmarketplaceFragment), null,
+			Collections.emptyList());
+		_assertExportImportFragments(
+			Collections.singletonList(marketplaceFragment),
+			"marketplace eq true",
+			Collections.singletonList(nonmarketplaceFragment));
+		_assertExportImportFragments(
+			Collections.singletonList(nonmarketplaceFragment),
+			"marketplace eq false",
+			Collections.singletonList(marketplaceFragment));
 	}
 
 	private void _testPostSiteFragmentDraft() throws Exception {

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
@@ -198,42 +198,8 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 	public void testGetSiteFragmentSetFragmentsPage() throws Exception {
 		super.testGetSiteFragmentSetFragmentsPage();
 
-		Fragment approvedAndDraftFragment = _postSiteFragmentSetFragment(
-			_randomFragment(true, true));
-		Fragment approvedFragment = _postSiteFragmentSetFragment(
-			_randomFragment(true, false));
-		Fragment draftFragment = _postSiteFragmentSetFragment(
-			_randomFragment(false, true));
-
-		FragmentCollection irrelevantFragmentCollection =
-			_addFragmentCollection();
-
-		Fragment irrelevantApprovedAndDraftFragment =
-			_postSiteFragmentSetFragment(
-				_randomFragment(true, true, irrelevantFragmentCollection),
-				irrelevantFragmentCollection.getExternalReferenceCode());
-		Fragment irrelevantApprovedFragment = _postSiteFragmentSetFragment(
-			_randomFragment(true, false, irrelevantFragmentCollection),
-			irrelevantFragmentCollection.getExternalReferenceCode());
-		Fragment irrelevantDraftFragment = _postSiteFragmentSetFragment(
-			_randomFragment(false, true, irrelevantFragmentCollection),
-			irrelevantFragmentCollection.getExternalReferenceCode());
-
-		Page<Fragment> page = fragmentResource.getSiteFragmentSetFragmentsPage(
-			testGroup.getExternalReferenceCode(),
-			_fragmentCollection.getExternalReferenceCode(),
-			Pagination.of(1, 10));
-
-		List<Fragment> items = (List<Fragment>)page.getItems();
-
-		assertContains(approvedAndDraftFragment, items);
-		assertContains(approvedFragment, items);
-		assertContains(draftFragment, items);
-		assertNotContains(irrelevantApprovedAndDraftFragment, items);
-		assertNotContains(irrelevantApprovedFragment, items);
-		assertNotContains(irrelevantDraftFragment, items);
-
 		_testGetSiteFragmentSetFragmentsPageWithNonexistentFragmentSet();
+		_testGetSiteFragmentSetFragmentsPageWithStatus();
 	}
 
 	@Override
@@ -958,6 +924,45 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 			Assert.assertEquals("NOT_FOUND", problem.getStatus());
 		}
+	}
+
+	private void _testGetSiteFragmentSetFragmentsPageWithStatus()
+		throws Exception {
+
+		Fragment approvedAndDraftFragment = _postSiteFragmentSetFragment(
+			_randomFragment(true, true));
+		Fragment approvedFragment = _postSiteFragmentSetFragment(
+			_randomFragment(true, false));
+		Fragment draftFragment = _postSiteFragmentSetFragment(
+			_randomFragment(false, true));
+
+		FragmentCollection irrelevantFragmentCollection =
+			_addFragmentCollection();
+
+		Fragment irrelevantApprovedAndDraftFragment =
+			_postSiteFragmentSetFragment(
+				_randomFragment(true, true, irrelevantFragmentCollection),
+				irrelevantFragmentCollection.getExternalReferenceCode());
+		Fragment irrelevantApprovedFragment = _postSiteFragmentSetFragment(
+			_randomFragment(true, false, irrelevantFragmentCollection),
+			irrelevantFragmentCollection.getExternalReferenceCode());
+		Fragment irrelevantDraftFragment = _postSiteFragmentSetFragment(
+			_randomFragment(false, true, irrelevantFragmentCollection),
+			irrelevantFragmentCollection.getExternalReferenceCode());
+
+		Page<Fragment> page = fragmentResource.getSiteFragmentSetFragmentsPage(
+			testGroup.getExternalReferenceCode(),
+			_fragmentCollection.getExternalReferenceCode(),
+			Pagination.of(1, 10));
+
+		List<Fragment> items = (List<Fragment>)page.getItems();
+
+		assertContains(approvedAndDraftFragment, items);
+		assertContains(approvedFragment, items);
+		assertContains(draftFragment, items);
+		assertNotContains(irrelevantApprovedAndDraftFragment, items);
+		assertNotContains(irrelevantApprovedFragment, items);
+		assertNotContains(irrelevantDraftFragment, items);
 	}
 
 	private void _testGetSiteFragmentsPageWithFilter() throws Exception {

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
@@ -690,8 +690,8 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 				endpoint, "&filter=", URLCodec.encodeURL(filterString));
 		}
 
-		JSONObject exportTaskJSONObject = _waitForExportFinish(
-			"COMPLETED",
+		JSONObject exportTaskJSONObject = _waitForFinish(
+			"COMPLETED", false,
 			HTTPTestUtil.invokeToJSONObject(null, endpoint, Http.Method.POST));
 
 		try (InputStream inputStream = HTTPTestUtil.invokeToInputStream(
@@ -2451,20 +2451,19 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		};
 	}
 
-	private JSONObject _waitForExportFinish(
-			String expectedExecuteStatus, JSONObject jsonObject)
+	private JSONObject _waitForFinish(
+			String expectedExecuteStatus, boolean importTask,
+			JSONObject jsonObject)
 		throws Exception {
 
-		String externalReferenceCode = jsonObject.getString(
-			"externalReferenceCode");
-
-		long time = System.currentTimeMillis() + _EXPORT_TIMEOUT;
+		String endpoint = StringBundler.concat(
+			"headless-batch-engine/v1.0/",
+			importTask ? "import-task" : "export-task",
+			"/by-external-reference-code/");
 
 		while (true) {
 			jsonObject = HTTPTestUtil.invokeToJSONObject(
-				null,
-				"headless-batch-engine/v1.0/export-task" +
-					"/by-external-reference-code/" + externalReferenceCode,
+				null, endpoint + jsonObject.getString("externalReferenceCode"),
 				Http.Method.GET);
 
 			String executeStatus = jsonObject.getString("executeStatus");
@@ -2476,21 +2475,8 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 				return jsonObject;
 			}
-
-			if (System.currentTimeMillis() > time) {
-				throw new AssertionError(
-					StringBundler.concat(
-						"Export task ", externalReferenceCode,
-						" did not finish within ", _EXPORT_TIMEOUT, " ms"));
-			}
-
-			Thread.sleep(_EXPORT_POLL_INTERVAL);
 		}
 	}
-
-	private static final long _EXPORT_POLL_INTERVAL = 500;
-
-	private static final long _EXPORT_TIMEOUT = 60000;
 
 	private static HttpServer _httpServer;
 	private static String _thumbnail1Base64;

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
@@ -925,7 +925,7 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		return fragmentSet;
 	}
 
-	private Fragment _randomMarketPlaceFragment() throws Exception {
+	private Fragment _randomMarketplaceFragment() throws Exception {
 		Fragment fragment = randomFragment();
 
 		fragment.setMarketplace(true);
@@ -1085,7 +1085,7 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 	}
 
 	private void _testGetSiteFragmentsPageWithFilter() throws Exception {
-		Fragment marketplaceFragment = _randomMarketPlaceFragment();
+		Fragment marketplaceFragment = _randomMarketplaceFragment();
 
 		marketplaceFragment = testGetSiteFragmentsPage_addFragment(
 			testGroup.getExternalReferenceCode(), marketplaceFragment);
@@ -1353,7 +1353,7 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 	private void _testPostSiteFragmentBatchWithLazyReferencingEnabled()
 		throws Exception {
 
-		Fragment marketplaceFragment = _randomMarketPlaceFragment();
+		Fragment marketplaceFragment = _randomMarketplaceFragment();
 
 		marketplaceFragment = _postSiteFragmentSetFragment(marketplaceFragment);
 
@@ -1474,7 +1474,7 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 	}
 
 	private void _testPostSiteFragmentMarketplace() throws Exception {
-		Fragment fragment = _randomMarketPlaceFragment();
+		Fragment fragment = _randomMarketplaceFragment();
 
 		Fragment postFragment = _postSiteFragmentSetFragment(fragment);
 

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
@@ -283,22 +283,6 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		_testPutSiteFragmentUpdateThumbnailURLReferenceURL();
 	}
 
-	protected void assertNotContains(
-		Fragment fragment, List<Fragment> fragments) {
-
-		boolean contains = false;
-
-		for (Fragment curFragment : fragments) {
-			if (equals(fragment, curFragment)) {
-				contains = true;
-
-				break;
-			}
-		}
-
-		Assert.assertFalse(fragments + " contains " + fragment, contains);
-	}
-
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
 		return new String[] {
@@ -578,7 +562,23 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		List<Fragment> fragments = (List<Fragment>)page.getItems();
 
 		assertContains(expectedFragment, fragments);
-		assertNotContains(notExpectedFragment, fragments);
+		_assertNotContains(notExpectedFragment, fragments);
+	}
+
+	private void _assertNotContains(
+		Fragment fragment, List<Fragment> fragments) {
+
+		boolean contains = false;
+
+		for (Fragment curFragment : fragments) {
+			if (equals(fragment, curFragment)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertFalse(fragments + " contains " + fragment, contains);
 	}
 
 	private void _assertProblemException(

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
@@ -164,6 +164,7 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		_testDeleteSiteFragment(false, true);
 		_testDeleteSiteFragment(true, false);
 		_testDeleteSiteFragment(true, true);
+		_testDeleteSiteFragmentNonexistent();
 	}
 
 	@Override
@@ -891,6 +892,14 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 			_fragmentEntryLocalService.getVersions(fragmentEntry);
 
 		Assert.assertTrue(fragmentEntryVersions.isEmpty());
+	}
+
+	private void _testDeleteSiteFragmentNonexistent() throws Exception {
+		assertHttpResponseStatusCode(
+			404,
+			fragmentResource.deleteSiteFragmentHttpResponse(
+				testGroup.getExternalReferenceCode(),
+				RandomTestUtil.randomString()));
 	}
 
 	private void _testGetSiteFragment(boolean approved, boolean draft)

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
@@ -63,7 +63,9 @@ import java.net.InetSocketAddress;
 import java.net.URL;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.AfterClass;
@@ -197,6 +199,15 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 	@Override
 	@Test
+	public void testGetSiteFragmentsPage() throws Exception {
+		super.testGetSiteFragmentsPage();
+
+		_testGetSiteFragmentsPageWithFilter();
+		_testGetSiteFragmentsPageWithFragmentSets();
+	}
+
+	@Override
+	@Test
 	public void testPostSiteFragment() throws Exception {
 		super.testPostSiteFragment();
 
@@ -275,6 +286,22 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		_testPutSiteFragmentUpdateThumbnailURLReferenceURL();
 	}
 
+	protected void assertNotContains(
+		Fragment fragment, List<Fragment> fragments) {
+
+		boolean contains = false;
+
+		for (Fragment curFragment : fragments) {
+			if (equals(fragment, curFragment)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertFalse(fragments + " contains " + fragment, contains);
+	}
+
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
 		return new String[] {
@@ -338,6 +365,28 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		throws Exception {
 
 		return _fragmentCollection.getExternalReferenceCode();
+	}
+
+	@Override
+	protected Fragment testGetSiteFragmentsPage_addFragment(
+			String siteExternalReferenceCode, Fragment fragment)
+		throws Exception {
+
+		try (SafeCloseable safeCloseable =
+				LazyReferencingTestUtil.setLazyReferencingWithSafeCloseable(
+					true)) {
+
+			return fragmentResource.postSiteFragment(
+				siteExternalReferenceCode, fragment);
+		}
+	}
+
+	@Override
+	protected Map<String, Map<String, String>>
+		testGetSiteFragmentsPage_getExpectedActions(
+			String siteExternalReferenceCode) {
+
+		return new HashMap<>();
 	}
 
 	@Override
@@ -435,6 +484,20 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 			fragmentSet.getExternalReferenceCode());
 		Assert.assertEquals(
 			expectedFragmentSet.getName(), fragmentSet.getName());
+	}
+
+	private void _assertGetSiteFragmentsPageWithFilter(
+			Fragment expectedFragment, String filterString,
+			Fragment notExpectedFragment)
+		throws Exception {
+
+		Page<Fragment> page = fragmentResource.getSiteFragmentsPage(
+			testGroup.getExternalReferenceCode(), filterString, null);
+
+		List<Fragment> fragments = (List<Fragment>)page.getItems();
+
+		assertContains(expectedFragment, fragments);
+		assertNotContains(notExpectedFragment, fragments);
 	}
 
 	private void _assertProblemException(
@@ -606,9 +669,17 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 	private Fragment _postSiteFragmentSetFragment(Fragment fragment)
 		throws Exception {
 
+		return _postSiteFragmentSetFragment(
+			fragment, _fragmentCollection.getExternalReferenceCode());
+	}
+
+	private Fragment _postSiteFragmentSetFragment(
+			Fragment fragment, String fragmentSetExternalReferenceCode)
+		throws Exception {
+
 		return fragmentResource.postSiteFragmentSetFragment(
 			testGroup.getExternalReferenceCode(),
-			_fragmentCollection.getExternalReferenceCode(), fragment);
+			fragmentSetExternalReferenceCode, fragment);
 	}
 
 	private Fragment _putSiteFragment(
@@ -655,8 +726,16 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 	}
 
 	private Fragment _randomFragment(
+			boolean approved, boolean draft,
+			FragmentCollection fragmentCollection)
+		throws Exception {
+
+		return _randomFragment(approved, draft, null, fragmentCollection, null);
+	}
+
+	private Fragment _randomFragment(
 			boolean approved, boolean draft, String externalReferenceCode,
-			String key)
+			FragmentCollection fragmentCollection, String key)
 		throws Exception {
 
 		Fragment fragment = super.randomFragment();
@@ -690,7 +769,7 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		}
 
 		fragment.setExternalReferenceCode(externalReferenceCode);
-		fragment.setFragmentSet(_toFragmentSet(_fragmentCollection));
+		fragment.setFragmentSet(_toFragmentSet(fragmentCollection));
 		fragment.setFragmentVersions(
 			fragmentVersions.toArray(new FragmentVersion[0]));
 
@@ -701,6 +780,15 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		fragment.setMarketplace(false);
 
 		return fragment;
+	}
+
+	private Fragment _randomFragment(
+			boolean approved, boolean draft, String externalReferenceCode,
+			String key)
+		throws Exception {
+
+		return _randomFragment(
+			approved, draft, externalReferenceCode, _fragmentCollection, key);
 	}
 
 	private FragmentSet _randomFragmentSet(String externalReferenceCode) {
@@ -737,6 +825,66 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 	private void _testGetSiteFragmentDraft() throws Exception {
 		_testGetSiteFragment(false, true);
+	}
+
+	private void _testGetSiteFragmentsPageWithFilter() throws Exception {
+		Fragment marketplaceFragment = randomFragment();
+
+		marketplaceFragment.setMarketplace(true);
+
+		marketplaceFragment = testGetSiteFragmentsPage_addFragment(
+			testGroup.getExternalReferenceCode(), marketplaceFragment);
+
+		Fragment nonmarketplaceFragment = randomFragment();
+
+		nonmarketplaceFragment.setMarketplace(false);
+
+		nonmarketplaceFragment = testGetSiteFragmentsPage_addFragment(
+			testGroup.getExternalReferenceCode(), nonmarketplaceFragment);
+
+		_assertGetSiteFragmentsPageWithFilter(
+			marketplaceFragment, "marketplace eq true", nonmarketplaceFragment);
+		_assertGetSiteFragmentsPageWithFilter(
+			nonmarketplaceFragment, "marketplace eq false",
+			marketplaceFragment);
+	}
+
+	private void _testGetSiteFragmentsPageWithFragmentSets() throws Exception {
+		FragmentCollection fragmentCollection1 = _addFragmentCollection();
+
+		Fragment approvedAndDraftFragment1 = _postSiteFragmentSetFragment(
+			_randomFragment(true, true, fragmentCollection1),
+			fragmentCollection1.getExternalReferenceCode());
+		Fragment approvedFragment1 = _postSiteFragmentSetFragment(
+			_randomFragment(true, false, fragmentCollection1),
+			fragmentCollection1.getExternalReferenceCode());
+		Fragment draftFragment1 = _postSiteFragmentSetFragment(
+			_randomFragment(false, true, fragmentCollection1),
+			fragmentCollection1.getExternalReferenceCode());
+
+		FragmentCollection fragmentCollection2 = _addFragmentCollection();
+
+		Fragment approvedAndDraftFragment2 = _postSiteFragmentSetFragment(
+			_randomFragment(true, true, fragmentCollection2),
+			fragmentCollection2.getExternalReferenceCode());
+		Fragment approvedFragment2 = _postSiteFragmentSetFragment(
+			_randomFragment(true, false, fragmentCollection2),
+			fragmentCollection2.getExternalReferenceCode());
+		Fragment draftFragment2 = _postSiteFragmentSetFragment(
+			_randomFragment(false, true, fragmentCollection2),
+			fragmentCollection2.getExternalReferenceCode());
+
+		Page<Fragment> page = fragmentResource.getSiteFragmentsPage(
+			testGroup.getExternalReferenceCode(), null, null);
+
+		List<Fragment> items = (List<Fragment>)page.getItems();
+
+		assertContains(approvedAndDraftFragment1, items);
+		assertContains(approvedAndDraftFragment2, items);
+		assertContains(approvedFragment1, items);
+		assertContains(approvedFragment2, items);
+		assertContains(draftFragment1, items);
+		assertContains(draftFragment2, items);
 	}
 
 	private void _testGetSiteFragmentThumbnailURLReference() throws Exception {

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
@@ -216,6 +216,7 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		_testPostSiteFragmentFragmentSetNonexisting();
 		_testPostSiteFragmentFragmentSetNonexistingProblemException();
 		_testPostSiteFragmentFragmentSetNullProblemException();
+		_testPostSiteFragmentMarketplace();
 		_testPostSiteFragmentThumbnailURLReferenceExternalReferenceCode();
 		_testPostSiteFragmentThumbnailURLReferenceExternalReferenceCodeAndFileBase64();
 		_testPostSiteFragmentThumbnailURLReferenceExternalReferenceCodeEmptyAndFileBase64();
@@ -489,6 +490,44 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 					fetchFragmentEntryByExternalReferenceCode(
 						fragment.getExternalReferenceCode(),
 						group.getGroupId()));
+		}
+	}
+
+	private void _assertExportImportFragmentsFails(String filterString)
+		throws Exception {
+
+		Group group = GroupTestUtil.addGroup();
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.batch.engine.internal." +
+					"BatchEngineImportTaskExecutorImpl",
+				LoggerTestUtil.ERROR);
+			SafeCloseable safeCloseable =
+				LazyReferencingTestUtil.setLazyReferencingWithSafeCloseable(
+					true)) {
+
+			waitForFinish(
+				"FAILED",
+				HTTPTestUtil.invokeToJSONObject(
+					_exportFragmentsToJSON(
+						filterString, testGroup.getExternalReferenceCode()),
+					"headless-admin-fragment/v1.0/sites/" +
+						group.getExternalReferenceCode() +
+							"/fragments/batch?createStrategy=INSERT",
+					Http.Method.POST));
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertFalse(logEntries.toString(), logEntries.isEmpty());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Throwable throwable = logEntry.getThrowable();
+
+			Assert.assertEquals(
+				_language.get(
+					LocaleUtil.getDefault(), "html-content-must-not-be-empty"),
+				throwable.getMessage());
 		}
 	}
 
@@ -1324,16 +1363,12 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 			nonmarketplaceFragment);
 
 		_assertExportImportFragments(
-			Arrays.asList(marketplaceFragment, nonmarketplaceFragment), null,
-			Collections.emptyList());
-		_assertExportImportFragments(
-			Collections.singletonList(marketplaceFragment),
-			"marketplace eq true",
-			Collections.singletonList(nonmarketplaceFragment));
-		_assertExportImportFragments(
 			Collections.singletonList(nonmarketplaceFragment),
 			"marketplace eq false",
 			Collections.singletonList(marketplaceFragment));
+
+		_assertExportImportFragmentsFails(null);
+		_assertExportImportFragmentsFails("marketplace eq true");
 	}
 
 	private void _testPostSiteFragmentDraft() throws Exception {
@@ -1436,6 +1471,57 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 			"a-fragment-set-external-reference-code-is-required-to-create-a-" +
 				"new-fragment",
 			() -> _postSiteFragment(fragment));
+	}
+
+	private void _testPostSiteFragmentMarketplace() throws Exception {
+		Fragment fragment = _randomMarketPlaceFragment();
+
+		Fragment postFragment = _postSiteFragmentSetFragment(fragment);
+
+		FragmentEntry fragmentEntry =
+			_fragmentEntryLocalService.getFragmentEntryByExternalReferenceCode(
+				postFragment.getExternalReferenceCode(),
+				testGroup.getGroupId());
+
+		FragmentEntry draftFragmentEntry =
+			_fragmentEntryLocalService.fetchDraft(
+				fragmentEntry.getFragmentEntryId());
+
+		FragmentVersion[] fragmentVersions = fragment.getFragmentVersions();
+
+		FragmentVersion[] postFragmentVersions =
+			postFragment.getFragmentVersions();
+
+		Assert.assertTrue(
+			Arrays.toString(postFragmentVersions),
+			postFragmentVersions.length > 0);
+
+		for (int i = 0; i < fragmentVersions.length; i++) {
+			FragmentVersion fragmentVersion = fragmentVersions[i];
+
+			FragmentVersion postFragmentVersion = postFragmentVersions[i];
+
+			Assert.assertNull(postFragmentVersion.getConfiguration());
+			Assert.assertNull(postFragmentVersion.getCss());
+			Assert.assertNull(postFragmentVersion.getHtml());
+			Assert.assertNull(postFragmentVersion.getJs());
+
+			FragmentEntry curFragmentEntry = fragmentEntry;
+
+			if (fragmentVersion.getStatus() == FragmentVersion.Status.DRAFT) {
+				curFragmentEntry = draftFragmentEntry;
+			}
+
+			Assert.assertEquals(
+				fragmentVersion.getConfiguration(),
+				curFragmentEntry.getConfiguration());
+			Assert.assertEquals(
+				fragmentVersion.getCss(), curFragmentEntry.getCss());
+			Assert.assertEquals(
+				fragmentVersion.getHtml(), curFragmentEntry.getHtml());
+			Assert.assertEquals(
+				fragmentVersion.getJs(), curFragmentEntry.getJs());
+		}
 	}
 
 	private void _testPostSiteFragmentSetFragmentApproved() throws Exception {

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
@@ -161,25 +161,9 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 	public void testDeleteSiteFragment() throws Exception {
 		super.testDeleteSiteFragment();
 
-		Fragment postFragment = _postSiteFragmentSetFragment(randomFragment());
-
-		FragmentEntry fragmentEntry =
-			_fragmentEntryLocalService.getFragmentEntryByExternalReferenceCode(
-				postFragment.getExternalReferenceCode(),
-				testGroup.getGroupId());
-
-		fragmentResource.deleteSiteFragment(
-			testGroup.getExternalReferenceCode(),
-			postFragment.getExternalReferenceCode());
-
-		Assert.assertNull(
-			_fragmentEntryLocalService.fetchFragmentEntry(
-				fragmentEntry.getFragmentEntryId()));
-
-		List<FragmentEntryVersion> fragmentEntryVersions =
-			_fragmentEntryLocalService.getVersions(fragmentEntry);
-
-		Assert.assertTrue(fragmentEntryVersions.isEmpty());
+		_testDeleteSiteFragment(false, true);
+		_testDeleteSiteFragment(true, false);
+		_testDeleteSiteFragment(true, true);
 	}
 
 	@Override
@@ -881,6 +865,32 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 				fetchFragmentEntryByExternalReferenceCode(
 					fragment2.getExternalReferenceCode(),
 					irrelevantGroup.getGroupId()));
+	}
+
+	private void _testDeleteSiteFragment(boolean approved, boolean draft)
+		throws Exception {
+
+		Fragment postFragment = _postSiteFragmentSetFragment(
+			_randomFragment(approved, draft));
+
+		FragmentEntry fragmentEntry =
+			_fragmentEntryLocalService.
+				fetchFragmentEntryByExternalReferenceCode(
+					postFragment.getExternalReferenceCode(),
+					testGroup.getGroupId(), approved);
+
+		fragmentResource.deleteSiteFragment(
+			testGroup.getExternalReferenceCode(),
+			postFragment.getExternalReferenceCode());
+
+		Assert.assertNull(
+			_fragmentEntryLocalService.fetchFragmentEntry(
+				fragmentEntry.getFragmentEntryId()));
+
+		List<FragmentEntryVersion> fragmentEntryVersions =
+			_fragmentEntryLocalService.getVersions(fragmentEntry);
+
+		Assert.assertTrue(fragmentEntryVersions.isEmpty());
 	}
 
 	private void _testGetSiteFragment(boolean approved, boolean draft)

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
@@ -185,6 +185,20 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		Fragment draftFragment = _postSiteFragmentSetFragment(
 			_randomFragment(false, true));
 
+		FragmentCollection irrelevantFragmentCollection =
+			_addFragmentCollection();
+
+		Fragment irrelevantApprovedAndDraftFragment =
+			_postSiteFragmentSetFragment(
+				_randomFragment(true, true, irrelevantFragmentCollection),
+				irrelevantFragmentCollection.getExternalReferenceCode());
+		Fragment irrelevantApprovedFragment = _postSiteFragmentSetFragment(
+			_randomFragment(true, false, irrelevantFragmentCollection),
+			irrelevantFragmentCollection.getExternalReferenceCode());
+		Fragment irrelevantDraftFragment = _postSiteFragmentSetFragment(
+			_randomFragment(false, true, irrelevantFragmentCollection),
+			irrelevantFragmentCollection.getExternalReferenceCode());
+
 		Page<Fragment> page = fragmentResource.getSiteFragmentSetFragmentsPage(
 			testGroup.getExternalReferenceCode(),
 			_fragmentCollection.getExternalReferenceCode(),
@@ -195,6 +209,11 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		assertContains(approvedAndDraftFragment, items);
 		assertContains(approvedFragment, items);
 		assertContains(draftFragment, items);
+		assertNotContains(irrelevantApprovedAndDraftFragment, items);
+		assertNotContains(irrelevantApprovedFragment, items);
+		assertNotContains(irrelevantDraftFragment, items);
+
+		_testGetSiteFragmentSetFragmentsPageWithNonexistentFragmentSet();
 	}
 
 	@Override
@@ -825,6 +844,23 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 	private void _testGetSiteFragmentDraft() throws Exception {
 		_testGetSiteFragment(false, true);
+	}
+
+	private void _testGetSiteFragmentSetFragmentsPageWithNonexistentFragmentSet()
+		throws Exception {
+
+		try {
+			fragmentResource.getSiteFragmentSetFragmentsPage(
+				testGroup.getExternalReferenceCode(),
+				RandomTestUtil.randomString(), Pagination.of(1, 10));
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("NOT_FOUND", problem.getStatus());
+		}
 	}
 
 	private void _testGetSiteFragmentsPageWithFilter() throws Exception {

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -405,10 +405,13 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 		FragmentSet fragmentSet2 = testPostSiteFragmentSet_addFragmentSet(
 			randomFragmentSet());
 
+		String json = _exportFragmentSetsToJSON(
+			testGroup.getExternalReferenceCode());
+
 		waitForFinish(
 			"COMPLETED",
 			HTTPTestUtil.invokeToJSONObject(
-				_exportFragmentSetsToJSON(testGroup.getExternalReferenceCode()),
+				json,
 				"headless-admin-fragment/v1.0/sites/" +
 					irrelevantGroup.getExternalReferenceCode() +
 						"/fragment-sets/batch?createStrategy=INSERT",
@@ -425,8 +428,7 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 			waitForFinish(
 				"FAILED",
 				HTTPTestUtil.invokeToJSONObject(
-					_exportFragmentSetsToJSON(
-						testGroup.getExternalReferenceCode()),
+					json,
 					"headless-admin-fragment/v1.0/sites/" +
 						irrelevantGroup.getExternalReferenceCode() +
 							"/fragment-sets/batch?createStrategy=INSERT",

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -405,13 +405,13 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 		FragmentSet fragmentSet2 = testPostSiteFragmentSet_addFragmentSet(
 			randomFragmentSet());
 
-		String json = _exportFragmentSetsToJSON(
+		String fragmentSetsJSON = _exportFragmentSetsToJSON(
 			testGroup.getExternalReferenceCode());
 
 		waitForFinish(
 			"COMPLETED",
 			HTTPTestUtil.invokeToJSONObject(
-				json,
+				fragmentSetsJSON,
 				"headless-admin-fragment/v1.0/sites/" +
 					irrelevantGroup.getExternalReferenceCode() +
 						"/fragment-sets/batch?createStrategy=INSERT",
@@ -428,7 +428,7 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 			waitForFinish(
 				"FAILED",
 				HTTPTestUtil.invokeToJSONObject(
-					json,
+					fragmentSetsJSON,
 					"headless-admin-fragment/v1.0/sites/" +
 						irrelevantGroup.getExternalReferenceCode() +
 							"/fragment-sets/batch?createStrategy=INSERT",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93513

## What Is Being Fixed

The headless-admin-fragment batch export could not exclude marketplace fragments, and a site's fragments could not be listed or filtered through the API by attributes such as marketplace status, creation date, or modification date. Fragment entries were not indexed for search, so there was no server-side filter to drive such an export. In addition, marketplace fragment versions exposed their full content (configuration, CSS, HTML, and JavaScript), which should not be re-importable.

## How It Is Being Fixed

Fragment entries are now indexed and searchable. The custom FragmentEntry service methods are annotated with @Indexable so that adding, copying, moving, updating, and deleting an entry keeps the index in sync, and a model search configurator together with document, keyword-query, and pre-filter contributors follow the established search SPI used by sibling entities. An indexed marketplace field is added alongside dateCreated and dateModified and exposed through a new FragmentEntityModel for OData filtering. A new getSiteFragmentsPage endpoint is added and the headless reads are migrated to SearchUtil.search(), so a batch export can now filter out marketplace fragments, for example with filter=marketplace eq false. The search field formerly named draftOnlyOrPublished is renamed to headListable and the pre-filter contributor filters by the head version. Marketplace fragment versions now return null content so their definition is not re-importable (LPD-94257). Deleting a draft-only fragment by its external reference code is fixed. The change adds integration coverage for reindexing on move, copy, and delete, the head pre-filter, the marketplace export filter, the new endpoint, and the delete paths per version state.

## PR Check

**pr-check: PASS** — tested on `db9e4b9e49d39bfb7fa4572898f93435c99434bf`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Service Builder | PASS |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

Source Format and Integration Test Compile were re-validated on `db9e4b9` (the only new commit renames three test methods); the remaining validations were run on the parent commit `9d4a5d7`, whose tree is identical apart from those test-method names.

<!-- pr-check {"result": "success", "sha": "db9e4b9e49d39bfb7fa4572898f93435c99434bf"} -->
